### PR TITLE
feat(engine): expose hash-chained ledger via MCP tool and HTTP endpoint

### DIFF
--- a/internal/engine/ledger_query.go
+++ b/internal/engine/ledger_query.go
@@ -1,0 +1,340 @@
+// ledger_query.go — read-side query API for the hash-chained event ledger.
+//
+// The write side (AppendEvent, CanonicalizeEvent, HashEvent) lives in ledger.go.
+// This file exposes filtered reads for MCP tools and HTTP endpoints without
+// reimplementing any of the canonicalization or hashing logic.
+package engine
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ErrSessionNotFound is returned when QueryLedger is scoped to a session that
+// has no events.jsonl on disk. Handlers map it to HTTP 404.
+var ErrSessionNotFound = errors.New("ledger: session not found")
+
+// ErrAfterSeqRequiresSession is returned when after_seq is set without
+// session_id. Cross-session sequence numbers are not monotonic so paginating
+// by seq only makes sense within a single session.
+var ErrAfterSeqRequiresSession = errors.New("ledger: after_seq requires session_id")
+
+// LedgerQuery selects and filters events. All fields are optional.
+type LedgerQuery struct {
+	SessionID      string // filter to a single session (empty = all sessions)
+	EventType      string // exact match, or "prefix.*" wildcard
+	AfterSeq       int64  // return events with seq > this (requires SessionID)
+	SinceTimestamp string // RFC3339; return events with timestamp >= this
+	Limit          int    // default 100, capped at 1000
+	VerifyChain    bool   // recompute hashes + validate prior_hash links
+}
+
+// LedgerEvent is the public JSON shape for a returned event. It flattens the
+// internal EventEnvelope so clients don't need to know about the two-level
+// hashed_payload/metadata split.
+type LedgerEvent struct {
+	Type      string                 `json:"type"`
+	Timestamp string                 `json:"timestamp"`
+	SessionID string                 `json:"session_id"`
+	Seq       int64                  `json:"seq"`
+	Hash      string                 `json:"hash"`
+	PriorHash string                 `json:"prior_hash,omitempty"`
+	Source    string                 `json:"source,omitempty"`
+	Data      map[string]interface{} `json:"data,omitempty"`
+}
+
+// LedgerVerification reports the result of optional chain verification.
+// When requested=false, only `requested` is meaningful.
+type LedgerVerification struct {
+	Requested          bool     `json:"requested"`
+	TotalChecked       int      `json:"total_checked"`
+	Valid              bool     `json:"valid"`
+	FirstBrokenSeq     int64    `json:"first_broken_seq,omitempty"`
+	FirstBrokenSession string   `json:"first_broken_session,omitempty"`
+	Errors             []string `json:"errors,omitempty"`
+}
+
+// LedgerQueryResult is the QueryLedger output.
+type LedgerQueryResult struct {
+	Count        int                `json:"count"`
+	Events       []LedgerEvent      `json:"events"`
+	NextAfterSeq int64              `json:"next_after_seq,omitempty"`
+	Truncated    bool               `json:"truncated"`
+	Verification LedgerVerification `json:"verification"`
+}
+
+const (
+	defaultLedgerLimit = 100
+	maxLedgerLimit     = 1000
+	ledgerScanBufSize  = 1 << 20 // 1 MiB per line, matches readLastJSONLEntries
+)
+
+// QueryLedger reads the hash-chained ledger under workspaceRoot and returns
+// events matching q. It never reimplements hashing — verification, when
+// requested, recomputes hashes via CanonicalizeEvent + HashEvent.
+//
+// Ordering:
+//   - Single-session query: ascending seq (file order).
+//   - Multi-session query: session mtime desc, then intra-session ascending seq.
+func QueryLedger(workspaceRoot string, q LedgerQuery) (*LedgerQueryResult, error) {
+	limit := q.Limit
+	if limit <= 0 {
+		limit = defaultLedgerLimit
+	}
+	if limit > maxLedgerLimit {
+		limit = maxLedgerLimit
+	}
+
+	if q.AfterSeq > 0 && q.SessionID == "" {
+		return nil, ErrAfterSeqRequiresSession
+	}
+
+	var sinceTime time.Time
+	var haveSince bool
+	if q.SinceTimestamp != "" {
+		ts, err := time.Parse(time.RFC3339, q.SinceTimestamp)
+		if err != nil {
+			return nil, fmt.Errorf("ledger: parse since_timestamp: %w", err)
+		}
+		sinceTime = ts
+		haveSince = true
+	}
+
+	typeMatch, err := compileEventTypeMatcher(q.EventType)
+	if err != nil {
+		return nil, err
+	}
+
+	sessions, err := listLedgerSessions(workspaceRoot, q.SessionID)
+	if err != nil {
+		return nil, err
+	}
+	if q.SessionID != "" && len(sessions) == 0 {
+		return nil, ErrSessionNotFound
+	}
+
+	hashAlg := GetHashAlgorithm(workspaceRoot)
+
+	result := &LedgerQueryResult{
+		Events:       []LedgerEvent{},
+		Verification: LedgerVerification{Requested: q.VerifyChain},
+	}
+
+	chainValid := true
+
+readLoop:
+	for _, sid := range sessions {
+		path := filepath.Join(workspaceRoot, ".cog", "ledger", sid, "events.jsonl")
+		f, err := os.Open(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("ledger: open %s: %w", sid, err)
+		}
+
+		scanner := bufio.NewScanner(f)
+		scanner.Buffer(make([]byte, 0, 64*1024), ledgerScanBufSize)
+
+		var lastHash string // chain cursor — advances on every parsed line, even filtered-out
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			if len(line) == 0 {
+				continue
+			}
+
+			var env EventEnvelope
+			if err := json.Unmarshal(line, &env); err != nil {
+				// Malformed line: note it under errors but keep going so the
+				// rest of the file remains visible. We can't verify the chain
+				// past this point, but we don't want to hide data.
+				if q.VerifyChain {
+					result.Verification.Errors = append(result.Verification.Errors,
+						fmt.Sprintf("session=%s: unmarshal line: %v", sid, err))
+					chainValid = false
+					if result.Verification.FirstBrokenSession == "" {
+						result.Verification.FirstBrokenSession = sid
+					}
+				}
+				continue
+			}
+
+			if q.VerifyChain {
+				result.Verification.TotalChecked++
+				if vErr := verifyEventAgainstChain(&env, lastHash, hashAlg); vErr != nil {
+					if chainValid {
+						result.Verification.FirstBrokenSeq = env.Metadata.Seq
+						result.Verification.FirstBrokenSession = sid
+					}
+					chainValid = false
+					result.Verification.Errors = append(result.Verification.Errors,
+						fmt.Sprintf("session=%s seq=%d: %v", sid, env.Metadata.Seq, vErr))
+				}
+			}
+
+			// Advance the chain cursor regardless of whether this event
+			// survives filtering — prior_hash linkage must stay accurate.
+			lastHash = env.Metadata.Hash
+
+			// Apply filters.
+			if typeMatch != nil && !typeMatch(env.HashedPayload.Type) {
+				continue
+			}
+			if q.AfterSeq > 0 && env.Metadata.Seq <= q.AfterSeq {
+				continue
+			}
+			if haveSince {
+				ts, err := time.Parse(time.RFC3339, env.HashedPayload.Timestamp)
+				if err != nil || ts.Before(sinceTime) {
+					continue
+				}
+			}
+
+			result.Events = append(result.Events, envelopeToLedgerEvent(&env))
+			if len(result.Events) >= limit {
+				result.Truncated = true
+				f.Close()
+				break readLoop
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			f.Close()
+			return nil, fmt.Errorf("ledger: scan %s: %w", sid, err)
+		}
+		f.Close()
+	}
+
+	result.Count = len(result.Events)
+	if q.VerifyChain {
+		result.Verification.Valid = chainValid
+	}
+	if q.SessionID != "" && len(result.Events) > 0 {
+		result.NextAfterSeq = result.Events[len(result.Events)-1].Seq
+	}
+
+	return result, nil
+}
+
+// envelopeToLedgerEvent flattens the on-disk envelope into the public shape.
+func envelopeToLedgerEvent(env *EventEnvelope) LedgerEvent {
+	return LedgerEvent{
+		Type:      env.HashedPayload.Type,
+		Timestamp: env.HashedPayload.Timestamp,
+		SessionID: env.HashedPayload.SessionID,
+		Seq:       env.Metadata.Seq,
+		Hash:      env.Metadata.Hash,
+		PriorHash: env.HashedPayload.PriorHash,
+		Source:    env.Metadata.Source,
+		Data:      env.HashedPayload.Data,
+	}
+}
+
+// verifyEventAgainstChain recomputes the canonical hash for env and checks
+// both that metadata.hash matches and that hashed_payload.prior_hash == the
+// previous event's hash (lastHash). Returns nil if the event is valid.
+func verifyEventAgainstChain(env *EventEnvelope, lastHash, hashAlg string) error {
+	canonical, err := CanonicalizeEvent(&env.HashedPayload)
+	if err != nil {
+		return fmt.Errorf("canonicalize: %w", err)
+	}
+	computed, err := HashEvent(canonical, hashAlg)
+	if err != nil {
+		return fmt.Errorf("hash: %w", err)
+	}
+	if computed != env.Metadata.Hash {
+		return fmt.Errorf("hash mismatch: computed=%s stored=%s", computed, env.Metadata.Hash)
+	}
+	if env.HashedPayload.PriorHash != lastHash {
+		return fmt.Errorf("prior_hash mismatch: stored=%s expected=%s",
+			env.HashedPayload.PriorHash, lastHash)
+	}
+	return nil
+}
+
+// compileEventTypeMatcher returns a predicate over event type strings.
+// An empty pattern matches everything. A trailing ".*" (or bare "*") acts as
+// a prefix wildcard; anything else is an exact match.
+func compileEventTypeMatcher(pattern string) (func(string) bool, error) {
+	if pattern == "" {
+		return nil, nil
+	}
+	if pattern == "*" {
+		return func(string) bool { return true }, nil
+	}
+	if strings.HasSuffix(pattern, ".*") {
+		prefix := strings.TrimSuffix(pattern, ".*")
+		if prefix == "" {
+			return func(string) bool { return true }, nil
+		}
+		// Match "prefix" itself or "prefix.<anything>" — callers expect
+		// "attention.*" to catch "attention.boost" and friends.
+		return func(t string) bool {
+			return t == prefix || strings.HasPrefix(t, prefix+".")
+		}, nil
+	}
+	exact := pattern
+	return func(t string) bool { return t == exact }, nil
+}
+
+// listLedgerSessions returns the session IDs to scan, in the order to scan
+// them. If filter is non-empty, returns just that session (iff its
+// events.jsonl exists). Otherwise returns all non-genesis sessions sorted by
+// events.jsonl mtime descending — "what happened recently" first.
+func listLedgerSessions(workspaceRoot, filter string) ([]string, error) {
+	base := filepath.Join(workspaceRoot, ".cog", "ledger")
+
+	if filter != "" {
+		eventsPath := filepath.Join(base, filter, "events.jsonl")
+		if _, err := os.Stat(eventsPath); err != nil {
+			if os.IsNotExist(err) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("ledger: stat %s: %w", filter, err)
+		}
+		return []string{filter}, nil
+	}
+
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("ledger: read %s: %w", base, err)
+	}
+
+	type sessionMtime struct {
+		id    string
+		mtime int64
+	}
+	var sessions []sessionMtime
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if e.Name() == "genesis" {
+			continue
+		}
+		eventsPath := filepath.Join(base, e.Name(), "events.jsonl")
+		info, err := os.Stat(eventsPath)
+		if err != nil {
+			continue
+		}
+		sessions = append(sessions, sessionMtime{id: e.Name(), mtime: info.ModTime().UnixNano()})
+	}
+	sort.Slice(sessions, func(i, j int) bool {
+		return sessions[i].mtime > sessions[j].mtime
+	})
+
+	out := make([]string, len(sessions))
+	for i, s := range sessions {
+		out[i] = s.id
+	}
+	return out, nil
+}

--- a/internal/engine/ledger_query_test.go
+++ b/internal/engine/ledger_query_test.go
@@ -1,0 +1,585 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ── Fixture helpers ────────────────────────────────────────────────────────
+
+// appendTestEvent writes a real, hash-chained event via AppendEvent. The
+// caller controls the type and data; timestamp defaults to now unless
+// supplied via ts.
+func appendTestEvent(t *testing.T, root, sessionID, evtType string, data map[string]interface{}, ts string) *EventEnvelope {
+	t.Helper()
+	env := &EventEnvelope{
+		HashedPayload: EventPayload{
+			Type:      evtType,
+			Timestamp: ts,
+			SessionID: sessionID,
+			Data:      data,
+		},
+		Metadata: EventMetadata{Source: "test"},
+	}
+	if ts == "" {
+		env.HashedPayload.Timestamp = nowISO()
+	}
+	if err := AppendEvent(root, sessionID, env); err != nil {
+		t.Fatalf("AppendEvent %s/%s: %v", sessionID, evtType, err)
+	}
+	return env
+}
+
+// readRawEventLines returns the on-disk JSONL lines verbatim.
+func readRawEventLines(t *testing.T, root, sessionID string) []string {
+	t.Helper()
+	path := filepath.Join(root, ".cog", "ledger", sessionID, "events.jsonl")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	raw := strings.Split(strings.TrimRight(string(b), "\n"), "\n")
+	return raw
+}
+
+// overwriteEventsFile writes the given JSONL lines back to disk (tests use
+// this to simulate tampering).
+func overwriteEventsFile(t *testing.T, root, sessionID string, lines []string) {
+	t.Helper()
+	path := filepath.Join(root, ".cog", "ledger", sessionID, "events.jsonl")
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0644); err != nil {
+		t.Fatalf("overwrite %s: %v", path, err)
+	}
+}
+
+// ── QueryLedger tests ──────────────────────────────────────────────────────
+
+func TestQueryLedgerEmpty(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	result, err := QueryLedger(root, LedgerQuery{})
+	if err != nil {
+		t.Fatalf("QueryLedger: %v", err)
+	}
+	if result.Count != 0 {
+		t.Errorf("Count = %d; want 0", result.Count)
+	}
+	if len(result.Events) != 0 {
+		t.Errorf("events len = %d; want 0", len(result.Events))
+	}
+	if result.Truncated {
+		t.Errorf("Truncated = true; want false")
+	}
+	if result.Verification.Requested {
+		t.Errorf("Verification.Requested = true; want false")
+	}
+}
+
+func TestQueryLedgerSingleSession(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	sid := "session-single"
+
+	appendTestEvent(t, root, sid, "process.start", nil, "")
+	appendTestEvent(t, root, sid, "attention.boost", map[string]interface{}{"weight": 1.0}, "")
+	appendTestEvent(t, root, sid, "insight.captured", map[string]interface{}{"summary": "hi"}, "")
+
+	result, err := QueryLedger(root, LedgerQuery{SessionID: sid})
+	if err != nil {
+		t.Fatalf("QueryLedger: %v", err)
+	}
+	if result.Count != 3 {
+		t.Errorf("Count = %d; want 3", result.Count)
+	}
+	// Intra-session events are ascending by seq.
+	for i, ev := range result.Events {
+		if ev.Seq != int64(i+1) {
+			t.Errorf("events[%d].Seq = %d; want %d", i, ev.Seq, i+1)
+		}
+		if ev.SessionID != sid {
+			t.Errorf("events[%d].SessionID = %q; want %q", i, ev.SessionID, sid)
+		}
+		if ev.Hash == "" {
+			t.Errorf("events[%d].Hash empty", i)
+		}
+	}
+	if result.NextAfterSeq != 3 {
+		t.Errorf("NextAfterSeq = %d; want 3", result.NextAfterSeq)
+	}
+}
+
+func TestQueryLedgerMultiSessionOrdering(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	// Session A first (older), then session B (newer) — mtime desc means B first.
+	appendTestEvent(t, root, "sess-a", "a.one", nil, "")
+	// Nudge mtime so the ordering is deterministic.
+	timeA := time.Now().Add(-2 * time.Minute)
+	_ = os.Chtimes(filepath.Join(root, ".cog", "ledger", "sess-a", "events.jsonl"), timeA, timeA)
+	appendTestEvent(t, root, "sess-b", "b.one", nil, "")
+	appendTestEvent(t, root, "sess-b", "b.two", nil, "")
+	timeB := time.Now()
+	_ = os.Chtimes(filepath.Join(root, ".cog", "ledger", "sess-b", "events.jsonl"), timeB, timeB)
+
+	result, err := QueryLedger(root, LedgerQuery{})
+	if err != nil {
+		t.Fatalf("QueryLedger: %v", err)
+	}
+	if result.Count != 3 {
+		t.Fatalf("Count = %d; want 3", result.Count)
+	}
+	// Expect sess-b events first (newer mtime), then sess-a.
+	if result.Events[0].SessionID != "sess-b" {
+		t.Errorf("events[0].SessionID = %q; want sess-b", result.Events[0].SessionID)
+	}
+	if result.Events[2].SessionID != "sess-a" {
+		t.Errorf("events[2].SessionID = %q; want sess-a", result.Events[2].SessionID)
+	}
+	// next_after_seq is only set for single-session queries.
+	if result.NextAfterSeq != 0 {
+		t.Errorf("NextAfterSeq = %d; want 0 (unset for multi-session)", result.NextAfterSeq)
+	}
+}
+
+func TestQueryLedgerFilterByTypeExact(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	sid := "session-filter-exact"
+	appendTestEvent(t, root, sid, "attention.boost", nil, "")
+	appendTestEvent(t, root, sid, "insight.captured", nil, "")
+	appendTestEvent(t, root, sid, "attention.boost", nil, "")
+
+	result, err := QueryLedger(root, LedgerQuery{SessionID: sid, EventType: "attention.boost"})
+	if err != nil {
+		t.Fatalf("QueryLedger: %v", err)
+	}
+	if result.Count != 2 {
+		t.Fatalf("Count = %d; want 2", result.Count)
+	}
+	for _, ev := range result.Events {
+		if ev.Type != "attention.boost" {
+			t.Errorf("event.Type = %q; want attention.boost", ev.Type)
+		}
+	}
+}
+
+func TestQueryLedgerFilterByTypeWildcard(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	sid := "session-filter-wild"
+	appendTestEvent(t, root, sid, "attention.boost", nil, "")
+	appendTestEvent(t, root, sid, "attention.decay", nil, "")
+	appendTestEvent(t, root, sid, "insight.captured", nil, "")
+
+	result, err := QueryLedger(root, LedgerQuery{SessionID: sid, EventType: "attention.*"})
+	if err != nil {
+		t.Fatalf("QueryLedger: %v", err)
+	}
+	if result.Count != 2 {
+		t.Fatalf("Count = %d; want 2", result.Count)
+	}
+	for _, ev := range result.Events {
+		if !strings.HasPrefix(ev.Type, "attention") {
+			t.Errorf("event.Type = %q; want attention.*", ev.Type)
+		}
+	}
+}
+
+func TestQueryLedgerAfterSeqPagination(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	sid := "session-paginate"
+	for i := 0; i < 5; i++ {
+		appendTestEvent(t, root, sid, fmt.Sprintf("e.%d", i), nil, "")
+	}
+
+	result, err := QueryLedger(root, LedgerQuery{SessionID: sid, AfterSeq: 2})
+	if err != nil {
+		t.Fatalf("QueryLedger: %v", err)
+	}
+	if result.Count != 3 {
+		t.Fatalf("Count = %d; want 3", result.Count)
+	}
+	if result.Events[0].Seq != 3 {
+		t.Errorf("events[0].Seq = %d; want 3", result.Events[0].Seq)
+	}
+	if result.NextAfterSeq != 5 {
+		t.Errorf("NextAfterSeq = %d; want 5", result.NextAfterSeq)
+	}
+}
+
+func TestQueryLedgerAfterSeqRequiresSessionID(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	_, err := QueryLedger(root, LedgerQuery{AfterSeq: 5})
+	if !errors.Is(err, ErrAfterSeqRequiresSession) {
+		t.Fatalf("err = %v; want ErrAfterSeqRequiresSession", err)
+	}
+}
+
+func TestQueryLedgerSinceTimestamp(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	sid := "session-since"
+
+	// Use fixed timestamps so the filter is deterministic.
+	appendTestEvent(t, root, sid, "old.event", nil, "2024-01-01T00:00:00Z")
+	appendTestEvent(t, root, sid, "new.event", nil, "2026-06-01T00:00:00Z")
+	appendTestEvent(t, root, sid, "newer.event", nil, "2026-07-01T00:00:00Z")
+
+	result, err := QueryLedger(root, LedgerQuery{
+		SessionID:      sid,
+		SinceTimestamp: "2026-05-01T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("QueryLedger: %v", err)
+	}
+	if result.Count != 2 {
+		t.Fatalf("Count = %d; want 2", result.Count)
+	}
+	for _, ev := range result.Events {
+		if ev.Timestamp < "2026-05-01T00:00:00Z" {
+			t.Errorf("event.Timestamp = %q; should be >= 2026-05-01", ev.Timestamp)
+		}
+	}
+}
+
+func TestQueryLedgerSinceTimestampBadRFC3339(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	_, err := QueryLedger(root, LedgerQuery{SinceTimestamp: "not-a-date"})
+	if err == nil {
+		t.Fatal("expected error for malformed timestamp")
+	}
+	if !strings.Contains(err.Error(), "since_timestamp") {
+		t.Errorf("err = %v; want since_timestamp mention", err)
+	}
+}
+
+func TestQueryLedgerLimitAndTruncation(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	sid := "session-limit"
+	for i := 0; i < 10; i++ {
+		appendTestEvent(t, root, sid, fmt.Sprintf("e.%d", i), nil, "")
+	}
+
+	result, err := QueryLedger(root, LedgerQuery{SessionID: sid, Limit: 4})
+	if err != nil {
+		t.Fatalf("QueryLedger: %v", err)
+	}
+	if result.Count != 4 {
+		t.Errorf("Count = %d; want 4", result.Count)
+	}
+	if !result.Truncated {
+		t.Error("Truncated should be true")
+	}
+	if result.NextAfterSeq != 4 {
+		t.Errorf("NextAfterSeq = %d; want 4", result.NextAfterSeq)
+	}
+}
+
+func TestQueryLedgerVerifyChainValid(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	sid := "session-verify-good"
+	for i := 0; i < 3; i++ {
+		appendTestEvent(t, root, sid, fmt.Sprintf("e.%d", i), map[string]interface{}{"i": i}, "")
+	}
+
+	result, err := QueryLedger(root, LedgerQuery{SessionID: sid, VerifyChain: true})
+	if err != nil {
+		t.Fatalf("QueryLedger: %v", err)
+	}
+	if !result.Verification.Requested {
+		t.Error("Verification.Requested = false; want true")
+	}
+	if !result.Verification.Valid {
+		t.Errorf("Verification.Valid = false; errors=%v", result.Verification.Errors)
+	}
+	if result.Verification.TotalChecked != 3 {
+		t.Errorf("TotalChecked = %d; want 3", result.Verification.TotalChecked)
+	}
+	if len(result.Verification.Errors) != 0 {
+		t.Errorf("errors = %v; want empty", result.Verification.Errors)
+	}
+}
+
+func TestQueryLedgerVerifyChainBroken(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	sid := "session-verify-broken"
+	appendTestEvent(t, root, sid, "e.0", nil, "")
+	appendTestEvent(t, root, sid, "e.1", nil, "")
+	appendTestEvent(t, root, sid, "e.2", nil, "")
+
+	// Tamper with the middle event's stored hash.
+	lines := readRawEventLines(t, root, sid)
+	var env EventEnvelope
+	if err := json.Unmarshal([]byte(lines[1]), &env); err != nil {
+		t.Fatalf("unmarshal middle line: %v", err)
+	}
+	env.Metadata.Hash = "deadbeef" + env.Metadata.Hash[8:]
+	tampered, err := json.Marshal(&env)
+	if err != nil {
+		t.Fatalf("marshal tampered: %v", err)
+	}
+	lines[1] = string(tampered)
+	overwriteEventsFile(t, root, sid, lines)
+
+	result, err := QueryLedger(root, LedgerQuery{SessionID: sid, VerifyChain: true})
+	if err != nil {
+		t.Fatalf("QueryLedger: %v", err)
+	}
+	// Data is still returned — the ledger is tamper-evident, not tamper-censoring.
+	if result.Count != 3 {
+		t.Errorf("Count = %d; want 3 (data should still be returned)", result.Count)
+	}
+	if result.Verification.Valid {
+		t.Error("Verification.Valid = true; want false")
+	}
+	if result.Verification.FirstBrokenSeq != 2 {
+		t.Errorf("FirstBrokenSeq = %d; want 2", result.Verification.FirstBrokenSeq)
+	}
+	if result.Verification.FirstBrokenSession != sid {
+		t.Errorf("FirstBrokenSession = %q; want %q", result.Verification.FirstBrokenSession, sid)
+	}
+	if len(result.Verification.Errors) == 0 {
+		t.Error("expected at least one error entry")
+	}
+}
+
+func TestQueryLedgerMalformedJSONLine(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	sid := "session-malformed"
+	appendTestEvent(t, root, sid, "good.event.1", nil, "")
+	appendTestEvent(t, root, sid, "good.event.2", nil, "")
+
+	// Inject a malformed line between the two valid events.
+	lines := readRawEventLines(t, root, sid)
+	lines = []string{lines[0], "{not valid json", lines[1]}
+	overwriteEventsFile(t, root, sid, lines)
+
+	// Non-verify path: malformed line is skipped, valid events returned.
+	result, err := QueryLedger(root, LedgerQuery{SessionID: sid})
+	if err != nil {
+		t.Fatalf("QueryLedger: %v", err)
+	}
+	if result.Count != 2 {
+		t.Errorf("Count = %d; want 2 (malformed line skipped)", result.Count)
+	}
+
+	// Verify path: malformed line is flagged in errors and chain is invalid.
+	vResult, err := QueryLedger(root, LedgerQuery{SessionID: sid, VerifyChain: true})
+	if err != nil {
+		t.Fatalf("QueryLedger (verify): %v", err)
+	}
+	if vResult.Verification.Valid {
+		t.Error("Verification.Valid = true; want false (malformed line breaks chain)")
+	}
+	if len(vResult.Verification.Errors) == 0 {
+		t.Error("expected verification.Errors to contain the unmarshal failure")
+	}
+	// FirstBrokenSession should be set even though seq is unknown for the bad line.
+	if vResult.Verification.FirstBrokenSession != sid {
+		t.Errorf("FirstBrokenSession = %q; want %q", vResult.Verification.FirstBrokenSession, sid)
+	}
+}
+
+func TestQueryLedgerSessionNotFound(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	_, err := QueryLedger(root, LedgerQuery{SessionID: "does-not-exist"})
+	if !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("err = %v; want ErrSessionNotFound", err)
+	}
+}
+
+func TestQueryLedgerExcludesGenesis(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	// Create a genesis session that should be excluded from unscoped queries.
+	appendTestEvent(t, root, "genesis", "node.genesis", nil, "")
+	appendTestEvent(t, root, "real-session", "e.1", nil, "")
+
+	result, err := QueryLedger(root, LedgerQuery{})
+	if err != nil {
+		t.Fatalf("QueryLedger: %v", err)
+	}
+	for _, ev := range result.Events {
+		if ev.SessionID == "genesis" {
+			t.Errorf("unscoped query returned genesis event: %+v", ev)
+		}
+	}
+
+	// But genesis is reachable when explicitly requested.
+	scoped, err := QueryLedger(root, LedgerQuery{SessionID: "genesis"})
+	if err != nil {
+		t.Fatalf("QueryLedger(genesis): %v", err)
+	}
+	if scoped.Count == 0 {
+		t.Error("explicit genesis query returned no events")
+	}
+}
+
+// ── MCP tool roundtrip ─────────────────────────────────────────────────────
+
+func TestToolReadLedgerRoundtrip(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	process := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	server := NewMCPServer(cfg, makeNucleus("Cog", "tester"), process)
+
+	appendTestEvent(t, root, "sess-x", "attention.boost", map[string]interface{}{"weight": 0.5}, "")
+	appendTestEvent(t, root, "sess-x", "insight.captured", nil, "")
+
+	result, _, err := server.toolReadLedger(context.Background(), nil, readLedgerInput{
+		SessionID:   "sess-x",
+		VerifyChain: true,
+	})
+	if err != nil {
+		t.Fatalf("toolReadLedger: %v", err)
+	}
+
+	var decoded LedgerQueryResult
+	decodeMCPJSON(t, result, &decoded)
+	if decoded.Count != 2 {
+		t.Errorf("Count = %d; want 2", decoded.Count)
+	}
+	if !decoded.Verification.Valid {
+		t.Errorf("Verification.Valid = false; errors=%v", decoded.Verification.Errors)
+	}
+	if decoded.Events[0].Type != "attention.boost" {
+		t.Errorf("events[0].Type = %q; want attention.boost", decoded.Events[0].Type)
+	}
+}
+
+// ── HTTP handler shape ─────────────────────────────────────────────────────
+
+func TestHandleLedgerOK(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+	root := srv.cfg.WorkspaceRoot
+
+	appendTestEvent(t, root, "sess-http", "e.1", nil, "")
+	appendTestEvent(t, root, "sess-http", "e.2", nil, "")
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/ledger?session_id=sess-http&limit=5", nil)
+	w := httptest.NewRecorder()
+	srv.handleLedger(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200 (body=%s)", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type = %q; want application/json", ct)
+	}
+	var body LedgerQueryResult
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body.Count != 2 {
+		t.Errorf("Count = %d; want 2", body.Count)
+	}
+}
+
+func TestHandleLedgerBadFilter(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+
+	// after_seq without session_id.
+	req := httptest.NewRequest(http.MethodGet, "/v1/ledger?after_seq=5", nil)
+	w := httptest.NewRecorder()
+	srv.handleLedger(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("after_seq without session_id: status = %d; want 400", w.Code)
+	}
+
+	// Unparseable after_seq.
+	req = httptest.NewRequest(http.MethodGet, "/v1/ledger?session_id=s&after_seq=abc", nil)
+	w = httptest.NewRecorder()
+	srv.handleLedger(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("bad after_seq: status = %d; want 400", w.Code)
+	}
+
+	// Bad since_timestamp.
+	vals := url.Values{}
+	vals.Set("since_timestamp", "nope")
+	req = httptest.NewRequest(http.MethodGet, "/v1/ledger?"+vals.Encode(), nil)
+	w = httptest.NewRecorder()
+	srv.handleLedger(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("bad since_timestamp: status = %d; want 400", w.Code)
+	}
+}
+
+func TestHandleLedgerSessionNotFound(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/ledger?session_id=ghost", nil)
+	w := httptest.NewRecorder()
+	srv.handleLedger(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d; want 404 (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleLedgerBrokenChainStillReturns200(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+	root := srv.cfg.WorkspaceRoot
+	sid := "sess-broken"
+	appendTestEvent(t, root, sid, "e.1", nil, "")
+	appendTestEvent(t, root, sid, "e.2", nil, "")
+
+	// Tamper with the second event's stored hash.
+	lines := readRawEventLines(t, root, sid)
+	var env EventEnvelope
+	if err := json.Unmarshal([]byte(lines[1]), &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	env.Metadata.Hash = "dead" + env.Metadata.Hash[4:]
+	tampered, _ := json.Marshal(&env)
+	lines[1] = string(tampered)
+	overwriteEventsFile(t, root, sid, lines)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/ledger?session_id="+sid+"&verify_chain=true", nil)
+	w := httptest.NewRecorder()
+	srv.handleLedger(w, req)
+
+	// Status must be 200: the whole point of the tamper-evident ledger is
+	// surfacing the evidence, not hiding it behind an error code.
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200 (body=%s)", w.Code, w.Body.String())
+	}
+	var body LedgerQueryResult
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Verification.Valid {
+		t.Error("Verification.Valid = true; want false")
+	}
+	if body.Count != 2 {
+		t.Errorf("Count = %d; want 2 (data should still flow)", body.Count)
+	}
+}

--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -1,7 +1,7 @@
 // mcp_server.go — MCP Streamable HTTP server for CogOS v3
 //
 // Embeds the MCP server into the existing HTTP server at /mcp.
-// Registers 10 MCP tools and 3 MCP resources. Four former tools
+// Registers 11 MCP tools and 3 MCP resources. Four former tools
 // (resolve_uri, get_trust, get_nucleus, get_index) are no longer
 // registered as MCP tools but their implementations remain — used
 // by the internal tool loop (tool_loop.go).
@@ -120,6 +120,11 @@ func (m *MCPServer) registerTools() {
 		Name:        "cog_emit_event",
 		Description: "Emit a typed event to the workspace ledger. Events: attention.boost (uri + weight), session.marker (label), insight.captured (summary), decision.made (decision + rationale). Fallback: events are JSONL in .cog/ledger/",
 	}, m.toolEmitEvent)
+
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name:        "cog_read_ledger",
+		Description: "Read the hash-chained event ledger. Filter by session_id, event_type (exact or 'prefix.*' wildcard), after_seq (requires session_id), since_timestamp (RFC3339), or limit (default 100, max 1000). Set verify_chain=true to recompute hashes and validate prior_hash links. Fallback: cat .cog/ledger/<session_id>/events.jsonl",
+	}, m.toolReadLedger)
 
 	mcp.AddTool(m.server, &mcp.Tool{
 		Name:        "cog_ingest",
@@ -359,6 +364,15 @@ type readCogdocResult struct {
 type emitEventInput struct {
 	Type    string         `json:"type" jsonschema:"Event type: attention.boost, session.marker, insight.captured, decision.made"`
 	Payload map[string]any `json:"payload,omitempty" jsonschema:"Event payload. attention.boost: {uri, weight}. session.marker: {label}. insight.captured: {summary, tags}. decision.made: {decision, rationale}."`
+}
+
+type readLedgerInput struct {
+	SessionID      string `json:"session_id,omitempty" jsonschema:"Filter to a single session; empty reads across all non-genesis sessions"`
+	EventType      string `json:"event_type,omitempty" jsonschema:"Exact event type, or a prefix wildcard like 'attention.*'"`
+	AfterSeq       int64  `json:"after_seq,omitempty" jsonschema:"Return events with seq greater than this. Requires session_id (seq is not monotonic across sessions)."`
+	SinceTimestamp string `json:"since_timestamp,omitempty" jsonschema:"RFC3339 timestamp; return events with timestamp >= this"`
+	Limit          int    `json:"limit,omitempty" jsonschema:"Maximum events to return. Default 100, capped at 1000."`
+	VerifyChain    bool   `json:"verify_chain,omitempty" jsonschema:"Recompute hashes and validate prior_hash links on returned events. Off by default (chain walk is O(N))."`
 }
 
 // getIndexInput — no longer an MCP tool; used by the internal tool loop (tool_loop.go).
@@ -825,6 +839,23 @@ func (m *MCPServer) toolEmitEvent(ctx context.Context, req *mcp.CallToolRequest,
 		"emitted": true,
 		"type":    input.Type,
 	})
+}
+
+func (m *MCPServer) toolReadLedger(ctx context.Context, req *mcp.CallToolRequest, input readLedgerInput) (*mcp.CallToolResult, any, error) {
+	q := LedgerQuery{
+		SessionID:      input.SessionID,
+		EventType:      input.EventType,
+		AfterSeq:       input.AfterSeq,
+		SinceTimestamp: input.SinceTimestamp,
+		Limit:          input.Limit,
+		VerifyChain:    input.VerifyChain,
+	}
+	result, err := QueryLedger(m.cfg.WorkspaceRoot, q)
+	if err != nil {
+		return fallbackResult(fmt.Sprintf("read ledger failed: %v", err),
+			"ls .cog/ledger/ && cat .cog/ledger/<session_id>/events.jsonl")
+	}
+	return marshalResult(result)
 }
 
 // toolGetIndex — no longer registered as an MCP tool; used by the internal tool loop (tool_loop.go).

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -9,6 +9,7 @@
 //	POST /v1/messages                      — Anthropic Messages-compatible chat
 //	POST /v1/context/foveated              — foveated context assembly for Claude Code hook
 //	GET  /v1/proprioceptive                — last 50 proprioceptive log entries + light cone status
+//	GET  /v1/ledger                        — query the hash-chained event ledger
 //	GET  /v1/lightcone                     — light cone metadata (placeholder)
 //
 // Constellation / attention endpoints (Phase 3, see serve_attention.go):
@@ -25,6 +26,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -33,6 +35,8 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -67,6 +71,7 @@ func NewServer(cfg *Config, nucleus *Nucleus, process *Process) *Server {
 	mux.HandleFunc("POST /v1/chat/completions", s.handleChat)
 	mux.HandleFunc("POST /v1/messages", s.handleAnthropicMessages)
 	mux.HandleFunc("GET /v1/proprioceptive", s.handleProprioceptive)
+	mux.HandleFunc("GET /v1/ledger", s.handleLedger)
 	mux.HandleFunc("GET /v1/lightcone", s.handleLightCone)
 	mux.HandleFunc("POST /v1/context/foveated", s.handleFoveatedContext)
 
@@ -900,6 +905,85 @@ func (s *Server) handleProprioceptive(w http.ResponseWriter, r *http.Request) {
 		"entries":    entries,
 		"light_cone": lcStatus,
 	})
+}
+
+// handleLedger exposes QueryLedger over HTTP. Query params map 1:1 with the
+// MCP tool input.
+//
+//	GET /v1/ledger?session_id=…&event_type=…&after_seq=…&since_timestamp=…&limit=…&verify_chain=…
+//	200 → { count, events, truncated, verification, next_after_seq? }
+//	400 → malformed query (bad int, bad RFC3339, after_seq without session_id)
+//	404 → session_id specified but no events.jsonl found
+//	500 → read/JSON failure
+//
+// Returns 200 with verification.valid=false when the chain is broken but data
+// read succeeded — tamper evidence is the point of the ledger, so hiding data
+// behind 500 would defeat the purpose.
+func (s *Server) handleLedger(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	q := r.URL.Query()
+	query := LedgerQuery{
+		SessionID:      q.Get("session_id"),
+		EventType:      q.Get("event_type"),
+		SinceTimestamp: q.Get("since_timestamp"),
+	}
+	if v := q.Get("after_seq"); v != "" {
+		n, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			writeLedgerError(w, http.StatusBadRequest, fmt.Sprintf("after_seq: %v", err))
+			return
+		}
+		query.AfterSeq = n
+	}
+	if v := q.Get("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			writeLedgerError(w, http.StatusBadRequest, fmt.Sprintf("limit: %v", err))
+			return
+		}
+		if n < 0 {
+			writeLedgerError(w, http.StatusBadRequest, "limit must be non-negative")
+			return
+		}
+		query.Limit = n
+	}
+	if v := q.Get("verify_chain"); v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			writeLedgerError(w, http.StatusBadRequest, fmt.Sprintf("verify_chain: %v", err))
+			return
+		}
+		query.VerifyChain = b
+	}
+
+	result, err := QueryLedger(s.cfg.WorkspaceRoot, query)
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrAfterSeqRequiresSession):
+			writeLedgerError(w, http.StatusBadRequest, err.Error())
+		case errors.Is(err, ErrSessionNotFound):
+			writeLedgerError(w, http.StatusNotFound, err.Error())
+		default:
+			// Filter-parse errors from QueryLedger (e.g. bad since_timestamp)
+			// are user input problems. Everything else is a 500.
+			msg := err.Error()
+			if strings.Contains(msg, "since_timestamp") || strings.Contains(msg, "event_type") {
+				writeLedgerError(w, http.StatusBadRequest, msg)
+				return
+			}
+			writeLedgerError(w, http.StatusInternalServerError, msg)
+		}
+		return
+	}
+
+	_ = json.NewEncoder(w).Encode(result)
+}
+
+// writeLedgerError writes a JSON error response with the given status code.
+func writeLedgerError(w http.ResponseWriter, code int, msg string) {
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
 }
 
 // handleLightCone returns light cone metadata from the LightConeManager.


### PR DESCRIPTION
## Summary

Read side of the hash-chained event ledger — closes the #1 critical MCP blindspot from Agent F's surface audit. Write side (`AppendEvent`, canonicalization, hash chaining) was already battle-tested and is untouched by this PR; we're just exposing what exists.

## What landed

- **`internal/engine/ledger_query.go`** (340 LOC) — `QueryLedger(workspaceRoot, LedgerQuery) (*LedgerQueryResult, error)` with filters for `session_id`, `event_type` (exact or `prefix.*` wildcard), `after_seq`, `since_timestamp`, `limit` (default 100, max 1000), and optional `verify_chain` that recomputes hashes + validates `prior_hash` links without reimplementing any existing hashing primitives.
- **`cog_read_ledger` MCP tool** registered alongside `cog_emit_event`.
- **`GET /v1/ledger` HTTP endpoint** with query params mapping 1:1 to the MCP input.

## Error-code mapping (HTTP)

- **400** — malformed query (bad int, bad RFC3339, `after_seq` without `session_id`)
- **404** — `session_id` specified but no `events.jsonl` found
- **500** — read/JSON failure
- **200 with `verification.valid=false`** — chain is broken but data read succeeded. Tamper evidence is the whole point of the ledger; we don't hide the evidence behind a 500.

## Design highlights

- Chain verification walks every event in the file (even filter-misses) so `prior_hash` linkage stays accurate under filters.
- Multi-session queries order by `events.jsonl` mtime desc; single-session queries populate `next_after_seq` for pagination.
- `genesis/` is excluded from unscoped queries but reachable via explicit `session_id=genesis`.
- Wildcard matcher: `prefix.*` matches both `prefix` itself and `prefix.anything` (subject-area filter).

## Test plan

- [x] 14 `TestQueryLedger*` — empty, single-session, multi-session ordering, type exact/wildcard, `after_seq` pagination, `after_seq`-requires-session error, `since_timestamp`, bad RFC3339, limit+truncation, `verify_chain` valid, `verify_chain` broken (manually tampered), malformed JSONL line, session-not-found, genesis exclusion
- [x] 1 `TestToolReadLedgerRoundtrip` — MCP handler
- [x] 4 `TestHandleLedger*` — HTTP: 200 shape, 400 bad filters, 404 session-not-found, 200-with-`valid=false` on broken chain
- [x] All pre-existing ledger tests still pass
- [x] `go build ./...` and `go vet ./...` silent

## Not in scope

`EmitLedgerEvent` (`internal/engine/mcp_stubs.go:229`) bypasses hash chaining and writes to a flat path — events emitted via `cog_emit_event` are orphaned from this read API. Tracked as follow-up: #10.