### PR TITLE
feat(engine): traces search API — cog_search_traces + GET /v1/traces

### DIFF
--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -125,6 +125,11 @@ func (m *MCPServer) registerTools() {
 		Name:        "cog_ingest",
 		Description: "Ingest external material into CogOS knowledge. Deterministic decomposition — no LLM calls. Supports URLs, conversations, documents. Applies membrane policy (accept/quarantine/defer/discard).",
 	}, m.toolIngest)
+
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name:        "cog_search_traces",
+		Description: "Search kernel trace JSONL streams in .cog/run/ (turn_metrics, attention, proprioceptive, internal_requests). Filter by source, session_id, level, case-insensitive substring, and time range (since/until accept RFC3339 or duration like 5m/1h). Returns unified chronological results with per-source scan diagnostics. Fallback: ls .cog/run/*.jsonl && jq -c . .cog/run/<name>.jsonl | head",
+	}, m.toolSearchTraces)
 }
 
 // registerResources registers MCP Resources — read-only addressable data.
@@ -373,6 +378,17 @@ type ingestInput struct {
 	Metadata map[string]string `json:"metadata,omitempty" jsonschema:"Optional context (discord_message_id, channel, etc.)"`
 }
 
+type searchTracesInput struct {
+	Source    string `json:"source,omitempty" jsonschema:"Trace source filter. One of: turn_metrics, attention, proprioceptive, internal_requests, all (default)."`
+	Level     string `json:"level,omitempty" jsonschema:"Level-like filter (exact match, case-insensitive). For proprioceptive source this matches the event field."`
+	SessionID string `json:"session_id,omitempty" jsonschema:"Filter to rows whose session_id matches. Only meaningful for sources that carry a session_id (turn_metrics, internal_requests)."`
+	Substring string `json:"substring,omitempty" jsonschema:"Case-insensitive substring match against the raw JSONL line. Capped at 1024 characters."`
+	Since     string `json:"since,omitempty" jsonschema:"Lower time bound. RFC3339 timestamp or Go duration (e.g. 5m, 1h, 24h for 'since N ago')."`
+	Until     string `json:"until,omitempty" jsonschema:"Upper time bound. RFC3339 timestamp or Go duration."`
+	Limit     int    `json:"limit,omitempty" jsonschema:"Maximum results (default 100, max 1000)."`
+	Order     string `json:"order,omitempty" jsonschema:"'desc' (default, newest first) or 'asc'."`
+}
+
 // ── Tool Implementations ─────────────────────────────────────────────────────
 
 // toolResolveURI — no longer registered as an MCP tool; used by the internal tool loop (tool_loop.go).
@@ -505,18 +521,18 @@ func (m *MCPServer) toolGetState(ctx context.Context, req *mcp.CallToolRequest, 
 	}
 
 	result := map[string]any{
-		"state":               m.process.State().String(),
-		"identity":            identity,
-		"session_id":          m.process.SessionID(),
-		"node_id":             m.process.NodeID,
-		"uptime_seconds":      int(time.Since(m.process.StartedAt()).Seconds()),
-		"field_size":          m.process.Field().Len(),
-		"trust_score":         trust.LocalScore,
-		"fingerprint":         m.process.Fingerprint(),
-		"last_heartbeat":      lastHeartbeat,
-		"coherence_state":     trust.CoherenceFingerprint,
-		"quarantined_count":   queue.Quarantined,
-		"deferred_count":      queue.Deferred,
+		"state":             m.process.State().String(),
+		"identity":          identity,
+		"session_id":        m.process.SessionID(),
+		"node_id":           m.process.NodeID,
+		"uptime_seconds":    int(time.Since(m.process.StartedAt()).Seconds()),
+		"field_size":        m.process.Field().Len(),
+		"trust_score":       trust.LocalScore,
+		"fingerprint":       m.process.Fingerprint(),
+		"last_heartbeat":    lastHeartbeat,
+		"coherence_state":   trust.CoherenceFingerprint,
+		"quarantined_count": queue.Quarantined,
+		"deferred_count":    queue.Deferred,
 	}
 
 	// Node health — sibling services probed on heartbeat.
@@ -956,6 +972,67 @@ func (m *MCPServer) toolIngest(ctx context.Context, req *mcp.CallToolRequest, in
 		"title":        result.Title,
 		"content_type": string(result.ContentType),
 	})
+}
+
+// toolSearchTraces serves the MCP-side entry for `cog_search_traces`.
+// Mirrors the HTTP /v1/traces handler: validates inputs, delegates to
+// QueryTraces, returns a JSON-encoded TraceQueryResult.
+func (m *MCPServer) toolSearchTraces(ctx context.Context, req *mcp.CallToolRequest, input searchTracesInput) (*mcp.CallToolResult, any, error) {
+	tq, err := buildTraceQueryFromInput(input)
+	if err != nil {
+		return textResult(fmt.Sprintf("invalid trace query: %v", err))
+	}
+	res, err := QueryTraces(m.cfg.WorkspaceRoot, tq)
+	if err != nil {
+		return fallbackResult(
+			fmt.Sprintf("trace search failed: %v", err),
+			"ls .cog/run/*.jsonl && jq -c . .cog/run/<name>.jsonl | head",
+		)
+	}
+	return marshalResult(res)
+}
+
+// buildTraceQueryFromInput validates the MCP input shape and normalizes it
+// into a TraceQuery. Shares semantics with parseTraceQueryFromRequest so that
+// the HTTP and MCP surfaces agree on defaults and bounds.
+func buildTraceQueryFromInput(in searchTracesInput) (TraceQuery, error) {
+	q := TraceQuery{
+		Source:    TraceSource(strings.TrimSpace(in.Source)),
+		Level:     strings.TrimSpace(in.Level),
+		SessionID: strings.TrimSpace(in.SessionID),
+		Substring: in.Substring,
+		Limit:     in.Limit,
+		Order:     strings.TrimSpace(in.Order),
+	}
+	if q.Source == "" {
+		q.Source = SourceAll
+	}
+	if _, err := resolveSources(q.Source); err != nil {
+		return TraceQuery{}, err
+	}
+
+	now := time.Now()
+	if in.Since != "" {
+		t, err := ParseTraceDurationOrTime(in.Since, now)
+		if err != nil {
+			return TraceQuery{}, fmt.Errorf("since: %w", err)
+		}
+		q.Since = t
+	}
+	if in.Until != "" {
+		t, err := ParseTraceDurationOrTime(in.Until, now)
+		if err != nil {
+			return TraceQuery{}, fmt.Errorf("until: %w", err)
+		}
+		q.Until = t
+	}
+	if q.Limit < 0 {
+		return TraceQuery{}, fmt.Errorf("limit: expected non-negative integer, got %d", q.Limit)
+	}
+	if q.Limit > maxTracesLimit {
+		return TraceQuery{}, fmt.Errorf("limit: %d exceeds max %d", q.Limit, maxTracesLimit)
+	}
+	return q, nil
 }
 
 // slugify converts a string to a URL-friendly slug.

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -33,6 +33,8 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -67,6 +69,7 @@ func NewServer(cfg *Config, nucleus *Nucleus, process *Process) *Server {
 	mux.HandleFunc("POST /v1/chat/completions", s.handleChat)
 	mux.HandleFunc("POST /v1/messages", s.handleAnthropicMessages)
 	mux.HandleFunc("GET /v1/proprioceptive", s.handleProprioceptive)
+	mux.HandleFunc("GET /v1/traces", s.handleTraces)
 	mux.HandleFunc("GET /v1/lightcone", s.handleLightCone)
 	mux.HandleFunc("POST /v1/context/foveated", s.handleFoveatedContext)
 
@@ -253,23 +256,23 @@ func (s *Server) handleCogDocRead(w http.ResponseWriter, r *http.Request) {
 // ── OpenAI-compatible wire types ─────────────────────────────────────────────
 
 type oaiChatRequest struct {
-	Model               string               `json:"model"`
-	Messages            []oaiMessage          `json:"messages"`
-	Stream              bool                  `json:"stream"`
-	Temperature         *float64              `json:"temperature,omitempty"`
-	MaxTokens           int                   `json:"max_tokens,omitempty"`
-	MaxCompletionTokens int                   `json:"max_completion_tokens,omitempty"`
-	TopP                *float64              `json:"top_p,omitempty"`
-	Stop                []string              `json:"stop,omitempty"`
-	Tools               []oaiToolDefinition   `json:"tools,omitempty"`
-	ToolChoice          json.RawMessage       `json:"tool_choice,omitempty"`
-	ParallelToolCalls   *bool                 `json:"parallel_tool_calls,omitempty"`
-	FrequencyPenalty    *float64              `json:"frequency_penalty,omitempty"`
-	PresencePenalty     *float64              `json:"presence_penalty,omitempty"`
-	Seed                *int                  `json:"seed,omitempty"`
-	User                string                `json:"user,omitempty"`
-	N                   *int                  `json:"n,omitempty"`
-	StreamOptions       *oaiStreamOpts        `json:"stream_options,omitempty"`
+	Model               string              `json:"model"`
+	Messages            []oaiMessage        `json:"messages"`
+	Stream              bool                `json:"stream"`
+	Temperature         *float64            `json:"temperature,omitempty"`
+	MaxTokens           int                 `json:"max_tokens,omitempty"`
+	MaxCompletionTokens int                 `json:"max_completion_tokens,omitempty"`
+	TopP                *float64            `json:"top_p,omitempty"`
+	Stop                []string            `json:"stop,omitempty"`
+	Tools               []oaiToolDefinition `json:"tools,omitempty"`
+	ToolChoice          json.RawMessage     `json:"tool_choice,omitempty"`
+	ParallelToolCalls   *bool               `json:"parallel_tool_calls,omitempty"`
+	FrequencyPenalty    *float64            `json:"frequency_penalty,omitempty"`
+	PresencePenalty     *float64            `json:"presence_penalty,omitempty"`
+	Seed                *int                `json:"seed,omitempty"`
+	User                string              `json:"user,omitempty"`
+	N                   *int                `json:"n,omitempty"`
+	StreamOptions       *oaiStreamOpts      `json:"stream_options,omitempty"`
 }
 
 // oaiStreamOpts carries OpenAI stream_options (e.g. include_usage).
@@ -357,9 +360,9 @@ func extractContent(raw json.RawMessage) string {
 
 // oaiContentPart represents a single element in the OpenAI multi-part content array.
 type oaiContentPart struct {
-	Type     string          `json:"type"`
-	Text     string          `json:"text,omitempty"`
-	ImageURL *oaiImageURL    `json:"image_url,omitempty"`
+	Type     string       `json:"type"`
+	Text     string       `json:"text,omitempty"`
+	ImageURL *oaiImageURL `json:"image_url,omitempty"`
 }
 
 // oaiImageURL carries the URL (typically a data: base64 URI) for an image content part.
@@ -900,6 +903,95 @@ func (s *Server) handleProprioceptive(w http.ResponseWriter, r *http.Request) {
 		"entries":    entries,
 		"light_cone": lcStatus,
 	})
+}
+
+// handleTraces exposes the unified kernel trace search surface.
+//
+// Per Agent Q's design (2026-04-21) this is additive — /v1/proprioceptive
+// stays byte-for-byte identical because dashboard.html:1265 and
+// canvas.html:1706 consume its exact {entries, light_cone} shape.
+//
+//	GET /v1/traces
+//	    ?source=turn_metrics   (or "all", default)
+//	    &level=…               (applies to sources with a level-like field)
+//	    &session_id=…
+//	    &substring=…           (case-insensitive, full-line match)
+//	    &since=5m              (RFC3339 OR Go duration)
+//	    &until=…               (RFC3339 upper bound)
+//	    &limit=100             (1..1000)
+//	    &order=desc            ("asc" | "desc")
+//
+//	200 → TraceQueryResult
+//	400 → unknown source / unparseable since|until / limit out of range / substring too long
+//	500 → I/O error
+func (s *Server) handleTraces(w http.ResponseWriter, r *http.Request) {
+	q, err := parseTraceQueryFromRequest(r)
+	if err != nil {
+		writeTraceError(w, http.StatusBadRequest, err)
+		return
+	}
+	result, err := QueryTraces(s.cfg.WorkspaceRoot, q)
+	if err != nil {
+		writeTraceError(w, http.StatusInternalServerError, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(result)
+}
+
+// parseTraceQueryFromRequest maps query params onto a TraceQuery.
+// Defaults: source=all, limit=100, order=desc.
+func parseTraceQueryFromRequest(r *http.Request) (TraceQuery, error) {
+	q := TraceQuery{
+		Source:    TraceSource(strings.TrimSpace(r.URL.Query().Get("source"))),
+		Level:     strings.TrimSpace(r.URL.Query().Get("level")),
+		SessionID: strings.TrimSpace(r.URL.Query().Get("session_id")),
+		Substring: r.URL.Query().Get("substring"),
+		Order:     strings.TrimSpace(r.URL.Query().Get("order")),
+	}
+
+	if q.Source == "" {
+		q.Source = SourceAll
+	}
+	// Validate source upfront so unknown values surface as 400, not 500.
+	if _, err := resolveSources(q.Source); err != nil {
+		return TraceQuery{}, err
+	}
+
+	now := time.Now()
+	if s := r.URL.Query().Get("since"); s != "" {
+		t, err := ParseTraceDurationOrTime(s, now)
+		if err != nil {
+			return TraceQuery{}, fmt.Errorf("since: %w", err)
+		}
+		q.Since = t
+	}
+	if s := r.URL.Query().Get("until"); s != "" {
+		t, err := ParseTraceDurationOrTime(s, now)
+		if err != nil {
+			return TraceQuery{}, fmt.Errorf("until: %w", err)
+		}
+		q.Until = t
+	}
+	if s := r.URL.Query().Get("limit"); s != "" {
+		n, err := strconv.Atoi(s)
+		if err != nil || n < 0 {
+			return TraceQuery{}, fmt.Errorf("limit: expected non-negative integer, got %q", s)
+		}
+		if n > maxTracesLimit {
+			return TraceQuery{}, fmt.Errorf("limit: %d exceeds max %d", n, maxTracesLimit)
+		}
+		q.Limit = n
+	}
+	return q, nil
+}
+
+// writeTraceError emits a {"error": "..."} JSON body with the given status.
+// Matches the existing serve.go convention (handleDebugLast etc.).
+func writeTraceError(w http.ResponseWriter, status int, err error) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 }
 
 // handleLightCone returns light cone metadata from the LightConeManager.

--- a/internal/engine/traces_query.go
+++ b/internal/engine/traces_query.go
@@ -1,0 +1,387 @@
+// traces_query.go — Unified search across kernel trace JSONL streams.
+//
+// Per Agent Q's Survey Q design (2026-04-21), this file implements the read
+// side of `.cog/run/*.jsonl` observability: a single entry point that scans
+// the populated trace sources (turn_metrics, attention, proprioceptive,
+// internal-requests), normalizes their heterogeneous per-source schemas into
+// one `{source, timestamp, session_id?, level?, line}` shape, and applies
+// caller-provided filters (time range, session, level, substring).
+//
+// These are TRACES — semantic metabolites under the kernel-ingestion-and-
+// digestion framing — not diagnostic log text. Kernel slog (stderr, text
+// handler) is intentionally out of scope; that couples to Windows stderr-
+// capture work (Agent K) and gets its own follow-up.
+//
+// Algorithmic shape mirrors Agent L's QueryLedger: read-side only, per-source
+// scan + normalize, filter, limit + truncated flag. The /v1/proprioceptive
+// endpoint is left byte-for-byte identical (dashboard.html and canvas.html
+// consume its exact shape); this file adds a new surface, it does not reshape
+// the old one.
+
+package engine
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// TraceSource identifies one of the known trace JSONL streams under .cog/run/.
+// "all" expands to every canonical source at query time.
+type TraceSource string
+
+const (
+	SourceTurnMetrics      TraceSource = "turn_metrics"
+	SourceAttention        TraceSource = "attention"
+	SourceProprioceptive   TraceSource = "proprioceptive"
+	SourceInternalRequests TraceSource = "internal_requests"
+	SourceAll              TraceSource = "all"
+)
+
+// Query limits mirror the ledger_query.go pattern from Agent L's design.
+const (
+	defaultTracesLimit = 100
+	maxTracesLimit     = 1000
+	tracesScanBufSize  = 1 << 20 // 1 MiB; handles turn_metrics rows with embedded prompts.
+	maxSubstringLen    = 1024    // v1 cap on substring filter length.
+)
+
+// TraceQuery bundles caller-provided filter parameters.
+// Zero values are the defaults: no filter, newest-first, limit=defaultTracesLimit.
+type TraceQuery struct {
+	Source    TraceSource
+	Level     string
+	SessionID string
+	Substring string // case-insensitive
+	Since     time.Time
+	Until     time.Time
+	Limit     int
+	Order     string // "desc" (default) | "asc"
+}
+
+// TraceResult is a single normalized row in the unified output.
+// Line is the raw JSONL bytes — callers that need per-source fields
+// unmarshal themselves.
+type TraceResult struct {
+	Source    string          `json:"source"`
+	Timestamp time.Time       `json:"timestamp"`
+	SessionID string          `json:"session_id,omitempty"`
+	Level     string          `json:"level,omitempty"`
+	Line      json.RawMessage `json:"line"`
+}
+
+// TraceQueryResult is the outer envelope returned by QueryTraces.
+type TraceQueryResult struct {
+	Count          int            `json:"count"`
+	Results        []TraceResult  `json:"results"`
+	Truncated      bool           `json:"truncated"`
+	SourcesChecked []SourceStatus `json:"sources_checked"`
+}
+
+// SourceStatus reports per-file scan diagnostics.
+// FileExists=false distinguishes "file absent" from "file present but empty",
+// which is critical for the "I got nothing — wrong filter or empty file?"
+// debugging use case called out in Agent Q §3.2.
+type SourceStatus struct {
+	Name       string `json:"name"`
+	Scanned    int    `json:"scanned"`
+	Matched    int    `json:"matched"`
+	FileExists bool   `json:"file_exists"`
+}
+
+// sourceSpec captures per-source normalization rules.
+type sourceSpec struct {
+	name         string
+	relPath      string
+	timestampKey string
+	sessionKey   string // "" if the source has no session_id field
+	levelKey     string // "" if the source has no level-like field
+}
+
+// sourceSpecs is the §3.4 normalization table materialized.
+//
+// Empirical verification (2026-04-21) against /Users/slowbro/cog-workspace/.cog/run:
+//   - turn_metrics.jsonl:      timestamp (RFC3339 w/ zone), session_id, no level
+//   - attention.jsonl:         occurred_at (RFC3339 Z), no session_id, no level
+//   - proprioceptive.jsonl:    timestamp (RFC3339 Z), no session_id, event as pseudo-level
+//   - internal-requests.jsonl: timestamp is FLOAT UNIX SECONDS (drift from spec's
+//     "observed RFC3339"); parseTimestamp handles both string and numeric forms.
+var sourceSpecs = map[TraceSource]sourceSpec{
+	SourceTurnMetrics: {
+		name:         "turn_metrics",
+		relPath:      filepath.Join(".cog", "run", "turn_metrics.jsonl"),
+		timestampKey: "timestamp",
+		sessionKey:   "session_id",
+	},
+	SourceAttention: {
+		name:         "attention",
+		relPath:      filepath.Join(".cog", "run", "attention.jsonl"),
+		timestampKey: "occurred_at",
+	},
+	SourceProprioceptive: {
+		name:         "proprioceptive",
+		relPath:      filepath.Join(".cog", "run", "proprioceptive.jsonl"),
+		timestampKey: "timestamp",
+		levelKey:     "event",
+	},
+	SourceInternalRequests: {
+		name:         "internal_requests",
+		relPath:      filepath.Join(".cog", "run", "internal-requests.jsonl"),
+		timestampKey: "timestamp",
+		sessionKey:   "session_id",
+	},
+}
+
+// canonicalSourceOrder preserves a stable iteration over sourceSpecs.
+// Map iteration is unstable; tests and diagnostic output benefit from
+// a predictable order.
+var canonicalSourceOrder = []TraceSource{
+	SourceTurnMetrics,
+	SourceAttention,
+	SourceProprioceptive,
+	SourceInternalRequests,
+}
+
+// resolveSources expands "all" (and the empty default) to every canonical
+// source, or returns the single requested spec. Unknown sources return an
+// error so callers can surface a 400.
+func resolveSources(src TraceSource) ([]sourceSpec, error) {
+	if src == "" || src == SourceAll {
+		specs := make([]sourceSpec, 0, len(canonicalSourceOrder))
+		for _, key := range canonicalSourceOrder {
+			specs = append(specs, sourceSpecs[key])
+		}
+		return specs, nil
+	}
+	spec, ok := sourceSpecs[src]
+	if !ok {
+		return nil, fmt.Errorf("unknown source %q (valid: turn_metrics, attention, proprioceptive, internal_requests, all)", src)
+	}
+	return []sourceSpec{spec}, nil
+}
+
+// QueryTraces is the entry point. It reads each resolved source, applies the
+// normalized filter set, merges results, sorts by timestamp per q.Order, and
+// returns the globally-limited slice plus per-source diagnostics.
+//
+// Missing files are not errors — they surface as file_exists=false in
+// SourcesChecked so callers can distinguish "file absent" from "empty match".
+func QueryTraces(workspaceRoot string, q TraceQuery) (*TraceQueryResult, error) {
+	if len(q.Substring) > maxSubstringLen {
+		return nil, fmt.Errorf("substring filter too long (%d > %d)", len(q.Substring), maxSubstringLen)
+	}
+
+	limit := q.Limit
+	if limit <= 0 {
+		limit = defaultTracesLimit
+	}
+	if limit > maxTracesLimit {
+		limit = maxTracesLimit
+	}
+
+	order := strings.ToLower(strings.TrimSpace(q.Order))
+	if order != "asc" {
+		order = "desc"
+	}
+
+	specs, err := resolveSources(q.Source)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &TraceQueryResult{
+		SourcesChecked: make([]SourceStatus, 0, len(specs)),
+	}
+
+	// Per-source pre-limit keeps one pathologically large source from starving
+	// the others. We grab up to limit+1 per source; the extra row is what
+	// allows Truncated=true to fire on a single-source query that has exactly
+	// one more match than requested. The global sort+trim in the final pass
+	// produces the correct merged result.
+	var merged []TraceResult
+	perSourceLimit := limit + 1
+	for _, spec := range specs {
+		rs, status := scanSource(workspaceRoot, spec, q, perSourceLimit)
+		merged = append(merged, rs...)
+		result.SourcesChecked = append(result.SourcesChecked, status)
+	}
+
+	sortByTimestamp(merged, order)
+
+	if len(merged) > limit {
+		merged = merged[:limit]
+		result.Truncated = true
+	}
+	result.Results = merged
+	result.Count = len(merged)
+	return result, nil
+}
+
+// scanSource reads one JSONL file, applies filters, and returns up to
+// perSourceLimit matches plus scan diagnostics.
+func scanSource(root string, spec sourceSpec, q TraceQuery, perSourceLimit int) ([]TraceResult, SourceStatus) {
+	path := filepath.Join(root, spec.relPath)
+	status := SourceStatus{Name: spec.name}
+
+	f, err := os.Open(path)
+	if err != nil {
+		// Missing file is not an error — reported via file_exists=false.
+		return nil, status
+	}
+	defer f.Close()
+	status.FileExists = true
+
+	substringLower := strings.ToLower(q.Substring)
+
+	var out []TraceResult
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), tracesScanBufSize)
+	for scanner.Scan() {
+		raw := scanner.Bytes()
+		if len(bytes.TrimSpace(raw)) == 0 {
+			continue
+		}
+		status.Scanned++
+
+		// Cheap byte-level substring check first — no JSON parse needed if it misses.
+		// Critical on turn_metrics.jsonl which is the heaviest source.
+		if q.Substring != "" && !bytes.Contains(bytes.ToLower(raw), []byte(substringLower)) {
+			continue
+		}
+
+		// Defensive copy: bufio.Scanner reuses its buffer between Scan() calls,
+		// so we must clone before storing in a retained slice.
+		lineCopy := make([]byte, len(raw))
+		copy(lineCopy, raw)
+
+		row, ok := extractFields(lineCopy, spec)
+		if !ok {
+			continue
+		}
+		if !q.Since.IsZero() && row.Timestamp.Before(q.Since) {
+			continue
+		}
+		if !q.Until.IsZero() && row.Timestamp.After(q.Until) {
+			continue
+		}
+		if q.SessionID != "" && row.SessionID != q.SessionID {
+			continue
+		}
+		if q.Level != "" && !strings.EqualFold(row.Level, q.Level) {
+			continue
+		}
+
+		out = append(out, row)
+		status.Matched++
+		if len(out) >= perSourceLimit {
+			break
+		}
+	}
+	return out, status
+}
+
+// extractFields parses one line and populates the normalized TraceResult.
+// Returns (row, false) only if the JSON is unparseable; missing or malformed
+// individual fields degrade gracefully (empty string, zero time).
+func extractFields(line []byte, spec sourceSpec) (TraceResult, bool) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(line, &raw); err != nil {
+		return TraceResult{}, false
+	}
+	r := TraceResult{Source: spec.name, Line: json.RawMessage(line)}
+
+	if tsRaw, ok := raw[spec.timestampKey]; ok {
+		if t, ok := parseTimestamp(tsRaw); ok {
+			r.Timestamp = t.UTC()
+		}
+	}
+	if spec.sessionKey != "" {
+		if sRaw, ok := raw[spec.sessionKey]; ok {
+			_ = json.Unmarshal(sRaw, &r.SessionID)
+		}
+	}
+	if spec.levelKey != "" {
+		if lRaw, ok := raw[spec.levelKey]; ok {
+			_ = json.Unmarshal(lRaw, &r.Level)
+		}
+	}
+	return r, true
+}
+
+// parseTimestamp accepts:
+//   - an RFC3339 / RFC3339Nano string (turn_metrics, attention, proprioceptive)
+//   - a numeric unix-seconds value, integer or float
+//     (internal-requests.jsonl uses this — drift from Agent Q §3.4
+//     which specified "observed RFC3339"; handled here without bubbling up
+//     a source-specific schema to callers.)
+func parseTimestamp(raw json.RawMessage) (time.Time, bool) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return time.Time{}, false
+	}
+	switch trimmed[0] {
+	case '"':
+		var s string
+		if err := json.Unmarshal(trimmed, &s); err != nil {
+			return time.Time{}, false
+		}
+		if s == "" {
+			return time.Time{}, false
+		}
+		if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+			return t, true
+		}
+		if t, err := time.Parse(time.RFC3339, s); err == nil {
+			return t, true
+		}
+		return time.Time{}, false
+	default:
+		var f float64
+		if err := json.Unmarshal(trimmed, &f); err != nil {
+			return time.Time{}, false
+		}
+		if f == 0 {
+			return time.Time{}, false
+		}
+		sec := int64(f)
+		nsec := int64((f - float64(sec)) * 1e9)
+		return time.Unix(sec, nsec), true
+	}
+}
+
+// sortByTimestamp sorts a merged slice in place. Stable ordering keeps the
+// per-source arrival order for ties.
+func sortByTimestamp(rows []TraceResult, order string) {
+	sort.SliceStable(rows, func(i, j int) bool {
+		if order == "asc" {
+			return rows[i].Timestamp.Before(rows[j].Timestamp)
+		}
+		return rows[i].Timestamp.After(rows[j].Timestamp)
+	})
+}
+
+// ParseTraceDurationOrTime interprets a since/until parameter. Accepts a Go
+// duration ("5m", "1h", "24h") — interpreted as "since N ago" — or an
+// RFC3339 / RFC3339Nano timestamp. Shared by the HTTP and MCP parsers.
+func ParseTraceDurationOrTime(s string, now time.Time) (time.Time, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}, nil
+	}
+	if d, err := time.ParseDuration(s); err == nil {
+		return now.Add(-d), nil
+	}
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return t, nil
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, nil
+	}
+	return time.Time{}, fmt.Errorf("expected RFC3339 timestamp or Go duration (e.g. 5m, 1h): %q", s)
+}

--- a/internal/engine/traces_query_test.go
+++ b/internal/engine/traces_query_test.go
@@ -1,0 +1,639 @@
+// traces_query_test.go — unit tests for QueryTraces.
+//
+// Test plan matches Agent Q §6.1 (12 unit tests) plus §6.2-6.3 (HTTP + MCP
+// roundtrip + /v1/proprioceptive regression guard).
+
+package engine
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ── fixtures ───────────────────────────────────────────────────────────────
+
+// writeTraceFixture writes lines to .cog/run/<name>.jsonl under root.
+// Each line is serialized via json.Marshal; use writeTraceRaw for malformed input.
+func writeTraceFixture(t *testing.T, root, name string, rows []map[string]any) {
+	t.Helper()
+	runDir := filepath.Join(root, ".cog", "run")
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		t.Fatalf("mkdir run: %v", err)
+	}
+	path := filepath.Join(runDir, name)
+	var buf bytes.Buffer
+	for _, row := range rows {
+		b, err := json.Marshal(row)
+		if err != nil {
+			t.Fatalf("marshal row: %v", err)
+		}
+		buf.Write(b)
+		buf.WriteByte('\n')
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// writeTraceRaw writes arbitrary bytes — useful for malformed-line tests.
+func writeTraceRaw(t *testing.T, root, name, contents string) {
+	t.Helper()
+	runDir := filepath.Join(root, ".cog", "run")
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		t.Fatalf("mkdir run: %v", err)
+	}
+	path := filepath.Join(runDir, name)
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// ── §6.1 unit tests ────────────────────────────────────────────────────────
+
+// 1. Empty workspace — no files — returns count=0, file_exists=false for all sources.
+func TestQueryEmptyWorkspace(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	res, err := QueryTraces(root, TraceQuery{Source: SourceAll})
+	if err != nil {
+		t.Fatalf("QueryTraces: %v", err)
+	}
+	if res.Count != 0 {
+		t.Errorf("Count = %d; want 0", res.Count)
+	}
+	if len(res.SourcesChecked) != len(canonicalSourceOrder) {
+		t.Errorf("SourcesChecked len = %d; want %d", len(res.SourcesChecked), len(canonicalSourceOrder))
+	}
+	for _, st := range res.SourcesChecked {
+		if st.FileExists {
+			t.Errorf("source %q: file_exists = true; want false", st.Name)
+		}
+	}
+}
+
+// 2. Single-source read of turn_metrics — all 3 rows returned with ts + session.
+func TestQuerySingleSourceTurnMetrics(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeTraceFixture(t, root, "turn_metrics.jsonl", []map[string]any{
+		{"session_id": "s1", "turn_index": 1, "timestamp": "2026-04-20T10:00:00Z", "query": "hello"},
+		{"session_id": "s1", "turn_index": 2, "timestamp": "2026-04-20T10:01:00Z", "query": "world"},
+		{"session_id": "s2", "turn_index": 1, "timestamp": "2026-04-20T10:02:00Z", "query": "second"},
+	})
+
+	res, err := QueryTraces(root, TraceQuery{Source: SourceTurnMetrics})
+	if err != nil {
+		t.Fatalf("QueryTraces: %v", err)
+	}
+	if res.Count != 3 {
+		t.Fatalf("Count = %d; want 3", res.Count)
+	}
+	// desc order by default — newest first.
+	if res.Results[0].SessionID != "s2" {
+		t.Errorf("Results[0].SessionID = %q; want s2 (newest)", res.Results[0].SessionID)
+	}
+	if res.Results[0].Timestamp.IsZero() {
+		t.Error("timestamp not populated")
+	}
+	// line preserved as raw JSON.
+	var decoded map[string]any
+	if err := json.Unmarshal(res.Results[0].Line, &decoded); err != nil {
+		t.Fatalf("decode Line: %v", err)
+	}
+	if decoded["query"].(string) != "second" {
+		t.Errorf("Line.query = %v; want second", decoded["query"])
+	}
+}
+
+// 3. Multi-source all + merged desc ordering.
+func TestQueryAllSourcesMerged(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeTraceFixture(t, root, "turn_metrics.jsonl", []map[string]any{
+		{"session_id": "s1", "timestamp": "2026-04-20T10:00:00Z", "query": "first"},
+		{"session_id": "s1", "timestamp": "2026-04-20T10:05:00Z", "query": "third"},
+	})
+	writeTraceFixture(t, root, "attention.jsonl", []map[string]any{
+		{"participant_id": "p1", "target_uri": "cog://x", "signal_type": "visit", "occurred_at": "2026-04-20T10:02:00Z"},
+		{"participant_id": "p1", "target_uri": "cog://y", "signal_type": "read", "occurred_at": "2026-04-20T10:06:00Z"},
+	})
+
+	res, err := QueryTraces(root, TraceQuery{Source: SourceAll})
+	if err != nil {
+		t.Fatalf("QueryTraces: %v", err)
+	}
+	if res.Count != 4 {
+		t.Fatalf("Count = %d; want 4", res.Count)
+	}
+	// Verify desc timestamps.
+	for i := 1; i < len(res.Results); i++ {
+		prev, cur := res.Results[i-1].Timestamp, res.Results[i].Timestamp
+		if cur.After(prev) {
+			t.Errorf("order violated at i=%d: %v is after %v", i, cur, prev)
+		}
+	}
+	// Both source names appear.
+	seen := map[string]bool{}
+	for _, r := range res.Results {
+		seen[r.Source] = true
+	}
+	if !seen["turn_metrics"] || !seen["attention"] {
+		t.Errorf("merged sources = %v; want both turn_metrics and attention", seen)
+	}
+}
+
+// 4. session_id filter — attention source (no session) gracefully returns 0.
+func TestQueryFilterBySessionID(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeTraceFixture(t, root, "turn_metrics.jsonl", []map[string]any{
+		{"session_id": "s1", "timestamp": "2026-04-20T10:00:00Z"},
+		{"session_id": "s2", "timestamp": "2026-04-20T10:01:00Z"},
+		{"session_id": "s1", "timestamp": "2026-04-20T10:02:00Z"},
+	})
+	writeTraceFixture(t, root, "attention.jsonl", []map[string]any{
+		{"participant_id": "p", "target_uri": "cog://x", "signal_type": "visit", "occurred_at": "2026-04-20T10:03:00Z"},
+	})
+
+	res, err := QueryTraces(root, TraceQuery{Source: SourceAll, SessionID: "s1"})
+	if err != nil {
+		t.Fatalf("QueryTraces: %v", err)
+	}
+	if res.Count != 2 {
+		t.Fatalf("Count = %d; want 2", res.Count)
+	}
+	for _, r := range res.Results {
+		if r.SessionID != "s1" {
+			t.Errorf("SessionID = %q; want s1", r.SessionID)
+		}
+	}
+	// attention source was scanned but contributed 0.
+	var attStatus SourceStatus
+	for _, st := range res.SourcesChecked {
+		if st.Name == "attention" {
+			attStatus = st
+		}
+	}
+	if !attStatus.FileExists {
+		t.Error("attention.file_exists = false; want true")
+	}
+	if attStatus.Matched != 0 {
+		t.Errorf("attention.matched = %d; want 0 (no session_id field)", attStatus.Matched)
+	}
+}
+
+// 5. since= as duration AND RFC3339.
+func TestQueryFilterBySinceDuration(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	now := time.Now().UTC().Truncate(time.Second)
+	old := now.Add(-2 * time.Hour).Format(time.RFC3339)
+	recent := now.Add(-10 * time.Minute).Format(time.RFC3339)
+	writeTraceFixture(t, root, "turn_metrics.jsonl", []map[string]any{
+		{"session_id": "s1", "timestamp": old},
+		{"session_id": "s1", "timestamp": recent},
+	})
+
+	res, err := QueryTraces(root, TraceQuery{
+		Source: SourceTurnMetrics,
+		Since:  now.Add(-30 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("QueryTraces: %v", err)
+	}
+	if res.Count != 1 {
+		t.Fatalf("Count = %d; want 1 (recent only)", res.Count)
+	}
+
+	// Same test via ParseTraceDurationOrTime resolution.
+	since, err := ParseTraceDurationOrTime("30m", now)
+	if err != nil {
+		t.Fatalf("ParseTraceDurationOrTime: %v", err)
+	}
+	res2, err := QueryTraces(root, TraceQuery{Source: SourceTurnMetrics, Since: since})
+	if err != nil {
+		t.Fatalf("QueryTraces: %v", err)
+	}
+	if res2.Count != 1 {
+		t.Fatalf("duration path Count = %d; want 1", res2.Count)
+	}
+}
+
+// 6. until= filter drops newer rows.
+func TestQueryFilterByUntilBound(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeTraceFixture(t, root, "turn_metrics.jsonl", []map[string]any{
+		{"session_id": "s1", "timestamp": "2026-04-20T10:00:00Z"},
+		{"session_id": "s2", "timestamp": "2026-04-20T12:00:00Z"},
+	})
+
+	until, _ := time.Parse(time.RFC3339, "2026-04-20T11:00:00Z")
+	res, err := QueryTraces(root, TraceQuery{Source: SourceTurnMetrics, Until: until})
+	if err != nil {
+		t.Fatalf("QueryTraces: %v", err)
+	}
+	if res.Count != 1 {
+		t.Fatalf("Count = %d; want 1", res.Count)
+	}
+	if res.Results[0].SessionID != "s1" {
+		t.Errorf("SessionID = %q; want s1", res.Results[0].SessionID)
+	}
+}
+
+// 7. substring match — case-insensitive.
+func TestQueryFilterBySubstring(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeTraceFixture(t, root, "turn_metrics.jsonl", []map[string]any{
+		{"session_id": "s1", "timestamp": "2026-04-20T10:00:00Z", "query": "QUOTA exceeded"},
+		{"session_id": "s2", "timestamp": "2026-04-20T10:01:00Z", "query": "plain request"},
+	})
+
+	res, err := QueryTraces(root, TraceQuery{
+		Source:    SourceTurnMetrics,
+		Substring: "quota",
+	})
+	if err != nil {
+		t.Fatalf("QueryTraces: %v", err)
+	}
+	if res.Count != 1 {
+		t.Fatalf("Count = %d; want 1", res.Count)
+	}
+	if res.Results[0].SessionID != "s1" {
+		t.Errorf("SessionID = %q; want s1", res.Results[0].SessionID)
+	}
+}
+
+// 8. level filter — proprioceptive maps event->level.
+func TestQueryFilterByLevelProprioceptive(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeTraceFixture(t, root, "proprioceptive.jsonl", []map[string]any{
+		{"timestamp": "2026-04-20T10:00:00Z", "event": "tool_call_rejected", "query": "q1"},
+		{"timestamp": "2026-04-20T10:01:00Z", "event": "prediction_logged", "query": "q2"},
+		{"timestamp": "2026-04-20T10:02:00Z", "event": "tool_call_rejected", "query": "q3"},
+	})
+
+	res, err := QueryTraces(root, TraceQuery{
+		Source: SourceProprioceptive,
+		Level:  "tool_call_rejected",
+	})
+	if err != nil {
+		t.Fatalf("QueryTraces: %v", err)
+	}
+	if res.Count != 2 {
+		t.Fatalf("Count = %d; want 2", res.Count)
+	}
+	for _, r := range res.Results {
+		if r.Level != "tool_call_rejected" {
+			t.Errorf("Level = %q; want tool_call_rejected", r.Level)
+		}
+	}
+
+	// level=other excludes all.
+	resOther, err := QueryTraces(root, TraceQuery{Source: SourceProprioceptive, Level: "nonexistent"})
+	if err != nil {
+		t.Fatalf("QueryTraces: %v", err)
+	}
+	if resOther.Count != 0 {
+		t.Errorf("Count for unmatched level = %d; want 0", resOther.Count)
+	}
+}
+
+// 9. truncation — 150 rows, limit=100 → 100 + truncated.
+func TestQueryTruncation(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	var rows []map[string]any
+	for i := 0; i < 150; i++ {
+		rows = append(rows, map[string]any{
+			"session_id": "s1",
+			"timestamp":  time.Date(2026, 4, 20, 10, 0, i, 0, time.UTC).Format(time.RFC3339),
+		})
+	}
+	writeTraceFixture(t, root, "turn_metrics.jsonl", rows)
+
+	res, err := QueryTraces(root, TraceQuery{Source: SourceTurnMetrics, Limit: 100})
+	if err != nil {
+		t.Fatalf("QueryTraces: %v", err)
+	}
+	if res.Count != 100 {
+		t.Fatalf("Count = %d; want 100", res.Count)
+	}
+	if !res.Truncated {
+		t.Error("Truncated = false; want true")
+	}
+}
+
+// 10. malformed line — scanned increments, row skipped, no error.
+func TestQueryMalformedLineSkipped(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeTraceRaw(t, root, "turn_metrics.jsonl",
+		`{"session_id":"s1","timestamp":"2026-04-20T10:00:00Z"}`+"\n"+
+			`not-json-garbage`+"\n"+
+			`{"session_id":"s2","timestamp":"2026-04-20T10:01:00Z"}`+"\n")
+
+	res, err := QueryTraces(root, TraceQuery{Source: SourceTurnMetrics})
+	if err != nil {
+		t.Fatalf("QueryTraces: %v", err)
+	}
+	if res.Count != 2 {
+		t.Fatalf("Count = %d; want 2 (malformed skipped)", res.Count)
+	}
+	var status SourceStatus
+	for _, st := range res.SourcesChecked {
+		if st.Name == "turn_metrics" {
+			status = st
+		}
+	}
+	if status.Scanned != 3 {
+		t.Errorf("Scanned = %d; want 3 (including garbage)", status.Scanned)
+	}
+}
+
+// 11. order=asc — chronologically increasing.
+func TestQueryOrderAsc(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeTraceFixture(t, root, "turn_metrics.jsonl", []map[string]any{
+		{"session_id": "s1", "timestamp": "2026-04-20T12:00:00Z"},
+		{"session_id": "s2", "timestamp": "2026-04-20T10:00:00Z"},
+		{"session_id": "s3", "timestamp": "2026-04-20T11:00:00Z"},
+	})
+
+	res, err := QueryTraces(root, TraceQuery{Source: SourceTurnMetrics, Order: "asc"})
+	if err != nil {
+		t.Fatalf("QueryTraces: %v", err)
+	}
+	if res.Count != 3 {
+		t.Fatalf("Count = %d; want 3", res.Count)
+	}
+	for i := 1; i < len(res.Results); i++ {
+		if res.Results[i].Timestamp.Before(res.Results[i-1].Timestamp) {
+			t.Errorf("asc order violated at i=%d", i)
+		}
+	}
+	if res.Results[0].SessionID != "s2" {
+		t.Errorf("Results[0].SessionID = %q; want s2 (oldest)", res.Results[0].SessionID)
+	}
+}
+
+// 12. bad source rejected.
+func TestQueryBadSourceRejected(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	_, err := QueryTraces(root, TraceQuery{Source: "bogus"})
+	if err == nil {
+		t.Fatal("QueryTraces with bogus source returned nil error; want validation error")
+	}
+	if !strings.Contains(err.Error(), "unknown source") {
+		t.Errorf("error = %v; want 'unknown source'", err)
+	}
+}
+
+// 13. Normalization correctness — attention (occurred_at) and turn_metrics (timestamp)
+// surface with populated Timestamp fields from different JSON keys, and
+// internal_requests (float unix) parses too (drift from spec §3.4).
+func TestQueryNormalizationAttentionVsTurnMetrics(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeTraceFixture(t, root, "attention.jsonl", []map[string]any{
+		{"participant_id": "p1", "target_uri": "cog://x", "signal_type": "visit", "occurred_at": "2026-04-20T10:00:00Z"},
+	})
+	writeTraceFixture(t, root, "turn_metrics.jsonl", []map[string]any{
+		{"session_id": "s1", "timestamp": "2026-04-20T10:01:00-04:00"},
+	})
+	writeTraceFixture(t, root, "internal-requests.jsonl", []map[string]any{
+		// Unix float timestamp — matches live workspace drift from spec.
+		{"type": "request", "timestamp": 1769281958.2577438, "request_id": "r1"},
+	})
+
+	res, err := QueryTraces(root, TraceQuery{Source: SourceAll})
+	if err != nil {
+		t.Fatalf("QueryTraces: %v", err)
+	}
+	if res.Count != 3 {
+		t.Fatalf("Count = %d; want 3 (one per source)", res.Count)
+	}
+	// All timestamps populated (non-zero) — proves the normalization worked.
+	for _, r := range res.Results {
+		if r.Timestamp.IsZero() {
+			t.Errorf("source %q: Timestamp zero; want populated", r.Source)
+		}
+	}
+	// attention row has no session_id — should be empty string.
+	for _, r := range res.Results {
+		if r.Source == "attention" && r.SessionID != "" {
+			t.Errorf("attention SessionID = %q; want empty", r.SessionID)
+		}
+		if r.Source == "turn_metrics" && r.SessionID != "s1" {
+			t.Errorf("turn_metrics SessionID = %q; want s1", r.SessionID)
+		}
+	}
+}
+
+// 14. Substring-too-long rejected.
+func TestQuerySubstringTooLong(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	long := strings.Repeat("a", maxSubstringLen+1)
+	_, err := QueryTraces(root, TraceQuery{Substring: long})
+	if err == nil {
+		t.Fatal("expected error for substring exceeding cap")
+	}
+}
+
+// ── §6.2 HTTP + MCP roundtrip ──────────────────────────────────────────────
+
+// 15. HTTP — GET /v1/traces returns a well-shaped TraceQueryResult.
+func TestHandleTracesHTTP(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+	root := srv.cfg.WorkspaceRoot
+	writeTraceFixture(t, root, "turn_metrics.jsonl", []map[string]any{
+		{"session_id": "sA", "timestamp": "2026-04-20T10:00:00Z", "query": "alpha"},
+		{"session_id": "sA", "timestamp": "2026-04-20T10:01:00Z", "query": "beta"},
+	})
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/v1/traces?source=turn_metrics&limit=5")
+	if err != nil {
+		t.Fatalf("GET /v1/traces: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d; want 200", resp.StatusCode)
+	}
+
+	var decoded TraceQueryResult
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if decoded.Count != 2 {
+		t.Fatalf("Count = %d; want 2", decoded.Count)
+	}
+	if len(decoded.SourcesChecked) != 1 {
+		t.Fatalf("SourcesChecked len = %d; want 1", len(decoded.SourcesChecked))
+	}
+	if decoded.SourcesChecked[0].Name != "turn_metrics" {
+		t.Errorf("SourcesChecked[0].Name = %q; want turn_metrics", decoded.SourcesChecked[0].Name)
+	}
+
+	// 400 on unknown source.
+	resp400, err := http.Get(ts.URL + "/v1/traces?source=bogus")
+	if err != nil {
+		t.Fatalf("GET /v1/traces (bad source): %v", err)
+	}
+	defer resp400.Body.Close()
+	if resp400.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d; want 400", resp400.StatusCode)
+	}
+}
+
+// 16. MCP — invoke toolSearchTraces directly.
+func TestToolSearchTracesMCP(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	process := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	server := NewMCPServer(cfg, makeNucleus("Cog", "tester"), process)
+
+	writeTraceFixture(t, root, "turn_metrics.jsonl", []map[string]any{
+		{"session_id": "mcp-s1", "timestamp": "2026-04-20T09:00:00Z", "query": "first"},
+		{"session_id": "mcp-s2", "timestamp": "2026-04-20T09:01:00Z", "query": "second"},
+	})
+
+	result, _, err := server.toolSearchTraces(context.Background(), nil, searchTracesInput{
+		Source: "turn_metrics",
+		Limit:  10,
+	})
+	if err != nil {
+		t.Fatalf("toolSearchTraces: %v", err)
+	}
+	var decoded TraceQueryResult
+	decodeMCPJSON(t, result, &decoded)
+	if decoded.Count != 2 {
+		t.Fatalf("Count = %d; want 2", decoded.Count)
+	}
+	// Filter path — session_id.
+	result2, _, err := server.toolSearchTraces(context.Background(), nil, searchTracesInput{
+		Source:    "turn_metrics",
+		SessionID: "mcp-s1",
+	})
+	if err != nil {
+		t.Fatalf("toolSearchTraces (filter): %v", err)
+	}
+	var filtered TraceQueryResult
+	decodeMCPJSON(t, result2, &filtered)
+	if filtered.Count != 1 {
+		t.Fatalf("filtered Count = %d; want 1", filtered.Count)
+	}
+}
+
+// ── §6.3 regression — /v1/proprioceptive shape unchanged ───────────────────
+
+// 17. Guards the backwards-compat commitment for dashboard.html:1265 and
+// canvas.html:1706, which consume {entries, light_cone}. If this test fails
+// the dashboard breaks silently.
+func TestProprioceptiveEndpointUnchanged(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+	root := srv.cfg.WorkspaceRoot
+	writeTraceFixture(t, root, "proprioceptive.jsonl", []map[string]any{
+		{"timestamp": "2026-04-20T10:00:00Z", "event": "tool_call_rejected", "query": "guarded", "predicted": []string{}, "actual": []string{}, "hits": 0, "delta": 0.0, "response_len": 0},
+	})
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/v1/proprioceptive")
+	if err != nil {
+		t.Fatalf("GET /v1/proprioceptive: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d; want 200", resp.StatusCode)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// Top-level keys: exactly "entries" and "light_cone".
+	if _, ok := raw["entries"]; !ok {
+		t.Error("missing top-level 'entries' key — dashboard.html:1265 WILL BREAK")
+	}
+	if _, ok := raw["light_cone"]; !ok {
+		t.Error("missing top-level 'light_cone' key — dashboard.html:1449/1458 WILL BREAK")
+	}
+	// Any *extra* top-level key would also count as a reshape; flag it loudly.
+	for k := range raw {
+		if k != "entries" && k != "light_cone" {
+			t.Errorf("unexpected top-level key %q — /v1/proprioceptive shape changed; dashboard consumers may break", k)
+		}
+	}
+
+	// entries must decode as []json.RawMessage (slice of raw JSONL rows).
+	var entries []json.RawMessage
+	if err := json.Unmarshal(raw["entries"], &entries); err != nil {
+		t.Fatalf("entries is not an array: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("entries len = %d; want 1", len(entries))
+	}
+	// Entry is the raw proprioceptive row — must still contain the 'event' field.
+	var e map[string]any
+	if err := json.Unmarshal(entries[0], &e); err != nil {
+		t.Fatalf("entry not an object: %v", err)
+	}
+	if e["event"] != "tool_call_rejected" {
+		t.Errorf("entry.event = %v; want tool_call_rejected", e["event"])
+	}
+
+	// light_cone must be an object with at least 'active' (dashboard reads it).
+	var lc map[string]any
+	if err := json.Unmarshal(raw["light_cone"], &lc); err != nil {
+		t.Fatalf("light_cone not an object: %v", err)
+	}
+	if _, ok := lc["active"]; !ok {
+		t.Error("light_cone.active key missing — dashboard check will fail")
+	}
+}
+
+// ── misc helper self-test ──────────────────────────────────────────────────
+
+// 18. ParseTraceDurationOrTime accepts RFC3339, duration, and rejects junk.
+func TestParseTraceDurationOrTime(t *testing.T) {
+	t.Parallel()
+	now, _ := time.Parse(time.RFC3339, "2026-04-20T10:00:00Z")
+	t1, err := ParseTraceDurationOrTime("30m", now)
+	if err != nil {
+		t.Fatalf("duration: %v", err)
+	}
+	if !t1.Equal(now.Add(-30 * time.Minute)) {
+		t.Errorf("duration result = %v; want %v", t1, now.Add(-30*time.Minute))
+	}
+	t2, err := ParseTraceDurationOrTime("2026-04-20T09:00:00Z", now)
+	if err != nil {
+		t.Fatalf("RFC3339: %v", err)
+	}
+	if t2.IsZero() {
+		t.Error("RFC3339 parse returned zero")
+	}
+	if _, err := ParseTraceDurationOrTime("garbage", now); err == nil {
+		t.Error("expected error on garbage input")
+	}
+}


### PR DESCRIPTION
## Summary

Unified traces search surface over the kernel's `.cog/run/*.jsonl` streams — closes Agent F's #7 critical MCP blindspot, reframed per Agent Q's design from "logs with search" to **trace observability**. (The `.cog/run/` streams are client-originated semantic metabolites per the kernel's metabolic-cycle framing, not diagnostic text.)

## What landed

- **`cog_search_traces` MCP tool** — unified query over multiple JSONL sources with filters for source, session_id, since/until (duration or RFC3339), level, substring, limit, order.
- **`GET /v1/traces` HTTP route** — 1:1 with the MCP input via query params; returns `{results, count, truncated}`.
- **Multi-source normalization** across `attention.jsonl`, `turn_metrics.jsonl`, `internal-requests.jsonl`, `proprioceptive.jsonl` (where present) into unified `{source, timestamp, session_id?, level?, line}` shape.

## Real drift surfaced + handled

Agent Q's normalization spec listed `internal-requests` as RFC3339 strings. On the live workspace the file's timestamps are **Python-style Unix float seconds** (e.g. `"timestamp": 1769281958.2577438`). Without detection this would have produced zero-timestamps for that entire source. `parseTimestamp()` now branches on the first byte of the raw JSON value (`"` → RFC3339, else → float64 unix seconds). No escape to callers; drift commented explicitly in `sourceSpecs`.

## `/v1/proprioceptive` preserved byte-for-byte

`dashboard.html:1265` and `canvas.html:1706` both consume the exact shape. **`TestProprioceptiveEndpointUnchanged`** asserts the top-level keys are *exactly* `{entries, light_cone}` with no extras. Any future reshape will break CI.

## Design judgments beyond spec

- **Per-source pre-limit = `limit+1`** so single-source queries can report truncation correctly (exact `limit` hides the overflow).
- **Unknown-source validation at parse-time** (400, not 500) via `resolveSources` in both HTTP and MCP parsers.
- **`internal.log` plain-text excluded** from v1 per Agent Q §8 Q3 — JSONL-only keeps the normalized shape clean.
- **Defensive byte-copy of scanner lines** — `bufio.Scanner` reuses internal buffer between `Scan()` calls; retained `TraceResult.Line` without copy would corrupt earlier entries silently.

## Test plan

- [x] 14 unit tests on `QueryTraces` — empty workspace, single-source, multi-source ordering, filters (session_id, since/until, level, source, substring), limit+truncation, malformed-line skip, order=asc, bad source reject, normalization correctness, substring-too-long reject
- [x] 2 integration tests — `TestHandleTracesHTTP` (shape + 400 bad source), `TestToolSearchTracesMCP` (filter roundtrip)
- [x] 1 regression test — `TestProprioceptiveEndpointUnchanged`
- [x] 1 utility test — `TestParseTraceDurationOrTime`
- [x] `go test ./internal/engine/... -short -count=1 -race` → `ok 1.674s`
- [x] `go build ./...` + `go vet ./...` silent

## Not in scope

- **Kernel slog / stderr log API** — separate follow-up gap coupled to Agent K's Windows stderr-capture work. Agent Q's §8 surfaces this as "gap #7b."
- **Live tail** — belongs to Agent N's event bus (`cog_tail_events` / `GET /v1/events/stream`), not this surface.
- Plain-text `internal.log` (non-JSONL).

## Design reference

Agent Q's design CogDoc: `~/cog-workspace/.cog/mem/semantic/surveys/2026-04-21-consolidation/agent-Q-logs-search-design.cog.md`

## Pre-existing flakes flagged (not this PR)

On `-count>=2`, ledger package has package-level state leaks between iterations in `TestCrossSessionChain`, `TestAppendEventConcurrent`, `TestAppendEventChainIntegrity` (`appendMu` + `lastEventCache`). Also `TestSyncWatcherMarksAlreadyPresentBlob` races the 10 ms poll vs fsnotify. Confirmed present on clean `upstream/main`; unrelated to this commit. Will file as a follow-up issue.