### PR TITLE
feat(engine): engine-side cogos emit subcommand (Track 5 Phase 1)

### DIFF
--- a/internal/engine/cli.go
+++ b/internal/engine/cli.go
@@ -90,6 +90,8 @@ func Main() {
 		case "node":
 			runNodeCmd(args[1:], *workspace)
 			return
+		case "emit":
+			os.Exit(runEmitCmd(args[1:], *workspace))
 		}
 	}
 

--- a/internal/engine/cli_emit.go
+++ b/internal/engine/cli_emit.go
@@ -1,0 +1,218 @@
+// cli_emit.go — `cogos emit` subcommand: ledger-append for hook-fired events.
+//
+// Supports two invocation shapes, both historically dispatched by the root
+// package's `case "emit":` (cog.go:5625 → cmdEmit at cog.go:2621).
+//
+// Hook-style (the live form, used by .cog/hooks/* via lib/cog_emit.py):
+//
+//	cogos emit --json '{"type":"SESSION_START","session_id":"…","data":{…}}' \
+//	           --identity system --source hook
+//
+// Handler-style (historical, used by SDK event client and manual invocations):
+//
+//	cogos emit <event-name> [--dry-run]
+//
+// Phase 1 of Track 5 (per Agent I2's revised dead-code plan):
+// this engine implementation exists alongside the root `cmdEmit`. The root
+// binary still dispatches to root's path today; once Phase 4 flips the
+// Makefile default build target to cmd/cogos/, the engine path takes over
+// for the installed `cogos` binary. Hook invocations must continue to
+// succeed at every step of the cutover.
+//
+// Engine-side behavior vs root:
+//   - Hook-style (--json path): engine ACTUALLY writes the event to the
+//     per-session ledger via AppendEvent (hash-chained). Root silently
+//     accepted these flags but treated "--json" as the event name and
+//     fired no handlers — so on-disk effect was zero. This is a strict
+//     improvement: hooks always returned 0 under root, and they continue
+//     to return 0 here, but now the event actually lands in the ledger.
+//   - Handler-style (<event> [--dry-run] path): engine emits a noop for
+//     now (no handler index port in Phase 1; events dir is empty in live
+//     workspaces). Root's path is retained until Phase 5 sweep.
+package engine
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// runEmitCmd dispatches `cogos emit` arguments to the appropriate path and
+// returns an exit code (0 = success). Stdout/stderr are written via the
+// package-level os.Stdout/os.Stderr; the *out/*errW parameters allow tests
+// to capture output. Passing nil uses os.Stdout/os.Stderr.
+//
+// This function does NOT call os.Exit; the caller in Main() does.
+func runEmitCmd(args []string, defaultWorkspace string) int {
+	return runEmitCmdWithIO(args, defaultWorkspace, os.Stdout, os.Stderr)
+}
+
+// runEmitCmdWithIO is the testable core. stdout/stderr default to os.Stdout/os.Stderr
+// when nil is passed.
+func runEmitCmdWithIO(args []string, defaultWorkspace string, stdout, stderr io.Writer) int {
+	if stdout == nil {
+		stdout = os.Stdout
+	}
+	if stderr == nil {
+		stderr = os.Stderr
+	}
+
+	// Detect invocation shape.
+	//
+	// Hook-style is recognized by the presence of "--json" anywhere in args.
+	// Handler-style is recognized by a bare positional first arg.
+	// Empty args mirror root's usage message and exit 1.
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "Usage: cog emit <event> [--dry-run]")
+		fmt.Fprintln(stderr)
+		fmt.Fprintln(stderr, "Events: cog.session.start, cog.session.end, etc.")
+		return 1
+	}
+
+	// Hook-style path: --json must appear as a flag.
+	if hasJSONFlag(args) {
+		return runEmitHookStyle(args, defaultWorkspace, stdout, stderr)
+	}
+
+	// Handler-style path: <event> [--dry-run].
+	return runEmitHandlerStyle(args, defaultWorkspace, stdout, stderr)
+}
+
+// hasJSONFlag reports whether args contains the "--json" flag.
+// It matches both "--json" (space-separated value) and "--json=…" shapes.
+func hasJSONFlag(args []string) bool {
+	for _, a := range args {
+		if a == "--json" || strings.HasPrefix(a, "--json=") {
+			return true
+		}
+	}
+	return false
+}
+
+// runEmitHookStyle parses the hook-style flag set and appends the event to
+// the per-session ledger via AppendEvent. Flags:
+//
+//	--json <payload>   (required) JSON envelope: {type, session_id, data}
+//	--identity <id>    (optional) who is emitting (e.g. "system", "hook")
+//	--source <src>     (optional) source tag (e.g. "hook")
+//
+// On success: stdout empty, stderr empty, exit 0. On malformed flags or bad
+// JSON: a short error on stderr + exit 1.
+func runEmitHookStyle(args []string, defaultWorkspace string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("emit", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	jsonPayload := fs.String("json", "", "JSON event payload")
+	identity := fs.String("identity", "", "Identity emitting the event")
+	source := fs.String("source", "", "Source tag for the event")
+	// --dry-run is accepted but ignored in hook-style; it's a noop since
+	// AppendEvent is always effectful. Preserves compat with callers that
+	// blindly append --dry-run.
+	dryRun := fs.Bool("dry-run", false, "Preview without emitting (noop in hook-style)")
+
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+
+	if *jsonPayload == "" {
+		fmt.Fprintln(stderr, "error: --json payload is required")
+		return 1
+	}
+
+	// Parse the envelope. Required: "type". Optional: "session_id", "data".
+	var payload map[string]interface{}
+	if err := json.Unmarshal([]byte(*jsonPayload), &payload); err != nil {
+		fmt.Fprintf(stderr, "error: invalid --json payload: %v\n", err)
+		return 1
+	}
+
+	eventType, _ := payload["type"].(string)
+	if eventType == "" {
+		fmt.Fprintln(stderr, "error: --json payload missing required \"type\" field")
+		return 1
+	}
+
+	sessionID, _ := payload["session_id"].(string)
+	if sessionID == "" {
+		// Mirror cog_emit.py which omits session_id when unknown. Fall back
+		// to a deterministic "unknown" bucket so the ledger still captures
+		// the event rather than silently dropping it.
+		sessionID = "unknown"
+	}
+
+	data, _ := payload["data"].(map[string]interface{})
+
+	// Resolve workspace.
+	workspace := defaultWorkspace
+	if workspace == "" {
+		wd, _ := os.Getwd()
+		ws, err := findWorkspaceRoot(wd)
+		if err != nil {
+			fmt.Fprintf(stderr, "error: could not detect workspace: %v\n", err)
+			return 1
+		}
+		workspace = ws
+	}
+
+	if *dryRun {
+		// No-op: don't actually append.
+		return 0
+	}
+
+	// Build the envelope and append.
+	metaSource := *source
+	if metaSource == "" {
+		metaSource = "emit-cli"
+	}
+	if *identity != "" {
+		// Fold identity into Data under "identity" so downstream consumers can
+		// see it. Do NOT shadow any existing "identity" key the caller set.
+		if data == nil {
+			data = make(map[string]interface{})
+		}
+		if _, ok := data["identity"]; !ok {
+			data["identity"] = *identity
+		}
+	}
+
+	env := &EventEnvelope{
+		HashedPayload: EventPayload{
+			Type:      eventType,
+			Timestamp: nowISO(),
+			SessionID: sessionID,
+			Data:      data,
+		},
+		Metadata: EventMetadata{Source: metaSource},
+	}
+	if err := AppendEvent(workspace, sessionID, env); err != nil {
+		fmt.Fprintf(stderr, "error: append event: %v\n", err)
+		return 1
+	}
+
+	return 0
+}
+
+// runEmitHandlerStyle mirrors root's behavior for the legacy `<event> [--dry-run]`
+// invocation: print a dry-run notice when requested, otherwise noop. Phase 1
+// does NOT port BuildEventIndex/execEffect into engine — the events/ directory
+// is empty in live workspaces, and root's path is still active in parallel
+// until Phase 5 sweeps it. Returning 0 matches root's behavior when no
+// handlers match the trigger.
+func runEmitHandlerStyle(args []string, defaultWorkspace string, stdout, stderr io.Writer) int {
+	eventName := args[0]
+	dryRun := false
+	for _, a := range args[1:] {
+		if a == "--dry-run" {
+			dryRun = true
+		}
+	}
+
+	// Root prints this to stderr when dry-run is set and no handlers match.
+	if dryRun {
+		fmt.Fprintf(stderr, "[dry-run] No handlers for event: %s\n", eventName)
+	}
+
+	return 0
+}

--- a/internal/engine/cli_emit_test.go
+++ b/internal/engine/cli_emit_test.go
@@ -1,0 +1,436 @@
+package engine
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newTestWorkspace creates a minimal workspace skeleton (so findWorkspaceRoot
+// would work if the test calls into it) and returns its root path.
+func newTestWorkspace(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	configDir := filepath.Join(root, ".cog", "config")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir .cog/config: %v", err)
+	}
+	return root
+}
+
+// readLedger returns every EventEnvelope in .cog/ledger/<sessionID>/events.jsonl.
+// Fails the test if the file is missing or malformed.
+func readLedger(t *testing.T, root, sessionID string) []*EventEnvelope {
+	t.Helper()
+	path := filepath.Join(root, ".cog", "ledger", sessionID, "events.jsonl")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read ledger: %v", err)
+	}
+	var out []*EventEnvelope
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line == "" {
+			continue
+		}
+		var env EventEnvelope
+		if err := json.Unmarshal([]byte(line), &env); err != nil {
+			t.Fatalf("unmarshal ledger line %q: %v", line, err)
+		}
+		out = append(out, &env)
+	}
+	return out
+}
+
+// TestRunEmitCmd_EmitsToLedger verifies that the hook-style invocation
+// (--json/--identity/--source) appends the event to the per-session ledger
+// via AppendEvent, with hash chaining intact.
+func TestRunEmitCmd_EmitsToLedger(t *testing.T) {
+	t.Parallel()
+	root := newTestWorkspace(t)
+	sessionID := "test-session-emit-ledger"
+
+	payload := map[string]interface{}{
+		"type":       "SESSION_START",
+		"session_id": sessionID,
+		"data": map[string]interface{}{
+			"cwd":         root,
+			"environment": "test",
+		},
+	}
+	payloadJSON, _ := json.Marshal(payload)
+
+	var stdout, stderr bytes.Buffer
+	code := runEmitCmdWithIO(
+		[]string{
+			"--json", string(payloadJSON),
+			"--identity", "system",
+			"--source", "hook",
+		},
+		root, &stdout, &stderr,
+	)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d; want 0 (stderr=%q)", code, stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("stdout should be empty; got %q", stdout.String())
+	}
+
+	// Ledger file must exist and contain exactly one event.
+	events := readLedger(t, root, sessionID)
+	if len(events) != 1 {
+		t.Fatalf("event count = %d; want 1", len(events))
+	}
+	ev := events[0]
+	if ev.HashedPayload.Type != "SESSION_START" {
+		t.Errorf("type = %q; want SESSION_START", ev.HashedPayload.Type)
+	}
+	if ev.HashedPayload.SessionID != sessionID {
+		t.Errorf("session_id = %q; want %q", ev.HashedPayload.SessionID, sessionID)
+	}
+	if ev.Metadata.Seq != 1 {
+		t.Errorf("seq = %d; want 1", ev.Metadata.Seq)
+	}
+	if len(ev.Metadata.Hash) != 64 {
+		t.Errorf("hash len = %d; want 64 (sha256)", len(ev.Metadata.Hash))
+	}
+	if ev.Metadata.Source != "hook" {
+		t.Errorf("metadata.source = %q; want %q", ev.Metadata.Source, "hook")
+	}
+	if ev.HashedPayload.Data["identity"] != "system" {
+		t.Errorf("data.identity = %v; want %q", ev.HashedPayload.Data["identity"], "system")
+	}
+	if ev.HashedPayload.Data["cwd"] != root {
+		t.Errorf("data.cwd = %v; want %q", ev.HashedPayload.Data["cwd"], root)
+	}
+
+	// A second emit chains to the first.
+	payload2 := map[string]interface{}{
+		"type":       "SESSION_HEARTBEAT",
+		"session_id": sessionID,
+		"data":       map[string]interface{}{"tick": float64(1)},
+	}
+	p2JSON, _ := json.Marshal(payload2)
+	stderr.Reset()
+	stdout.Reset()
+	code = runEmitCmdWithIO(
+		[]string{"--json", string(p2JSON), "--identity", "system", "--source", "hook"},
+		root, &stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("second emit exit = %d (stderr=%q)", code, stderr.String())
+	}
+
+	events = readLedger(t, root, sessionID)
+	if len(events) != 2 {
+		t.Fatalf("after second emit: event count = %d; want 2", len(events))
+	}
+	if events[1].HashedPayload.PriorHash != events[0].Metadata.Hash {
+		t.Errorf("chain broken: events[1].prior_hash=%q events[0].hash=%q",
+			events[1].HashedPayload.PriorHash, events[0].Metadata.Hash)
+	}
+}
+
+// TestRunEmitCmd_FlagsMatchRootShape verifies the argument schema accepted by
+// runEmitCmd matches what real hook invocations pass. The live shape
+// (per `ps -ef` capture cited in Agent I2's plan) is:
+//
+//	cogos --workspace <path> emit --json {...} --identity system --source hook
+//
+// After the top-level flag.Parse() strips --workspace, runEmitCmd sees
+// ["--json", "{...}", "--identity", "system", "--source", "hook"].
+// It must ACCEPT this exact shape and succeed.
+func TestRunEmitCmd_FlagsMatchRootShape(t *testing.T) {
+	t.Parallel()
+	root := newTestWorkspace(t)
+
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{
+			name: "hook SESSION_START shape (exact form from ps -ef)",
+			args: []string{
+				"--json", `{"type":"SESSION_START","data":{"cwd":"/tmp","workspace_root":"/tmp","environment":"local"},"session_id":"abc-123"}`,
+				"--identity", "system",
+				"--source", "hook",
+			},
+		},
+		{
+			name: "flags in different order",
+			args: []string{
+				"--source", "hook",
+				"--identity", "system",
+				"--json", `{"type":"TOOL_INVOKED","session_id":"s","data":{"tool":"Read"}}`,
+			},
+		},
+		{
+			name: "only --json (identity and source optional)",
+			args: []string{"--json", `{"type":"PING","session_id":"s","data":{}}`},
+		},
+		{
+			name: "handler-style: bare event name, no dry-run",
+			args: []string{"cog.widget.started"},
+		},
+		{
+			name: "handler-style: bare event name + --dry-run",
+			args: []string{"cog.session.start", "--dry-run"},
+		},
+		{
+			name:    "no args → usage error",
+			args:    []string{},
+			wantErr: true,
+		},
+		{
+			name:    "--json with empty value",
+			args:    []string{"--json", ""},
+			wantErr: true,
+		},
+		{
+			name:    "--json with invalid payload",
+			args:    []string{"--json", "not-json", "--identity", "x", "--source", "y"},
+			wantErr: true,
+		},
+		{
+			name:    "--json with payload missing type",
+			args:    []string{"--json", `{"session_id":"s","data":{}}`, "--identity", "x"},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var stdout, stderr bytes.Buffer
+			code := runEmitCmdWithIO(tc.args, root, &stdout, &stderr)
+			if tc.wantErr {
+				if code == 0 {
+					t.Errorf("expected non-zero exit; got 0 (stderr=%q)", stderr.String())
+				}
+			} else {
+				if code != 0 {
+					t.Errorf("expected 0 exit; got %d (stderr=%q)", code, stderr.String())
+				}
+			}
+		})
+	}
+}
+
+// TestRunEmitCmd_OutputMatchesRootShape checks stdout/stderr byte-compatibility
+// for the cases where root's cmdEmit writes identifiable text:
+//
+//   - Root with no args: "Usage: cog emit <event> [--dry-run]\n\nEvents: cog.session.start, cog.session.end, etc.\n" on stderr.
+//   - Root with bare event name + --dry-run (no handlers dir): "[dry-run] No handlers for event: <name>\n" on stderr.
+//   - Root with hook-style flags: stdout/stderr both empty on success.
+func TestRunEmitCmd_OutputMatchesRootShape(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no args → root usage text on stderr", func(t *testing.T) {
+		t.Parallel()
+		var stdout, stderr bytes.Buffer
+		code := runEmitCmdWithIO(nil, "", &stdout, &stderr)
+		if code != 1 {
+			t.Errorf("exit = %d; want 1", code)
+		}
+		wantStderr := "Usage: cog emit <event> [--dry-run]\n\nEvents: cog.session.start, cog.session.end, etc.\n"
+		if stderr.String() != wantStderr {
+			t.Errorf("stderr mismatch\n got: %q\nwant: %q", stderr.String(), wantStderr)
+		}
+		if stdout.String() != "" {
+			t.Errorf("stdout should be empty; got %q", stdout.String())
+		}
+	})
+
+	t.Run("handler-style dry-run → matches root stderr", func(t *testing.T) {
+		t.Parallel()
+		root := newTestWorkspace(t)
+		var stdout, stderr bytes.Buffer
+		code := runEmitCmdWithIO([]string{"cog.session.start", "--dry-run"}, root, &stdout, &stderr)
+		if code != 0 {
+			t.Errorf("exit = %d; want 0", code)
+		}
+		wantStderr := "[dry-run] No handlers for event: cog.session.start\n"
+		if stderr.String() != wantStderr {
+			t.Errorf("stderr mismatch\n got: %q\nwant: %q", stderr.String(), wantStderr)
+		}
+		if stdout.String() != "" {
+			t.Errorf("stdout should be empty; got %q", stdout.String())
+		}
+	})
+
+	t.Run("hook-style success → stdout+stderr both empty", func(t *testing.T) {
+		t.Parallel()
+		root := newTestWorkspace(t)
+		var stdout, stderr bytes.Buffer
+		code := runEmitCmdWithIO(
+			[]string{
+				"--json", `{"type":"X","session_id":"s","data":{}}`,
+				"--identity", "system",
+				"--source", "hook",
+			},
+			root, &stdout, &stderr,
+		)
+		if code != 0 {
+			t.Errorf("exit = %d; want 0 (stderr=%q)", code, stderr.String())
+		}
+		if stdout.String() != "" {
+			t.Errorf("stdout must be silent on hook success; got %q", stdout.String())
+		}
+		if stderr.String() != "" {
+			t.Errorf("stderr must be silent on hook success; got %q", stderr.String())
+		}
+	})
+
+	t.Run("handler-style non-dry-run → silent", func(t *testing.T) {
+		t.Parallel()
+		root := newTestWorkspace(t)
+		var stdout, stderr bytes.Buffer
+		code := runEmitCmdWithIO([]string{"cog.session.start"}, root, &stdout, &stderr)
+		if code != 0 {
+			t.Errorf("exit = %d; want 0", code)
+		}
+		if stdout.String() != "" {
+			t.Errorf("stdout = %q; want empty", stdout.String())
+		}
+		if stderr.String() != "" {
+			t.Errorf("stderr = %q; want empty", stderr.String())
+		}
+	})
+}
+
+// TestRunEmitCmd_ExitCodes pins the exit-code contract:
+//   - 0 on successful emit (hook-style and handler-style)
+//   - 1 on usage errors (no args, missing required flags, bad JSON)
+//   - 1 on AppendEvent failure (e.g. unwritable workspace)
+func TestRunEmitCmd_ExitCodes(t *testing.T) {
+	t.Parallel()
+
+	// Success: hook-style.
+	t.Run("success hook-style → 0", func(t *testing.T) {
+		t.Parallel()
+		root := newTestWorkspace(t)
+		var out, errW bytes.Buffer
+		code := runEmitCmdWithIO(
+			[]string{"--json", `{"type":"X","session_id":"s","data":{}}`, "--identity", "i", "--source", "s"},
+			root, &out, &errW,
+		)
+		if code != 0 {
+			t.Errorf("exit = %d; want 0 (stderr=%q)", code, errW.String())
+		}
+	})
+
+	// Success: handler-style (no handlers configured, exit 0 like root).
+	t.Run("success handler-style → 0", func(t *testing.T) {
+		t.Parallel()
+		root := newTestWorkspace(t)
+		var out, errW bytes.Buffer
+		code := runEmitCmdWithIO([]string{"some.event.name"}, root, &out, &errW)
+		if code != 0 {
+			t.Errorf("exit = %d; want 0", code)
+		}
+	})
+
+	// Failure: no args at all.
+	t.Run("no args → 1", func(t *testing.T) {
+		t.Parallel()
+		var out, errW bytes.Buffer
+		code := runEmitCmdWithIO(nil, "", &out, &errW)
+		if code != 1 {
+			t.Errorf("exit = %d; want 1", code)
+		}
+	})
+
+	// Failure: --json with malformed JSON.
+	t.Run("bad JSON → 1", func(t *testing.T) {
+		t.Parallel()
+		root := newTestWorkspace(t)
+		var out, errW bytes.Buffer
+		code := runEmitCmdWithIO(
+			[]string{"--json", "{not valid json", "--identity", "s", "--source", "h"},
+			root, &out, &errW,
+		)
+		if code != 1 {
+			t.Errorf("exit = %d; want 1", code)
+		}
+		if !strings.Contains(errW.String(), "invalid --json payload") {
+			t.Errorf("stderr should mention invalid payload; got %q", errW.String())
+		}
+	})
+
+	// Failure: --json empty.
+	t.Run("empty --json value → 1", func(t *testing.T) {
+		t.Parallel()
+		root := newTestWorkspace(t)
+		var out, errW bytes.Buffer
+		code := runEmitCmdWithIO(
+			[]string{"--json", "", "--identity", "s"},
+			root, &out, &errW,
+		)
+		if code != 1 {
+			t.Errorf("exit = %d; want 1", code)
+		}
+	})
+
+	// Failure: --json payload missing "type".
+	t.Run("json missing type → 1", func(t *testing.T) {
+		t.Parallel()
+		root := newTestWorkspace(t)
+		var out, errW bytes.Buffer
+		code := runEmitCmdWithIO(
+			[]string{"--json", `{"session_id":"s","data":{}}`, "--identity", "sys", "--source", "hook"},
+			root, &out, &errW,
+		)
+		if code != 1 {
+			t.Errorf("exit = %d; want 1", code)
+		}
+		if !strings.Contains(errW.String(), "missing required \"type\" field") {
+			t.Errorf("stderr should mention missing type; got %q", errW.String())
+		}
+	})
+
+	// --dry-run in hook-style is accepted and is a noop (exit 0, no ledger write).
+	t.Run("hook-style --dry-run → 0 and no ledger write", func(t *testing.T) {
+		t.Parallel()
+		root := newTestWorkspace(t)
+		sessionID := "dry-run-sess"
+		var out, errW bytes.Buffer
+		code := runEmitCmdWithIO(
+			[]string{
+				"--json", `{"type":"X","session_id":"` + sessionID + `","data":{}}`,
+				"--identity", "sys", "--source", "hook", "--dry-run",
+			},
+			root, &out, &errW,
+		)
+		if code != 0 {
+			t.Errorf("exit = %d; want 0 (stderr=%q)", code, errW.String())
+		}
+		// Ledger file must NOT exist.
+		ledger := filepath.Join(root, ".cog", "ledger", sessionID, "events.jsonl")
+		if _, err := os.Stat(ledger); !os.IsNotExist(err) {
+			t.Errorf("ledger should not exist on --dry-run; stat err = %v", err)
+		}
+	})
+
+	// Missing session_id in JSON falls back to "unknown" (does not error).
+	t.Run("missing session_id falls back to unknown bucket", func(t *testing.T) {
+		t.Parallel()
+		root := newTestWorkspace(t)
+		var out, errW bytes.Buffer
+		code := runEmitCmdWithIO(
+			[]string{"--json", `{"type":"X","data":{}}`, "--identity", "sys", "--source", "hook"},
+			root, &out, &errW,
+		)
+		if code != 0 {
+			t.Errorf("exit = %d; want 0 (stderr=%q)", code, errW.String())
+		}
+		ledger := filepath.Join(root, ".cog", "ledger", "unknown", "events.jsonl")
+		if _, err := os.Stat(ledger); err != nil {
+			t.Errorf("expected unknown-session ledger at %s; stat err = %v", ledger, err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

First migration phase of Agent I2's revised Track 5 plan (\`agent-I2-revised-dead-code-plan.cog.md\`). Adds an engine-side \`cogos emit\` subcommand so that after the eventual Makefile switch (Phase 4) + root sweep (Phase 5), \`~/.claude/hooks/\` invocations keep working byte-compatibly.

**Additive only in this PR.** Root's \`case "emit":\` in \`cog.go:5625\` is left intact. Both coexist until Phase 4 flips the build target. No behavior change for current users — the installed binary still dispatches through root until the Makefile update.

## Bonus bug fix — root \`cogos emit\` is currently a no-op write

Surfaced during implementation: root's \`cmdEmit\` accepts hook invocations and returns success but **never writes events to the per-session ledger**. Hooks have been firing successfully while landing nowhere consequential. The engine-side implementation here actually calls \`AppendEvent(workspaceRoot, sessionID, *EventEnvelope)\` — so session-start events join the hash chain, get proper sequence numbers, and show up in \`cog_read_ledger\` queries.

This is a silent data-loss fix in addition to the migration.

## What landed

- \`case "emit":\` dispatch in \`internal/engine/cli.go:44-90\` (2 lines).
- \`internal/engine/cli_emit.go\` (218 LOC) — two paths:
  - **Hook-style** (\`--json <payload>\` present): parses JSON, extracts \`session_id\` / \`type\` / \`data\`, constructs \`EventEnvelope\`, calls \`AppendEvent\`. Missing \`session_id\` falls back to \`unknown\` bucket without error.
  - **Handler-style** (bare event name): accepts \`--dry-run\`; does not fire \`.cog/events/*.cog.md\` handler effects (no live consumers found; dormant — Phase 5 should decide between porting \`BuildEventIndex\`+\`execEffect\` or deleting the \`sdk/clients/event.go\` SDK alongside).
- \`internal/engine/cli_emit_test.go\` (436 LOC, 4 top-level + 23 subtests).

## Flag schema accepted

\`\`\`
# Hook-style (live form, matches ps -ef capture exactly):
cogos emit --json <payload-json>
           [--identity <id>]         # optional; folded into data.identity
           [--source <src>]          # optional, default "emit-cli"; goes into metadata.source
           [--dry-run]               # optional; skips ledger write

# Handler-style (legacy; dormant today):
cogos emit <event-name> [--dry-run]

# JSON payload:
{"type": "<event-type>", ...}                    # required
{"session_id": "<id>", ...}                      # optional; "unknown" bucket if missing
{"data": {<arbitrary>}, ...}                     # optional
\`\`\`

## Implementation choice: \`AppendEvent\` (not \`(*Process).EmitEvent\`, not \`EmitLedgerEvent\`)

- \`AppendEvent\` is the right level for a stateless CLI: filesystem + hash chain, no running kernel process. Honors hash-chain continuity with any pre-existing session events.
- \`(*Process).EmitEvent\` requires loading \`Config\`/\`Nucleus\`/goroutines — too heavy for a cold-start hook subprocess.
- \`EmitLedgerEvent\` in \`mcp_stubs.go\` writes to flat \`.cog/ledger/events.jsonl\` (cogos#10) — wrong model.
- PR #16's event bus broker wraps \`AppendEvent\` internally, so when that merges, engine emit picks up the broker for free.

## Test plan

- [x] \`TestRunEmitCmd_EmitsToLedger\` — verifies seq=1, sha256 hash, metadata.source, data.identity, chain continuity across 2 emits
- [x] \`TestRunEmitCmd_FlagsMatchRootShape\` (9 subtests) — exact hook invocation, flag-order independence, optional flags, bare-name handler, error paths
- [x] \`TestRunEmitCmd_OutputMatchesRootShape\` (4 subtests) — byte-exact stderr usage, dry-run msg, silent success, silent handler noop
- [x] \`TestRunEmitCmd_ExitCodes\` (7 subtests) — 0 on success, 1 on usage/parse errors, dry-run doesn't write, missing session_id falls back
- [x] \`go test ./internal/engine/... -short -count=1 -race\` — pass
- [x] \`go build ./...\` + \`go vet ./...\` — silent

## Minor incompatibility surfaced (improvement, not regression)

Root's \`cogos --workspace X emit ...\` actually fails today (\`Unknown command: --workspace\` → exit 1) — hooks that accidentally passed \`--workspace\` relied on the root binary silently rejecting it. Engine parses top-level flags correctly, so post-cutover that flag is honored. Any hook author relying on the rejection will see the flag take effect instead. Documented for Phase 4 landing.

## Not in scope

- **Makefile switch** to \`cmd/cogos/\` — Track 5 Phase 4.
- **Delete root's \`cmdEmit\`** — Track 5 Phase 5 sweep.
- **Port \`.cog/events/*.cog.md\` handler effects** — Phase 5 will decide port-vs-delete alongside the SDK event client.

## Design reference

Agent I2's revised plan (§Phase 1): \`cog://mem/semantic/surveys/2026-04-21-consolidation/agent-I2-revised-dead-code-plan.cog.md\`