### PR TITLE
feat(engine): event bus with MCP tools, real SSE stream + cogos#10 fix

### DIFF
--- a/bus_api_contract_test.go
+++ b/bus_api_contract_test.go
@@ -1,0 +1,136 @@
+package main
+
+// bus_api_contract_test.go — regression tests asserting the HTTP contract for
+// the root-package bus API remains byte-compatible with pre-event-bus-PR
+// consumers (e.g. cog-sandbox-mcp HTTP bridge).
+//
+// These tests do NOT exercise the internal/engine event bus. The two worlds
+// coexist: internal/engine/ is the v3 kernel surface; the root package
+// serves the legacy bus_* endpoints. The event-bus PR only touches
+// internal/engine, but this file pins the root-package shape so an
+// accidental reshape there is caught in CI.
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+// TestBusSendResponseShape asserts the JSON keys and types on
+// busSendResponse, which is what POST /v1/bus/send returns. Any rename,
+// removal, or retyping would break the cog-sandbox-mcp bridge at
+// localhost:7823.
+//
+// Expected shape (contract, byte-compatible with pre-PR daemons):
+//
+//	{"ok": bool, "seq": int, "hash": string}
+func TestBusSendResponseShape(t *testing.T) {
+	t.Parallel()
+	resp := busSendResponse{OK: true, Seq: 42, Hash: "deadbeef"}
+	raw, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	want := map[string]interface{}{
+		"ok":   true,
+		"seq":  float64(42), // JSON numbers decode as float64
+		"hash": "deadbeef",
+	}
+	if !reflect.DeepEqual(decoded, want) {
+		t.Errorf("busSendResponse keys = %v; want %v (HTTP contract violation)", decoded, want)
+	}
+
+	// Extra paranoia: ensure exactly these three keys and no more.
+	gotKeys := map[string]bool{}
+	for k := range decoded {
+		gotKeys[k] = true
+	}
+	wantKeys := map[string]bool{"ok": true, "seq": true, "hash": true}
+	if !reflect.DeepEqual(gotKeys, wantKeys) {
+		t.Errorf("busSendResponse key set = %v; want %v", gotKeys, wantKeys)
+	}
+}
+
+// TestBusEventsResponseShape pins the per-event shape returned by
+// GET /v1/bus/{bus_id}/events. The response is a JSON array of full
+// CogBlock values; downstream consumers depend on `seq`, `hash`,
+// `prev_hash`, `type`, `from`, `payload`, `ts`, and `bus_id`.
+func TestBusEventsResponseShape(t *testing.T) {
+	t.Parallel()
+	// Build a minimal but realistic event — mirrors what appendBusEvent
+	// produces.
+	evt := CogBlock{
+		V:        2,
+		BusID:    "test-bus",
+		Seq:      7,
+		Ts:       "2026-04-21T00:00:00Z",
+		From:     "contract-test",
+		Type:     "message",
+		Payload:  map[string]interface{}{"content": "hi"},
+		Hash:     "h7",
+		PrevHash: "h6",
+		Prev:     []string{"h6"},
+	}
+	events := []CogBlock{evt}
+	raw, err := json.Marshal(events)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded []map[string]interface{}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(decoded) != 1 {
+		t.Fatalf("len=%d; want 1", len(decoded))
+	}
+	got := decoded[0]
+
+	// Core fields the cog-sandbox-mcp bridge consumes. We do NOT assert a
+	// strict key-set because CogBlock has many optional fields (Sig, To,
+	// Meta, Agent, Prev, LegacyPrev, etc.) that are conditionally present.
+	for _, k := range []string{"bus_id", "seq", "ts", "from", "type", "payload", "hash"} {
+		if _, ok := got[k]; !ok {
+			t.Errorf("event missing required key %q; full value: %v", k, got)
+		}
+	}
+
+	// seq must be a JSON number.
+	if _, ok := got["seq"].(float64); !ok {
+		t.Errorf("seq type = %T; want number", got["seq"])
+	}
+	// hash must be a string.
+	if _, ok := got["hash"].(string); !ok {
+		t.Errorf("hash type = %T; want string", got["hash"])
+	}
+	// payload must be a JSON object.
+	if _, ok := got["payload"].(map[string]interface{}); !ok {
+		t.Errorf("payload type = %T; want object", got["payload"])
+	}
+}
+
+// TestBusSendRequestShape asserts the request body shape accepted by
+// POST /v1/bus/send. A rename here would silently drop fields.
+func TestBusSendRequestShape(t *testing.T) {
+	t.Parallel()
+	// Canonical request body that cog-sandbox-mcp sends.
+	body := `{
+		"bus_id": "b",
+		"from": "alice",
+		"to": "bob",
+		"message": "hello",
+		"type": "message"
+	}`
+	var req busSendRequest
+	if err := json.Unmarshal([]byte(body), &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if req.BusID != "b" || req.From != "alice" || req.To != "bob" ||
+		req.Message != "hello" || req.Type != "message" {
+		t.Errorf("decoded request = %+v; expected all fields set", req)
+	}
+}

--- a/internal/engine/eventbus.go
+++ b/internal/engine/eventbus.go
@@ -1,0 +1,524 @@
+// eventbus.go — in-process event broker for the kernel ledger.
+//
+// The broker is the live fan-out companion to the hash-chained ledger. Every
+// call to AppendEvent publishes the envelope here; subscribers get filtered,
+// non-blocking deliveries via a buffered channel. A small ring buffer retains
+// recent events so that reconnecting subscribers can replay the tail without
+// re-reading the JSONL ledger.
+//
+// Design constraints (from Agent N's design survey):
+//
+//   - Broker hook lives INSIDE AppendEvent (the single write sink) so that
+//     consolidate.go, cogblock_ledger.go, process.go — all of which call
+//     AppendEvent directly — feed the live bus without extra wiring.
+//   - Publish is fire-and-forget: the ledger never blocks on a slow SSE
+//     consumer. Full subscriber channels drop events and increment a counter.
+//   - A package-level currentBroker is set once by NewProcess; tests that want
+//     isolation use SetCurrentBroker(nil).
+//   - Close unblocks all waiting subscribers so servers can shut down cleanly.
+package engine
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	// DefaultRingSize is the default capacity of the recent-events ring
+	// buffer. See Agent N §7.1 — 1024 events × ~320 B/event ≈ 320 KB.
+	DefaultRingSize = 1024
+
+	// DefaultSubChanBuffer is the per-subscriber channel buffer. A healthy
+	// SSE writer empties this quickly; a wedged one gets dropped frames.
+	DefaultSubChanBuffer = 64
+
+	// DefaultMaxSubscribers caps concurrent subscribers per broker. Single
+	// global kernel bus — no per-bus scoping.
+	DefaultMaxSubscribers = 50
+)
+
+// EventFilter selects which events a subscriber receives. Zero values are
+// no-ops (don't filter on that field).
+type EventFilter struct {
+	// SessionID filters to a single session when non-empty.
+	SessionID string
+
+	// EventTypePattern is the raw pattern (exact, "prefix.*", or "*").
+	// It is compiled once on Subscribe via compileEventTypeMatcher.
+	EventTypePattern string
+
+	// Source filters on envelope.Metadata.Source (e.g. "kernel-v3").
+	Source string
+
+	// Since, when non-zero, drops envelopes whose parsed Timestamp is
+	// before it. Used for live-only tailing; replay uses the ring +
+	// disk path instead.
+	Since time.Time
+}
+
+// subscriber is an internal record for a live consumer.
+type subscriber struct {
+	id        int
+	ch        chan *EventEnvelope
+	filter    EventFilter
+	matcher   func(string) bool // compiled from filter.EventTypePattern
+	ctx       context.Context
+	cancel    context.CancelFunc
+	connected time.Time
+	dropped   atomic.Uint64
+}
+
+// eventRing is a fixed-capacity circular buffer of recent envelopes.
+// Reads take RLock; Push takes Lock. The buffer stores pointers, so
+// copy-on-write isn't needed — envelopes are effectively immutable once
+// AppendEvent has returned.
+type eventRing struct {
+	mu   sync.RWMutex
+	buf  []*EventEnvelope
+	head int // next write position
+	size int // items currently stored (capped at cap)
+	cap  int
+}
+
+func newEventRing(capacity int) *eventRing {
+	if capacity <= 0 {
+		capacity = DefaultRingSize
+	}
+	return &eventRing{buf: make([]*EventEnvelope, capacity), cap: capacity}
+}
+
+// Push appends env to the ring, evicting the oldest event when full.
+func (r *eventRing) Push(env *EventEnvelope) {
+	r.mu.Lock()
+	r.buf[r.head] = env
+	r.head = (r.head + 1) % r.cap
+	if r.size < r.cap {
+		r.size++
+	}
+	r.mu.Unlock()
+}
+
+// Snapshot returns a slice of the current contents in chronological order
+// (oldest first). The returned slice is a copy; callers may mutate freely.
+func (r *eventRing) Snapshot() []*EventEnvelope {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]*EventEnvelope, 0, r.size)
+	if r.size == 0 {
+		return out
+	}
+	start := r.head - r.size
+	if start < 0 {
+		start += r.cap
+	}
+	for i := 0; i < r.size; i++ {
+		idx := (start + i) % r.cap
+		out = append(out, r.buf[idx])
+	}
+	return out
+}
+
+// Len returns the current number of items in the ring.
+func (r *eventRing) Len() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.size
+}
+
+// Cap returns the ring capacity.
+func (r *eventRing) Cap() int {
+	return r.cap
+}
+
+// EventBroker fans out kernel events to live subscribers.
+type EventBroker struct {
+	mu             sync.RWMutex
+	subs           map[int]*subscriber
+	nextID         int
+	ring           *eventRing
+	closed         atomic.Bool
+	maxSubscribers int
+	chanBuffer     int
+}
+
+// EventBrokerOptions configures NewEventBroker.
+type EventBrokerOptions struct {
+	RingSize       int
+	MaxSubscribers int
+	ChanBuffer     int
+}
+
+// NewEventBroker constructs a broker with sane defaults.
+func NewEventBroker(opts EventBrokerOptions) *EventBroker {
+	if opts.RingSize <= 0 {
+		opts.RingSize = DefaultRingSize
+	}
+	if opts.MaxSubscribers <= 0 {
+		opts.MaxSubscribers = DefaultMaxSubscribers
+	}
+	if opts.ChanBuffer <= 0 {
+		opts.ChanBuffer = DefaultSubChanBuffer
+	}
+	return &EventBroker{
+		subs:           make(map[int]*subscriber),
+		ring:           newEventRing(opts.RingSize),
+		maxSubscribers: opts.MaxSubscribers,
+		chanBuffer:     opts.ChanBuffer,
+	}
+}
+
+// ErrBrokerClosed is returned by Subscribe after Close has been called.
+type ErrBrokerClosed struct{}
+
+func (ErrBrokerClosed) Error() string { return "event broker: closed" }
+
+// ErrTooManySubscribers is returned when Subscribe would exceed maxSubscribers.
+type ErrTooManySubscribers struct{ Max int }
+
+func (e ErrTooManySubscribers) Error() string {
+	return "event broker: too many subscribers"
+}
+
+// ── Package-level broker registry ───────────────────────────────────────────
+//
+// In production there is exactly one *Process per kernel, so exactly one
+// broker. In tests the suite spins up many parallel processes; a single-slot
+// "current broker" would race. We use a registry instead — AppendEvent
+// publishes to every installed broker, matchers on the broker side handle
+// the filtering. This is the same big-O cost as single-slot for N=1 and
+// works correctly for N>1 without serialising tests.
+
+var (
+	brokersMu sync.RWMutex
+	brokers   = map[*EventBroker]struct{}{}
+	// legacyCurrent tracks the most recently installed broker for the
+	// CurrentBroker() convenience accessor used in tests. Not consulted
+	// by AppendEvent.
+	legacyCurrent *EventBroker
+)
+
+// RegisterBroker adds b to the package-level broker registry. AppendEvent
+// publishes to every registered broker. Idempotent. Safe for concurrent use.
+func RegisterBroker(b *EventBroker) {
+	if b == nil {
+		return
+	}
+	brokersMu.Lock()
+	brokers[b] = struct{}{}
+	legacyCurrent = b
+	brokersMu.Unlock()
+}
+
+// UnregisterBroker removes b from the registry. Idempotent. Safe for concurrent use.
+func UnregisterBroker(b *EventBroker) {
+	if b == nil {
+		return
+	}
+	brokersMu.Lock()
+	delete(brokers, b)
+	if legacyCurrent == b {
+		legacyCurrent = nil
+	}
+	brokersMu.Unlock()
+}
+
+// SetCurrentBroker replaces the registry with just b (or clears it if nil).
+// Kept for compatibility with earlier single-slot wiring; prefer Register /
+// UnregisterBroker for additive wiring.
+func SetCurrentBroker(b *EventBroker) {
+	brokersMu.Lock()
+	brokers = map[*EventBroker]struct{}{}
+	if b != nil {
+		brokers[b] = struct{}{}
+	}
+	legacyCurrent = b
+	brokersMu.Unlock()
+}
+
+// CurrentBroker returns the most recently registered broker, or nil.
+// Tests use this as a convenience — production code should hold a direct
+// *Process reference and call p.Broker().
+func CurrentBroker() *EventBroker {
+	brokersMu.RLock()
+	defer brokersMu.RUnlock()
+	return legacyCurrent
+}
+
+// brokerSnapshot returns a slice copy of all registered brokers so that
+// AppendEvent can publish without holding the registry lock across sends.
+func brokerSnapshot() []*EventBroker {
+	brokersMu.RLock()
+	defer brokersMu.RUnlock()
+	if len(brokers) == 0 {
+		return nil
+	}
+	out := make([]*EventBroker, 0, len(brokers))
+	for b := range brokers {
+		out = append(out, b)
+	}
+	return out
+}
+
+// ── Publish / Subscribe ─────────────────────────────────────────────────────
+
+// Publish fans env out to matching subscribers. Non-blocking: a full sub
+// channel increments its drop counter rather than stalling the ledger. Safe
+// after Close — returns silently.
+func (b *EventBroker) Publish(env *EventEnvelope) {
+	if b == nil || env == nil {
+		return
+	}
+	if b.closed.Load() {
+		return
+	}
+	// Ring first; cheap enough to do unconditionally.
+	b.ring.Push(env)
+
+	// Snapshot subscribers under RLock, then release before sending to avoid
+	// holding the lock across a channel send (even a non-blocking one).
+	b.mu.RLock()
+	snap := make([]*subscriber, 0, len(b.subs))
+	for _, s := range b.subs {
+		snap = append(snap, s)
+	}
+	b.mu.RUnlock()
+
+	for _, s := range snap {
+		if !subscriberMatches(s, env) {
+			continue
+		}
+		select {
+		case s.ch <- env:
+		default:
+			s.dropped.Add(1)
+		}
+	}
+}
+
+// subscriberMatches applies the filter to env and reports whether it should
+// be delivered.
+func subscriberMatches(s *subscriber, env *EventEnvelope) bool {
+	if s == nil || env == nil {
+		return false
+	}
+	if s.filter.SessionID != "" && env.HashedPayload.SessionID != s.filter.SessionID {
+		return false
+	}
+	if s.matcher != nil && !s.matcher(env.HashedPayload.Type) {
+		return false
+	}
+	if s.filter.Source != "" && env.Metadata.Source != s.filter.Source {
+		return false
+	}
+	if !s.filter.Since.IsZero() {
+		ts, err := time.Parse(time.RFC3339, env.HashedPayload.Timestamp)
+		if err != nil || ts.Before(s.filter.Since) {
+			return false
+		}
+	}
+	return true
+}
+
+// Subscription is returned by Subscribe. Close unsubscribes and drains the
+// channel. Dropped returns the number of events dropped due to a full
+// channel — callers can surface this to consumers as a _meta frame.
+type Subscription struct {
+	Events  <-chan *EventEnvelope
+	Dropped func() uint64
+	Cancel  func()
+}
+
+// Subscribe registers a new live subscriber. The returned channel streams
+// matching events; when the passed ctx is cancelled or Cancel is called,
+// the subscription is removed and the channel closed.
+//
+// Replay is handled by the caller via RingReplay — keeping replay out of
+// Subscribe avoids a race where events can arrive on the channel before
+// the caller has finished streaming the ring snapshot.
+func (b *EventBroker) Subscribe(ctx context.Context, filter EventFilter) (*Subscription, error) {
+	if b == nil {
+		return nil, ErrBrokerClosed{}
+	}
+	if b.closed.Load() {
+		return nil, ErrBrokerClosed{}
+	}
+
+	matcher, err := compileEventTypeMatcher(filter.EventTypePattern)
+	if err != nil {
+		return nil, err
+	}
+
+	b.mu.Lock()
+	if len(b.subs) >= b.maxSubscribers {
+		b.mu.Unlock()
+		return nil, ErrTooManySubscribers{Max: b.maxSubscribers}
+	}
+
+	subCtx, cancel := context.WithCancel(ctx)
+	s := &subscriber{
+		ch:        make(chan *EventEnvelope, b.chanBuffer),
+		filter:    filter,
+		matcher:   matcher,
+		ctx:       subCtx,
+		cancel:    cancel,
+		connected: time.Now().UTC(),
+	}
+	id := b.nextID
+	s.id = id
+	b.nextID++
+	b.subs[id] = s
+	b.mu.Unlock()
+
+	// When ctx is cancelled upstream (client disconnect, max_duration),
+	// remove ourselves and close the channel so the reader loop exits.
+	go func() {
+		<-subCtx.Done()
+		b.removeSub(id)
+	}()
+
+	sub := &Subscription{
+		Events:  s.ch,
+		Dropped: func() uint64 { return s.dropped.Load() },
+		Cancel:  cancel,
+	}
+	return sub, nil
+}
+
+func (b *EventBroker) removeSub(id int) {
+	b.mu.Lock()
+	s, ok := b.subs[id]
+	if ok {
+		delete(b.subs, id)
+	}
+	b.mu.Unlock()
+	if ok {
+		// close under the sub's own cancel guarantee — no more sends
+		// will race because Publish snapshots subs under RLock before
+		// sending.
+		close(s.ch)
+	}
+}
+
+// SubscriberCount returns the current number of live subscribers.
+func (b *EventBroker) SubscriberCount() int {
+	if b == nil {
+		return 0
+	}
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return len(b.subs)
+}
+
+// RingReplay returns a filtered copy of the current ring contents. Callers
+// use this to drain the replay window before consuming live events. Events
+// with a parsed timestamp earlier than `since` are dropped when since is
+// non-zero.
+func (b *EventBroker) RingReplay(filter EventFilter, since time.Time) []*EventEnvelope {
+	if b == nil {
+		return nil
+	}
+	matcher, err := compileEventTypeMatcher(filter.EventTypePattern)
+	if err != nil {
+		// An invalid pattern at replay time is unusual — the Subscribe
+		// path already validated it. Fall back to "no matcher" (the
+		// downstream subscriber will still filter).
+		matcher = nil
+	}
+	pseudo := &subscriber{filter: filter, matcher: matcher}
+	all := b.ring.Snapshot()
+	out := make([]*EventEnvelope, 0, len(all))
+	for _, env := range all {
+		if !since.IsZero() {
+			ts, err := time.Parse(time.RFC3339, env.HashedPayload.Timestamp)
+			if err != nil || ts.Before(since) {
+				continue
+			}
+		}
+		if !subscriberMatches(pseudo, env) {
+			continue
+		}
+		out = append(out, env)
+	}
+	return out
+}
+
+// RingOldestHash returns the hash of the oldest envelope currently in the
+// ring, or "" if empty. Used by SSE handlers to decide whether a
+// Last-Event-ID resume point fits inside the ring or needs to fall through
+// to disk.
+func (b *EventBroker) RingOldestHash() string {
+	if b == nil {
+		return ""
+	}
+	snap := b.ring.Snapshot()
+	if len(snap) == 0 {
+		return ""
+	}
+	return snap[0].Metadata.Hash
+}
+
+// RingContainsHash reports whether the given hash is present in the ring.
+func (b *EventBroker) RingContainsHash(hash string) bool {
+	if b == nil || hash == "" {
+		return false
+	}
+	for _, env := range b.ring.Snapshot() {
+		if env.Metadata.Hash == hash {
+			return true
+		}
+	}
+	return false
+}
+
+// Close unblocks all current subscribers, unregisters the broker so
+// AppendEvent stops publishing to it, and prevents new subscriptions.
+// Idempotent.
+func (b *EventBroker) Close() error {
+	if b == nil {
+		return nil
+	}
+	if !b.closed.CompareAndSwap(false, true) {
+		return nil
+	}
+	UnregisterBroker(b)
+	b.mu.Lock()
+	subs := b.subs
+	b.subs = map[int]*subscriber{}
+	b.mu.Unlock()
+	for _, s := range subs {
+		s.cancel()
+		// removeSub closes the channel, but we skipped that by swapping
+		// b.subs; close here to unblock any pending reader.
+		// Guard against a concurrent close.
+		defer func(ch chan *EventEnvelope) {
+			defer func() { _ = recover() }()
+			close(ch)
+		}(s.ch)
+	}
+	return nil
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+// ParseSinceDuration parses `since` as either an RFC3339 timestamp or a
+// shorthand duration like "5m", "1h", "30s". Relative forms are resolved
+// against `now`. Empty string returns the zero Time.
+func ParseSinceDuration(s string, now time.Time) (time.Time, error) {
+	if s == "" {
+		return time.Time{}, nil
+	}
+	// Try RFC3339 first.
+	if ts, err := time.Parse(time.RFC3339, s); err == nil {
+		return ts, nil
+	}
+	// Fall back to duration shorthand. Go's time.ParseDuration already
+	// handles "5m", "1h30m", "45s" — we just need to subtract from now.
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return now.Add(-d), nil
+}
+

--- a/internal/engine/eventbus_test.go
+++ b/internal/engine/eventbus_test.go
@@ -1,0 +1,559 @@
+// eventbus_test.go — unit tests for the in-process event broker and ring.
+//
+// These tests are broker-local (no disk, no HTTP). Wiring tests that go
+// through AppendEvent live alongside to exercise the ledger → broker path.
+package engine
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// ── Broker unit tests ──────────────────────────────────────────────────────
+
+func newBrokerForTest(t *testing.T, ring, chanBuf int) *EventBroker {
+	t.Helper()
+	b := NewEventBroker(EventBrokerOptions{
+		RingSize:       ring,
+		MaxSubscribers: 100,
+		ChanBuffer:     chanBuf,
+	})
+	t.Cleanup(func() { _ = b.Close() })
+	return b
+}
+
+func mkEnv(sid, typ, src string, t time.Time) *EventEnvelope {
+	return &EventEnvelope{
+		HashedPayload: EventPayload{
+			Type:      typ,
+			Timestamp: t.UTC().Format(time.RFC3339),
+			SessionID: sid,
+			Data:      map[string]interface{}{"i": typ},
+		},
+		Metadata: EventMetadata{
+			Source: src,
+			Hash:   fmt.Sprintf("%s-%s-%d", sid, typ, t.UnixNano()),
+			Seq:    1,
+		},
+	}
+}
+
+func TestBrokerPublishFanOut(t *testing.T) {
+	t.Parallel()
+	b := newBrokerForTest(t, 1024, 16)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var subs [3]*Subscription
+	for i := range subs {
+		s, err := b.Subscribe(ctx, EventFilter{})
+		if err != nil {
+			t.Fatalf("Subscribe[%d]: %v", i, err)
+		}
+		subs[i] = s
+	}
+
+	now := time.Now()
+	for i := 0; i < 5; i++ {
+		b.Publish(mkEnv("s", fmt.Sprintf("evt.%d", i), "kernel-v3", now.Add(time.Duration(i)*time.Millisecond)))
+	}
+
+	for i, s := range subs {
+		for j := 0; j < 5; j++ {
+			select {
+			case env := <-s.Events:
+				want := fmt.Sprintf("evt.%d", j)
+				if env.HashedPayload.Type != want {
+					t.Errorf("sub[%d] evt[%d]: got %s want %s", i, j, env.HashedPayload.Type, want)
+				}
+			case <-time.After(time.Second):
+				t.Fatalf("sub[%d] evt[%d]: timed out", i, j)
+			}
+		}
+	}
+}
+
+func TestBrokerFilterByType(t *testing.T) {
+	t.Parallel()
+	b := newBrokerForTest(t, 1024, 16)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	s, err := b.Subscribe(ctx, EventFilter{EventTypePattern: "attention.*"})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	now := time.Now()
+	b.Publish(mkEnv("s", "attention.boost", "kernel-v3", now))
+	b.Publish(mkEnv("s", "cycle.tick", "kernel-v3", now))
+	b.Publish(mkEnv("s", "attention.decay", "kernel-v3", now))
+
+	got := []string{}
+	deadline := time.After(500 * time.Millisecond)
+collect:
+	for len(got) < 2 {
+		select {
+		case env := <-s.Events:
+			got = append(got, env.HashedPayload.Type)
+		case <-deadline:
+			break collect
+		}
+	}
+
+	if len(got) != 2 || got[0] != "attention.boost" || got[1] != "attention.decay" {
+		t.Errorf("got %v; want [attention.boost attention.decay]", got)
+	}
+}
+
+func TestBrokerFilterBySession(t *testing.T) {
+	t.Parallel()
+	b := newBrokerForTest(t, 1024, 16)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	s, err := b.Subscribe(ctx, EventFilter{SessionID: "A"})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	now := time.Now()
+	b.Publish(mkEnv("A", "x", "kernel-v3", now))
+	b.Publish(mkEnv("B", "x", "kernel-v3", now))
+	b.Publish(mkEnv("A", "y", "kernel-v3", now))
+
+	// Expect 2 events (A/x, A/y), then timeout before any B.
+	got := 0
+	for i := 0; i < 2; i++ {
+		select {
+		case env := <-s.Events:
+			if env.HashedPayload.SessionID != "A" {
+				t.Errorf("sub got session %s; want A", env.HashedPayload.SessionID)
+			}
+			got++
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("timed out waiting for session=A event")
+		}
+	}
+	// Drain any stragglers — expect none.
+	select {
+	case env := <-s.Events:
+		t.Errorf("unexpected extra event: session=%s type=%s",
+			env.HashedPayload.SessionID, env.HashedPayload.Type)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if got != 2 {
+		t.Errorf("delivered %d; want 2", got)
+	}
+}
+
+func TestBrokerFilterSince(t *testing.T) {
+	t.Parallel()
+	b := newBrokerForTest(t, 1024, 16)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// since=now+1s — nothing published at `now` should be delivered.
+	future := time.Now().Add(1 * time.Second)
+	s, err := b.Subscribe(ctx, EventFilter{Since: future})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	now := time.Now()
+	b.Publish(mkEnv("s", "early", "kernel-v3", now))
+	b.Publish(mkEnv("s", "late", "kernel-v3", future.Add(2*time.Second)))
+
+	select {
+	case env := <-s.Events:
+		if env.HashedPayload.Type != "late" {
+			t.Errorf("first event type=%s; want late", env.HashedPayload.Type)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected 'late' event")
+	}
+
+	select {
+	case env := <-s.Events:
+		t.Errorf("unexpected 'early' delivery: %s", env.HashedPayload.Type)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestBrokerReplayFromRing(t *testing.T) {
+	t.Parallel()
+	b := newBrokerForTest(t, 5, 16)
+
+	// Publish 10 events with size-5 ring.
+	now := time.Now()
+	for i := 0; i < 10; i++ {
+		b.Publish(mkEnv("s", fmt.Sprintf("evt.%d", i), "kernel-v3", now.Add(time.Duration(i)*time.Millisecond)))
+	}
+
+	if b.ring.Len() != 5 {
+		t.Errorf("ring len = %d; want 5", b.ring.Len())
+	}
+
+	// Replay from zero time should return all ring contents.
+	replay := b.RingReplay(EventFilter{}, time.Time{})
+	if len(replay) != 5 {
+		t.Fatalf("replay len=%d; want 5", len(replay))
+	}
+	// Should be the last 5 events (5-9).
+	for i, env := range replay {
+		want := fmt.Sprintf("evt.%d", i+5)
+		if env.HashedPayload.Type != want {
+			t.Errorf("replay[%d]=%s; want %s", i, env.HashedPayload.Type, want)
+		}
+	}
+}
+
+func TestBrokerReplayFilterApplied(t *testing.T) {
+	t.Parallel()
+	b := newBrokerForTest(t, 1024, 16)
+	now := time.Now()
+	b.Publish(mkEnv("A", "foo", "kernel-v3", now))
+	b.Publish(mkEnv("B", "foo", "kernel-v3", now))
+	b.Publish(mkEnv("A", "bar", "mcp-client", now))
+
+	replay := b.RingReplay(EventFilter{SessionID: "A", EventTypePattern: "foo"}, time.Time{})
+	if len(replay) != 1 || replay[0].HashedPayload.SessionID != "A" || replay[0].HashedPayload.Type != "foo" {
+		t.Errorf("unexpected replay: %+v", replay)
+	}
+}
+
+func TestBrokerBackpressureDrop(t *testing.T) {
+	t.Parallel()
+	// Core assertion: a slow subscriber with a tiny channel buffer must not
+	// block the broker; dropped events increment the slow sub's counter
+	// while healthy subs continue receiving. Fast sub buffer is sized
+	// generously so scheduling jitter doesn't starve it.
+	b := NewEventBroker(EventBrokerOptions{
+		RingSize:       1024,
+		MaxSubscribers: 10,
+		ChanBuffer:     4, // default for slow
+	})
+	t.Cleanup(func() { _ = b.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	slow, err := b.Subscribe(ctx, EventFilter{})
+	if err != nil {
+		t.Fatalf("Subscribe slow: %v", err)
+	}
+
+	// Publish 20 events WITHOUT reading slow at all. Slow's channel fills
+	// at 4, the remaining 16 must be dropped via the non-blocking send.
+	now := time.Now()
+	const pubN = 20
+	for i := 0; i < pubN; i++ {
+		b.Publish(mkEnv("s", fmt.Sprintf("e.%d", i), "kernel-v3", now.Add(time.Duration(i)*time.Millisecond)))
+	}
+
+	// Slow's dropped counter should be positive and at least pubN - chanBuf.
+	drop := slow.Dropped()
+	if drop == 0 {
+		t.Errorf("slow sub dropped counter=0; expected >0 with chan buf=4 and %d events", pubN)
+	}
+	if drop < uint64(pubN-4) {
+		t.Errorf("slow sub dropped=%d; expected >= %d", drop, pubN-4)
+	}
+
+	// Verify slow still has buffered events we can read (nothing is lost
+	// from the buffered fraction).
+	var received int
+drain:
+	for {
+		select {
+		case _, ok := <-slow.Events:
+			if !ok {
+				break drain
+			}
+			received++
+		case <-time.After(100 * time.Millisecond):
+			break drain
+		}
+	}
+	if received == 0 {
+		t.Errorf("slow sub received=0; expected >0 buffered events")
+	}
+
+	// Healthy sub: reads actively, should get all events if we trickle.
+	fast, err := b.Subscribe(ctx, EventFilter{})
+	if err != nil {
+		t.Fatalf("Subscribe fast: %v", err)
+	}
+	var fastGot int32
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range fast.Events {
+			atomic.AddInt32(&fastGot, 1)
+		}
+	}()
+
+	// Publish with a tiny yield between sends so fast drains.
+	for i := 0; i < pubN; i++ {
+		b.Publish(mkEnv("s", fmt.Sprintf("e2.%d", i), "kernel-v3", now.Add(time.Duration(i)*time.Millisecond)))
+		time.Sleep(time.Millisecond) // allow goroutine to run
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) && atomic.LoadInt32(&fastGot) < int32(pubN) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := atomic.LoadInt32(&fastGot); got != int32(pubN) {
+		t.Errorf("fast sub received=%d; want %d (trickled publishing)", got, pubN)
+	}
+
+	slow.Cancel()
+	fast.Cancel()
+	wg.Wait()
+}
+
+func TestBrokerContextCancelUnsubscribes(t *testing.T) {
+	t.Parallel()
+	b := newBrokerForTest(t, 1024, 16)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	sub, err := b.Subscribe(ctx, EventFilter{})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	if n := b.SubscriberCount(); n != 1 {
+		t.Fatalf("SubscriberCount=%d; want 1", n)
+	}
+	cancel()
+	// The removal happens in a goroutine; poll briefly.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) && b.SubscriberCount() != 0 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if n := b.SubscriberCount(); n != 0 {
+		t.Errorf("SubscriberCount after cancel=%d; want 0", n)
+	}
+	// Ensure the channel is eventually closed.
+	select {
+	case _, ok := <-sub.Events:
+		if ok {
+			t.Errorf("expected closed channel after cancel")
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Errorf("channel not closed after cancel")
+	}
+}
+
+func TestBrokerCloseUnblocksSubs(t *testing.T) {
+	t.Parallel()
+	b := NewEventBroker(EventBrokerOptions{})
+
+	ctx := context.Background()
+	sub, err := b.Subscribe(ctx, EventFilter{})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		for range sub.Events {
+		}
+		close(done)
+	}()
+
+	if err := b.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reader goroutine still blocked after Close")
+	}
+
+	// Second Close should be a no-op.
+	if err := b.Close(); err != nil {
+		t.Errorf("second Close: %v", err)
+	}
+
+	// Subscribe after Close should return an error.
+	if _, err := b.Subscribe(ctx, EventFilter{}); err == nil {
+		t.Errorf("Subscribe after Close returned nil error")
+	}
+}
+
+func TestBrokerConcurrentPubSub(t *testing.T) {
+	t.Parallel()
+	const (
+		nSubs    = 5
+		nPubs    = 5
+		perPub   = 200
+		totalPub = nPubs * perPub
+	)
+	b := newBrokerForTest(t, totalPub+10, totalPub+10) // ample buffer so no drops
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	subs := make([]*Subscription, nSubs)
+	for i := range subs {
+		s, err := b.Subscribe(ctx, EventFilter{})
+		if err != nil {
+			t.Fatalf("Subscribe[%d]: %v", i, err)
+		}
+		subs[i] = s
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(nPubs)
+	start := time.Now()
+	for p := 0; p < nPubs; p++ {
+		go func(p int) {
+			defer wg.Done()
+			for i := 0; i < perPub; i++ {
+				env := mkEnv(fmt.Sprintf("s-%d", p), fmt.Sprintf("e.%d.%d", p, i), "kernel-v3",
+					start.Add(time.Duration(p*perPub+i)*time.Microsecond))
+				b.Publish(env)
+			}
+		}(p)
+	}
+	wg.Wait()
+
+	// Each sub should drain exactly totalPub events. Use a deadline guard.
+	for i, s := range subs {
+		got := 0
+		deadline := time.After(3 * time.Second)
+	drain:
+		for got < totalPub {
+			select {
+			case <-s.Events:
+				got++
+			case <-deadline:
+				break drain
+			}
+		}
+		if got != totalPub {
+			t.Errorf("sub[%d] received %d; want %d", i, got, totalPub)
+		}
+	}
+}
+
+func TestBrokerMaxSubscribersEnforced(t *testing.T) {
+	t.Parallel()
+	b := NewEventBroker(EventBrokerOptions{MaxSubscribers: 2})
+	t.Cleanup(func() { _ = b.Close() })
+
+	ctx := context.Background()
+	for i := 0; i < 2; i++ {
+		if _, err := b.Subscribe(ctx, EventFilter{}); err != nil {
+			t.Fatalf("Subscribe[%d]: %v", i, err)
+		}
+	}
+	if _, err := b.Subscribe(ctx, EventFilter{}); err == nil {
+		t.Errorf("third Subscribe succeeded; want ErrTooManySubscribers")
+	}
+}
+
+// ── AppendEvent ↔ broker wiring tests ──────────────────────────────────────
+
+func TestAppendEventPublishesToBroker(t *testing.T) {
+	t.Parallel()
+	// Additive registration — other tests' brokers stay registered, but
+	// our session filter ensures we only see our own event.
+	b := NewEventBroker(EventBrokerOptions{})
+	RegisterBroker(b)
+	t.Cleanup(func() { _ = b.Close() }) // Close unregisters.
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	sid := "wiring-test-session-" + nowISO()
+	sub, err := b.Subscribe(ctx, EventFilter{SessionID: sid})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	root := t.TempDir()
+	env := &EventEnvelope{
+		HashedPayload: EventPayload{
+			Type:      "observer.surprise",
+			Timestamp: nowISO(),
+			SessionID: sid,
+		},
+		Metadata: EventMetadata{Source: "kernel-v3"},
+	}
+	if err := AppendEvent(root, sid, env); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+
+	select {
+	case got := <-sub.Events:
+		if got.HashedPayload.Type != "observer.surprise" {
+			t.Errorf("broker received type=%s; want observer.surprise", got.HashedPayload.Type)
+		}
+		if got.Metadata.Hash == "" {
+			t.Errorf("broker envelope missing hash — AppendEvent should set it before publishing")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("broker did not receive event")
+	}
+}
+
+func TestAppendEventNilBrokerSafe(t *testing.T) {
+	t.Parallel()
+	// No broker installed for this test's session — the additive registry
+	// means other brokers may still receive it (and drop on session
+	// filter), but AppendEvent must not crash when the local slot is unset.
+	root := t.TempDir()
+	sid := "nil-broker-session-" + nowISO()
+	env := &EventEnvelope{
+		HashedPayload: EventPayload{
+			Type:      "test.event",
+			Timestamp: nowISO(),
+			SessionID: sid,
+		},
+		Metadata: EventMetadata{Source: "kernel-v3"},
+	}
+	if err := AppendEvent(root, sid, env); err != nil {
+		t.Fatalf("AppendEvent with no local broker: %v", err)
+	}
+}
+
+// ── Helper tests ───────────────────────────────────────────────────────────
+
+func TestParseSinceDuration(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		in   string
+		want time.Time
+	}{
+		{"", time.Time{}},
+		{"2026-04-21T11:00:00Z", time.Date(2026, 4, 21, 11, 0, 0, 0, time.UTC)},
+		{"5m", now.Add(-5 * time.Minute)},
+		{"1h", now.Add(-time.Hour)},
+	}
+	for _, c := range cases {
+		got, err := ParseSinceDuration(c.in, now)
+		if err != nil {
+			t.Errorf("ParseSinceDuration(%q): %v", c.in, err)
+			continue
+		}
+		if !got.Equal(c.want) {
+			t.Errorf("ParseSinceDuration(%q) = %v; want %v", c.in, got, c.want)
+		}
+	}
+
+	if _, err := ParseSinceDuration("not-a-duration", now); err == nil {
+		t.Errorf("ParseSinceDuration accepted garbage")
+	}
+}

--- a/internal/engine/events_query.go
+++ b/internal/engine/events_query.go
@@ -1,0 +1,126 @@
+// events_query.go — observability-flavored wrapper around QueryLedger.
+//
+// The hash-chained ledger (ledger.go / ledger_query.go) is the source of
+// truth. This file exists so the event-bus surface (MCP cog_read_events,
+// HTTP GET /v1/events) can reuse that read path without dragging audit
+// semantics (verify_chain, seq pagination) into a debugging tool.
+//
+// Differences vs. QueryLedger:
+//   - Accepts a Source filter in addition to SessionID/EventType.
+//   - Since/Until accept either RFC3339 or duration shorthand ("5m"),
+//     resolved by the caller via ParseSinceDuration before construction.
+//   - Order toggles asc/desc (QueryLedger is always asc within a session).
+//     Default is desc (newest first — "what's happening right now?").
+//   - No verify_chain, no NextAfterSeq. Paging is via next_before (time-
+//     based) for the multi-session case.
+package engine
+
+import (
+	"time"
+)
+
+// EventQuery is the input shape for QueryEvents.
+type EventQuery struct {
+	SessionID        string
+	EventTypePattern string
+	Source           string
+	Since            time.Time
+	Until            time.Time
+	Limit            int
+	Order            string // "asc" or "desc" (default "desc")
+}
+
+// EventQueryResult is the QueryEvents output.
+type EventQueryResult struct {
+	Count      int           `json:"count"`
+	Events     []LedgerEvent `json:"events"`
+	Truncated  bool          `json:"truncated"`
+	NextBefore string        `json:"next_before,omitempty"` // RFC3339 timestamp for pagination
+}
+
+// QueryEvents reads matching events from the hash-chained ledger. Internally
+// this delegates to QueryLedger with verify_chain=false and then applies the
+// extra filters (source, until, order). We pull enough rows from QueryLedger
+// to honour the caller's limit after filtering.
+func QueryEvents(workspaceRoot string, q EventQuery) (*EventQueryResult, error) {
+	limit := q.Limit
+	if limit <= 0 {
+		limit = defaultLedgerLimit
+	}
+	if limit > maxLedgerLimit {
+		limit = maxLedgerLimit
+	}
+
+	// Build the ledger query. Pull more than the requested limit so we can
+	// apply source/until filters after reading. Cap at the ledger max.
+	ledgerLimit := limit * 2
+	if ledgerLimit > maxLedgerLimit {
+		ledgerLimit = maxLedgerLimit
+	}
+
+	lq := LedgerQuery{
+		SessionID: q.SessionID,
+		EventType: q.EventTypePattern,
+		Limit:     ledgerLimit,
+	}
+	if !q.Since.IsZero() {
+		lq.SinceTimestamp = q.Since.UTC().Format(time.RFC3339)
+	}
+
+	raw, err := QueryLedger(workspaceRoot, lq)
+	if err != nil {
+		return nil, err
+	}
+
+	// Apply source filter + until bound.
+	filtered := make([]LedgerEvent, 0, len(raw.Events))
+	for _, evt := range raw.Events {
+		if q.Source != "" && evt.Source != q.Source {
+			continue
+		}
+		if !q.Until.IsZero() {
+			ts, err := time.Parse(time.RFC3339, evt.Timestamp)
+			if err == nil && !ts.Before(q.Until) {
+				continue
+			}
+		}
+		filtered = append(filtered, evt)
+	}
+
+	// QueryLedger delivers ascending-within-session, descending-by-session-mtime.
+	// Default "desc" here means newest-first globally. Implementers of the
+	// observability tool expect that ordering.
+	order := q.Order
+	if order == "" {
+		order = "desc"
+	}
+	if order == "desc" {
+		reverseEvents(filtered)
+	}
+
+	truncated := raw.Truncated
+	if len(filtered) > limit {
+		filtered = filtered[:limit]
+		truncated = true
+	}
+
+	result := &EventQueryResult{
+		Count:     len(filtered),
+		Events:    filtered,
+		Truncated: truncated,
+	}
+
+	// next_before: for "give me everything before this timestamp" pagination.
+	// Only meaningful when we truncated a desc-ordered multi-session query.
+	if truncated && len(filtered) > 0 && order == "desc" {
+		result.NextBefore = filtered[len(filtered)-1].Timestamp
+	}
+
+	return result, nil
+}
+
+func reverseEvents(xs []LedgerEvent) {
+	for i, j := 0, len(xs)-1; i < j; i, j = i+1, j-1 {
+		xs[i], xs[j] = xs[j], xs[i]
+	}
+}

--- a/internal/engine/events_query_test.go
+++ b/internal/engine/events_query_test.go
@@ -1,0 +1,119 @@
+// events_query_test.go — tests for the observability-flavored query wrapper.
+package engine
+
+import (
+	"testing"
+	"time"
+)
+
+func TestQueryEventsEmpty(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	res, err := QueryEvents(root, EventQuery{})
+	if err != nil {
+		t.Fatalf("QueryEvents: %v", err)
+	}
+	if res.Count != 0 {
+		t.Errorf("Count = %d; want 0", res.Count)
+	}
+	if len(res.Events) != 0 {
+		t.Errorf("len(events) = %d; want 0", len(res.Events))
+	}
+}
+
+func TestQueryEventsFilterBySource(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	sid := "query-src"
+
+	// Append two events with different sources via the shared test helper.
+	// We build envelopes manually because appendTestEvent uses a fixed
+	// "test" source.
+	mkEvt := func(typ, src string) *EventEnvelope {
+		return &EventEnvelope{
+			HashedPayload: EventPayload{
+				Type:      typ,
+				Timestamp: nowISO(),
+				SessionID: sid,
+			},
+			Metadata: EventMetadata{Source: src},
+		}
+	}
+	for _, ev := range []*EventEnvelope{
+		mkEvt("foo", "kernel-v3"),
+		mkEvt("bar", "mcp-client"),
+		mkEvt("baz", "kernel-v3"),
+	} {
+		if err := AppendEvent(root, sid, ev); err != nil {
+			t.Fatalf("AppendEvent: %v", err)
+		}
+	}
+
+	res, err := QueryEvents(root, EventQuery{Source: "kernel-v3"})
+	if err != nil {
+		t.Fatalf("QueryEvents: %v", err)
+	}
+	if res.Count != 2 {
+		t.Errorf("Count=%d; want 2 (source filter)", res.Count)
+	}
+	for _, ev := range res.Events {
+		if ev.Source != "kernel-v3" {
+			t.Errorf("event source=%s; want kernel-v3", ev.Source)
+		}
+	}
+}
+
+func TestQueryEventsOrderDefaults(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	sid := "query-order"
+
+	// Append three events in known chronological order.
+	for _, name := range []string{"first", "second", "third"} {
+		appendTestEvent(t, root, sid, name, nil, "")
+		time.Sleep(1 * time.Millisecond) // ensure distinct timestamps
+	}
+
+	// Default (desc): newest first.
+	res, err := QueryEvents(root, EventQuery{SessionID: sid})
+	if err != nil {
+		t.Fatalf("QueryEvents desc: %v", err)
+	}
+	if res.Count != 3 {
+		t.Fatalf("count=%d; want 3", res.Count)
+	}
+	if res.Events[0].Type != "third" {
+		t.Errorf("desc order: first event type=%s; want third", res.Events[0].Type)
+	}
+
+	// asc: oldest first.
+	res, err = QueryEvents(root, EventQuery{SessionID: sid, Order: "asc"})
+	if err != nil {
+		t.Fatalf("QueryEvents asc: %v", err)
+	}
+	if res.Events[0].Type != "first" {
+		t.Errorf("asc order: first event type=%s; want first", res.Events[0].Type)
+	}
+}
+
+func TestQueryEventsLimitTruncates(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	sid := "query-limit"
+	for i := 0; i < 5; i++ {
+		appendTestEvent(t, root, sid, "e", nil, "")
+	}
+	res, err := QueryEvents(root, EventQuery{SessionID: sid, Limit: 2})
+	if err != nil {
+		t.Fatalf("QueryEvents: %v", err)
+	}
+	if res.Count != 2 {
+		t.Errorf("Count=%d; want 2", res.Count)
+	}
+	if !res.Truncated {
+		t.Errorf("Truncated=false; want true")
+	}
+	if res.NextBefore == "" {
+		t.Errorf("NextBefore empty; want RFC3339 timestamp")
+	}
+}

--- a/internal/engine/ingest_test.go
+++ b/internal/engine/ingest_test.go
@@ -294,8 +294,12 @@ func TestEmitIngestEvent(t *testing.T) {
 		t.Fatalf("EmitIngestEvent: %v", err)
 	}
 
-	// Read the ledger file and verify the event.
-	ledgerPath := filepath.Join(tmp, ".cog", "ledger", "events.jsonl")
+	// Post-cogos#10 refactor: EmitLedgerEvent routes through AppendEvent so
+	// ingestion events land in .cog/ledger/<session>/events.jsonl (not the
+	// flat orphan file). When called without a live Process the session
+	// bucket is "mcp-client" — the same path other MCP-client-originated
+	// events use.
+	ledgerPath := filepath.Join(tmp, ".cog", "ledger", "mcp-client", "events.jsonl")
 	data, err := os.ReadFile(ledgerPath)
 	if err != nil {
 		t.Fatalf("ReadFile ledger: %v", err)
@@ -306,25 +310,34 @@ func TestEmitIngestEvent(t *testing.T) {
 		t.Fatalf("expected 1 ledger line, got %d", len(lines))
 	}
 
-	var event map[string]any
-	if err := json.Unmarshal([]byte(lines[0]), &event); err != nil {
-		t.Fatalf("unmarshal ledger event: %v", err)
+	// Envelope shape: {hashed_payload:{type,timestamp,session_id,data:{...}}, metadata:{hash,seq,source}}
+	var env EventEnvelope
+	if err := json.Unmarshal([]byte(lines[0]), &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
 	}
 
-	if event["type"] != IngestEventType {
-		t.Errorf("event type = %v; want %q", event["type"], IngestEventType)
+	if env.HashedPayload.Type != IngestEventType {
+		t.Errorf("event type = %v; want %q", env.HashedPayload.Type, IngestEventType)
 	}
-	if event["title"] != "Test Article" {
-		t.Errorf("event title = %v; want %q", event["title"], "Test Article")
-	}
-	if event["cogdoc_path"] != cogdocPath {
-		t.Errorf("event cogdoc_path = %v; want %q", event["cogdoc_path"], cogdocPath)
-	}
-	if event["cogdoc_uri"] != "cog:mem/"+cogdocPath {
-		t.Errorf("event cogdoc_uri = %v; want %q", event["cogdoc_uri"], "cog:mem/"+cogdocPath)
-	}
-	if _, ok := event["timestamp"]; !ok {
+	if env.HashedPayload.Timestamp == "" {
 		t.Error("event missing timestamp")
+	}
+	if env.HashedPayload.SessionID != "mcp-client" {
+		t.Errorf("event session_id = %q; want mcp-client", env.HashedPayload.SessionID)
+	}
+	if env.Metadata.Hash == "" {
+		t.Error("event missing hash — AppendEvent should set it")
+	}
+
+	data2 := env.HashedPayload.Data
+	if data2["title"] != "Test Article" {
+		t.Errorf("event data.title = %v; want %q", data2["title"], "Test Article")
+	}
+	if data2["cogdoc_path"] != cogdocPath {
+		t.Errorf("event data.cogdoc_path = %v; want %q", data2["cogdoc_path"], cogdocPath)
+	}
+	if data2["cogdoc_uri"] != "cog:mem/"+cogdocPath {
+		t.Errorf("event data.cogdoc_uri = %v; want %q", data2["cogdoc_uri"], "cog:mem/"+cogdocPath)
 	}
 }
 

--- a/internal/engine/ledger.go
+++ b/internal/engine/ledger.go
@@ -199,6 +199,14 @@ func AppendEvent(workspaceRoot, sessionID string, envelope *EventEnvelope) error
 
 	// Update cache after successful write.
 	setCachedLastEvent(sessionID, envelope)
+
+	// Publish to every registered broker so live subscribers see this
+	// event without needing to tail the JSONL. Publish is fire-and-forget:
+	// a slow consumer cannot hold up the ledger (source of truth). When no
+	// broker is installed (unit tests), the snapshot is nil and we no-op.
+	for _, broker := range brokerSnapshot() {
+		broker.Publish(envelope)
+	}
 	return nil
 }
 

--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -127,6 +127,16 @@ func (m *MCPServer) registerTools() {
 	}, m.toolReadLedger)
 
 	mcp.AddTool(m.server, &mcp.Tool{
+		Name:        "cog_read_events",
+		Description: "Query recent kernel events for observability. Returns historical events from the ledger without chain verification (use cog_read_ledger for audit). Filters: session_id, event_type (exact or 'attention.*' wildcard), source ('kernel-v3' / 'mcp-client'), since/until (RFC3339 or duration shorthand like '5m'), limit (default 100, max 1000), order ('desc' newest-first default, 'asc' oldest-first). Fallback: ls .cog/ledger/ && cat .cog/ledger/*/events.jsonl",
+	}, m.toolReadEvents)
+
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name:        "cog_tail_events",
+		Description: "Tail kernel events as they are appended to the ledger, like 'tail -f'. Blocks until max_events or max_duration reached. Same filters as cog_read_events plus since= for replay before going live. Bounded by max_events (default 100, max 1000) and max_duration (default 60s, max 10m). Fallback: curl -N http://localhost:6931/v1/events/stream",
+	}, m.toolTailEvents)
+
+	mcp.AddTool(m.server, &mcp.Tool{
 		Name:        "cog_ingest",
 		Description: "Ingest external material into CogOS knowledge. Deterministic decomposition — no LLM calls. Supports URLs, conversations, documents. Applies membrane policy (accept/quarantine/defer/discard).",
 	}, m.toolIngest)
@@ -373,6 +383,25 @@ type readLedgerInput struct {
 	SinceTimestamp string `json:"since_timestamp,omitempty" jsonschema:"RFC3339 timestamp; return events with timestamp >= this"`
 	Limit          int    `json:"limit,omitempty" jsonschema:"Maximum events to return. Default 100, capped at 1000."`
 	VerifyChain    bool   `json:"verify_chain,omitempty" jsonschema:"Recompute hashes and validate prior_hash links on returned events. Off by default (chain walk is O(N))."`
+}
+
+type readEventsInput struct {
+	SessionID string `json:"session_id,omitempty" jsonschema:"Filter to a single session; empty reads across all"`
+	EventType string `json:"event_type,omitempty" jsonschema:"Exact event type, or a prefix wildcard like 'attention.*'"`
+	Source    string `json:"source,omitempty" jsonschema:"Filter by source (e.g. 'kernel-v3', 'mcp-client')"`
+	Since     string `json:"since,omitempty" jsonschema:"RFC3339 timestamp or duration shorthand ('5m', '1h')"`
+	Until     string `json:"until,omitempty" jsonschema:"RFC3339 timestamp or duration shorthand (upper bound)"`
+	Limit     int    `json:"limit,omitempty" jsonschema:"Maximum events to return. Default 100, capped at 1000."`
+	Order     string `json:"order,omitempty" jsonschema:"'desc' (default, newest first) or 'asc'"`
+}
+
+type tailEventsInput struct {
+	SessionID   string `json:"session_id,omitempty" jsonschema:"Filter to a single session; empty reads across all"`
+	EventType   string `json:"event_type,omitempty" jsonschema:"Exact event type, or a prefix wildcard like 'attention.*'"`
+	Source      string `json:"source,omitempty" jsonschema:"Filter by source (e.g. 'kernel-v3', 'mcp-client')"`
+	Since       string `json:"since,omitempty" jsonschema:"RFC3339 timestamp or duration shorthand; replay before going live"`
+	MaxEvents   int    `json:"max_events,omitempty" jsonschema:"Stop after receiving this many events. Default 100, capped at 1000."`
+	MaxDuration string `json:"max_duration,omitempty" jsonschema:"Stop after this duration ('30s', '5m'). Default 60s, capped at 10m."`
 }
 
 // getIndexInput — no longer an MCP tool; used by the internal tool loop (tool_loop.go).
@@ -809,16 +838,23 @@ func (m *MCPServer) toolEmitEvent(ctx context.Context, req *mcp.CallToolRequest,
 	if input.Type == "" {
 		return textResult("event type is required. Valid types: attention.boost, session.marker, insight.captured, decision.made")
 	}
-
-	event := map[string]any{
-		"type": input.Type,
+	if m.process == nil {
+		return fallbackResult("process not initialized", "echo '{\"type\":\"...\"}' >> .cog/ledger/<session_id>/events.jsonl")
 	}
+
+	// Build the event data. Legacy shape exposed payload under a separate
+	// "payload" key; the on-disk envelope shape uses "data". We flatten so
+	// subscribers see a uniform envelope and the historical payload is still
+	// reachable under data.payload.
+	data := map[string]any{}
 	if input.Payload != nil {
-		event["payload"] = input.Payload
+		data["payload"] = input.Payload
 	}
 
-	// Handle attention.boost: resolve URI to field key, then boost.
-	if input.Type == "attention.boost" && m.process != nil {
+	// Handle attention.boost: resolve URI to field key, then boost. Side
+	// effects are recorded in the event data so downstream consumers know
+	// the field mutated.
+	if input.Type == "attention.boost" {
 		if uri, ok := input.Payload["uri"].(string); ok && uri != "" {
 			fieldKey := ResolveToFieldKey(m.cfg.WorkspaceRoot, uri)
 			weight := 1.0
@@ -826,18 +862,23 @@ func (m *MCPServer) toolEmitEvent(ctx context.Context, req *mcp.CallToolRequest,
 				weight = w
 			}
 			m.process.Field().Boost(fieldKey, weight)
-			event["field_boosted"] = true
-			event["resolved_key"] = fieldKey
+			data["field_boosted"] = true
+			data["resolved_key"] = fieldKey
 		}
 	}
 
-	if err := EmitLedgerEvent(m.cfg, event); err != nil {
-		return fallbackResult(fmt.Sprintf("emit failed: %v", err), "echo '{\"type\":\"...\"}' >> .cog/ledger/events.jsonl")
+	// Route every emission through AppendEvent (hash chain + broker fan-out).
+	// Fixes the cogos#10 orphan-file bug: pre-refactor writes landed in a
+	// flat .cog/ledger/events.jsonl bypassing both the chain and the bus.
+	if err := m.process.EmitEvent(input.Type, data, "mcp-client"); err != nil {
+		return fallbackResult(fmt.Sprintf("emit failed: %v", err),
+			"echo '{\"type\":\"...\"}' >> .cog/ledger/<session_id>/events.jsonl")
 	}
 
 	return marshalResult(map[string]any{
-		"emitted": true,
-		"type":    input.Type,
+		"emitted":    true,
+		"type":       input.Type,
+		"session_id": m.process.SessionID(),
 	})
 }
 
@@ -856,6 +897,151 @@ func (m *MCPServer) toolReadLedger(ctx context.Context, req *mcp.CallToolRequest
 			"ls .cog/ledger/ && cat .cog/ledger/<session_id>/events.jsonl")
 	}
 	return marshalResult(result)
+}
+
+func (m *MCPServer) toolReadEvents(ctx context.Context, req *mcp.CallToolRequest, input readEventsInput) (*mcp.CallToolResult, any, error) {
+	now := time.Now().UTC()
+
+	sinceTime, err := ParseSinceDuration(input.Since, now)
+	if err != nil {
+		return fallbackResult(fmt.Sprintf("bad since: %v", err),
+			"check duration format (RFC3339 or '5m'/'1h')")
+	}
+	untilTime, err := ParseSinceDuration(input.Until, now)
+	if err != nil {
+		return fallbackResult(fmt.Sprintf("bad until: %v", err),
+			"check duration format (RFC3339 or '5m'/'1h')")
+	}
+
+	q := EventQuery{
+		SessionID:        input.SessionID,
+		EventTypePattern: input.EventType,
+		Source:           input.Source,
+		Since:            sinceTime,
+		Until:            untilTime,
+		Limit:            input.Limit,
+		Order:            input.Order,
+	}
+	result, err := QueryEvents(m.cfg.WorkspaceRoot, q)
+	if err != nil {
+		return fallbackResult(fmt.Sprintf("read events failed: %v", err),
+			"ls .cog/ledger/ && cat .cog/ledger/*/events.jsonl")
+	}
+	return marshalResult(result)
+}
+
+func (m *MCPServer) toolTailEvents(ctx context.Context, req *mcp.CallToolRequest, input tailEventsInput) (*mcp.CallToolResult, any, error) {
+	if m.process == nil {
+		return fallbackResult("process not initialised",
+			"curl -N http://localhost:6931/v1/events/stream")
+	}
+	broker := m.process.Broker()
+	if broker == nil {
+		return fallbackResult("event broker not available",
+			"curl -N http://localhost:6931/v1/events/stream")
+	}
+
+	// Parse bounds.
+	const (
+		defaultTailMaxEvents = 100
+		maxTailMaxEvents     = 1000
+		defaultTailDuration  = 60 * time.Second
+		maxTailDuration      = 10 * time.Minute
+	)
+	maxEvents := input.MaxEvents
+	if maxEvents <= 0 {
+		maxEvents = defaultTailMaxEvents
+	}
+	if maxEvents > maxTailMaxEvents {
+		maxEvents = maxTailMaxEvents
+	}
+	maxDur := defaultTailDuration
+	if input.MaxDuration != "" {
+		d, err := time.ParseDuration(input.MaxDuration)
+		if err != nil || d <= 0 {
+			return fallbackResult(fmt.Sprintf("bad max_duration: %q", input.MaxDuration),
+				"use a Go duration string like '30s' or '5m'")
+		}
+		maxDur = d
+	}
+	if maxDur > maxTailDuration {
+		maxDur = maxTailDuration
+	}
+
+	// Parse `since` for replay.
+	now := time.Now().UTC()
+	sinceTime, err := ParseSinceDuration(input.Since, now)
+	if err != nil {
+		return fallbackResult(fmt.Sprintf("bad since: %v", err),
+			"check duration format (RFC3339 or '5m'/'1h')")
+	}
+
+	filter := EventFilter{
+		SessionID:        input.SessionID,
+		EventTypePattern: input.EventType,
+		Source:           input.Source,
+	}
+
+	// Apply request context if available, plus our own max-duration cap.
+	tailCtx, cancel := context.WithTimeout(ctx, maxDur)
+	defer cancel()
+
+	sub, err := broker.Subscribe(tailCtx, filter)
+	if err != nil {
+		return fallbackResult(fmt.Sprintf("subscribe failed: %v", err),
+			"curl -N http://localhost:6931/v1/events/stream")
+	}
+	defer sub.Cancel()
+
+	// Replay matching ring entries first so reconnecting clients catch up.
+	replay := broker.RingReplay(filter, sinceTime)
+	events := make([]LedgerEvent, 0, maxEvents)
+	for _, env := range replay {
+		events = append(events, envelopeToLedgerEvent(env))
+		if len(events) >= maxEvents {
+			return marshalResult(map[string]any{
+				"count":          len(events),
+				"events":         events,
+				"stopped_reason": "max_events",
+			})
+		}
+	}
+
+	// Live loop.
+	stopped := "max_duration"
+tailLoop:
+	for len(events) < maxEvents {
+		select {
+		case env, ok := <-sub.Events:
+			if !ok {
+				stopped = "session_end"
+				break tailLoop
+			}
+			events = append(events, envelopeToLedgerEvent(env))
+			if len(events) >= maxEvents {
+				stopped = "max_events"
+				break tailLoop
+			}
+		case <-tailCtx.Done():
+			// Either ctx cancelled by caller or maxDur expired. ctx.Err
+			// distinguishes: deadline → max_duration, canceled → client_cancel.
+			if tailCtx.Err() == context.DeadlineExceeded {
+				stopped = "max_duration"
+			} else {
+				stopped = "client_cancel"
+			}
+			break tailLoop
+		}
+	}
+	if len(events) >= maxEvents {
+		stopped = "max_events"
+	}
+
+	return marshalResult(map[string]any{
+		"count":          len(events),
+		"events":         events,
+		"stopped_reason": stopped,
+	})
 }
 
 // toolGetIndex — no longer registered as an MCP tool; used by the internal tool loop (tool_loop.go).

--- a/internal/engine/mcp_stubs.go
+++ b/internal/engine/mcp_stubs.go
@@ -7,7 +7,6 @@ package engine
 
 import (
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"math"
 	"os"
@@ -227,28 +226,64 @@ func CheckCoherenceMCP(cfg *Config, nucleus *Nucleus) (any, error) {
 }
 
 // EmitLedgerEvent appends an event to the workspace ledger.
+//
+// Historical shape: pre-PR this helper wrote to a flat
+// .cog/ledger/events.jsonl outside the hash chain and outside any session
+// subdirectory (cogos#10). Post-refactor it builds a proper EventEnvelope
+// and routes through AppendEvent, which:
+//
+//   - chains the event by prior_hash / seq,
+//   - files it under .cog/ledger/<session_id>/events.jsonl,
+//   - fans out to live subscribers via the in-process EventBroker.
+//
+// Callers that have a live *Process should prefer (*Process).EmitEvent for
+// accurate session attribution. This helper exists for the paths that only
+// hold *Config (CogDocService.emitLedgerEvent, EmitIngestEvent, tests).
+//
+// Source (envelope.Metadata.Source): pulled from event["source"] if set,
+// otherwise defaults to "mcp-client". Type: event["type"]. All other keys
+// become envelope.data.
 func EmitLedgerEvent(cfg *Config, event map[string]any) error {
-	event["timestamp"] = time.Now().UTC().Format(time.RFC3339)
-
-	ledgerPath := filepath.Join(cfg.WorkspaceRoot, ".cog", "ledger", "events.jsonl")
-
-	// Ensure ledger directory exists
-	if err := os.MkdirAll(filepath.Dir(ledgerPath), 0755); err != nil {
-		return fmt.Errorf("mkdir ledger: %w", err)
+	if cfg == nil {
+		return fmt.Errorf("emit ledger: nil config")
+	}
+	eventType, _ := event["type"].(string)
+	if eventType == "" {
+		return fmt.Errorf("emit ledger: event missing 'type'")
+	}
+	source, _ := event["source"].(string)
+	if source == "" {
+		source = "mcp-client"
 	}
 
-	f, err := os.OpenFile(ledgerPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return fmt.Errorf("open ledger: %w", err)
+	// Build data by stripping the control fields that landed in the
+	// envelope header.
+	data := make(map[string]any, len(event))
+	for k, v := range event {
+		switch k {
+		case "type", "source", "timestamp":
+			continue
+		}
+		data[k] = v
 	}
-	defer f.Close()
 
-	b, err := json.Marshal(event)
-	if err != nil {
-		return fmt.Errorf("marshal event: %w", err)
+	// Callers that hold only *Config don't have access to the live process
+	// session id. Use a predictable bucket so events are still chained and
+	// live in a per-session directory — no more orphan flat file. Paths
+	// that want accurate session attribution should use
+	// (*Process).EmitEvent directly.
+	const sessionID = "mcp-client"
+
+	env := &EventEnvelope{
+		HashedPayload: EventPayload{
+			Type:      eventType,
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+			SessionID: sessionID,
+			Data:      data,
+		},
+		Metadata: EventMetadata{Source: source},
 	}
-	_, err = f.Write(append(b, '\n'))
-	return err
+	return AppendEvent(cfg.WorkspaceRoot, sessionID, env)
 }
 
 // BuildMemoryIndex builds a lightweight index of all CogDocs.

--- a/internal/engine/process.go
+++ b/internal/engine/process.go
@@ -162,6 +162,12 @@ type Process struct {
 	// hookRegistry holds ADR-072 state-transition hooks loaded from
 	// .cog/hooks/transitions/*.yaml. May be nil if the directory is missing.
 	hookRegistry *stateHookRegistry
+
+	// broker fans out ledger events to live subscribers (SSE /
+	// cog_tail_events). Nil if the process was constructed without one.
+	// AppendEvent publishes through the package-level CurrentBroker() set
+	// by NewProcess, so call sites don't need to thread this pointer.
+	broker *EventBroker
 }
 
 // NewProcess constructs and initialises the process.
@@ -169,6 +175,12 @@ func NewProcess(cfg *Config, nucleus *Nucleus) *Process {
 	field := NewAttentionalField(cfg)
 	gate := NewGate(field, cfg)
 	now := time.Now().UTC()
+	broker := NewEventBroker(EventBrokerOptions{})
+	// Additive registration — every process's broker receives every
+	// ledger append. In production there's only one process so this is
+	// functionally identical to SetCurrentBroker; in tests it lets
+	// multiple parallel processes coexist without racing a single slot.
+	RegisterBroker(broker)
 	return &Process{
 		state:     StateReceptive,
 		nucleus:   nucleus,
@@ -191,7 +203,16 @@ func NewProcess(cfg *Config, nucleus *Nucleus) *Process {
 		nodeHealth:          NewNodeHealth(),
 		nodeManifest:        loadManifestQuiet(cfg),
 		hookRegistry:        loadStateHookRegistry(workspaceRootFromCfg(cfg)),
+		broker:              broker,
 	}
+}
+
+// Broker returns the process event broker (nil if not initialised).
+func (p *Process) Broker() *EventBroker {
+	if p == nil {
+		return nil
+	}
+	return p.broker
 }
 
 // workspaceRootFromCfg returns the workspace root from the config, or "" if nil.
@@ -774,6 +795,28 @@ func (p *Process) CurrentCycleID() string {
 
 // emitEvent records a ledger event for the process session.
 func (p *Process) emitEvent(eventType string, data map[string]interface{}) {
+	_ = p.EmitEvent(eventType, data, "kernel-v3")
+}
+
+// EmitEvent appends a single event to the session ledger via AppendEvent,
+// which means it flows through the hash chain AND the in-process broker.
+// Callers: MCP cog_emit_event tool, internal emitEvent helper.
+//
+// The `source` field lands on envelope.Metadata.Source — subscribers use it
+// to distinguish kernel-generated events (kernel-v3) from MCP-client events
+// (mcp-client) and future external sources.
+//
+// This replaces the pre-PR EmitLedgerEvent in mcp_stubs.go which wrote to a
+// flat .cog/ledger/events.jsonl orphan file bypassing hash chaining
+// (cogos#10). Post-refactor: every event — kernel or MCP — goes through
+// AppendEvent, so the live broker sees everything.
+func (p *Process) EmitEvent(eventType string, data map[string]interface{}, source string) error {
+	if p == nil {
+		return fmt.Errorf("process: nil receiver")
+	}
+	if source == "" {
+		source = "kernel-v3"
+	}
 	env := &EventEnvelope{
 		HashedPayload: EventPayload{
 			Type:      eventType,
@@ -782,12 +825,14 @@ func (p *Process) emitEvent(eventType string, data map[string]interface{}) {
 			Data:      data,
 		},
 		Metadata: EventMetadata{
-			Source: "kernel-v3",
+			Source: source,
 		},
 	}
 	if err := AppendEvent(p.cfg.WorkspaceRoot, p.sessionID, env); err != nil {
 		slog.Debug("process: ledger append failed", "err", fmt.Sprintf("%v", err))
+		return err
 	}
+	return nil
 }
 
 func loadOrCreateNodeID(cfg *Config) string {

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -81,6 +81,7 @@ func NewServer(cfg *Config, nucleus *Nucleus, process *Process) *Server {
 	// Block sync endpoints (Phase 3 block sync protocol)
 	s.registerBlockRoutes(mux)
 	s.registerCompatRoutes(mux)
+	s.registerEventBusRoutes(mux)
 	s.registerMCPRoutes(mux)
 
 	s.srv = &http.Server{

--- a/internal/engine/serve_compat.go
+++ b/internal/engine/serve_compat.go
@@ -11,13 +11,16 @@
 //
 //	GET  /v1/card            — kernel capability card (OpenClaw auth flow)
 //	GET  /v1/models          — OpenAI-compatible model list
-//	GET  /v1/events/stream   — SSE stub (CogBus keepalive)
-//	POST /v1/bus/{bus_id}/ack — bus event acknowledgment stub
 //	GET  /memory/search      — memory search (was missing from v2 too)
 //	GET  /memory/read        — memory read (was missing from v2 too)
 //	GET  /coherence/check    — coherence check
 //	GET  /v1/providers       — provider list with health
 //	GET  /v1/taa             — TAA context visibility stub
+//
+// Removed in the event-bus PR (were always stubs):
+//
+//	GET  /v1/events/stream   — replaced by the real broker-backed handler in serve.go
+//	POST /v1/bus/{bus_id}/ack — dropped; no consumer, new SSE uses Last-Event-ID
 package engine
 
 import (
@@ -42,9 +45,9 @@ func (s *Server) registerCompatRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /v1/card", s.handleCard)
 	mux.HandleFunc("GET /v1/models", s.handleModels)
 
-	// Tier B: blocking for CogBus plugin
-	mux.HandleFunc("GET /v1/events/stream", s.handleEventsStream)
-	mux.HandleFunc("POST /v1/bus/{bus_id}/ack", s.handleBusAck)
+	// Tier B: event stream + bus ack — now real, registered in serve.go
+	// (handleEvents + handleEventsStream). handleBusAck deleted — no
+	// consumer relied on it and the new SSE resume uses Last-Event-ID.
 
 	// Tier C: operational stability
 	mux.HandleFunc("GET /v1/providers", s.handleProviders)
@@ -167,63 +170,6 @@ func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
 			mkModel("local", "cogos"),
 		},
 	})
-}
-
-// ── Tier B: CogBus plugin ──────────────────────────────────────────────────────
-
-// handleEventsStream is a stub SSE endpoint that keeps CogBus connections alive.
-// Sends a heartbeat every 30s. Full event routing is Phase 1.
-func (s *Server) handleEventsStream(w http.ResponseWriter, r *http.Request) {
-	s.logCompatDeprecated(r)
-	busID := r.URL.Query().Get("bus_id")
-	consumer := r.URL.Query().Get("consumer")
-
-	slog.Info("compat: SSE connected", "bus_id", busID, "consumer", consumer)
-
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("X-Accel-Buffering", "no")
-	w.Header().Set("Connection", "keep-alive")
-
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
-		return
-	}
-
-	// Send initial connected event.
-	fmt.Fprintf(w, "data: {\"type\":\"connected\",\"bus_id\":%q,\"consumer\":%q}\n\n", busID, consumer)
-	flusher.Flush()
-
-	ticker := time.NewTicker(30 * time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-r.Context().Done():
-			slog.Info("compat: SSE disconnected", "bus_id", busID, "consumer", consumer)
-			return
-		case <-ticker.C:
-			fmt.Fprintf(w, ": heartbeat\n\n")
-			flusher.Flush()
-		}
-	}
-}
-
-// handleBusAck is a stub that accepts bus event acknowledgments.
-func (s *Server) handleBusAck(w http.ResponseWriter, r *http.Request) {
-	s.logCompatDeprecated(r)
-	busID := r.PathValue("bus_id")
-	var req struct {
-		ConsumerID string `json:"consumer_id"`
-		Seq        int    `json:"seq"`
-	}
-	_ = json.NewDecoder(r.Body).Decode(&req)
-
-	slog.Debug("compat: bus ack", "bus_id", busID, "consumer", req.ConsumerID, "seq", req.Seq)
-
-	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "seq": req.Seq})
 }
 
 // ── Tier C: Operational stability ──────────────────────────────────────────────

--- a/internal/engine/serve_events.go
+++ b/internal/engine/serve_events.go
@@ -1,0 +1,307 @@
+// serve_events.go — HTTP surface for the kernel event bus.
+//
+// Two endpoints:
+//
+//	GET  /v1/events         — historical read. Thin wrapper around QueryLedger
+//	                          with observability-flavored defaults (no
+//	                          verify_chain, "since" accepts durations).
+//	GET  /v1/events/stream  — live SSE stream backed by the EventBroker. Emits
+//	                          `event: ledger.appended` frames with `id: <hash>`
+//	                          for standard Last-Event-ID resume.
+//
+// Internal invariant: both endpoints source from AppendEvent's ledger (the
+// single write sink). There is no duplicate storage — QueryLedger reads
+// disk, the SSE stream reads the broker's ring + live fan-out.
+package engine
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultSSEMaxDuration = 1 * time.Hour
+	maxSSEMaxDuration     = 2 * time.Hour
+	sseHeartbeatInterval  = 30 * time.Second
+	sseWriteDeadline      = 10 * time.Second
+)
+
+// registerEventBusRoutes attaches the real event bus endpoints. Called from
+// NewServer AFTER registerCompatRoutes so that the live handlers shadow any
+// stale stub registrations (the stubs have been deleted, but this keeps the
+// ordering future-proof against re-introductions).
+func (s *Server) registerEventBusRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /v1/events", s.handleEvents)
+	mux.HandleFunc("GET /v1/events/stream", s.handleEventsStream)
+}
+
+// handleEvents is the non-streaming historical query. Mirrors handleLedger
+// but with observability-flavored semantics: `since` accepts durations
+// ("5m"), verify_chain is always off (use /v1/ledger for audit).
+//
+//	GET /v1/events?session_id=…&event_type=…&source=…&since=…&until=…
+//	                &limit=…&order=…
+//	200 → { count, events, truncated, next_before? }
+//	400 → bad query
+//	404 → session_id specified but no events on disk
+//	500 → read failure
+func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	q := r.URL.Query()
+	now := time.Now().UTC()
+
+	eq := EventQuery{
+		SessionID:        q.Get("session_id"),
+		EventTypePattern: q.Get("event_type"),
+		Source:           q.Get("source"),
+		Order:            q.Get("order"),
+	}
+
+	if v := q.Get("since"); v != "" {
+		ts, err := ParseSinceDuration(v, now)
+		if err != nil {
+			writeEventsError(w, http.StatusBadRequest, fmt.Sprintf("since: %v", err))
+			return
+		}
+		eq.Since = ts
+	}
+	if v := q.Get("until"); v != "" {
+		ts, err := ParseSinceDuration(v, now)
+		if err != nil {
+			writeEventsError(w, http.StatusBadRequest, fmt.Sprintf("until: %v", err))
+			return
+		}
+		eq.Until = ts
+	}
+	if v := q.Get("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			writeEventsError(w, http.StatusBadRequest, fmt.Sprintf("limit: %v", err))
+			return
+		}
+		if n < 0 {
+			writeEventsError(w, http.StatusBadRequest, "limit must be non-negative")
+			return
+		}
+		eq.Limit = n
+	}
+
+	result, err := QueryEvents(s.cfg.WorkspaceRoot, eq)
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrSessionNotFound):
+			writeEventsError(w, http.StatusNotFound, err.Error())
+		default:
+			msg := err.Error()
+			if strings.Contains(msg, "event_type") || strings.Contains(msg, "since") {
+				writeEventsError(w, http.StatusBadRequest, msg)
+				return
+			}
+			writeEventsError(w, http.StatusInternalServerError, msg)
+		}
+		return
+	}
+
+	_ = json.NewEncoder(w).Encode(result)
+}
+
+// handleEventsStream is the live SSE endpoint. Replaces the serve_compat.go
+// stub that previously just emitted heartbeats. Subscribers receive:
+//
+//   - `event: connected` on open (one-shot)
+//   - `event: ledger.appended` per envelope (id = event hash)
+//   - `: heartbeat` every 30s (SSE comment — invisible to EventSource)
+//
+// Query params:
+//
+//	session_id     optional filter
+//	event_type     optional filter (exact or "prefix.*")
+//	source         optional filter
+//	since          RFC3339 timestamp or duration shorthand ("5m"); replays
+//	               matching ring/disk entries before going live
+//	last_event_id  standard SSE resume. If the hash is still in the ring,
+//	               replay from the event AFTER it; otherwise fall back to
+//	               `since` (or emit nothing before live).
+//	max_events     stop after N delivered events
+//	max_duration   hard cap on connection lifetime (default 1h, cap 2h)
+func (s *Server) handleEventsStream(w http.ResponseWriter, r *http.Request) {
+	broker := s.process.Broker()
+	if broker == nil {
+		http.Error(w, "event broker not initialised", http.StatusInternalServerError)
+		return
+	}
+
+	q := r.URL.Query()
+	now := time.Now().UTC()
+
+	filter := EventFilter{
+		SessionID:        q.Get("session_id"),
+		EventTypePattern: q.Get("event_type"),
+		Source:           q.Get("source"),
+	}
+
+	var sinceTime time.Time
+	if v := q.Get("since"); v != "" {
+		ts, err := ParseSinceDuration(v, now)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("since: %v", err), http.StatusBadRequest)
+			return
+		}
+		sinceTime = ts
+	}
+
+	// Prefer Last-Event-ID over `since`. The standard header is the browser
+	// EventSource resume mechanism; the query-param form is the manual fallback.
+	lastEventID := r.Header.Get("Last-Event-ID")
+	if lastEventID == "" {
+		lastEventID = q.Get("last_event_id")
+	}
+
+	maxEvents := 0
+	if v := q.Get("max_events"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			http.Error(w, fmt.Sprintf("max_events: invalid %q", v), http.StatusBadRequest)
+			return
+		}
+		maxEvents = n
+	}
+
+	maxDur := defaultSSEMaxDuration
+	if v := q.Get("max_duration"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil || d <= 0 {
+			http.Error(w, fmt.Sprintf("max_duration: invalid %q", v), http.StatusBadRequest)
+			return
+		}
+		if d > maxSSEMaxDuration {
+			d = maxSSEMaxDuration
+		}
+		maxDur = d
+	}
+
+	// Compile filter type early so bad patterns return 400 before we
+	// touch the writer.
+	if _, err := compileEventTypeMatcher(filter.EventTypePattern); err != nil {
+		http.Error(w, fmt.Sprintf("event_type: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.Header().Set("Connection", "keep-alive")
+
+	// Subscribe BEFORE replaying so we don't miss events that arrive
+	// between snapshot and live.
+	sub, err := broker.Subscribe(r.Context(), filter)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("subscribe: %v", err), http.StatusServiceUnavailable)
+		return
+	}
+	defer sub.Cancel()
+
+	rc := http.NewResponseController(w)
+	// `WriteTimeout=5m` on the server would otherwise kill long-lived
+	// connections — extend per-write.
+	_ = rc.SetWriteDeadline(time.Now().Add(sseWriteDeadline))
+
+	// Initial handshake: retry hint + connected event.
+	fmt.Fprintf(w, "retry: 3000\n")
+	connectedPayload, _ := json.Marshal(map[string]string{
+		"session_id": filter.SessionID,
+		"at":         now.Format(time.RFC3339),
+	})
+	fmt.Fprintf(w, "event: connected\ndata: %s\n\n", connectedPayload)
+	flusher.Flush()
+
+	// Build replay. Priority: Last-Event-ID (ring hit) > since. If the
+	// Last-Event-ID is in the ring we replay events strictly AFTER it;
+	// otherwise we fall through to `since` (client's job to notice they
+	// missed events — we can't reconstruct from disk when the ring has
+	// rolled over).
+	var replay []*EventEnvelope
+	var skipUntilAfterHash string
+	if lastEventID != "" && broker.RingContainsHash(lastEventID) {
+		replay = broker.RingReplay(filter, time.Time{})
+		skipUntilAfterHash = lastEventID
+	} else if !sinceTime.IsZero() {
+		replay = broker.RingReplay(filter, sinceTime)
+	}
+
+	// Deliver replay.
+	delivered := 0
+	emit := func(env *EventEnvelope) bool {
+		_ = rc.SetWriteDeadline(time.Now().Add(sseWriteDeadline))
+		evt := envelopeToLedgerEvent(env)
+		b, err := json.Marshal(evt)
+		if err != nil {
+			slog.Debug("events: marshal failed", "err", err)
+			return true // keep going
+		}
+		fmt.Fprintf(w, "id: %s\nevent: ledger.appended\ndata: %s\n\n", env.Metadata.Hash, b)
+		flusher.Flush()
+		delivered++
+		return maxEvents == 0 || delivered < maxEvents
+	}
+
+	for _, env := range replay {
+		if skipUntilAfterHash != "" {
+			if env.Metadata.Hash == skipUntilAfterHash {
+				skipUntilAfterHash = ""
+				continue
+			}
+			// Haven't reached the resume point yet — skip.
+			if skipUntilAfterHash != "" {
+				continue
+			}
+		}
+		if !emit(env) {
+			return
+		}
+	}
+
+	// Live loop.
+	deadline := time.NewTimer(maxDur)
+	defer deadline.Stop()
+	hb := time.NewTicker(sseHeartbeatInterval)
+	defer hb.Stop()
+
+	for {
+		select {
+		case env, ok := <-sub.Events:
+			if !ok {
+				return
+			}
+			if !emit(env) {
+				return
+			}
+		case <-hb.C:
+			_ = rc.SetWriteDeadline(time.Now().Add(sseWriteDeadline))
+			fmt.Fprintf(w, ": heartbeat\n\n")
+			flusher.Flush()
+		case <-deadline.C:
+			return
+		case <-r.Context().Done():
+			return
+		}
+	}
+}
+
+func writeEventsError(w http.ResponseWriter, code int, msg string) {
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/internal/engine/serve_events_test.go
+++ b/internal/engine/serve_events_test.go
@@ -1,0 +1,268 @@
+// serve_events_test.go — integration tests for the HTTP event bus surface.
+//
+// Tests spin up a real *Server via httptest.NewServer + Process (so the
+// EventBroker wiring matches production). The SSE tests are bounded by a
+// short timeout because the stream blocks indefinitely otherwise.
+package engine
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newEventsTestServer builds a real Server + Process pair rooted at a tmpdir and
+// returns its Handler. Cleanup is registered via t.Cleanup.
+func newEventsTestServer(t *testing.T) (http.Handler, *Process, string) {
+	t.Helper()
+	root := t.TempDir()
+	cfg := &Config{WorkspaceRoot: root, CogDir: root + "/.cog", Port: 0}
+	nucleus := &Nucleus{Name: "test"}
+	proc := NewProcess(cfg, nucleus)
+	srv := NewServer(cfg, nucleus, proc)
+	t.Cleanup(func() {
+		_ = proc.Broker().Close()
+	})
+	return srv.Handler(), proc, root
+}
+
+// readSSEUntil reads lines from the SSE stream until N `event: ledger.appended`
+// frames are seen, or timeout expires. Returns collected events as parsed
+// LedgerEvent structs plus all raw headers encountered.
+func readSSEUntil(t *testing.T, r io.Reader, n int, timeout time.Duration) ([]LedgerEvent, []string) {
+	t.Helper()
+	out := []LedgerEvent{}
+	headers := []string{}
+	done := make(chan struct{})
+	var data string
+	var lastID string
+	var lastEvent string
+
+	go func() {
+		defer close(done)
+		scanner := bufio.NewScanner(r)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+		for scanner.Scan() {
+			line := scanner.Text()
+			switch {
+			case strings.HasPrefix(line, "id: "):
+				lastID = strings.TrimPrefix(line, "id: ")
+			case strings.HasPrefix(line, "event: "):
+				lastEvent = strings.TrimPrefix(line, "event: ")
+				headers = append(headers, lastEvent)
+			case strings.HasPrefix(line, "data: "):
+				data = strings.TrimPrefix(line, "data: ")
+			case line == "":
+				if lastEvent == "ledger.appended" && data != "" {
+					var e LedgerEvent
+					if err := json.Unmarshal([]byte(data), &e); err != nil {
+						continue
+					}
+					// Trust the stream's id: header as source of truth.
+					if e.Hash == "" {
+						e.Hash = lastID
+					}
+					out = append(out, e)
+					if len(out) >= n {
+						return
+					}
+				}
+				data = ""
+				lastEvent = ""
+			}
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(timeout):
+	}
+	return out, headers
+}
+
+func TestServeEventsHTTPHistorical(t *testing.T) {
+	t.Parallel()
+	handler, proc, root := newEventsTestServer(t)
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	sid := proc.SessionID()
+	// Emit a couple of events through the real path.
+	for i := 0; i < 3; i++ {
+		if err := proc.EmitEvent(fmt.Sprintf("evt.%d", i), map[string]any{"i": i}, "kernel-v3"); err != nil {
+			t.Fatalf("EmitEvent[%d]: %v", i, err)
+		}
+	}
+	_ = root
+
+	resp, err := http.Get(server.URL + "/v1/events?session_id=" + sid + "&limit=10")
+	if err != nil {
+		t.Fatalf("GET /v1/events: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, b)
+	}
+	var result EventQueryResult
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if result.Count != 3 {
+		t.Errorf("count=%d; want 3", result.Count)
+	}
+}
+
+func TestServeEventsSSEEndToEnd(t *testing.T) {
+	t.Parallel()
+	handler, proc, _ := newEventsTestServer(t)
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	sid := proc.SessionID()
+
+	// Open the SSE stream with a short max_duration so the test is bounded.
+	req, err := http.NewRequestWithContext(context.Background(), "GET",
+		server.URL+"/v1/events/stream?session_id="+sid+"&max_duration=3s&max_events=2", nil)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("SSE GET: %v", err)
+	}
+	t.Cleanup(func() { resp.Body.Close() })
+
+	if got := resp.Header.Get("Content-Type"); !strings.HasPrefix(got, "text/event-stream") {
+		t.Errorf("Content-Type=%s; want text/event-stream", got)
+	}
+
+	// Publish 2 events a beat apart so the reader has time to subscribe.
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		_ = proc.EmitEvent("sse.one", nil, "kernel-v3")
+		time.Sleep(50 * time.Millisecond)
+		_ = proc.EmitEvent("sse.two", nil, "kernel-v3")
+	}()
+
+	got, headers := readSSEUntil(t, resp.Body, 2, 3*time.Second)
+
+	// Expect `connected` frame + two `ledger.appended` frames.
+	if len(got) < 2 {
+		t.Fatalf("received %d events; want 2; headers=%v", len(got), headers)
+	}
+	if got[0].Type != "sse.one" || got[1].Type != "sse.two" {
+		t.Errorf("event types=[%s,%s]; want [sse.one,sse.two]", got[0].Type, got[1].Type)
+	}
+	if got[0].Hash == "" {
+		t.Errorf("first event missing id/hash")
+	}
+	haveConnected := false
+	for _, h := range headers {
+		if h == "connected" {
+			haveConnected = true
+		}
+	}
+	if !haveConnected {
+		t.Errorf("no 'connected' event observed in SSE headers: %v", headers)
+	}
+}
+
+func TestServeBusAckRemoved(t *testing.T) {
+	t.Parallel()
+	handler, _, _ := newEventsTestServer(t)
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	resp, err := http.Post(server.URL+"/v1/bus/some-bus/ack", "application/json",
+		strings.NewReader(`{"consumer_id":"x","seq":1}`))
+	if err != nil {
+		t.Fatalf("POST /v1/bus/.../ack: %v", err)
+	}
+	defer resp.Body.Close()
+	// The old stub returned 200 with {"ok":true,"seq":N}. Removal means the
+	// route is no longer registered — Go's mux maps to either 404 (no match)
+	// or 405 (path collides with another method's pattern). Anything other
+	// than a 2xx is fine; what matters is the stub is gone.
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		t.Errorf("status=%d; want non-2xx (handleBusAck stub removed)", resp.StatusCode)
+	}
+}
+
+func TestEmitEventReachesLedgerAndBus(t *testing.T) {
+	t.Parallel()
+	handler, proc, root := newEventsTestServer(t)
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	sid := proc.SessionID()
+	broker := proc.Broker()
+	if broker == nil {
+		t.Fatal("process broker nil")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Subscribe first so we see the live event even if the ring is warm.
+	sub, err := broker.Subscribe(ctx, EventFilter{SessionID: sid})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	// Drive an MCP-style emit through the process method the tool uses.
+	if err := proc.EmitEvent("insight.captured",
+		map[string]any{"summary": "round-trip"}, "mcp-client"); err != nil {
+		t.Fatalf("EmitEvent: %v", err)
+	}
+
+	// Broker should deliver the event.
+	select {
+	case env := <-sub.Events:
+		if env.HashedPayload.Type != "insight.captured" {
+			t.Errorf("broker got type=%s; want insight.captured", env.HashedPayload.Type)
+		}
+		if env.Metadata.Source != "mcp-client" {
+			t.Errorf("broker got source=%s; want mcp-client", env.Metadata.Source)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("broker did not deliver emitted event")
+	}
+
+	// Ledger should also have the event in the per-session dir (not orphan
+	// file). QueryLedger confirms.
+	res, err := QueryLedger(root, LedgerQuery{SessionID: sid, EventType: "insight.captured"})
+	if err != nil {
+		t.Fatalf("QueryLedger: %v", err)
+	}
+	if res.Count != 1 {
+		t.Errorf("ledger count=%d; want 1 (cogos#10 fix: event must reach per-session ledger)", res.Count)
+	}
+	// And crucially: NO flat orphan file. The old bug wrote to
+	// .cog/ledger/events.jsonl — verify that's not there.
+	orphan := root + "/.cog/ledger/events.jsonl"
+	if _, err := readFileIfExists(orphan); err == nil {
+		t.Errorf("orphan file %s exists — cogos#10 regression", orphan)
+	}
+}
+
+// readFileIfExists is a thin helper used only for the orphan-file assertion
+// above. Returns nil error if the file exists (so the test fails), error
+// otherwise.
+func readFileIfExists(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return io.ReadAll(f)
+}


### PR DESCRIPTION
## Summary

Event bus implementation — closes Agent F's #2 critical MCP blindspot. Also **fixes cogos#10** (the \`EmitLedgerEvent\` orphan-file bug) inline, because per Agent N's design the broker hook must live inside \`AppendEvent\` itself (\`consolidate.go\`, \`cogblock_ledger.go\`, \`process.go\` all call \`AppendEvent\` directly, not \`emitEvent\`).

> **Draft / stacked on PR #11.** This branch is based on \`feat/ledger-api\` (PR #11 head). The event-bus diff begins with commit \`73f1071\`; commits before that belong to PR #11. Once #11 merges, I'll rebase onto main, force-push, and retarget this PR's base.

Closes #10.

## What landed

- **Two MCP tools**: \`cog_read_events\` (historical, bounded) + \`cog_tail_events\` (live stream, bounded by \`max_events\` / \`max_duration\`). Kept separate from \`cog_read_ledger\` because audit vs. observability semantics differ.
- **Two HTTP routes**: \`GET /v1/events\` (historical) + \`GET /v1/events/stream\` (SSE, replacing the keepalive-only stub at \`serve_compat.go:174\`).
- **Broker hook inside \`AppendEvent\`** so every event source (not just \`emitEvent\`) flows to subscribers.
- **\`EmitLedgerEvent\` rewrite**: signature preserved (no call-site churn), body refactored to build an \`EventEnvelope\` and call \`AppendEvent(workspaceRoot, sessionID, envelope)\` with \`sessionID = "mcp-client"\` fallback. Callers with a live \`*Process\` (the MCP \`toolEmitEvent\`) get accurate session attribution via new \`(*Process).EmitEvent\`.

## HTTP contract preservation (critical)

A parallel substrate depends on these root-package routes: \`POST /v1/bus/send\`, \`GET /v1/bus/{bus_id}/events\`, \`GET /v1/bus/events\`. They remain **byte-compatible** — this PR touches only \`internal/engine/\`, not the root package.

Added \`bus_api_contract_test.go\` (3 regression tests) locking the JSON shape of \`busSendResponse\`, \`busSendRequest\`, and the bus-events array element keys. Future PRs that reshape the root bus API will break CI.

**\`handleBusAck\` deleted** — route \`POST /v1/bus/{bus_id}/ack\` dropped acks on the floor (per Agent N §"Real bugs"). Regression test \`TestServeBusAckRemoved\` confirms the route returns non-2xx.

## Design judgments beyond Agent N's spec

- **Additive broker registry** instead of single-slot \`currentBroker\`. The test suite spins up many parallel \`*Process\` instances; a single slot races. \`RegisterBroker\` / \`UnregisterBroker\` (auto-called on \`Close\`) lets parallel processes coexist. Production still has exactly one; behavior identical.
- **\`GET /v1/events\` filter wrapper** includes \`Source\`, \`Until\`, \`Order\` (default desc), \`next_before\` pagination cursor.
- **\`cog_tail_events\` caps**: defaults 100 events / 60s; hard caps 1000 / 10m.
- **SSE \`last_event_id\` resume**: reads both the SSE \`Last-Event-ID\` header and a \`last_event_id\` query param, preferring the header.

## Test plan

- [x] 14 broker/wiring/helper unit tests — pass
- [x] 4 \`events_query\` tests — pass
- [x] 4 HTTP/SSE/MCP integration tests — pass
- [x] 3 HTTP-contract regression tests (root package) — pass
- [x] PR #11 ledger tests still pass (no regression)
- [x] \`go test ./internal/engine/... -short -count=1\` → \`ok\` in 0.93s
- [x] \`go test ./... -short -count=1\` — pass
- [x] \`go vet ./...\` + \`go build ./...\` silent
- [x] \`-race\` run over broker/HTTP/wiring — clean

## Design reference

Agent N's design CogDoc: \`~/cog-workspace/.cog/mem/semantic/surveys/2026-04-21-consolidation/agent-N-event-bus-design.cog.md\`