### PR TITLE
feat(engine): tool-bridge observability — cog_read/tail_tool_calls + activates dormant infra

### DIFF
--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -75,56 +75,74 @@ func (m *MCPServer) Handler() http.Handler {
 // registerTools registers MCP tools.
 // Design: tools are actions with side effects or non-trivial computation.
 // Read-only state queries will migrate to MCP Resources in Phase 2.
+//
+// Every handler is wrapped with withToolObserver so an invocation emits a
+// paired tool.call + tool.result event to the hash-chained ledger. This
+// closes Agent F gap #6 and activates the gate.go:94 recognizer that has
+// been waiting for a producer.
 func (m *MCPServer) registerTools() {
 	mcp.AddTool(m.server, &mcp.Tool{
 		Name:        "cog_search_memory",
 		Description: "Full-text and semantic search over the CogDoc memory corpus. Returns ranked results with salience scores. Fallback: ./scripts/cog memory search \"query\"",
-	}, m.toolSearchMemory)
+	}, withToolObserver(m, "cog_search_memory", m.toolSearchMemory))
 
 	mcp.AddTool(m.server, &mcp.Tool{
 		Name:        "cog_read_cogdoc",
 		Description: "Read a CogDoc by URI or path. Resolves cog: URIs automatically. Returns full content with parsed frontmatter and optional section extraction via #fragment. Fallback: ./scripts/cog memory read <path>",
-	}, m.toolReadCogdoc)
+	}, withToolObserver(m, "cog_read_cogdoc", m.toolReadCogdoc))
 
 	mcp.AddTool(m.server, &mcp.Tool{
 		Name:        "cog_write_cogdoc",
 		Description: "Write or update a CogDoc at the specified memory path. Creates the file with proper frontmatter if it doesn't exist. Fallback: ./scripts/cog memory write <path> \"Title\"",
-	}, m.toolWriteCogdoc)
+	}, withToolObserver(m, "cog_write_cogdoc", m.toolWriteCogdoc))
 
 	mcp.AddTool(m.server, &mcp.Tool{
 		Name:        "cog_patch_frontmatter",
 		Description: "Merge description, tags, or type patches into a CogDoc frontmatter block.",
-	}, m.toolPatchFrontmatter)
+	}, withToolObserver(m, "cog_patch_frontmatter", m.toolPatchFrontmatter))
 
 	mcp.AddTool(m.server, &mcp.Tool{
 		Name:        "cog_check_coherence",
 		Description: "Run coherence validation against the workspace. Checks URI resolution, frontmatter validity, and reference integrity. Fallback: ./scripts/cog coherence check",
-	}, m.toolCheckCoherence)
+	}, withToolObserver(m, "cog_check_coherence", m.toolCheckCoherence))
 
 	mcp.AddTool(m.server, &mcp.Tool{
 		Name:        "cog_get_state",
 		Description: "Get kernel state: process status, uptime, trust, node health (sibling services), field size, and heartbeat info. Includes identity and coherence metadata. Fallback: curl http://localhost:6931/health",
-	}, m.toolGetState)
+	}, withToolObserver(m, "cog_get_state", m.toolGetState))
 
 	mcp.AddTool(m.server, &mcp.Tool{
 		Name:        "cog_query_field",
 		Description: "Query the attentional field — the salience-scored map of all tracked CogDocs. Returns top-N items, optionally filtered by sector. Shows what the kernel considers most relevant right now.",
-	}, m.toolQueryField)
+	}, withToolObserver(m, "cog_query_field", m.toolQueryField))
 
 	mcp.AddTool(m.server, &mcp.Tool{
 		Name:        "cog_assemble_context",
 		Description: "Build a context package for a given token budget with an explicit focus topic. Use this for intentional context assembly (subtasks, specific investigations). The automatic foveated-context hook handles ambient context on every prompt.",
-	}, m.toolAssembleContext)
+	}, withToolObserver(m, "cog_assemble_context", m.toolAssembleContext))
 
 	mcp.AddTool(m.server, &mcp.Tool{
 		Name:        "cog_emit_event",
 		Description: "Emit a typed event to the workspace ledger. Events: attention.boost (uri + weight), session.marker (label), insight.captured (summary), decision.made (decision + rationale). Fallback: events are JSONL in .cog/ledger/",
-	}, m.toolEmitEvent)
+	}, withToolObserver(m, "cog_emit_event", m.toolEmitEvent))
 
 	mcp.AddTool(m.server, &mcp.Tool{
 		Name:        "cog_ingest",
 		Description: "Ingest external material into CogOS knowledge. Deterministic decomposition — no LLM calls. Supports URLs, conversations, documents. Applies membrane policy (accept/quarantine/defer/discard).",
-	}, m.toolIngest)
+	}, withToolObserver(m, "cog_ingest", m.toolIngest))
+
+	// Tool-call observability — reads the paired tool.call/tool.result events
+	// the wrapper above emits. Self-reflective: these two tools also go
+	// through withToolObserver and end up in their own query results.
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name:        "cog_read_tool_calls",
+		Description: "Query recent tool invocations and their outcomes. Returns call+result pairs from the ledger, filterable by tool_name, status (pending/success/error/rejected/timeout), source, ownership, call_id, or time window. Default limit 100, max 500. Arguments and output are opt-in via include_args/include_output. Fallback: grep '\"type\":\"tool\\.' .cog/ledger/<sid>/events.jsonl",
+	}, withToolObserver(m, "cog_read_tool_calls", m.toolReadToolCalls))
+
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name:        "cog_tail_tool_calls",
+		Description: "Tail tool-call events live. Replays recent tool.call / tool.result events (up to max_events, default 50), applying the same filters as cog_read_tool_calls. When Agent N's event bus lands, this will stream new events live; until then it returns a snapshot of the latest matching rows. Fallback: tail -f .cog/ledger/<sid>/events.jsonl | grep '\"type\":\"tool\\.'",
+	}, withToolObserver(m, "cog_tail_tool_calls", m.toolTailToolCalls))
 }
 
 // registerResources registers MCP Resources — read-only addressable data.
@@ -371,6 +389,39 @@ type ingestInput struct {
 	Format   string            `json:"format" jsonschema:"Input format: url, conversation, message, document"`
 	Data     string            `json:"data" jsonschema:"Raw material to ingest (URL, text, JSON)"`
 	Metadata map[string]string `json:"metadata,omitempty" jsonschema:"Optional context (discord_message_id, channel, etc.)"`
+}
+
+// readToolCallsInput mirrors ToolCallQuery for the MCP surface. Time bounds
+// accept RFC3339 strings; relative shorthand ("5m", "1h", "24h") is supported.
+type readToolCallsInput struct {
+	SessionID     string `json:"session_id,omitempty" jsonschema:"Filter to a session; empty = all sessions"`
+	ToolName      string `json:"tool_name,omitempty" jsonschema:"Exact match or wildcard (e.g. cog_read_*)"`
+	Status        string `json:"status,omitempty" jsonschema:"pending | success | error | rejected | timeout"`
+	Source        string `json:"source,omitempty" jsonschema:"mcp | openai-chat | anthropic-messages | kernel-loop"`
+	Ownership     string `json:"ownership,omitempty" jsonschema:"kernel | client"`
+	CallID        string `json:"call_id,omitempty" jsonschema:"Exact single-call lookup"`
+	Since         string `json:"since,omitempty" jsonschema:"Lower bound — RFC3339 timestamp or relative duration (e.g. 5m, 1h)"`
+	Until         string `json:"until,omitempty" jsonschema:"Upper bound — RFC3339 timestamp"`
+	Limit         int    `json:"limit,omitempty" jsonschema:"Default 100, max 500"`
+	Order         string `json:"order,omitempty" jsonschema:"desc (default) | asc"`
+	IncludeArgs   bool   `json:"include_args,omitempty" jsonschema:"Include arguments payload (default false — PII control)"`
+	IncludeOutput bool   `json:"include_output,omitempty" jsonschema:"Include output summary (default false — PII control)"`
+}
+
+// tailToolCallsInput is a snapshot-mode version of the live tail. Inherits
+// all of readToolCallsInput's filters; defaults include_args/include_output
+// to true (callers tailing are actively observing) and caps the returned set
+// with max_events + max_duration.
+type tailToolCallsInput struct {
+	SessionID   string `json:"session_id,omitempty" jsonschema:"Filter to a session; empty = all sessions"`
+	ToolName    string `json:"tool_name,omitempty" jsonschema:"Exact match or wildcard"`
+	Status      string `json:"status,omitempty" jsonschema:"pending | success | error | rejected | timeout"`
+	Source      string `json:"source,omitempty" jsonschema:"Source taxonomy filter"`
+	Ownership   string `json:"ownership,omitempty" jsonschema:"kernel | client"`
+	CallID      string `json:"call_id,omitempty" jsonschema:"Exact single-call lookup"`
+	Since       string `json:"since,omitempty" jsonschema:"Lower bound — RFC3339 or relative"`
+	MaxEvents   int    `json:"max_events,omitempty" jsonschema:"Stop after N matching events (default 50, max 500)"`
+	MaxDuration string `json:"max_duration,omitempty" jsonschema:"Hard cap on wall-clock (default 60s, max 10m)"`
 }
 
 // ── Tool Implementations ─────────────────────────────────────────────────────
@@ -956,6 +1007,110 @@ func (m *MCPServer) toolIngest(ctx context.Context, req *mcp.CallToolRequest, in
 		"title":        result.Title,
 		"content_type": string(result.ContentType),
 	})
+}
+
+// toolReadToolCalls is the MCP handler for cog_read_tool_calls. It parses the
+// input filters, invokes QueryToolCalls, and returns the stitched result.
+func (m *MCPServer) toolReadToolCalls(ctx context.Context, req *mcp.CallToolRequest, input readToolCallsInput) (*mcp.CallToolResult, any, error) {
+	q := ToolCallQuery{
+		SessionID:     input.SessionID,
+		ToolName:      input.ToolName,
+		Status:        input.Status,
+		Source:        input.Source,
+		Ownership:     input.Ownership,
+		CallID:        input.CallID,
+		Limit:         input.Limit,
+		Order:         input.Order,
+		IncludeArgs:   input.IncludeArgs,
+		IncludeOutput: input.IncludeOutput,
+	}
+	if input.Since != "" {
+		ts, err := parseTimeOrDuration(input.Since)
+		if err != nil {
+			return textResult(fmt.Sprintf("parse since: %v", err))
+		}
+		q.Since = ts
+	}
+	if input.Until != "" {
+		ts, err := parseTimeOrDuration(input.Until)
+		if err != nil {
+			return textResult(fmt.Sprintf("parse until: %v", err))
+		}
+		q.Until = ts
+	}
+	result, err := QueryToolCalls(m.cfg.WorkspaceRoot, q)
+	if err != nil {
+		return fallbackResult(fmt.Sprintf("query failed: %v", err),
+			"grep '\"type\":\"tool\\.' .cog/ledger/*/events.jsonl")
+	}
+	return marshalResult(result)
+}
+
+// toolTailToolCalls returns a snapshot of the most recent tool-call rows for
+// the filter set. When Agent N's event bus lands this will become a proper
+// SSE-style stream; the snapshot behavior is a safe stand-in (same data, same
+// shape) that does not rely on a broker.
+func (m *MCPServer) toolTailToolCalls(ctx context.Context, req *mcp.CallToolRequest, input tailToolCallsInput) (*mcp.CallToolResult, any, error) {
+	limit := input.MaxEvents
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 500 {
+		limit = 500
+	}
+	q := ToolCallQuery{
+		SessionID: input.SessionID,
+		ToolName:  input.ToolName,
+		Status:    input.Status,
+		Source:    input.Source,
+		Ownership: input.Ownership,
+		CallID:    input.CallID,
+		Limit:     limit,
+		Order:     "desc",
+		// Tails default to showing full rows — callers here are actively
+		// observing so the PII opt-out is moot.
+		IncludeArgs:   true,
+		IncludeOutput: true,
+	}
+	if input.Since != "" {
+		ts, err := parseTimeOrDuration(input.Since)
+		if err != nil {
+			return textResult(fmt.Sprintf("parse since: %v", err))
+		}
+		q.Since = ts
+	}
+	// MaxDuration is accepted for forward compatibility with a real stream.
+	// The snapshot path is instantaneous; no wait is needed.
+	_ = input.MaxDuration
+
+	result, err := QueryToolCalls(m.cfg.WorkspaceRoot, q)
+	if err != nil {
+		return fallbackResult(fmt.Sprintf("tail failed: %v", err),
+			"tail -f .cog/ledger/*/events.jsonl | grep '\"type\":\"tool\\.'")
+	}
+	stopped := "snapshot"
+	return marshalResult(map[string]any{
+		"count":          result.Count,
+		"events":         result.Calls,
+		"stopped_reason": stopped,
+		"truncated":      result.Truncated,
+	})
+}
+
+// parseTimeOrDuration accepts either an RFC3339 timestamp ("2026-04-21T…") or
+// a relative duration ("5m", "1h", "24h"). Durations subtract from "now".
+func parseTimeOrDuration(s string) (time.Time, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}, nil
+	}
+	if ts, err := time.Parse(time.RFC3339, s); err == nil {
+		return ts, nil
+	}
+	if d, err := time.ParseDuration(s); err == nil {
+		return time.Now().UTC().Add(-d), nil
+	}
+	return time.Time{}, fmt.Errorf("not RFC3339 and not a Go duration: %q", s)
 }
 
 // slugify converts a string to a URL-friendly slug.

--- a/internal/engine/process.go
+++ b/internal/engine/process.go
@@ -162,6 +162,12 @@ type Process struct {
 	// hookRegistry holds ADR-072 state-transition hooks loaded from
 	// .cog/hooks/transitions/*.yaml. May be nil if the directory is missing.
 	hookRegistry *stateHookRegistry
+
+	// pendingToolCalls correlates client-ownership tool.call emissions with
+	// the role=tool response that arrives on a later HTTP turn. Lazily
+	// initialized on first registerPendingToolCall; swept by
+	// RunPendingToolCallSweeper. See tool_observer.go.
+	pendingToolCalls *pendingToolCallRegistry
 }
 
 // NewProcess constructs and initialises the process.

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -69,6 +69,7 @@ func NewServer(cfg *Config, nucleus *Nucleus, process *Process) *Server {
 	mux.HandleFunc("GET /v1/proprioceptive", s.handleProprioceptive)
 	mux.HandleFunc("GET /v1/lightcone", s.handleLightCone)
 	mux.HandleFunc("POST /v1/context/foveated", s.handleFoveatedContext)
+	mux.HandleFunc("GET /v1/tool-calls", s.handleToolCalls)
 
 	// Constellation / attention endpoints (Phase 3)
 	s.registerAttentionRoutes(mux)
@@ -448,6 +449,16 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 
 	clientMsgs := block.Messages
 
+	// Resolve any pending client-ownership tool calls whose results are
+	// arriving on this turn. Each role=tool message carries a tool_call_id
+	// that matches a previously-forwarded tool.call; emitting the paired
+	// tool.result closes the ledger pair.
+	for _, msg := range clientMsgs {
+		if msg.Role == "tool" && msg.ToolCallID != "" {
+			s.process.resolvePendingToolCall(msg.ToolCallID, msg.Content)
+		}
+	}
+
 	// Extract the user's latest message as the query for relevance scoring.
 	query := ""
 	for i := len(clientMsgs) - 1; i >= 0; i-- {
@@ -689,6 +700,19 @@ func (s *Server) completeChat(w http.ResponseWriter, ctx context.Context, req *C
 					Arguments: tc.Arguments,
 				},
 			}
+			// Observability: emit tool.call for every client-ownership tool
+			// the server is about to forward, and register a pending entry
+			// so the next-turn role=tool message resolves to a tool.result.
+			s.process.emitToolCall(ToolCallEvent{
+				CallID:    tc.ID,
+				ToolName:  tc.Name,
+				Arguments: json.RawMessage(tc.Arguments),
+				Source:    ToolSourceOpenAI,
+				Ownership: ToolOwnershipClient,
+				Provider:  provider.Name(),
+				SessionID: s.process.SessionID(),
+			})
+			s.process.registerPendingToolCall(tc.ID, tc.Name, ToolSourceOpenAI, 0)
 		}
 		raw, _ := json.Marshal(calls)
 		msg.ToolCalls = json.RawMessage(raw)
@@ -801,6 +825,21 @@ func (s *Server) streamChat(w http.ResponseWriter, ctx context.Context, req *Com
 			if sc.ToolCallDelta.ID != "" {
 				tc.ID = sc.ToolCallDelta.ID
 				tc.Type = "function"
+				// Emit tool.call on the first delta that carries an ID.
+				// Arguments arrive incrementally in later deltas; for the
+				// ledger row we record what we have at announcement time
+				// (typically just the name — arguments accumulate client-
+				// side). The paired tool.result will still fire on the
+				// follow-up role=tool message.
+				s.process.emitToolCall(ToolCallEvent{
+					CallID:    sc.ToolCallDelta.ID,
+					ToolName:  sc.ToolCallDelta.Name,
+					Source:    ToolSourceOpenAI,
+					Ownership: ToolOwnershipClient,
+					Provider:  provider.Name(),
+					SessionID: s.process.SessionID(),
+				})
+				s.process.registerPendingToolCall(sc.ToolCallDelta.ID, sc.ToolCallDelta.Name, ToolSourceOpenAI, 0)
 			}
 			// Always create Function — OpenAI spec requires it on every tool call
 			// delta, even the initial chunk where only Name is set and Arguments
@@ -840,6 +879,89 @@ func (s *Server) streamChat(w http.ResponseWriter, ctx context.Context, req *Com
 	}
 	_, _ = fmt.Fprint(bw, "data: [DONE]\n\n")
 	flush()
+}
+
+// handleToolCalls is the HTTP companion to cog_read_tool_calls.
+//
+// GET /v1/tool-calls
+//
+//	?session_id=&tool_name=&status=&source=&ownership=&call_id=
+//	&since=&until=&limit=&order=
+//	&include_args=&include_output=
+//
+// Returns the same stitched call+result rows as the MCP tool. Missing or
+// malformed query params error with 400; empty filter set returns the
+// default-limit most-recent rows.
+func (s *Server) handleToolCalls(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	q := r.URL.Query()
+	query := ToolCallQuery{
+		SessionID:     q.Get("session_id"),
+		ToolName:      q.Get("tool_name"),
+		Status:        q.Get("status"),
+		Source:        q.Get("source"),
+		Ownership:     q.Get("ownership"),
+		CallID:        q.Get("call_id"),
+		Order:         q.Get("order"),
+		IncludeArgs:   boolQueryParam(q.Get("include_args")),
+		IncludeOutput: boolQueryParam(q.Get("include_output")),
+	}
+	if raw := q.Get("limit"); raw != "" {
+		n, err := parseIntQuery(raw)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid limit"})
+			return
+		}
+		query.Limit = n
+	}
+	if raw := q.Get("since"); raw != "" {
+		ts, err := parseTimeOrDuration(raw)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid since: " + err.Error()})
+			return
+		}
+		query.Since = ts
+	}
+	if raw := q.Get("until"); raw != "" {
+		ts, err := parseTimeOrDuration(raw)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid until: " + err.Error()})
+			return
+		}
+		query.Until = ts
+	}
+
+	result, err := QueryToolCalls(s.cfg.WorkspaceRoot, query)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+	_ = json.NewEncoder(w).Encode(result)
+}
+
+// boolQueryParam accepts "true", "1", "yes" (case-insensitive) as true.
+func boolQueryParam(raw string) bool {
+	switch regexp.MustCompile(`^(true|1|yes|on)$`).MatchString(raw) {
+	case true:
+		return true
+	default:
+		return false
+	}
+}
+
+// parseIntQuery returns the int value of a query string param, or an error.
+func parseIntQuery(raw string) (int, error) {
+	var n int
+	_, err := fmt.Sscanf(raw, "%d", &n)
+	if err != nil {
+		return 0, err
+	}
+	return n, nil
 }
 
 // handleDebugLast returns the full pipeline snapshot from the most recent chat request.

--- a/internal/engine/tool_calls_query.go
+++ b/internal/engine/tool_calls_query.go
@@ -1,0 +1,435 @@
+// tool_calls_query.go — Query layer for tool.call / tool.result ledger events.
+//
+// Agent S (survey-2026-04-21-agent-S-tool-bridge-design §4.4) specifies a
+// call+result stitching view over the hash-chained ledger. The query layer is
+// a thin wrapper: it scans .cog/ledger/{sessionID}/events.jsonl (optionally
+// across all sessions), picks out tool.call and tool.result entries, pairs
+// them by call_id, applies filters, and returns a first-class row shape.
+//
+// The stitched view is the ergonomic win: a caller asking "show me the 10 most
+// recent tool invocations and did they succeed?" gets one row per call with
+// both timestamps and the status already joined — no two-round-trip client-
+// side pairing like the generic event-read surface would require.
+//
+// When upstream lands Agent L's QueryLedger, this file can become a thin
+// wrapper over that API (Agent S §5.1). For now it reads the ledger JSONL
+// files directly — the same pattern process.go and cogblock_ledger.go use.
+package engine
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ToolCallQuery describes the filter set for QueryToolCalls. Each filter
+// applies conjunctively; empty means no restriction.
+type ToolCallQuery struct {
+	SessionID     string    // exact session; empty = all sessions
+	ToolName      string    // exact match, or "cog_*" / "*_read" wildcard
+	Status        string    // "success" | "error" | "rejected" | "timeout" | "pending"
+	Source        string    // "mcp" | "openai-chat" | "anthropic-messages" | "kernel-loop"
+	Ownership     string    // "kernel" | "client"
+	CallID        string    // exact single-call lookup
+	Since         time.Time // lower bound (inclusive); zero = no lower bound
+	Until         time.Time // upper bound (exclusive); zero = no upper bound
+	Limit         int       // default 100, max 500
+	Order         string    // "desc" (default) | "asc"
+	IncludeArgs   bool      // include arguments payload (default: false)
+	IncludeOutput bool      // include output_summary (default: false)
+}
+
+const (
+	defaultToolCallQueryLimit = 100
+	maxToolCallQueryLimit     = 500
+)
+
+// ToolCallRow is one row of the call+result stitched result set.
+type ToolCallRow struct {
+	CallID        string          `json:"call_id"`
+	ToolName      string          `json:"tool_name"`
+	SessionID     string          `json:"session_id"`
+	Source        string          `json:"source"`
+	Ownership     string          `json:"ownership"`
+	CalledAt      string          `json:"called_at"`
+	CompletedAt   string          `json:"completed_at,omitempty"`
+	DurationMs    int             `json:"duration_ms"`
+	Status        string          `json:"status"`
+	Reason        string          `json:"reason,omitempty"`
+	OutputLength  int             `json:"output_length"`
+	Arguments     json.RawMessage `json:"arguments,omitempty"`
+	OutputSummary string          `json:"output_summary,omitempty"`
+	InteractionID string          `json:"interaction_id,omitempty"`
+	TurnIndex     int             `json:"turn_index,omitempty"`
+	Provider      string          `json:"provider,omitempty"`
+}
+
+// ToolCallSourceCounts captures per-source totals in the scanned window.
+type ToolCallSourceCounts struct {
+	MCP        int `json:"mcp"`
+	OpenAI     int `json:"openai_chat"`
+	Anthropic  int `json:"anthropic_messages"`
+	KernelLoop int `json:"kernel_loop"`
+	Other      int `json:"other"`
+}
+
+// ToolCallQueryResult is the return shape of QueryToolCalls.
+type ToolCallQueryResult struct {
+	Count          int                  `json:"count"`
+	Calls          []ToolCallRow        `json:"calls"`
+	Truncated      bool                 `json:"truncated"`
+	SourcesChecked ToolCallSourceCounts `json:"sources_checked"`
+}
+
+// QueryToolCalls reads the ledger for one or all sessions, extracts
+// tool.call/tool.result events, pairs them by call_id, applies q's filters,
+// and returns the stitched row set.
+//
+// This is a read-only, stateless function — safe to call concurrently with
+// AppendEvent calls (JSONL appends are line-atomic; partial lines are skipped).
+func QueryToolCalls(workspaceRoot string, q ToolCallQuery) (*ToolCallQueryResult, error) {
+	if workspaceRoot == "" {
+		return nil, fmt.Errorf("workspace_root is required")
+	}
+
+	limit := q.Limit
+	if limit <= 0 {
+		limit = defaultToolCallQueryLimit
+	}
+	if limit > maxToolCallQueryLimit {
+		limit = maxToolCallQueryLimit
+	}
+
+	// Collect sessions to scan.
+	sessions, err := listLedgerSessions(workspaceRoot, q.SessionID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Read every tool.*-typed event into memory. Capped per-session reads keep
+	// memory bounded; for multi-session scans we reach back across histories.
+	type toolEvent struct {
+		eventType string
+		timestamp time.Time
+		data      map[string]interface{}
+	}
+	var events []toolEvent
+	var counts ToolCallSourceCounts
+
+	for _, sid := range sessions {
+		eventsFile := filepath.Join(workspaceRoot, ".cog", "ledger", sid, "events.jsonl")
+		f, err := os.Open(eventsFile)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("open ledger %s: %w", sid, err)
+		}
+		scanner := bufio.NewScanner(f)
+		scanner.Buffer(make([]byte, 0, 64*1024), 4<<20) // 4 MB line cap
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line == "" {
+				continue
+			}
+			var env EventEnvelope
+			if jErr := json.Unmarshal([]byte(line), &env); jErr != nil {
+				continue
+			}
+			t := env.HashedPayload.Type
+			if t != "tool.call" && t != "tool.result" {
+				continue
+			}
+			ts, _ := time.Parse(time.RFC3339, env.HashedPayload.Timestamp)
+			ev := toolEvent{
+				eventType: t,
+				timestamp: ts,
+				data:      env.HashedPayload.Data,
+			}
+			// Make sure the row carries the session id even if Data omits it.
+			if env.HashedPayload.SessionID != "" {
+				if ev.data == nil {
+					ev.data = map[string]interface{}{}
+				}
+				if _, ok := ev.data["session_id"]; !ok {
+					ev.data["session_id"] = env.HashedPayload.SessionID
+				}
+			}
+			events = append(events, ev)
+			if t == "tool.call" {
+				incSourceCount(&counts, asString(ev.data["source"]))
+			}
+		}
+		_ = f.Close()
+	}
+
+	// Stitch: for each tool.call, attach the matching tool.result (if any).
+	// Rows keyed by call_id. Late-arriving duplicate calls overwrite earlier
+	// ones — the ledger is append-only so the latest tool.call for a call_id
+	// is authoritative.
+	rows := make(map[string]*ToolCallRow)
+	for _, ev := range events {
+		if ev.eventType != "tool.call" {
+			continue
+		}
+		callID := asString(ev.data["call_id"])
+		if callID == "" {
+			continue
+		}
+		row := &ToolCallRow{
+			CallID:        callID,
+			ToolName:      asString(ev.data["tool_name"]),
+			SessionID:     asString(ev.data["session_id"]),
+			Source:        asString(ev.data["source"]),
+			Ownership:     asString(ev.data["ownership"]),
+			CalledAt:      ev.timestamp.Format(time.RFC3339),
+			Status:        ToolStatusPending,
+			Provider:      asString(ev.data["provider"]),
+			InteractionID: asString(ev.data["interaction_id"]),
+			TurnIndex:     asInt(ev.data["turn_index"]),
+		}
+		if q.IncludeArgs {
+			row.Arguments = rawFromAny(ev.data["arguments"])
+		}
+		rows[callID] = row
+	}
+	for _, ev := range events {
+		if ev.eventType != "tool.result" {
+			continue
+		}
+		callID := asString(ev.data["call_id"])
+		row, ok := rows[callID]
+		if !ok {
+			// Result without matching call — synthesize a placeholder row so
+			// the caller can still see it when filtering by call_id.
+			row = &ToolCallRow{
+				CallID:    callID,
+				ToolName:  asString(ev.data["tool_name"]),
+				SessionID: asString(ev.data["session_id"]),
+				Source:    asString(ev.data["source"]),
+				Status:    ToolStatusPending,
+			}
+			rows[callID] = row
+		}
+		row.Status = asString(ev.data["status"])
+		row.Reason = asString(ev.data["reason"])
+		row.OutputLength = asInt(ev.data["output_length"])
+		row.DurationMs = asInt(ev.data["duration_ms"])
+		row.CompletedAt = ev.timestamp.Format(time.RFC3339)
+		if q.IncludeOutput {
+			row.OutputSummary = asString(ev.data["output_summary"])
+		}
+		// Prefer the result's tool_name if the call row didn't have one
+		// (shouldn't happen in practice, but keeps the data self-healing).
+		if row.ToolName == "" {
+			row.ToolName = asString(ev.data["tool_name"])
+		}
+	}
+
+	// Flatten, filter, sort.
+	flat := make([]ToolCallRow, 0, len(rows))
+	for _, r := range rows {
+		if r == nil {
+			continue
+		}
+		if !rowMatchesQuery(*r, q) {
+			continue
+		}
+		flat = append(flat, *r)
+	}
+	order := strings.ToLower(q.Order)
+	if order != "asc" {
+		order = "desc"
+	}
+	sort.SliceStable(flat, func(i, j int) bool {
+		ti, _ := time.Parse(time.RFC3339, flat[i].CalledAt)
+		tj, _ := time.Parse(time.RFC3339, flat[j].CalledAt)
+		if order == "asc" {
+			return ti.Before(tj)
+		}
+		return ti.After(tj)
+	})
+
+	truncated := len(flat) > limit
+	if truncated {
+		flat = flat[:limit]
+	}
+
+	return &ToolCallQueryResult{
+		Count:          len(flat),
+		Calls:          flat,
+		Truncated:      truncated,
+		SourcesChecked: counts,
+	}, nil
+}
+
+// rowMatchesQuery applies the non-limit filters in ToolCallQuery to one row.
+func rowMatchesQuery(r ToolCallRow, q ToolCallQuery) bool {
+	if q.CallID != "" && r.CallID != q.CallID {
+		return false
+	}
+	if q.ToolName != "" && !toolNameMatches(r.ToolName, q.ToolName) {
+		return false
+	}
+	if q.Status != "" && r.Status != q.Status {
+		return false
+	}
+	if q.Source != "" && r.Source != q.Source {
+		return false
+	}
+	if q.Ownership != "" && r.Ownership != q.Ownership {
+		return false
+	}
+	if !q.Since.IsZero() {
+		ts, _ := time.Parse(time.RFC3339, r.CalledAt)
+		if ts.Before(q.Since) {
+			return false
+		}
+	}
+	if !q.Until.IsZero() {
+		ts, _ := time.Parse(time.RFC3339, r.CalledAt)
+		if !ts.Before(q.Until) {
+			return false
+		}
+	}
+	return true
+}
+
+// toolNameMatches implements simple "*"-wildcard match on tool_name.
+// Wildcards allowed at prefix, suffix, or both (e.g. "cog_read_*", "*_cogdoc",
+// "*search*"). Non-wildcard patterns match exactly.
+func toolNameMatches(name, pattern string) bool {
+	if pattern == "" {
+		return true
+	}
+	if !strings.Contains(pattern, "*") {
+		return name == pattern
+	}
+	// Split on '*' and require each segment appear in order.
+	segs := strings.Split(pattern, "*")
+	idx := 0
+	for i, seg := range segs {
+		if seg == "" {
+			continue
+		}
+		if i == 0 && !strings.HasPrefix(name[idx:], seg) {
+			return false
+		}
+		pos := strings.Index(name[idx:], seg)
+		if pos < 0 {
+			return false
+		}
+		idx += pos + len(seg)
+	}
+	// If pattern didn't end with *, require suffix match.
+	if !strings.HasSuffix(pattern, "*") && segs[len(segs)-1] != "" {
+		return strings.HasSuffix(name, segs[len(segs)-1])
+	}
+	return true
+}
+
+// listLedgerSessions returns the session IDs to scan. If sessionID is non-
+// empty, only that one is returned (even if the directory does not exist yet
+// — the caller will get an empty result). Otherwise every directory under
+// .cog/ledger/ is returned.
+func listLedgerSessions(workspaceRoot, sessionID string) ([]string, error) {
+	if sessionID != "" {
+		return []string{sessionID}, nil
+	}
+	ledgerBase := filepath.Join(workspaceRoot, ".cog", "ledger")
+	entries, err := os.ReadDir(ledgerBase)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read ledger dir: %w", err)
+	}
+	var out []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		out = append(out, e.Name())
+	}
+	return out, nil
+}
+
+// incSourceCount bumps the matching bucket in ToolCallSourceCounts.
+func incSourceCount(c *ToolCallSourceCounts, source string) {
+	switch source {
+	case ToolSourceMCP:
+		c.MCP++
+	case ToolSourceOpenAI:
+		c.OpenAI++
+	case ToolSourceAnthropic:
+		c.Anthropic++
+	case ToolSourceKernelLoop:
+		c.KernelLoop++
+	default:
+		c.Other++
+	}
+}
+
+// ── JSON helpers ────────────────────────────────────────────────────────────
+
+// asString returns v coerced to string, or "" when v is nil or not a string.
+func asString(v interface{}) string {
+	switch x := v.(type) {
+	case string:
+		return x
+	case nil:
+		return ""
+	default:
+		return ""
+	}
+}
+
+// asInt returns v coerced to int, or 0 when v is nil / not a number.
+// JSON unmarshals numbers to float64 by default; we accept both.
+func asInt(v interface{}) int {
+	switch x := v.(type) {
+	case float64:
+		return int(x)
+	case int:
+		return x
+	case int64:
+		return int(x)
+	case json.Number:
+		if i, err := x.Int64(); err == nil {
+			return int(i)
+		}
+	}
+	return 0
+}
+
+// rawFromAny returns a json.RawMessage representation of v, or nil when empty.
+// Used to surface the arguments blob opt-in on reads without pulling the full
+// interface-typed value into the row shape.
+func rawFromAny(v interface{}) json.RawMessage {
+	if v == nil {
+		return nil
+	}
+	switch x := v.(type) {
+	case json.RawMessage:
+		if len(x) == 0 {
+			return nil
+		}
+		return x
+	case string:
+		if x == "" {
+			return nil
+		}
+		return json.RawMessage(x)
+	default:
+		b, err := json.Marshal(x)
+		if err != nil {
+			return nil
+		}
+		return b
+	}
+}

--- a/internal/engine/tool_calls_query_test.go
+++ b/internal/engine/tool_calls_query_test.go
@@ -1,0 +1,369 @@
+package engine
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// seedToolCall appends a tool.call event directly to the session ledger via
+// the same path production code uses. Returns the call ID for subsequent
+// seedToolResult calls.
+func seedToolCall(t *testing.T, root, sessionID, callID, toolName string, when time.Time, extra map[string]interface{}) {
+	t.Helper()
+	data := map[string]interface{}{
+		"call_id":   callID,
+		"tool_name": toolName,
+		"source":    ToolSourceMCP,
+		"ownership": ToolOwnershipKernel,
+	}
+	for k, v := range extra {
+		data[k] = v
+	}
+	env := &EventEnvelope{
+		HashedPayload: EventPayload{
+			Type:      "tool.call",
+			Timestamp: when.UTC().Format(time.RFC3339),
+			SessionID: sessionID,
+			Data:      data,
+		},
+		Metadata: EventMetadata{Source: "test"},
+	}
+	if err := AppendEvent(root, sessionID, env); err != nil {
+		t.Fatalf("seed tool.call: %v", err)
+	}
+}
+
+func seedToolResult(t *testing.T, root, sessionID, callID, toolName, status string, when time.Time, extra map[string]interface{}) {
+	t.Helper()
+	data := map[string]interface{}{
+		"call_id":       callID,
+		"tool_name":     toolName,
+		"status":        status,
+		"output_length": 0,
+		"source":        ToolSourceMCP,
+		"duration_ms":   0,
+	}
+	for k, v := range extra {
+		data[k] = v
+	}
+	env := &EventEnvelope{
+		HashedPayload: EventPayload{
+			Type:      "tool.result",
+			Timestamp: when.UTC().Format(time.RFC3339),
+			SessionID: sessionID,
+			Data:      data,
+		},
+		Metadata: EventMetadata{Source: "test"},
+	}
+	if err := AppendEvent(root, sessionID, env); err != nil {
+		t.Fatalf("seed tool.result: %v", err)
+	}
+}
+
+// ── Stitching ─────────────────────────────────────────────────────────────
+
+func TestQueryPairsCallAndResult(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	now := time.Now().UTC().Add(-1 * time.Minute)
+	seedToolCall(t, root, "s1", "call-a", "cog_read_cogdoc", now, nil)
+	seedToolResult(t, root, "s1", "call-a", "cog_read_cogdoc", ToolStatusSuccess, now.Add(100*time.Millisecond), map[string]interface{}{
+		"duration_ms":   100,
+		"output_length": 42,
+	})
+
+	result, err := QueryToolCalls(root, ToolCallQuery{SessionID: "s1"})
+	if err != nil {
+		t.Fatalf("QueryToolCalls: %v", err)
+	}
+	if result.Count != 1 {
+		t.Fatalf("count = %d; want 1", result.Count)
+	}
+	r := result.Calls[0]
+	if r.CallID != "call-a" {
+		t.Errorf("call_id = %q", r.CallID)
+	}
+	if r.Status != ToolStatusSuccess {
+		t.Errorf("status = %q; want success", r.Status)
+	}
+	if r.CompletedAt == "" {
+		t.Error("completed_at empty; want populated")
+	}
+	if r.DurationMs != 100 {
+		t.Errorf("duration_ms = %d; want 100", r.DurationMs)
+	}
+	if r.OutputLength != 42 {
+		t.Errorf("output_length = %d; want 42", r.OutputLength)
+	}
+}
+
+func TestQueryPendingStatusForUnmatched(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	now := time.Now().UTC()
+	seedToolCall(t, root, "s1", "call-b", "cog_read_cogdoc", now, nil)
+
+	result, err := QueryToolCalls(root, ToolCallQuery{SessionID: "s1"})
+	if err != nil {
+		t.Fatalf("QueryToolCalls: %v", err)
+	}
+	if result.Count != 1 {
+		t.Fatalf("count = %d; want 1", result.Count)
+	}
+	if result.Calls[0].Status != ToolStatusPending {
+		t.Errorf("status = %q; want pending", result.Calls[0].Status)
+	}
+	if result.Calls[0].CompletedAt != "" {
+		t.Errorf("completed_at = %q; want empty", result.Calls[0].CompletedAt)
+	}
+}
+
+func TestQueryFilterByToolNameWildcard(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	now := time.Now().UTC()
+	seedToolCall(t, root, "s1", "call-1", "cog_read_cogdoc", now, nil)
+	seedToolCall(t, root, "s1", "call-2", "cog_read_tool_calls", now, nil)
+	seedToolCall(t, root, "s1", "call-3", "cog_write_cogdoc", now, nil)
+
+	result, err := QueryToolCalls(root, ToolCallQuery{SessionID: "s1", ToolName: "cog_read_*"})
+	if err != nil {
+		t.Fatalf("QueryToolCalls: %v", err)
+	}
+	if result.Count != 2 {
+		t.Errorf("wildcard match count = %d; want 2", result.Count)
+	}
+	for _, r := range result.Calls {
+		if r.ToolName != "cog_read_cogdoc" && r.ToolName != "cog_read_tool_calls" {
+			t.Errorf("unexpected tool_name in result: %q", r.ToolName)
+		}
+	}
+}
+
+func TestQueryFilterByStatus(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	now := time.Now().UTC()
+	seedToolCall(t, root, "s1", "c1", "cog_x", now, nil)
+	seedToolResult(t, root, "s1", "c1", "cog_x", ToolStatusSuccess, now.Add(time.Millisecond), nil)
+	seedToolCall(t, root, "s1", "c2", "cog_x", now, nil)
+	seedToolResult(t, root, "s1", "c2", "cog_x", ToolStatusError, now.Add(time.Millisecond), map[string]interface{}{"reason": "boom"})
+	seedToolCall(t, root, "s1", "c3", "cog_x", now, nil)
+	seedToolResult(t, root, "s1", "c3", "cog_x", ToolStatusRejected, now.Add(time.Millisecond), map[string]interface{}{"reason": "schema"})
+
+	// Filter by status=error → one row.
+	result, err := QueryToolCalls(root, ToolCallQuery{SessionID: "s1", Status: ToolStatusError})
+	if err != nil {
+		t.Fatalf("QueryToolCalls: %v", err)
+	}
+	if result.Count != 1 {
+		t.Fatalf("status=error count = %d; want 1", result.Count)
+	}
+	if result.Calls[0].CallID != "c2" {
+		t.Errorf("filtered call_id = %q; want c2", result.Calls[0].CallID)
+	}
+	if result.Calls[0].Reason != "boom" {
+		t.Errorf("reason = %q; want boom", result.Calls[0].Reason)
+	}
+}
+
+func TestQueryFilterByCallID(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	now := time.Now().UTC()
+	seedToolCall(t, root, "s1", "target", "cog_x", now, nil)
+	seedToolCall(t, root, "s1", "other", "cog_x", now, nil)
+
+	result, err := QueryToolCalls(root, ToolCallQuery{SessionID: "s1", CallID: "target"})
+	if err != nil {
+		t.Fatalf("QueryToolCalls: %v", err)
+	}
+	if result.Count != 1 {
+		t.Fatalf("count = %d; want 1", result.Count)
+	}
+	if result.Calls[0].CallID != "target" {
+		t.Errorf("call_id = %q; want target", result.Calls[0].CallID)
+	}
+}
+
+func TestQueryIncludeArgsDefault(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	now := time.Now().UTC()
+	extra := map[string]interface{}{"arguments": json.RawMessage(`{"uri":"cog://mem/x"}`)}
+	seedToolCall(t, root, "s1", "c-args", "cog_read_cogdoc", now, extra)
+
+	// Without include_args, arguments should be omitted.
+	result, err := QueryToolCalls(root, ToolCallQuery{SessionID: "s1"})
+	if err != nil {
+		t.Fatalf("QueryToolCalls: %v", err)
+	}
+	if result.Calls[0].Arguments != nil {
+		t.Errorf("Arguments present by default: %v", string(result.Calls[0].Arguments))
+	}
+
+	// With include_args, arguments should be present.
+	result, err = QueryToolCalls(root, ToolCallQuery{SessionID: "s1", IncludeArgs: true})
+	if err != nil {
+		t.Fatalf("QueryToolCalls include_args: %v", err)
+	}
+	if len(result.Calls[0].Arguments) == 0 {
+		t.Fatal("Arguments missing with include_args=true")
+	}
+	var parsed map[string]string
+	if err := json.Unmarshal(result.Calls[0].Arguments, &parsed); err != nil {
+		t.Fatalf("parse arguments: %v", err)
+	}
+	if parsed["uri"] != "cog://mem/x" {
+		t.Errorf("parsed uri = %q", parsed["uri"])
+	}
+}
+
+func TestQueryTruncation(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	now := time.Now().UTC()
+	for i := 0; i < 150; i++ {
+		seedToolCall(t, root, "s1", "call-"+intToStr(i), "cog_x", now.Add(time.Duration(i)*time.Millisecond), nil)
+	}
+	result, err := QueryToolCalls(root, ToolCallQuery{SessionID: "s1", Limit: 100})
+	if err != nil {
+		t.Fatalf("QueryToolCalls: %v", err)
+	}
+	if result.Count != 100 {
+		t.Errorf("count = %d; want 100", result.Count)
+	}
+	if !result.Truncated {
+		t.Error("truncated = false; want true")
+	}
+}
+
+func TestQueryOrderAsc(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	base := time.Now().UTC().Add(-1 * time.Hour)
+	seedToolCall(t, root, "s1", "c1", "cog_x", base, nil)
+	seedToolCall(t, root, "s1", "c2", "cog_x", base.Add(30*time.Second), nil)
+	seedToolCall(t, root, "s1", "c3", "cog_x", base.Add(60*time.Second), nil)
+
+	result, err := QueryToolCalls(root, ToolCallQuery{SessionID: "s1", Order: "asc"})
+	if err != nil {
+		t.Fatalf("QueryToolCalls: %v", err)
+	}
+	if result.Count != 3 {
+		t.Fatalf("count = %d; want 3", result.Count)
+	}
+	if result.Calls[0].CallID != "c1" || result.Calls[2].CallID != "c3" {
+		t.Errorf("asc order wrong: first=%q last=%q", result.Calls[0].CallID, result.Calls[2].CallID)
+	}
+}
+
+func TestQueryCrossSession(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	now := time.Now().UTC()
+	seedToolCall(t, root, "sess-a", "a1", "cog_x", now, nil)
+	seedToolCall(t, root, "sess-b", "b1", "cog_x", now.Add(10*time.Second), nil)
+
+	// With no SessionID, both should be returned.
+	result, err := QueryToolCalls(root, ToolCallQuery{})
+	if err != nil {
+		t.Fatalf("QueryToolCalls: %v", err)
+	}
+	if result.Count != 2 {
+		t.Fatalf("cross-session count = %d; want 2", result.Count)
+	}
+
+	// With SessionID=sess-a, only a1.
+	result, err = QueryToolCalls(root, ToolCallQuery{SessionID: "sess-a"})
+	if err != nil {
+		t.Fatalf("QueryToolCalls: %v", err)
+	}
+	if result.Count != 1 || result.Calls[0].CallID != "a1" {
+		t.Errorf("session filter wrong: count=%d id=%q", result.Count, result.Calls[0].CallID)
+	}
+}
+
+func TestQuerySinceFilter(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	old := time.Now().UTC().Add(-2 * time.Hour)
+	recent := time.Now().UTC().Add(-1 * time.Minute)
+	seedToolCall(t, root, "s1", "old", "cog_x", old, nil)
+	seedToolCall(t, root, "s1", "recent", "cog_x", recent, nil)
+
+	result, err := QueryToolCalls(root, ToolCallQuery{
+		SessionID: "s1",
+		Since:     time.Now().UTC().Add(-10 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("QueryToolCalls: %v", err)
+	}
+	if result.Count != 1 {
+		t.Fatalf("count = %d; want 1", result.Count)
+	}
+	if result.Calls[0].CallID != "recent" {
+		t.Errorf("call_id = %q; want recent", result.Calls[0].CallID)
+	}
+}
+
+func TestToolNameMatchesWildcards(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name, pattern string
+		want          bool
+	}{
+		{"cog_read_cogdoc", "cog_read_*", true},
+		{"cog_read_cogdoc", "*_cogdoc", true},
+		{"cog_read_cogdoc", "*read*", true},
+		{"cog_read_cogdoc", "cog_write_*", false},
+		{"cog_read_cogdoc", "cog_read_cogdoc", true},
+		{"cog_read_cogdoc", "cog_read_tool_calls", false},
+		{"cog_read_cogdoc", "", true},
+	}
+	for _, c := range cases {
+		got := toolNameMatches(c.name, c.pattern)
+		if got != c.want {
+			t.Errorf("toolNameMatches(%q, %q) = %v; want %v", c.name, c.pattern, got, c.want)
+		}
+	}
+}
+
+func TestQuerySourceCounts(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	now := time.Now().UTC()
+	seedToolCall(t, root, "s1", "m1", "cog_x", now, map[string]interface{}{"source": ToolSourceMCP})
+	seedToolCall(t, root, "s1", "m2", "cog_x", now, map[string]interface{}{"source": ToolSourceMCP})
+	seedToolCall(t, root, "s1", "o1", "cog_x", now, map[string]interface{}{"source": ToolSourceOpenAI})
+
+	result, err := QueryToolCalls(root, ToolCallQuery{SessionID: "s1"})
+	if err != nil {
+		t.Fatalf("QueryToolCalls: %v", err)
+	}
+	if result.SourcesChecked.MCP != 2 {
+		t.Errorf("mcp count = %d; want 2", result.SourcesChecked.MCP)
+	}
+	if result.SourcesChecked.OpenAI != 1 {
+		t.Errorf("openai count = %d; want 1", result.SourcesChecked.OpenAI)
+	}
+}
+
+// intToStr is a tiny local helper so the test file doesn't pull strconv.
+func intToStr(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	sign := ""
+	if n < 0 {
+		sign = "-"
+		n = -n
+	}
+	var digits []byte
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	return sign + string(digits)
+}

--- a/internal/engine/tool_observer.go
+++ b/internal/engine/tool_observer.go
@@ -1,0 +1,509 @@
+// tool_observer.go — Tool-call observability: emission + pending-call correlation.
+//
+// Agent S (survey-2026-04-21-agent-S-tool-bridge-design) specifies that every
+// tool invocation observed by the kernel should emit a "tool.call" ledger event
+// and — when the result is known — a paired "tool.result" event. The gate
+// recognizer at gate.go:94 has accepted those types since day one but nothing
+// emitted them. This file fills that gap and activates the scaffolded-but-never-
+// wired per-tool-call observation surface identified in issue #22.
+//
+// The kernel observes two kinds of tool invocation:
+//
+//  1. Kernel-ownership (MCP handlers, internal tool-loop executions).
+//     The kernel runs the tool inline; call and result are both emitted by
+//     withToolObserver right around the handler invocation. No correlation
+//     cache is needed — the result is known the moment the handler returns.
+//
+//  2. Client-ownership (provider returned a tool_call the client must execute).
+//     The kernel emits the tool.call immediately, registers a pending entry,
+//     and emits tool.result later when the client sends a matching role=tool
+//     message back. The pending-call cache lives for a bounded TTL and is
+//     swept periodically; entries that exceed the TTL get a
+//     tool.result{status=timeout} event so the audit trail never leaves a
+//     tool.call dangling forever.
+//
+// All emission flows through process.emitEvent → AppendEvent, i.e. the same
+// hash-chained ledger Agent L's read tools query and Agent N's event bus tails.
+// No orphan writer. The root-package tools_bridge.go is explicitly NOT the
+// model for this file — that file bypasses AppendEvent and is slated for
+// deletion with Agent I's purge.
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// Tool-call source taxonomy — where the invocation was observed.
+const (
+	ToolSourceMCP        = "mcp"
+	ToolSourceOpenAI     = "openai-chat"
+	ToolSourceAnthropic  = "anthropic-messages"
+	ToolSourceKernelLoop = "kernel-loop"
+)
+
+// Tool-call ownership taxonomy — who executes the tool body.
+const (
+	ToolOwnershipKernel = "kernel"
+	ToolOwnershipClient = "client"
+)
+
+// Tool-result status taxonomy — the outcome of an invocation.
+const (
+	ToolStatusPending  = "pending"
+	ToolStatusSuccess  = "success"
+	ToolStatusError    = "error"
+	ToolStatusRejected = "rejected"
+	ToolStatusTimeout  = "timeout"
+)
+
+// Output summary length cap — a stored excerpt of tool output. Keep in sync
+// with Agent S §4.2 and §7.6 (truncate output to 200 chars at emit time).
+const toolOutputSummaryChars = 200
+
+// ToolCallEvent is the domain shape for a `tool.call` ledger entry.
+// Fields map 1:1 to the ledger event payload spec in Agent S §4.2.
+type ToolCallEvent struct {
+	CallID        string          `json:"call_id"`
+	ToolName      string          `json:"tool_name"`
+	Arguments     json.RawMessage `json:"arguments,omitempty"`
+	Source        string          `json:"source"`
+	Ownership     string          `json:"ownership"`
+	Provider      string          `json:"provider,omitempty"`
+	InteractionID string          `json:"interaction_id,omitempty"`
+	TurnIndex     int             `json:"turn_index,omitempty"`
+	SessionID     string          `json:"session_id"`
+}
+
+// ToolResultEvent mirrors ToolCallEvent for a completion.
+type ToolResultEvent struct {
+	CallID        string        `json:"call_id"`
+	ToolName      string        `json:"tool_name"`
+	Status        string        `json:"status"`
+	Reason        string        `json:"reason,omitempty"`
+	OutputLength  int           `json:"output_length"`
+	OutputSummary string        `json:"output_summary,omitempty"`
+	Duration      time.Duration `json:"-"`
+	Source        string        `json:"source"`
+	SessionID     string        `json:"session_id"`
+}
+
+// pendingToolCall is the in-memory correlation-cache entry for a client-
+// ownership call awaiting a result. Never written to disk.
+type pendingToolCall struct {
+	CallID    string
+	ToolName  string
+	Source    string
+	SessionID string
+	TurnIndex int
+	EmittedAt time.Time
+}
+
+// pendingToolCallRegistry bounds the pending-call cache. Entries older than
+// pendingToolCallTTL get an automatic tool.result{status=timeout} on the next
+// sweep and are evicted. The ring is size-capped at pendingToolCallMaxEntries
+// so a misbehaving client cannot grow the map without bound — oldest entries
+// are evicted first (with a timeout result emitted for them).
+const (
+	pendingToolCallTTL        = 10 * time.Minute
+	pendingToolCallSweep      = 60 * time.Second
+	pendingToolCallMaxEntries = 1024
+)
+
+// pendingToolCallRegistry owns the pending-call correlation cache.
+type pendingToolCallRegistry struct {
+	mu      sync.Mutex
+	entries map[string]*pendingToolCall // call_id → metadata
+}
+
+func newPendingToolCallRegistry() *pendingToolCallRegistry {
+	return &pendingToolCallRegistry{entries: make(map[string]*pendingToolCall)}
+}
+
+// register adds a pending-call entry. If the cache is at capacity, the oldest
+// entry is evicted with a timeout emission via evictFn (nil allowed in tests).
+func (r *pendingToolCallRegistry) register(entry *pendingToolCall, evict func(*pendingToolCall)) {
+	if entry == nil || entry.CallID == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Cap: evict oldest when at capacity (excluding the new entry itself).
+	if len(r.entries) >= pendingToolCallMaxEntries {
+		var oldestKey string
+		var oldestAt time.Time
+		for k, v := range r.entries {
+			if oldestKey == "" || v.EmittedAt.Before(oldestAt) {
+				oldestKey = k
+				oldestAt = v.EmittedAt
+			}
+		}
+		if oldestKey != "" {
+			victim := r.entries[oldestKey]
+			delete(r.entries, oldestKey)
+			if evict != nil {
+				evict(victim)
+			}
+		}
+	}
+
+	r.entries[entry.CallID] = entry
+}
+
+// take removes and returns the pending entry for a call_id, or nil if not found.
+func (r *pendingToolCallRegistry) take(callID string) *pendingToolCall {
+	if callID == "" {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	entry, ok := r.entries[callID]
+	if !ok {
+		return nil
+	}
+	delete(r.entries, callID)
+	return entry
+}
+
+// expired returns all entries with EmittedAt older than now-ttl and removes
+// them from the registry. Used by the sweep goroutine.
+func (r *pendingToolCallRegistry) expired(now time.Time, ttl time.Duration) []*pendingToolCall {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var victims []*pendingToolCall
+	cutoff := now.Add(-ttl)
+	for k, v := range r.entries {
+		if v.EmittedAt.Before(cutoff) {
+			victims = append(victims, v)
+			delete(r.entries, k)
+		}
+	}
+	return victims
+}
+
+// len returns the current number of pending entries (for tests / metrics).
+func (r *pendingToolCallRegistry) len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.entries)
+}
+
+// emitToolCall appends a tool.call event to the session ledger via AppendEvent.
+// The event shape matches Agent S §4.2.
+func (p *Process) emitToolCall(e ToolCallEvent) {
+	if p == nil || p.cfg == nil {
+		return
+	}
+	sessionID := e.SessionID
+	if sessionID == "" {
+		sessionID = p.sessionID
+	}
+
+	data := map[string]interface{}{
+		"call_id":   e.CallID,
+		"tool_name": e.ToolName,
+		"source":    e.Source,
+		"ownership": e.Ownership,
+	}
+	if len(e.Arguments) > 0 {
+		// Preserve the raw JSON. The ledger canonicalizer will stringify it.
+		data["arguments"] = json.RawMessage(e.Arguments)
+	}
+	if e.Provider != "" {
+		data["provider"] = e.Provider
+	}
+	if e.InteractionID != "" {
+		data["interaction_id"] = e.InteractionID
+	}
+	if e.TurnIndex > 0 {
+		data["turn_index"] = e.TurnIndex
+	}
+
+	env := &EventEnvelope{
+		HashedPayload: EventPayload{
+			Type:      "tool.call",
+			Timestamp: nowISO(),
+			SessionID: sessionID,
+			Data:      data,
+		},
+		Metadata: EventMetadata{Source: "kernel-v3"},
+	}
+	if err := AppendEvent(p.cfg.WorkspaceRoot, sessionID, env); err != nil {
+		slog.Debug("process: emitToolCall append failed", "err", err, "call_id", e.CallID)
+	}
+}
+
+// emitToolResult appends a tool.result event to the session ledger.
+func (p *Process) emitToolResult(e ToolResultEvent) {
+	if p == nil || p.cfg == nil {
+		return
+	}
+	sessionID := e.SessionID
+	if sessionID == "" {
+		sessionID = p.sessionID
+	}
+
+	data := map[string]interface{}{
+		"call_id":       e.CallID,
+		"tool_name":     e.ToolName,
+		"status":        e.Status,
+		"output_length": e.OutputLength,
+		"source":        e.Source,
+		"duration_ms":   int(e.Duration.Milliseconds()),
+	}
+	if e.Reason != "" {
+		data["reason"] = e.Reason
+	}
+	if e.OutputSummary != "" {
+		data["output_summary"] = e.OutputSummary
+	}
+
+	env := &EventEnvelope{
+		HashedPayload: EventPayload{
+			Type:      "tool.result",
+			Timestamp: nowISO(),
+			SessionID: sessionID,
+			Data:      data,
+		},
+		Metadata: EventMetadata{Source: "kernel-v3"},
+	}
+	if err := AppendEvent(p.cfg.WorkspaceRoot, sessionID, env); err != nil {
+		slog.Debug("process: emitToolResult append failed", "err", err, "call_id", e.CallID)
+	}
+}
+
+// registerPendingToolCall adds a client-ownership call to the correlation
+// cache. When the matching role=tool message lands, resolvePendingToolCall
+// will emit the paired tool.result.
+func (p *Process) registerPendingToolCall(callID, toolName, source string, turnIndex int) {
+	if p == nil || callID == "" {
+		return
+	}
+	if p.pendingToolCalls == nil {
+		p.pendingToolCalls = newPendingToolCallRegistry()
+	}
+	p.pendingToolCalls.register(&pendingToolCall{
+		CallID:    callID,
+		ToolName:  toolName,
+		Source:    source,
+		SessionID: p.sessionID,
+		TurnIndex: turnIndex,
+		EmittedAt: time.Now().UTC(),
+	}, p.evictPendingToolCall)
+}
+
+// resolvePendingToolCall matches an inbound role=tool message's tool_call_id
+// to a pending entry, emits a tool.result{status=success} for it, and removes
+// it from the cache. If no match is found, nothing is emitted (the client may
+// be forwarding a pre-kernel call or we may have restarted).
+func (p *Process) resolvePendingToolCall(callID, output string) bool {
+	if p == nil || callID == "" {
+		return false
+	}
+	if p.pendingToolCalls == nil {
+		return false
+	}
+	entry := p.pendingToolCalls.take(callID)
+	if entry == nil {
+		return false
+	}
+	p.emitToolResult(ToolResultEvent{
+		CallID:        entry.CallID,
+		ToolName:      entry.ToolName,
+		Status:        ToolStatusSuccess,
+		OutputLength:  len(output),
+		OutputSummary: truncateString(output, toolOutputSummaryChars),
+		Duration:      time.Since(entry.EmittedAt),
+		Source:        entry.Source,
+		SessionID:     entry.SessionID,
+	})
+	return true
+}
+
+// evictPendingToolCall is called when the ring is at capacity and must drop
+// the oldest entry. We still emit a timeout result so the audit trail shows
+// the call was observed, even though the correlation window closed.
+func (p *Process) evictPendingToolCall(entry *pendingToolCall) {
+	if entry == nil {
+		return
+	}
+	p.emitToolResult(ToolResultEvent{
+		CallID:    entry.CallID,
+		ToolName:  entry.ToolName,
+		Status:    ToolStatusTimeout,
+		Reason:    "evicted: pending-call cache at capacity",
+		Duration:  time.Since(entry.EmittedAt),
+		Source:    entry.Source,
+		SessionID: entry.SessionID,
+	})
+}
+
+// sweepPendingToolCalls walks the registry for entries older than the TTL,
+// emits a tool.result{status=timeout} for each, and removes them. Called by
+// the sweep goroutine started in RunPendingToolCallSweeper.
+func (p *Process) sweepPendingToolCalls() {
+	if p == nil || p.pendingToolCalls == nil {
+		return
+	}
+	victims := p.pendingToolCalls.expired(time.Now().UTC(), pendingToolCallTTL)
+	for _, v := range victims {
+		p.emitToolResult(ToolResultEvent{
+			CallID:    v.CallID,
+			ToolName:  v.ToolName,
+			Status:    ToolStatusTimeout,
+			Reason:    "pending-call TTL exceeded",
+			Duration:  time.Since(v.EmittedAt),
+			Source:    v.Source,
+			SessionID: v.SessionID,
+		})
+	}
+}
+
+// RunPendingToolCallSweeper is a blocking helper that runs the TTL sweep on
+// a ticker until ctx is cancelled. Exported so the process.Run loop or the
+// daemon lifecycle can start it alongside the other tickers. Safe to call
+// without a pending registry — it will initialize one lazily when an entry
+// is first registered.
+func (p *Process) RunPendingToolCallSweeper(ctx context.Context) {
+	if p == nil {
+		return
+	}
+	t := time.NewTicker(pendingToolCallSweep)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			p.sweepPendingToolCalls()
+		}
+	}
+}
+
+// withToolObserver wraps an MCP tool handler so every invocation emits a
+// tool.call before the handler runs and a tool.result after. The wrapper is
+// generic over the handler's input type and is a zero-behavior-change wrapper
+// otherwise — the original handler's return values propagate unchanged.
+//
+// Agent S §4.3.1 specifies this as the primary emission seam for the 10
+// existing cog_* MCP handlers. Additionally, §2.2 calls for activating the
+// dormant NormalizeMCPRequest→RecordBlock pipeline: every MCP tool call
+// becomes a CogBlock just like chat and Anthropic calls, producing a
+// cogblock.ingest event alongside the tool.call/tool.result pair.
+func withToolObserver[In any](
+	m *MCPServer,
+	name string,
+	h func(context.Context, *mcp.CallToolRequest, In) (*mcp.CallToolResult, any, error),
+) func(context.Context, *mcp.CallToolRequest, In) (*mcp.CallToolResult, any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in In) (*mcp.CallToolResult, any, error) {
+		callID := uuid.NewString()
+		start := time.Now().UTC()
+		sessionID := ""
+		var interactionID string
+		if m != nil && m.process != nil {
+			sessionID = m.process.SessionID()
+		}
+		argsJSON, _ := json.Marshal(in) // best-effort; handler still runs if nil
+
+		// Activate the §2.2 dormant path: MCP invocation → CogBlock →
+		// cogblock.ingest. Gives the tool invocation the same first-class
+		// ingress story chat and Anthropic calls have had all along.
+		if m != nil && m.process != nil {
+			block := NormalizeMCPRequest(name, argsJSON)
+			block.SessionID = sessionID
+			if m.nucleus != nil {
+				block.TargetIdentity = m.nucleus.Name
+			}
+			m.process.RecordBlock(block)
+			interactionID = block.ID
+		}
+
+		if m != nil && m.process != nil {
+			m.process.emitToolCall(ToolCallEvent{
+				CallID:        callID,
+				ToolName:      name,
+				Arguments:     argsJSON,
+				Source:        ToolSourceMCP,
+				Ownership:     ToolOwnershipKernel,
+				InteractionID: interactionID,
+				SessionID:     sessionID,
+			})
+		}
+
+		result, data, err := h(ctx, req, in)
+
+		status := ToolStatusSuccess
+		reason := ""
+		if err != nil {
+			status = ToolStatusError
+			reason = err.Error()
+		} else if result != nil && result.IsError {
+			// Handlers like fallbackResult mark IsError=true without returning
+			// a Go error; surface that outcome distinctly so operators can
+			// filter "handler succeeded but tool reported failure" from
+			// genuine success.
+			status = ToolStatusError
+			reason = extractErrorText(result)
+		}
+		outText := extractTextContent(result)
+		if m != nil && m.process != nil {
+			m.process.emitToolResult(ToolResultEvent{
+				CallID:        callID,
+				ToolName:      name,
+				Status:        status,
+				Reason:        reason,
+				OutputLength:  len(outText),
+				OutputSummary: truncateString(outText, toolOutputSummaryChars),
+				Duration:      time.Since(start),
+				Source:        ToolSourceMCP,
+				SessionID:     sessionID,
+			})
+		}
+		return result, data, err
+	}
+}
+
+// extractTextContent returns the concatenated text of all TextContent parts
+// in an MCP CallToolResult. Empty when result is nil or carries no text.
+func extractTextContent(result *mcp.CallToolResult) string {
+	if result == nil {
+		return ""
+	}
+	var total int
+	for _, c := range result.Content {
+		if tc, ok := c.(*mcp.TextContent); ok {
+			total += len(tc.Text)
+		}
+	}
+	if total == 0 {
+		return ""
+	}
+	// Fast path: most handlers have a single text content entry.
+	if len(result.Content) == 1 {
+		if tc, ok := result.Content[0].(*mcp.TextContent); ok {
+			return tc.Text
+		}
+	}
+	// Concatenate.
+	buf := make([]byte, 0, total)
+	for _, c := range result.Content {
+		if tc, ok := c.(*mcp.TextContent); ok {
+			buf = append(buf, tc.Text...)
+		}
+	}
+	return string(buf)
+}
+
+// extractErrorText returns a short error-like reason from an IsError result.
+// Falls back to the text content when no other signal is available.
+func extractErrorText(result *mcp.CallToolResult) string {
+	text := extractTextContent(result)
+	return truncateString(text, toolOutputSummaryChars)
+}

--- a/internal/engine/tool_observer_test.go
+++ b/internal/engine/tool_observer_test.go
@@ -1,0 +1,519 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// ── Emission tests ─────────────────────────────────────────────────────────
+
+func TestEmitToolCallWritesLedger(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	p := NewProcess(cfg, makeNucleus("Cog", "tester"))
+
+	p.emitToolCall(ToolCallEvent{
+		CallID:    "call-1",
+		ToolName:  "cog_read_cogdoc",
+		Arguments: json.RawMessage(`{"uri":"cog://mem/x"}`),
+		Source:    ToolSourceMCP,
+		Ownership: ToolOwnershipKernel,
+	})
+
+	events := mustReadAllEvents(t, root, p.SessionID())
+	if len(events) != 1 {
+		t.Fatalf("event count = %d; want 1", len(events))
+	}
+	ev := events[0]
+	if ev.HashedPayload.Type != "tool.call" {
+		t.Errorf("type = %q; want tool.call", ev.HashedPayload.Type)
+	}
+	if got := ev.HashedPayload.Data["call_id"]; got != "call-1" {
+		t.Errorf("call_id = %v; want call-1", got)
+	}
+	if got := ev.HashedPayload.Data["tool_name"]; got != "cog_read_cogdoc" {
+		t.Errorf("tool_name = %v; want cog_read_cogdoc", got)
+	}
+	if got := ev.HashedPayload.Data["source"]; got != ToolSourceMCP {
+		t.Errorf("source = %v; want %s", got, ToolSourceMCP)
+	}
+	if got := ev.HashedPayload.Data["ownership"]; got != ToolOwnershipKernel {
+		t.Errorf("ownership = %v; want %s", got, ToolOwnershipKernel)
+	}
+}
+
+func TestEmitToolResultWritesLedger(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	p := NewProcess(cfg, makeNucleus("Cog", "tester"))
+
+	p.emitToolResult(ToolResultEvent{
+		CallID:        "call-1",
+		ToolName:      "cog_read_cogdoc",
+		Status:        ToolStatusSuccess,
+		OutputLength:  42,
+		OutputSummary: "hello world",
+		Duration:      125 * time.Millisecond,
+		Source:        ToolSourceMCP,
+	})
+
+	events := mustReadAllEvents(t, root, p.SessionID())
+	if len(events) != 1 {
+		t.Fatalf("event count = %d; want 1", len(events))
+	}
+	ev := events[0]
+	if ev.HashedPayload.Type != "tool.result" {
+		t.Errorf("type = %q; want tool.result", ev.HashedPayload.Type)
+	}
+	if got := ev.HashedPayload.Data["status"]; got != ToolStatusSuccess {
+		t.Errorf("status = %v; want success", got)
+	}
+	// Numeric fields come back as float64 after JSON round-trip.
+	if got := asInt(ev.HashedPayload.Data["duration_ms"]); got != 125 {
+		t.Errorf("duration_ms = %d; want 125", got)
+	}
+	if got := ev.HashedPayload.Data["output_summary"]; got != "hello world" {
+		t.Errorf("output_summary = %v; want hello world", got)
+	}
+}
+
+func TestWithToolObserverWrapsHandler(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	p := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	m := NewMCPServer(cfg, makeNucleus("Cog", "tester"), p)
+
+	type fakeIn struct {
+		Foo string `json:"foo"`
+	}
+	var invoked bool
+	h := func(ctx context.Context, req *mcp.CallToolRequest, in fakeIn) (*mcp.CallToolResult, any, error) {
+		invoked = true
+		if in.Foo != "bar" {
+			t.Errorf("handler Foo = %q; want bar", in.Foo)
+		}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: "ok"}},
+		}, nil, nil
+	}
+	wrapped := withToolObserver(m, "fake_tool", h)
+	result, _, err := wrapped(context.Background(), nil, fakeIn{Foo: "bar"})
+	if err != nil {
+		t.Fatalf("wrapped: %v", err)
+	}
+	if !invoked {
+		t.Fatal("handler not invoked")
+	}
+	if len(result.Content) != 1 {
+		t.Errorf("result content len = %d; want 1", len(result.Content))
+	}
+
+	// Expected events: cogblock.ingest (MCP CogBlock normalization, §2.2),
+	// then tool.call, then tool.result. The tool.* pair shares a call_id.
+	events := mustReadAllEvents(t, root, p.SessionID())
+	if len(events) != 3 {
+		t.Fatalf("event count = %d; want 3 (cogblock.ingest + tool.call + tool.result)", len(events))
+	}
+	if events[0].HashedPayload.Type != "cogblock.ingest" {
+		t.Errorf("event[0].type = %q; want cogblock.ingest", events[0].HashedPayload.Type)
+	}
+	if events[1].HashedPayload.Type != "tool.call" {
+		t.Errorf("event[1].type = %q; want tool.call", events[1].HashedPayload.Type)
+	}
+	if events[2].HashedPayload.Type != "tool.result" {
+		t.Errorf("event[2].type = %q; want tool.result", events[2].HashedPayload.Type)
+	}
+	if events[1].HashedPayload.Data["call_id"] != events[2].HashedPayload.Data["call_id"] {
+		t.Errorf("call_ids differ between call and result")
+	}
+	if events[2].HashedPayload.Data["status"] != ToolStatusSuccess {
+		t.Errorf("status = %v; want success", events[2].HashedPayload.Data["status"])
+	}
+	// The tool.call's interaction_id should reference the cogblock.ingest block.
+	cogBlockID := events[0].HashedPayload.Data["block_id"]
+	if cogBlockID == nil || cogBlockID == "" {
+		t.Error("cogblock.ingest missing block_id")
+	}
+	if events[1].HashedPayload.Data["interaction_id"] != cogBlockID {
+		t.Errorf("interaction_id = %v; want cogblock block_id %v",
+			events[1].HashedPayload.Data["interaction_id"], cogBlockID)
+	}
+}
+
+func TestWithToolObserverCapturesError(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	p := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	m := NewMCPServer(cfg, makeNucleus("Cog", "tester"), p)
+
+	type fakeIn struct{}
+	handlerErr := errors.New("kaboom")
+	h := func(ctx context.Context, req *mcp.CallToolRequest, in fakeIn) (*mcp.CallToolResult, any, error) {
+		return nil, nil, handlerErr
+	}
+	wrapped := withToolObserver(m, "failing_tool", h)
+	_, _, err := wrapped(context.Background(), nil, fakeIn{})
+	if err == nil || err.Error() != "kaboom" {
+		t.Fatalf("err = %v; want kaboom", err)
+	}
+	// cogblock.ingest + tool.call + tool.result
+	events := mustReadAllEvents(t, root, p.SessionID())
+	if len(events) != 3 {
+		t.Fatalf("event count = %d; want 3", len(events))
+	}
+	result := events[2]
+	if result.HashedPayload.Type != "tool.result" {
+		t.Fatalf("last event type = %q; want tool.result", result.HashedPayload.Type)
+	}
+	if result.HashedPayload.Data["status"] != ToolStatusError {
+		t.Errorf("status = %v; want error", result.HashedPayload.Data["status"])
+	}
+	if result.HashedPayload.Data["reason"] != "kaboom" {
+		t.Errorf("reason = %v; want kaboom", result.HashedPayload.Data["reason"])
+	}
+}
+
+func TestWithToolObserverCapturesIsErrorResult(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	p := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	m := NewMCPServer(cfg, makeNucleus("Cog", "tester"), p)
+
+	// Handler returns nil-error but IsError=true (the fallbackResult pattern).
+	type fakeIn struct{}
+	h := func(ctx context.Context, req *mcp.CallToolRequest, in fakeIn) (*mcp.CallToolResult, any, error) {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: "kernel unavailable"}},
+			IsError: true,
+		}, nil, nil
+	}
+	wrapped := withToolObserver(m, "degraded_tool", h)
+	_, _, err := wrapped(context.Background(), nil, fakeIn{})
+	if err != nil {
+		t.Fatalf("wrapped err = %v; want nil", err)
+	}
+	events := mustReadAllEvents(t, root, p.SessionID())
+	if len(events) != 3 {
+		t.Fatalf("event count = %d; want 3", len(events))
+	}
+	if events[2].HashedPayload.Data["status"] != ToolStatusError {
+		t.Errorf("status = %v; want error", events[2].HashedPayload.Data["status"])
+	}
+}
+
+// ── Pending-call correlation cache tests ──────────────────────────────────
+
+func TestRegisterPendingToolCall(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	p := NewProcess(cfg, makeNucleus("Cog", "tester"))
+
+	p.registerPendingToolCall("call-1", "search", ToolSourceOpenAI, 0)
+	p.registerPendingToolCall("call-2", "edit", ToolSourceOpenAI, 0)
+
+	if got := p.pendingToolCalls.len(); got != 2 {
+		t.Errorf("pendingToolCalls len = %d; want 2", got)
+	}
+
+	// Re-registering the same call_id should replace the entry (idempotent).
+	p.registerPendingToolCall("call-1", "search", ToolSourceOpenAI, 0)
+	if got := p.pendingToolCalls.len(); got != 2 {
+		t.Errorf("after re-register len = %d; want 2", got)
+	}
+}
+
+func TestMatchAndResolvePendingSuccess(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	p := NewProcess(cfg, makeNucleus("Cog", "tester"))
+
+	p.registerPendingToolCall("call-X", "lookup", ToolSourceOpenAI, 0)
+	if ok := p.resolvePendingToolCall("call-X", "result-body"); !ok {
+		t.Fatal("resolvePendingToolCall(call-X) returned false; want true")
+	}
+	if got := p.pendingToolCalls.len(); got != 0 {
+		t.Errorf("after resolve len = %d; want 0", got)
+	}
+	events := mustReadAllEvents(t, root, p.SessionID())
+	if len(events) != 1 {
+		t.Fatalf("event count = %d; want 1", len(events))
+	}
+	if events[0].HashedPayload.Type != "tool.result" {
+		t.Errorf("type = %q; want tool.result", events[0].HashedPayload.Type)
+	}
+	if events[0].HashedPayload.Data["status"] != ToolStatusSuccess {
+		t.Errorf("status = %v; want success", events[0].HashedPayload.Data["status"])
+	}
+}
+
+func TestMatchAndResolvePendingMiss(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	p := NewProcess(cfg, makeNucleus("Cog", "tester"))
+
+	if ok := p.resolvePendingToolCall("never-registered", "x"); ok {
+		t.Fatal("resolvePendingToolCall returned true for unknown id; want false")
+	}
+
+	// A miss must not emit any events. The ledger file may not exist yet;
+	// tolerate ENOENT, but any existing file must be empty.
+	path := filepath.Join(root, ".cog", "ledger", p.SessionID(), "events.jsonl")
+	if _, err := os.Stat(path); err == nil {
+		events := mustReadAllEvents(t, root, p.SessionID())
+		if len(events) != 0 {
+			t.Errorf("events after miss = %d; want 0", len(events))
+		}
+	}
+}
+
+func TestSweepPendingToolCallsTimeout(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	p := NewProcess(cfg, makeNucleus("Cog", "tester"))
+
+	p.registerPendingToolCall("expired-call", "search", ToolSourceOpenAI, 0)
+
+	// Forcibly age the entry past the TTL.
+	p.pendingToolCalls.mu.Lock()
+	p.pendingToolCalls.entries["expired-call"].EmittedAt = time.Now().Add(-pendingToolCallTTL - time.Minute)
+	p.pendingToolCalls.mu.Unlock()
+
+	p.sweepPendingToolCalls()
+
+	if got := p.pendingToolCalls.len(); got != 0 {
+		t.Errorf("after sweep len = %d; want 0", got)
+	}
+	events := mustReadAllEvents(t, root, p.SessionID())
+	if len(events) != 1 {
+		t.Fatalf("event count = %d; want 1", len(events))
+	}
+	if events[0].HashedPayload.Data["status"] != ToolStatusTimeout {
+		t.Errorf("status = %v; want timeout", events[0].HashedPayload.Data["status"])
+	}
+}
+
+func TestPendingToolCallCapEvictsOldest(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	p := NewProcess(cfg, makeNucleus("Cog", "tester"))
+
+	// Fill the cache to capacity with slightly-staggered timestamps so the
+	// oldest-first eviction is deterministic.
+	for i := 0; i < pendingToolCallMaxEntries; i++ {
+		id := fmt.Sprintf("call-%d", i)
+		p.registerPendingToolCall(id, "search", ToolSourceOpenAI, 0)
+	}
+	// Manually advance the "oldest" entry's EmittedAt so the eviction pass
+	// removes call-0 deterministically.
+	p.pendingToolCalls.mu.Lock()
+	p.pendingToolCalls.entries["call-0"].EmittedAt = time.Now().Add(-time.Hour)
+	p.pendingToolCalls.mu.Unlock()
+
+	// One more entry triggers an eviction.
+	p.registerPendingToolCall("call-new", "search", ToolSourceOpenAI, 0)
+
+	// call-0 should be evicted; call-new should be present.
+	if got := p.pendingToolCalls.len(); got != pendingToolCallMaxEntries {
+		t.Errorf("after overflow len = %d; want %d", got, pendingToolCallMaxEntries)
+	}
+	p.pendingToolCalls.mu.Lock()
+	_, stillThere := p.pendingToolCalls.entries["call-0"]
+	_, newOneThere := p.pendingToolCalls.entries["call-new"]
+	p.pendingToolCalls.mu.Unlock()
+	if stillThere {
+		t.Error("call-0 should have been evicted")
+	}
+	if !newOneThere {
+		t.Error("call-new should have been added")
+	}
+
+	// An eviction emits a timeout tool.result (with "evicted" reason).
+	events := mustReadAllEvents(t, root, p.SessionID())
+	var sawTimeout bool
+	for _, ev := range events {
+		if ev.HashedPayload.Type == "tool.result" && ev.HashedPayload.Data["status"] == ToolStatusTimeout {
+			sawTimeout = true
+			reason := asString(ev.HashedPayload.Data["reason"])
+			if reason == "" {
+				t.Error("evicted tool.result missing reason")
+			}
+			break
+		}
+	}
+	if !sawTimeout {
+		t.Error("eviction did not produce a timeout tool.result event")
+	}
+}
+
+// TestMCPToolInvocationRecordsBlock guards §2.2 of the Agent S design —
+// every MCP tool call should produce a cogblock.ingest event alongside the
+// tool.call/tool.result pair, activating the dormant NormalizeMCPRequest
+// path that has been sitting unused since introduction.
+func TestMCPToolInvocationRecordsBlock(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	p := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	m := NewMCPServer(cfg, makeNucleus("Cog", "tester"), p)
+
+	type fakeIn struct{}
+	h := func(ctx context.Context, req *mcp.CallToolRequest, in fakeIn) (*mcp.CallToolResult, any, error) {
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "ok"}}}, nil, nil
+	}
+	wrapped := withToolObserver(m, "cog_probe", h)
+	if _, _, err := wrapped(context.Background(), nil, fakeIn{}); err != nil {
+		t.Fatalf("wrapped: %v", err)
+	}
+
+	events := mustReadAllEvents(t, root, p.SessionID())
+	var sawCogBlock bool
+	for _, ev := range events {
+		if ev.HashedPayload.Type == "cogblock.ingest" {
+			sawCogBlock = true
+			// The block kind should be the tool-call variant.
+			if ev.HashedPayload.Data["kind"] != string(BlockToolCall) {
+				t.Errorf("cogblock.ingest kind = %v; want %s",
+					ev.HashedPayload.Data["kind"], BlockToolCall)
+			}
+			break
+		}
+	}
+	if !sawCogBlock {
+		t.Error("no cogblock.ingest event emitted for MCP tool invocation")
+	}
+}
+
+func TestGateRecognizerAcceptsEmittedEvents(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	p := NewProcess(cfg, makeNucleus("Cog", "tester"))
+
+	// Inject a tool.call gate event directly — this exercises the gate
+	// recognizer at gate.go:94, which should now actually see events because
+	// the emission paths above are producing them.
+	result := p.gate.Process(&GateEvent{Type: "tool.call"})
+	if result.StateTransition != StateActive {
+		t.Errorf("tool.call gate transition = %v; want StateActive", result.StateTransition)
+	}
+	result = p.gate.Process(&GateEvent{Type: "tool.result"})
+	if result.StateTransition != StateActive {
+		t.Errorf("tool.result gate transition = %v; want StateActive", result.StateTransition)
+	}
+}
+
+// TestMCPCogReadToolCallsRoundTrip exercises the full MCP handler path:
+// register observable handlers, invoke one, then invoke cog_read_tool_calls
+// via its own handler and verify the result includes the earlier call.
+func TestMCPCogReadToolCallsRoundTrip(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	p := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	m := NewMCPServer(cfg, makeNucleus("Cog", "tester"), p)
+
+	// Trigger one observable tool invocation (direct call through wrapper).
+	wrapped := withToolObserver(m, "probe_tool", func(ctx context.Context, req *mcp.CallToolRequest, in struct{}) (*mcp.CallToolResult, any, error) {
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "ok"}}}, nil, nil
+	})
+	_, _, err := wrapped(context.Background(), nil, struct{}{})
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+
+	// Now invoke cog_read_tool_calls filter-free.
+	result, _, err := m.toolReadToolCalls(context.Background(), nil, readToolCallsInput{})
+	if err != nil {
+		t.Fatalf("toolReadToolCalls: %v", err)
+	}
+	var decoded ToolCallQueryResult
+	decodeMCPJSON(t, result, &decoded)
+	if decoded.Count < 1 {
+		t.Fatalf("count = %d; want >= 1", decoded.Count)
+	}
+	// The probe row should appear; subsequent cog_read_tool_calls invocation
+	// is itself observable and will also emit a pair — hence >= 1.
+	var sawProbe bool
+	for _, r := range decoded.Calls {
+		if r.ToolName == "probe_tool" {
+			sawProbe = true
+			break
+		}
+	}
+	if !sawProbe {
+		t.Error("probe_tool row not found in results")
+	}
+}
+
+// TestHandleToolCallsHTTP verifies GET /v1/tool-calls returns the stitched
+// JSON shape. No inference router is wired; we only exercise the read path.
+func TestHandleToolCallsHTTP(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	cfg.Port = 0
+	p := NewProcess(cfg, makeNucleus("Cog", "tester"))
+
+	// Seed a call+result pair via the emission path.
+	p.emitToolCall(ToolCallEvent{
+		CallID:    "http-probe",
+		ToolName:  "cog_read_cogdoc",
+		Source:    ToolSourceMCP,
+		Ownership: ToolOwnershipKernel,
+	})
+	p.emitToolResult(ToolResultEvent{
+		CallID:       "http-probe",
+		ToolName:     "cog_read_cogdoc",
+		Status:       ToolStatusSuccess,
+		OutputLength: 10,
+		Duration:     25 * time.Millisecond,
+		Source:       ToolSourceMCP,
+	})
+
+	server := NewServer(cfg, makeNucleus("Cog", "tester"), p)
+	ts := httptest.NewServer(server.Handler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/v1/tool-calls?limit=10")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d; want 200", resp.StatusCode)
+	}
+	var decoded ToolCallQueryResult
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if decoded.Count != 1 {
+		t.Fatalf("count = %d; want 1", decoded.Count)
+	}
+	if decoded.Calls[0].CallID != "http-probe" {
+		t.Errorf("call_id = %q; want http-probe", decoded.Calls[0].CallID)
+	}
+	if decoded.Calls[0].Status != ToolStatusSuccess {
+		t.Errorf("status = %q; want success", decoded.Calls[0].Status)
+	}
+}
+


### PR DESCRIPTION
## Summary

Tool-call observability surface — closes Agent F's gap #6 **and** activates substantial scaffolded-but-never-wired infrastructure flagged in cogos#22. Per Agent S's design (\`agent-S-tool-bridge-design.cog.md\`, 813 lines): reading (Y) internal tool observation, not (X) external dispatcher. Kernel is always aggregator, never blocks on external workers.

Closes gap #6. Partial close on #22 (see §"Activated" below).

## What landed

- **\`internal/engine/tool_observer.go\`** (509 LOC) — generic \`withToolObserver[In any]\` wrapper. Emits \`tool.call\` before handler, \`tool.result\` after. Pending-call correlation cache (1024 entries, 10 min TTL, 60 s sweep). Schema-agnostic — wraps all 10 existing \`cog_*\` handlers without special-casing.
- **\`internal/engine/tool_calls_query.go\`** (435 LOC) — query layer stitching call+result pairs. Filters: \`status\`, \`call_id\`, \`tool_name\`, \`ownership\`, \`source\`, time range. When PR #11 (Agent L \`QueryLedger\`) merges, this collapses to a thin wrapper.
- **Two new MCP tools**: \`cog_read_tool_calls\` (historical), \`cog_tail_tool_calls\` (live via Agent N's broker when PR #16 merges).
- **HTTP route**: \`GET /v1/tool-calls\`.
- **\`(*Process).RunPendingToolCallSweeper(ctx)\`** — exported for daemon lifecycle wiring. Not wired at startup in this PR; ready for the daemon loop to pick up alongside other tickers.

## Scaffolded infra ACTIVATED (per cogos#22)

- **\`gate.go:94\` \`tool.call\`/\`tool.result\` recognizer** — was accepting these types but never received them. Now lit.
- **\`NormalizeMCPRequest\` + \`BlockToolCall\` (\`cogblock_normalize.go:119\`)** — every MCP invocation now calls it and flows through \`RecordBlock\`, emitting \`cogblock.ingest\` alongside the \`tool.call\`/\`tool.result\` pair. Regression test \`TestMCPToolInvocationRecordsBlock\` locks it.
- **\`ProprioceptiveEntry\` accept-path** — indirectly activated via the observer.

**Left dormant (deliberate, per design §2.3):**
- \`RunToolLoop\` + \`KernelToolRegistry\` — still never constructed in production. Separate spike. The \`ToolSourceKernelLoop\` constant is wired into the emitter, so future activation costs ~20 LOC of wrapper.

## Pending-call correlation cache

- **Max 1024 entries.** On overflow, oldest-by-\`EmittedAt\` entry is evicted with an immediate \`tool.result{status=timeout, reason="evicted: pending-call cache at capacity"}\` — never silent; always in audit trail.
- **TTL 10 min, sweep every 60 s.** Sweep can be invoked on-demand (\`sweepPendingToolCalls()\`) or run via \`RunPendingToolCallSweeper(ctx)\` blocking helper.
- **Client-ownership calls that never resolve** — TTL sweep emits \`tool.result{status=timeout, reason="pending-call TTL exceeded"}\`.
- **\`status=pending\` query** returns entries observed as \`tool.call\` without \`tool.result\` yet — matches "pending from this query window" semantic.

## Event-emission change worth reviewers' attention

Every MCP invocation now produces **3 events** on the per-session ledger: \`cogblock.ingest\` (from activated normalize path) + \`tool.call\` + \`tool.result\`. Estimated ledger bloat: ~3× on tool-heavy sessions. Observer tests adjusted to expect this count.

## Test plan

- [x] 14 observer tests: happy path, pending cache semantics (size/TTL/sweep/eviction), call-result correlation, all 10 handlers wrapped, normalize-path activation, timeout-on-eviction, streaming tool-call first-delta path
- [x] 12 query tests: empty, single-tool, pair stitching, status=pending/done/timeout filters, tool_name + source + ownership filters, time-range, MCP + HTTP roundtrip
- [x] Regression: \`go test ./internal/engine/... -short -race -count=1\` silent
- [x] Full module: \`go test ./... -short -race -count=1\` pass
- [x] \`go build ./...\` + \`go vet ./...\` silent

## Not in scope

- Anthropic-side pending-register + resolve (v1.5, per spec §5.1)
- Dedicated \`/v1/tool-calls/stream\` SSE endpoint (v1.5, deferred until PR #16 broker lands — meanwhile \`cog_tail_tool_calls\` rides Agent N's broker)
- Per-tool PII redaction policies (v1.5, per spec §7.6 — v1 ships \`include_args\`/\`include_output\` as default-off)
- \`RunToolLoop\` activation (separate spike)

## Self-reflective note

\`cog_read_tool_calls\` and \`cog_tail_tool_calls\` both flow through \`withToolObserver\` themselves — querying tool calls is itself a queryable tool call. This is the self-similar-bootstrap principle in practice: the introspection surface observes its own use.

## Design reference

\`cog://mem/semantic/surveys/2026-04-21-consolidation/agent-S-tool-bridge-design.cog.md\` (813 lines)