### PR TITLE
feat(engine): persist conversation turns via ledger + sidecar

### DIFF
--- a/internal/engine/conversation_query.go
+++ b/internal/engine/conversation_query.go
@@ -1,0 +1,341 @@
+// conversation_query.go — Reader for the turn.completed ledger stream.
+//
+// Thin wrapper that scans .cog/ledger/<sid>/events.jsonl for
+// turn.completed events and optionally hydrates each with the full text
+// from the per-session sidecar .cog/run/turns/<sid>.jsonl.
+//
+// When Agent L's QueryLedger API lands this wrapper will collapse to a
+// 5-line shim over QueryLedger(event_type="turn.completed"); until then
+// we do the (small) ledger scan locally. The scan is O(events-in-session)
+// — cheap for typical sessions of <100 turns.
+package engine
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"time"
+)
+
+// ConversationQuery parameterises a read over the turn history.
+type ConversationQuery struct {
+	SessionID    string
+	AfterTurn    int       // turn_index > AfterTurn (0 means no lower bound)
+	BeforeTurn   int       // turn_index < BeforeTurn (0 means no upper bound)
+	Since        time.Time // zero means no since-filter
+	Limit        int       // default 20, max 200 (turns are bigger than events)
+	IncludeFull  bool      // default true — hydrate prompt/response from sidecar
+	IncludeTools bool      // default true — include tool-call transcript
+	Order        string    // "asc" (default) | "desc"
+}
+
+// ConversationTurn is the reader-side projection of a turn.
+type ConversationTurn struct {
+	TurnID            string           `json:"turn_id"`
+	TurnIndex         int              `json:"turn_index"`
+	SessionID         string           `json:"session_id"`
+	Timestamp         string           `json:"timestamp"`
+	DurationMs        int64            `json:"duration_ms,omitempty"`
+	Prompt            string           `json:"prompt"`
+	PromptTruncated   bool             `json:"prompt_truncated,omitempty"`
+	Response          string           `json:"response"`
+	ResponseTruncated bool             `json:"response_truncated,omitempty"`
+	ToolCalls         []ToolCallRecord `json:"tool_calls,omitempty"`
+	Provider          string           `json:"provider,omitempty"`
+	Model             string           `json:"model,omitempty"`
+	Usage             TurnUsage        `json:"usage,omitempty"`
+	BlockID           string           `json:"block_id,omitempty"`
+	Status            string           `json:"status,omitempty"`
+	Error             string           `json:"error,omitempty"`
+	LedgerHash        string           `json:"ledger_hash,omitempty"`
+	SidecarMissing    bool             `json:"sidecar_missing,omitempty"`
+}
+
+// ConversationQueryResult is the envelope returned to MCP/HTTP callers.
+type ConversationQueryResult struct {
+	Count         int                 `json:"count"`
+	SessionID     string              `json:"session_id,omitempty"`
+	Turns         []ConversationTurn  `json:"turns"`
+	Truncated     bool                `json:"truncated"`
+	NextAfterTurn int                 `json:"next_after_turn,omitempty"`
+}
+
+// QueryConversation reads turn.completed events for the given session and
+// (optionally) hydrates each from the sidecar. Returns turns in ascending
+// turn_index order by default.
+//
+// If q.SessionID is "" the result is empty — caller must scope the read;
+// cross-session scanning is explicitly out of scope for v1 (matches
+// Agent R §9.9: default to current session, scoped reads only).
+func QueryConversation(workspaceRoot string, q ConversationQuery) (*ConversationQueryResult, error) {
+	if q.AfterTurn != 0 && q.BeforeTurn != 0 && q.AfterTurn >= q.BeforeTurn {
+		return nil, errors.New("after_turn must be < before_turn")
+	}
+	limit := q.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 200 {
+		limit = 200
+	}
+	order := q.Order
+	if order == "" {
+		order = "asc"
+	}
+	if order != "asc" && order != "desc" {
+		return nil, fmt.Errorf("order must be asc or desc; got %q", order)
+	}
+
+	res := &ConversationQueryResult{SessionID: q.SessionID, Turns: []ConversationTurn{}}
+	if q.SessionID == "" {
+		return res, nil
+	}
+
+	turnEvents, err := readTurnCompletedEvents(workspaceRoot, q.SessionID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Optional sidecar hydration. Loaded lazily and only once.
+	var sidecar map[string]TurnRecord
+	if q.IncludeFull {
+		sidecar, err = loadSidecarIndex(workspaceRoot, q.SessionID)
+		if err != nil && !os.IsNotExist(err) {
+			// Don't fail the read — mark each turn's SidecarMissing instead.
+			sidecar = nil
+		}
+	}
+
+	// Apply turn-index / since filters, then build projection.
+	projected := make([]ConversationTurn, 0, len(turnEvents))
+	for _, ev := range turnEvents {
+		idx, _ := intField(ev.HashedPayload.Data, "turn_index")
+		if q.AfterTurn > 0 && idx <= q.AfterTurn {
+			continue
+		}
+		if q.BeforeTurn > 0 && idx >= q.BeforeTurn {
+			continue
+		}
+		if !q.Since.IsZero() {
+			t, err := time.Parse(time.RFC3339, ev.HashedPayload.Timestamp)
+			if err == nil && t.Before(q.Since) {
+				continue
+			}
+		}
+		turn := projectTurnFromEvent(ev, sidecar, q.IncludeFull, q.IncludeTools)
+		projected = append(projected, turn)
+	}
+
+	// Sort: natural reading order is ascending turn_index. Events may
+	// already be in order but hash-chain may interleave cross-session writes
+	// in future so we sort explicitly.
+	sort.Slice(projected, func(i, j int) bool {
+		if order == "desc" {
+			return projected[i].TurnIndex > projected[j].TurnIndex
+		}
+		return projected[i].TurnIndex < projected[j].TurnIndex
+	})
+
+	// Apply limit.
+	if len(projected) > limit {
+		res.Truncated = true
+		projected = projected[:limit]
+	}
+
+	// Pagination cursor: only meaningful in ascending order.
+	if order == "asc" && len(projected) > 0 {
+		res.NextAfterTurn = projected[len(projected)-1].TurnIndex
+	}
+
+	res.Turns = projected
+	res.Count = len(projected)
+	return res, nil
+}
+
+// readTurnCompletedEvents scans the session ledger for all turn.completed
+// events. Ignores other event types. Safe on a missing ledger file.
+func readTurnCompletedEvents(workspaceRoot, sessionID string) ([]EventEnvelope, error) {
+	path := filepath.Join(workspaceRoot, ".cog", "ledger", sessionID, "events.jsonl")
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("open ledger: %w", err)
+	}
+	defer f.Close()
+
+	var out []EventEnvelope
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 4<<20) // allow up to 4 MB per line (big preview)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var env EventEnvelope
+		if err := json.Unmarshal(line, &env); err != nil {
+			continue
+		}
+		if env.HashedPayload.Type != "turn.completed" {
+			continue
+		}
+		out = append(out, env)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("scan ledger: %w", err)
+	}
+	return out, nil
+}
+
+// loadSidecarIndex loads the per-session sidecar into a map keyed by
+// turn_id for fast per-turn hydration. Returns os.IsNotExist error if the
+// sidecar file is missing (caller distinguishes "no sidecar yet" from
+// real parse errors).
+func loadSidecarIndex(workspaceRoot, sessionID string) (map[string]TurnRecord, error) {
+	path := turnSidecarPath(workspaceRoot, sessionID)
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	out := make(map[string]TurnRecord)
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 64<<20) // allow up to 64 MB per row (huge turns)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var row TurnRecord
+		if err := json.Unmarshal(line, &row); err != nil {
+			continue
+		}
+		if row.TurnID == "" {
+			continue
+		}
+		out[row.TurnID] = row
+	}
+	return out, sc.Err()
+}
+
+// projectTurnFromEvent builds a ConversationTurn from a turn.completed
+// ledger event + optional sidecar row. When IncludeFull is true and a
+// sidecar row is present, the full Prompt/Response are returned.
+// Otherwise the ledger previews (which may be truncated) are returned.
+func projectTurnFromEvent(ev EventEnvelope, sidecar map[string]TurnRecord, includeFull, includeTools bool) ConversationTurn {
+	d := ev.HashedPayload.Data
+	turnID, _ := stringField(d, "turn_id")
+	idx, _ := intField(d, "turn_index")
+	promptPreview, _ := stringField(d, "prompt_preview")
+	respPreview, _ := stringField(d, "response_preview")
+	promptTrunc, _ := boolField(d, "prompt_truncated")
+	respTrunc, _ := boolField(d, "response_truncated")
+	provider, _ := stringField(d, "provider")
+	model, _ := stringField(d, "model")
+	status, _ := stringField(d, "status")
+	errStr, _ := stringField(d, "error")
+	durMs, _ := intField(d, "duration_ms")
+	blockID, _ := stringField(d, "block_id")
+
+	// Usage sub-map is optional.
+	var usage TurnUsage
+	if usageMap, ok := d["usage"].(map[string]interface{}); ok {
+		usage.InputTokens, _ = intFieldFromMap(usageMap, "input_tokens")
+		usage.OutputTokens, _ = intFieldFromMap(usageMap, "output_tokens")
+		usage.TotalTokens, _ = intFieldFromMap(usageMap, "total_tokens")
+	}
+
+	ct := ConversationTurn{
+		TurnID:            turnID,
+		TurnIndex:         idx,
+		SessionID:         ev.HashedPayload.SessionID,
+		Timestamp:         ev.HashedPayload.Timestamp,
+		DurationMs:        int64(durMs),
+		Prompt:            promptPreview,
+		PromptTruncated:   promptTrunc,
+		Response:          respPreview,
+		ResponseTruncated: respTrunc,
+		Provider:          provider,
+		Model:             model,
+		Usage:             usage,
+		BlockID:           blockID,
+		Status:            status,
+		Error:             errStr,
+		LedgerHash:        ev.Metadata.Hash,
+	}
+
+	if includeFull {
+		row, ok := sidecar[turnID]
+		if ok {
+			ct.Prompt = row.Prompt
+			ct.Response = row.Response
+			ct.PromptTruncated = false
+			ct.ResponseTruncated = false
+			if includeTools {
+				ct.ToolCalls = row.ToolCalls
+			}
+			if row.DurationMs != 0 {
+				ct.DurationMs = row.DurationMs
+			}
+		} else if sidecar != nil {
+			// Sidecar file exists but this turn's row is missing — surface
+			// the gap so callers can investigate without failing the read.
+			ct.SidecarMissing = true
+		}
+	}
+
+	return ct
+}
+
+// ── small helpers for untyped map access ───────────────────────────────────
+
+func stringField(m map[string]interface{}, key string) (string, bool) {
+	if v, ok := m[key]; ok {
+		if s, ok := v.(string); ok {
+			return s, true
+		}
+	}
+	return "", false
+}
+
+func boolField(m map[string]interface{}, key string) (bool, bool) {
+	if v, ok := m[key]; ok {
+		if b, ok := v.(bool); ok {
+			return b, true
+		}
+	}
+	return false, false
+}
+
+func intField(m map[string]interface{}, key string) (int, bool) {
+	return intFieldFromMap(m, key)
+}
+
+func intFieldFromMap(m map[string]interface{}, key string) (int, bool) {
+	if v, ok := m[key]; ok {
+		switch n := v.(type) {
+		case float64:
+			return int(n), true
+		case int:
+			return n, true
+		case int64:
+			return int(n), true
+		case json.Number:
+			if i, err := n.Int64(); err == nil {
+				return int(i), true
+			}
+		case string:
+			if i, err := strconv.Atoi(n); err == nil {
+				return i, true
+			}
+		}
+	}
+	return 0, false
+}

--- a/internal/engine/conversation_query_test.go
+++ b/internal/engine/conversation_query_test.go
@@ -1,0 +1,301 @@
+package engine
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// writeTurnsForTest synthesises n turns in the given session and returns
+// their turn_ids in order. Uses NextTurnIndex so turn_index is 1..n.
+func writeTurnsForTest(t *testing.T, p *Process, root, sessionID string, n int) []string {
+	t.Helper()
+	var ids []string
+	for i := 0; i < n; i++ {
+		turn := &TurnRecord{
+			TurnID:    uuid.NewString(),
+			TurnIndex: NextTurnIndex(root, sessionID),
+			SessionID: sessionID,
+			Prompt:    "prompt-" + string(rune('A'+i)),
+			Response:  "response-" + string(rune('A'+i)),
+			Timestamp: time.Date(2026, 1, 1, 0, i, 0, 0, time.UTC),
+			Provider:  "stub",
+			Model:     "test",
+		}
+		if err := p.RecordTurn(turn); err != nil {
+			t.Fatalf("RecordTurn[%d]: %v", i, err)
+		}
+		ids = append(ids, turn.TurnID)
+	}
+	return ids
+}
+
+func TestQueryEmptySession(t *testing.T) {
+	root := makeWorkspace(t)
+	resetTurnIndexCacheForTests()
+
+	res, err := QueryConversation(root, ConversationQuery{SessionID: "no-such-session"})
+	if err != nil {
+		t.Fatalf("QueryConversation: %v", err)
+	}
+	if res.Count != 0 {
+		t.Errorf("Count = %d; want 0", res.Count)
+	}
+	if len(res.Turns) != 0 {
+		t.Errorf("Turns len = %d; want 0", len(res.Turns))
+	}
+	if res.Truncated {
+		t.Errorf("Truncated = true; want false")
+	}
+}
+
+func TestQuerySingleSessionTurnsOrdered(t *testing.T) {
+	p, root, sessionID := newTestProcessForTurns(t)
+	ids := writeTurnsForTest(t, p, root, sessionID, 5)
+	_ = ids
+
+	// Ascending (default).
+	resAsc, err := QueryConversation(root, ConversationQuery{SessionID: sessionID, IncludeFull: true, IncludeTools: true})
+	if err != nil {
+		t.Fatalf("asc: %v", err)
+	}
+	if resAsc.Count != 5 {
+		t.Errorf("asc Count = %d; want 5", resAsc.Count)
+	}
+	for i, tr := range resAsc.Turns {
+		if tr.TurnIndex != i+1 {
+			t.Errorf("asc[%d].TurnIndex = %d; want %d", i, tr.TurnIndex, i+1)
+		}
+	}
+
+	// Descending.
+	resDesc, err := QueryConversation(root, ConversationQuery{SessionID: sessionID, IncludeFull: true, Order: "desc"})
+	if err != nil {
+		t.Fatalf("desc: %v", err)
+	}
+	for i, tr := range resDesc.Turns {
+		if tr.TurnIndex != 5-i {
+			t.Errorf("desc[%d].TurnIndex = %d; want %d", i, tr.TurnIndex, 5-i)
+		}
+	}
+}
+
+func TestQueryAfterTurnPagination(t *testing.T) {
+	p, root, sessionID := newTestProcessForTurns(t)
+	_ = writeTurnsForTest(t, p, root, sessionID, 10)
+
+	res, err := QueryConversation(root, ConversationQuery{
+		SessionID:   sessionID,
+		AfterTurn:   3,
+		IncludeFull: true,
+	})
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	if res.Count != 7 {
+		t.Errorf("Count = %d; want 7", res.Count)
+	}
+	if res.Turns[0].TurnIndex != 4 {
+		t.Errorf("first TurnIndex = %d; want 4", res.Turns[0].TurnIndex)
+	}
+	if res.NextAfterTurn != 10 {
+		t.Errorf("NextAfterTurn = %d; want 10", res.NextAfterTurn)
+	}
+}
+
+func TestQueryIncludeFullFalse(t *testing.T) {
+	p, root, sessionID := newTestProcessForTurns(t)
+	writeTurnsForTest(t, p, root, sessionID, 2)
+
+	// Destroy the sidecar so hydration would fail if we try to hit it.
+	_ = os.Remove(turnSidecarPath(root, sessionID))
+
+	res, err := QueryConversation(root, ConversationQuery{
+		SessionID:   sessionID,
+		IncludeFull: false,
+	})
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	if res.Count != 2 {
+		t.Fatalf("Count = %d; want 2", res.Count)
+	}
+	// Prompts served from ledger preview must be non-empty.
+	for _, tr := range res.Turns {
+		if tr.Prompt == "" {
+			t.Errorf("empty prompt with IncludeFull=false; expected ledger preview to carry text")
+		}
+	}
+}
+
+func TestQueryBadFilterCombo(t *testing.T) {
+	root := makeWorkspace(t)
+	_, err := QueryConversation(root, ConversationQuery{
+		SessionID:  "x",
+		AfterTurn:  10,
+		BeforeTurn: 5,
+	})
+	if err == nil {
+		t.Error("expected error for after_turn >= before_turn")
+	}
+}
+
+func TestQueryBadOrder(t *testing.T) {
+	root := makeWorkspace(t)
+	_, err := QueryConversation(root, ConversationQuery{
+		SessionID: "x",
+		Order:     "weird",
+	})
+	if err == nil {
+		t.Error("expected error for invalid order")
+	}
+}
+
+func TestQueryLimitTruncation(t *testing.T) {
+	p, root, sessionID := newTestProcessForTurns(t)
+	_ = writeTurnsForTest(t, p, root, sessionID, 25)
+
+	res, err := QueryConversation(root, ConversationQuery{
+		SessionID:   sessionID,
+		Limit:       5,
+		IncludeFull: true,
+	})
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	if res.Count != 5 {
+		t.Errorf("Count = %d; want 5", res.Count)
+	}
+	if !res.Truncated {
+		t.Error("Truncated = false; want true (25 turns, limit=5)")
+	}
+}
+
+func TestQuerySinceFilter(t *testing.T) {
+	p, root, sessionID := newTestProcessForTurns(t)
+	_ = writeTurnsForTest(t, p, root, sessionID, 5)
+
+	// Turn timestamps are 2026-01-01 00:00, 00:01, 00:02, ...
+	since := time.Date(2026, 1, 1, 0, 2, 0, 0, time.UTC)
+	res, err := QueryConversation(root, ConversationQuery{
+		SessionID:   sessionID,
+		Since:       since,
+		IncludeFull: true,
+	})
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	if res.Count != 3 { // turns 3,4,5 have ts >= 00:02
+		t.Errorf("Count = %d; want 3", res.Count)
+	}
+}
+
+func TestQueryIncludeFullHydratesFromSidecar(t *testing.T) {
+	p, root, sessionID := newTestProcessForTurns(t)
+
+	// Write a turn whose prompt exceeds the preview cap → ledger has a
+	// truncated preview. Sidecar carries the full text.
+	fullPrompt := strings.Repeat("X", DefaultPromptPreviewCap*2+11)
+	turn := &TurnRecord{
+		TurnID:    uuid.NewString(),
+		TurnIndex: NextTurnIndex(root, sessionID),
+		SessionID: sessionID,
+		Prompt:    fullPrompt,
+		Response:  "r",
+	}
+	if err := p.RecordTurn(turn); err != nil {
+		t.Fatal(err)
+	}
+
+	// IncludeFull=true (default): hydrated Prompt == fullPrompt.
+	res, err := QueryConversation(root, ConversationQuery{SessionID: sessionID, IncludeFull: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Turns) != 1 {
+		t.Fatalf("Turns len = %d; want 1", len(res.Turns))
+	}
+	got := res.Turns[0].Prompt
+	if got != fullPrompt {
+		t.Errorf("hydrated prompt len = %d; want %d", len(got), len(fullPrompt))
+	}
+	if res.Turns[0].PromptTruncated {
+		t.Error("hydrated PromptTruncated = true; want false")
+	}
+}
+
+func TestQueryToolCallsIncludedByDefault(t *testing.T) {
+	p, root, sessionID := newTestProcessForTurns(t)
+
+	turn := &TurnRecord{
+		TurnID:    uuid.NewString(),
+		TurnIndex: NextTurnIndex(root, sessionID),
+		SessionID: sessionID,
+		Prompt:    "q",
+		Response:  "r",
+		ToolCalls: []ToolCallRecord{
+			{ID: "call-1", Name: "lookup", Arguments: `{"q":"x"}`, Result: `{"ok":true}`, DurationMs: 3},
+			{ID: "call-2", Name: "lookup", Arguments: `{"q":"y"}`, Rejected: true, RejectReason: "bad"},
+		},
+	}
+	if err := p.RecordTurn(turn); err != nil {
+		t.Fatal(err)
+	}
+
+	// include_tools default = true.
+	res, err := QueryConversation(root, ConversationQuery{SessionID: sessionID, IncludeFull: true, IncludeTools: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Turns) != 1 {
+		t.Fatalf("Turns len = %d", len(res.Turns))
+	}
+	if len(res.Turns[0].ToolCalls) != 2 {
+		t.Errorf("ToolCalls len = %d; want 2", len(res.Turns[0].ToolCalls))
+	}
+	// with IncludeTools=false → tool calls omitted.
+	res2, err := QueryConversation(root, ConversationQuery{SessionID: sessionID, IncludeFull: true, IncludeTools: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res2.Turns[0].ToolCalls) != 0 {
+		t.Errorf("IncludeTools=false ToolCalls len = %d; want 0", len(res2.Turns[0].ToolCalls))
+	}
+}
+
+func TestQueryCountMatchesTruncationFlag(t *testing.T) {
+	p, root, sessionID := newTestProcessForTurns(t)
+	_ = writeTurnsForTest(t, p, root, sessionID, 20)
+
+	res, err := QueryConversation(root, ConversationQuery{
+		SessionID:   sessionID,
+		IncludeFull: true,
+		// Limit omitted = default 20.
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Count != 20 {
+		t.Errorf("Count = %d; want 20", res.Count)
+	}
+	if res.Truncated {
+		t.Error("Truncated = true; want false (exactly at default limit)")
+	}
+}
+
+func TestQueryCrossSessionIgnored(t *testing.T) {
+	p, root, sessionID := newTestProcessForTurns(t)
+	_ = writeTurnsForTest(t, p, root, sessionID, 2)
+
+	// SessionID = "" → return empty (cross-session reads require explicit opt-in in v1).
+	res, err := QueryConversation(root, ConversationQuery{SessionID: "", IncludeFull: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Count != 0 {
+		t.Errorf("Count with empty SessionID = %d; want 0", res.Count)
+	}
+}

--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -125,6 +125,15 @@ func (m *MCPServer) registerTools() {
 		Name:        "cog_ingest",
 		Description: "Ingest external material into CogOS knowledge. Deterministic decomposition — no LLM calls. Supports URLs, conversations, documents. Applies membrane policy (accept/quarantine/defer/discard).",
 	}, m.toolIngest)
+
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name: "cog_read_conversation",
+		Description: "Read conversation turns (prompt + response pairs) from a session's chat history. " +
+			"Each turn is a complete user-to-assistant exchange; kernel tool calls are inlined when include_tools=true. " +
+			"Backed by the turn.completed ledger event + per-session sidecar (.cog/run/turns/<sid>.jsonl). " +
+			"Use after_turn / before_turn for pagination. Default: current process session, 20 turns, ascending. " +
+			"Fallback (kernel unavailable): jq -c . .cog/run/turns/<sid>.jsonl",
+	}, m.toolReadConversation)
 }
 
 // registerResources registers MCP Resources — read-only addressable data.
@@ -371,6 +380,18 @@ type ingestInput struct {
 	Format   string            `json:"format" jsonschema:"Input format: url, conversation, message, document"`
 	Data     string            `json:"data" jsonschema:"Raw material to ingest (URL, text, JSON)"`
 	Metadata map[string]string `json:"metadata,omitempty" jsonschema:"Optional context (discord_message_id, channel, etc.)"`
+}
+
+// readConversationInput drives cog_read_conversation — see Agent R §5.2.
+type readConversationInput struct {
+	SessionID    string `json:"session_id,omitempty" jsonschema:"Session to read. Empty = current process session."`
+	AfterTurn    int    `json:"after_turn,omitempty" jsonschema:"Pagination: return turns with turn_index > this."`
+	BeforeTurn   int    `json:"before_turn,omitempty" jsonschema:"Reverse pagination: turn_index < this."`
+	Since        string `json:"since,omitempty" jsonschema:"RFC3339 lower bound on turn timestamp."`
+	Limit        int    `json:"limit,omitempty" jsonschema:"Max turns (default 20, max 200)."`
+	IncludeFull  *bool  `json:"include_full,omitempty" jsonschema:"Hydrate prompt/response from the sidecar (default true)."`
+	IncludeTools *bool  `json:"include_tools,omitempty" jsonschema:"Include kernel tool-call transcript (default true)."`
+	Order        string `json:"order,omitempty" jsonschema:"asc (default, natural reading order) or desc."`
 }
 
 // ── Tool Implementations ─────────────────────────────────────────────────────
@@ -956,6 +977,45 @@ func (m *MCPServer) toolIngest(ctx context.Context, req *mcp.CallToolRequest, in
 		"title":        result.Title,
 		"content_type": string(result.ContentType),
 	})
+}
+
+// toolReadConversation is the MCP handler for cog_read_conversation.
+// Thin wrapper over QueryConversation — same shape the HTTP surface returns.
+func (m *MCPServer) toolReadConversation(ctx context.Context, req *mcp.CallToolRequest, input readConversationInput) (*mcp.CallToolResult, any, error) {
+	sessionID := input.SessionID
+	if sessionID == "" && m.process != nil {
+		sessionID = m.process.SessionID()
+	}
+	includeFull := true
+	if input.IncludeFull != nil {
+		includeFull = *input.IncludeFull
+	}
+	includeTools := true
+	if input.IncludeTools != nil {
+		includeTools = *input.IncludeTools
+	}
+	q := ConversationQuery{
+		SessionID:    sessionID,
+		AfterTurn:    input.AfterTurn,
+		BeforeTurn:   input.BeforeTurn,
+		Limit:        input.Limit,
+		IncludeFull:  includeFull,
+		IncludeTools: includeTools,
+		Order:        input.Order,
+	}
+	if input.Since != "" {
+		t, err := time.Parse(time.RFC3339, input.Since)
+		if err != nil {
+			return textResult(fmt.Sprintf("invalid since (want RFC3339): %v", err))
+		}
+		q.Since = t
+	}
+	res, err := QueryConversation(m.cfg.WorkspaceRoot, q)
+	if err != nil {
+		return fallbackResult(fmt.Sprintf("query failed: %v", err),
+			fmt.Sprintf("jq -c . .cog/run/turns/%s.jsonl", sessionID))
+	}
+	return marshalResult(res)
 }
 
 // slugify converts a string to a URL-friendly slug.

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -33,6 +33,8 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -69,6 +71,7 @@ func NewServer(cfg *Config, nucleus *Nucleus, process *Process) *Server {
 	mux.HandleFunc("GET /v1/proprioceptive", s.handleProprioceptive)
 	mux.HandleFunc("GET /v1/lightcone", s.handleLightCone)
 	mux.HandleFunc("POST /v1/context/foveated", s.handleFoveatedContext)
+	mux.HandleFunc("GET /v1/conversation", s.handleConversation)
 
 	// Constellation / attention endpoints (Phase 3)
 	s.registerAttentionRoutes(mux)
@@ -623,17 +626,37 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 		instruments.ChatRequests.Add(ctx, 1)
 	}
 
+	// Prepare the turn record. Fully populated by the provider path (complete/stream)
+	// below, then persisted via RecordTurn once the response is on its way to the client.
+	turn := &TurnRecord{
+		TurnID:    uuid.New().String(),
+		TurnIndex: NextTurnIndex(s.cfg.WorkspaceRoot, block.SessionID),
+		SessionID: block.SessionID,
+		Timestamp: time.Now().UTC(),
+		Prompt:    query,
+		Provider:  provider.Name(),
+		Model:     model,
+		BlockID:   block.ID,
+	}
+
 	inferStart := time.Now()
 	if req.Stream {
-		s.streamChat(w, r.Context(), creq, provider, respID, model, req.StreamOptions)
+		s.streamChat(w, r.Context(), creq, provider, respID, model, req.StreamOptions, turn)
 	} else {
-		s.completeChat(w, r.Context(), creq, provider, respID, model)
+		s.completeChat(w, r.Context(), creq, provider, respID, model, turn)
 	}
 
 	inferMs := float64(time.Since(inferStart).Milliseconds())
 	span.SetAttributes(attribute.Float64("cogos.inference.latency_ms", inferMs))
 	if instruments.InferenceLatency != nil {
 		instruments.InferenceLatency.Record(ctx, inferMs)
+	}
+
+	// Persist the turn (ledger event + sidecar). Closes cogos#20 by
+	// capturing the full prompt/response pair, which RecordBlock drops.
+	turn.DurationMs = time.Since(inferStart).Milliseconds()
+	if err := s.process.RecordTurn(turn); err != nil {
+		slog.Warn("chat: RecordTurn failed", "err", err, "session", turn.SessionID)
 	}
 
 	// Capture debug snapshot (best-effort, non-blocking).
@@ -647,12 +670,18 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 }
 
 // completeChat handles non-streaming chat completions.
+// The optional turn record is populated with the response text, usage, and
+// any tool-call traces so the caller can persist the full turn via RecordTurn.
 func (s *Server) completeChat(w http.ResponseWriter, ctx context.Context, req *CompletionRequest,
-	provider Provider, respID, model string) {
+	provider Provider, respID, model string, turn *TurnRecord) {
 
 	resp, err := provider.Complete(ctx, req)
 	if err != nil {
 		slog.Warn("chat: complete error", "err", err)
+		if turn != nil {
+			turn.Status = "error"
+			turn.Error = err.Error()
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -664,6 +693,25 @@ func (s *Server) completeChat(w http.ResponseWriter, ctx context.Context, req *C
 			},
 		})
 		return
+	}
+	if turn != nil {
+		turn.Response = resp.Content
+		turn.Usage = TurnUsage{
+			InputTokens:  resp.Usage.InputTokens,
+			OutputTokens: resp.Usage.OutputTokens,
+			TotalTokens:  resp.Usage.InputTokens + resp.Usage.OutputTokens,
+		}
+		// Non-kernel tool calls returned to the client become transcript
+		// entries with empty result (the client will execute them).
+		if len(resp.ToolCalls) > 0 {
+			for _, tc := range resp.ToolCalls {
+				turn.ToolCalls = append(turn.ToolCalls, ToolCallRecord{
+					ID:        tc.ID,
+					Name:      tc.Name,
+					Arguments: tc.Arguments,
+				})
+			}
+		}
 	}
 
 	msg := &oaiMessage{Role: "assistant", Content: mustMarshalString(resp.Content)}
@@ -715,12 +763,18 @@ func (s *Server) completeChat(w http.ResponseWriter, ctx context.Context, req *C
 }
 
 // streamChat handles streaming chat completions via SSE.
+// The optional turn record accumulates the response text (and usage from
+// the final chunk) so the caller can persist the full turn via RecordTurn.
 func (s *Server) streamChat(w http.ResponseWriter, ctx context.Context, req *CompletionRequest,
-	provider Provider, respID, model string, streamOpts *oaiStreamOpts) {
+	provider Provider, respID, model string, streamOpts *oaiStreamOpts, turn *TurnRecord) {
 
 	chunks, err := provider.Stream(ctx, req)
 	if err != nil {
 		slog.Warn("chat: stream error", "err", err)
+		if turn != nil {
+			turn.Status = "error"
+			turn.Error = err.Error()
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -733,6 +787,7 @@ func (s *Server) streamChat(w http.ResponseWriter, ctx context.Context, req *Com
 		})
 		return
 	}
+	var respBuf strings.Builder
 
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
@@ -759,6 +814,10 @@ func (s *Server) streamChat(w http.ResponseWriter, ctx context.Context, req *Com
 	for sc := range chunks {
 		if sc.Error != nil {
 			slog.Warn("chat: stream chunk error", "err", sc.Error)
+			if turn != nil {
+				turn.Status = "error"
+				turn.Error = sc.Error.Error()
+			}
 			break
 		}
 
@@ -770,6 +829,17 @@ func (s *Server) streamChat(w http.ResponseWriter, ctx context.Context, req *Com
 				finishReason = "stop"
 				if sawToolCall {
 					finishReason = "tool_calls"
+				}
+			}
+			// Populate the turn record with accumulated response + final usage.
+			if turn != nil {
+				turn.Response = respBuf.String()
+				if sc.Usage != nil {
+					turn.Usage = TurnUsage{
+						InputTokens:  sc.Usage.InputTokens,
+						OutputTokens: sc.Usage.OutputTokens,
+						TotalTokens:  sc.Usage.InputTokens + sc.Usage.OutputTokens,
+					}
 				}
 			}
 			data := oaiChatResponse{
@@ -826,6 +896,9 @@ func (s *Server) streamChat(w http.ResponseWriter, ctx context.Context, req *Com
 
 		// Text delta.
 		if sc.Delta != "" {
+			if turn != nil {
+				respBuf.WriteString(sc.Delta)
+			}
 			delta := &oaiMessage{Role: "assistant", Content: mustMarshalString(sc.Delta)}
 			data := oaiChatResponse{
 				ID:      respID,
@@ -837,6 +910,11 @@ func (s *Server) streamChat(w http.ResponseWriter, ctx context.Context, req *Com
 			b, _ := json.Marshal(data)
 			writeSSE(b)
 		}
+	}
+	// Ensure the turn record picks up the response text even when the
+	// stream never sent a Done chunk (error mid-stream, client disconnect).
+	if turn != nil && turn.Response == "" {
+		turn.Response = respBuf.String()
 	}
 	_, _ = fmt.Fprint(bw, "data: [DONE]\n\n")
 	flush()
@@ -931,6 +1009,94 @@ func (s *Server) handleLightCone(w http.ResponseWriter, r *http.Request) {
 		"count":  len(cones),
 		"cones":  cones,
 	})
+}
+
+// handleConversation returns the conversation turns for a session.
+//
+//	GET /v1/conversation
+//	  ?session_id=…            default: current process session
+//	  &after_turn=N            pagination: turn_index > N
+//	  &before_turn=N           reverse pagination: turn_index < N
+//	  &since=RFC3339           time filter
+//	  &limit=20                default 20, max 200
+//	  &include_full=true       default true — hydrate from sidecar
+//	  &include_tools=true      default true — include tool-call transcript
+//	  &order=asc               asc (default) | desc
+//
+//	200 → ConversationQueryResult
+//	400 → parse error
+//
+// Backed by the turn.completed ledger event stream + the per-session
+// sidecar JSONL. Closes Agent F gap #4.
+func (s *Server) handleConversation(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	sessionID := q.Get("session_id")
+	if sessionID == "" && s.process != nil {
+		sessionID = s.process.SessionID()
+	}
+	cq := ConversationQuery{
+		SessionID:    sessionID,
+		IncludeFull:  parseBoolDefault(q.Get("include_full"), true),
+		IncludeTools: parseBoolDefault(q.Get("include_tools"), true),
+		Order:        q.Get("order"),
+	}
+	if v := q.Get("after_turn"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			writeConversationError(w, http.StatusBadRequest, "invalid after_turn: "+err.Error())
+			return
+		}
+		cq.AfterTurn = n
+	}
+	if v := q.Get("before_turn"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			writeConversationError(w, http.StatusBadRequest, "invalid before_turn: "+err.Error())
+			return
+		}
+		cq.BeforeTurn = n
+	}
+	if v := q.Get("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			writeConversationError(w, http.StatusBadRequest, "invalid limit: "+err.Error())
+			return
+		}
+		cq.Limit = n
+	}
+	if v := q.Get("since"); v != "" {
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			writeConversationError(w, http.StatusBadRequest, "invalid since (want RFC3339): "+err.Error())
+			return
+		}
+		cq.Since = t
+	}
+
+	res, err := QueryConversation(s.cfg.WorkspaceRoot, cq)
+	if err != nil {
+		writeConversationError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(res)
+}
+
+func writeConversationError(w http.ResponseWriter, code int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}
+
+func parseBoolDefault(s string, def bool) bool {
+	if s == "" {
+		return def
+	}
+	b, err := strconv.ParseBool(s)
+	if err != nil {
+		return def
+	}
+	return b
 }
 
 // readLastJSONLEntries reads the last n lines from a JSONL file and returns

--- a/internal/engine/serve_anthropic.go
+++ b/internal/engine/serve_anthropic.go
@@ -9,6 +9,8 @@ import (
 	"log/slog"
 	"net/http"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -195,25 +197,65 @@ func (s *Server) handleAnthropicMessages(w http.ResponseWriter, r *http.Request)
 		model = anthropicReq.Model
 	}
 
-	if anthropicReq.Stream {
-		s.streamAnthropicMessages(w, r.Context(), creq, provider, respID, model)
-		return
+	// Prepare the turn record — fills in during complete/stream, persisted below.
+	turn := &TurnRecord{
+		TurnID:    uuid.NewString(),
+		TurnIndex: NextTurnIndex(s.cfg.WorkspaceRoot, block.SessionID),
+		SessionID: block.SessionID,
+		Timestamp: time.Now().UTC(),
+		Prompt:    query,
+		Provider:  provider.Name(),
+		Model:     model,
+		BlockID:   block.ID,
 	}
-	s.completeAnthropicMessages(w, r.Context(), creq, provider, respID, model)
+
+	turnStart := time.Now()
+	if anthropicReq.Stream {
+		s.streamAnthropicMessages(w, r.Context(), creq, provider, respID, model, turn)
+	} else {
+		s.completeAnthropicMessages(w, r.Context(), creq, provider, respID, model, turn)
+	}
+
+	turn.DurationMs = time.Since(turnStart).Milliseconds()
+	if err := s.process.RecordTurn(turn); err != nil {
+		slog.Warn("anthropic: RecordTurn failed", "err", err, "session", turn.SessionID)
+	}
 }
 
 func (s *Server) completeAnthropicMessages(w http.ResponseWriter, ctx context.Context, req *CompletionRequest,
-	provider Provider, respID, model string) {
+	provider Provider, respID, model string, turn *TurnRecord) {
 
 	resp, err := provider.Complete(ctx, req)
 	if err != nil {
 		slog.Warn("anthropic: complete error", "err", err)
+		if turn != nil {
+			turn.Status = "error"
+			turn.Error = err.Error()
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"error": map[string]string{"type": "inference_error", "message": err.Error()},
 		})
 		return
+	}
+
+	if turn != nil {
+		turn.Response = resp.Content
+		turn.Usage = TurnUsage{
+			InputTokens:  resp.Usage.InputTokens,
+			OutputTokens: resp.Usage.OutputTokens,
+			TotalTokens:  resp.Usage.InputTokens + resp.Usage.OutputTokens,
+		}
+		if len(resp.ToolCalls) > 0 {
+			for _, tc := range resp.ToolCalls {
+				turn.ToolCalls = append(turn.ToolCalls, ToolCallRecord{
+					ID:        tc.ID,
+					Name:      tc.Name,
+					Arguments: tc.Arguments,
+				})
+			}
+		}
 	}
 
 	response := anthropicMessagesResponse{
@@ -234,11 +276,15 @@ func (s *Server) completeAnthropicMessages(w http.ResponseWriter, ctx context.Co
 }
 
 func (s *Server) streamAnthropicMessages(w http.ResponseWriter, ctx context.Context, req *CompletionRequest,
-	provider Provider, respID, model string) {
+	provider Provider, respID, model string, turn *TurnRecord) {
 
 	chunks, err := provider.Stream(ctx, req)
 	if err != nil {
 		slog.Warn("anthropic: stream error", "err", err)
+		if turn != nil {
+			turn.Status = "error"
+			turn.Error = err.Error()
+		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -281,10 +327,16 @@ func (s *Server) streamAnthropicMessages(w http.ResponseWriter, ctx context.Cont
 		},
 	})
 
+	var respBuf strings.Builder
 	usage := anthropicMessagesUsage{}
 	for sc := range chunks {
 		if sc.Error != nil {
 			slog.Warn("anthropic: stream chunk error", "err", sc.Error)
+			if turn != nil {
+				turn.Status = "error"
+				turn.Error = sc.Error.Error()
+				turn.Response = respBuf.String()
+			}
 			break
 		}
 		if sc.Usage != nil {
@@ -292,6 +344,9 @@ func (s *Server) streamAnthropicMessages(w http.ResponseWriter, ctx context.Cont
 			usage.OutputTokens = sc.Usage.OutputTokens
 		}
 		if sc.Delta != "" {
+			if turn != nil {
+				respBuf.WriteString(sc.Delta)
+			}
 			writeEvent("content_block_delta", map[string]any{
 				"type":  "content_block_delta",
 				"index": 0,
@@ -302,6 +357,14 @@ func (s *Server) streamAnthropicMessages(w http.ResponseWriter, ctx context.Cont
 			})
 		}
 		if sc.Done {
+			if turn != nil {
+				turn.Response = respBuf.String()
+				turn.Usage = TurnUsage{
+					InputTokens:  usage.InputTokens,
+					OutputTokens: usage.OutputTokens,
+					TotalTokens:  usage.InputTokens + usage.OutputTokens,
+				}
+			}
 			writeEvent("content_block_stop", map[string]any{"type": "content_block_stop", "index": 0})
 			writeEvent("message_delta", map[string]any{
 				"type": "message_delta",
@@ -313,5 +376,9 @@ func (s *Server) streamAnthropicMessages(w http.ResponseWriter, ctx context.Cont
 			writeEvent("message_stop", map[string]any{"type": "message_stop"})
 			return
 		}
+	}
+	// In case the loop exited without sc.Done (error path), preserve what we captured.
+	if turn != nil && turn.Response == "" {
+		turn.Response = respBuf.String()
 	}
 }

--- a/internal/engine/tool_loop.go
+++ b/internal/engine/tool_loop.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -302,15 +303,10 @@ func ValidateToolCall(tc ToolCall, toolDefs []ToolDefinition) ToolCallValidation
 	return result
 }
 
-// RunToolLoop executes the kernel tool loop.
-// Given a CompletionResponse with tool_calls, it:
-// 1. Separates kernel tools from client tools
-// 2. Executes kernel tools
-// 3. Appends results to messages
-// 4. Re-calls the provider
-// 5. Repeats until no more kernel tool calls or max iterations
-//
-// Returns the final response and any client tool calls that need forwarding.
+// RunToolLoop executes the kernel tool loop. See RunToolLoopWithTranscript
+// for the full detail — this wrapper drops the per-turn tool-call transcript
+// for callers that don't need it. Preserved for backwards compatibility
+// with existing tests / call sites.
 func RunToolLoop(
 	ctx context.Context,
 	provider Provider,
@@ -318,13 +314,43 @@ func RunToolLoop(
 	initialResp *CompletionResponse,
 	registry *KernelToolRegistry,
 ) (*CompletionResponse, []ToolCall, error) {
+	resp, clientCalls, _, err := RunToolLoopWithTranscript(ctx, provider, req, initialResp, registry)
+	return resp, clientCalls, err
+}
+
+// RunToolLoopWithTranscript executes the kernel tool loop and returns a
+// transcript of kernel-owned tool calls executed (and any rejected ones).
+// The transcript is threaded back to chat handlers so it can be stored
+// alongside the prompt/response in the turn.completed record (Agent R
+// §5.4).
+//
+// Given a CompletionResponse with tool_calls, it:
+// 1. Separates kernel tools from client tools
+// 2. Executes kernel tools (capturing a ToolCallRecord for each)
+// 3. Appends results to messages
+// 4. Re-calls the provider
+// 5. Repeats until no more kernel tool calls or max iterations
+//
+// Returns:
+//   - final response
+//   - any client tool calls that need forwarding
+//   - per-turn tool-call transcript (kernel calls + rejections)
+//   - error
+func RunToolLoopWithTranscript(
+	ctx context.Context,
+	provider Provider,
+	req *CompletionRequest,
+	initialResp *CompletionResponse,
+	registry *KernelToolRegistry,
+) (*CompletionResponse, []ToolCall, []ToolCallRecord, error) {
 
 	resp := initialResp
 	var clientToolCalls []ToolCall
+	var transcript []ToolCallRecord
 
 	for i := 0; i < maxToolLoopIterations; i++ {
 		if len(resp.ToolCalls) == 0 {
-			return resp, clientToolCalls, nil
+			return resp, clientToolCalls, transcript, nil
 		}
 
 		// Add the assistant message with tool calls to the conversation.
@@ -356,6 +382,13 @@ func RunToolLoop(
 				}
 
 				rejected = append(rejected, validation)
+				transcript = append(transcript, ToolCallRecord{
+					ID:           tc.ID,
+					Name:         tc.Name,
+					Arguments:    tc.Arguments,
+					Rejected:     true,
+					RejectReason: validation.Reason,
+				})
 				recordToolCallRejection(provider.Name())
 				if registry != nil {
 					registry.logRejectedToolCall(provider.Name(), tc, validation)
@@ -377,7 +410,7 @@ func RunToolLoop(
 				var err error
 				resp, err = provider.Complete(ctx, req)
 				if err != nil {
-					return nil, clientToolCalls, fmt.Errorf("tool_loop re-call after rejection: %w", err)
+					return nil, clientToolCalls, transcript, fmt.Errorf("tool_loop re-call after rejection: %w", err)
 				}
 
 				slog.Info("tool_loop: provider re-called after tool rejection",
@@ -402,7 +435,7 @@ func RunToolLoop(
 
 		// If no kernel calls, return — client needs to handle the rest.
 		if len(kernelCalls) == 0 {
-			return resp, clientToolCalls, nil
+			return resp, clientToolCalls, transcript, nil
 		}
 
 		// Execute kernel tools and add results.
@@ -412,14 +445,27 @@ func RunToolLoop(
 				"iteration", i+1,
 			)
 
+			start := time.Now()
 			result, err := registry.Execute(ctx, tc.Name, tc.Arguments)
+			dur := time.Since(start).Milliseconds()
+			rec := ToolCallRecord{
+				ID:         tc.ID,
+				Name:       tc.Name,
+				Arguments:  tc.Arguments,
+				Result:     result,
+				DurationMs: dur,
+			}
 			if err != nil {
-				result = fmt.Sprintf(`{"error": %q}`, err.Error())
+				rec.Rejected = false
+				rec.RejectReason = ""
+				rec.Result = fmt.Sprintf(`{"error": %q}`, err.Error())
+				result = rec.Result
 				slog.Warn("tool_loop: tool execution failed",
 					"tool", tc.Name,
 					"err", err,
 				)
 			}
+			transcript = append(transcript, rec)
 
 			req.Messages = append(req.Messages, ProviderMessage{
 				Role:       "tool",
@@ -431,14 +477,14 @@ func RunToolLoop(
 		// If there are also client tool calls, we need to stop and let the client handle them.
 		if len(clientToolCalls) > 0 {
 			// Return a synthetic response that includes both the text and pending client calls.
-			return resp, clientToolCalls, nil
+			return resp, clientToolCalls, transcript, nil
 		}
 
 		// Re-call the provider with the updated messages.
 		var err error
 		resp, err = provider.Complete(ctx, req)
 		if err != nil {
-			return nil, clientToolCalls, fmt.Errorf("tool_loop re-call: %w", err)
+			return nil, clientToolCalls, transcript, fmt.Errorf("tool_loop re-call: %w", err)
 		}
 
 		slog.Info("tool_loop: provider re-called",
@@ -449,7 +495,7 @@ func RunToolLoop(
 	}
 
 	slog.Warn("tool_loop: max iterations reached", "max", maxToolLoopIterations)
-	return resp, clientToolCalls, nil
+	return resp, clientToolCalls, transcript, nil
 }
 
 // ── Schema helpers ───────────────────────────────────────────────────────────

--- a/internal/engine/turn_storage.go
+++ b/internal/engine/turn_storage.go
@@ -1,0 +1,305 @@
+// turn_storage.go — Chat-history turn persistence (Agent R hybrid design).
+//
+// Closes Agent F gap #4 and cogos#20 (RecordBlock data-loss bug).
+// RecordBlock at cogblock_ledger.go is persistence-theatre: it writes a
+// metadata-only event and drops the full CogBlock payload on the floor.
+// Instead of mutating RecordBlock (its call-site pattern is used elsewhere
+// for metadata-only ingest events), we add a parallel RecordTurn path that
+// captures the prompt/response pair — a first-class "turn" — via:
+//
+//  1. A sidecar JSONL file at .cog/run/turns/<sessionID>.jsonl carrying
+//     the full turn (prompt, response, tool-call transcript, usage, model).
+//  2. A hash-chained `turn.completed` ledger event with TRUNCATED previews
+//     (defaults: 8 KB prompt / 16 KB response) + pointer to the sidecar.
+//
+// Readers (cog_read_conversation, GET /v1/conversation) hydrate from the
+// sidecar. Agent N's broker, once it lands, will fan out turn.completed on
+// the live event bus for free — no extra code in this file.
+package engine
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+	"unicode/utf8"
+)
+
+// Default truncation caps for the ledger-event preview fields. The sidecar
+// row carries the full text; these only apply to the hashed payload.
+const (
+	DefaultPromptPreviewCap   = 8 * 1024  // 8 KB — covers most user messages
+	DefaultResponsePreviewCap = 16 * 1024 // 16 KB — covers most assistant replies
+)
+
+// TurnRecord is one complete prompt → response exchange.
+// Stored in full in the session sidecar; stored as a truncated preview in
+// the turn.completed ledger event.
+type TurnRecord struct {
+	TurnID     string           `json:"turn_id"`               // UUID minted at turn-start
+	TurnIndex  int              `json:"turn_index"`             // 1-based within session
+	SessionID  string           `json:"session_id"`
+	Timestamp  time.Time        `json:"timestamp"`              // turn-start, UTC
+	DurationMs int64            `json:"duration_ms,omitempty"`  // turn-end minus turn-start
+	Prompt     string           `json:"prompt"`                 // user message text (full)
+	Response   string           `json:"response"`               // assistant message text (full)
+	ToolCalls  []ToolCallRecord `json:"tool_calls,omitempty"`   // kernel-tool transcript
+	Provider   string           `json:"provider,omitempty"`
+	Model      string           `json:"model,omitempty"`
+	Usage      TurnUsage        `json:"usage,omitempty"`
+	BlockID    string           `json:"block_id,omitempty"`     // links to cogblock.ingest
+	Status     string           `json:"status,omitempty"`       // "ok" | "error"
+	Error      string           `json:"error,omitempty"`        // on status="error"
+	LedgerHash string           `json:"ledger_hash,omitempty"`  // turn.completed hash, filled after append
+}
+
+// TurnUsage is a minimal (provider-neutral) token tally for a turn.
+type TurnUsage struct {
+	InputTokens  int `json:"input_tokens,omitempty"`
+	OutputTokens int `json:"output_tokens,omitempty"`
+	TotalTokens  int `json:"total_tokens,omitempty"`
+}
+
+// ToolCallRecord is one kernel-owned tool invocation within a turn.
+// Populated by the tool loop (tool_loop.go) and threaded back to the
+// handler so it can be stored alongside the prompt/response in the turn.
+type ToolCallRecord struct {
+	ID            string `json:"id,omitempty"`
+	Name          string `json:"name"`
+	Arguments     string `json:"arguments,omitempty"`
+	Result        string `json:"result,omitempty"`
+	DurationMs    int64  `json:"duration_ms,omitempty"`
+	Rejected      bool   `json:"rejected,omitempty"`
+	RejectReason  string `json:"reject_reason,omitempty"`
+}
+
+// turnIndexCache tracks the next turn_index per session in-memory, seeded
+// from the sidecar on first access. Matches the lastEventCache pattern in
+// ledger.go — cheap O(1) increment after the first O(N) scan.
+var turnIndexCache = struct {
+	mu      sync.Mutex
+	next    map[string]int
+	primed  map[string]bool
+}{
+	next:   make(map[string]int),
+	primed: make(map[string]bool),
+}
+
+// NextTurnIndex returns the next 1-based turn index for sessionID,
+// incrementing the in-memory counter. On first access it seeds the counter
+// by scanning the sidecar file (if present) and taking the max turn_index
+// plus one. This handles kernel restarts cleanly — a restarted session
+// won't reset to turn 1.
+func NextTurnIndex(workspaceRoot, sessionID string) int {
+	turnIndexCache.mu.Lock()
+	defer turnIndexCache.mu.Unlock()
+
+	if !turnIndexCache.primed[sessionID] {
+		// Seed from disk — idx = (max existing turn_index) + 1, or 1 if new.
+		turnIndexCache.next[sessionID] = readSidecarMaxTurnIndex(workspaceRoot, sessionID) + 1
+		turnIndexCache.primed[sessionID] = true
+	}
+
+	idx := turnIndexCache.next[sessionID]
+	turnIndexCache.next[sessionID] = idx + 1
+	return idx
+}
+
+// resetTurnIndexCacheForTests clears the in-memory counter so tests using
+// the same sessionID across t.TempDir() workspaces don't see stale state.
+func resetTurnIndexCacheForTests() {
+	turnIndexCache.mu.Lock()
+	defer turnIndexCache.mu.Unlock()
+	turnIndexCache.next = make(map[string]int)
+	turnIndexCache.primed = make(map[string]bool)
+}
+
+// readSidecarMaxTurnIndex scans the session's sidecar for the highest
+// turn_index value. Returns 0 if the file doesn't exist or is empty.
+func readSidecarMaxTurnIndex(workspaceRoot, sessionID string) int {
+	path := turnSidecarPath(workspaceRoot, sessionID)
+	f, err := os.Open(path)
+	if err != nil {
+		return 0
+	}
+	defer f.Close()
+
+	dec := json.NewDecoder(f)
+	maxIdx := 0
+	for dec.More() {
+		var row TurnRecord
+		if err := dec.Decode(&row); err != nil {
+			break // give up on first parse error — counter will still be monotonic
+		}
+		if row.TurnIndex > maxIdx {
+			maxIdx = row.TurnIndex
+		}
+	}
+	return maxIdx
+}
+
+// turnSidecarPath returns the sidecar path for a session's turn JSONL.
+func turnSidecarPath(workspaceRoot, sessionID string) string {
+	return filepath.Join(workspaceRoot, ".cog", "run", "turns", sessionID+".jsonl")
+}
+
+// turnSidecarRelPath returns the workspace-relative sidecar path used in
+// the ledger event's `sidecar_path` field (stable across absolute-path
+// rewrites by downstream consumers).
+func turnSidecarRelPath(sessionID string) string {
+	return filepath.Join(".cog", "run", "turns", sessionID+".jsonl")
+}
+
+// truncateUTF8Bytes returns a prefix of s containing at most capBytes bytes,
+// cut on a UTF-8 boundary (never slices inside a multibyte rune). The
+// returned bool is true if the cut happened (s exceeded the cap).
+//
+// capBytes <= 0 means "no truncation".
+func truncateUTF8Bytes(s string, capBytes int) (string, bool) {
+	if capBytes <= 0 || len(s) <= capBytes {
+		return s, false
+	}
+	// Walk backwards from capBytes to find a valid UTF-8 boundary.
+	cut := capBytes
+	for cut > 0 {
+		if utf8.RuneStart(s[cut]) {
+			break
+		}
+		cut--
+	}
+	return s[:cut], true
+}
+
+// appendTurnSidecar appends one JSONL row to the session sidecar. Creates
+// the parent directory and file as needed. Holds appendMu briefly during
+// the write so concurrent RecordTurn calls for the same session don't
+// interleave their lines.
+var sidecarMu sync.Mutex
+
+func appendTurnSidecar(workspaceRoot string, turn *TurnRecord) error {
+	path := turnSidecarPath(workspaceRoot, turn.SessionID)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("turns dir: %w", err)
+	}
+	line, err := json.Marshal(turn)
+	if err != nil {
+		return fmt.Errorf("marshal turn: %w", err)
+	}
+	sidecarMu.Lock()
+	defer sidecarMu.Unlock()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open sidecar: %w", err)
+	}
+	defer f.Close()
+	if _, err := fmt.Fprintf(f, "%s\n", line); err != nil {
+		return fmt.Errorf("write sidecar: %w", err)
+	}
+	return nil
+}
+
+// countRejectedToolCalls is a small utility used to populate the ledger
+// preview's tool_rejected_count field.
+func countRejectedToolCalls(calls []ToolCallRecord) int {
+	n := 0
+	for _, c := range calls {
+		if c.Rejected {
+			n++
+		}
+	}
+	return n
+}
+
+// RecordTurn persists a completed turn: full text to the session sidecar,
+// truncated preview to a hash-chained `turn.completed` ledger event.
+//
+// This is the fix for cogos#20 (RecordBlock data-loss): the existing
+// cogblock.ingest event at cogblock_ledger.go:46 stays as-is (message_count
+// metadata) for consumers that treat it as an ingest receipt, while the
+// new turn.completed event is the authoritative persistence point for the
+// conversation text. Chat handlers call BOTH — RecordBlock for the block
+// envelope, RecordTurn for the turn content — so nothing is lost.
+//
+// If turn.Timestamp is zero it defaults to time.Now().UTC(). If turn.Status
+// is "" it defaults to "ok".
+func (p *Process) RecordTurn(turn *TurnRecord) error {
+	if p == nil || p.cfg == nil {
+		return fmt.Errorf("process or config nil")
+	}
+	if turn == nil {
+		return fmt.Errorf("turn is nil")
+	}
+	if turn.SessionID == "" {
+		turn.SessionID = p.sessionID
+	}
+	if turn.Timestamp.IsZero() {
+		turn.Timestamp = time.Now().UTC()
+	}
+	if turn.Status == "" {
+		turn.Status = "ok"
+	}
+
+	// 1. Write full turn to the per-session sidecar JSONL.
+	if err := appendTurnSidecar(p.cfg.WorkspaceRoot, turn); err != nil {
+		// Continue on — a missing sidecar row is recoverable, but we must
+		// still try to emit the ledger event so downstream consumers at
+		// least see that a turn happened.
+		slog.Warn("RecordTurn: sidecar append failed", "err", fmt.Sprintf("%v", err), "session", turn.SessionID)
+	}
+
+	// 2. Build the ledger preview payload.
+	promptCap := DefaultPromptPreviewCap
+	respCap := DefaultResponsePreviewCap
+
+	promptPreview, promptTrunc := truncateUTF8Bytes(turn.Prompt, promptCap)
+	respPreview, respTrunc := truncateUTF8Bytes(turn.Response, respCap)
+
+	data := map[string]interface{}{
+		"turn_id":             turn.TurnID,
+		"turn_index":          turn.TurnIndex,
+		"prompt_preview":      promptPreview,
+		"prompt_truncated":    promptTrunc,
+		"response_preview":    respPreview,
+		"response_truncated":  respTrunc,
+		"sidecar_path":        turnSidecarRelPath(turn.SessionID),
+		"provider":            turn.Provider,
+		"model":               turn.Model,
+		"duration_ms":         turn.DurationMs,
+		"block_id":            turn.BlockID,
+		"tool_call_count":     len(turn.ToolCalls),
+		"tool_rejected_count": countRejectedToolCalls(turn.ToolCalls),
+		"status":              turn.Status,
+	}
+	if turn.Usage != (TurnUsage{}) {
+		data["usage"] = map[string]interface{}{
+			"input_tokens":  turn.Usage.InputTokens,
+			"output_tokens": turn.Usage.OutputTokens,
+			"total_tokens":  turn.Usage.TotalTokens,
+		}
+	}
+	if turn.Error != "" {
+		data["error"] = turn.Error
+	}
+
+	env := &EventEnvelope{
+		HashedPayload: EventPayload{
+			Type:      "turn.completed",
+			Timestamp: turn.Timestamp.UTC().Format(time.RFC3339),
+			SessionID: turn.SessionID,
+			Data:      data,
+		},
+		Metadata: EventMetadata{Source: "kernel-v3"},
+	}
+
+	// 3. Append to the hash-chained ledger. This is what Agent N's broker
+	// will fan out; `cog_tail_events event_type=turn.completed` becomes
+	// live turn replay the moment the broker lands.
+	if err := AppendEvent(p.cfg.WorkspaceRoot, turn.SessionID, env); err != nil {
+		return fmt.Errorf("turn.completed ledger append: %w", err)
+	}
+	turn.LedgerHash = env.Metadata.Hash
+	return nil
+}

--- a/internal/engine/turn_storage_test.go
+++ b/internal/engine/turn_storage_test.go
@@ -1,0 +1,409 @@
+package engine
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// newTestProcessForTurns builds a minimal process backed by a tempdir
+// workspace. Does NOT start any goroutines — RecordTurn is synchronous.
+func newTestProcessForTurns(t *testing.T) (*Process, string, string) {
+	t.Helper()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	nucleus := makeNucleus("Test", "turns")
+	p := NewProcess(cfg, nucleus)
+	// Reset cache because sessionID is random UUID per process but we want
+	// isolation per test.
+	resetTurnIndexCacheForTests()
+	return p, root, p.SessionID()
+}
+
+// TestWriteTurnCompletedHappyPath — small turn, verify sidecar has one JSONL
+// row with full text; verify ledger has one turn.completed event with
+// matching turn_id.
+func TestWriteTurnCompletedHappyPath(t *testing.T) {
+	p, root, sessionID := newTestProcessForTurns(t)
+
+	turn := &TurnRecord{
+		TurnID:    uuid.NewString(),
+		TurnIndex: NextTurnIndex(root, sessionID),
+		SessionID: sessionID,
+		Prompt:    "hello, how are you?",
+		Response:  "I am well, thanks for asking.",
+		Provider:  "stub",
+		Model:     "test-model",
+		Usage:     TurnUsage{InputTokens: 10, OutputTokens: 20, TotalTokens: 30},
+		BlockID:   "blk-123",
+	}
+	if err := p.RecordTurn(turn); err != nil {
+		t.Fatalf("RecordTurn: %v", err)
+	}
+
+	// Ledger: exactly one turn.completed event with matching turn_id.
+	events := mustReadAllEvents(t, root, sessionID)
+	var gotTurnEvent *EventEnvelope
+	for i := range events {
+		if events[i].HashedPayload.Type == "turn.completed" {
+			gotTurnEvent = &events[i]
+			break
+		}
+	}
+	if gotTurnEvent == nil {
+		t.Fatalf("no turn.completed event in ledger; saw %d events", len(events))
+	}
+	tid, _ := gotTurnEvent.HashedPayload.Data["turn_id"].(string)
+	if tid != turn.TurnID {
+		t.Errorf("ledger turn_id = %q; want %q", tid, turn.TurnID)
+	}
+	if turn.LedgerHash == "" {
+		t.Error("turn.LedgerHash not populated after RecordTurn")
+	}
+
+	// Sidecar: one JSONL row with full text.
+	sidecar := turnSidecarPath(root, sessionID)
+	lines := readJSONLFile(t, sidecar)
+	if len(lines) != 1 {
+		t.Fatalf("sidecar line count = %d; want 1", len(lines))
+	}
+	var got TurnRecord
+	if err := json.Unmarshal(lines[0], &got); err != nil {
+		t.Fatalf("parse sidecar row: %v", err)
+	}
+	if got.Prompt != turn.Prompt {
+		t.Errorf("sidecar prompt = %q; want %q", got.Prompt, turn.Prompt)
+	}
+	if got.Response != turn.Response {
+		t.Errorf("sidecar response = %q; want %q", got.Response, turn.Response)
+	}
+}
+
+// TestWriteTurnCompletedPromptTruncation — prompt exceeds cap; verify sidecar
+// carries full prompt while ledger event has truncated preview +
+// prompt_truncated=true.
+func TestWriteTurnCompletedPromptTruncation(t *testing.T) {
+	p, root, sessionID := newTestProcessForTurns(t)
+
+	// Prompt bigger than cap (8 KB by default).
+	fullPrompt := strings.Repeat("A", DefaultPromptPreviewCap*2+5)
+	turn := &TurnRecord{
+		TurnID:    uuid.NewString(),
+		TurnIndex: NextTurnIndex(root, sessionID),
+		SessionID: sessionID,
+		Prompt:    fullPrompt,
+		Response:  "short",
+	}
+	if err := p.RecordTurn(turn); err != nil {
+		t.Fatalf("RecordTurn: %v", err)
+	}
+
+	// Ledger preview must be capped and marked truncated.
+	events := mustReadAllEvents(t, root, sessionID)
+	var turnEv *EventEnvelope
+	for i := range events {
+		if events[i].HashedPayload.Type == "turn.completed" {
+			turnEv = &events[i]
+		}
+	}
+	if turnEv == nil {
+		t.Fatal("no turn.completed event")
+	}
+	preview, _ := turnEv.HashedPayload.Data["prompt_preview"].(string)
+	trunc, _ := turnEv.HashedPayload.Data["prompt_truncated"].(bool)
+	if !trunc {
+		t.Error("prompt_truncated = false; want true")
+	}
+	if len(preview) > DefaultPromptPreviewCap {
+		t.Errorf("preview len = %d; want <= %d", len(preview), DefaultPromptPreviewCap)
+	}
+
+	// Sidecar must have full text.
+	sidecar := readJSONLFile(t, turnSidecarPath(root, sessionID))
+	if len(sidecar) != 1 {
+		t.Fatalf("sidecar rows = %d; want 1", len(sidecar))
+	}
+	var row TurnRecord
+	_ = json.Unmarshal(sidecar[0], &row)
+	if row.Prompt != fullPrompt {
+		t.Errorf("sidecar prompt len = %d; want %d (full)", len(row.Prompt), len(fullPrompt))
+	}
+}
+
+// TestWriteTurnCompletedResponseTruncation — same for response field.
+func TestWriteTurnCompletedResponseTruncation(t *testing.T) {
+	p, root, sessionID := newTestProcessForTurns(t)
+
+	fullResp := strings.Repeat("B", DefaultResponsePreviewCap*2+7)
+	turn := &TurnRecord{
+		TurnID:    uuid.NewString(),
+		TurnIndex: NextTurnIndex(root, sessionID),
+		SessionID: sessionID,
+		Prompt:    "ask",
+		Response:  fullResp,
+	}
+	if err := p.RecordTurn(turn); err != nil {
+		t.Fatalf("RecordTurn: %v", err)
+	}
+
+	events := mustReadAllEvents(t, root, sessionID)
+	var turnEv *EventEnvelope
+	for i := range events {
+		if events[i].HashedPayload.Type == "turn.completed" {
+			turnEv = &events[i]
+		}
+	}
+	if turnEv == nil {
+		t.Fatal("no turn.completed event")
+	}
+	preview, _ := turnEv.HashedPayload.Data["response_preview"].(string)
+	trunc, _ := turnEv.HashedPayload.Data["response_truncated"].(bool)
+	if !trunc {
+		t.Error("response_truncated = false; want true")
+	}
+	if len(preview) > DefaultResponsePreviewCap {
+		t.Errorf("preview len = %d; want <= %d", len(preview), DefaultResponsePreviewCap)
+	}
+
+	sidecar := readJSONLFile(t, turnSidecarPath(root, sessionID))
+	var row TurnRecord
+	_ = json.Unmarshal(sidecar[0], &row)
+	if row.Response != fullResp {
+		t.Errorf("sidecar response len = %d; want %d", len(row.Response), len(fullResp))
+	}
+}
+
+// TestTruncateUTF8Bytes_Boundary — cap falls inside a multibyte rune; the
+// returned preview must end on a valid UTF-8 boundary.
+func TestTruncateUTF8Bytes_Boundary(t *testing.T) {
+	t.Parallel()
+	// "日" = 3 bytes in UTF-8. Build a string of 10 copies (30 bytes).
+	s := strings.Repeat("日", 10)
+	// Cap at 8 bytes — cuts inside the 3rd "日".
+	got, trunc := truncateUTF8Bytes(s, 8)
+	if !trunc {
+		t.Error("trunc = false; want true")
+	}
+	// Valid UTF-8 prefix — should end at a rune boundary.
+	if got != "日日" { // 2 full runes = 6 bytes, below cap
+		t.Errorf("got = %q (%d bytes); want %q (6 bytes)", got, len(got), "日日")
+	}
+	// Cap >= len: no truncation.
+	got2, trunc2 := truncateUTF8Bytes(s, 1000)
+	if trunc2 {
+		t.Error("trunc2 = true; want false")
+	}
+	if got2 != s {
+		t.Errorf("got2 != s")
+	}
+	// Cap <= 0: no truncation.
+	got3, trunc3 := truncateUTF8Bytes(s, 0)
+	if trunc3 {
+		t.Error("trunc3 = true; want false")
+	}
+	if got3 != s {
+		t.Errorf("got3 != s")
+	}
+}
+
+// TestWriteTurnCompletedSidecarAppendDurable — multiple writes to same session
+// produce JSONL with all rows in write order.
+func TestWriteTurnCompletedSidecarAppendDurable(t *testing.T) {
+	p, root, sessionID := newTestProcessForTurns(t)
+
+	for i := 0; i < 5; i++ {
+		turn := &TurnRecord{
+			TurnID:    uuid.NewString(),
+			TurnIndex: NextTurnIndex(root, sessionID),
+			SessionID: sessionID,
+			Prompt:    "prompt-" + string(rune('0'+i)),
+			Response:  "response-" + string(rune('0'+i)),
+		}
+		if err := p.RecordTurn(turn); err != nil {
+			t.Fatalf("RecordTurn[%d]: %v", i, err)
+		}
+	}
+
+	lines := readJSONLFile(t, turnSidecarPath(root, sessionID))
+	if len(lines) != 5 {
+		t.Fatalf("sidecar rows = %d; want 5", len(lines))
+	}
+	for i, line := range lines {
+		var row TurnRecord
+		if err := json.Unmarshal(line, &row); err != nil {
+			t.Fatalf("row %d: parse: %v", i, err)
+		}
+		if row.TurnIndex != i+1 {
+			t.Errorf("row %d: TurnIndex = %d; want %d", i, row.TurnIndex, i+1)
+		}
+	}
+}
+
+// TestWriteTurnCompletedConcurrent — concurrent writes to same session, verify
+// all rows land and ledger hash-chain stays consistent.
+func TestWriteTurnCompletedConcurrent(t *testing.T) {
+	p, root, sessionID := newTestProcessForTurns(t)
+
+	const workers = 8
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func(n int) {
+			defer wg.Done()
+			turn := &TurnRecord{
+				TurnID:    uuid.NewString(),
+				TurnIndex: NextTurnIndex(root, sessionID),
+				SessionID: sessionID,
+				Prompt:    "concurrent-prompt",
+				Response:  "concurrent-response",
+			}
+			if err := p.RecordTurn(turn); err != nil {
+				t.Errorf("worker %d: %v", n, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Sidecar row count matches workers.
+	lines := readJSONLFile(t, turnSidecarPath(root, sessionID))
+	if len(lines) != workers {
+		t.Errorf("sidecar rows = %d; want %d", len(lines), workers)
+	}
+
+	// Ledger has `workers` turn.completed events with monotonic seq numbers.
+	events := mustReadAllEvents(t, root, sessionID)
+	turnEvents := 0
+	seqs := make(map[int64]bool)
+	for _, ev := range events {
+		if ev.HashedPayload.Type != "turn.completed" {
+			continue
+		}
+		turnEvents++
+		if seqs[ev.Metadata.Seq] {
+			t.Errorf("duplicate seq %d", ev.Metadata.Seq)
+		}
+		seqs[ev.Metadata.Seq] = true
+	}
+	if turnEvents != workers {
+		t.Errorf("ledger turn events = %d; want %d", turnEvents, workers)
+	}
+}
+
+// TestNextTurnIndexPrimingFromSidecar — simulate restart: write 3 turns, drop
+// the in-memory counter, verify NextTurnIndex returns 4.
+func TestNextTurnIndexPrimingFromSidecar(t *testing.T) {
+	p, root, sessionID := newTestProcessForTurns(t)
+
+	for i := 0; i < 3; i++ {
+		turn := &TurnRecord{
+			TurnID:    uuid.NewString(),
+			TurnIndex: NextTurnIndex(root, sessionID),
+			SessionID: sessionID,
+			Prompt:    "p",
+			Response:  "r",
+		}
+		if err := p.RecordTurn(turn); err != nil {
+			t.Fatalf("RecordTurn: %v", err)
+		}
+	}
+	// Simulate restart: clear the in-memory counter.
+	resetTurnIndexCacheForTests()
+	// Next call should see 3 rows in sidecar → max_idx=3 → next=4.
+	got := NextTurnIndex(root, sessionID)
+	if got != 4 {
+		t.Errorf("NextTurnIndex after restart = %d; want 4", got)
+	}
+}
+
+// TestRecordTurnStatusDefault — missing status defaults to "ok".
+func TestRecordTurnStatusDefault(t *testing.T) {
+	p, root, sessionID := newTestProcessForTurns(t)
+	turn := &TurnRecord{
+		TurnID:    uuid.NewString(),
+		TurnIndex: NextTurnIndex(root, sessionID),
+		SessionID: sessionID,
+		Prompt:    "x",
+		Response:  "y",
+	}
+	if err := p.RecordTurn(turn); err != nil {
+		t.Fatal(err)
+	}
+	if turn.Status != "ok" {
+		t.Errorf("Status = %q; want ok", turn.Status)
+	}
+	if turn.Timestamp.IsZero() {
+		t.Error("Timestamp is zero; want auto-populated")
+	}
+}
+
+// TestRecordTurnNilGuards — defensive nil handling.
+func TestRecordTurnNilGuards(t *testing.T) {
+	t.Parallel()
+	var p *Process
+	if err := p.RecordTurn(&TurnRecord{}); err == nil {
+		t.Error("RecordTurn on nil process: expected error")
+	}
+	p2 := &Process{cfg: &Config{WorkspaceRoot: t.TempDir()}}
+	if err := p2.RecordTurn(nil); err == nil {
+		t.Error("RecordTurn with nil turn: expected error")
+	}
+}
+
+// TestRecordTurnTimestampRespected — if provided, timestamp is preserved in
+// the ledger event.
+func TestRecordTurnTimestampRespected(t *testing.T) {
+	p, root, sessionID := newTestProcessForTurns(t)
+	ts := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	turn := &TurnRecord{
+		TurnID:    uuid.NewString(),
+		TurnIndex: NextTurnIndex(root, sessionID),
+		SessionID: sessionID,
+		Prompt:    "x",
+		Response:  "y",
+		Timestamp: ts,
+	}
+	if err := p.RecordTurn(turn); err != nil {
+		t.Fatal(err)
+	}
+	events := mustReadAllEvents(t, root, sessionID)
+	for _, ev := range events {
+		if ev.HashedPayload.Type == "turn.completed" {
+			if ev.HashedPayload.Timestamp != ts.Format(time.RFC3339) {
+				t.Errorf("ledger timestamp = %q; want %q", ev.HashedPayload.Timestamp, ts.Format(time.RFC3339))
+			}
+			return
+		}
+	}
+	t.Fatal("no turn.completed event found")
+}
+
+// readJSONLFile reads a JSONL file and returns each line as raw bytes.
+func readJSONLFile(t *testing.T, path string) [][]byte {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer f.Close()
+	var lines [][]byte
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 4<<20)
+	for sc.Scan() {
+		raw := append([]byte(nil), sc.Bytes()...)
+		if len(raw) == 0 {
+			continue
+		}
+		lines = append(lines, raw)
+	}
+	return lines
+}
+
+// Silence "unused import" if a test path doesn't exercise filepath.
+var _ = filepath.Join


### PR DESCRIPTION
## Summary

Full conversation-turn capture via a new \`turn.completed\` ledger event + full-text sidecar file. Closes Agent F's gap #4 (Chat History / Turn Replay) **and** cogos#20 (\`RecordBlock\` silently dropping prompt/response text). Per Agent R's hybrid design (\`agent-R-chat-history-design.cog.md\`, 916 lines).

Closes #20.

## What landed

- **\`internal/engine/turn_storage.go\`** (305 LOC) — \`RecordTurn\` + sidecar writer. Appends \`turn.completed\` event via \`AppendEvent\` (per-session hash chain) with truncated preview fields, then appends full \`TurnRecord\` to \`.cog/run/turns/<sessionID>.jsonl\`.
- **\`internal/engine/conversation_query.go\`** (341 LOC) — \`QueryConversation\` over per-session events with optional sidecar hydration for full text.
- **\`cog_read_conversation\` MCP tool** + **\`GET /v1/conversation\` HTTP route**.
- **Wired into both chat handlers**: \`serve.go:handleChat\` + \`serve_anthropic.go:handleAnthropicMessages\`.
- **\`tool_loop.go\` tap** via new \`RunToolLoopWithTranscript\` returning \`[]ToolCallRecord\`. Existing \`RunToolLoop\` is now a 1-line delegator; existing tests unchanged.

## Truncation + sidecar defaults

- \`DefaultPromptPreviewCap = 8 KB\` — in-event preview for \`cog_read_events event_type=turn.completed\` (broker fan-out).
- \`DefaultResponsePreviewCap = 16 KB\` — in-event preview.
- UTF-8 boundary-safe — \`truncateUTF8Bytes\` never slices mid-multibyte-rune.
- **Full text always goes to sidecar** regardless of truncation — nothing is lost.
- Estimated ledger bloat: ~9× on the current 36 MB live ledger; still well under modern disk budgets.

## Free wins from already-landed PRs

- **Agent N broker (PR #16)**, once merged: \`cog_tail_events event_type=turn.completed\` becomes live turn replay with zero additional code. Broker hooks \`AppendEvent\` internally.
- **Agent L hash chain (PR #11)**, once merged: conversation history is automatically tamper-evident.

## \`RecordBlock\` preserved

Left untouched per Agent R spec. The metadata-only \`cogblock.ingest\` event remains the receipt for other ingest paths (ingest pipeline, etc.). \`RecordTurn\` is the **parallel** new path for full turn content. Semantic separation: \`RecordBlock\` = "ingested a thing, here's the shape"; \`RecordTurn\` = "completed a conversational turn, here's the content." Both coexist cleanly.

## Test plan

- [x] **turn_storage_test.go** (11 tests): happy path, prompt truncation, response truncation, durable sidecar append, concurrent writes, UTF-8 boundary, next-turn-index priming, status default, nil guards, timestamp respected.
- [x] **conversation_query_test.go** (11 tests): empty session, ordering, pagination (after_turn), include_full=false, bad filter combo, bad order, limit truncation, since filter, include_full hydrates from sidecar, tool_calls included by default, count-matches-truncation-flag, cross-session ignored.
- [x] **380 existing engine tests still pass** — 0 regression.
- [x] \`go test ./... -short -count=1 -race\` — green.
- [x] \`go build ./...\` + \`go vet ./...\` — silent.

## Dependency note

This PR's \`QueryConversation\` is currently implemented as a local O(N) per-session scan of \`events.jsonl\` filtered by \`type=="turn.completed"\`. Agent L's \`QueryLedger\` (PR #11) isn't on \`main\` yet. Once #11 merges, \`QueryConversation\` will collapse to a thin wrapper over \`QueryLedger\` with a small diff (~30 LOC).

## Not in scope

- \`context.assembly\` cross-linking by timestamp proximity — deferred to a follow-up PR per Agent R §6.4 "v1 is lazy."
- Retention/rotation for sidecar files — deferred; grows roughly in line with ledger.
- Encryption at rest — out of scope; kernel is localhost-trusted.

## Design reference

\`cog://mem/semantic/surveys/2026-04-21-consolidation/agent-R-chat-history-design.cog.md\` (916 lines)