### PR TITLE
feat: Wave 0-3 — EA/EFM kernel overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # CogOS
 
-**Cognitive infrastructure for AI agents.** Memory, context, identity, and trust — as a daemon.
+**Externalized attention and executive function modulation for intelligent systems.**
 
-CogOS is a background kernel that gives AI agents the things they can't give themselves: persistent memory that survives across sessions, context assembly that knows what matters right now, multi-provider inference routing that keeps data local, and a tamper-evident ledger that records every decision. It runs on your hardware, it works with any agent, and everything it knows stays yours.
+CogOS is the substrate between observers and generators. It externalizes the cognitive functions that models do poorly and expensively — deciding what's relevant, managing working memory, routing between providers, validating tool calls, maintaining identity across sessions — so that any model, on any device, can generate effectively from pre-digested context.
+
+The model doesn't think. The substrate thinks. The model generates.
 
 ```sh
 make build
@@ -78,17 +80,27 @@ Organelles don't communicate directly. They read from and write to the substrate
 
 ## Ecosystem
 
-CogOS is not a monolith. Each subsystem is its own repo, its own release cycle, its own organelle:
+CogOS is not a monolith. It's a cell. Each subsystem is its own repo, its own release cycle, its own organelle:
 
-| Repo | Role | What it does |
+| Repo | Verb | What it does |
 |------|------|-------------|
-| [cogos-dev/cogos](https://github.com/cogos-dev/cogos) | Kernel | Continuous process daemon — context, memory, ledger, routing |
-| [cogos-dev/constellation](https://github.com/cogos-dev/constellation) | Identity & Trust | Distributed identity where trust is earned through temporal consistency |
-| [cogos-dev/mod3](https://github.com/cogos-dev/mod3) | Modality | Multi-model TTS with adaptive playback, VAD, and speech queuing |
+| [cogos](https://github.com/cogos-dev/cogos) | **IS** | The cell — nucleus, substrate, membrane as a continuous process daemon |
+| [constellation](https://github.com/cogos-dev/constellation) | **TRUSTS** | Distributed identity where trust is earned through temporal coherence |
+| [mod3](https://github.com/cogos-dev/mod3) | **ACTS** | Modality bus — translates between thinking and acting across any modality |
+| [charts](https://github.com/cogos-dev/charts) | **DEPLOYS** | Helm charts + Docker Compose for single-node through multi-node topologies |
+| [desktop](https://github.com/cogos-dev/desktop) | **PRESENTS** | Native macOS app — kernel management, terminal, dashboard |
 
 Each organelle is independently deployable. They coordinate through the substrate, not through imports. The workspace discovers available organelles at runtime through capability scanning — like a cell discovering what enzymes are available in the cytoplasm.
 
 ## Core ideas
+
+### The model generates. The substrate thinks.
+
+Every other approach says "make the model smarter." CogOS says: make the environment more structured so that any intelligence — human or machine — can operate more effectively within it. The substrate provides two things models do poorly:
+
+**Externalized Attention** — deciding what information is relevant *before* the model sees it. The foveated context engine, TRM, salience scoring, and zone ordering ensure the model never attends to irrelevant information.
+
+**Executive Function Modulation** — deciding how the model should behave *before* it generates. The process state machine, sovereignty gradient, tool-call validation gate, and consolidation policy shape behavior through conditioning signals, not English prompts.
 
 ### Your workspace is the cognitive object, not the model
 
@@ -189,9 +201,9 @@ make e2e          # Containerized e2e
 
 v3 kernel — ground-up rewrite after a year of daily use across multiple agent harnesses.
 
-Working: continuous process, foveated context, hash-chained ledger, multi-provider routing, MCP server, blob store, salience scoring, OpenAI/Anthropic compatibility, workspace scaffolding, e2e testing, web dashboard, OpenTelemetry.
+Working: continuous process, foveated context with Mamba TRM, hash-chained ledger, multi-provider routing (Gemma 4 E4B default), MCP server, blob store, salience scoring, tool-call hallucination gate, digestion pipeline (Claude Code + OpenClaw adapters), memory consolidation, constellation bridge interface, OpenAI/Anthropic compatibility, workspace scaffolding, e2e testing, web dashboard, OpenTelemetry.
 
-Next: Constellation protocol integration with kernel, memory consolidation loop, multi-agent process management, `cog` CLI.
+Next: wire digestion tailers into process loop, constellation library integration, multi-agent process management, `cog` CLI, README updates across ecosystem.
 
 ## Deeper
 

--- a/docs/E2E-TEST-PLAN.md
+++ b/docs/E2E-TEST-PLAN.md
@@ -1,0 +1,289 @@
+# CogOS E2E Integration Test Plan
+
+This document defines end-to-end integration test specifications for Wave 0-2 capabilities in the `cogos` kernel. It is a **test plan/spec**, not test implementation code.
+
+## Global Conventions
+
+- Kernel binary: `./cogos`
+- Default test port examples: `5299` (override per test to avoid collisions)
+- Test workspace root: `/tmp/cogos-e2e-*`
+- Ledger path pattern: `.cog/ledger/<session_id>/events.jsonl`
+- Proprioceptive log path: `.cog/run/proprioceptive.jsonl`
+- Sync inbox path: `.cog/sync/inbox/`
+- Unless stated otherwise, all API calls target `http://localhost:$PORT`
+
+---
+
+## 1) Standalone Kernel Test
+
+Validates baseline kernel lifecycle and API behavior (current `scripts/e2e-test.sh` coverage).
+
+### Prerequisites
+
+- `cogos` binary built and executable
+- `curl` available
+- No process currently bound to the selected test port
+
+### Setup Commands
+
+```bash
+export COGOS_BIN=./cogos
+export E2E_WORKSPACE=/tmp/cogos-e2e-standalone
+export E2E_PORT=5299
+rm -rf "$E2E_WORKSPACE"
+"$COGOS_BIN" init --workspace "$E2E_WORKSPACE"
+"$COGOS_BIN" serve --workspace "$E2E_WORKSPACE" --port "$E2E_PORT" &
+KERNEL_PID=$!
+```
+
+### Test Steps
+
+1. Poll `GET /health` until ready.
+2. Verify `/health` includes:
+   - `status: "ok"`
+   - `identity` (expected default: `CogOS`)
+   - `state` (expected initial: `receptive`)
+3. Send `POST /v1/chat/completions` with a minimal user message.
+4. Verify the request created a ledger event in `.cog/ledger/*/events.jsonl` (event type `cogblock.ingest`).
+5. Verify context assembly includes nucleus:
+   - `GET /v1/context` returns `nucleus` field
+   - `nucleus` equals identity (`CogOS` in default scaffold)
+6. Stop kernel (`kill $KERNEL_PID`) and confirm `/health` is no longer reachable.
+
+### Expected Outcomes
+
+- Kernel starts from clean workspace without fatal errors.
+- Health endpoint returns identity and runtime state.
+- Chat completion endpoint accepts OpenAI-compatible request.
+- Ledger records interaction as append-only hash-chained event.
+- Context endpoint includes nucleus identity.
+- Shutdown is graceful (process exits; port is released).
+
+### Cleanup
+
+```bash
+kill "$KERNEL_PID" 2>/dev/null || true
+wait "$KERNEL_PID" 2>/dev/null || true
+rm -rf "$E2E_WORKSPACE"
+```
+
+---
+
+## 2) Gemma 4 Integration Test (Ollama Required)
+
+Validates local-provider routing to `gemma4:e4b` and tool-call hallucination gate behavior.
+
+### Prerequisites
+
+- Ollama daemon running at `http://localhost:11434`
+- `gemma4:e4b` model available in Ollama
+- `cogos` binary built and executable
+
+### Setup Commands
+
+```bash
+export COGOS_BIN=./cogos
+export E2E_WORKSPACE=/tmp/cogos-e2e-gemma
+export E2E_PORT=5300
+rm -rf "$E2E_WORKSPACE"
+"$COGOS_BIN" init --workspace "$E2E_WORKSPACE"
+"$COGOS_BIN" serve --workspace "$E2E_WORKSPACE" --port "$E2E_PORT" &
+KERNEL_PID=$!
+```
+
+### Test Steps
+
+1. Confirm provider readiness through successful `POST /v1/chat/completions` using a simple prompt (e.g. “Reply with the word READY”).
+2. Verify returned completion content is non-empty and attributed to local model routing.
+3. Send a tool-enabled request designed to provoke an invalid/unsupported tool call (hallucinated function name or malformed arguments).
+4. Verify hallucination gate activates by checking one of:
+   - Provider is re-called with rejection feedback and tool call is not executed.
+   - Result avoids unsafe tool execution and returns normal content or corrected output.
+5. Verify proprioceptive logging captured validation failure in `.cog/run/proprioceptive.jsonl` with event `tool_call_rejected` and reason details.
+
+### Expected Outcomes
+
+- Kernel uses Gemma 4 E4B as default local inference path.
+- Normal prompt returns successful completion.
+- Invalid model-emitted tool call is blocked by validation gate.
+- Proprioceptive log includes rejection telemetry (`provider`, `tool_name`, `reason`).
+
+### Cleanup
+
+```bash
+kill "$KERNEL_PID" 2>/dev/null || true
+wait "$KERNEL_PID" 2>/dev/null || true
+rm -rf "$E2E_WORKSPACE"
+```
+
+---
+
+## 3) Digestion Pipeline Test
+
+Validates StreamTailer-based ingestion from JSONL and process-state gating.
+
+### Prerequisites
+
+- `cogos` binary built and executable
+- Writable test JSONL file path
+- Adapter format chosen to match configured tailer (`claudecode` or `openclaw`)
+
+### Setup Commands
+
+```bash
+export COGOS_BIN=./cogos
+export E2E_WORKSPACE=/tmp/cogos-e2e-digest
+export E2E_PORT=5301
+export DIGEST_FILE=/tmp/cogos-e2e-digest-input.jsonl
+rm -rf "$E2E_WORKSPACE" "$DIGEST_FILE"
+"$COGOS_BIN" init --workspace "$E2E_WORKSPACE"
+touch "$DIGEST_FILE"
+```
+
+Update `"$E2E_WORKSPACE/.cog/config/kernel.yaml"` to include:
+
+```yaml
+digest_paths:
+  claudecode: /tmp/cogos-e2e-digest-input.jsonl
+```
+
+Then start kernel:
+
+```bash
+"$COGOS_BIN" serve --workspace "$E2E_WORKSPACE" --port "$E2E_PORT" &
+KERNEL_PID=$!
+```
+
+### Test Steps
+
+1. Append valid JSONL lines representing digest input events to `$DIGEST_FILE`.
+2. Wait for poll interval and ingestion cycle.
+3. Verify CogBlock ingestion records appear in ledger (`cogblock.ingest`) with provenance fields reflecting adapter/source channel.
+4. Force kernel into/observe non-ingesting state (Consolidating or Dormant), append additional lines, and verify these are not ingested until state returns to Receptive/Active.
+5. Return to Receptive/Active, append another line, and verify ingestion resumes.
+
+### Expected Outcomes
+
+- Tailer reads new lines and emits normalized blocks.
+- Ledger contains ingestion events with correct provenance metadata.
+- Ingestion is state-gated: accepted in `receptive`/`active`, dropped or deferred outside those states.
+- No duplicate ingestion for unchanged lines.
+
+### Cleanup
+
+```bash
+kill "$KERNEL_PID" 2>/dev/null || true
+wait "$KERNEL_PID" 2>/dev/null || true
+rm -rf "$E2E_WORKSPACE" "$DIGEST_FILE"
+```
+
+---
+
+## 4) Constellation Bridge Test (Constellation Binary Required)
+
+Validates heartbeat bridge payload and SyncWatcher envelope handling.
+
+### Prerequisites
+
+- `cogos` binary built and executable
+- Constellation binary installed and runnable
+- Constellation test configuration available for local node
+
+### Setup Commands
+
+```bash
+export COGOS_BIN=./cogos
+export E2E_WORKSPACE=/tmp/cogos-e2e-constellation
+export E2E_PORT=5302
+rm -rf "$E2E_WORKSPACE"
+"$COGOS_BIN" init --workspace "$E2E_WORKSPACE"
+mkdir -p "$E2E_WORKSPACE/.cog/sync/inbox"
+```
+
+Start constellation node using test config, then start kernel bound to that constellation integration.
+
+### Test Steps
+
+1. Wait for dormant heartbeat cycle.
+2. Verify bridge heartbeat payload includes `KernelHeartbeatPayload` fields:
+   - `process_state`
+   - `field_size`
+   - `coherence_fingerprint`
+   - `nucleus_fingerprint`
+   - `timestamp`
+3. Create a valid `SyncEnvelope` JSON file in `.cog/sync/inbox/`.
+4. Verify `SyncWatcher` detects envelope and performs structural validation.
+5. Verify validation result marks envelope as valid (or invalid with explicit reason if malformed variant is tested).
+
+### Expected Outcomes
+
+- Kernel emits bridge heartbeat during dormant cadence.
+- Heartbeat payload conforms to expected schema.
+- Sync inbox drop is discovered by watcher.
+- Envelope validation behavior matches schema rules (version, IDs, hash format, RFC3339 timestamp, kind, signature).
+
+### Cleanup
+
+```bash
+kill "$KERNEL_PID" 2>/dev/null || true
+wait "$KERNEL_PID" 2>/dev/null || true
+# stop constellation process(es)
+rm -rf "$E2E_WORKSPACE"
+```
+
+---
+
+## 5) Full Stack Test (Kernel + mod3 + Constellation)
+
+Validates cross-repo/system integration and attention signaling through full runtime topology.
+
+### Prerequisites
+
+- `cogos` binary built and executable
+- `mod3` process/binary available and configured
+- Constellation binary running with compatible node identity/trust config
+- Shared test workspace and interoperable endpoint configuration
+
+### Setup Commands
+
+1. Initialize shared workspace for stack test.
+2. Start constellation service(s).
+3. Start `mod3` with test speech input/output adapters enabled.
+4. Start kernel (`cogos serve`) with matching integration config and dedicated test port.
+
+### Test Steps
+
+1. Confirm all three processes are healthy.
+2. Send a controlled event through one subsystem (e.g. mod3 speech utterance).
+3. Verify event propagates across stack:
+   - mod3 emits speech event
+   - kernel receives/records corresponding perturbation or attention event
+   - constellation-facing state remains coherent/available
+4. Verify kernel produces attention updates (state transition or salience/context impact) attributable to mod3 speech trigger.
+5. Verify ledger captures cross-system interaction trail for traceability.
+
+### Expected Outcomes
+
+- Kernel, mod3, and constellation communicate without deadlock or protocol mismatch.
+- Speech-originated perturbations reach kernel and trigger attention behavior.
+- Observable cross-system telemetry/ledger evidence exists for the same interaction window.
+
+### Cleanup
+
+1. Stop kernel.
+2. Stop mod3.
+3. Stop constellation services.
+4. Remove test workspace and temporary runtime artifacts.
+
+---
+
+## Exit Criteria
+
+The E2E plan is considered passing when all five scenarios complete with expected outcomes and no unresolved critical failures in:
+
+- API availability and correctness
+- ledger/provenance integrity
+- tool-call safety gate behavior
+- digestion state gating
+- constellation bridge/sync envelope handling
+- cross-system signaling in full-stack runtime

--- a/internal/engine/config.go
+++ b/internal/engine/config.go
@@ -62,6 +62,10 @@ type Config struct {
 	// Providers that advertise CapToolUse are trusted and skip this guardrail.
 	ToolCallValidationEnabled bool
 
+	// DigestPaths maps stream tailer adapter names to JSONL file/directory paths.
+	// Empty map means external digestion is disabled.
+	DigestPaths map[string]string
+
 	LocalModel string
 
 	localModelConfigured bool
@@ -69,18 +73,19 @@ type Config struct {
 
 // kernelConfigSection holds settings that can appear at the top level or inside v3:.
 type kernelConfigSection struct {
-	Port                  int    `yaml:"port"`
-	ConsolidationInterval int    `yaml:"consolidation_interval"`
-	HeartbeatInterval     int    `yaml:"heartbeat_interval"`
-	SalienceDaysWindow    int    `yaml:"salience_days_window"`
-	OutputReserve         int    `yaml:"output_reserve"`
-	TRMWeightsPath        string `yaml:"trm_weights_path"`
-	TRMEmbeddingsPath     string `yaml:"trm_embeddings_path"`
-	TRMChunksPath         string `yaml:"trm_chunks_path"`
-	OllamaEmbedEndpoint   string `yaml:"ollama_embed_endpoint"`
-	OllamaEmbedModel      string `yaml:"ollama_embed_model"`
-	ToolCallValidation    *bool  `yaml:"tool_call_validation_enabled"`
-	LocalModel            string `yaml:"local_model"`
+	Port                  int               `yaml:"port"`
+	ConsolidationInterval int               `yaml:"consolidation_interval"`
+	HeartbeatInterval     int               `yaml:"heartbeat_interval"`
+	SalienceDaysWindow    int               `yaml:"salience_days_window"`
+	OutputReserve         int               `yaml:"output_reserve"`
+	TRMWeightsPath        string            `yaml:"trm_weights_path"`
+	TRMEmbeddingsPath     string            `yaml:"trm_embeddings_path"`
+	TRMChunksPath         string            `yaml:"trm_chunks_path"`
+	OllamaEmbedEndpoint   string            `yaml:"ollama_embed_endpoint"`
+	OllamaEmbedModel      string            `yaml:"ollama_embed_model"`
+	ToolCallValidation    *bool             `yaml:"tool_call_validation_enabled"`
+	LocalModel            string            `yaml:"local_model"`
+	DigestPaths           map[string]string `yaml:"digest_paths"`
 }
 
 // kernelConfig is the on-disk YAML shape of .cog/config/kernel.yaml.
@@ -117,6 +122,7 @@ func LoadConfig(workspaceRoot string, port int) (*Config, error) {
 		OutputReserve:             4096,
 		ToolCallValidationEnabled: true,
 		LocalModel:                defaultOllamaModel,
+		DigestPaths:               make(map[string]string),
 	}
 
 	// Load from file if present.
@@ -176,6 +182,14 @@ func applyKernelSection(cfg *Config, s kernelConfigSection) {
 	if s.LocalModel != "" {
 		cfg.LocalModel = s.LocalModel
 		cfg.localModelConfigured = true
+	}
+	if len(s.DigestPaths) > 0 {
+		if cfg.DigestPaths == nil {
+			cfg.DigestPaths = make(map[string]string, len(s.DigestPaths))
+		}
+		for name, path := range s.DigestPaths {
+			cfg.DigestPaths[name] = path
+		}
 	}
 }
 

--- a/internal/engine/config.go
+++ b/internal/engine/config.go
@@ -57,6 +57,14 @@ type Config struct {
 	// OllamaEmbedModel is the embedding model name for Ollama.
 	// Default: nomic-embed-text
 	OllamaEmbedModel string
+
+	// ToolCallValidationEnabled gates runtime validation for model-emitted tool calls.
+	// Providers that advertise CapToolUse are trusted and skip this guardrail.
+	ToolCallValidationEnabled bool
+
+	LocalModel string
+
+	localModelConfigured bool
 }
 
 // kernelConfigSection holds settings that can appear at the top level or inside v3:.
@@ -71,6 +79,8 @@ type kernelConfigSection struct {
 	TRMChunksPath         string `yaml:"trm_chunks_path"`
 	OllamaEmbedEndpoint   string `yaml:"ollama_embed_endpoint"`
 	OllamaEmbedModel      string `yaml:"ollama_embed_model"`
+	ToolCallValidation    *bool  `yaml:"tool_call_validation_enabled"`
+	LocalModel            string `yaml:"local_model"`
 }
 
 // kernelConfig is the on-disk YAML shape of .cog/config/kernel.yaml.
@@ -98,13 +108,15 @@ func LoadConfig(workspaceRoot string, port int) (*Config, error) {
 	}
 
 	cfg := &Config{
-		WorkspaceRoot:         workspaceRoot,
-		CogDir:                filepath.Join(workspaceRoot, ".cog"),
-		Port:                  6931,
-		ConsolidationInterval: 900,
-		HeartbeatInterval:     60,
-		SalienceDaysWindow:    90,
-		OutputReserve:         4096,
+		WorkspaceRoot:             workspaceRoot,
+		CogDir:                    filepath.Join(workspaceRoot, ".cog"),
+		Port:                      6931,
+		ConsolidationInterval:     3600,
+		HeartbeatInterval:         60,
+		SalienceDaysWindow:        90,
+		OutputReserve:             4096,
+		ToolCallValidationEnabled: true,
+		LocalModel:                defaultOllamaModel,
 	}
 
 	// Load from file if present.
@@ -157,6 +169,13 @@ func applyKernelSection(cfg *Config, s kernelConfigSection) {
 	}
 	if s.OllamaEmbedModel != "" {
 		cfg.OllamaEmbedModel = s.OllamaEmbedModel
+	}
+	if s.ToolCallValidation != nil {
+		cfg.ToolCallValidationEnabled = *s.ToolCallValidation
+	}
+	if s.LocalModel != "" {
+		cfg.LocalModel = s.LocalModel
+		cfg.localModelConfigured = true
 	}
 }
 

--- a/internal/engine/config_test.go
+++ b/internal/engine/config_test.go
@@ -39,6 +39,9 @@ func TestLoadConfigDefaults(t *testing.T) {
 	if !cfg.ToolCallValidationEnabled {
 		t.Error("ToolCallValidationEnabled = false; want true by default")
 	}
+	if len(cfg.DigestPaths) != 0 {
+		t.Errorf("DigestPaths len = %d; want 0", len(cfg.DigestPaths))
+	}
 }
 
 func TestLoadConfigFromFile(t *testing.T) {
@@ -51,6 +54,9 @@ heartbeat_interval: 120
 salience_days_window: 30
 local_model: gemma4:e2b
 tool_call_validation_enabled: false
+digest_paths:
+  claude-code: ~/.claude/events.jsonl
+  openclaw: /tmp/openclaw
 `
 	writeTestFile(t, filepath.Join(root, ".cog", "config", "kernel.yaml"), kernelYAML)
 
@@ -76,6 +82,12 @@ tool_call_validation_enabled: false
 	}
 	if cfg.ToolCallValidationEnabled {
 		t.Error("ToolCallValidationEnabled = true; want false from file")
+	}
+	if cfg.DigestPaths["claude-code"] != "~/.claude/events.jsonl" {
+		t.Errorf("DigestPaths[claude-code] = %q; want ~/.claude/events.jsonl", cfg.DigestPaths["claude-code"])
+	}
+	if cfg.DigestPaths["openclaw"] != "/tmp/openclaw" {
+		t.Errorf("DigestPaths[openclaw] = %q; want /tmp/openclaw", cfg.DigestPaths["openclaw"])
 	}
 }
 

--- a/internal/engine/config_test.go
+++ b/internal/engine/config_test.go
@@ -18,8 +18,8 @@ func TestLoadConfigDefaults(t *testing.T) {
 	if cfg.Port != 6931 {
 		t.Errorf("Port = %d; want 6931", cfg.Port)
 	}
-	if cfg.ConsolidationInterval != 900 {
-		t.Errorf("ConsolidationInterval = %d; want 900", cfg.ConsolidationInterval)
+	if cfg.ConsolidationInterval != 3600 {
+		t.Errorf("ConsolidationInterval = %d; want 3600", cfg.ConsolidationInterval)
 	}
 	if cfg.HeartbeatInterval != 60 {
 		t.Errorf("HeartbeatInterval = %d; want 60", cfg.HeartbeatInterval)
@@ -33,6 +33,12 @@ func TestLoadConfigDefaults(t *testing.T) {
 	if cfg.CogDir != filepath.Join(root, ".cog") {
 		t.Errorf("CogDir = %q; want %q", cfg.CogDir, filepath.Join(root, ".cog"))
 	}
+	if cfg.LocalModel != defaultOllamaModel {
+		t.Errorf("LocalModel = %q; want %q", cfg.LocalModel, defaultOllamaModel)
+	}
+	if !cfg.ToolCallValidationEnabled {
+		t.Error("ToolCallValidationEnabled = false; want true by default")
+	}
 }
 
 func TestLoadConfigFromFile(t *testing.T) {
@@ -43,6 +49,8 @@ func TestLoadConfigFromFile(t *testing.T) {
 consolidation_interval: 600
 heartbeat_interval: 120
 salience_days_window: 30
+local_model: gemma4:e2b
+tool_call_validation_enabled: false
 `
 	writeTestFile(t, filepath.Join(root, ".cog", "config", "kernel.yaml"), kernelYAML)
 
@@ -62,6 +70,12 @@ salience_days_window: 30
 	}
 	if cfg.SalienceDaysWindow != 30 {
 		t.Errorf("SalienceDaysWindow = %d; want 30", cfg.SalienceDaysWindow)
+	}
+	if cfg.LocalModel != "gemma4:e2b" {
+		t.Errorf("LocalModel = %q; want gemma4:e2b", cfg.LocalModel)
+	}
+	if cfg.ToolCallValidationEnabled {
+		t.Error("ToolCallValidationEnabled = true; want false from file")
 	}
 }
 

--- a/internal/engine/consolidate.go
+++ b/internal/engine/consolidate.go
@@ -1,0 +1,497 @@
+package engine
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const defaultConsolidationEventLimit = 100
+
+type ConsolidationAction struct {
+	WorkspaceRoot string
+	MaxEvents     int
+	Now           func() time.Time
+}
+
+type consolidationGroupKey struct {
+	sessionID string
+	threadID  string
+}
+
+type consolidationEvent struct {
+	env       EventEnvelope
+	timestamp time.Time
+	threadID  string
+}
+
+type archivedSessionRange struct {
+	minEventCount int
+	maxEventCount int
+}
+
+func (a ConsolidationAction) Run() (int, error) {
+	workspaceRoot := a.WorkspaceRoot
+	if workspaceRoot == "" {
+		return 0, fmt.Errorf("consolidation workspace root is empty")
+	}
+
+	limit := a.MaxEvents
+	if limit <= 0 {
+		limit = defaultConsolidationEventLimit
+	}
+
+	nowFn := a.Now
+	if nowFn == nil {
+		nowFn = func() time.Time { return time.Now().UTC() }
+	}
+
+	events, summaries, err := readLedgerEvents(workspaceRoot)
+	if err != nil {
+		return 0, err
+	}
+	if len(events) == 0 {
+		return 0, nil
+	}
+
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].timestamp.After(events[j].timestamp)
+	})
+	if len(events) > limit {
+		events = events[:limit]
+	}
+
+	groups := make(map[consolidationGroupKey][]consolidationEvent)
+	for _, event := range events {
+		key := consolidationGroupKey{
+			sessionID: event.env.HashedPayload.SessionID,
+			threadID:  event.threadID,
+		}
+		groups[key] = append(groups[key], event)
+	}
+
+	consolidatedSessions := make(map[string]struct{})
+	archivedRanges := make(map[string]archivedSessionRange)
+	for key, group := range groups {
+		if len(group) <= 10 {
+			continue
+		}
+
+		sort.Slice(group, func(i, j int) bool {
+			return group[i].timestamp.Before(group[j].timestamp)
+		})
+
+		lastSummaryAt, ok := summaries[key]
+		if ok && !group[len(group)-1].timestamp.After(lastSummaryAt) {
+			continue
+		}
+
+		summaryData := buildConsolidationSummary(key, group)
+		block, err := newConsolidationBlock(workspaceRoot, key, summaryData, nowFn())
+		if err != nil {
+			return 0, err
+		}
+		if err := appendConsolidationSummary(workspaceRoot, block, summaryData); err != nil {
+			return 0, err
+		}
+
+		consolidatedSessions[key.sessionID] = struct{}{}
+		if current, exists := archivedRanges[key.sessionID]; exists {
+			if len(group) < current.minEventCount {
+				current.minEventCount = len(group)
+			}
+			if len(group) > current.maxEventCount {
+				current.maxEventCount = len(group)
+			}
+			archivedRanges[key.sessionID] = current
+		} else {
+			archivedRanges[key.sessionID] = archivedSessionRange{minEventCount: len(group), maxEventCount: len(group)}
+		}
+	}
+
+	if len(consolidatedSessions) > 0 {
+		if err := appendArchivedSessionsEvent(workspaceRoot, consolidatedSessions, archivedRanges, nowFn()); err != nil {
+			return 0, err
+		}
+	}
+
+	return len(consolidatedSessions), nil
+}
+
+func readLedgerEvents(workspaceRoot string) ([]consolidationEvent, map[consolidationGroupKey]time.Time, error) {
+	ledgerRoot := filepath.Join(workspaceRoot, ".cog", "ledger")
+	entries, err := os.ReadDir(ledgerRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, map[consolidationGroupKey]time.Time{}, nil
+		}
+		return nil, nil, fmt.Errorf("read ledger root: %w", err)
+	}
+
+	var events []consolidationEvent
+	summaries := make(map[consolidationGroupKey]time.Time)
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		eventsPath := filepath.Join(ledgerRoot, entry.Name(), "events.jsonl")
+		f, err := os.Open(eventsPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, nil, fmt.Errorf("open ledger %s: %w", entry.Name(), err)
+		}
+
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			if len(line) == 0 {
+				continue
+			}
+
+			var env EventEnvelope
+			if err := json.Unmarshal(line, &env); err != nil {
+				continue
+			}
+			if env.HashedPayload.SessionID == "" {
+				env.HashedPayload.SessionID = entry.Name()
+			}
+
+			ts, err := time.Parse(time.RFC3339, env.HashedPayload.Timestamp)
+			if err != nil {
+				continue
+			}
+
+			if env.HashedPayload.Type == "memory.consolidation" {
+				key, lastTimestamp, ok := parseConsolidationSummary(env)
+				if ok {
+					if current, exists := summaries[key]; !exists || lastTimestamp.After(current) {
+						summaries[key] = lastTimestamp
+					}
+				}
+				continue
+			}
+			if env.HashedPayload.Type == "consolidation.archived" {
+				continue
+			}
+
+			events = append(events, consolidationEvent{
+				env:       env,
+				timestamp: ts,
+				threadID:  eventThreadID(env),
+			})
+		}
+		if err := scanner.Err(); err != nil {
+			_ = f.Close()
+			return nil, nil, fmt.Errorf("scan ledger %s: %w", entry.Name(), err)
+		}
+		_ = f.Close()
+	}
+
+	return events, summaries, nil
+}
+
+func parseConsolidationSummary(env EventEnvelope) (consolidationGroupKey, time.Time, bool) {
+	data := env.HashedPayload.Data
+	threadID, _ := data["thread_id"].(string)
+	summary, ok := data["summary"].(map[string]interface{})
+	if !ok {
+		return consolidationGroupKey{}, time.Time{}, false
+	}
+	lastTimestamp, _ := summary["last_timestamp"].(string)
+	parsed, err := time.Parse(time.RFC3339, lastTimestamp)
+	if err != nil {
+		return consolidationGroupKey{}, time.Time{}, false
+	}
+	return consolidationGroupKey{sessionID: env.HashedPayload.SessionID, threadID: threadID}, parsed, true
+}
+
+func eventThreadID(env EventEnvelope) string {
+	if threadID, _ := env.HashedPayload.Data["thread_id"].(string); threadID != "" {
+		return threadID
+	}
+	return ""
+}
+
+func buildConsolidationSummary(key consolidationGroupKey, group []consolidationEvent) map[string]interface{} {
+	sources := make(map[string]struct{})
+	var texts []string
+	for _, event := range group {
+		source := eventSource(event.env)
+		if source != "" {
+			sources[source] = struct{}{}
+		}
+		texts = append(texts, extractEventTexts(event.env)...)
+	}
+
+	uniqueSources := make([]string, 0, len(sources))
+	for source := range sources {
+		uniqueSources = append(uniqueSources, source)
+	}
+	sort.Strings(uniqueSources)
+
+	summary := map[string]interface{}{
+		"session_id":      key.sessionID,
+		"first_timestamp": group[0].timestamp.UTC().Format(time.RFC3339),
+		"last_timestamp":  group[len(group)-1].timestamp.UTC().Format(time.RFC3339),
+		"event_count":     len(group),
+		"unique_sources":  uniqueSources,
+		"key_topics":      extractTopics(texts),
+	}
+	if key.threadID != "" {
+		summary["thread_id"] = key.threadID
+	}
+	return summary
+}
+
+func newConsolidationBlock(workspaceRoot string, key consolidationGroupKey, summary map[string]interface{}, now time.Time) (*CogBlock, error) {
+	raw, err := json.Marshal(summary)
+	if err != nil {
+		return nil, fmt.Errorf("marshal consolidation summary: %w", err)
+	}
+
+	return &CogBlock{
+		ID:              uuid.NewString(),
+		Timestamp:       now.UTC(),
+		SessionID:       key.sessionID,
+		ThreadID:        key.threadID,
+		SourceChannel:   "internal",
+		SourceTransport: "direct",
+		SourceIdentity:  "consolidation",
+		WorkspaceID:     filepath.Base(workspaceRoot),
+		Kind:            BlockSystemEvent,
+		RawPayload:      raw,
+		Messages:        []ProviderMessage{{Role: "system", Content: "memory consolidation summary"}},
+		Provenance: BlockProvenance{
+			OriginSession: key.sessionID,
+			OriginChannel: "internal",
+			IngestedAt:    now.UTC(),
+			NormalizedBy:  "consolidation",
+		},
+		TrustContext: TrustContext{
+			Authenticated: true,
+			TrustScore:    1.0,
+			Scope:         "local",
+		},
+	}, nil
+}
+
+func appendConsolidationSummary(workspaceRoot string, block *CogBlock, summary map[string]interface{}) error {
+	data := map[string]interface{}{
+		"block_id":                 block.ID,
+		"thread_id":                block.ThreadID,
+		"kind":                     string(block.Kind),
+		"source_channel":           block.SourceChannel,
+		"source_transport":         block.SourceTransport,
+		"source_identity":          block.SourceIdentity,
+		"workspace_id":             block.WorkspaceID,
+		"provenance_normalized_by": block.Provenance.NormalizedBy,
+		"summary":                  summary,
+	}
+
+	env := &EventEnvelope{
+		HashedPayload: EventPayload{
+			Type:      "memory.consolidation",
+			Timestamp: block.Timestamp.UTC().Format(time.RFC3339),
+			SessionID: block.SessionID,
+			Data:      data,
+		},
+		Metadata: EventMetadata{Source: "kernel-v3"},
+	}
+
+	if err := AppendEvent(workspaceRoot, block.SessionID, env); err != nil {
+		return fmt.Errorf("append consolidation summary: %w", err)
+	}
+	block.LedgerRef = env.Metadata.Hash
+	return nil
+}
+
+func appendArchivedSessionsEvent(workspaceRoot string, sessions map[string]struct{}, ranges map[string]archivedSessionRange, now time.Time) error {
+	sessionIDs := make([]string, 0, len(sessions))
+	for sessionID := range sessions {
+		sessionIDs = append(sessionIDs, sessionID)
+	}
+	sort.Strings(sessionIDs)
+
+	archived := make([]interface{}, 0, len(sessionIDs))
+	for _, sessionID := range sessionIDs {
+		eventRange := ranges[sessionID]
+		archived = append(archived, map[string]interface{}{
+			"session_id":      sessionID,
+			"min_event_count": eventRange.minEventCount,
+			"max_event_count": eventRange.maxEventCount,
+		})
+	}
+
+	env := &EventEnvelope{
+		Metadata: EventMetadata{Source: "kernel-v3"},
+	}
+
+	for _, sessionID := range sessionIDs {
+		env.HashedPayload = EventPayload{
+			Type:      "consolidation.archived",
+			Timestamp: now.UTC().Format(time.RFC3339),
+			SessionID: sessionID,
+			Data: map[string]interface{}{
+				"archived_sessions": archived,
+			},
+		}
+		if err := AppendEvent(workspaceRoot, sessionID, env); err != nil {
+			return fmt.Errorf("append archived sessions: %w", err)
+		}
+	}
+	return nil
+}
+
+func ArchivedSessions(workspaceRoot, sessionID string) (map[string]struct{}, error) {
+	archived := make(map[string]struct{})
+	path := filepath.Join(workspaceRoot, ".cog", "ledger", sessionID, "events.jsonl")
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return archived, nil
+		}
+		return nil, fmt.Errorf("open ledger %s: %w", sessionID, err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var env EventEnvelope
+		if err := json.Unmarshal(line, &env); err != nil {
+			continue
+		}
+		if env.HashedPayload.Type != "consolidation.archived" {
+			continue
+		}
+		items, _ := env.HashedPayload.Data["archived_sessions"].([]interface{})
+		for _, item := range items {
+			entry, _ := item.(map[string]interface{})
+			if archivedSessionID, _ := entry["session_id"].(string); archivedSessionID != "" {
+				archived[archivedSessionID] = struct{}{}
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan ledger %s: %w", sessionID, err)
+	}
+
+	return archived, nil
+}
+
+func eventSource(env EventEnvelope) string {
+	if env.Metadata.Source != "" {
+		return env.Metadata.Source
+	}
+	if source, _ := env.HashedPayload.Data["source_identity"].(string); source != "" {
+		return source
+	}
+	if source, _ := env.HashedPayload.Data["source_channel"].(string); source != "" {
+		return source
+	}
+	return env.HashedPayload.Type
+}
+
+func extractEventTexts(env EventEnvelope) []string {
+	var texts []string
+	for key, value := range env.HashedPayload.Data {
+		collectEventTexts(key, value, &texts)
+	}
+	return texts
+}
+
+func collectEventTexts(key string, value interface{}, texts *[]string) {
+	switch typed := value.(type) {
+	case string:
+		if isTextField(key) {
+			*texts = append(*texts, typed)
+		}
+	case []interface{}:
+		for _, item := range typed {
+			collectEventTexts(key, item, texts)
+		}
+	case map[string]interface{}:
+		for nestedKey, nestedValue := range typed {
+			collectEventTexts(nestedKey, nestedValue, texts)
+		}
+	}
+}
+
+func isTextField(key string) bool {
+	key = strings.ToLower(key)
+	switch key {
+	case "content", "message", "messages", "prompt", "query", "text":
+		return true
+	default:
+		return false
+	}
+}
+
+func extractTopics(texts []string) []string {
+	counts := make(map[string]int)
+	for _, text := range texts {
+		for _, token := range tokenize(text) {
+			if _, stop := consolidationStopwords[token]; stop {
+				continue
+			}
+			counts[token]++
+		}
+	}
+
+	type topicCount struct {
+		topic string
+		count int
+	}
+	list := make([]topicCount, 0, len(counts))
+	for topic, count := range counts {
+		list = append(list, topicCount{topic: topic, count: count})
+	}
+	sort.Slice(list, func(i, j int) bool {
+		if list[i].count == list[j].count {
+			return list[i].topic < list[j].topic
+		}
+		return list[i].count > list[j].count
+	})
+
+	if len(list) > 5 {
+		list = list[:5]
+	}
+	result := make([]string, 0, len(list))
+	for _, item := range list {
+		result = append(result, item.topic)
+	}
+	return result
+}
+
+func tokenize(text string) []string {
+	parts := strings.FieldsFunc(strings.ToLower(text), func(r rune) bool {
+		return (r < 'a' || r > 'z') && (r < '0' || r > '9')
+	})
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if len(part) < 3 {
+			continue
+		}
+		result = append(result, part)
+	}
+	return result
+}
+
+var consolidationStopwords = map[string]struct{}{
+	"and": {}, "are": {}, "but": {}, "for": {}, "from": {}, "has": {},
+	"have": {}, "into": {}, "not": {}, "that": {}, "the": {}, "their": {},
+	"them": {}, "this": {}, "was": {}, "with": {}, "you": {},
+}

--- a/internal/engine/consolidate_test.go
+++ b/internal/engine/consolidate_test.go
@@ -1,0 +1,244 @@
+package engine
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestConsolidationProducesSummaryCogBlocks(t *testing.T) {
+	t.Parallel()
+
+	root := makeWorkspace(t)
+	action := ConsolidationAction{WorkspaceRoot: root, MaxEvents: 40}
+
+	sessionA := testSessionID(t, "alpha")
+	sessionB := testSessionID(t, "beta")
+	base := mustTime(t, "2026-01-01T00:00:00Z")
+
+	for i := 0; i < 11; i++ {
+		appendFixtureEvent(t, root, sessionA, "thread-a", base.Add(time.Duration(i)*time.Minute), "http", fmt.Sprintf("memory topic alpha %d", i))
+	}
+	for i := 0; i < 12; i++ {
+		appendFixtureEvent(t, root, sessionB, "thread-b", base.Add(time.Duration(i+20)*time.Minute), "cli", fmt.Sprintf("memory topic beta %d", i))
+	}
+
+	count, err := action.Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("consolidated session count = %d; want 2", count)
+	}
+
+	if len(findConsolidationEvents(t, root, sessionA)) != 1 {
+		t.Fatalf("session %s should have exactly one consolidation summary", sessionA)
+	}
+	if len(findConsolidationEvents(t, root, sessionB)) != 1 {
+		t.Fatalf("session %s should have exactly one consolidation summary", sessionB)
+	}
+	if got, err := filepath.Glob(filepath.Join(root, ".cog", "ledger", "*", "events.jsonl")); err != nil || len(got) == 0 {
+		t.Fatalf("expected ledger fixture to exist, glob=%v err=%v", got, err)
+	}
+}
+
+func TestConsolidationSkipsGroupsBelowThreshold(t *testing.T) {
+	t.Parallel()
+
+	root := makeWorkspace(t)
+	action := ConsolidationAction{WorkspaceRoot: root, MaxEvents: 30}
+
+	sessionID := testSessionID(t, "split")
+	base := mustTime(t, "2026-02-01T00:00:00Z")
+
+	for i := 0; i < 6; i++ {
+		appendFixtureEvent(t, root, sessionID, "thread-a", base.Add(time.Duration(i)*time.Minute), "http", fmt.Sprintf("focus thread a %d", i))
+	}
+	for i := 0; i < 6; i++ {
+		appendFixtureEvent(t, root, sessionID, "thread-b", base.Add(time.Duration(i+10)*time.Minute), "http", fmt.Sprintf("focus thread b %d", i))
+	}
+
+	count, err := action.Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("consolidated session count = %d; want 0", count)
+	}
+	if len(findConsolidationEvents(t, root, sessionID)) != 0 {
+		t.Fatal("expected no consolidation summaries for groups under threshold")
+	}
+}
+
+func TestConsolidationSummaryIncludesMetadata(t *testing.T) {
+	t.Parallel()
+
+	root := makeWorkspace(t)
+	action := ConsolidationAction{WorkspaceRoot: root, MaxEvents: 20}
+
+	sessionID := testSessionID(t, "metadata")
+	threadID := "thread-meta"
+	base := mustTime(t, "2026-03-01T12:00:00Z")
+
+	for i := 0; i < 11; i++ {
+		source := "http"
+		if i%2 == 1 {
+			source = "kernel-v3"
+		}
+		appendFixtureEvent(t, root, sessionID, threadID, base.Add(time.Duration(i)*time.Minute), source, fmt.Sprintf("memory archive planning planning %d", i))
+	}
+
+	count, err := action.Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("consolidated session count = %d; want 1", count)
+	}
+
+	consolidations := findConsolidationEvents(t, root, sessionID)
+	if len(consolidations) != 1 {
+		t.Fatalf("consolidation events len = %d; want 1", len(consolidations))
+	}
+
+	data := consolidations[0].HashedPayload.Data
+	if got, _ := data["kind"].(string); got != string(BlockSystemEvent) {
+		t.Fatalf("kind = %q; want %q", got, BlockSystemEvent)
+	}
+	if got, _ := data["provenance_normalized_by"].(string); got != "consolidation" {
+		t.Fatalf("provenance_normalized_by = %q; want consolidation", got)
+	}
+
+	summary, ok := data["summary"].(map[string]interface{})
+	if !ok {
+		t.Fatal("summary payload missing")
+	}
+	if got, _ := summary["first_timestamp"].(string); got != "2026-03-01T12:00:00Z" {
+		t.Fatalf("first_timestamp = %q; want 2026-03-01T12:00:00Z", got)
+	}
+	if got, _ := summary["last_timestamp"].(string); got != "2026-03-01T12:10:00Z" {
+		t.Fatalf("last_timestamp = %q; want 2026-03-01T12:10:00Z", got)
+	}
+	if got, _ := summary["event_count"].(float64); got != 11 {
+		t.Fatalf("event_count = %v; want 11", got)
+	}
+	if got, _ := summary["thread_id"].(string); got != threadID {
+		t.Fatalf("thread_id = %q; want %q", got, threadID)
+	}
+
+	uniqueSources := stringSlice(summary["unique_sources"])
+	sort.Strings(uniqueSources)
+	if strings.Join(uniqueSources, ",") != "http,kernel-v3" {
+		t.Fatalf("unique_sources = %v; want [http kernel-v3]", uniqueSources)
+	}
+
+	keyTopics := stringSlice(summary["key_topics"])
+	if len(keyTopics) == 0 || keyTopics[0] != "planning" {
+		t.Fatalf("key_topics = %v; want planning ranked first", keyTopics)
+	}
+}
+
+func TestArchivedSessionsRecordedAfterConsolidation(t *testing.T) {
+	t.Parallel()
+
+	root := makeWorkspace(t)
+	action := ConsolidationAction{WorkspaceRoot: root, MaxEvents: 40}
+
+	sessionA := testSessionID(t, "archive-a")
+	sessionB := testSessionID(t, "archive-b")
+	base := mustTime(t, "2026-03-15T08:00:00Z")
+
+	for i := 0; i < 11; i++ {
+		appendFixtureEvent(t, root, sessionA, "thread-a", base.Add(time.Duration(i)*time.Minute), "http", fmt.Sprintf("archive alpha %d", i))
+	}
+	for i := 0; i < 12; i++ {
+		appendFixtureEvent(t, root, sessionB, "thread-b", base.Add(time.Duration(i+20)*time.Minute), "cli", fmt.Sprintf("archive beta %d", i))
+	}
+
+	if _, err := action.Run(); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	archived, err := ArchivedSessions(root, sessionA)
+	if err != nil {
+		t.Fatalf("ArchivedSessions: %v", err)
+	}
+	if _, ok := archived[sessionA]; !ok {
+		t.Fatalf("archived sessions missing %s", sessionA)
+	}
+	if _, ok := archived[sessionB]; !ok {
+		t.Fatalf("archived sessions missing %s", sessionB)
+	}
+}
+
+func TestHeartbeatTriggersDormantConsolidation(t *testing.T) {
+	t.Parallel()
+
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	cfg.ConsolidationInterval = 3600
+	p := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	p.lastConsolidation = time.Now().Add(-2 * time.Hour)
+
+	sessionID := testSessionID(t, "heartbeat")
+	base := mustTime(t, "2026-04-01T09:00:00Z")
+	for i := 0; i < 11; i++ {
+		appendFixtureEvent(t, root, sessionID, "thread-heartbeat", base.Add(time.Duration(i)*time.Minute), "http", fmt.Sprintf("sleep memory rehearsal %d", i))
+	}
+
+	p.emitHeartbeat()
+
+	if len(findConsolidationEvents(t, root, sessionID)) != 1 {
+		t.Fatal("expected heartbeat to trigger one consolidation summary")
+	}
+}
+
+func appendFixtureEvent(t *testing.T, root, sessionID, threadID string, timestamp time.Time, source, content string) {
+	t.Helper()
+	env := &EventEnvelope{
+		HashedPayload: EventPayload{
+			Type:      "user.message",
+			Timestamp: timestamp.UTC().Format(time.RFC3339),
+			SessionID: sessionID,
+			Data: map[string]interface{}{
+				"thread_id": threadID,
+				"content":   content,
+			},
+		},
+		Metadata: EventMetadata{Source: source},
+	}
+	if err := AppendEvent(root, sessionID, env); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+}
+
+func findConsolidationEvents(t *testing.T, root, sessionID string) []EventEnvelope {
+	t.Helper()
+	var summaries []EventEnvelope
+	for _, event := range mustReadAllEvents(t, root, sessionID) {
+		if event.HashedPayload.Type == "memory.consolidation" {
+			summaries = append(summaries, event)
+		}
+	}
+	return summaries
+}
+
+func stringSlice(value interface{}) []string {
+	items, _ := value.([]interface{})
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if text, ok := item.(string); ok {
+			out = append(out, text)
+		}
+	}
+	return out
+}
+
+func testSessionID(t *testing.T, suffix string) string {
+	t.Helper()
+	name := strings.ReplaceAll(t.Name(), "/", "-")
+	return strings.ToLower(name + "-" + suffix)
+}

--- a/internal/engine/constellation_bridge.go
+++ b/internal/engine/constellation_bridge.go
@@ -1,0 +1,85 @@
+package engine
+
+import (
+	"context"
+	"time"
+)
+
+// KernelHeartbeatPayload captures the kernel state exported to the constellation bridge.
+type KernelHeartbeatPayload struct {
+	ProcessState         string    `json:"process_state"`
+	FieldSize            int       `json:"field_size"`
+	CoherenceFingerprint string    `json:"coherence_fingerprint"`
+	NucleusFingerprint   string    `json:"nucleus_fingerprint"`
+	LedgerHead           string    `json:"ledger_head,omitempty"`
+	Timestamp            time.Time `json:"timestamp"`
+}
+
+// HeartbeatReceipt summarizes the result of a bridge heartbeat emission.
+type HeartbeatReceipt struct {
+	Hash      string    `json:"hash,omitempty"`
+	Timestamp time.Time `json:"timestamp,omitempty"`
+	PeersSent int       `json:"peers_sent"`
+}
+
+// ConstellationBridge defines the kernel-side integration point for constellation.
+type ConstellationBridge interface {
+	EmitHeartbeat(payload KernelHeartbeatPayload) (HeartbeatReceipt, error)
+	TrustSnapshot() ConstellationTrustSnapshot
+	Start(ctx context.Context) error
+	Stop()
+}
+
+// ConstellationTrustSnapshot summarizes current local and peer trust state.
+type ConstellationTrustSnapshot struct {
+	SelfCoherencePass    bool      `json:"self_coherence_pass"`
+	SelfTrustScore       float64   `json:"self_trust_score"`
+	PeerTrustMean        float64   `json:"peer_trust_mean"`
+	PeerCount            int       `json:"peer_count"`
+	TrustedPeerCount     int       `json:"trusted_peer_count"`
+	ConstellationHealthy bool      `json:"constellation_healthy"`
+	Timestamp            time.Time `json:"timestamp"`
+}
+
+// NilBridge provides neutral standalone-mode behavior when no constellation is configured.
+type NilBridge struct{}
+
+func (NilBridge) EmitHeartbeat(KernelHeartbeatPayload) (HeartbeatReceipt, error) {
+	return HeartbeatReceipt{}, nil
+}
+
+func (NilBridge) TrustSnapshot() ConstellationTrustSnapshot {
+	return ConstellationTrustSnapshot{
+		SelfCoherencePass:    true,
+		SelfTrustScore:       1.0,
+		PeerTrustMean:        0.0,
+		PeerCount:            0,
+		TrustedPeerCount:     0,
+		ConstellationHealthy: true,
+		Timestamp:            time.Now().UTC(),
+	}
+}
+
+func (NilBridge) Start(context.Context) error {
+	return nil
+}
+
+func (NilBridge) Stop() {}
+
+func (p *Process) constellationBridge() ConstellationBridge {
+	if p == nil || p.bridge == nil {
+		return NilBridge{}
+	}
+	return p.bridge
+}
+
+func (p *Process) currentLedgerHead() string {
+	if p == nil || p.cfg == nil || p.sessionID == "" {
+		return ""
+	}
+	last, err := GetLastEvent(p.cfg.WorkspaceRoot, p.sessionID)
+	if err != nil || last == nil {
+		return ""
+	}
+	return last.Metadata.Hash
+}

--- a/internal/engine/constellation_bridge_test.go
+++ b/internal/engine/constellation_bridge_test.go
@@ -1,0 +1,66 @@
+package engine
+
+import "testing"
+
+func TestNilBridgeTrustSnapshotHealthyDefaults(t *testing.T) {
+	t.Parallel()
+
+	bridge := NilBridge{}
+	snapshot := bridge.TrustSnapshot()
+
+	if !snapshot.SelfCoherencePass {
+		t.Fatal("SelfCoherencePass = false; want true")
+	}
+	if snapshot.SelfTrustScore != 1.0 {
+		t.Fatalf("SelfTrustScore = %v; want 1.0", snapshot.SelfTrustScore)
+	}
+	if snapshot.PeerCount != 0 {
+		t.Fatalf("PeerCount = %d; want 0", snapshot.PeerCount)
+	}
+	if snapshot.TrustedPeerCount != 0 {
+		t.Fatalf("TrustedPeerCount = %d; want 0", snapshot.TrustedPeerCount)
+	}
+	if !snapshot.ConstellationHealthy {
+		t.Fatal("ConstellationHealthy = false; want true")
+	}
+	if snapshot.Timestamp.IsZero() {
+		t.Fatal("Timestamp should be set")
+	}
+}
+
+func TestNilBridgeEmitHeartbeatReturnsZeroReceipt(t *testing.T) {
+	t.Parallel()
+
+	bridge := NilBridge{}
+	receipt, err := bridge.EmitHeartbeat(KernelHeartbeatPayload{})
+	if err != nil {
+		t.Fatalf("EmitHeartbeat returned error: %v", err)
+	}
+	if receipt.Hash != "" {
+		t.Fatalf("Hash = %q; want empty", receipt.Hash)
+	}
+	if !receipt.Timestamp.IsZero() {
+		t.Fatalf("Timestamp = %v; want zero", receipt.Timestamp)
+	}
+	if receipt.PeersSent != 0 {
+		t.Fatalf("PeersSent = %d; want 0", receipt.PeersSent)
+	}
+}
+
+func TestProcessEmitHeartbeatUsesNilBridgeWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	root := makeWorkspace(t)
+	p := NewProcess(makeConfig(t, root), makeNucleus("Cog", "tester"))
+	p.bridge = nil
+
+	p.emitHeartbeat()
+
+	events := mustReadAllEvents(t, root, p.SessionID())
+	if len(events) < 2 {
+		t.Fatalf("events len = %d; want at least heartbeat event + cogblock record", len(events))
+	}
+	if p.TrustSnapshot().LastHeartbeatHash == "" {
+		t.Fatal("LastHeartbeatHash should be set after heartbeat")
+	}
+}

--- a/internal/engine/constellation_bridge_test.go
+++ b/internal/engine/constellation_bridge_test.go
@@ -32,7 +32,14 @@ func TestNilBridgeEmitHeartbeatReturnsZeroReceipt(t *testing.T) {
 	t.Parallel()
 
 	bridge := NilBridge{}
-	receipt, err := bridge.EmitHeartbeat(KernelHeartbeatPayload{})
+	payload := KernelHeartbeatPayload{
+		ProcessState:         "dormant",
+		FieldSize:            42,
+		CoherenceFingerprint: "sha256:coherence",
+		NucleusFingerprint:   "sha256:nucleus",
+		LedgerHead:           "sha256:ledger",
+	}
+	receipt, err := bridge.EmitHeartbeat(payload)
 	if err != nil {
 		t.Fatalf("EmitHeartbeat returned error: %v", err)
 	}

--- a/internal/engine/context_assembly.go
+++ b/internal/engine/context_assembly.go
@@ -93,6 +93,55 @@ func estTokens(s string) int {
 	return n
 }
 
+// estTokensPrecise estimates tokens using rune-aware character-class heuristics.
+//
+// Heuristic selection:
+//   - ASCII-heavy text: runes/4
+//   - >20% non-ASCII: runes/2
+//   - >30% non-alphanumeric: runes/3
+//
+// The result is never allowed to fall below the fast byte-based estimate, and a
+// 10% safety margin is added to reduce underestimation near full contexts.
+func estTokensPrecise(s string) int {
+	if s == "" {
+		return 0
+	}
+
+	runes := 0
+	nonASCII := 0
+	nonAlnum := 0
+	for _, r := range s {
+		runes++
+		if r > unicode.MaxASCII {
+			nonASCII++
+		}
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+			nonAlnum++
+		}
+	}
+	if runes == 0 {
+		return 0
+	}
+
+	divisor := 4
+	if nonASCII*5 > runes {
+		divisor = 2
+	}
+	if nonAlnum*10 > runes*3 && divisor > 3 {
+		divisor = 3
+	}
+
+	base := (runes + divisor - 1) / divisor
+	if fast := estTokens(s); fast > base {
+		base = fast
+	}
+	estimate := (base*11 + 9) / 10
+	if estimate < 1 {
+		return 1
+	}
+	return estimate
+}
+
 // AssembleContext builds a ContextPackage from the full client request.
 //
 // It decomposes the incoming messages[], scores conversation history alongside
@@ -107,7 +156,7 @@ func (p *Process) AssembleContext(query string, messages []ProviderMessage, budg
 	for _, o := range opts {
 		o(&ao)
 	}
-	return p.assembleContextInnerWithOpts(ao.ctx, ao.convID, query, messages, budget, ao.manifestMode)
+	return p.assembleContextInnerWithOpts(ao.ctx, ao.convID, query, messages, budget, ao.manifestMode, ao.iris)
 }
 
 // AssembleOption configures optional AssembleContext parameters.
@@ -116,6 +165,7 @@ type AssembleOption func(*assembleOpts)
 type assembleOpts struct {
 	ctx          context.Context
 	convID       string
+	iris         irisSignal
 	manifestMode bool
 }
 
@@ -133,6 +183,12 @@ func WithConversationID(id string) AssembleOption {
 	return func(o *assembleOpts) { o.convID = id }
 }
 
+// WithIrisSignal sets the current context-window usage signal for pressure-aware
+// token estimation.
+func WithIrisSignal(signal irisSignal) AssembleOption {
+	return func(o *assembleOpts) { o.iris = signal }
+}
+
 // WithManifestMode switches CogDoc injection from full-body content to
 // summary manifests with on-demand retrieval.
 func WithManifestMode(enabled bool) AssembleOption {
@@ -140,12 +196,21 @@ func WithManifestMode(enabled bool) AssembleOption {
 }
 
 func (p *Process) assembleContextInner(ctx context.Context, convID string, query string, messages []ProviderMessage, budget int) (*ContextPackage, error) {
-	return p.assembleContextInnerWithOpts(ctx, convID, query, messages, budget, false)
+	return p.assembleContextInnerWithOpts(ctx, convID, query, messages, budget, false, irisSignal{})
 }
 
-func (p *Process) assembleContextInnerWithOpts(ctx context.Context, convID string, query string, messages []ProviderMessage, budget int, manifestMode bool) (*ContextPackage, error) {
+func (p *Process) assembleContextInnerWithOpts(ctx context.Context, convID string, query string, messages []ProviderMessage, budget int, manifestMode bool, iris irisSignal) (*ContextPackage, error) {
 	if budget <= 0 {
 		budget = 32768
+	}
+
+	estimateTokens := estTokens
+	pressure := 0.0
+	if iris.Size > 0 {
+		pressure = float64(iris.Used) / float64(iris.Size)
+		if pressure > 0.8 {
+			estimateTokens = estTokensPrecise
+		}
 	}
 
 	outputReserve := p.cfg.OutputReserve
@@ -187,11 +252,11 @@ func (p *Process) assembleContextInnerWithOpts(ctx context.Context, convID strin
 	p.nucleus.mu.RUnlock()
 	pkg.NucleusText = nucleusCard
 
-	nucleusTokens := estTokens(nucleusCard)
-	clientSysTokens := estTokens(pkg.ClientSystem)
+	nucleusTokens := estimateTokens(nucleusCard)
+	clientSysTokens := estimateTokens(pkg.ClientSystem)
 	currentMsgTokens := 0
 	if pkg.CurrentMessage != nil {
-		currentMsgTokens = estTokens(pkg.CurrentMessage.Content)
+		currentMsgTokens = estimateTokens(pkg.CurrentMessage.Content)
 	}
 
 	// Budget available for CogDocs + conversation history.
@@ -267,11 +332,11 @@ func (p *Process) assembleContextInnerWithOpts(ctx context.Context, convID strin
 
 	// === Score conversation history ===
 
-	scoredHistory := scoreConversation(history, keywords)
+	scoredHistory := scoreConversationWithEstimator(history, keywords, estimateTokens)
 
 	// === Evict to fit budget ===
 
-	pkg.FovealDocs, pkg.Conversation = evictForBudgetMode(docCandidates, scoredHistory, flexBudget, p.cfg.WorkspaceRoot, manifestMode)
+	pkg.FovealDocs, pkg.Conversation = evictForBudgetModeWithEstimator(docCandidates, scoredHistory, flexBudget, p.cfg.WorkspaceRoot, manifestMode, estimateTokens)
 
 	// Compute total tokens.
 	total := nucleusTokens + clientSysTokens + currentMsgTokens
@@ -294,6 +359,8 @@ func (p *Process) assembleContextInnerWithOpts(ctx context.Context, convID strin
 		"budget":           budget,
 		"output_reserve":   outputReserve,
 		"flex_budget":      flexBudget,
+		"iris_pressure":    pressure,
+		"precise_tokens":   pressure > 0.8,
 		"used_trm":         usedTRM,
 	})
 
@@ -302,6 +369,7 @@ func (p *Process) assembleContextInnerWithOpts(ctx context.Context, convID strin
 		"conv_turns", len(pkg.Conversation),
 		"tokens", pkg.TotalTokens,
 		"budget", budget,
+		"pressure", fmt.Sprintf("%.1f%%", pressure*100),
 	)
 
 	return pkg, nil
@@ -362,6 +430,10 @@ func (pkg *ContextPackage) FormatForProvider() (string, []ProviderMessage) {
 // scoreConversation scores conversation turns by recency and query relevance.
 // Returns ScoredMessage slice preserving chronological order.
 func scoreConversation(history []ProviderMessage, keywords []string) []ScoredMessage {
+	return scoreConversationWithEstimator(history, keywords, estTokens)
+}
+
+func scoreConversationWithEstimator(history []ProviderMessage, keywords []string, estimateTokens func(string) int) []ScoredMessage {
 	if len(history) == 0 {
 		return nil
 	}
@@ -376,7 +448,7 @@ func scoreConversation(history []ProviderMessage, keywords []string) []ScoredMes
 		scored[i] = ScoredMessage{
 			Role:           m.Role,
 			Content:        m.Content,
-			Tokens:         estTokens(m.Content),
+			Tokens:         estimateTokens(m.Content),
 			TurnIndex:      i,
 			RecencyScore:   recency,
 			RelevanceScore: relevance,
@@ -397,6 +469,10 @@ func evictForBudget(docs []FovealDoc, conv []ScoredMessage, budget int, workspac
 }
 
 func evictForBudgetMode(docs []FovealDoc, conv []ScoredMessage, budget int, workspaceRoot string, manifestMode bool) ([]FovealDoc, []ScoredMessage) {
+	return evictForBudgetModeWithEstimator(docs, conv, budget, workspaceRoot, manifestMode, estTokens)
+}
+
+func evictForBudgetModeWithEstimator(docs []FovealDoc, conv []ScoredMessage, budget int, workspaceRoot string, manifestMode bool, estimateTokens func(string) int) ([]FovealDoc, []ScoredMessage) {
 	if budget <= 0 {
 		return nil, nil
 	}
@@ -410,7 +486,7 @@ func evictForBudgetMode(docs []FovealDoc, conv []ScoredMessage, budget int, work
 			break
 		}
 		if manifestMode {
-			manifestDoc, err := buildManifestDoc(doc, workspaceRoot)
+			manifestDoc, err := buildManifestDocWithEstimator(doc, workspaceRoot, estimateTokens)
 			if err != nil || manifestDoc.Summary == "" {
 				continue
 			}
@@ -423,7 +499,7 @@ func evictForBudgetMode(docs []FovealDoc, conv []ScoredMessage, budget int, work
 			if err != nil || content == "" {
 				continue
 			}
-			tokens := estTokens(content)
+			tokens := estimateTokens(content)
 			title := doc.Title
 			if title == "" {
 				title = filepath.Base(doc.Path)
@@ -447,6 +523,15 @@ func evictForBudgetMode(docs []FovealDoc, conv []ScoredMessage, budget int, work
 				break
 			}
 			m := conv[i]
+			if m.Role == "assistant" && i > 0 && conv[i-1].Role == "user" {
+				pairTokens := conv[i-1].Tokens + m.Tokens
+				if pairTokens <= remaining {
+					keptConv = append(keptConv, m, conv[i-1])
+					remaining -= pairTokens
+				}
+				i--
+				continue
+			}
 			if m.Tokens <= remaining {
 				keptConv = append(keptConv, m)
 				remaining -= m.Tokens
@@ -604,6 +689,10 @@ func renderWorkspaceManifest(docs []FovealDoc) string {
 }
 
 func buildManifestDoc(doc FovealDoc, workspaceRoot string) (FovealDoc, error) {
+	return buildManifestDocWithEstimator(doc, workspaceRoot, estTokens)
+}
+
+func buildManifestDocWithEstimator(doc FovealDoc, workspaceRoot string, estimateTokens func(string) int) (FovealDoc, error) {
 	source, err := readManifestSource(doc.Path, 100)
 	if err != nil {
 		return FovealDoc{}, err
@@ -636,7 +725,7 @@ func buildManifestDoc(doc FovealDoc, workspaceRoot string) (FovealDoc, error) {
 	doc.Content = ""
 	doc.Summary = summary
 	doc.SchemaIssues = missingSchemaIssues(source)
-	doc.Tokens = estTokens(fmt.Sprintf("- %s — %s [salience: %.2f]", firstNonBlank(uri, doc.Path), summary, doc.Salience))
+	doc.Tokens = estimateTokens(fmt.Sprintf("- %s — %s [salience: %.2f]", firstNonBlank(uri, doc.Path), summary, doc.Salience))
 	return doc, nil
 }
 

--- a/internal/engine/context_assembly_test.go
+++ b/internal/engine/context_assembly_test.go
@@ -4,6 +4,7 @@ package engine
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -97,6 +98,64 @@ func TestAssembleContextSkipsArchiveDirs(t *testing.T) {
 
 // ── conversation scoring ─────────────────────────────────────────────────────
 
+func TestEstTokensPreciseHigherForJSON(t *testing.T) {
+	t.Parallel()
+	jsonText := `{"user":{"id":123,"name":"Ada","roles":["admin","editor"],"active":true},"items":[{"k":"v1"},{"k":"v2"}],"count":2}`
+
+	fast := estTokens(jsonText)
+	precise := estTokensPrecise(jsonText)
+	if precise <= fast {
+		t.Fatalf("precise = %d; want > fast = %d", precise, fast)
+	}
+}
+
+func TestEstTokensPreciseHigherForCJK(t *testing.T) {
+	t.Parallel()
+	cjkText := strings.Repeat("漢字かなカナ混在テキスト", 16)
+
+	fast := estTokens(cjkText)
+	precise := estTokensPrecise(cjkText)
+	if precise <= fast {
+		t.Fatalf("precise = %d; want > fast = %d", precise, fast)
+	}
+}
+
+func TestEstTokensPreciseMatchesEnglishWithinTenPercent(t *testing.T) {
+	t.Parallel()
+	englishText := strings.Repeat("plain english prose with ordinary words ", 64)
+
+	fast := estTokens(englishText)
+	precise := estTokensPrecise(englishText)
+	if precise < fast {
+		t.Fatalf("precise = %d; want >= fast = %d", precise, fast)
+	}
+	if float64(precise-fast) > float64(fast)*0.10 {
+		t.Fatalf("precise = %d; want within 10%% of fast = %d", precise, fast)
+	}
+}
+
+func TestAssembleContextUsesPreciseEstimatorUnderHighIrisPressure(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	p := NewProcess(cfg, makeNucleus("T", "r"))
+
+	messages := []ProviderMessage{{Role: "user", Content: `{"payload":{"id":123,"flags":[true,false,true],"meta":{"nested":"value"}}}`}}
+
+	lowPressure, err := p.AssembleContext("payload", messages, 0, WithIrisSignal(irisSignal{Size: 1000, Used: 700}))
+	if err != nil {
+		t.Fatalf("AssembleContext low pressure: %v", err)
+	}
+	highPressure, err := p.AssembleContext("payload", messages, 0, WithIrisSignal(irisSignal{Size: 1000, Used: 900}))
+	if err != nil {
+		t.Fatalf("AssembleContext high pressure: %v", err)
+	}
+
+	if highPressure.TotalTokens <= lowPressure.TotalTokens {
+		t.Fatalf("high pressure total = %d; want > low pressure total = %d", highPressure.TotalTokens, lowPressure.TotalTokens)
+	}
+}
+
 func TestScoreConversationRecency(t *testing.T) {
 	t.Parallel()
 	history := []ProviderMessage{
@@ -155,23 +214,41 @@ func TestEvictForBudgetFitsAll(t *testing.T) {
 	_ = keptDocs
 }
 
-func TestEvictForBudgetDropsOldestConversation(t *testing.T) {
+func TestEvictForBudgetKeepsTurnPairsAndStandaloneMessages(t *testing.T) {
 	t.Parallel()
 	conv := []ScoredMessage{
-		{Role: "user", Content: "old message that is fairly long", Tokens: 8},
-		{Role: "assistant", Content: "old reply that is also long", Tokens: 7},
-		{Role: "user", Content: "new", Tokens: 1},
-		{Role: "assistant", Content: "new reply", Tokens: 2},
+		{Role: "system", Content: "system note", Tokens: 1},
+		{Role: "user", Content: "old prompt", Tokens: 4},
+		{Role: "assistant", Content: "old answer", Tokens: 2},
+		{Role: "tool_result", Content: "tool output", Tokens: 1},
+		{Role: "user", Content: "new prompt", Tokens: 1},
+		{Role: "assistant", Content: "new answer", Tokens: 2},
 	}
-	// Budget only fits the newest turns.
-	_, keptConv := evictForBudget(nil, conv, 5, t.TempDir())
-	// Should keep newest turns, drop oldest.
-	if len(keptConv) > 2 {
-		t.Errorf("expected eviction, got %d turns", len(keptConv))
+	// Budget fits the newest user/assistant pair, fits standalone messages,
+	// but only the old assistant would fit on its own.
+	_, keptConv := evictForBudget(nil, conv, 7, t.TempDir())
+
+	if len(keptConv) != 4 {
+		t.Fatalf("kept conv len = %d; want 4", len(keptConv))
 	}
-	// Newest turn should be present.
-	if len(keptConv) > 0 && keptConv[len(keptConv)-1].Content != "new reply" {
-		t.Errorf("last kept message = %q; want 'new reply'", keptConv[len(keptConv)-1].Content)
+
+	got := []string{
+		keptConv[0].Content,
+		keptConv[1].Content,
+		keptConv[2].Content,
+		keptConv[3].Content,
+	}
+	want := []string{"system note", "tool output", "new prompt", "new answer"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("keptConv[%d] = %q; want %q", i, got[i], want[i])
+		}
+	}
+
+	for _, msg := range keptConv {
+		if msg.Content == "old prompt" || msg.Content == "old answer" {
+			t.Fatalf("old turn pair should be dropped together, kept %q", msg.Content)
+		}
 	}
 }
 

--- a/internal/engine/defaults/kernel.yaml
+++ b/internal/engine/defaults/kernel.yaml
@@ -2,7 +2,8 @@
 # See docs for all options: https://github.com/cogos-dev/cogos
 
 port: 6931
-consolidation_interval: 900   # seconds between consolidation sweeps
+consolidation_interval: 3600  # seconds between consolidation sweeps
 heartbeat_interval: 60         # seconds between dormant heartbeats
 salience_days_window: 90       # git history window for salience scoring
 output_reserve: 4096           # tokens reserved for model generation
+local_model: "gemma4:e4b"

--- a/internal/engine/defaults/providers.yaml
+++ b/internal/engine/defaults/providers.yaml
@@ -7,7 +7,7 @@ providers:
     type: ollama
     enabled: true
     endpoint: "http://localhost:11434"
-    model: "llama3.2"
+    model: "gemma4:e4b"
     timeout: 120
     context_window: 128000
 

--- a/internal/engine/process.go
+++ b/internal/engine/process.go
@@ -71,6 +71,7 @@ type Process struct {
 	nucleus *Nucleus
 	field   *AttentionalField
 	gate    *Gate
+	bridge  ConstellationBridge
 	cfg     *Config
 
 	// sessionID is the persistent process session identifier.
@@ -105,9 +106,10 @@ type Process struct {
 	// lightCones manages per-conversation SSM hidden states.
 	lightCones *LightConeManager
 
-	// lastConsolidation records when the previous consolidation ran, so the
-	// observer can filter the attention log to the current tick window.
+	// lastConsolidation records the last dormant memory consolidation pass.
 	lastConsolidation time.Time
+
+	lastMaintenanceTick time.Time
 
 	// lastCoherenceReport caches the most recent coherence result so the
 	// heartbeat can reuse it instead of recomputing.
@@ -128,6 +130,7 @@ func NewProcess(cfg *Config, nucleus *Nucleus) *Process {
 		nucleus:   nucleus,
 		field:     field,
 		gate:      gate,
+		bridge:    NilBridge{},
 		cfg:       cfg,
 		sessionID: uuid.New().String(),
 		startedAt: now,
@@ -136,9 +139,10 @@ func NewProcess(cfg *Config, nucleus *Nucleus) *Process {
 			LocalScore:           1.0,
 			CoherenceFingerprint: "sha256:" + sha256Hex("coherence:unknown"),
 		},
-		externalCh:        make(chan *GateEvent, 64),
-		observer:          NewTrajectoryModel(),
-		lastConsolidation: now,
+		externalCh:          make(chan *GateEvent, 64),
+		observer:            NewTrajectoryModel(),
+		lastConsolidation:   now,
+		lastMaintenanceTick: now,
 	}
 }
 
@@ -319,10 +323,10 @@ func (p *Process) handleExternal(evt *GateEvent) {
 func (p *Process) runConsolidation() {
 	p.transition(StateConsolidating)
 
-	// Record the current tick window before updating lastConsolidation.
+	// Record the current tick window before updating the maintenance watermark.
 	now := time.Now()
-	tickStart := p.lastConsolidation
-	p.lastConsolidation = now
+	tickStart := p.lastMaintenanceTick
+	p.lastMaintenanceTick = now
 
 	slog.Debug("process: consolidating", "window_since", tickStart.Format(time.RFC3339))
 
@@ -448,13 +452,34 @@ func (p *Process) emitHeartbeat() {
 	p.mu.Unlock()
 
 	p.transition(StateDormant)
+	state := p.State().String()
+	fieldSize := p.field.Len()
+	fingerprint := p.Fingerprint()
+	receipt, err := p.constellationBridge().EmitHeartbeat(KernelHeartbeatPayload{
+		ProcessState:         state,
+		FieldSize:            fieldSize,
+		CoherenceFingerprint: coherenceHash,
+		NucleusFingerprint:   p.nucleusDigest(),
+		LedgerHead:           p.currentLedgerHead(),
+		Timestamp:            now,
+	})
+	if err != nil {
+		slog.Warn("process: constellation heartbeat failed", "err", err)
+		receipt = HeartbeatReceipt{}
+	}
+
 	heartbeat := map[string]interface{}{
-		"state":          p.State().String(),
-		"field_size":     p.field.Len(),
-		"node_id":        p.NodeID,
-		"fingerprint":    p.Fingerprint(),
-		"timestamp":      now.Format(time.RFC3339),
-		"coherence_hash": coherenceHash,
+		"state":                      state,
+		"field_size":                 fieldSize,
+		"node_id":                    p.NodeID,
+		"fingerprint":                fingerprint,
+		"timestamp":                  now.Format(time.RFC3339),
+		"coherence_hash":             coherenceHash,
+		"constellation_receipt_hash": receipt.Hash,
+		"constellation_peers_sent":   receipt.PeersSent,
+	}
+	if !receipt.Timestamp.IsZero() {
+		heartbeat["constellation_receipt_at"] = receipt.Timestamp.Format(time.RFC3339)
 	}
 	p.emitEvent("heartbeat", heartbeat)
 
@@ -486,12 +511,33 @@ func (p *Process) emitHeartbeat() {
 	if p.nucleus != nil {
 		block.TargetIdentity = p.nucleus.Name
 	}
+	if receipt.Hash != "" {
+		block.Artifacts = append(block.Artifacts, BlockArtifact{
+			Kind: "constellation_receipt",
+			Ref:  receipt.Hash,
+		})
+	}
 	ref := p.RecordBlock(block)
 
 	p.mu.Lock()
 	p.TrustState.LastHeartbeatHash = ref
 	p.TrustState.LastHeartbeatAt = now
 	p.mu.Unlock()
+
+	interval := time.Duration(p.cfg.ConsolidationInterval) * time.Second
+	if interval <= 0 || now.Sub(p.lastConsolidation) < interval {
+		return
+	}
+
+	action := ConsolidationAction{WorkspaceRoot: p.cfg.WorkspaceRoot}
+	count, err := action.Run()
+	if err != nil {
+		slog.Warn("process: memory consolidation failed", "err", err)
+		return
+	}
+
+	p.lastConsolidation = now
+	slog.Info("process: memory consolidated", "sessions", count)
 }
 
 // transition moves the process to a new state (with logging).

--- a/internal/engine/process.go
+++ b/internal/engine/process.go
@@ -89,6 +89,12 @@ type Process struct {
 	// externalCh receives events from the HTTP serve layer.
 	externalCh chan *GateEvent
 
+	// tailerCh receives normalized CogBlocks from StreamTailer adapters.
+	tailerCh chan CogBlock
+
+	// tailerManager coordinates configured digestion stream tailers.
+	tailerManager *TailerManager
+
 	// index is the CogDoc index, rebuilt on each consolidation.
 	indexMu sync.RWMutex
 	index   *CogDocIndex
@@ -140,6 +146,7 @@ func NewProcess(cfg *Config, nucleus *Nucleus) *Process {
 			CoherenceFingerprint: "sha256:" + sha256Hex("coherence:unknown"),
 		},
 		externalCh:          make(chan *GateEvent, 64),
+		tailerCh:            make(chan CogBlock, 64),
 		observer:            NewTrajectoryModel(),
 		lastConsolidation:   now,
 		lastMaintenanceTick: now,
@@ -257,6 +264,7 @@ func (p *Process) Run(ctx context.Context) error {
 		p.indexMu.Unlock()
 		slog.Info("process: index built", "docs", len(idx.ByURI))
 	}
+	p.initTailers(ctx)
 
 	// Update attentional field (slow — git log per file, runs in background).
 	go func() {
@@ -294,6 +302,9 @@ func (p *Process) Run(ctx context.Context) error {
 		case evt := <-p.externalCh:
 			p.handleExternal(evt)
 
+		case block := <-p.tailerCh:
+			p.handleTailerBlock(block)
+
 		case <-consolidationTicker.C:
 			p.runConsolidation()
 
@@ -301,6 +312,86 @@ func (p *Process) Run(ctx context.Context) error {
 			p.emitHeartbeat()
 		}
 	}
+}
+
+func (p *Process) initTailers(ctx context.Context) {
+	if p.tailerManager == nil {
+		p.tailerManager = NewTailerManager(p.tailerCh)
+		p.registerConfiguredTailers(p.tailerManager)
+	}
+
+	if p.tailerManager == nil {
+		return
+	}
+
+	go func() {
+		if err := p.tailerManager.Run(ctx); err != nil {
+			slog.Warn("process: tailer manager stopped with error", "err", err)
+		}
+	}()
+}
+
+func (p *Process) registerConfiguredTailers(manager *TailerManager) {
+	if p == nil || p.cfg == nil || manager == nil || len(p.cfg.DigestPaths) == 0 {
+		return
+	}
+
+	for adapterName, configuredPath := range p.cfg.DigestPaths {
+		path := strings.TrimSpace(configuredPath)
+		switch adapterName {
+		case claudeCodeSourceChannel:
+			if path == "" {
+				path = "~/.claude/"
+			}
+			path = expandDigestPath(path)
+			if err := manager.Register(&ClaudeCodeTailer{}, path); err != nil {
+				slog.Warn("process: digest tailer register failed", "adapter", adapterName, "path", path, "err", err)
+				continue
+			}
+			slog.Info("process: digest tailer registered", "adapter", adapterName, "path", path)
+
+		case "openclaw":
+			if path == "" {
+				slog.Warn("process: digest tailer path empty", "adapter", adapterName)
+				continue
+			}
+			path = expandDigestPath(path)
+			if err := manager.Register(&OpenClawTailer{}, path); err != nil {
+				slog.Warn("process: digest tailer register failed", "adapter", adapterName, "path", path, "err", err)
+				continue
+			}
+			slog.Info("process: digest tailer registered", "adapter", adapterName, "path", path)
+
+		default:
+			slog.Warn("process: unknown digest adapter", "adapter", adapterName)
+		}
+	}
+}
+
+func expandDigestPath(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			return filepath.Join(home, strings.TrimPrefix(path, "~/"))
+		}
+	}
+	return path
+}
+
+func (p *Process) handleTailerBlock(block CogBlock) {
+	state := p.State()
+	if state != StateReceptive && state != StateActive {
+		slog.Debug("process: dropping tailer block outside receptive states", "state", state.String(), "source_channel", block.SourceChannel, "kind", block.Kind)
+		return
+	}
+
+	b := block
+	if b.Timestamp.IsZero() {
+		b.Timestamp = time.Now().UTC()
+	}
+
+	ref := p.RecordBlock(&b)
+	slog.Info("process: tailer block ingested", "source_channel", b.SourceChannel, "kind", b.Kind, "ledger_ref", ref)
 }
 
 // handleExternal processes an external perturbation.

--- a/internal/engine/process_test.go
+++ b/internal/engine/process_test.go
@@ -2,6 +2,8 @@ package engine
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -181,4 +183,80 @@ func TestProcessEmitsStartEvent(t *testing.T) {
 	if events[0].HashedPayload.Type != "process.start" {
 		t.Errorf("first event type = %q; want process.start", events[0].HashedPayload.Type)
 	}
+}
+
+func TestProcessIngestsTailerBlockIntoLedger(t *testing.T) {
+	t.Parallel()
+
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	p := NewProcess(cfg, makeNucleus("T", "r"))
+
+	tailerOut := make(chan CogBlock, 1)
+	manager := NewTailerManager(tailerOut)
+	if err := manager.Register(&singleBlockTailer{block: CogBlock{
+		ID:            "mock-block-1",
+		Kind:          BlockMessage,
+		SourceChannel: "mock",
+		Timestamp:     time.Now().UTC(),
+	}}, "/tmp/mock.jsonl"); err != nil {
+		t.Fatalf("Register mock tailer: %v", err)
+	}
+	p.tailerManager = manager
+	p.tailerCh = tailerOut
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- p.Run(ctx) }()
+
+	eventsPath := filepath.Join(root, ".cog", "ledger", p.SessionID(), "events.jsonl")
+	deadline := time.After(2 * time.Second)
+	tick := time.NewTicker(20 * time.Millisecond)
+	defer tick.Stop()
+
+	found := false
+	for !found {
+		select {
+		case <-deadline:
+			cancel()
+			t.Fatal("timed out waiting for tailer ingestion event")
+		case <-tick.C:
+			if _, err := os.Stat(eventsPath); err != nil {
+				continue
+			}
+			events := mustReadAllEvents(t, root, p.SessionID())
+			for _, event := range events {
+				if event.HashedPayload.Type == "cogblock.ingest" && event.HashedPayload.Data["block_id"] == "mock-block-1" {
+					found = true
+					break
+				}
+			}
+		}
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run returned error on cancel: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not stop after context cancellation")
+	}
+}
+
+type singleBlockTailer struct {
+	block CogBlock
+}
+
+func (s *singleBlockTailer) Name() string { return "mock" }
+
+func (s *singleBlockTailer) Tail(ctx context.Context, path string, out chan<- CogBlock) error {
+	select {
+	case out <- s.block:
+	case <-ctx.Done():
+		return nil
+	}
+	<-ctx.Done()
+	return nil
 }

--- a/internal/engine/proprioceptive.go
+++ b/internal/engine/proprioceptive.go
@@ -20,6 +20,12 @@ import (
 // ProprioceptiveEntry is a single prediction-vs-reality log entry.
 type ProprioceptiveEntry struct {
 	Timestamp   string           `json:"timestamp"`
+	Event       string           `json:"event,omitempty"`
+	Provider    string           `json:"provider,omitempty"`
+	ToolName    string           `json:"tool_name,omitempty"`
+	ToolCallID  string           `json:"tool_call_id,omitempty"`
+	ToolArgs    string           `json:"tool_args,omitempty"`
+	Reason      string           `json:"reason,omitempty"`
 	Query       string           `json:"query"`
 	Predicted   []PredictedChunk `json:"predicted"`
 	Actual      []string         `json:"actual"`

--- a/internal/engine/provider.go
+++ b/internal/engine/provider.go
@@ -176,8 +176,8 @@ type StreamChunk struct {
 	Delta         string         `json:"delta,omitempty"`
 	ToolCallDelta *ToolCallDelta `json:"tool_call_delta,omitempty"`
 	Done          bool           `json:"done"`
-	StopReason    string         `json:"stop_reason,omitempty"`    // e.g. "end_turn", "max_tokens", "tool_use"
-	Usage         *TokenUsage    `json:"usage,omitempty"`          // populated on final chunk
+	StopReason    string         `json:"stop_reason,omitempty"`   // e.g. "end_turn", "max_tokens", "tool_use"
+	Usage         *TokenUsage    `json:"usage,omitempty"`         // populated on final chunk
 	ProviderMeta  *ProviderMeta  `json:"provider_meta,omitempty"` // populated on final chunk
 	Error         error          `json:"-"`
 }
@@ -245,13 +245,14 @@ type ToolCall struct {
 type Capability string
 
 const (
-	CapStreaming   Capability = "streaming"
-	CapToolUse     Capability = "tool_use"
-	CapVision      Capability = "vision"
-	CapLongContext Capability = "long_context"
-	CapJSON        Capability = "json_output"
-	CapCaching     Capability = "caching"
-	CapBatch       Capability = "batch"
+	CapStreaming          Capability = "streaming"
+	CapToolUse            Capability = "tool_use"
+	CapToolCallValidation Capability = "tool_call_validation"
+	CapVision             Capability = "vision"
+	CapLongContext        Capability = "long_context"
+	CapJSON               Capability = "json_output"
+	CapCaching            Capability = "caching"
+	CapBatch              Capability = "batch"
 )
 
 // ProviderCapabilities describes what a provider can do.
@@ -329,14 +330,15 @@ type ProviderScore struct {
 
 // RouterStats tracks routing patterns for observability.
 type RouterStats struct {
-	TotalRequests        int64                    `json:"total_requests"`
-	RequestsByProvider   map[string]int64         `json:"requests_by_provider"`
-	EscalationCount      int64                    `json:"escalation_count"`
-	FallbackCount        int64                    `json:"fallback_count"`
-	SovereigntyRatio     float64                  `json:"sovereignty_ratio"`
-	TotalCostUSD         float64                  `json:"total_cost_usd"`
-	TokensByProvider     map[string]TokenUsage    `json:"tokens_by_provider"`
-	AvgLatencyByProvider map[string]time.Duration `json:"avg_latency_by_provider"`
+	TotalRequests                int64                    `json:"total_requests"`
+	RequestsByProvider           map[string]int64         `json:"requests_by_provider"`
+	ToolCallRejectionsByProvider map[string]int64         `json:"tool_call_rejections_by_provider,omitempty"`
+	EscalationCount              int64                    `json:"escalation_count"`
+	FallbackCount                int64                    `json:"fallback_count"`
+	SovereigntyRatio             float64                  `json:"sovereignty_ratio"`
+	TotalCostUSD                 float64                  `json:"total_cost_usd"`
+	TokensByProvider             map[string]TokenUsage    `json:"tokens_by_provider"`
+	AvgLatencyByProvider         map[string]time.Duration `json:"avg_latency_by_provider"`
 }
 
 // ── Configuration types ───────────────────────────────────────────────────────

--- a/internal/engine/provider_ollama.go
+++ b/internal/engine/provider_ollama.go
@@ -18,6 +18,41 @@ import (
 	"time"
 )
 
+const defaultOllamaModel = "gemma4:e4b"
+
+type ollamaModelProfile struct {
+	Capabilities     []Capability
+	MaxContextTokens int
+	MaxOutputTokens  int
+}
+
+var ollamaModelProfiles = map[string]ollamaModelProfile{
+	"gemma4:e4b": {
+		Capabilities:     []Capability{CapStreaming, CapJSON, CapToolCallValidation},
+		MaxContextTokens: 128000,
+		MaxOutputTokens:  4096,
+	},
+	"gemma4:e2b": {
+		Capabilities:     []Capability{CapStreaming, CapJSON, CapToolCallValidation},
+		MaxContextTokens: 128000,
+		MaxOutputTokens:  4096,
+	},
+	"qwen3.5:9b": {
+		Capabilities:    []Capability{CapStreaming, CapJSON},
+		MaxOutputTokens: 4096,
+	},
+}
+
+func lookupOllamaModelProfile(model string) ollamaModelProfile {
+	if profile, ok := ollamaModelProfiles[model]; ok {
+		return profile
+	}
+	return ollamaModelProfile{
+		Capabilities:    []Capability{CapStreaming, CapJSON},
+		MaxOutputTokens: 4096,
+	}
+}
+
 // OllamaProvider implements Provider against a local Ollama server.
 type OllamaProvider struct {
 	name          string
@@ -84,14 +119,22 @@ func (p *OllamaProvider) Available(ctx context.Context) bool {
 
 // Capabilities returns what Ollama supports.
 func (p *OllamaProvider) Capabilities() ProviderCapabilities {
+	profile := lookupOllamaModelProfile(p.model)
 	ctxTokens := p.contextWindow
 	if ctxTokens <= 0 {
-		ctxTokens = 4096 // Ollama default when num_ctx not set
+		ctxTokens = profile.MaxContextTokens
+	}
+	if ctxTokens <= 0 {
+		ctxTokens = 4096
+	}
+	maxOutputTokens := profile.MaxOutputTokens
+	if maxOutputTokens <= 0 {
+		maxOutputTokens = 4096
 	}
 	return ProviderCapabilities{
-		Capabilities:       []Capability{CapStreaming, CapJSON},
+		Capabilities:       append([]Capability(nil), profile.Capabilities...),
 		MaxContextTokens:   ctxTokens,
-		MaxOutputTokens:    4096,
+		MaxOutputTokens:    maxOutputTokens,
 		ModelsAvailable:    []string{p.model},
 		IsLocal:            true,
 		AgenticHarness:     false,

--- a/internal/engine/provider_ollama_test.go
+++ b/internal/engine/provider_ollama_test.go
@@ -346,3 +346,50 @@ func TestOllamaCapabilities(t *testing.T) {
 	}
 }
 
+func TestLookupOllamaModelProfileGemma4E4B(t *testing.T) {
+	t.Parallel()
+
+	profile := lookupOllamaModelProfile("gemma4:e4b")
+
+	if !containsCapability(profile.Capabilities, CapStreaming) {
+		t.Error("gemma4:e4b should support streaming")
+	}
+	if !containsCapability(profile.Capabilities, CapJSON) {
+		t.Error("gemma4:e4b should support json output")
+	}
+	if !containsCapability(profile.Capabilities, CapToolCallValidation) {
+		t.Error("gemma4:e4b should require tool call validation")
+	}
+	if containsCapability(profile.Capabilities, CapToolUse) {
+		t.Error("gemma4:e4b should not advertise reliable tool use")
+	}
+	if profile.MaxContextTokens != 128000 {
+		t.Errorf("MaxContextTokens = %d; want 128000", profile.MaxContextTokens)
+	}
+}
+
+func TestOllamaCapabilitiesUseKnownModelProfile(t *testing.T) {
+	t.Parallel()
+
+	p := NewOllamaProvider("ollama", ProviderConfig{Model: "gemma4:e4b"})
+	caps := p.Capabilities()
+
+	if !caps.HasCapability(CapToolCallValidation) {
+		t.Error("gemma4:e4b should advertise tool_call_validation")
+	}
+	if caps.HasCapability(CapToolUse) {
+		t.Error("gemma4:e4b should not advertise tool_use")
+	}
+	if caps.MaxContextTokens != 128000 {
+		t.Errorf("MaxContextTokens = %d; want 128000", caps.MaxContextTokens)
+	}
+}
+
+func containsCapability(caps []Capability, want Capability) bool {
+	for _, cap := range caps {
+		if cap == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/engine/router.go
+++ b/internal/engine/router.go
@@ -1,11 +1,11 @@
 // router.go — SimpleRouter + BuildRouter
 //
 // SimpleRouter implements the Router interface with rule-based provider selection:
-//   1. Check process-state routing overrides
-//   2. Try preferred provider first, then fallback chain
-//   3. Filter by availability + required capabilities
-//   4. Score local > cloud (sovereignty gradient)
-//   5. Record every routing decision for future sentinel training
+//  1. Check process-state routing overrides
+//  2. Try preferred provider first, then fallback chain
+//  3. Filter by availability + required capabilities
+//  4. Score local > cloud (sovereignty gradient)
+//  5. Record every routing decision for future sentinel training
 //
 // BuildRouter reads .cog/config/providers.yaml and instantiates enabled providers.
 // Falls back to a default Ollama config when no providers.yaml is present.
@@ -23,6 +23,8 @@ import (
 
 	"gopkg.in/yaml.v3"
 )
+
+var toolCallRejectionsByProvider sync.Map // map[string]*atomic.Int64
 
 // SimpleRouter implements Router with rule-based provider selection.
 type SimpleRouter struct {
@@ -164,13 +166,18 @@ func (r *SimpleRouter) Route(ctx context.Context, req *CompletionRequest) (Provi
 // Stats returns current routing statistics.
 func (r *SimpleRouter) Stats() RouterStats {
 	stats := RouterStats{
-		TotalRequests:      r.totalRequests.Load(),
-		EscalationCount:    r.escalations.Load(),
-		FallbackCount:      r.fallbacks.Load(),
-		RequestsByProvider: make(map[string]int64),
+		TotalRequests:                r.totalRequests.Load(),
+		EscalationCount:              r.escalations.Load(),
+		FallbackCount:                r.fallbacks.Load(),
+		RequestsByProvider:           make(map[string]int64),
+		ToolCallRejectionsByProvider: make(map[string]int64),
 	}
 	r.byProvider.Range(func(k, v any) bool {
 		stats.RequestsByProvider[k.(string)] = v.(*atomic.Int64).Load()
+		return true
+	})
+	toolCallRejectionsByProvider.Range(func(k, v any) bool {
+		stats.ToolCallRejectionsByProvider[k.(string)] = v.(*atomic.Int64).Load()
 		return true
 	})
 	if stats.TotalRequests > 0 {
@@ -187,6 +194,14 @@ func (r *SimpleRouter) Stats() RouterStats {
 		stats.SovereigntyRatio = float64(local) / float64(stats.TotalRequests)
 	}
 	return stats
+}
+
+func recordToolCallRejection(providerName string) {
+	if providerName == "" {
+		return
+	}
+	counter, _ := toolCallRejectionsByProvider.LoadOrStore(providerName, &atomic.Int64{})
+	counter.(*atomic.Int64).Add(1)
 }
 
 // buildCandidateOrder returns providers ordered by routing preference.
@@ -252,7 +267,7 @@ func BuildRouter(cfg *Config, opts ...BuildRouterOption) (Router, error) {
 	pcfg, err := loadProvidersConfig(cfg)
 	if err != nil {
 		slog.Warn("router: providers.yaml not found, using default (ollama)", "err", err)
-		pcfg = defaultProvidersConfig()
+		pcfg = defaultProvidersConfig(cfg.LocalModel)
 	}
 
 	router := NewSimpleRouter(pcfg.Routing)
@@ -295,7 +310,27 @@ func loadProvidersConfig(cfg *Config) (ProvidersConfig, error) {
 	if err := yaml.Unmarshal(data, &pcfg); err != nil {
 		return ProvidersConfig{}, fmt.Errorf("parse providers.yaml: %w", err)
 	}
+	applyLocalModelConfig(cfg, &pcfg)
 	return pcfg, nil
+}
+
+func applyLocalModelConfig(cfg *Config, pcfg *ProvidersConfig) {
+	if cfg == nil || pcfg == nil || cfg.LocalModel == "" {
+		return
+	}
+	for name, pc := range pcfg.Providers {
+		providerType := pc.Type
+		if providerType == "" {
+			providerType = name
+		}
+		if providerType != "ollama" {
+			continue
+		}
+		if pc.Model == "" || cfg.localModelConfigured {
+			pc.Model = cfg.LocalModel
+			pcfg.Providers[name] = pc
+		}
+	}
 }
 
 // makeProvider instantiates a Provider from a ProviderConfig.
@@ -325,15 +360,18 @@ func makeProvider(name string, pc ProviderConfig, procMgr *ProcessManager) (Prov
 }
 
 // defaultProvidersConfig returns a minimal config pointing at local Ollama.
-func defaultProvidersConfig() ProvidersConfig {
+func defaultProvidersConfig(localModel string) ProvidersConfig {
 	enabled := true
+	if localModel == "" {
+		localModel = defaultOllamaModel
+	}
 	return ProvidersConfig{
 		Providers: map[string]ProviderConfig{
 			"ollama": {
 				Type:     "ollama",
 				Enabled:  &enabled,
 				Endpoint: "http://localhost:11434",
-				Model:    "qwen3.5:9b",
+				Model:    localModel,
 				Timeout:  60,
 			},
 		},

--- a/internal/engine/router_test.go
+++ b/internal/engine/router_test.go
@@ -3,6 +3,7 @@ package engine
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 )
 
@@ -237,11 +238,47 @@ func TestMakeProviderInfersTypeFromName(t *testing.T) {
 
 func TestDefaultProvidersConfig(t *testing.T) {
 	t.Parallel()
-	pcfg := defaultProvidersConfig()
+	pcfg := defaultProvidersConfig(defaultOllamaModel)
 	if _, ok := pcfg.Providers["ollama"]; !ok {
 		t.Error("default config should have ollama provider")
 	}
 	if pcfg.Routing.Default != "ollama" {
 		t.Errorf("default routing = %q; want ollama", pcfg.Routing.Default)
+	}
+	if pcfg.Providers["ollama"].Model != defaultOllamaModel {
+		t.Errorf("default ollama model = %q; want %q", pcfg.Providers["ollama"].Model, defaultOllamaModel)
+	}
+}
+
+func TestLoadProvidersConfigAppliesExplicitLocalModel(t *testing.T) {
+	t.Parallel()
+
+	root := makeWorkspace(t)
+	writeTestFile(t, filepath.Join(root, ".cog", "config", "kernel.yaml"), "local_model: gemma4:e2b\n")
+	writeTestFile(t, filepath.Join(root, ".cog", "config", "providers.yaml"), `providers:
+  ollama:
+    type: ollama
+    enabled: true
+    endpoint: "http://localhost:11434"
+    model: "qwen3.5:9b"
+    timeout: 60
+routing:
+  default: ollama
+  fallback_chain:
+    - ollama
+`)
+
+	cfg, err := LoadConfig(root, 0)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	pcfg, err := loadProvidersConfig(cfg)
+	if err != nil {
+		t.Fatalf("loadProvidersConfig: %v", err)
+	}
+
+	if pcfg.Providers["ollama"].Model != "gemma4:e2b" {
+		t.Errorf("ollama model = %q; want gemma4:e2b", pcfg.Providers["ollama"].Model)
 	}
 }

--- a/internal/engine/serve_foveated.go
+++ b/internal/engine/serve_foveated.go
@@ -298,25 +298,35 @@ func extractAnchor(prompt string) string {
 func extractGoal(prompt string) string {
 	lower := strings.ToLower(strings.TrimSpace(prompt))
 
-	// Question patterns.
-	questionStarts := []string{"what", "how", "why", "where", "when", "who", "which", "can", "could", "would", "is", "are", "does", "do"}
-	for _, q := range questionStarts {
-		if strings.HasPrefix(lower, q+" ") || strings.HasPrefix(lower, q+"'") {
+	actionVerbs := []string{"build", "create", "implement", "write", "add", "fix", "update", "refactor", "delete", "remove", "move", "rename"}
+	for _, verb := range actionVerbs {
+		if strings.Contains(lower, verb) {
+			return "action: " + verb + " " + truncateGoal(prompt)
+		}
+	}
+
+	questionVerbs := []string{"explain", "describe", "analyze", "review", "document"}
+	for _, verb := range questionVerbs {
+		if strings.Contains(lower, verb) {
 			return "understand: " + truncateGoal(prompt)
 		}
 	}
 
-	// Action patterns.
-	actionStarts := []string{"build", "create", "add", "implement", "fix", "write", "make", "set up", "wire", "connect", "run", "start", "deploy", "update", "remove", "delete", "refactor", "test"}
-	for _, a := range actionStarts {
-		if strings.HasPrefix(lower, a+" ") || strings.HasPrefix(lower, a+".") {
-			return truncateGoal(prompt)
+	opsVerbs := []string{"deploy", "configure", "install", "setup", "set up", "migrate", "optimize", "test", "debug"}
+	for _, verb := range opsVerbs {
+		if strings.Contains(lower, verb) {
+			return "operate: " + verb + " " + truncateGoal(prompt)
 		}
 	}
 
 	// Imperative patterns (let's, lets).
 	if strings.HasPrefix(lower, "let") {
-		return truncateGoal(prompt)
+		return "action: let " + truncateGoal(prompt)
+	}
+
+	// Question-mark fallback.
+	if strings.Contains(lower, "?") {
+		return "understand: " + truncateGoal(prompt)
 	}
 
 	// Default: exploration.

--- a/internal/engine/serve_foveated_test.go
+++ b/internal/engine/serve_foveated_test.go
@@ -178,10 +178,12 @@ func TestExtractGoal(t *testing.T) {
 		prompt string
 		prefix string
 	}{
-		{"how does this work?", "understand:"},
-		{"build the auto-doc pipeline", "build the auto-doc pipeline"},
-		{"let's knock it out", "let's knock it out"},
+		{"Please explain how to build the router", "action: build"},
+		{"Could you help me debug this?", "operate: debug"},
+		{"What is the meaning of life?", "understand:"},
+		{"let's knock it out", "action: let"},
 		{"interesting stuff", "(exploring/discussing)"},
+		{"hello", "(exploring/discussing)"},
 	}
 	for _, tt := range tests {
 		got := extractGoal(tt.prompt)

--- a/internal/engine/stream_tailer.go
+++ b/internal/engine/stream_tailer.go
@@ -1,0 +1,345 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+)
+
+const DefaultFileWatcherPollInterval = time.Second
+
+// StreamTailer watches an external harness stream and emits normalized blocks.
+type StreamTailer interface {
+	// Tail starts watching a file/directory for new JSONL lines.
+	// It sends normalized CogBlocks on the output channel.
+	// It respects context cancellation for graceful shutdown.
+	Tail(ctx context.Context, path string, out chan<- CogBlock) error
+	// Name returns the adapter name (e.g., "claude-code", "openclaw").
+	Name() string
+}
+
+// TailerStats captures manager-side ingestion state for a single tailer.
+type TailerStats struct {
+	EventsIngested uint64
+	Errors         uint64
+	LastEventTime  time.Time
+}
+
+type tailerRegistration struct {
+	tailer StreamTailer
+	path   string
+}
+
+// TailerManager runs multiple stream tailers and tracks per-tailer stats.
+type TailerManager struct {
+	mu            sync.RWMutex
+	registrations []tailerRegistration
+	stats         map[string]TailerStats
+	out           chan<- CogBlock
+}
+
+// NewTailerManager creates a manager that forwards normalized blocks to out.
+func NewTailerManager(out chan<- CogBlock) *TailerManager {
+	return &TailerManager{
+		stats: make(map[string]TailerStats),
+		out:   out,
+	}
+}
+
+// Register adds a tailer and source path to the manager.
+func (m *TailerManager) Register(tailer StreamTailer, path string) error {
+	if tailer == nil {
+		return errors.New("stream tailer: nil tailer")
+	}
+	if path == "" {
+		return fmt.Errorf("stream tailer %q: empty path", tailer.Name())
+	}
+	if tailer.Name() == "" {
+		return errors.New("stream tailer: empty name")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.stats[tailer.Name()]; exists {
+		return fmt.Errorf("stream tailer %q already registered", tailer.Name())
+	}
+
+	m.registrations = append(m.registrations, tailerRegistration{tailer: tailer, path: path})
+	m.stats[tailer.Name()] = TailerStats{}
+	return nil
+}
+
+// Stats returns a snapshot of current per-tailer metrics.
+func (m *TailerManager) Stats() map[string]TailerStats {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	snapshot := make(map[string]TailerStats, len(m.stats))
+	for name, stats := range m.stats {
+		snapshot[name] = stats
+	}
+	return snapshot
+}
+
+// Run starts all registered tailers and blocks until they stop.
+func (m *TailerManager) Run(ctx context.Context) error {
+	if m.out == nil {
+		return errors.New("tailer manager: nil output channel")
+	}
+
+	m.mu.RLock()
+	registrations := append([]tailerRegistration(nil), m.registrations...)
+	m.mu.RUnlock()
+
+	if len(registrations) == 0 {
+		return nil
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	errCh := make(chan error, len(registrations))
+	var workers sync.WaitGroup
+
+	for _, registration := range registrations {
+		registration := registration
+		localOut := make(chan CogBlock, 16)
+
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			for block := range localOut {
+				m.recordEvent(registration.tailer.Name(), block.Timestamp)
+				select {
+				case m.out <- block:
+				case <-runCtx.Done():
+				}
+			}
+		}()
+
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			defer close(localOut)
+
+			err := registration.tailer.Tail(runCtx, registration.path, localOut)
+			if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return
+			}
+
+			m.recordError(registration.tailer.Name())
+			errCh <- fmt.Errorf("%s: %w", registration.tailer.Name(), err)
+			cancel()
+		}()
+	}
+
+	workers.Wait()
+	close(errCh)
+
+	var runErr error
+	for err := range errCh {
+		runErr = errors.Join(runErr, err)
+	}
+	return runErr
+}
+
+func (m *TailerManager) recordEvent(name string, blockTime time.Time) {
+	if blockTime.IsZero() {
+		blockTime = time.Now().UTC()
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	stats := m.stats[name]
+	stats.EventsIngested++
+	stats.LastEventTime = blockTime
+	m.stats[name] = stats
+}
+
+func (m *TailerManager) recordError(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	stats := m.stats[name]
+	stats.Errors++
+	m.stats[name] = stats
+}
+
+// FileWatcher polls a file for newly appended newline-delimited content.
+type FileWatcher struct {
+	PollInterval time.Duration
+}
+
+// NewFileWatcher creates a polling file watcher.
+func NewFileWatcher(pollInterval time.Duration) *FileWatcher {
+	return &FileWatcher{PollInterval: pollInterval}
+}
+
+// Watch monitors path for appended lines and invokes onLine for each complete line.
+func (w *FileWatcher) Watch(ctx context.Context, path string, onLine func([]byte) error) error {
+	if onLine == nil {
+		return errors.New("file watcher: nil line callback")
+	}
+
+	state := fileWatcherState{path: path}
+	defer state.close()
+
+	ticker := time.NewTicker(w.pollInterval())
+	defer ticker.Stop()
+
+	for {
+		if err := state.poll(onLine); err != nil {
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func (w *FileWatcher) pollInterval() time.Duration {
+	if w == nil || w.PollInterval <= 0 {
+		return DefaultFileWatcherPollInterval
+	}
+	return w.PollInterval
+}
+
+type fileWatcherState struct {
+	path       string
+	file       *os.File
+	fileInfo   os.FileInfo
+	offset     int64
+	partialBuf []byte
+}
+
+func (s *fileWatcherState) poll(onLine func([]byte) error) error {
+	currentInfo, statErr := os.Stat(s.path)
+	if statErr != nil && !os.IsNotExist(statErr) {
+		return fmt.Errorf("stat watched file %q: %w", s.path, statErr)
+	}
+
+	if s.file == nil {
+		if currentInfo == nil {
+			return nil
+		}
+		if err := s.openCurrent(); err != nil {
+			return err
+		}
+	}
+
+	if currentInfo != nil && s.fileInfo != nil && !os.SameFile(s.fileInfo, currentInfo) {
+		if err := s.readAvailable(onLine); err != nil {
+			return err
+		}
+		s.close()
+		if err := s.openCurrent(); err != nil {
+			return err
+		}
+	}
+
+	if s.file == nil {
+		return nil
+	}
+
+	return s.readAvailable(onLine)
+}
+
+func (s *fileWatcherState) openCurrent() error {
+	file, err := os.Open(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("open watched file %q: %w", s.path, err)
+	}
+
+	fileInfo, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return fmt.Errorf("stat opened file %q: %w", s.path, err)
+	}
+
+	s.file = file
+	s.fileInfo = fileInfo
+	s.offset = 0
+	s.partialBuf = nil
+	return nil
+}
+
+func (s *fileWatcherState) readAvailable(onLine func([]byte) error) error {
+	fileInfo, err := s.file.Stat()
+	if err != nil {
+		return fmt.Errorf("stat active file %q: %w", s.path, err)
+	}
+
+	if fileInfo.Size() < s.offset {
+		if _, err := s.file.Seek(0, io.SeekStart); err != nil {
+			return fmt.Errorf("rewind truncated file %q: %w", s.path, err)
+		}
+		s.offset = 0
+		s.partialBuf = nil
+	}
+
+	if fileInfo.Size() == s.offset {
+		s.fileInfo = fileInfo
+		return nil
+	}
+
+	if _, err := s.file.Seek(s.offset, io.SeekStart); err != nil {
+		return fmt.Errorf("seek watched file %q: %w", s.path, err)
+	}
+
+	data, err := io.ReadAll(s.file)
+	if err != nil {
+		return fmt.Errorf("read watched file %q: %w", s.path, err)
+	}
+	if len(data) == 0 {
+		s.fileInfo = fileInfo
+		return nil
+	}
+
+	s.offset += int64(len(data))
+	combined := append(append([]byte(nil), s.partialBuf...), data...)
+	start := 0
+	for index, value := range combined {
+		if value != '\n' {
+			continue
+		}
+
+		line := combined[start:index]
+		if len(line) > 0 && line[len(line)-1] == '\r' {
+			line = line[:len(line)-1]
+		}
+		if err := onLine(append([]byte(nil), line...)); err != nil {
+			return err
+		}
+		start = index + 1
+	}
+
+	if start < len(combined) {
+		s.partialBuf = append([]byte(nil), combined[start:]...)
+	} else {
+		s.partialBuf = nil
+	}
+	s.fileInfo = fileInfo
+	return nil
+}
+
+func (s *fileWatcherState) close() {
+	if s.file != nil {
+		_ = s.file.Close()
+	}
+	s.file = nil
+	s.fileInfo = nil
+	s.offset = 0
+	s.partialBuf = nil
+}

--- a/internal/engine/stream_tailer_test.go
+++ b/internal/engine/stream_tailer_test.go
@@ -1,0 +1,219 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestFileWatcherDetectsAppendedLines(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	path := filepath.Join(root, "events.jsonl")
+	if err := os.WriteFile(path, nil, 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	watcher := NewFileWatcher(10 * time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	received := make(chan string, 2)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- watcher.Watch(ctx, path, func(line []byte) error {
+			received <- string(line)
+			return nil
+		})
+	}()
+
+	appendLine(t, path, `{"event":"one"}`+"\n")
+	if got := waitForString(t, received); got != `{"event":"one"}` {
+		t.Fatalf("first line = %q; want %q", got, `{"event":"one"}`)
+	}
+
+	appendLine(t, path, `{"event":"two"}`+"\n")
+	if got := waitForString(t, received); got != `{"event":"two"}` {
+		t.Fatalf("second line = %q; want %q", got, `{"event":"two"}`)
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Watch returned error: %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("watcher did not stop after cancellation")
+	}
+}
+
+func TestTailerManagerRunsMultipleTailers(t *testing.T) {
+	t.Parallel()
+
+	out := make(chan CogBlock, 4)
+	manager := NewTailerManager(out)
+
+	if err := manager.Register(&stubStreamTailer{
+		name: "claude-code",
+		blocks: []CogBlock{{
+			ID:        "claude-1",
+			Kind:      BlockImport,
+			Timestamp: time.Now().UTC(),
+		}},
+	}, "/tmp/claude.jsonl"); err != nil {
+		t.Fatalf("Register claude-code: %v", err)
+	}
+
+	if err := manager.Register(&stubStreamTailer{
+		name: "openclaw",
+		blocks: []CogBlock{{
+			ID:        "openclaw-1",
+			Kind:      BlockImport,
+			Timestamp: time.Now().UTC(),
+		}},
+	}, "/tmp/openclaw.jsonl"); err != nil {
+		t.Fatalf("Register openclaw: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- manager.Run(ctx)
+	}()
+
+	seen := map[string]bool{}
+	for len(seen) < 2 {
+		select {
+		case block := <-out:
+			seen[block.ID] = true
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for tailer output")
+		}
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("manager did not stop after cancellation")
+	}
+
+	stats := manager.Stats()
+	if stats["claude-code"].EventsIngested != 1 {
+		t.Fatalf("claude-code events = %d; want 1", stats["claude-code"].EventsIngested)
+	}
+	if stats["openclaw"].EventsIngested != 1 {
+		t.Fatalf("openclaw events = %d; want 1", stats["openclaw"].EventsIngested)
+	}
+	if stats["claude-code"].LastEventTime.IsZero() {
+		t.Fatal("claude-code last event time should be set")
+	}
+	if stats["openclaw"].LastEventTime.IsZero() {
+		t.Fatal("openclaw last event time should be set")
+	}
+}
+
+func TestTailerManagerGracefulShutdown(t *testing.T) {
+	t.Parallel()
+
+	out := make(chan CogBlock, 1)
+	manager := NewTailerManager(out)
+
+	stopped := make(chan struct{})
+	if err := manager.Register(&blockingTailer{name: "cursor", stopped: stopped}, "/tmp/cursor.jsonl"); err != nil {
+		t.Fatalf("Register cursor: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- manager.Run(ctx)
+	}()
+
+	cancel()
+
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("tailer did not observe cancellation")
+	}
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("manager did not return after cancellation")
+	}
+
+	stats := manager.Stats()
+	if stats["cursor"].Errors != 0 {
+		t.Fatalf("cursor errors = %d; want 0", stats["cursor"].Errors)
+	}
+}
+
+type stubStreamTailer struct {
+	name   string
+	blocks []CogBlock
+}
+
+func (s *stubStreamTailer) Name() string { return s.name }
+
+func (s *stubStreamTailer) Tail(ctx context.Context, path string, out chan<- CogBlock) error {
+	for _, block := range s.blocks {
+		select {
+		case out <- block:
+		case <-ctx.Done():
+			return nil
+		}
+	}
+	<-ctx.Done()
+	return nil
+}
+
+type blockingTailer struct {
+	name    string
+	stopped chan struct{}
+}
+
+func (b *blockingTailer) Name() string { return b.name }
+
+func (b *blockingTailer) Tail(ctx context.Context, path string, out chan<- CogBlock) error {
+	<-ctx.Done()
+	close(b.stopped)
+	return nil
+}
+
+func appendLine(t *testing.T, path, content string) {
+	t.Helper()
+
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	defer file.Close()
+
+	if _, err := file.WriteString(content); err != nil {
+		t.Fatalf("WriteString: %v", err)
+	}
+}
+
+func waitForString(t *testing.T, values <-chan string) string {
+	t.Helper()
+
+	select {
+	case value := <-values:
+		return value
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for watched line")
+		return ""
+	}
+}

--- a/internal/engine/sync_watcher.go
+++ b/internal/engine/sync_watcher.go
@@ -1,0 +1,211 @@
+package engine
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const DefaultSyncWatcherPollInterval = 5 * time.Second
+
+// SyncEnvelope describes a bridge envelope dropped into .cog/sync/inbox/.
+type SyncEnvelope struct {
+	Version      int    `json:"version"`
+	OriginNodeID string `json:"origin_node_id"`
+	TargetNodeID string `json:"target_node_id"`
+	BlobHash     string `json:"blob_hash"`
+	Timestamp    string `json:"timestamp"`
+	Kind         string `json:"kind"`
+	Signature    string `json:"signature"`
+}
+
+// SyncEvent reports a discovered sync envelope and its structural validation result.
+type SyncEvent struct {
+	Envelope        SyncEnvelope
+	FilePath        string
+	Valid           bool
+	ValidationError string
+	AlreadyHave     bool
+}
+
+// SyncWatcher polls a Syncthing inbox directory for new SyncEnvelope files.
+type SyncWatcher struct {
+	BlobStore    *BlobStore
+	PollInterval time.Duration
+}
+
+// NewSyncWatcher creates a polling sync watcher.
+func NewSyncWatcher(blobStore *BlobStore, pollInterval time.Duration) *SyncWatcher {
+	return &SyncWatcher{BlobStore: blobStore, PollInterval: pollInterval}
+}
+
+// Watch monitors path for new .json envelopes and emits SyncEvents to out.
+func (w *SyncWatcher) Watch(ctx context.Context, path string, out chan<- SyncEvent) error {
+	if out == nil {
+		return errors.New("sync watcher: nil output channel")
+	}
+	if strings.TrimSpace(path) == "" {
+		return errors.New("sync watcher: empty inbox path")
+	}
+	if w == nil || w.BlobStore == nil {
+		return errors.New("sync watcher: nil blob store")
+	}
+
+	state := syncWatcherState{
+		path: path,
+		seen: make(map[string]struct{}),
+	}
+
+	ticker := time.NewTicker(w.pollInterval())
+	defer ticker.Stop()
+
+	for {
+		err := state.poll(func(filePath string) error {
+			event := w.inspectFile(filePath)
+			select {
+			case out <- event:
+				return nil
+			case <-ctx.Done():
+				return context.Canceled
+			}
+		})
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return nil
+			}
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func (w *SyncWatcher) pollInterval() time.Duration {
+	if w == nil || w.PollInterval <= 0 {
+		return DefaultSyncWatcherPollInterval
+	}
+	return w.PollInterval
+}
+
+func (w *SyncWatcher) inspectFile(path string) SyncEvent {
+	event := SyncEvent{FilePath: path}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		event.ValidationError = fmt.Sprintf("read envelope: %v", err)
+		return event
+	}
+
+	if err := json.Unmarshal(data, &event.Envelope); err != nil {
+		event.ValidationError = fmt.Sprintf("parse envelope: %v", err)
+		return event
+	}
+
+	if err := validateSyncEnvelope(event.Envelope); err != nil {
+		event.ValidationError = err.Error()
+		return event
+	}
+
+	event.Valid = true
+	event.AlreadyHave = w.BlobStore.Exists(strings.ToLower(strings.TrimSpace(event.Envelope.BlobHash)))
+	return event
+}
+
+func validateSyncEnvelope(envelope SyncEnvelope) error {
+	if envelope.Version != 1 {
+		return fmt.Errorf("version must be 1")
+	}
+	if strings.TrimSpace(envelope.OriginNodeID) == "" {
+		return errors.New("origin_node_id is required")
+	}
+	if strings.TrimSpace(envelope.TargetNodeID) == "" {
+		return errors.New("target_node_id is required")
+	}
+	if strings.TrimSpace(envelope.BlobHash) == "" {
+		return errors.New("blob_hash is required")
+	}
+	if !isSHA256Hex(envelope.BlobHash) {
+		return errors.New("blob_hash must be a 64-character hex SHA-256")
+	}
+	if strings.TrimSpace(envelope.Timestamp) == "" {
+		return errors.New("timestamp is required")
+	}
+	if _, err := time.Parse(time.RFC3339, envelope.Timestamp); err != nil {
+		return fmt.Errorf("timestamp must be RFC3339: %w", err)
+	}
+	if strings.TrimSpace(envelope.Kind) == "" {
+		return errors.New("kind is required")
+	}
+	if !isSupportedSyncKind(envelope.Kind) {
+		return fmt.Errorf("kind %q is not supported", envelope.Kind)
+	}
+	if strings.TrimSpace(envelope.Signature) == "" {
+		return errors.New("signature is required")
+	}
+	return nil
+}
+
+func isSupportedSyncKind(kind string) bool {
+	switch strings.TrimSpace(kind) {
+	case "block", "event", "manifest":
+		return true
+	default:
+		return false
+	}
+}
+
+func isSHA256Hex(hash string) bool {
+	hash = strings.TrimSpace(hash)
+	if len(hash) != 64 {
+		return false
+	}
+	_, err := hex.DecodeString(hash)
+	return err == nil
+}
+
+type syncWatcherState struct {
+	path string
+	seen map[string]struct{}
+}
+
+func (s *syncWatcherState) poll(onFile func(string) error) error {
+	entries, err := os.ReadDir(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read sync inbox %q: %w", s.path, err)
+	}
+
+	paths := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		paths = append(paths, filepath.Join(s.path, entry.Name()))
+	}
+	sort.Strings(paths)
+
+	for _, path := range paths {
+		if _, ok := s.seen[path]; ok {
+			continue
+		}
+		if err := onFile(path); err != nil {
+			return err
+		}
+		s.seen[path] = struct{}{}
+	}
+
+	return nil
+}

--- a/internal/engine/sync_watcher_test.go
+++ b/internal/engine/sync_watcher_test.go
@@ -157,6 +157,75 @@ func TestSyncWatcherGracefulShutdown(t *testing.T) {
 	assertSyncWatcherStopped(t, errCh)
 }
 
+func TestSyncWatcherIgnoresNonJSONFilesInInbox(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	inboxPath := mustMakeSyncInbox(t, workspaceRoot)
+	blobStore := newTestBlobStore(t, workspaceRoot)
+	watcher := NewSyncWatcher(blobStore, 10*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out := make(chan SyncEvent, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- watcher.Watch(ctx, inboxPath, out)
+	}()
+
+	if err := os.WriteFile(filepath.Join(inboxPath, "README.txt"), []byte("ignore me"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	select {
+	case event := <-out:
+		t.Fatalf("unexpected event for non-json file: %+v", event)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	writeSyncEnvelopeFile(t, filepath.Join(inboxPath, "envelope.json"), SyncEnvelope{
+		Version:      1,
+		OriginNodeID: "node-a",
+		TargetNodeID: "node-b",
+		BlobHash:     "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		Timestamp:    time.Now().UTC().Format(time.RFC3339),
+		Kind:         "event",
+		Signature:    "signature",
+	})
+
+	event := waitForSyncEvent(t, out)
+	if !event.Valid {
+		t.Fatalf("Valid = false, want true (error: %s)", event.ValidationError)
+	}
+
+	cancel()
+	assertSyncWatcherStopped(t, errCh)
+}
+
+func TestSyncWatcherHandlesEmptyDirectoryGracefully(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	inboxPath := mustMakeSyncInbox(t, workspaceRoot)
+
+	state := syncWatcherState{
+		path: inboxPath,
+		seen: make(map[string]struct{}),
+	}
+
+	called := false
+	if err := state.poll(func(string) error {
+		called = true
+		return nil
+	}); err != nil {
+		t.Fatalf("poll returned error: %v", err)
+	}
+	if called {
+		t.Fatal("poll callback called for empty directory")
+	}
+}
+
 func newTestBlobStore(t *testing.T, workspaceRoot string) *BlobStore {
 	t.Helper()
 

--- a/internal/engine/sync_watcher_test.go
+++ b/internal/engine/sync_watcher_test.go
@@ -1,0 +1,215 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSyncWatcherDetectsNewEnvelopeFile(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	inboxPath := mustMakeSyncInbox(t, workspaceRoot)
+	blobStore := newTestBlobStore(t, workspaceRoot)
+	watcher := NewSyncWatcher(blobStore, 10*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out := make(chan SyncEvent, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- watcher.Watch(ctx, inboxPath, out)
+	}()
+
+	envelopePath := filepath.Join(inboxPath, "envelope.json")
+	writeSyncEnvelopeFile(t, envelopePath, SyncEnvelope{
+		Version:      1,
+		OriginNodeID: "node-a",
+		TargetNodeID: "node-b",
+		BlobHash:     "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		Timestamp:    time.Now().UTC().Format(time.RFC3339),
+		Kind:         "block",
+		Signature:    "signature",
+	})
+
+	event := waitForSyncEvent(t, out)
+	if !event.Valid {
+		t.Fatalf("Valid = false, want true (error: %s)", event.ValidationError)
+	}
+	if event.FilePath != envelopePath {
+		t.Fatalf("FilePath = %q, want %q", event.FilePath, envelopePath)
+	}
+	if event.AlreadyHave {
+		t.Fatal("AlreadyHave = true, want false")
+	}
+	if event.Envelope.OriginNodeID != "node-a" {
+		t.Fatalf("OriginNodeID = %q, want %q", event.Envelope.OriginNodeID, "node-a")
+	}
+
+	cancel()
+	assertSyncWatcherStopped(t, errCh)
+}
+
+func TestSyncWatcherFlagsInvalidEnvelope(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	inboxPath := mustMakeSyncInbox(t, workspaceRoot)
+	blobStore := newTestBlobStore(t, workspaceRoot)
+	watcher := NewSyncWatcher(blobStore, 10*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out := make(chan SyncEvent, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- watcher.Watch(ctx, inboxPath, out)
+	}()
+
+	writeSyncEnvelopeFile(t, filepath.Join(inboxPath, "invalid.json"), SyncEnvelope{
+		Version:      1,
+		OriginNodeID: "node-a",
+		BlobHash:     "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		Timestamp:    time.Now().UTC().Format(time.RFC3339),
+		Kind:         "block",
+		Signature:    "signature",
+	})
+
+	event := waitForSyncEvent(t, out)
+	if event.Valid {
+		t.Fatal("Valid = true, want false")
+	}
+	if event.ValidationError == "" {
+		t.Fatal("ValidationError = empty, want message")
+	}
+	if event.AlreadyHave {
+		t.Fatal("AlreadyHave = true, want false")
+	}
+
+	cancel()
+	assertSyncWatcherStopped(t, errCh)
+}
+
+func TestSyncWatcherMarksAlreadyPresentBlob(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	inboxPath := mustMakeSyncInbox(t, workspaceRoot)
+	blobStore := newTestBlobStore(t, workspaceRoot)
+	hash, err := blobStore.Store([]byte("hello, constellation"), "text/plain")
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+
+	watcher := NewSyncWatcher(blobStore, 10*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out := make(chan SyncEvent, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- watcher.Watch(ctx, inboxPath, out)
+	}()
+
+	writeSyncEnvelopeFile(t, filepath.Join(inboxPath, "existing-blob.json"), SyncEnvelope{
+		Version:      1,
+		OriginNodeID: "node-a",
+		TargetNodeID: "node-b",
+		BlobHash:     hash,
+		Timestamp:    time.Now().UTC().Format(time.RFC3339),
+		Kind:         "manifest",
+		Signature:    "signature",
+	})
+
+	event := waitForSyncEvent(t, out)
+	if !event.Valid {
+		t.Fatalf("Valid = false, want true (error: %s)", event.ValidationError)
+	}
+	if !event.AlreadyHave {
+		t.Fatal("AlreadyHave = false, want true")
+	}
+
+	cancel()
+	assertSyncWatcherStopped(t, errCh)
+}
+
+func TestSyncWatcherGracefulShutdown(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	inboxPath := mustMakeSyncInbox(t, workspaceRoot)
+	blobStore := newTestBlobStore(t, workspaceRoot)
+	watcher := NewSyncWatcher(blobStore, 10*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- watcher.Watch(ctx, inboxPath, make(chan SyncEvent))
+	}()
+
+	cancel()
+	assertSyncWatcherStopped(t, errCh)
+}
+
+func newTestBlobStore(t *testing.T, workspaceRoot string) *BlobStore {
+	t.Helper()
+
+	blobStore := NewBlobStore(workspaceRoot)
+	if err := blobStore.Init(); err != nil {
+		t.Fatalf("Init blob store: %v", err)
+	}
+	return blobStore
+}
+
+func mustMakeSyncInbox(t *testing.T, workspaceRoot string) string {
+	t.Helper()
+
+	inboxPath := filepath.Join(workspaceRoot, ".cog", "sync", "inbox")
+	if err := os.MkdirAll(inboxPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	return inboxPath
+}
+
+func writeSyncEnvelopeFile(t *testing.T, path string, envelope SyncEnvelope) {
+	t.Helper()
+
+	data, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func waitForSyncEvent(t *testing.T, out <-chan SyncEvent) SyncEvent {
+	t.Helper()
+
+	select {
+	case event := <-out:
+		return event
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for sync event")
+		return SyncEvent{}
+	}
+}
+
+func assertSyncWatcherStopped(t *testing.T, errCh <-chan error) {
+	t.Helper()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Watch returned error: %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("watcher did not stop after cancellation")
+	}
+}

--- a/internal/engine/tailer_claudecode.go
+++ b/internal/engine/tailer_claudecode.go
@@ -1,0 +1,220 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	claudeCodeSourceChannel = "claude-code"
+	claudeCodeNormalizedBy  = "tailer-claude-code"
+)
+
+// ClaudeCodeTailer tails Claude Code JSONL logs and emits normalized CogBlocks.
+type ClaudeCodeTailer struct {
+	Watcher *FileWatcher
+}
+
+func (t *ClaudeCodeTailer) Name() string { return claudeCodeSourceChannel }
+
+func (t *ClaudeCodeTailer) Tail(ctx context.Context, path string, out chan<- CogBlock) error {
+	if out == nil {
+		return errors.New("claude code tailer: nil output channel")
+	}
+	if strings.TrimSpace(path) == "" {
+		return errors.New("claude code tailer: empty path")
+	}
+
+	watcher := t.Watcher
+	if watcher == nil {
+		watcher = NewFileWatcher(DefaultFileWatcherPollInterval)
+	}
+
+	return watcher.Watch(ctx, path, func(line []byte) error {
+		if len(strings.TrimSpace(string(line))) == 0 {
+			return nil
+		}
+
+		block, err := normalizeClaudeCodeLine(line)
+		if err != nil {
+			return err
+		}
+
+		select {
+		case out <- block:
+			return nil
+		case <-ctx.Done():
+			return nil
+		}
+	})
+}
+
+type claudeCodeLogLine struct {
+	Role       string          `json:"role"`
+	Content    json.RawMessage `json:"content"`
+	Timestamp  json.RawMessage `json:"timestamp"`
+	ToolUse    json.RawMessage `json:"tool_use"`
+	ToolResult json.RawMessage `json:"tool_result"`
+	Type       string          `json:"type"`
+}
+
+func normalizeClaudeCodeLine(line []byte) (CogBlock, error) {
+	var entry claudeCodeLogLine
+	if err := json.Unmarshal(line, &entry); err != nil {
+		return CogBlock{}, fmt.Errorf("parse claude code jsonl line: %w", err)
+	}
+
+	now := time.Now().UTC()
+	blockTime := parseClaudeCodeTimestamp(entry.Timestamp)
+	if blockTime.IsZero() {
+		blockTime = now
+	}
+
+	content := parseClaudeCodeContent(entry.Content)
+	role := strings.TrimSpace(entry.Role)
+
+	block := CogBlock{
+		ID:              uuid.New().String(),
+		Timestamp:       blockTime,
+		SourceChannel:   claudeCodeSourceChannel,
+		SourceTransport: "jsonl",
+		SourceIdentity:  role,
+		Kind:            classifyClaudeCodeKind(entry),
+		RawPayload:      append(json.RawMessage(nil), line...),
+		Messages: []ProviderMessage{{
+			Role:    role,
+			Content: content,
+		}},
+		Provenance: BlockProvenance{
+			OriginChannel: claudeCodeSourceChannel,
+			IngestedAt:    now,
+			NormalizedBy:  claudeCodeNormalizedBy,
+		},
+		TrustContext: TrustContext{
+			Authenticated: true,
+			TrustScore:    1.0,
+			Scope:         "local",
+		},
+	}
+	return block, nil
+}
+
+func classifyClaudeCodeKind(entry claudeCodeLogLine) CogBlockKind {
+	eventType := strings.TrimSpace(entry.Type)
+	switch {
+	case hasJSONValue(entry.ToolUse), eventType == "tool_use":
+		return BlockToolCall
+	case hasJSONValue(entry.ToolResult), eventType == "tool_result":
+		return BlockToolResult
+	default:
+		return BlockMessage
+	}
+}
+
+func hasJSONValue(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	trimmed := strings.TrimSpace(string(raw))
+	return trimmed != "" && trimmed != "null"
+}
+
+func parseClaudeCodeContent(raw json.RawMessage) string {
+	if !hasJSONValue(raw) {
+		return ""
+	}
+
+	var contentText string
+	if err := json.Unmarshal(raw, &contentText); err == nil {
+		return contentText
+	}
+
+	var parts []struct {
+		Type    string `json:"type"`
+		Text    string `json:"text"`
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &parts); err == nil {
+		texts := make([]string, 0, len(parts))
+		for _, part := range parts {
+			switch {
+			case strings.TrimSpace(part.Text) != "":
+				texts = append(texts, part.Text)
+			case strings.TrimSpace(part.Content) != "":
+				texts = append(texts, part.Content)
+			}
+		}
+		if len(texts) > 0 {
+			return strings.Join(texts, "\n")
+		}
+	}
+
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err == nil {
+		if text := decodeOptionalJSONString(obj["text"]); text != "" {
+			return text
+		}
+		if text := decodeOptionalJSONString(obj["content"]); text != "" {
+			return text
+		}
+	}
+
+	return strings.TrimSpace(string(raw))
+}
+
+func decodeOptionalJSONString(raw json.RawMessage) string {
+	if !hasJSONValue(raw) {
+		return ""
+	}
+	var text string
+	if err := json.Unmarshal(raw, &text); err != nil {
+		return ""
+	}
+	return text
+}
+
+func parseClaudeCodeTimestamp(raw json.RawMessage) time.Time {
+	if !hasJSONValue(raw) {
+		return time.Time{}
+	}
+
+	var tsString string
+	if err := json.Unmarshal(raw, &tsString); err == nil {
+		tsString = strings.TrimSpace(tsString)
+		if tsString == "" {
+			return time.Time{}
+		}
+		for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+			if ts, err := time.Parse(layout, tsString); err == nil {
+				return ts.UTC()
+			}
+		}
+		if unix, err := strconv.ParseInt(tsString, 10, 64); err == nil {
+			return unixToTime(unix)
+		}
+	}
+
+	var unixFloat float64
+	if err := json.Unmarshal(raw, &unixFloat); err == nil {
+		return unixToTime(int64(unixFloat))
+	}
+
+	return time.Time{}
+}
+
+func unixToTime(value int64) time.Time {
+	if value <= 0 {
+		return time.Time{}
+	}
+	if value >= 1_000_000_000_000 {
+		return time.UnixMilli(value).UTC()
+	}
+	return time.Unix(value, 0).UTC()
+}

--- a/internal/engine/tailer_claudecode_test.go
+++ b/internal/engine/tailer_claudecode_test.go
@@ -53,6 +53,38 @@ func TestClaudeCodeTailerNormalizesJSONL(t *testing.T) {
 	}
 }
 
+func TestNormalizeClaudeCodeLineToolUseKind(t *testing.T) {
+	t.Parallel()
+
+	block, err := normalizeClaudeCodeLine([]byte(`{"role":"assistant","content":"calling","tool_use":{"name":"shell"},"timestamp":"2026-01-02T03:04:06Z"}`))
+	if err != nil {
+		t.Fatalf("normalizeClaudeCodeLine: %v", err)
+	}
+	if block.Kind != BlockToolCall {
+		t.Fatalf("Kind = %q; want %q", block.Kind, BlockToolCall)
+	}
+}
+
+func TestNormalizeClaudeCodeLineToolResultKind(t *testing.T) {
+	t.Parallel()
+
+	block, err := normalizeClaudeCodeLine([]byte(`{"role":"tool","content":"ok","tool_result":{"status":"ok"},"timestamp":"2026-01-02T03:04:07Z"}`))
+	if err != nil {
+		t.Fatalf("normalizeClaudeCodeLine: %v", err)
+	}
+	if block.Kind != BlockToolResult {
+		t.Fatalf("Kind = %q; want %q", block.Kind, BlockToolResult)
+	}
+}
+
+func TestNormalizeClaudeCodeLineMalformedJSONReturnsError(t *testing.T) {
+	t.Parallel()
+
+	if _, err := normalizeClaudeCodeLine([]byte(`{"role":"assistant","content":"oops"`)); err == nil {
+		t.Fatal("normalizeClaudeCodeLine error = nil; want parse error")
+	}
+}
+
 func assertClaudeCodeBlock(t *testing.T, block CogBlock, kind CogBlockKind, role, content string) {
 	t.Helper()
 

--- a/internal/engine/tailer_claudecode_test.go
+++ b/internal/engine/tailer_claudecode_test.go
@@ -1,0 +1,95 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestClaudeCodeTailerNormalizesJSONL(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	path := filepath.Join(root, "conversation.jsonl")
+	fixture := "" +
+		`{"role":"user","content":"hello from user","timestamp":"2026-01-02T03:04:05Z"}` + "\n" +
+		`{"role":"assistant","content":"calling tool","tool_use":{"name":"shell"},"timestamp":"2026-01-02T03:04:06Z"}` + "\n" +
+		`{"role":"tool","content":"tool output","tool_result":{"status":"ok"},"timestamp":"2026-01-02T03:04:07Z"}` + "\n"
+	if err := os.WriteFile(path, []byte(fixture), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	tailer := &ClaudeCodeTailer{
+		Watcher: NewFileWatcher(10 * time.Millisecond),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out := make(chan CogBlock, 3)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- tailer.Tail(ctx, path, out)
+	}()
+
+	first := waitForBlock(t, out)
+	second := waitForBlock(t, out)
+	third := waitForBlock(t, out)
+
+	assertClaudeCodeBlock(t, first, BlockMessage, "user", "hello from user")
+	assertClaudeCodeBlock(t, second, BlockToolCall, "assistant", "calling tool")
+	assertClaudeCodeBlock(t, third, BlockToolResult, "tool", "tool output")
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Tail returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("tailer did not stop after cancellation")
+	}
+}
+
+func assertClaudeCodeBlock(t *testing.T, block CogBlock, kind CogBlockKind, role, content string) {
+	t.Helper()
+
+	if block.Kind != kind {
+		t.Fatalf("Kind = %q; want %q", block.Kind, kind)
+	}
+	if block.SourceChannel != "claude-code" {
+		t.Fatalf("SourceChannel = %q; want claude-code", block.SourceChannel)
+	}
+	if block.SourceIdentity != role {
+		t.Fatalf("SourceIdentity = %q; want %q", block.SourceIdentity, role)
+	}
+	if block.Provenance.OriginChannel != "claude-code" {
+		t.Fatalf("Provenance.OriginChannel = %q; want claude-code", block.Provenance.OriginChannel)
+	}
+	if block.Provenance.NormalizedBy != "tailer-claude-code" {
+		t.Fatalf("Provenance.NormalizedBy = %q; want tailer-claude-code", block.Provenance.NormalizedBy)
+	}
+	if len(block.Messages) != 1 {
+		t.Fatalf("len(Messages) = %d; want 1", len(block.Messages))
+	}
+	if block.Messages[0].Role != role {
+		t.Fatalf("Messages[0].Role = %q; want %q", block.Messages[0].Role, role)
+	}
+	if block.Messages[0].Content != content {
+		t.Fatalf("Messages[0].Content = %q; want %q", block.Messages[0].Content, content)
+	}
+}
+
+func waitForBlock(t *testing.T, blocks <-chan CogBlock) CogBlock {
+	t.Helper()
+
+	select {
+	case block := <-blocks:
+		return block
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for block")
+		return CogBlock{}
+	}
+}

--- a/internal/engine/tailer_openclaw.go
+++ b/internal/engine/tailer_openclaw.go
@@ -1,0 +1,246 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const DefaultOpenClawTailerScanInterval = time.Second
+
+// OpenClawTailer watches OpenClaw JSONL logs and emits normalized CogBlocks.
+type OpenClawTailer struct {
+	Watcher      *FileWatcher
+	ScanInterval time.Duration
+}
+
+func (t *OpenClawTailer) Name() string {
+	return "openclaw"
+}
+
+func (t *OpenClawTailer) Tail(ctx context.Context, path string, out chan<- CogBlock) error {
+	if out == nil {
+		return errors.New("openclaw tailer: nil output channel")
+	}
+
+	info, err := os.Stat(path)
+	if err == nil && info.IsDir() {
+		return t.tailDirectory(ctx, path, out)
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("openclaw tailer: stat path %q: %w", path, err)
+	}
+
+	return t.tailFile(ctx, path, out)
+}
+
+func (t *OpenClawTailer) tailDirectory(ctx context.Context, dir string, out chan<- CogBlock) error {
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	ticker := time.NewTicker(t.scanInterval())
+	defer ticker.Stop()
+
+	errCh := make(chan error, 1)
+	active := map[string]context.CancelFunc{}
+	var mu sync.Mutex
+
+	startFile := func(filePath string) {
+		mu.Lock()
+		if _, exists := active[filePath]; exists {
+			mu.Unlock()
+			return
+		}
+		fileCtx, fileCancel := context.WithCancel(runCtx)
+		active[filePath] = fileCancel
+		mu.Unlock()
+
+		go func() {
+			if err := t.tailFile(fileCtx, filePath, out); err != nil {
+				select {
+				case errCh <- err:
+				default:
+				}
+				cancel()
+			}
+			mu.Lock()
+			delete(active, filePath)
+			mu.Unlock()
+		}()
+	}
+
+	scan := func() error {
+		entries, readErr := os.ReadDir(dir)
+		if readErr != nil {
+			return fmt.Errorf("openclaw tailer: read directory %q: %w", dir, readErr)
+		}
+		for _, entry := range entries {
+			if entry.IsDir() || filepath.Ext(entry.Name()) != ".jsonl" {
+				continue
+			}
+			startFile(filepath.Join(dir, entry.Name()))
+		}
+		return nil
+	}
+
+	if err := scan(); err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			mu.Lock()
+			for _, stop := range active {
+				stop()
+			}
+			mu.Unlock()
+			return nil
+		case err := <-errCh:
+			if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				continue
+			}
+			return err
+		case <-ticker.C:
+			if err := scan(); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (t *OpenClawTailer) tailFile(ctx context.Context, path string, out chan<- CogBlock) error {
+	return t.watcher().Watch(ctx, path, func(line []byte) error {
+		block, ok := normalizeOpenClawLine(line)
+		if !ok {
+			return nil
+		}
+
+		select {
+		case out <- block:
+			return nil
+		case <-ctx.Done():
+			return nil
+		}
+	})
+}
+
+func (t *OpenClawTailer) watcher() *FileWatcher {
+	if t != nil && t.Watcher != nil {
+		return t.Watcher
+	}
+	return NewFileWatcher(DefaultFileWatcherPollInterval)
+}
+
+func (t *OpenClawTailer) scanInterval() time.Duration {
+	if t == nil || t.ScanInterval <= 0 {
+		return DefaultOpenClawTailerScanInterval
+	}
+	return t.ScanInterval
+}
+
+type openClawJSONLLine struct {
+	ID        string          `json:"id"`
+	Type      string          `json:"type"`
+	Role      string          `json:"role"`
+	Content   json.RawMessage `json:"content"`
+	Timestamp string          `json:"timestamp"`
+	SessionID string          `json:"session_id"`
+	ThreadID  string          `json:"thread_id"`
+}
+
+func normalizeOpenClawLine(line []byte) (CogBlock, bool) {
+	var entry openClawJSONLLine
+	if err := json.Unmarshal(line, &entry); err != nil {
+		return CogBlock{}, false
+	}
+
+	kind, ok := openClawKind(entry.Type)
+	if !ok {
+		return CogBlock{}, false
+	}
+
+	now := time.Now().UTC()
+	ts := now
+	if entry.Timestamp != "" {
+		if parsed, err := time.Parse(time.RFC3339Nano, entry.Timestamp); err == nil {
+			ts = parsed.UTC()
+		}
+	}
+
+	blockID := entry.ID
+	if blockID == "" {
+		blockID = uuid.NewString()
+	}
+
+	content := openClawContent(entry.Content)
+	block := CogBlock{
+		ID:              blockID,
+		Timestamp:       ts,
+		SessionID:       entry.SessionID,
+		ThreadID:        entry.ThreadID,
+		SourceChannel:   "openclaw",
+		SourceTransport: "jsonl",
+		Kind:            kind,
+		RawPayload:      append(json.RawMessage(nil), line...),
+		Provenance: BlockProvenance{
+			OriginSession: entry.SessionID,
+			OriginChannel: "openclaw",
+			IngestedAt:    now,
+			NormalizedBy:  "tailer-openclaw",
+		},
+		TrustContext: TrustContext{
+			Authenticated: true,
+			TrustScore:    1.0,
+			Scope:         "local",
+		},
+	}
+
+	if entry.Role != "" || content != "" {
+		block.Messages = []ProviderMessage{{
+			Role:    entry.Role,
+			Content: content,
+		}}
+	}
+
+	return block, true
+}
+
+func openClawKind(value string) (CogBlockKind, bool) {
+	switch value {
+	case string(BlockMessage):
+		return BlockMessage, true
+	case string(BlockToolCall):
+		return BlockToolCall, true
+	case string(BlockToolResult):
+		return BlockToolResult, true
+	default:
+		return "", false
+	}
+}
+
+func openClawContent(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return text
+	}
+
+	compact := make(json.RawMessage, len(raw))
+	copy(compact, raw)
+	if json.Valid(compact) {
+		return string(compact)
+	}
+
+	return ""
+}

--- a/internal/engine/tailer_openclaw_test.go
+++ b/internal/engine/tailer_openclaw_test.go
@@ -1,0 +1,91 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestOpenClawTailerTailsJSONLFile(t *testing.T) {
+	t.Parallel()
+
+	fixturePath := filepath.Join("testdata", "openclaw_session.jsonl")
+	fixture, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("ReadFile fixture: %v", err)
+	}
+
+	root := t.TempDir()
+	logPath := filepath.Join(root, "session.jsonl")
+	if err := os.WriteFile(logPath, fixture, 0644); err != nil {
+		t.Fatalf("WriteFile log: %v", err)
+	}
+
+	tailer := &OpenClawTailer{Watcher: NewFileWatcher(10 * time.Millisecond)}
+	if got := tailer.Name(); got != "openclaw" {
+		t.Fatalf("Name() = %q; want %q", got, "openclaw")
+	}
+
+	out := make(chan CogBlock, 3)
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- tailer.Tail(ctx, logPath, out)
+	}()
+
+	got := make([]CogBlock, 0, 3)
+	for len(got) < 3 {
+		select {
+		case block := <-out:
+			got = append(got, block)
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for openclaw blocks")
+		}
+	}
+
+	check := func(index int, kind CogBlockKind, role, content string) {
+		if got[index].Kind != kind {
+			t.Fatalf("block[%d].Kind = %q; want %q", index, got[index].Kind, kind)
+		}
+		if got[index].SourceChannel != "openclaw" {
+			t.Fatalf("block[%d].SourceChannel = %q; want openclaw", index, got[index].SourceChannel)
+		}
+		if got[index].Provenance.OriginChannel != "openclaw" {
+			t.Fatalf("block[%d].Provenance.OriginChannel = %q; want openclaw", index, got[index].Provenance.OriginChannel)
+		}
+		if got[index].Provenance.NormalizedBy != "tailer-openclaw" {
+			t.Fatalf("block[%d].Provenance.NormalizedBy = %q; want tailer-openclaw", index, got[index].Provenance.NormalizedBy)
+		}
+		if got[index].SessionID != "sess-123" {
+			t.Fatalf("block[%d].SessionID = %q; want sess-123", index, got[index].SessionID)
+		}
+		if len(got[index].Messages) != 1 {
+			t.Fatalf("block[%d].Messages len = %d; want 1", index, len(got[index].Messages))
+		}
+		if got[index].Messages[0].Role != role {
+			t.Fatalf("block[%d].Messages[0].Role = %q; want %q", index, got[index].Messages[0].Role, role)
+		}
+		if got[index].Messages[0].Content != content {
+			t.Fatalf("block[%d].Messages[0].Content = %q; want %q", index, got[index].Messages[0].Content, content)
+		}
+		if got[index].Timestamp.IsZero() {
+			t.Fatalf("block[%d].Timestamp should be set", index)
+		}
+	}
+
+	check(0, BlockMessage, "user", "hello from openclaw")
+	check(1, BlockToolCall, "assistant", `{"name":"search","arguments":{"q":"weather"}}`)
+	check(2, BlockToolResult, "tool", "sunny")
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Tail returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("tailer did not stop after cancellation")
+	}
+}

--- a/internal/engine/tailer_openclaw_test.go
+++ b/internal/engine/tailer_openclaw_test.go
@@ -89,3 +89,81 @@ func TestOpenClawTailerTailsJSONLFile(t *testing.T) {
 		t.Fatal("tailer did not stop after cancellation")
 	}
 }
+
+func TestOpenClawTailerDirectoryModeDiscoversNewJSONLFiles(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	tailer := &OpenClawTailer{
+		Watcher:      NewFileWatcher(10 * time.Millisecond),
+		ScanInterval: 10 * time.Millisecond,
+	}
+
+	out := make(chan CogBlock, 2)
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- tailer.Tail(ctx, root, out)
+	}()
+
+	time.Sleep(30 * time.Millisecond)
+	logPath := filepath.Join(root, "new-session.jsonl")
+	line := `{"id":"evt-1","type":"message","role":"user","content":"hello","timestamp":"2026-01-02T03:04:05Z","session_id":"sess-1"}` + "\n"
+	if err := os.WriteFile(logPath, []byte(line), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	block := waitForBlock(t, out)
+	if block.Kind != BlockMessage {
+		t.Fatalf("Kind = %q; want %q", block.Kind, BlockMessage)
+	}
+	if block.SessionID != "sess-1" {
+		t.Fatalf("SessionID = %q; want %q", block.SessionID, "sess-1")
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Tail returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("tailer did not stop after cancellation")
+	}
+}
+
+func TestOpenClawTailerSkipsMalformedJSONLines(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	logPath := filepath.Join(root, "session.jsonl")
+	fixture := "" +
+		`{"id":"evt-bad","type":"message","role":"user","content":"unterminated"` + "\n" +
+		`{"id":"evt-good","type":"message","role":"user","content":"hello","timestamp":"2026-01-02T03:04:05Z","session_id":"sess-2"}` + "\n"
+	if err := os.WriteFile(logPath, []byte(fixture), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	tailer := &OpenClawTailer{Watcher: NewFileWatcher(10 * time.Millisecond)}
+	out := make(chan CogBlock, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- tailer.Tail(ctx, logPath, out)
+	}()
+
+	block := waitForBlock(t, out)
+	if block.ID != "evt-good" {
+		t.Fatalf("ID = %q; want evt-good", block.ID)
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Tail returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("tailer did not stop after cancellation")
+	}
+}

--- a/internal/engine/testdata/openclaw_session.jsonl
+++ b/internal/engine/testdata/openclaw_session.jsonl
@@ -1,0 +1,3 @@
+{"type":"message","role":"user","content":"hello from openclaw","timestamp":"2026-04-01T10:00:00Z","session_id":"sess-123"}
+{"type":"tool_call","role":"assistant","content":"{\"name\":\"search\",\"arguments\":{\"q\":\"weather\"}}","timestamp":"2026-04-01T10:00:01Z","session_id":"sess-123"}
+{"type":"tool_result","role":"tool","content":"sunny","timestamp":"2026-04-01T10:00:02Z","session_id":"sess-123"}

--- a/internal/engine/testhelper_test.go
+++ b/internal/engine/testhelper_test.go
@@ -58,12 +58,13 @@ func makeWorkspace(t *testing.T) string {
 func makeConfig(t *testing.T, root string) *Config {
 	t.Helper()
 	return &Config{
-		WorkspaceRoot:         root,
-		CogDir:                filepath.Join(root, ".cog"),
-		Port:                  0,
-		ConsolidationInterval: 99999,
-		HeartbeatInterval:     99999,
-		SalienceDaysWindow:    90,
+		WorkspaceRoot:             root,
+		CogDir:                    filepath.Join(root, ".cog"),
+		Port:                      0,
+		ConsolidationInterval:     99999,
+		HeartbeatInterval:         99999,
+		SalienceDaysWindow:        90,
+		ToolCallValidationEnabled: true,
 	}
 }
 

--- a/internal/engine/tool_loop.go
+++ b/internal/engine/tool_loop.go
@@ -17,6 +17,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -26,8 +29,10 @@ const maxToolLoopIterations = 10
 // KernelToolRegistry holds the kernel's tool definitions and executors.
 // Populated at startup from the MCP server's tool set.
 type KernelToolRegistry struct {
+	cfg         *Config
 	definitions []ToolDefinition
 	executors   map[string]toolExecutor
+	proprio     *ProprioceptiveLogger
 }
 
 // toolExecutor is a function that takes JSON arguments and returns a JSON result.
@@ -36,7 +41,11 @@ type toolExecutor func(ctx context.Context, arguments string) (string, error)
 // NewKernelToolRegistry builds the tool registry from the MCP server.
 func NewKernelToolRegistry(mcpSrv *MCPServer) *KernelToolRegistry {
 	reg := &KernelToolRegistry{
+		cfg:       mcpSrv.cfg,
 		executors: make(map[string]toolExecutor),
+	}
+	if mcpSrv.cfg != nil && mcpSrv.cfg.WorkspaceRoot != "" {
+		reg.proprio = NewProprioceptiveLogger(filepath.Join(mcpSrv.cfg.WorkspaceRoot, ".cog", "run", "proprioceptive.jsonl"))
 	}
 
 	// Register each tool with its schema and executor.
@@ -216,6 +225,85 @@ func (r *KernelToolRegistry) Definitions() []ToolDefinition {
 	return r.definitions
 }
 
+func toolCallValidationEnabled(provider Provider, cfg *Config) bool {
+	caps := provider.Capabilities()
+	if caps.HasCapability(CapToolUse) {
+		return false
+	}
+	if !caps.HasCapability(CapToolCallValidation) {
+		return false
+	}
+	if cfg == nil {
+		return true
+	}
+	return cfg.ToolCallValidationEnabled
+}
+
+func (r *KernelToolRegistry) logRejectedToolCall(providerName string, tc ToolCall, validation ToolCallValidationResult) {
+	if r == nil {
+		return
+	}
+	if r.proprio == nil && r.cfg != nil && r.cfg.WorkspaceRoot != "" {
+		r.proprio = NewProprioceptiveLogger(filepath.Join(r.cfg.WorkspaceRoot, ".cog", "run", "proprioceptive.jsonl"))
+	}
+	if r.proprio == nil {
+		return
+	}
+	r.proprio.Log(ProprioceptiveEntry{
+		Event:       "tool_call_rejected",
+		Provider:    providerName,
+		ToolName:    tc.Name,
+		ToolCallID:  tc.ID,
+		ToolArgs:    truncateString(tc.Arguments, 500),
+		Reason:      validation.Reason,
+		Query:       fmt.Sprintf("tool_call:%s", tc.Name),
+		ResponseLen: len(tc.Arguments),
+	})
+}
+
+// ToolCallValidationResult describes whether a model-emitted tool call is safe to run.
+type ToolCallValidationResult struct {
+	Valid    bool
+	Reason   string
+	ToolName string
+}
+
+// ValidateToolCall verifies that the model requested a known tool with arguments
+// that match the registered input schema.
+func ValidateToolCall(tc ToolCall, toolDefs []ToolDefinition) ToolCallValidationResult {
+	result := ToolCallValidationResult{
+		ToolName: tc.Name,
+	}
+
+	def, ok := lookupToolDefinition(toolDefs, tc.Name)
+	if !ok {
+		result.Reason = fmt.Sprintf("unknown tool %q", tc.Name)
+		return result
+	}
+
+	args := map[string]interface{}{}
+	raw := strings.TrimSpace(tc.Arguments)
+	if raw != "" && raw != "{}" {
+		if err := json.Unmarshal([]byte(raw), &args); err != nil {
+			result.Reason = fmt.Sprintf("invalid JSON arguments: %v", err)
+			return result
+		}
+	}
+
+	if hasEmbeddedResult(args) {
+		result.Reason = "embedded result field is not allowed in tool arguments"
+		return result
+	}
+
+	if reason := validateObjectAgainstSchema(args, def.InputSchema, ""); reason != "" {
+		result.Reason = reason
+		return result
+	}
+
+	result.Valid = true
+	return result
+}
+
 // RunToolLoop executes the kernel tool loop.
 // Given a CompletionResponse with tool_calls, it:
 // 1. Separates kernel tools from client tools
@@ -241,10 +329,73 @@ func RunToolLoop(
 			return resp, clientToolCalls, nil
 		}
 
+		// Add the assistant message with tool calls to the conversation.
+		assistantMsg := ProviderMessage{
+			Role:      "assistant",
+			ToolCalls: resp.ToolCalls,
+		}
+		if resp.Content != "" {
+			assistantMsg.Content = resp.Content
+		}
+		req.Messages = append(req.Messages, assistantMsg)
+
+		var cfg *Config
+		if registry != nil {
+			cfg = registry.cfg
+		}
+		if toolCallValidationEnabled(provider, cfg) {
+			toolDefs := make([]ToolDefinition, 0, len(req.Tools))
+			toolDefs = append(toolDefs, req.Tools...)
+			if registry != nil {
+				toolDefs = append(toolDefs, registry.Definitions()...)
+			}
+
+			var rejected []ToolCallValidationResult
+			for _, tc := range resp.ToolCalls {
+				validation := ValidateToolCall(tc, toolDefs)
+				if validation.Valid {
+					continue
+				}
+
+				rejected = append(rejected, validation)
+				recordToolCallRejection(provider.Name())
+				if registry != nil {
+					registry.logRejectedToolCall(provider.Name(), tc, validation)
+				}
+				slog.Warn("tool_loop: rejected tool call",
+					"provider", provider.Name(),
+					"tool", tc.Name,
+					"reason", validation.Reason,
+					"iteration", i+1,
+				)
+			}
+
+			if len(rejected) > 0 {
+				req.Messages = append(req.Messages, ProviderMessage{
+					Role:    "system",
+					Content: fmt.Sprintf("Tool call rejected: %s. Please try again with valid parameters.", rejected[0].Reason),
+				})
+
+				var err error
+				resp, err = provider.Complete(ctx, req)
+				if err != nil {
+					return nil, clientToolCalls, fmt.Errorf("tool_loop re-call after rejection: %w", err)
+				}
+
+				slog.Info("tool_loop: provider re-called after tool rejection",
+					"iteration", i+1,
+					"rejected", len(rejected),
+					"tool_calls", len(resp.ToolCalls),
+					"has_content", resp.Content != "",
+				)
+				continue
+			}
+		}
+
 		// Separate kernel vs client tool calls.
 		var kernelCalls []ToolCall
 		for _, tc := range resp.ToolCalls {
-			if registry.IsKernelTool(tc.Name) {
+			if registry != nil && registry.IsKernelTool(tc.Name) {
 				kernelCalls = append(kernelCalls, tc)
 			} else {
 				clientToolCalls = append(clientToolCalls, tc)
@@ -255,16 +406,6 @@ func RunToolLoop(
 		if len(kernelCalls) == 0 {
 			return resp, clientToolCalls, nil
 		}
-
-		// Add the assistant message with tool calls to the conversation.
-		assistantMsg := ProviderMessage{
-			Role:      "assistant",
-			ToolCalls: resp.ToolCalls,
-		}
-		if resp.Content != "" {
-			assistantMsg.Content = resp.Content
-		}
-		req.Messages = append(req.Messages, assistantMsg)
 
 		// Execute kernel tools and add results.
 		for _, tc := range kernelCalls {
@@ -411,5 +552,159 @@ func makeExecutor[In any](mcpSrv *MCPServer, handler func(context.Context, *mcp.
 			}
 		}
 		return "{}", nil
+	}
+}
+
+func lookupToolDefinition(toolDefs []ToolDefinition, name string) (ToolDefinition, bool) {
+	for i := len(toolDefs) - 1; i >= 0; i-- {
+		if toolDefs[i].Name == name {
+			return toolDefs[i], true
+		}
+	}
+	return ToolDefinition{}, false
+}
+
+func hasEmbeddedResult(args map[string]interface{}) bool {
+	for name := range args {
+		if strings.EqualFold(name, "result") {
+			return true
+		}
+	}
+	return false
+}
+
+func validateObjectAgainstSchema(args map[string]interface{}, schema map[string]interface{}, path string) string {
+	if len(schema) == 0 {
+		return ""
+	}
+
+	for _, required := range schemaStringSlice(schema["required"]) {
+		if _, ok := args[required]; !ok {
+			if path == "" {
+				return fmt.Sprintf("missing required parameter %q", required)
+			}
+			return fmt.Sprintf("missing required parameter %q in %s", required, path)
+		}
+	}
+
+	props, _ := schema["properties"].(map[string]interface{})
+	for name, value := range args {
+		propSchema, ok := props[name].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		fieldPath := name
+		if path != "" {
+			fieldPath = path + "." + name
+		}
+		if reason := validateValueAgainstSchema(value, propSchema, fieldPath); reason != "" {
+			return reason
+		}
+	}
+
+	return ""
+}
+
+func validateValueAgainstSchema(value interface{}, schema map[string]interface{}, path string) string {
+	if len(schema) == 0 {
+		return ""
+	}
+
+	typeName := schemaType(schema)
+	if typeName == "" {
+		if props, ok := schema["properties"].(map[string]interface{}); ok && len(props) > 0 {
+			typeName = "object"
+		}
+	}
+
+	switch typeName {
+	case "":
+		return ""
+	case "string":
+		if _, ok := value.(string); !ok {
+			return fmt.Sprintf("parameter %q must be string", path)
+		}
+	case "integer", "int":
+		if !isJSONInteger(value) {
+			return fmt.Sprintf("parameter %q must be integer", path)
+		}
+	case "number":
+		if !isJSONNumber(value) {
+			return fmt.Sprintf("parameter %q must be number", path)
+		}
+	case "boolean", "bool":
+		if _, ok := value.(bool); !ok {
+			return fmt.Sprintf("parameter %q must be boolean", path)
+		}
+	case "array":
+		items, ok := value.([]interface{})
+		if !ok {
+			return fmt.Sprintf("parameter %q must be array", path)
+		}
+		itemSchema, _ := schema["items"].(map[string]interface{})
+		for i, item := range items {
+			if reason := validateValueAgainstSchema(item, itemSchema, fmt.Sprintf("%s[%d]", path, i)); reason != "" {
+				return reason
+			}
+		}
+	case "object":
+		obj, ok := value.(map[string]interface{})
+		if !ok {
+			return fmt.Sprintf("parameter %q must be object", path)
+		}
+		return validateObjectAgainstSchema(obj, schema, path)
+	}
+
+	return ""
+}
+
+func schemaType(schema map[string]interface{}) string {
+	if raw, ok := schema["type"].(string); ok {
+		return raw
+	}
+	return ""
+}
+
+func schemaStringSlice(raw interface{}) []string {
+	switch v := raw.(type) {
+	case []string:
+		return append([]string(nil), v...)
+	case []interface{}:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func isJSONNumber(value interface{}) bool {
+	switch n := value.(type) {
+	case float64:
+		return true
+	case json.Number:
+		_, err := n.Float64()
+		return err == nil
+	default:
+		return false
+	}
+}
+
+func isJSONInteger(value interface{}) bool {
+	switch n := value.(type) {
+	case float64:
+		return n == float64(int64(n))
+	case json.Number:
+		if _, err := n.Int64(); err == nil {
+			return true
+		}
+		f, err := strconv.ParseFloat(n.String(), 64)
+		return err == nil && f == float64(int64(f))
+	default:
+		return false
 	}
 }

--- a/internal/engine/tool_loop_test.go
+++ b/internal/engine/tool_loop_test.go
@@ -4,6 +4,7 @@ package engine
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -50,6 +51,22 @@ func TestValidateToolCallMissingRequiredParam(t *testing.T) {
 	}
 	if result.Reason != `missing required parameter "query"` {
 		t.Fatalf("Reason = %q; want missing required parameter rejection", result.Reason)
+	}
+}
+
+func TestValidateToolCallWrongParamType(t *testing.T) {
+	t.Parallel()
+
+	result := ValidateToolCall(ToolCall{
+		Name:      "lookup",
+		Arguments: `{"query":123}`,
+	}, []ToolDefinition{testToolDefinition()})
+
+	if result.Valid {
+		t.Fatal("Valid = true; want false")
+	}
+	if result.Reason != `parameter "query" must be string` {
+		t.Fatalf("Reason = %q; want wrong parameter type rejection", result.Reason)
 	}
 }
 
@@ -142,6 +159,8 @@ func TestRunToolLoopRejectsInvalidToolCall(t *testing.T) {
 }
 
 func TestRunToolLoopSkipsValidationForTrustedProviders(t *testing.T) {
+	t.Parallel()
+
 	executed := 0
 	registry := &KernelToolRegistry{
 		cfg: &Config{
@@ -207,6 +226,58 @@ func TestRunToolLoopSkipsValidationForTrustedProviders(t *testing.T) {
 	}
 	if resp.Content != "tool completed" {
 		t.Fatalf("final content = %q; want tool completed", resp.Content)
+	}
+}
+
+func TestRunToolLoopTracksToolCallRejections(t *testing.T) {
+	providerName := "rejection-counter-provider"
+	toolCallRejectionsByProvider.Delete(providerName)
+	t.Cleanup(func() {
+		toolCallRejectionsByProvider.Delete(providerName)
+	})
+
+	registry := &KernelToolRegistry{
+		cfg: &Config{ToolCallValidationEnabled: true},
+	}
+	provider := &scriptedToolLoopProvider{
+		name: providerName,
+		caps: ProviderCapabilities{
+			Capabilities: []Capability{CapToolCallValidation},
+			IsLocal:      true,
+		},
+		responses: []*CompletionResponse{{
+			Content:    "retry succeeded",
+			StopReason: "end_turn",
+			ProviderMeta: ProviderMeta{
+				Provider: providerName,
+				Model:    "test",
+			},
+		}},
+	}
+
+	initial := &CompletionResponse{
+		ToolCalls: []ToolCall{{
+			ID:        "call-1",
+			Name:      "lookup",
+			Arguments: `{"query":"kernel"}`,
+		}},
+		StopReason: "tool_use",
+		ProviderMeta: ProviderMeta{
+			Provider: providerName,
+			Model:    "test",
+		},
+	}
+
+	if _, _, err := RunToolLoop(context.Background(), provider, &CompletionRequest{}, initial, registry); err != nil {
+		t.Fatalf("RunToolLoop: %v", err)
+	}
+
+	counter, ok := toolCallRejectionsByProvider.Load(providerName)
+	if !ok {
+		t.Fatalf("missing rejection counter for provider %q", providerName)
+	}
+	if got := counter.(*atomic.Int64).Load(); got != 1 {
+		t.Fatalf("rejection count = %d; want 1", got)
 	}
 }
 

--- a/internal/engine/tool_loop_test.go
+++ b/internal/engine/tool_loop_test.go
@@ -1,0 +1,267 @@
+//go:build mcpserver
+
+package engine
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestValidateToolCallValid(t *testing.T) {
+	t.Parallel()
+
+	result := ValidateToolCall(ToolCall{
+		Name:      "lookup",
+		Arguments: `{"query":"kernel"}`,
+	}, []ToolDefinition{testToolDefinition()})
+
+	if !result.Valid {
+		t.Fatalf("Valid = false; want true (reason: %s)", result.Reason)
+	}
+}
+
+func TestValidateToolCallUnknownTool(t *testing.T) {
+	t.Parallel()
+
+	result := ValidateToolCall(ToolCall{
+		Name:      "missing",
+		Arguments: `{"query":"kernel"}`,
+	}, []ToolDefinition{testToolDefinition()})
+
+	if result.Valid {
+		t.Fatal("Valid = true; want false")
+	}
+	if result.Reason != `unknown tool "missing"` {
+		t.Fatalf("Reason = %q; want unknown tool rejection", result.Reason)
+	}
+}
+
+func TestValidateToolCallMissingRequiredParam(t *testing.T) {
+	t.Parallel()
+
+	result := ValidateToolCall(ToolCall{
+		Name:      "lookup",
+		Arguments: `{}`,
+	}, []ToolDefinition{testToolDefinition()})
+
+	if result.Valid {
+		t.Fatal("Valid = true; want false")
+	}
+	if result.Reason != `missing required parameter "query"` {
+		t.Fatalf("Reason = %q; want missing required parameter rejection", result.Reason)
+	}
+}
+
+func TestValidateToolCallEmbeddedResult(t *testing.T) {
+	t.Parallel()
+
+	result := ValidateToolCall(ToolCall{
+		Name:      "lookup",
+		Arguments: `{"query":"kernel","result":"fabricated"}`,
+	}, []ToolDefinition{testToolDefinition()})
+
+	if result.Valid {
+		t.Fatal("Valid = true; want false")
+	}
+	if result.Reason != "embedded result field is not allowed in tool arguments" {
+		t.Fatalf("Reason = %q; want embedded result rejection", result.Reason)
+	}
+}
+
+func TestRunToolLoopRejectsInvalidToolCall(t *testing.T) {
+	root := makeWorkspace(t)
+	registry := &KernelToolRegistry{
+		cfg: &Config{
+			WorkspaceRoot:             root,
+			CogDir:                    root + "/.cog",
+			ToolCallValidationEnabled: true,
+		},
+		definitions: []ToolDefinition{testToolDefinition()},
+		executors: map[string]toolExecutor{
+			"lookup": func(context.Context, string) (string, error) {
+				t.Fatal("executor should not run for rejected tool call")
+				return "", nil
+			},
+		},
+	}
+
+	provider := &scriptedToolLoopProvider{
+		name: "validator-provider",
+		caps: ProviderCapabilities{
+			Capabilities: []Capability{CapToolCallValidation},
+			IsLocal:      true,
+		},
+		responses: []*CompletionResponse{{
+			Content:    "retry succeeded",
+			StopReason: "end_turn",
+			ProviderMeta: ProviderMeta{
+				Provider: "validator-provider",
+				Model:    "test",
+			},
+		}},
+	}
+
+	req := &CompletionRequest{}
+	initial := &CompletionResponse{
+		ToolCalls: []ToolCall{{
+			ID:        "call-1",
+			Name:      "lookup",
+			Arguments: `{"query":"kernel","result":"fabricated"}`,
+		}},
+		StopReason: "tool_use",
+		ProviderMeta: ProviderMeta{
+			Provider: "validator-provider",
+			Model:    "test",
+		},
+	}
+
+	resp, clientCalls, err := RunToolLoop(context.Background(), provider, req, initial, registry)
+	if err != nil {
+		t.Fatalf("RunToolLoop: %v", err)
+	}
+	if len(clientCalls) != 0 {
+		t.Fatalf("clientCalls len = %d; want 0", len(clientCalls))
+	}
+	if resp.Content != "retry succeeded" {
+		t.Fatalf("final content = %q; want retry succeeded", resp.Content)
+	}
+	if len(provider.requests) != 1 {
+		t.Fatalf("provider recalls = %d; want 1", len(provider.requests))
+	}
+	if len(provider.requests[0].Messages) != 2 {
+		t.Fatalf("messages sent on retry = %d; want 2", len(provider.requests[0].Messages))
+	}
+	if provider.requests[0].Messages[1].Role != "system" {
+		t.Fatalf("retry message role = %q; want system", provider.requests[0].Messages[1].Role)
+	}
+	want := "Tool call rejected: embedded result field is not allowed in tool arguments. Please try again with valid parameters."
+	if provider.requests[0].Messages[1].Content != want {
+		t.Fatalf("retry message = %q; want %q", provider.requests[0].Messages[1].Content, want)
+	}
+}
+
+func TestRunToolLoopSkipsValidationForTrustedProviders(t *testing.T) {
+	executed := 0
+	registry := &KernelToolRegistry{
+		cfg: &Config{
+			ToolCallValidationEnabled: true,
+		},
+		definitions: []ToolDefinition{testToolDefinition()},
+		executors: map[string]toolExecutor{
+			"lookup": func(_ context.Context, arguments string) (string, error) {
+				executed++
+				return `{"ok":true}`, nil
+			},
+		},
+	}
+
+	provider := &scriptedToolLoopProvider{
+		name: "trusted-provider",
+		caps: ProviderCapabilities{
+			Capabilities: []Capability{CapToolUse, CapToolCallValidation},
+			IsLocal:      true,
+		},
+		responses: []*CompletionResponse{{
+			Content:    "tool completed",
+			StopReason: "end_turn",
+			ProviderMeta: ProviderMeta{
+				Provider: "trusted-provider",
+				Model:    "test",
+			},
+		}},
+	}
+
+	req := &CompletionRequest{}
+	initial := &CompletionResponse{
+		ToolCalls: []ToolCall{{
+			ID:        "call-1",
+			Name:      "lookup",
+			Arguments: `{"query":"kernel","result":"fabricated"}`,
+		}},
+		StopReason: "tool_use",
+		ProviderMeta: ProviderMeta{
+			Provider: "trusted-provider",
+			Model:    "test",
+		},
+	}
+
+	resp, clientCalls, err := RunToolLoop(context.Background(), provider, req, initial, registry)
+	if err != nil {
+		t.Fatalf("RunToolLoop: %v", err)
+	}
+	if len(clientCalls) != 0 {
+		t.Fatalf("clientCalls len = %d; want 0", len(clientCalls))
+	}
+	if executed != 1 {
+		t.Fatalf("executor ran %d times; want 1", executed)
+	}
+	if len(provider.requests) != 1 {
+		t.Fatalf("provider recalls = %d; want 1", len(provider.requests))
+	}
+	if len(provider.requests[0].Messages) != 2 {
+		t.Fatalf("messages sent on retry = %d; want 2", len(provider.requests[0].Messages))
+	}
+	if provider.requests[0].Messages[1].Role != "tool" {
+		t.Fatalf("second message role = %q; want tool", provider.requests[0].Messages[1].Role)
+	}
+	if resp.Content != "tool completed" {
+		t.Fatalf("final content = %q; want tool completed", resp.Content)
+	}
+}
+
+func testToolDefinition() ToolDefinition {
+	return ToolDefinition{
+		Name: "lookup",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"query": map[string]interface{}{
+					"type": "string",
+				},
+			},
+			"required": []string{"query"},
+		},
+	}
+}
+
+type scriptedToolLoopProvider struct {
+	name      string
+	caps      ProviderCapabilities
+	responses []*CompletionResponse
+	requests  []*CompletionRequest
+}
+
+func (p *scriptedToolLoopProvider) Complete(_ context.Context, req *CompletionRequest) (*CompletionResponse, error) {
+	clone := *req
+	clone.Messages = append([]ProviderMessage(nil), req.Messages...)
+	p.requests = append(p.requests, &clone)
+
+	if len(p.responses) == 0 {
+		return &CompletionResponse{
+			StopReason: "end_turn",
+			ProviderMeta: ProviderMeta{
+				Provider: p.name,
+				Model:    "test",
+			},
+		}, nil
+	}
+
+	resp := p.responses[0]
+	p.responses = p.responses[1:]
+	return resp, nil
+}
+
+func (p *scriptedToolLoopProvider) Stream(context.Context, *CompletionRequest) (<-chan StreamChunk, error) {
+	ch := make(chan StreamChunk)
+	close(ch)
+	return ch, nil
+}
+
+func (p *scriptedToolLoopProvider) Name() string { return p.name }
+
+func (p *scriptedToolLoopProvider) Available(context.Context) bool { return true }
+
+func (p *scriptedToolLoopProvider) Capabilities() ProviderCapabilities { return p.caps }
+
+func (p *scriptedToolLoopProvider) Ping(context.Context) (time.Duration, error) { return 0, nil }


### PR DESCRIPTION
## Summary

Complete implementation of the CogOS externalized attention and executive function modulation (EA/EFM) architecture across 10 commits:

- **Kernel bug fixes**: Turn-pair eviction, precision token estimation (rune-aware + iris pressure), keyword-anywhere intent extraction
- **Gemma 4 E4B**: Default local model with model profiles, CapToolCallValidation capability
- **Tool-call hallucination gate**: "Model proposes, runtime disposes" — validates tool calls before execution, proprioceptive logging, per-provider rejection tracking
- **Digestion pipeline**: StreamTailer + FileWatcher + Claude Code/OpenClaw JSONL adapters, wired into process loop (state-gated)
- **Memory consolidation**: ConsolidationAction during Dormant state + archive eviction policy
- **Constellation bridge**: ConstellationBridge interface + NilBridge + SyncWatcher for BEP-synced blocks
- **Comprehensive test suite**: 35+ new tests across all subsystems
- **E2E test plan**: 5-scenario spec (standalone, Gemma 4, digestion, constellation, full stack)
- **README**: Reframed with EA/EFM thesis + ecosystem overview

## Test plan

- [x] `go build ./...` passes
- [x] All new tests pass (`go test ./internal/engine/... -short`)
- [x] Pre-existing `TestClaudeCodeBuildPromptIncludesMultipleUserTurns` failure is unchanged (not caused by these changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code) + [Codex](https://codex.openai.com)