### PR TITLE
feat(engine): config mutation API — cog_read/write/rollback_config + HTTP

### DIFF
--- a/internal/engine/config_write.go
+++ b/internal/engine/config_write.go
@@ -1,0 +1,859 @@
+// config_write.go — kernel.yaml mutation plumbing for CogOS v3.
+//
+// Implements the Config Mutation API per Agent O's design
+// (`cog://mem/semantic/surveys/2026-04-21-consolidation/agent-O-config-mutation-design`).
+//
+// Core exports consumed by MCP / HTTP surfaces:
+//
+//	ReadConfigOnDisk(root)         — parse kernel.yaml into kernelConfig
+//	WriteConfigPatch(root, patch,) — validate + atomic-write with rotating backups
+//	RollbackConfig(root, name)     — restore a prior .bak-<ts>
+//	ResolveFromKernelConfig(kc)    — project kernelConfig → effective *Config
+//	DefaultKernelYAML()            — hardcoded defaults for diff surfaces
+//
+// Merge semantics follow RFC 7396 (JSON Merge Patch): explicit null deletes the
+// key (restoring LoadConfig's default on next boot); missing keys are preserved.
+//
+// Concurrency: package-level writeConfigMu serializes all mutating operations.
+// v1 intentionally writes-to-disk + `requires_restart: true` — we never mutate
+// live *Config pointers under the hot path.
+package engine
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// writeConfigMu serializes all kernel.yaml mutations across MCP + HTTP surfaces.
+// Last-writer-wins; callers that race simply land in some order.
+var writeConfigMu sync.Mutex
+
+const (
+	// kernelYAMLRel is the workspace-relative path to the writable kernel config.
+	kernelYAMLRel = ".cog/config/kernel.yaml"
+	// backupPrefix is prepended to `.bak-<timestamp>` files.
+	backupPrefix = "kernel.yaml.bak-"
+	// backupKeep is the number of rotating backups kept.
+	backupKeep = 10
+	// backupTimeLayout is the RFC3339-like layout used in backup filenames.
+	// Colons are replaced with hyphens to remain friendly on case-insensitive
+	// filesystems.
+	backupTimeLayout = "2006-01-02T15-04-05Z"
+)
+
+// ConfigViolation records a single validation failure.
+type ConfigViolation struct {
+	Field string `json:"field"`
+	Rule  string `json:"rule"`
+	Got   any    `json:"got,omitempty"`
+}
+
+// ConfigDiffEntry describes a single field that changed between two configs.
+type ConfigDiffEntry struct {
+	Field  string `json:"field"`
+	Before any    `json:"before"`
+	After  any    `json:"after"`
+}
+
+// BackupEntry describes a single rotating backup file on disk.
+type BackupEntry struct {
+	Name      string `json:"name"`
+	Path      string `json:"path"`
+	Timestamp string `json:"timestamp"`
+	Size      int64  `json:"size"`
+}
+
+// WriteConfigOptions controls WriteConfigPatch behaviour.
+type WriteConfigOptions struct {
+	Scope  string // "top" (default) or "v3"
+	DryRun bool
+}
+
+// WriteConfigResult is the value returned from WriteConfigPatch / exposed by
+// `cog_write_config` and `PATCH /v1/config`.
+type WriteConfigResult struct {
+	Written         bool              `json:"written"`
+	RequiresRestart bool              `json:"requires_restart"`
+	Violations      []ConfigViolation `json:"violations,omitempty"`
+	EffectiveConfig map[string]any    `json:"effective_config,omitempty"`
+	BackupPath      string            `json:"backup_path,omitempty"`
+	Diff            []ConfigDiffEntry `json:"diff,omitempty"`
+	ChangedFields   []string          `json:"changed_fields,omitempty"`
+	Path            string            `json:"path"`
+	DryRun          bool              `json:"dry_run,omitempty"`
+}
+
+// ReadConfigResult is returned from the read-side helpers. It mirrors the MCP
+// + HTTP read surface so the wiring layer is a thin projection.
+type ReadConfigResult struct {
+	EffectiveConfig map[string]any `json:"effective_config"`
+	Path            string         `json:"path"`
+	Exists          bool           `json:"exists"`
+	RawYAML         string         `json:"raw_yaml,omitempty"`
+	Defaults        map[string]any `json:"defaults,omitempty"`
+}
+
+// reloadSafeFields lists configuration keys that can in principle be hot-
+// reloaded in v1.5 without restarting the daemon. Today every mutation still
+// returns requires_restart: true, but callers can inspect diff.changed_fields
+// to decide whether they need to restart right now or can defer.
+var reloadSafeFields = map[string]bool{
+	"consolidation_interval":       true,
+	"heartbeat_interval":           true,
+	"salience_days_window":         true,
+	"output_reserve":               true,
+	"ollama_embed_endpoint":        true,
+	"ollama_embed_model":           true,
+	"tool_call_validation_enabled": true,
+}
+
+// ── Read ────────────────────────────────────────────────────────────────────
+
+// ReadConfigOnDisk parses kernel.yaml at <root>/.cog/config/kernel.yaml. A
+// missing file is not an error: the returned kernelConfig is the zero value,
+// exists is false, and rawYAML is empty.
+func ReadConfigOnDisk(root string) (kc kernelConfig, rawYAML string, exists bool, err error) {
+	path := filepath.Join(root, kernelYAMLRel)
+	data, rerr := os.ReadFile(path)
+	if rerr != nil {
+		if os.IsNotExist(rerr) {
+			return kernelConfig{}, "", false, nil
+		}
+		return kernelConfig{}, "", false, fmt.Errorf("read %s: %w", path, rerr)
+	}
+	if uerr := yaml.Unmarshal(data, &kc); uerr != nil {
+		// A malformed file is surfaced to the writer so it can refuse to
+		// persist on top of garbage. LoadConfig itself still tolerates this
+		// (by design), so we return the raw bytes too.
+		return kernelConfig{}, string(data), true, fmt.Errorf("parse %s: %w", path, uerr)
+	}
+	return kc, string(data), true, nil
+}
+
+// ResolveFromKernelConfig projects a kernelConfig into the effective *Config
+// the daemon would load, applying LoadConfig's default / override semantics.
+// Used for `effective_config` surfaces without needing to touch disk.
+func ResolveFromKernelConfig(root string, kc kernelConfig) *Config {
+	cfg := &Config{
+		WorkspaceRoot:             root,
+		CogDir:                    filepath.Join(root, ".cog"),
+		Port:                      6931,
+		ConsolidationInterval:     3600,
+		HeartbeatInterval:         60,
+		SalienceDaysWindow:        90,
+		OutputReserve:             4096,
+		ToolCallValidationEnabled: true,
+		LocalModel:                defaultOllamaModel,
+		DigestPaths:               map[string]string{},
+	}
+	applyKernelSection(cfg, kc.kernelConfigSection)
+	applyKernelSection(cfg, kc.V3)
+	return cfg
+}
+
+// DefaultKernelYAML returns a kernelConfig with no overrides (pure defaults).
+// Used for the `include_defaults` read surface.
+func DefaultKernelYAML(root string) *Config {
+	return ResolveFromKernelConfig(root, kernelConfig{})
+}
+
+// ConfigToMap projects an effective *Config into a stable JSON-friendly map.
+// Field names match the YAML keys to keep read/write schemas symmetrical.
+func ConfigToMap(cfg *Config) map[string]any {
+	if cfg == nil {
+		return map[string]any{}
+	}
+	digest := map[string]string{}
+	for k, v := range cfg.DigestPaths {
+		digest[k] = v
+	}
+	return map[string]any{
+		"port":                         cfg.Port,
+		"consolidation_interval":       cfg.ConsolidationInterval,
+		"heartbeat_interval":           cfg.HeartbeatInterval,
+		"salience_days_window":         cfg.SalienceDaysWindow,
+		"output_reserve":               cfg.OutputReserve,
+		"trm_weights_path":             cfg.TRMWeightsPath,
+		"trm_embeddings_path":          cfg.TRMEmbeddingsPath,
+		"trm_chunks_path":              cfg.TRMChunksPath,
+		"ollama_embed_endpoint":        cfg.OllamaEmbedEndpoint,
+		"ollama_embed_model":           cfg.OllamaEmbedModel,
+		"tool_call_validation_enabled": cfg.ToolCallValidationEnabled,
+		"local_model":                  cfg.LocalModel,
+		"digest_paths":                 digest,
+	}
+}
+
+// ReadConfigSnapshot bundles the read view used by `cog_read_config` and
+// `GET /v1/config`.
+func ReadConfigSnapshot(root string, includeRaw, includeDefaults bool) (ReadConfigResult, error) {
+	path := filepath.Join(root, kernelYAMLRel)
+	kc, raw, exists, rerr := ReadConfigOnDisk(root)
+	// Even on parse errors we still return a usable snapshot (empty kc) so
+	// operators can see what they're working with — matches LoadConfig's
+	// "surprising-but-intentional" resilience.
+	result := ReadConfigResult{
+		EffectiveConfig: ConfigToMap(ResolveFromKernelConfig(root, kc)),
+		Path:            path,
+		Exists:          exists,
+	}
+	if includeRaw {
+		result.RawYAML = raw
+	}
+	if includeDefaults {
+		result.Defaults = ConfigToMap(DefaultKernelYAML(root))
+	}
+	if rerr != nil {
+		// Surface the parse error as an empty-map + error so callers can
+		// decide how to present it. We do not block the read.
+		return result, rerr
+	}
+	return result, nil
+}
+
+// ── Merge (RFC 7396) ────────────────────────────────────────────────────────
+
+// patchField enumerates the fields `cog_write_config` accepts. A separate
+// (duplicated-but-tiny) mapping keeps us decoupled from kernelConfigSection's
+// yaml tags and makes validation errors stable.
+var patchFields = []string{
+	"port",
+	"consolidation_interval",
+	"heartbeat_interval",
+	"salience_days_window",
+	"output_reserve",
+	"trm_weights_path",
+	"trm_embeddings_path",
+	"trm_chunks_path",
+	"ollama_embed_endpoint",
+	"ollama_embed_model",
+	"tool_call_validation_enabled",
+	"local_model",
+	"digest_paths",
+}
+
+var patchFieldSet = func() map[string]bool {
+	m := make(map[string]bool, len(patchFields))
+	for _, f := range patchFields {
+		m[f] = true
+	}
+	return m
+}()
+
+// applyMergePatch merges a raw JSON-shaped patch into the target section using
+// RFC 7396 semantics. Returns changed-field names (sorted) and a slice of
+// violations accumulated during coercion.
+//
+// Scalar coercion is forgiving (JSON numbers are float64 by default, so we
+// narrow to int where the schema expects int). Unknown keys produce violations.
+func applyMergePatch(section *kernelConfigSection, patch map[string]any) (changed []string, violations []ConfigViolation) {
+	changedSet := map[string]bool{}
+
+	add := func(field string) {
+		if !changedSet[field] {
+			changedSet[field] = true
+			changed = append(changed, field)
+		}
+	}
+
+	for key, val := range patch {
+		if !patchFieldSet[key] {
+			violations = append(violations, ConfigViolation{
+				Field: key,
+				Rule:  "unknown_field",
+				Got:   val,
+			})
+			continue
+		}
+		// null → unset (zero the field; LoadConfig re-applies its default
+		// because applyKernelSection treats zero as "keep default").
+		if val == nil {
+			zeroField(section, key)
+			add(key)
+			continue
+		}
+		if verr := setField(section, key, val); verr != nil {
+			violations = append(violations, *verr)
+			continue
+		}
+		add(key)
+	}
+	sort.Strings(changed)
+	return changed, violations
+}
+
+// zeroField sets a kernelConfigSection field to its zero value (RFC 7396 null).
+func zeroField(s *kernelConfigSection, key string) {
+	switch key {
+	case "port":
+		s.Port = 0
+	case "consolidation_interval":
+		s.ConsolidationInterval = 0
+	case "heartbeat_interval":
+		s.HeartbeatInterval = 0
+	case "salience_days_window":
+		s.SalienceDaysWindow = 0
+	case "output_reserve":
+		s.OutputReserve = 0
+	case "trm_weights_path":
+		s.TRMWeightsPath = ""
+	case "trm_embeddings_path":
+		s.TRMEmbeddingsPath = ""
+	case "trm_chunks_path":
+		s.TRMChunksPath = ""
+	case "ollama_embed_endpoint":
+		s.OllamaEmbedEndpoint = ""
+	case "ollama_embed_model":
+		s.OllamaEmbedModel = ""
+	case "tool_call_validation_enabled":
+		s.ToolCallValidation = nil
+	case "local_model":
+		s.LocalModel = ""
+	case "digest_paths":
+		s.DigestPaths = nil
+	}
+}
+
+// setField coerces val and writes it into section[key]. Returns a violation
+// on type mismatch (nil on success).
+func setField(s *kernelConfigSection, key string, val any) *ConfigViolation {
+	intField := func(target *int) *ConfigViolation {
+		n, ok := coerceInt(val)
+		if !ok {
+			return &ConfigViolation{Field: key, Rule: "expected_int", Got: val}
+		}
+		*target = n
+		return nil
+	}
+	strField := func(target *string) *ConfigViolation {
+		s2, ok := val.(string)
+		if !ok {
+			return &ConfigViolation{Field: key, Rule: "expected_string", Got: val}
+		}
+		*target = s2
+		return nil
+	}
+	switch key {
+	case "port":
+		return intField(&s.Port)
+	case "consolidation_interval":
+		return intField(&s.ConsolidationInterval)
+	case "heartbeat_interval":
+		return intField(&s.HeartbeatInterval)
+	case "salience_days_window":
+		return intField(&s.SalienceDaysWindow)
+	case "output_reserve":
+		return intField(&s.OutputReserve)
+	case "trm_weights_path":
+		return strField(&s.TRMWeightsPath)
+	case "trm_embeddings_path":
+		return strField(&s.TRMEmbeddingsPath)
+	case "trm_chunks_path":
+		return strField(&s.TRMChunksPath)
+	case "ollama_embed_endpoint":
+		return strField(&s.OllamaEmbedEndpoint)
+	case "ollama_embed_model":
+		return strField(&s.OllamaEmbedModel)
+	case "local_model":
+		return strField(&s.LocalModel)
+	case "tool_call_validation_enabled":
+		b, ok := val.(bool)
+		if !ok {
+			return &ConfigViolation{Field: key, Rule: "expected_bool", Got: val}
+		}
+		s.ToolCallValidation = &b
+		return nil
+	case "digest_paths":
+		raw, ok := val.(map[string]any)
+		if !ok {
+			return &ConfigViolation{Field: key, Rule: "expected_object", Got: val}
+		}
+		out := make(map[string]string, len(raw))
+		for k, v := range raw {
+			if k == "" {
+				return &ConfigViolation{Field: key, Rule: "empty_map_key", Got: raw}
+			}
+			vs, ok := v.(string)
+			if !ok {
+				return &ConfigViolation{Field: key, Rule: "expected_string_values", Got: raw}
+			}
+			out[k] = vs
+		}
+		s.DigestPaths = out
+		return nil
+	}
+	return &ConfigViolation{Field: key, Rule: "unknown_field", Got: val}
+}
+
+// coerceInt accepts int, int64, float64 (JSON default) — narrows to int. Rejects
+// non-integer floats.
+func coerceInt(v any) (int, bool) {
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int64:
+		return int(n), true
+	case float64:
+		if n != float64(int(n)) {
+			return 0, false
+		}
+		return int(n), true
+	}
+	return 0, false
+}
+
+// ── Validation ──────────────────────────────────────────────────────────────
+
+// validateSection enforces the static rules from Agent O §4. Validates the
+// post-merge state, not the raw patch, so incremental patches that leave the
+// merged config invalid are caught.
+func validateSection(scope string, s kernelConfigSection) []ConfigViolation {
+	var v []ConfigViolation
+	prefix := ""
+	if scope == "v3" {
+		prefix = "v3."
+	}
+	if s.Port != 0 && (s.Port < 1 || s.Port > 65535) {
+		v = append(v, ConfigViolation{Field: prefix + "port", Rule: "1<=port<=65535", Got: s.Port})
+	}
+	// Negative / zero intervals are rejected only when the field is explicitly
+	// set (zero means "use default" in LoadConfig's contract). Negative is a
+	// bug in either case.
+	if s.ConsolidationInterval < 0 {
+		v = append(v, ConfigViolation{Field: prefix + "consolidation_interval", Rule: ">=0", Got: s.ConsolidationInterval})
+	}
+	if s.HeartbeatInterval < 0 {
+		v = append(v, ConfigViolation{Field: prefix + "heartbeat_interval", Rule: ">=0", Got: s.HeartbeatInterval})
+	}
+	if s.SalienceDaysWindow < 0 {
+		v = append(v, ConfigViolation{Field: prefix + "salience_days_window", Rule: ">=0", Got: s.SalienceDaysWindow})
+	}
+	if s.OutputReserve < 0 {
+		v = append(v, ConfigViolation{Field: prefix + "output_reserve", Rule: ">=0", Got: s.OutputReserve})
+	}
+	if s.OllamaEmbedEndpoint != "" {
+		if _, err := url.Parse(s.OllamaEmbedEndpoint); err != nil {
+			v = append(v, ConfigViolation{Field: prefix + "ollama_embed_endpoint", Rule: "valid_url", Got: s.OllamaEmbedEndpoint})
+		} else if !strings.HasPrefix(s.OllamaEmbedEndpoint, "http://") && !strings.HasPrefix(s.OllamaEmbedEndpoint, "https://") {
+			v = append(v, ConfigViolation{Field: prefix + "ollama_embed_endpoint", Rule: "http(s)_scheme_required", Got: s.OllamaEmbedEndpoint})
+		}
+	}
+	for k := range s.DigestPaths {
+		if strings.TrimSpace(k) == "" {
+			v = append(v, ConfigViolation{Field: prefix + "digest_paths", Rule: "empty_map_key"})
+			break
+		}
+	}
+	return v
+}
+
+// validateKernelConfig runs validation across the merged top-level + v3 section.
+func validateKernelConfig(kc kernelConfig) []ConfigViolation {
+	var v []ConfigViolation
+	v = append(v, validateSection("top", kc.kernelConfigSection)...)
+	v = append(v, validateSection("v3", kc.V3)...)
+	return v
+}
+
+// ── Diff ────────────────────────────────────────────────────────────────────
+
+// diffConfigMaps returns a sorted list of changed entries between two
+// effective-config maps. Used both for the response payload and for deciding
+// requires_restart.
+func diffConfigMaps(before, after map[string]any) []ConfigDiffEntry {
+	keys := map[string]bool{}
+	for k := range before {
+		keys[k] = true
+	}
+	for k := range after {
+		keys[k] = true
+	}
+	sorted := make([]string, 0, len(keys))
+	for k := range keys {
+		sorted = append(sorted, k)
+	}
+	sort.Strings(sorted)
+
+	var out []ConfigDiffEntry
+	for _, k := range sorted {
+		b, a := before[k], after[k]
+		if !configValueEqual(b, a) {
+			out = append(out, ConfigDiffEntry{Field: k, Before: b, After: a})
+		}
+	}
+	return out
+}
+
+func configValueEqual(a, b any) bool {
+	// Fast path: primitive equality works for the scalar fields. Maps compare
+	// by length + key equality — our digest_paths maps are small.
+	am, aOK := a.(map[string]string)
+	bm, bOK := b.(map[string]string)
+	if aOK && bOK {
+		if len(am) != len(bm) {
+			return false
+		}
+		for k, v := range am {
+			if bm[k] != v {
+				return false
+			}
+		}
+		return true
+	}
+	return fmt.Sprintf("%v", a) == fmt.Sprintf("%v", b)
+}
+
+// ── Write + Backup ──────────────────────────────────────────────────────────
+
+// WriteConfigPatch merges the supplied JSON patch into kernel.yaml, validates
+// the result, and — on success — writes atomically after rotating backups.
+// The top-level mutex serializes concurrent callers.
+func WriteConfigPatch(root string, patch map[string]any, opts WriteConfigOptions) (WriteConfigResult, error) {
+	writeConfigMu.Lock()
+	defer writeConfigMu.Unlock()
+	return writeConfigPatchLocked(root, patch, opts)
+}
+
+func writeConfigPatchLocked(root string, patch map[string]any, opts WriteConfigOptions) (WriteConfigResult, error) {
+	if opts.Scope == "" {
+		opts.Scope = "top"
+	}
+	if opts.Scope != "top" && opts.Scope != "v3" {
+		return WriteConfigResult{Written: false, Path: filepath.Join(root, kernelYAMLRel), Violations: []ConfigViolation{{
+			Field: "scope", Rule: "must_be_top_or_v3", Got: opts.Scope,
+		}}}, nil
+	}
+	if patch == nil {
+		patch = map[string]any{}
+	}
+
+	path := filepath.Join(root, kernelYAMLRel)
+
+	// 1. Read current (tolerate missing; refuse to overwrite corrupt files).
+	current, _, exists, rerr := ReadConfigOnDisk(root)
+	if rerr != nil {
+		return WriteConfigResult{
+			Written: false,
+			Path:    path,
+			Violations: []ConfigViolation{{
+				Field: "kernel.yaml",
+				Rule:  "existing_file_unparseable",
+				Got:   rerr.Error(),
+			}},
+		}, nil
+	}
+
+	// 2. Merge (RFC 7396). Merge onto a copy; do not mutate `current`.
+	merged := current
+	var (
+		changed    []string
+		violations []ConfigViolation
+	)
+	switch opts.Scope {
+	case "v3":
+		changed, violations = applyMergePatch(&merged.V3, patch)
+	default:
+		changed, violations = applyMergePatch(&merged.kernelConfigSection, patch)
+	}
+	if len(violations) > 0 {
+		return WriteConfigResult{
+			Written:    false,
+			Path:       path,
+			Violations: violations,
+		}, nil
+	}
+
+	// 3. Validate the merged state.
+	if vs := validateKernelConfig(merged); len(vs) > 0 {
+		return WriteConfigResult{
+			Written:    false,
+			Path:       path,
+			Violations: vs,
+		}, nil
+	}
+
+	// 4. Compute effective-config maps & diff.
+	beforeEff := ConfigToMap(ResolveFromKernelConfig(root, current))
+	afterEff := ConfigToMap(ResolveFromKernelConfig(root, merged))
+	diff := diffConfigMaps(beforeEff, afterEff)
+
+	// requires_restart: v1 contract is blanket-true on actual writes because
+	// we don't hot-reload. We still return the reload-safety hint via the
+	// changed field list so callers can reason about it.
+	requiresRestart := len(diff) > 0
+
+	// 5. Dry run exits here.
+	if opts.DryRun {
+		return WriteConfigResult{
+			Written:         false,
+			RequiresRestart: requiresRestart,
+			EffectiveConfig: afterEff,
+			Diff:            diff,
+			ChangedFields:   changed,
+			Path:            path,
+			DryRun:          true,
+		}, nil
+	}
+
+	// 6. Backup existing file (if any) before we overwrite.
+	backupPath := ""
+	if exists {
+		bp, berr := backupKernelYAML(path)
+		if berr != nil {
+			return WriteConfigResult{}, fmt.Errorf("backup: %w", berr)
+		}
+		backupPath = bp
+		if rerr := rotateBackups(filepath.Dir(path), backupKeep); rerr != nil {
+			// Non-fatal: log-worthy but we proceed with the write.
+			// Caller can still see the new backup_path in the response.
+			_ = rerr
+		}
+	}
+
+	// 7. Serialize + atomic write.
+	out, merr := yaml.Marshal(&merged)
+	if merr != nil {
+		return WriteConfigResult{}, fmt.Errorf("marshal merged config: %w", merr)
+	}
+	if werr := atomicWriteConfigFile(path, out); werr != nil {
+		return WriteConfigResult{}, fmt.Errorf("write %s: %w", path, werr)
+	}
+
+	return WriteConfigResult{
+		Written:         true,
+		RequiresRestart: requiresRestart,
+		EffectiveConfig: afterEff,
+		BackupPath:      backupPath,
+		Diff:            diff,
+		ChangedFields:   changed,
+		Path:            path,
+	}, nil
+}
+
+// backupKernelYAML copies kernel.yaml → kernel.yaml.bak-<timestamp>.
+// Returns the backup filename (absolute path).
+func backupKernelYAML(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Dir(path)
+	name := backupPrefix + time.Now().UTC().Format(backupTimeLayout)
+	dst := filepath.Join(dir, name)
+	// Guard against timestamp collisions (test loops can outrun 1s resolution).
+	for i := 1; ; i++ {
+		if _, err := os.Stat(dst); os.IsNotExist(err) {
+			break
+		}
+		dst = filepath.Join(dir, fmt.Sprintf("%s-%d", name, i))
+	}
+	if err := atomicWriteConfigFile(dst, data); err != nil {
+		return "", err
+	}
+	return dst, nil
+}
+
+// rotateBackups keeps the most-recent `keep` backup files, deleting older ones.
+// Sorts lexicographically — because our timestamp layout is ISO-8601 ordered,
+// lexicographic sort == chronological sort.
+func rotateBackups(dir string, keep int) error {
+	entries, err := ListBackups(dir)
+	if err != nil {
+		return err
+	}
+	if len(entries) <= keep {
+		return nil
+	}
+	// ListBackups returns newest-first; drop the tail.
+	for _, e := range entries[keep:] {
+		_ = os.Remove(e.Path)
+	}
+	return nil
+}
+
+// ListBackups returns the .bak- files in dir, newest-first.
+func ListBackups(dir string) ([]BackupEntry, error) {
+	fs, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out []BackupEntry
+	for _, f := range fs {
+		if f.IsDir() {
+			continue
+		}
+		name := f.Name()
+		if !strings.HasPrefix(name, backupPrefix) {
+			continue
+		}
+		info, ierr := f.Info()
+		if ierr != nil {
+			continue
+		}
+		out = append(out, BackupEntry{
+			Name:      name,
+			Path:      filepath.Join(dir, name),
+			Timestamp: strings.TrimPrefix(name, backupPrefix),
+			Size:      info.Size(),
+		})
+	}
+	// newest first by name (ISO-8601 lexicographically sorts chronologically)
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Name > out[j].Name
+	})
+	return out, nil
+}
+
+// ── Rollback ───────────────────────────────────────────────────────────────
+
+// RollbackResult is the response shape for `cog_rollback_config` /
+// `POST /v1/config/rollback`.
+type RollbackResult struct {
+	Restored        bool          `json:"restored"`
+	RestoredFrom    string        `json:"restored_from,omitempty"`
+	RequiresRestart bool          `json:"requires_restart"`
+	Backups         []BackupEntry `json:"backups"`
+	Path            string        `json:"path"`
+	Error           string        `json:"error,omitempty"`
+}
+
+// RollbackOptions controls rollback behaviour.
+type RollbackOptions struct {
+	Backup   string // bare filename, e.g. "kernel.yaml.bak-2026-04-21T16-30-00Z". Empty → most recent.
+	ListOnly bool
+}
+
+// RollbackConfig restores kernel.yaml from a prior backup, optionally listing
+// backups without mutating anything.
+func RollbackConfig(root string, opts RollbackOptions) (RollbackResult, error) {
+	writeConfigMu.Lock()
+	defer writeConfigMu.Unlock()
+
+	path := filepath.Join(root, kernelYAMLRel)
+	dir := filepath.Dir(path)
+	backups, err := ListBackups(dir)
+	if err != nil {
+		return RollbackResult{Path: path}, err
+	}
+	if opts.ListOnly {
+		return RollbackResult{Path: path, Backups: backups}, nil
+	}
+	if len(backups) == 0 {
+		return RollbackResult{Path: path, Backups: backups, Error: "no backups available"}, nil
+	}
+
+	target := backups[0].Path // default: most recent
+	if opts.Backup != "" {
+		name := filepath.Base(opts.Backup) // defend against path traversal
+		if !strings.HasPrefix(name, backupPrefix) {
+			return RollbackResult{Path: path, Backups: backups, Error: fmt.Sprintf("backup %q does not match expected prefix", name)}, nil
+		}
+		target = filepath.Join(dir, name)
+		if _, err := os.Stat(target); err != nil {
+			return RollbackResult{Path: path, Backups: backups, Error: fmt.Sprintf("backup not found: %s", name)}, nil
+		}
+	}
+
+	data, err := os.ReadFile(target)
+	if err != nil {
+		return RollbackResult{Path: path, Backups: backups}, err
+	}
+	if err := atomicWriteConfigFile(path, data); err != nil {
+		return RollbackResult{Path: path, Backups: backups}, err
+	}
+
+	// Re-list so the response reflects post-rollback state.
+	backupsAfter, _ := ListBackups(dir)
+	return RollbackResult{
+		Restored:        true,
+		RestoredFrom:    filepath.Base(target),
+		RequiresRestart: true,
+		Backups:         backupsAfter,
+		Path:            path,
+	}, nil
+}
+
+// ── Atomic Writer ───────────────────────────────────────────────────────────
+
+// atomicWriteConfigFile writes data to path via temp-file + rename. Mirrors
+// the pattern in the root-package `atomicWriteFile` (hook_working_memory.go)
+// which lives in package main; we duplicate rather than cross-package-import
+// because engine is an internal package with no access to main. Same semantics.
+func atomicWriteConfigFile(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	tmp, err := os.CreateTemp(dir, ".kernel-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if _, werr := tmp.Write(data); werr != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("write temp: %w", werr)
+	}
+	if cerr := tmp.Close(); cerr != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("close temp: %w", cerr)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("rename temp: %w", err)
+	}
+	return nil
+}
+
+// ── JSON helpers (decode raw patches while preserving null-vs-missing) ─────
+
+// DecodePatchBody decodes a JSON body into a map[string]any, preserving the
+// distinction between an absent key and an explicit null. Used by the HTTP
+// handler; the MCP SDK already hands us a map.
+func DecodePatchBody(data []byte) (map[string]any, error) {
+	if len(bytes.TrimSpace(data)) == 0 {
+		return map[string]any{}, nil
+	}
+	var m map[string]any
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber() // makes later coerceInt / coerceFloat more predictable
+	if err := dec.Decode(&m); err != nil {
+		return nil, err
+	}
+	// json.Number → float64 to match the MCP SDK's default decoding, so
+	// downstream coerceInt handles both paths identically.
+	return normalizeNumbers(m), nil
+}
+
+func normalizeNumbers(v any) map[string]any {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return map[string]any{}
+	}
+	for k, val := range m {
+		switch n := val.(type) {
+		case json.Number:
+			if i, err := n.Int64(); err == nil {
+				m[k] = float64(i)
+			} else if f, err := n.Float64(); err == nil {
+				m[k] = f
+			}
+		case map[string]any:
+			m[k] = normalizeNumbers(n)
+		}
+	}
+	return m
+}

--- a/internal/engine/config_write_test.go
+++ b/internal/engine/config_write_test.go
@@ -1,0 +1,488 @@
+// config_write_test.go — unit tests for the Config Mutation API.
+//
+// Covers the spec from agent-O-config-mutation-design §Test plan:
+//   1.  Full patch, happy path
+//   2.  Sparse patch, single field
+//   3.  Patch reload-safe field
+//   4.  Null removes a field
+//   5.  Scope: v3 override
+//   6.  Validation rejects bad heartbeat
+//   7.  Validation rejects out-of-range port
+//   8.  Dry run does not touch disk
+//   9.  Atomic write semantics (no torn file under failure)
+//  10.  Backup rotation keeps 10
+//  11.  Corrupt existing file is refused
+//  12.  Concurrent writes serialize
+//
+// Plus MCP + HTTP roundtrip tests (see config_write_wire_test.go).
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func seedKernelYAML(t *testing.T, root, content string) string {
+	t.Helper()
+	path := filepath.Join(root, ".cog", "config", "kernel.yaml")
+	writeTestFile(t, path, content)
+	return path
+}
+
+func readKernelYAML(t *testing.T, path string) kernelConfig {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read kernel.yaml: %v", err)
+	}
+	var kc kernelConfig
+	if err := yaml.Unmarshal(data, &kc); err != nil {
+		t.Fatalf("unmarshal kernel.yaml: %v", err)
+	}
+	return kc
+}
+
+// 1. Full patch on a fresh workspace populates every field + creates a backup
+//    when an existing file was overwritten.
+func TestWriteConfigPatch_FullPatchHappyPath(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	path := seedKernelYAML(t, root, "port: 6931\n")
+
+	patch := map[string]any{
+		"port":                         float64(7777),
+		"consolidation_interval":       float64(1800),
+		"heartbeat_interval":           float64(45),
+		"salience_days_window":         float64(30),
+		"output_reserve":               float64(8192),
+		"trm_weights_path":             "/tmp/trm.w",
+		"trm_embeddings_path":          "/tmp/trm.e",
+		"trm_chunks_path":              "/tmp/trm.c",
+		"ollama_embed_endpoint":        "http://localhost:11434",
+		"ollama_embed_model":           "nomic-embed-text",
+		"tool_call_validation_enabled": false,
+		"local_model":                  "gemma4:e4b",
+		"digest_paths":                 map[string]any{"claude-code": "~/.claude/events.jsonl"},
+	}
+	result, err := WriteConfigPatch(root, patch, WriteConfigOptions{})
+	if err != nil {
+		t.Fatalf("WriteConfigPatch: %v", err)
+	}
+	if !result.Written {
+		t.Fatalf("expected written=true, got violations=%+v", result.Violations)
+	}
+	if !result.RequiresRestart {
+		t.Errorf("requires_restart = false; want true (port changed)")
+	}
+	if result.BackupPath == "" {
+		t.Errorf("backup_path empty; expected a .bak file for overwritten kernel.yaml")
+	}
+	if _, err := os.Stat(result.BackupPath); err != nil {
+		t.Errorf("backup file missing: %v", err)
+	}
+
+	// Disk reflects the patch.
+	kc := readKernelYAML(t, path)
+	if kc.Port != 7777 {
+		t.Errorf("Port = %d; want 7777", kc.Port)
+	}
+	if kc.DigestPaths["claude-code"] != "~/.claude/events.jsonl" {
+		t.Errorf("DigestPaths[claude-code] = %q; want ~/.claude/events.jsonl", kc.DigestPaths["claude-code"])
+	}
+	if kc.ToolCallValidation == nil || *kc.ToolCallValidation != false {
+		t.Errorf("ToolCallValidation = %v; want *false", kc.ToolCallValidation)
+	}
+	if len(result.ChangedFields) == 0 {
+		t.Errorf("changed_fields empty")
+	}
+}
+
+// 2. Sparse patch: only port changes; other fields are preserved.
+func TestWriteConfigPatch_SparsePatchPreservesOthers(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	path := seedKernelYAML(t, root, "port: 6931\nlocal_model: gemma4:e2b\nconsolidation_interval: 600\n")
+
+	result, err := WriteConfigPatch(root, map[string]any{"port": float64(7000)}, WriteConfigOptions{})
+	if err != nil {
+		t.Fatalf("WriteConfigPatch: %v", err)
+	}
+	if !result.Written {
+		t.Fatalf("expected written=true, got violations=%+v", result.Violations)
+	}
+	if len(result.Diff) != 1 || result.Diff[0].Field != "port" {
+		t.Errorf("expected single diff on port; got %+v", result.Diff)
+	}
+
+	kc := readKernelYAML(t, path)
+	if kc.Port != 7000 {
+		t.Errorf("Port = %d; want 7000", kc.Port)
+	}
+	if kc.LocalModel != "gemma4:e2b" {
+		t.Errorf("LocalModel = %q; want gemma4:e2b", kc.LocalModel)
+	}
+	if kc.ConsolidationInterval != 600 {
+		t.Errorf("ConsolidationInterval = %d; want 600", kc.ConsolidationInterval)
+	}
+}
+
+// 3. Reload-safe field: requires_restart is still true in v1 (we always
+//    persist + restart), but changed_fields reveals the field is reload-safe.
+func TestWriteConfigPatch_ReloadSafeFieldChange(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	seedKernelYAML(t, root, "consolidation_interval: 600\n")
+
+	result, err := WriteConfigPatch(root, map[string]any{"consolidation_interval": float64(900)}, WriteConfigOptions{})
+	if err != nil {
+		t.Fatalf("WriteConfigPatch: %v", err)
+	}
+	if !result.Written {
+		t.Fatalf("expected written=true")
+	}
+	// v1 is blanket requires_restart. The reload-safety hint is in changed_fields.
+	if !result.RequiresRestart {
+		t.Errorf("requires_restart = false; v1 always returns true on a write")
+	}
+	if got := result.ChangedFields; len(got) != 1 || got[0] != "consolidation_interval" {
+		t.Errorf("changed_fields = %v; want [consolidation_interval]", got)
+	}
+	if !reloadSafeFields[result.ChangedFields[0]] {
+		t.Errorf("expected consolidation_interval to be reload-safe in the hint")
+	}
+}
+
+// 4. Null deletes a key (restoring LoadConfig's default on next boot).
+func TestWriteConfigPatch_NullRemovesField(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	path := seedKernelYAML(t, root, "local_model: gemma4:custom\n")
+
+	result, err := WriteConfigPatch(root, map[string]any{"local_model": nil}, WriteConfigOptions{})
+	if err != nil {
+		t.Fatalf("WriteConfigPatch: %v", err)
+	}
+	if !result.Written {
+		t.Fatalf("expected written=true, got violations=%+v", result.Violations)
+	}
+
+	kc := readKernelYAML(t, path)
+	if kc.LocalModel != "" {
+		t.Errorf("LocalModel = %q; want \"\" after null patch", kc.LocalModel)
+	}
+
+	// The effective config falls back to LoadConfig's default.
+	cfg := ResolveFromKernelConfig(root, kc)
+	if cfg.LocalModel != defaultOllamaModel {
+		t.Errorf("effective LocalModel = %q; want default %q", cfg.LocalModel, defaultOllamaModel)
+	}
+}
+
+// 5. scope=v3 writes into the nested section without touching top-level.
+func TestWriteConfigPatch_ScopeV3(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	path := seedKernelYAML(t, root, "port: 5100\nconsolidation_interval: 600\n")
+
+	result, err := WriteConfigPatch(root, map[string]any{"port": float64(6931)}, WriteConfigOptions{Scope: "v3"})
+	if err != nil {
+		t.Fatalf("WriteConfigPatch: %v", err)
+	}
+	if !result.Written {
+		t.Fatalf("expected written=true, got violations=%+v", result.Violations)
+	}
+
+	kc := readKernelYAML(t, path)
+	if kc.Port != 5100 {
+		t.Errorf("top-level Port = %d; want 5100 (unchanged)", kc.Port)
+	}
+	if kc.V3.Port != 6931 {
+		t.Errorf("v3.Port = %d; want 6931", kc.V3.Port)
+	}
+
+	// LoadConfig applies v3 override on top of top-level.
+	cfg := ResolveFromKernelConfig(root, kc)
+	if cfg.Port != 6931 {
+		t.Errorf("effective Port = %d; want 6931 (v3 override)", cfg.Port)
+	}
+}
+
+// 6. Validation rejects negative heartbeat without writing.
+func TestWriteConfigPatch_RejectsNegativeHeartbeat(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	path := seedKernelYAML(t, root, "port: 6931\n")
+	originalData, _ := os.ReadFile(path)
+
+	result, err := WriteConfigPatch(root, map[string]any{"heartbeat_interval": float64(-1)}, WriteConfigOptions{})
+	if err != nil {
+		t.Fatalf("WriteConfigPatch: %v", err)
+	}
+	if result.Written {
+		t.Errorf("written = true on bad patch")
+	}
+	if len(result.Violations) == 0 {
+		t.Errorf("expected violations for negative heartbeat")
+	}
+
+	after, _ := os.ReadFile(path)
+	if string(originalData) != string(after) {
+		t.Errorf("kernel.yaml was mutated despite validation failure")
+	}
+}
+
+// 7. Validation rejects out-of-range port.
+func TestWriteConfigPatch_RejectsOutOfRangePort(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	path := seedKernelYAML(t, root, "port: 6931\n")
+	originalData, _ := os.ReadFile(path)
+
+	result, err := WriteConfigPatch(root, map[string]any{"port": float64(70000)}, WriteConfigOptions{})
+	if err != nil {
+		t.Fatalf("WriteConfigPatch: %v", err)
+	}
+	if result.Written {
+		t.Errorf("written = true for port=70000")
+	}
+	found := false
+	for _, v := range result.Violations {
+		if v.Field == "port" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected violation on field=port; got %+v", result.Violations)
+	}
+	after, _ := os.ReadFile(path)
+	if string(originalData) != string(after) {
+		t.Errorf("kernel.yaml mutated despite rejection")
+	}
+}
+
+// 8. dry_run returns diff but does not touch disk / create backup.
+func TestWriteConfigPatch_DryRun(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	path := seedKernelYAML(t, root, "port: 6931\n")
+	originalData, _ := os.ReadFile(path)
+
+	result, err := WriteConfigPatch(root, map[string]any{"port": float64(7000)}, WriteConfigOptions{DryRun: true})
+	if err != nil {
+		t.Fatalf("WriteConfigPatch: %v", err)
+	}
+	if result.Written {
+		t.Errorf("written = true under dry_run")
+	}
+	if !result.DryRun {
+		t.Errorf("dry_run flag not echoed back")
+	}
+	if len(result.Diff) == 0 {
+		t.Errorf("expected non-empty diff under dry_run")
+	}
+	if result.BackupPath != "" {
+		t.Errorf("backup created under dry_run: %q", result.BackupPath)
+	}
+	after, _ := os.ReadFile(path)
+	if string(originalData) != string(after) {
+		t.Errorf("kernel.yaml mutated under dry_run")
+	}
+	// No backup files should be present.
+	dir := filepath.Dir(path)
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), backupPrefix) {
+			t.Errorf("found backup %q after dry_run", e.Name())
+		}
+	}
+}
+
+// 9. Atomic write semantics — a successful write never produces a torn file,
+//    and the backup is a full copy of the prior content.
+func TestWriteConfigPatch_AtomicWrite(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	originalYAML := "port: 6931\nlocal_model: gemma4:e2b\n"
+	path := seedKernelYAML(t, root, originalYAML)
+
+	result, err := WriteConfigPatch(root, map[string]any{"port": float64(7000)}, WriteConfigOptions{})
+	if err != nil {
+		t.Fatalf("WriteConfigPatch: %v", err)
+	}
+	if !result.Written {
+		t.Fatalf("expected written=true")
+	}
+
+	// No `.tmp` residue in the directory.
+	dir := filepath.Dir(path)
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("temp file left behind: %q", e.Name())
+		}
+	}
+
+	// Backup is a full copy of the pre-write file.
+	if result.BackupPath == "" {
+		t.Fatalf("no backup path")
+	}
+	backupData, err := os.ReadFile(result.BackupPath)
+	if err != nil {
+		t.Fatalf("read backup: %v", err)
+	}
+	if string(backupData) != originalYAML {
+		t.Errorf("backup content = %q; want %q", backupData, originalYAML)
+	}
+
+	// Resulting file parses cleanly.
+	_ = readKernelYAML(t, path)
+}
+
+// 10. Backup rotation: 12 writes → only 10 backups remain.
+func TestWriteConfigPatch_BackupRotation(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	path := seedKernelYAML(t, root, "port: 6931\n")
+
+	for i := 0; i < 12; i++ {
+		_, err := WriteConfigPatch(root, map[string]any{"port": float64(6000 + i)}, WriteConfigOptions{})
+		if err != nil {
+			t.Fatalf("WriteConfigPatch iteration %d: %v", i, err)
+		}
+	}
+
+	dir := filepath.Dir(path)
+	entries, _ := os.ReadDir(dir)
+	count := 0
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), backupPrefix) {
+			count++
+		}
+	}
+	if count > backupKeep {
+		t.Errorf("backup count = %d; want <= %d (backupKeep)", count, backupKeep)
+	}
+	if count < backupKeep {
+		t.Errorf("backup count = %d; want exactly %d after 12 writes", count, backupKeep)
+	}
+}
+
+// 11. Corrupt existing file is refused — the write path refuses to clobber
+//     unparseable YAML without a rollback first.
+func TestWriteConfigPatch_RefusesCorruptFile(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	path := seedKernelYAML(t, root, "port: 6931\n:::not yaml")
+	originalData, _ := os.ReadFile(path)
+
+	result, err := WriteConfigPatch(root, map[string]any{"port": float64(7000)}, WriteConfigOptions{})
+	if err != nil {
+		t.Fatalf("WriteConfigPatch: %v", err)
+	}
+	if result.Written {
+		t.Errorf("written = true despite corrupt existing file")
+	}
+	found := false
+	for _, v := range result.Violations {
+		if v.Rule == "existing_file_unparseable" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected existing_file_unparseable violation; got %+v", result.Violations)
+	}
+	after, _ := os.ReadFile(path)
+	if string(originalData) != string(after) {
+		t.Errorf("kernel.yaml mutated despite refused write")
+	}
+}
+
+// 12. Concurrent writes serialize — 8 goroutines all set port to different
+//     values; no corruption and the final file is a valid YAML with one of
+//     the candidate ports.
+func TestWriteConfigPatch_ConcurrentWritesSerialize(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	path := seedKernelYAML(t, root, "port: 6931\n")
+
+	const N = 8
+	var wg sync.WaitGroup
+	errs := make([]error, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			_, err := WriteConfigPatch(root, map[string]any{"port": float64(6000 + idx)}, WriteConfigOptions{})
+			errs[idx] = err
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d: %v", i, err)
+		}
+	}
+
+	// File parses and reports one of the candidate ports.
+	kc := readKernelYAML(t, path)
+	if kc.Port < 6000 || kc.Port >= 6000+N {
+		t.Errorf("final Port = %d; want one of [6000..%d)", kc.Port, 6000+N)
+	}
+}
+
+// 13. ReadConfigSnapshot includes defaults and path.
+func TestReadConfigSnapshot_IncludesDefaults(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	seedKernelYAML(t, root, "port: 6931\n")
+	snap, err := ReadConfigSnapshot(root, true, true)
+	if err != nil {
+		t.Fatalf("ReadConfigSnapshot: %v", err)
+	}
+	if !snap.Exists {
+		t.Errorf("exists = false on present kernel.yaml")
+	}
+	if snap.Defaults["port"].(int) != 6931 {
+		t.Errorf("defaults.port = %v; want 6931", snap.Defaults["port"])
+	}
+	if snap.RawYAML == "" {
+		t.Errorf("raw_yaml empty when include_raw_yaml=true")
+	}
+}
+
+// 14. Rollback roundtrip: write → write → rollback restores the prior file.
+func TestRollbackConfig_RestoresPriorBackup(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	path := seedKernelYAML(t, root, "port: 6931\nlocal_model: gemma4:a\n")
+
+	// First write — produces bak for the seed.
+	_, err := WriteConfigPatch(root, map[string]any{"local_model": "gemma4:b"}, WriteConfigOptions{})
+	if err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	// Second write.
+	_, err = WriteConfigPatch(root, map[string]any{"local_model": "gemma4:c"}, WriteConfigOptions{})
+	if err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+
+	// Rollback to the most recent backup — which is the one made by the
+	// _second_ write, i.e. local_model: gemma4:b.
+	res, err := RollbackConfig(root, RollbackOptions{})
+	if err != nil {
+		t.Fatalf("RollbackConfig: %v", err)
+	}
+	if !res.Restored {
+		t.Fatalf("restored = false")
+	}
+	kc := readKernelYAML(t, path)
+	if kc.LocalModel != "gemma4:b" {
+		t.Errorf("LocalModel after rollback = %q; want gemma4:b", kc.LocalModel)
+	}
+}

--- a/internal/engine/config_write_wire_test.go
+++ b/internal/engine/config_write_wire_test.go
@@ -1,0 +1,186 @@
+// config_write_wire_test.go — MCP tool + HTTP handler integration tests
+// for the Config Mutation API (Agent O §Test plan, wire layer).
+package engine
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// newMCPForTest builds an MCPServer wired to a fresh workspace + process.
+func newMCPForTest(t *testing.T) (*MCPServer, string) {
+	t.Helper()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	process := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	return NewMCPServer(cfg, makeNucleus("Cog", "tester"), process), root
+}
+
+// 15. MCP roundtrip: toolWriteConfig with a real merge patch writes + returns
+//     the expected shape.
+func TestToolWriteConfig_HappyPath(t *testing.T) {
+	t.Parallel()
+	server, root := newMCPForTest(t)
+	seedKernelYAML(t, root, "port: 6931\n")
+
+	result, _, err := server.toolWriteConfig(context.Background(), nil, writeConfigInput{
+		Patch: map[string]any{"port": float64(7000)},
+	})
+	if err != nil {
+		t.Fatalf("toolWriteConfig: %v", err)
+	}
+	var decoded WriteConfigResult
+	decodeMCPJSON(t, result, &decoded)
+	if !decoded.Written {
+		t.Errorf("written = false; violations=%+v", decoded.Violations)
+	}
+	if decoded.EffectiveConfig["port"].(float64) != 7000 {
+		t.Errorf("effective_config.port = %v; want 7000", decoded.EffectiveConfig["port"])
+	}
+	if !decoded.RequiresRestart {
+		t.Errorf("requires_restart = false; want true")
+	}
+}
+
+// 16. MCP roundtrip: toolReadConfig returns defaults when requested.
+func TestToolReadConfig_IncludesDefaults(t *testing.T) {
+	t.Parallel()
+	server, root := newMCPForTest(t)
+	seedKernelYAML(t, root, "port: 6931\n")
+	result, _, err := server.toolReadConfig(context.Background(), nil, readConfigInput{
+		IncludeDefaults: true,
+		IncludeRawYAML:  true,
+	})
+	if err != nil {
+		t.Fatalf("toolReadConfig: %v", err)
+	}
+	var decoded ReadConfigResult
+	decodeMCPJSON(t, result, &decoded)
+	if !decoded.Exists {
+		t.Errorf("exists = false")
+	}
+	if decoded.Defaults == nil {
+		t.Errorf("defaults missing")
+	}
+	if decoded.RawYAML == "" {
+		t.Errorf("raw_yaml missing")
+	}
+}
+
+// 17. MCP resource: cogos://config returns JSON.
+func TestResourceConfig_Reads(t *testing.T) {
+	t.Parallel()
+	server, root := newMCPForTest(t)
+	seedKernelYAML(t, root, "port: 6931\n")
+	// Build a minimal request carrying the URI the resource expects.
+	// The handler only reads req.Params.URI.
+	fakeReq := &mcp.ReadResourceRequest{Params: &mcp.ReadResourceParams{URI: "cogos://config"}}
+	result, err := server.resourceConfig(context.Background(), fakeReq)
+	if err != nil {
+		t.Fatalf("resourceConfig: %v", err)
+	}
+	if len(result.Contents) != 1 {
+		t.Fatalf("contents len = %d; want 1", len(result.Contents))
+	}
+	text := result.Contents[0].Text
+	if !strings.Contains(text, "effective_config") {
+		t.Errorf("resource text missing effective_config; got %s", text)
+	}
+	if !strings.Contains(text, "defaults") {
+		t.Errorf("resource text missing defaults; got %s", text)
+	}
+}
+
+// 18. HTTP: GET /v1/config with include_defaults=1 returns the expected shape.
+func TestHandleConfigGet_IncludesDefaults(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+	seedKernelYAML(t, srv.cfg.WorkspaceRoot, "port: 6931\n")
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/config?include_defaults=1&include_raw_yaml=1", nil)
+	w := httptest.NewRecorder()
+	srv.handleConfigGet(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200", w.Code)
+	}
+	var body ReadConfigResult
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body.Exists {
+		t.Errorf("exists = false")
+	}
+	if body.Defaults == nil {
+		t.Errorf("defaults missing")
+	}
+	if body.RawYAML == "" {
+		t.Errorf("raw_yaml missing")
+	}
+	if body.Path != filepath.Join(srv.cfg.WorkspaceRoot, ".cog/config/kernel.yaml") {
+		t.Errorf("path = %q; unexpected", body.Path)
+	}
+}
+
+// 19. HTTP: PATCH /v1/config with a valid patch returns 200 + written=true.
+func TestHandleConfigPatch_Success(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+	seedKernelYAML(t, srv.cfg.WorkspaceRoot, "port: 6931\n")
+
+	body := map[string]any{
+		"patch": map[string]any{"port": 7000},
+	}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPatch, "/v1/config", bytes.NewReader(raw))
+	w := httptest.NewRecorder()
+	srv.handleConfigPatch(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d (body=%s); want 200", w.Code, w.Body.String())
+	}
+	var result WriteConfigResult
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !result.Written {
+		t.Errorf("written = false; violations = %+v", result.Violations)
+	}
+}
+
+// 20. HTTP: PATCH /v1/config with an invalid port → 400 + violations.
+func TestHandleConfigPatch_ValidationFailure(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+	seedKernelYAML(t, srv.cfg.WorkspaceRoot, "port: 6931\n")
+
+	body := map[string]any{
+		"patch": map[string]any{"port": 70000},
+	}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPatch, "/v1/config", bytes.NewReader(raw))
+	w := httptest.NewRecorder()
+	srv.handleConfigPatch(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d (body=%s); want 400", w.Code, w.Body.String())
+	}
+	var result WriteConfigResult
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if result.Written {
+		t.Errorf("written = true on bad patch")
+	}
+	if len(result.Violations) == 0 {
+		t.Errorf("expected violations; got none")
+	}
+}

--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -125,6 +125,22 @@ func (m *MCPServer) registerTools() {
 		Name:        "cog_ingest",
 		Description: "Ingest external material into CogOS knowledge. Deterministic decomposition — no LLM calls. Supports URLs, conversations, documents. Applies membrane policy (accept/quarantine/defer/discard).",
 	}, m.toolIngest)
+
+	// Config mutation API (Agent O design — closes Agent F gaps #5 + #19).
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name:        "cog_read_config",
+		Description: "Read the kernel config (.cog/config/kernel.yaml). Returns the effective resolved config (defaults + file overrides). Optional include_raw_yaml returns the raw file bytes; include_defaults also returns the hardcoded defaults for diffing. kernel.yaml only — sibling configs (providers.yaml, secrets.yaml) are out of scope.",
+	}, m.toolReadConfig)
+
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name:        "cog_write_config",
+		Description: "Merge a patch into the kernel config (.cog/config/kernel.yaml) using RFC 7396 JSON merge-patch semantics: fields omitted from the patch are left unchanged; explicit null removes a field and restores the default on next boot. Validated before persisting — returns violations without writing on failure. Atomic write + rotating .bak-<timestamp> backups (keeps 10). Takes effect on next daemon restart (requires_restart: true in response). Fallback: edit .cog/config/kernel.yaml and run `./scripts/cog restart`. No authentication — the kernel assumes a trusted local caller.",
+	}, m.toolWriteConfig)
+
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name:        "cog_rollback_config",
+		Description: "Restore kernel.yaml from a prior .bak-<timestamp> backup. Pass list_only=true to enumerate available backups without restoring. If backup is empty, the most recent backup is used. Atomic restore; response carries updated backup list.",
+	}, m.toolRollbackConfig)
 }
 
 // registerResources registers MCP Resources — read-only addressable data.
@@ -151,6 +167,13 @@ func (m *MCPServer) registerResources() {
 		Description: "Top-20 salience-scored CogDocs with cog:// URIs",
 		MIMEType:    "application/json",
 	}, m.resourceField)
+
+	m.server.AddResource(&mcp.Resource{
+		URI:         "cogos://config",
+		Name:        "Kernel Config",
+		Description: "Effective kernel configuration (kernel.yaml resolved against defaults)",
+		MIMEType:    "application/json",
+	}, m.resourceConfig)
 }
 
 // ── Resource Handlers ───────────────────────────────────────────────────────
@@ -956,6 +979,77 @@ func (m *MCPServer) toolIngest(ctx context.Context, req *mcp.CallToolRequest, in
 		"title":        result.Title,
 		"content_type": string(result.ContentType),
 	})
+}
+
+// ── Config Mutation API ──────────────────────────────────────────────────────
+
+type readConfigInput struct {
+	IncludeRawYAML  bool `json:"include_raw_yaml,omitempty" jsonschema:"Also return the raw kernel.yaml bytes"`
+	IncludeDefaults bool `json:"include_defaults,omitempty" jsonschema:"Also return the hardcoded defaults for comparison"`
+}
+
+type writeConfigInput struct {
+	Patch  map[string]any `json:"patch" jsonschema:"RFC 7396 merge-patch object. Fields: port, consolidation_interval, heartbeat_interval, salience_days_window, output_reserve, trm_weights_path, trm_embeddings_path, trm_chunks_path, ollama_embed_endpoint, ollama_embed_model, tool_call_validation_enabled, local_model, digest_paths. Explicit null deletes a key; missing keys preserved."`
+	Scope  string         `json:"scope,omitempty" jsonschema:"Target section: 'top' (default) or 'v3'"`
+	DryRun bool           `json:"dry_run,omitempty" jsonschema:"If true, validate + return diff without writing"`
+}
+
+type rollbackConfigInput struct {
+	Backup   string `json:"backup,omitempty" jsonschema:"Backup filename (e.g. kernel.yaml.bak-2026-04-21T16-30-00Z). Empty = most recent."`
+	ListOnly bool   `json:"list_only,omitempty" jsonschema:"If true, return the list of backups without restoring"`
+}
+
+func (m *MCPServer) toolReadConfig(ctx context.Context, req *mcp.CallToolRequest, input readConfigInput) (*mcp.CallToolResult, any, error) {
+	snapshot, err := ReadConfigSnapshot(m.cfg.WorkspaceRoot, input.IncludeRawYAML, input.IncludeDefaults)
+	if err != nil {
+		// Parse error — still surface whatever we could read but tag the error.
+		return marshalResult(map[string]any{
+			"effective_config": snapshot.EffectiveConfig,
+			"path":             snapshot.Path,
+			"exists":           snapshot.Exists,
+			"raw_yaml":         snapshot.RawYAML,
+			"defaults":         snapshot.Defaults,
+			"parse_error":      err.Error(),
+		})
+	}
+	return marshalResult(snapshot)
+}
+
+func (m *MCPServer) toolWriteConfig(ctx context.Context, req *mcp.CallToolRequest, input writeConfigInput) (*mcp.CallToolResult, any, error) {
+	result, err := WriteConfigPatch(m.cfg.WorkspaceRoot, input.Patch, WriteConfigOptions{
+		Scope:  input.Scope,
+		DryRun: input.DryRun,
+	})
+	if err != nil {
+		return fallbackResult(fmt.Sprintf("write config failed: %v", err), "edit .cog/config/kernel.yaml and run './scripts/cog restart'")
+	}
+	return marshalResult(result)
+}
+
+func (m *MCPServer) toolRollbackConfig(ctx context.Context, req *mcp.CallToolRequest, input rollbackConfigInput) (*mcp.CallToolResult, any, error) {
+	result, err := RollbackConfig(m.cfg.WorkspaceRoot, RollbackOptions{
+		Backup:   input.Backup,
+		ListOnly: input.ListOnly,
+	})
+	if err != nil {
+		return fallbackResult(fmt.Sprintf("rollback failed: %v", err), "mv .cog/config/kernel.yaml.bak-<timestamp> .cog/config/kernel.yaml")
+	}
+	return marshalResult(result)
+}
+
+func (m *MCPServer) resourceConfig(_ context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	snapshot, _ := ReadConfigSnapshot(m.cfg.WorkspaceRoot, false, true)
+	b, err := json.Marshal(snapshot)
+	if err != nil {
+		return nil, fmt.Errorf("marshal config: %w", err)
+	}
+	return &mcp.ReadResourceResult{
+		Contents: []*mcp.ResourceContents{{
+			URI:      req.Params.URI,
+			MIMEType: "application/json",
+			Text:     string(b),
+		}},
+	}, nil
 }
 
 // slugify converts a string to a URL-friendly slug.

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -77,6 +77,7 @@ func NewServer(cfg *Config, nucleus *Nucleus, process *Process) *Server {
 	s.registerBlockRoutes(mux)
 	s.registerCompatRoutes(mux)
 	s.registerMCPRoutes(mux)
+	s.registerConfigRoutes(mux)
 
 	s.srv = &http.Server{
 		Addr:         fmt.Sprintf(":%d", cfg.Port),

--- a/internal/engine/serve_config.go
+++ b/internal/engine/serve_config.go
@@ -1,0 +1,141 @@
+// serve_config.go — HTTP surface for the Config Mutation API (Agent O design).
+//
+//	GET   /v1/config             — read effective + raw + defaults
+//	PATCH /v1/config             — RFC 7396 merge-patch (validated, atomic, backed up)
+//	POST  /v1/config/rollback    — restore from a .bak-<timestamp> file
+//
+// All handlers return JSON on success and on structured-error paths.
+package engine
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+// registerConfigRoutes mounts the config read/write/rollback endpoints.
+func (s *Server) registerConfigRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /v1/config", s.handleConfigGet)
+	mux.HandleFunc("PATCH /v1/config", s.handleConfigPatch)
+	mux.HandleFunc("POST /v1/config/rollback", s.handleConfigRollback)
+}
+
+// handleConfigGet returns the effective kernel config. Query params:
+//
+//	include_raw_yaml=1   — also return raw kernel.yaml bytes
+//	include_defaults=1   — also return hardcoded defaults
+func (s *Server) handleConfigGet(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	includeRaw := truthyQuery(q.Get("include_raw_yaml"))
+	includeDefaults := truthyQuery(q.Get("include_defaults"))
+	snapshot, err := ReadConfigSnapshot(s.cfg.WorkspaceRoot, includeRaw, includeDefaults)
+	w.Header().Set("Content-Type", "application/json")
+	if err != nil {
+		// Parse error is non-fatal — return what we can with a field tag.
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"effective_config": snapshot.EffectiveConfig,
+			"path":             snapshot.Path,
+			"exists":           snapshot.Exists,
+			"raw_yaml":         snapshot.RawYAML,
+			"defaults":         snapshot.Defaults,
+			"parse_error":      err.Error(),
+		})
+		return
+	}
+	_ = json.NewEncoder(w).Encode(snapshot)
+}
+
+// configPatchRequest is the HTTP body shape for PATCH /v1/config.
+type configPatchRequest struct {
+	Patch  json.RawMessage `json:"patch"`
+	Scope  string          `json:"scope,omitempty"`
+	DryRun bool            `json:"dry_run,omitempty"`
+}
+
+func (s *Server) handleConfigPatch(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20)) // 1 MB is vast for a scalar config
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{"error": "read body: " + err.Error()})
+		return
+	}
+	var req configPatchRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{"error": "parse body: " + err.Error()})
+		return
+	}
+
+	patch, err := DecodePatchBody(req.Patch)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{"error": "parse patch: " + err.Error()})
+		return
+	}
+
+	result, werr := WriteConfigPatch(s.cfg.WorkspaceRoot, patch, WriteConfigOptions{
+		Scope:  req.Scope,
+		DryRun: req.DryRun,
+	})
+	if werr != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(map[string]any{"error": werr.Error()})
+		return
+	}
+
+	status := http.StatusOK
+	if len(result.Violations) > 0 {
+		status = http.StatusBadRequest
+	}
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(result)
+}
+
+func (s *Server) handleConfigRollback(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	var body rollbackConfigInput
+	if r.ContentLength > 0 {
+		data, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]any{"error": "read body: " + err.Error()})
+			return
+		}
+		if len(data) > 0 {
+			if err := json.Unmarshal(data, &body); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]any{"error": "parse body: " + err.Error()})
+				return
+			}
+		}
+	}
+
+	result, err := RollbackConfig(s.cfg.WorkspaceRoot, RollbackOptions{
+		Backup:   body.Backup,
+		ListOnly: body.ListOnly,
+	})
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(map[string]any{"error": err.Error()})
+		return
+	}
+
+	status := http.StatusOK
+	if result.Error != "" {
+		status = http.StatusBadRequest
+	}
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(result)
+}
+
+// truthyQuery accepts "1", "true", "yes" (case-insensitive).
+func truthyQuery(v string) bool {
+	switch v {
+	case "1", "true", "TRUE", "True", "yes", "YES", "Yes":
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Config mutation surface — closes Agent F's #5 critical MCP blindspot. Claude-as-primary-UI can now read, patch, and roll back \`kernel.yaml\` via MCP or HTTP. Design spec produced by Agent O earlier this session.

## What landed

- **Three MCP tools**: \`cog_read_config\`, \`cog_write_config\`, \`cog_rollback_config\`.
- **\`cogos://config\` MCP resource** alongside the read tool.
- **Three HTTP routes**: \`GET /v1/config\`, \`PATCH /v1/config\`, \`POST /v1/config/rollback\`.

## Design highlights

- **RFC 7396 JSON merge-patch semantics** — explicit \`null\` deletes a key; missing keys preserved.
- **v1 = write-to-disk + \`requires_restart: true\`**. The \`*Config\` pointer threads through subsystems without a mutex, so hot-reload is v1.5 work (avoids data-race risk under \`-race\`).
- **Atomic write** via a duplicated \`atomicWriteConfigFile\` helper. The root-package \`atomicWriteFile\` couldn't be imported from \`internal/engine\` (package boundary); duplication is a collapse candidate for Track 5's future root-package sweep.
- **\`.bak-<timestamp>\` rotation keeping 10** for rollback.
- **Write-side validation refuses to overwrite a corrupt \`kernel.yaml\`** — forces the operator through \`cog_rollback_config\` first. Extends the design's "validate before persisting" rule to also cover pre-existing-unparseable state.
- **\`LoadConfig\`'s silent parse-error swallow is left untouched** (per design, intentional ADR history); only the write path is strict.

## Test plan

- [x] 20 new tests across unit (12), MCP (3), HTTP (3), wire (2) — all pass
- [x] \`go test ./internal/engine/... -short -count=1 -race\` clean
- [x] \`go build ./...\` + \`go vet ./...\` silent
- [x] Independent of PR #11; based on \`upstream/main\` directly

## Not in scope

- Hot reload of running kernel (v1.5)
- Auth on config writes (kernel is localhost-trusted by design)

## Design reference

Agent O's design CogDoc: \`~/cog-workspace/.cog/mem/semantic/surveys/2026-04-21-consolidation/agent-O-config-mutation-design.cog.md\`