### PR TITLE
chore: add Windows build targets and install docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ GOOS := $(shell go env GOOS)
 GOARCH := $(shell go env GOARCH)
 
 # Build targets
-PLATFORMS := darwin-arm64 darwin-amd64 linux-amd64 linux-arm64 android-arm64
+PLATFORMS := darwin-arm64 darwin-amd64 linux-amd64 linux-arm64 android-arm64 windows-amd64 windows-arm64
 
 .PHONY: all build clean test test-coverage test-integration bench install push image run e2e e2e-local $(PLATFORMS)
 
@@ -61,6 +61,16 @@ linux-arm64:
 # Android requires PIE (position-independent executables)
 android-arm64:
 	GOOS=android GOARCH=arm64 $(GO) build -tags "$(BUILD_TAGS)" -buildmode=pie -ldflags="$(LDFLAGS)" -o $(BINARY)-android-arm64 .
+
+# Windows cross-compile: matches .github/workflows/release.yml exactly.
+# CGO_ENABLED=0 avoids tree-sitter's CGO path; ./cmd/cogos/ is the real entry
+# point published by CI (the root package pulls in test-only deps).
+# .exe suffix is required to execute on Windows.
+windows-amd64:
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 $(GO) build -ldflags="$(LDFLAGS)" -o $(BINARY)-windows-amd64.exe ./cmd/cogos/
+
+windows-arm64:
+	CGO_ENABLED=0 GOOS=windows GOARCH=arm64 $(GO) build -ldflags="$(LDFLAGS)" -o $(BINARY)-windows-arm64.exe ./cmd/cogos/
 
 INSTALL_DIR := $(HOME)/.cog/bin
 INSTALL_TARGET := $(INSTALL_DIR)/cogos

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -37,3 +37,77 @@ chmod +x cogos
 # Download cogos-windows-amd64.exe from the latest release
 cogos.exe serve
 ```
+
+## Installing on Windows (developer preview)
+
+The Windows binaries are a developer preview: they are **not yet code-signed**, so Windows SmartScreen will warn before the first run. The binary itself is the same PE32+ executable that CI produces from the same source tree as the macOS and Linux targets.
+
+### Download
+
+Pick the right architecture for your machine (most users want `amd64`; `arm64` is for Windows-on-ARM devices such as Surface Pro X / Copilot+ PCs).
+
+Using PowerShell:
+```powershell
+# amd64 (x86-64)
+Invoke-WebRequest -Uri https://github.com/cogos-dev/cogos/releases/latest/download/cogos-windows-amd64.exe -OutFile cogos.exe
+
+# arm64
+Invoke-WebRequest -Uri https://github.com/cogos-dev/cogos/releases/latest/download/cogos-windows-arm64.exe -OutFile cogos.exe
+```
+
+Or download manually from the [latest release](https://github.com/cogos-dev/cogos/releases/latest) and rename to `cogos.exe`.
+
+Verify the SHA-256 against `checksums.txt` from the same release:
+```powershell
+Get-FileHash -Algorithm SHA256 cogos.exe
+```
+
+### SmartScreen on first run
+
+Because the binary is unsigned, Windows Defender SmartScreen will show a blue "Windows protected your PC" dialog the first time you run it. To proceed:
+
+1. Click **More info** in the dialog.
+2. Click **Run anyway**.
+
+This is a one-time prompt per binary. Code signing will remove this step in a future release.
+
+### Install to PATH
+
+The recommended location for per-user installs is `%LOCALAPPDATA%\cogos\`, which does not require admin privileges:
+
+```powershell
+# Create the install directory and move the binary
+$InstallDir = "$env:LOCALAPPDATA\cogos"
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+Move-Item -Force .\cogos.exe "$InstallDir\cogos.exe"
+
+# Add to the User PATH (persists across sessions; no admin needed)
+$UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if ($UserPath -notlike "*$InstallDir*") {
+    [Environment]::SetEnvironmentVariable("Path", "$UserPath;$InstallDir", "User")
+}
+```
+
+Open a **new** PowerShell window so the updated PATH is picked up.
+
+### Sanity check
+
+Verify the install:
+```powershell
+cogos.exe version
+```
+You should see a line like `cogos version=dev build=<timestamp>` (or the real version string on a tagged release).
+
+To confirm the daemon comes up and the HTTP API responds, in one terminal:
+```powershell
+cogos.exe serve
+```
+and in a second terminal:
+```powershell
+cogos.exe health
+```
+Expected output: `healthy`.
+
+### Stretch goal: Windows Service / SCM integration
+
+Running `cogos` as a background Windows Service (via the Service Control Manager) is not included in the v0.x developer preview. For now, run `cogos serve` in a foreground terminal, or wrap it with Task Scheduler / NSSM if you need it to start at login. First-class `cogos install-service` support is a planned follow-up and will land in a later release.


### PR DESCRIPTION
## Summary

Makefile Windows cross-compile targets + RELEASING.md Windows install section. Addresses Agent K's §"Proposed PRs" #1 and #2 from the Windows release audit. **No version tag is cut** — that decision is still open.

## What landed

**\`Makefile\`:** \`windows-amd64\` and \`windows-arm64\` targets, matching \`release.yml\`'s proven \`CGO_ENABLED=0 ./cmd/cogos/\` recipe. Extended the existing \`PLATFORMS\` list.

**\`docs/RELEASING.md\`:** New \`## Installing on Windows (developer preview)\` section covering:
- PowerShell download via \`Invoke-WebRequest\` from \`/releases/latest/download/cogos-windows-{amd64,arm64}.exe\`
- SmartScreen workaround (unsigned binary — click "More info" → "Run anyway")
- \`%LOCALAPPDATA%\\cogos\\\` install path with User PATH update (no admin needed, persists)
- Sanity check via \`cogos.exe version\` + \`cogos.exe serve\` + \`cogos.exe health\` (all verified real subcommands in \`internal/engine/cli.go:66-71\`)
- SHA-256 checksum verification via \`Get-FileHash\`
- Note that Windows Service / SCM integration is follow-up, not v0.x

## Pre-existing issue surfaced (NOT fixed here)

The existing \`linux-*/darwin-*\` Makefile cross-compile targets are **broken** — they build \`.\` (root package) without \`CGO_ENABLED=0\`, failing cross-compile with \`go-tree-sitter\` CGO errors. Only the host-native target works. Separate PR candidate to reconcile with \`release.yml\`'s recipe. Flagged; not in this PR's scope.

## Test plan

- [x] \`go build ./...\` + \`go vet ./...\` silent (no \`.go\` code touched)
- [x] \`make windows-amd64\` locally → valid PE32+ x86-64 executable
- [x] \`make windows-arm64\` locally → valid PE32+ Aarch64 executable

## Not in scope

- Version tag cut (\`v0.3.0\` vs \`v2.6.0\` — maintainer decision)
- Code signing (cert cost gate)
- Scoop / Chocolatey / winget manifests
- Windows Service SCM integration

## Design reference

Agent K's audit: \`~/cog-workspace/.cog/mem/semantic/surveys/2026-04-21-consolidation/agent-K-windows-release-audit.cog.md\`