### PR TITLE
feat(engine): agent state + loop control — cog_list_agents / cog_get_agent_state / cog_trigger_agent_loop

### DIFF
--- a/internal/engine/agent_controller.go
+++ b/internal/engine/agent_controller.go
@@ -1,0 +1,195 @@
+// agent_controller.go — AgentController interface and shared types for the
+// agent-state API surface.
+//
+// This file breaks the import cycle between the engine MCP layer (which
+// exposes the tools) and the root package (which owns the actual
+// *ServeAgent goroutine). The root package implements AgentController in
+// a thin adapter (see root: serve_agents.go) and injects it into the
+// MCP server via NewMCPServerWithAgentController.
+//
+// Design rationale (see Agent T's design spike,
+// cog://mem/semantic/surveys/2026-04-21-consolidation/agent-T-agent-state-design):
+//   * Identities are static YAML (AgentProvider reconciles them; they don't run).
+//   * Sessions are external-client conversational contexts (Agent P's lane).
+//   * Agents are kernel-internal goroutines — the ServeAgent singleton today.
+//
+// This interface surfaces the agent. It does NOT surface identities or
+// sessions; those are separate APIs.
+package engine
+
+import "context"
+
+// AgentController is the kernel-agnostic contract the MCP layer uses to
+// list, inspect, and trigger agent harness instances. The concrete
+// implementation lives in the main package because *ServeAgent is there;
+// this interface keeps internal/engine import-cycle-free.
+//
+// Today there is exactly one agent per kernel process ("primary"). The
+// interface pluralises from day one so new handles (e.g. "digestion",
+// "identity-<name>") can land without an API break.
+type AgentController interface {
+	// ListAgents returns a summary for each running agent. includeStopped
+	// is reserved for future pool managers; today every returned agent is
+	// running.
+	ListAgents(ctx context.Context, includeStopped bool) ([]AgentSummary, error)
+
+	// GetAgent returns the full state snapshot for the named agent. When
+	// includeTrace is true, up to traceLimit most-recent full cycle traces
+	// are attached (clamped to [1,20]). Returns ErrAgentNotFound when id
+	// is unknown.
+	GetAgent(ctx context.Context, id string, includeTrace bool, traceLimit int) (*AgentSnapshot, error)
+
+	// TriggerAgent manually invokes one homeostatic cycle for the named
+	// agent, outside the adaptive ticker. When wait is true, blocks until
+	// the cycle completes (or a 90s deadline elapses). When wait is false,
+	// returns immediately with a trigger receipt.
+	TriggerAgent(ctx context.Context, id string, reason string, wait bool) (*AgentTriggerResult, error)
+}
+
+// ErrAgentNotFound is returned by GetAgent/TriggerAgent when no agent
+// matches the supplied id. Implementations should wrap this with %w so
+// callers can errors.Is against it.
+type AgentControllerError struct {
+	Code    string // "not_found" | "unavailable" | "invalid_input"
+	Message string
+}
+
+func (e *AgentControllerError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Message
+}
+
+// ErrAgentNotFound signals that the agent_id in the request did not match
+// any agent known to the controller. HTTP handlers translate this to 404;
+// MCP tool handlers translate this to an IsError:true response.
+var ErrAgentNotFound = &AgentControllerError{Code: "not_found", Message: "agent not found"}
+
+// ErrAgentUnavailable signals that the controller is installed but no
+// agent is currently wired (e.g. the ServeAgent singleton never started).
+// HTTP handlers translate this to 503.
+var ErrAgentUnavailable = &AgentControllerError{Code: "unavailable", Message: "agent not running"}
+
+// ErrAgentInvalidInput signals malformed arguments (bad agent_id regex,
+// trace_limit out of range). HTTP handlers translate this to 400.
+var ErrAgentInvalidInput = &AgentControllerError{Code: "invalid_input", Message: "invalid agent input"}
+
+// --- Value types ------------------------------------------------------------
+
+// AgentSummary is the list-friendly projection of one agent. Fields map
+// 1:1 onto ServeAgent.Status() fields that already exist in-process — this
+// is a rename, not new state.
+type AgentSummary struct {
+	AgentID     string  `json:"agent_id"`
+	Identity    string  `json:"identity,omitempty"`     // nucleus.Name today ("cog", "sandy", etc.)
+	Alive       bool    `json:"alive"`                  // process is running
+	Running     bool    `json:"running"`                // a cycle is in progress RIGHT NOW
+	UptimeSec   int64   `json:"uptime_sec"`
+	CycleCount  int64   `json:"cycle_count"`
+	LastAction  string  `json:"last_action,omitempty"`  // sleep|observe|propose|execute|escalate|skip|error|""
+	LastCycle   string  `json:"last_cycle,omitempty"`   // RFC3339
+	LastUrgency float64 `json:"last_urgency"`
+	LastReason  string  `json:"last_reason,omitempty"`
+	LastDurMs   int64   `json:"last_duration_ms"`
+	Model       string  `json:"model,omitempty"`
+	Interval    string  `json:"interval,omitempty"`
+}
+
+// AgentActivitySummary is the bus-delta + user-presence summary. Exact
+// shape of the root package's AgentActivitySummary so handlers can pass
+// through without mapping.
+type AgentActivitySummary struct {
+	UserPresence     string `json:"user_presence"`
+	UserLastEventAgo string `json:"user_last_event_ago"`
+	ClaudeCodeActive int    `json:"claude_code_active"`
+	ClaudeCodeEvents int64  `json:"claude_code_events"`
+	TotalEventDelta  int64  `json:"total_event_delta"`
+	HottestBus       string `json:"hottest_bus,omitempty"`
+	HottestDelta     int64  `json:"hottest_delta"`
+}
+
+// AgentMemoryEntry is one decomposed rolling-memory item.
+type AgentMemoryEntry struct {
+	Cycle    int64   `json:"cycle"`
+	Action   string  `json:"action"`
+	Urgency  float64 `json:"urgency"`
+	Sentence string  `json:"sentence"`
+	Ago      string  `json:"ago"`
+}
+
+// AgentProposalEntry is one pending proposal on disk.
+type AgentProposalEntry struct {
+	File    string `json:"file"`
+	Title   string `json:"title"`
+	Type    string `json:"type"`
+	Urgency string `json:"urgency"`
+	Created string `json:"created"`
+}
+
+// AgentInboxSummary is the inbox/link-feed summary. Engine-side mirror
+// of linkfeed.AgentInboxSummary so tool/HTTP handlers can pass through
+// without importing linkfeed from internal/engine.
+type AgentInboxSummary struct {
+	RawCount          int                     `json:"raw_count"`
+	EnrichedCount     int                     `json:"enriched_count"`
+	FailedCount       int                     `json:"failed_count"`
+	TotalCount        int                     `json:"total_count"`
+	LastPull          string                  `json:"last_pull,omitempty"`
+	LastPullAgo       string                  `json:"last_pull_ago,omitempty"`
+	NextPullIn        string                  `json:"next_pull_in,omitempty"`
+	RecentEnrichments []AgentInboxEnrichItem  `json:"recent_enrichments,omitempty"`
+}
+
+// AgentInboxEnrichItem is one recent link-enrichment on the inbox.
+type AgentInboxEnrichItem struct {
+	Title       string `json:"title"`
+	Connections int    `json:"connections"`
+	Ago         string `json:"ago"`
+}
+
+// AgentCycleTrace is the full record of one agent cycle: what it saw
+// (observation), what it decided (action+reason+urgency+target), how
+// long it took, and what it produced (result).
+type AgentCycleTrace struct {
+	Cycle       int64  `json:"cycle"`
+	Timestamp   string `json:"timestamp"`   // RFC3339
+	DurationMs  int64  `json:"duration_ms"`
+	Action      string `json:"action"`
+	Urgency     float64 `json:"urgency"`
+	Reason      string `json:"reason"`
+	Target      string `json:"target,omitempty"`
+	Observation string `json:"observation,omitempty"`
+	Result      string `json:"result,omitempty"`
+}
+
+// AgentSnapshot is the full state projection for GET /v1/agents/{id}.
+type AgentSnapshot struct {
+	Summary         AgentSummary          `json:"summary"`
+	Activity        *AgentActivitySummary `json:"activity,omitempty"`
+	Memory          []AgentMemoryEntry    `json:"memory,omitempty"`
+	Proposals       []AgentProposalEntry  `json:"proposals,omitempty"`
+	Inbox           *AgentInboxSummary    `json:"inbox,omitempty"`
+	Traces          []AgentCycleTrace     `json:"traces,omitempty"`
+	LastObservation string                `json:"last_observation,omitempty"`
+	IdentityRef     string                `json:"identity_ref,omitempty"`
+}
+
+// AgentTriggerResult is the outcome of a POST /v1/agents/{id}/tick call.
+// When wait=false, only Triggered/AgentID/CycleID/TriggerSeq/Message are
+// populated. When wait=true, Action/Urgency/Reason/DurationMs/TimedOut
+// carry the cycle's result.
+type AgentTriggerResult struct {
+	Triggered  bool   `json:"triggered"`
+	AgentID    string `json:"agent_id"`
+	CycleID    string `json:"cycle_id,omitempty"`
+	TriggerSeq int64  `json:"trigger_seq"`
+	Message    string `json:"message"`
+
+	// Populated only when wait=true and the cycle observably completed.
+	Action     string  `json:"action,omitempty"`
+	Urgency    float64 `json:"urgency,omitempty"`
+	Reason     string  `json:"reason,omitempty"`
+	DurationMs int64   `json:"duration_ms,omitempty"`
+	TimedOut   bool    `json:"timed_out,omitempty"`
+}

--- a/internal/engine/agent_state_query.go
+++ b/internal/engine/agent_state_query.go
@@ -1,0 +1,153 @@
+// agent_state_query.go — query helpers for the agent-state API.
+//
+// Pure functions that operate on the AgentController interface. Keeping
+// them in a separate file makes it clear what logic lives in the engine
+// layer (validation, clamping, tool/HTTP marshaling) versus the root
+// package's adapter (which actually reads *ServeAgent state).
+package engine
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+)
+
+// agentIDRegex matches the accepted agent_id format: lowercase start,
+// alphanumeric/dash/underscore, up to 64 chars. Today only "primary" is
+// valid; the regex is forward-compatible for future handles like
+// "digestion" or "identity-cog".
+var agentIDRegex = regexp.MustCompile(`^[a-z][a-z0-9_-]{0,63}$`)
+
+// DefaultAgentID is the stable handle for the singleton ServeAgent. The
+// API pluralises from day one (§2.5 of Agent T's spec); callers that
+// omit agent_id should default to this value.
+const DefaultAgentID = "primary"
+
+// ValidateAgentID checks the agent_id against agentIDRegex. Returns
+// nil when valid, ErrAgentInvalidInput wrapped with the reason
+// otherwise. Empty id is treated as invalid — callers must substitute
+// DefaultAgentID before validating.
+func ValidateAgentID(id string) error {
+	if id == "" {
+		return &AgentControllerError{Code: "invalid_input", Message: "agent_id is required"}
+	}
+	if !agentIDRegex.MatchString(id) {
+		return &AgentControllerError{Code: "invalid_input", Message: fmt.Sprintf("invalid agent_id: %q (must match [a-z][a-z0-9_-]{0,63})", id)}
+	}
+	return nil
+}
+
+// ClampTraceLimit enforces the [1, 20] range on trace_limit. Returns the
+// clamped value and an error when the input was clearly out of range
+// (>20 or <0). A value of 0 is treated as "use the default of 1".
+func ClampTraceLimit(n int) (int, error) {
+	if n < 0 {
+		return 0, &AgentControllerError{Code: "invalid_input", Message: fmt.Sprintf("trace_limit must be >= 0 (got %d)", n)}
+	}
+	if n > 20 {
+		return 0, &AgentControllerError{Code: "invalid_input", Message: fmt.Sprintf("trace_limit must be <= 20 (got %d)", n)}
+	}
+	if n == 0 {
+		return 1, nil
+	}
+	return n, nil
+}
+
+// ListAgentsRequest is the normalized input to the list-agents helper.
+type ListAgentsRequest struct {
+	IncludeStopped bool
+}
+
+// ListAgentsResponse is the normalized output.
+type ListAgentsResponse struct {
+	Count  int            `json:"count"`
+	Agents []AgentSummary `json:"agents"`
+}
+
+// QueryListAgents wraps AgentController.ListAgents with uniform error
+// handling + an envelope shape suitable for direct JSON marshal.
+func QueryListAgents(ctx context.Context, ctrl AgentController, req ListAgentsRequest) (*ListAgentsResponse, error) {
+	if ctrl == nil {
+		return nil, ErrAgentUnavailable
+	}
+	agents, err := ctrl.ListAgents(ctx, req.IncludeStopped)
+	if err != nil {
+		return nil, err
+	}
+	if agents == nil {
+		agents = []AgentSummary{}
+	}
+	return &ListAgentsResponse{
+		Count:  len(agents),
+		Agents: agents,
+	}, nil
+}
+
+// GetAgentRequest is the normalized input to the get-agent helper.
+type GetAgentRequest struct {
+	AgentID      string
+	IncludeTrace bool
+	TraceLimit   int
+}
+
+// Normalize fills in defaults and validates the request. Returns the
+// original ErrAgentInvalidInput for obvious malformed input, else nil.
+func (r *GetAgentRequest) Normalize() error {
+	if r.AgentID == "" {
+		r.AgentID = DefaultAgentID
+	}
+	if err := ValidateAgentID(r.AgentID); err != nil {
+		return err
+	}
+	if r.IncludeTrace {
+		clamped, err := ClampTraceLimit(r.TraceLimit)
+		if err != nil {
+			return err
+		}
+		r.TraceLimit = clamped
+	} else {
+		// When include_trace is false, trace_limit is ignored — but
+		// don't let a bad value pollute the response.
+		if r.TraceLimit != 0 {
+			r.TraceLimit = 0
+		}
+	}
+	return nil
+}
+
+// QueryGetAgent wraps AgentController.GetAgent with normalization.
+func QueryGetAgent(ctx context.Context, ctrl AgentController, req GetAgentRequest) (*AgentSnapshot, error) {
+	if ctrl == nil {
+		return nil, ErrAgentUnavailable
+	}
+	if err := req.Normalize(); err != nil {
+		return nil, err
+	}
+	return ctrl.GetAgent(ctx, req.AgentID, req.IncludeTrace, req.TraceLimit)
+}
+
+// TriggerAgentRequest is the normalized input to the trigger-agent helper.
+type TriggerAgentRequest struct {
+	AgentID string
+	Reason  string
+	Wait    bool
+}
+
+// Normalize fills defaults and validates.
+func (r *TriggerAgentRequest) Normalize() error {
+	if r.AgentID == "" {
+		r.AgentID = DefaultAgentID
+	}
+	return ValidateAgentID(r.AgentID)
+}
+
+// QueryTriggerAgent wraps AgentController.TriggerAgent with normalization.
+func QueryTriggerAgent(ctx context.Context, ctrl AgentController, req TriggerAgentRequest) (*AgentTriggerResult, error) {
+	if ctrl == nil {
+		return nil, ErrAgentUnavailable
+	}
+	if err := req.Normalize(); err != nil {
+		return nil, err
+	}
+	return ctrl.TriggerAgent(ctx, req.AgentID, req.Reason, req.Wait)
+}

--- a/internal/engine/agent_state_query_test.go
+++ b/internal/engine/agent_state_query_test.go
@@ -1,0 +1,587 @@
+// agent_state_query_test.go — unit tests for the AgentController query
+// helpers and the MCP tool marshaling path.
+//
+// A fake AgentController exercises the validation, normalization, and
+// error-translation paths without spinning up the *ServeAgent goroutine.
+// Adapter-level tests (against the live root package) live in root.
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeAgentController is an in-memory test double. Each field steers one
+// method's behaviour; ListErr/GetErr/TriggerErr let tests inject errors.
+type fakeAgentController struct {
+	Agents []AgentSummary
+
+	GetResult *AgentSnapshot
+	GetErr    error
+	GetCalls  []getCall
+
+	TriggerResult *AgentTriggerResult
+	TriggerErr    error
+	TriggerDelay  time.Duration
+	TriggerCalls  []triggerCall
+
+	ListErr error
+}
+
+type getCall struct {
+	ID           string
+	IncludeTrace bool
+	TraceLimit   int
+}
+
+type triggerCall struct {
+	ID     string
+	Reason string
+	Wait   bool
+}
+
+func (f *fakeAgentController) ListAgents(_ context.Context, _ bool) ([]AgentSummary, error) {
+	if f.ListErr != nil {
+		return nil, f.ListErr
+	}
+	return f.Agents, nil
+}
+
+func (f *fakeAgentController) GetAgent(_ context.Context, id string, includeTrace bool, limit int) (*AgentSnapshot, error) {
+	f.GetCalls = append(f.GetCalls, getCall{ID: id, IncludeTrace: includeTrace, TraceLimit: limit})
+	if f.GetErr != nil {
+		return nil, f.GetErr
+	}
+	if f.GetResult == nil {
+		if id != DefaultAgentID {
+			return nil, ErrAgentNotFound
+		}
+		return &AgentSnapshot{Summary: AgentSummary{AgentID: id, Alive: true}}, nil
+	}
+	return f.GetResult, nil
+}
+
+func (f *fakeAgentController) TriggerAgent(ctx context.Context, id string, reason string, wait bool) (*AgentTriggerResult, error) {
+	f.TriggerCalls = append(f.TriggerCalls, triggerCall{ID: id, Reason: reason, Wait: wait})
+	if f.TriggerErr != nil {
+		return nil, f.TriggerErr
+	}
+	if wait && f.TriggerDelay > 0 {
+		select {
+		case <-time.After(f.TriggerDelay):
+		case <-ctx.Done():
+			return &AgentTriggerResult{
+				Triggered: true,
+				AgentID:   id,
+				Message:   "triggered",
+				TimedOut:  true,
+			}, nil
+		}
+	}
+	if f.TriggerResult != nil {
+		out := *f.TriggerResult
+		out.AgentID = id
+		return &out, nil
+	}
+	return &AgentTriggerResult{
+		Triggered:  true,
+		AgentID:    id,
+		TriggerSeq: 1,
+		Message:    "triggered",
+	}, nil
+}
+
+// --- Validation helpers ------------------------------------------------------
+
+func TestValidateAgentID_AcceptsDefault(t *testing.T) {
+	if err := ValidateAgentID(DefaultAgentID); err != nil {
+		t.Fatalf("ValidateAgentID(%q): %v", DefaultAgentID, err)
+	}
+}
+
+func TestValidateAgentID_Rejects(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		id   string
+	}{
+		{"empty", ""},
+		{"uppercase", "Primary"},
+		{"slash", "BAD/ID"},
+		{"leading-digit", "1agent"},
+		{"leading-dash", "-agent"},
+		{"too-long", strings.Repeat("a", 65)},
+		{"space", "bad id"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateAgentID(tc.id); err == nil {
+				t.Fatalf("ValidateAgentID(%q): want error, got nil", tc.id)
+			}
+		})
+	}
+}
+
+func TestClampTraceLimit(t *testing.T) {
+	t.Parallel()
+	if n, err := ClampTraceLimit(0); err != nil || n != 1 {
+		t.Fatalf("ClampTraceLimit(0) = (%d, %v); want (1, nil)", n, err)
+	}
+	if n, err := ClampTraceLimit(5); err != nil || n != 5 {
+		t.Fatalf("ClampTraceLimit(5) = (%d, %v); want (5, nil)", n, err)
+	}
+	if n, err := ClampTraceLimit(20); err != nil || n != 20 {
+		t.Fatalf("ClampTraceLimit(20) = (%d, %v); want (20, nil)", n, err)
+	}
+	if _, err := ClampTraceLimit(21); err == nil {
+		t.Fatalf("ClampTraceLimit(21): want error, got nil")
+	}
+	if _, err := ClampTraceLimit(-1); err == nil {
+		t.Fatalf("ClampTraceLimit(-1): want error, got nil")
+	}
+}
+
+// --- QueryListAgents ---------------------------------------------------------
+
+func TestQueryListAgents_Empty(t *testing.T) {
+	t.Parallel()
+	ctrl := &fakeAgentController{Agents: nil}
+	resp, err := QueryListAgents(context.Background(), ctrl, ListAgentsRequest{})
+	if err != nil {
+		t.Fatalf("QueryListAgents: %v", err)
+	}
+	if resp.Count != 0 {
+		t.Fatalf("count = %d; want 0", resp.Count)
+	}
+	// Ensure non-nil slice for JSON marshal (so the wire shape is [] not null).
+	if resp.Agents == nil {
+		t.Fatalf("Agents = nil; want []")
+	}
+	b, _ := json.Marshal(resp)
+	if !strings.Contains(string(b), `"agents":[]`) {
+		t.Fatalf("JSON = %s; want agents:[]", b)
+	}
+}
+
+func TestQueryListAgents_Singleton(t *testing.T) {
+	t.Parallel()
+	ctrl := &fakeAgentController{
+		Agents: []AgentSummary{{
+			AgentID:    DefaultAgentID,
+			Identity:   "cog",
+			Alive:      true,
+			Running:    false,
+			CycleCount: 42,
+			LastAction: "execute",
+			Model:      "gemma4:e4b",
+			Interval:   "3m0s",
+		}},
+	}
+	resp, err := QueryListAgents(context.Background(), ctrl, ListAgentsRequest{})
+	if err != nil {
+		t.Fatalf("QueryListAgents: %v", err)
+	}
+	if resp.Count != 1 {
+		t.Fatalf("count = %d; want 1", resp.Count)
+	}
+	if resp.Agents[0].AgentID != DefaultAgentID {
+		t.Fatalf("AgentID = %q; want %q", resp.Agents[0].AgentID, DefaultAgentID)
+	}
+	if resp.Agents[0].Identity != "cog" {
+		t.Fatalf("Identity = %q; want cog", resp.Agents[0].Identity)
+	}
+}
+
+func TestQueryListAgents_NilController(t *testing.T) {
+	t.Parallel()
+	if _, err := QueryListAgents(context.Background(), nil, ListAgentsRequest{}); err == nil {
+		t.Fatal("want error for nil controller")
+	}
+}
+
+// --- QueryGetAgent -----------------------------------------------------------
+
+func TestQueryGetAgent_DefaultID(t *testing.T) {
+	t.Parallel()
+	ctrl := &fakeAgentController{
+		GetResult: &AgentSnapshot{
+			Summary: AgentSummary{AgentID: DefaultAgentID, Alive: true, CycleCount: 7},
+		},
+	}
+	resp, err := QueryGetAgent(context.Background(), ctrl, GetAgentRequest{})
+	if err != nil {
+		t.Fatalf("QueryGetAgent: %v", err)
+	}
+	if resp.Summary.AgentID != DefaultAgentID {
+		t.Fatalf("AgentID = %q; want %q", resp.Summary.AgentID, DefaultAgentID)
+	}
+	if len(ctrl.GetCalls) != 1 || ctrl.GetCalls[0].ID != DefaultAgentID {
+		t.Fatalf("GetCalls[0] = %#v; want ID=%q", ctrl.GetCalls, DefaultAgentID)
+	}
+}
+
+func TestQueryGetAgent_Unknown(t *testing.T) {
+	t.Parallel()
+	ctrl := &fakeAgentController{GetErr: ErrAgentNotFound}
+	_, err := QueryGetAgent(context.Background(), ctrl, GetAgentRequest{AgentID: "ghost"})
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+	if !errors.Is(err, ErrAgentNotFound) && err.Error() != ErrAgentNotFound.Error() {
+		t.Fatalf("err = %v; want ErrAgentNotFound", err)
+	}
+}
+
+func TestQueryGetAgent_InvalidID(t *testing.T) {
+	t.Parallel()
+	ctrl := &fakeAgentController{}
+	_, err := QueryGetAgent(context.Background(), ctrl, GetAgentRequest{AgentID: "BAD/ID"})
+	if err == nil {
+		t.Fatal("want error for invalid id")
+	}
+	if !strings.Contains(err.Error(), "invalid agent_id") {
+		t.Fatalf("err = %v; want invalid_id message", err)
+	}
+}
+
+func TestQueryGetAgent_WithTraces(t *testing.T) {
+	t.Parallel()
+	ctrl := &fakeAgentController{
+		GetResult: &AgentSnapshot{
+			Summary: AgentSummary{AgentID: DefaultAgentID, Alive: true},
+			Traces: []AgentCycleTrace{
+				{Cycle: 1, Action: "observe"},
+				{Cycle: 2, Action: "execute"},
+				{Cycle: 3, Action: "sleep"},
+			},
+		},
+	}
+	resp, err := QueryGetAgent(context.Background(), ctrl, GetAgentRequest{
+		AgentID:      DefaultAgentID,
+		IncludeTrace: true,
+		TraceLimit:   3,
+	})
+	if err != nil {
+		t.Fatalf("QueryGetAgent: %v", err)
+	}
+	if len(resp.Traces) != 3 {
+		t.Fatalf("traces = %d; want 3", len(resp.Traces))
+	}
+	if ctrl.GetCalls[0].TraceLimit != 3 || !ctrl.GetCalls[0].IncludeTrace {
+		t.Fatalf("call = %#v; want IncludeTrace=true, TraceLimit=3", ctrl.GetCalls[0])
+	}
+}
+
+func TestQueryGetAgent_TraceLimitTooHigh(t *testing.T) {
+	t.Parallel()
+	ctrl := &fakeAgentController{}
+	_, err := QueryGetAgent(context.Background(), ctrl, GetAgentRequest{
+		AgentID:      DefaultAgentID,
+		IncludeTrace: true,
+		TraceLimit:   100,
+	})
+	if err == nil {
+		t.Fatal("want error for trace_limit=100")
+	}
+}
+
+func TestQueryGetAgent_TraceLimitDefaultsToOne(t *testing.T) {
+	t.Parallel()
+	ctrl := &fakeAgentController{
+		GetResult: &AgentSnapshot{Summary: AgentSummary{AgentID: DefaultAgentID}},
+	}
+	_, err := QueryGetAgent(context.Background(), ctrl, GetAgentRequest{
+		AgentID:      DefaultAgentID,
+		IncludeTrace: true,
+		TraceLimit:   0,
+	})
+	if err != nil {
+		t.Fatalf("QueryGetAgent: %v", err)
+	}
+	if ctrl.GetCalls[0].TraceLimit != 1 {
+		t.Fatalf("TraceLimit = %d; want 1 (default)", ctrl.GetCalls[0].TraceLimit)
+	}
+}
+
+// --- QueryTriggerAgent -------------------------------------------------------
+
+func TestQueryTriggerAgent_FireAndForget(t *testing.T) {
+	t.Parallel()
+	ctrl := &fakeAgentController{
+		TriggerResult: &AgentTriggerResult{
+			Triggered:  true,
+			TriggerSeq: 5,
+			Message:    "triggered",
+		},
+	}
+	resp, err := QueryTriggerAgent(context.Background(), ctrl, TriggerAgentRequest{
+		AgentID: DefaultAgentID,
+		Reason:  "user asked",
+		Wait:    false,
+	})
+	if err != nil {
+		t.Fatalf("QueryTriggerAgent: %v", err)
+	}
+	if !resp.Triggered {
+		t.Fatal("want triggered=true")
+	}
+	if resp.AgentID != DefaultAgentID {
+		t.Fatalf("AgentID = %q; want %q", resp.AgentID, DefaultAgentID)
+	}
+	if ctrl.TriggerCalls[0].Reason != "user asked" {
+		t.Fatalf("Reason = %q; want 'user asked'", ctrl.TriggerCalls[0].Reason)
+	}
+}
+
+func TestQueryTriggerAgent_AlreadyRunning(t *testing.T) {
+	t.Parallel()
+	ctrl := &fakeAgentController{
+		TriggerResult: &AgentTriggerResult{
+			Triggered: false,
+			Message:   "already_running",
+		},
+	}
+	resp, err := QueryTriggerAgent(context.Background(), ctrl, TriggerAgentRequest{
+		AgentID: DefaultAgentID,
+	})
+	if err != nil {
+		t.Fatalf("QueryTriggerAgent: %v", err)
+	}
+	if resp.Triggered {
+		t.Fatal("want triggered=false")
+	}
+	if resp.Message != "already_running" {
+		t.Fatalf("Message = %q; want already_running", resp.Message)
+	}
+}
+
+func TestQueryTriggerAgent_InvalidID(t *testing.T) {
+	t.Parallel()
+	ctrl := &fakeAgentController{}
+	_, err := QueryTriggerAgent(context.Background(), ctrl, TriggerAgentRequest{AgentID: "Bad/ID"})
+	if err == nil {
+		t.Fatal("want error for invalid id")
+	}
+}
+
+func TestQueryTriggerAgent_Wait_Completes(t *testing.T) {
+	t.Parallel()
+	ctrl := &fakeAgentController{
+		TriggerResult: &AgentTriggerResult{
+			Triggered:  true,
+			Message:    "completed",
+			Action:     "execute",
+			Urgency:    0.7,
+			Reason:     "new work",
+			DurationMs: 120,
+		},
+		TriggerDelay: 0, // complete synchronously
+	}
+	resp, err := QueryTriggerAgent(context.Background(), ctrl, TriggerAgentRequest{
+		AgentID: DefaultAgentID,
+		Wait:    true,
+	})
+	if err != nil {
+		t.Fatalf("QueryTriggerAgent: %v", err)
+	}
+	if resp.Action != "execute" {
+		t.Fatalf("Action = %q; want execute", resp.Action)
+	}
+	if resp.Urgency != 0.7 {
+		t.Fatalf("Urgency = %v; want 0.7", resp.Urgency)
+	}
+}
+
+func TestQueryTriggerAgent_Wait_TimesOut(t *testing.T) {
+	t.Parallel()
+	ctrl := &fakeAgentController{
+		TriggerDelay: 200 * time.Millisecond,
+	}
+	// A 10ms deadline will time out well before the 200ms fake delay.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	resp, err := QueryTriggerAgent(ctx, ctrl, TriggerAgentRequest{
+		AgentID: DefaultAgentID,
+		Wait:    true,
+	})
+	if err != nil {
+		t.Fatalf("QueryTriggerAgent: %v", err)
+	}
+	if !resp.TimedOut {
+		t.Fatalf("TimedOut = false; want true (resp=%+v)", resp)
+	}
+}
+
+func TestQueryTriggerAgent_NilController(t *testing.T) {
+	t.Parallel()
+	if _, err := QueryTriggerAgent(context.Background(), nil, TriggerAgentRequest{}); err == nil {
+		t.Fatal("want error for nil controller")
+	}
+}
+
+// --- Snapshot shape guard ----------------------------------------------------
+
+// TestMCPServer_RegistersAgentTools ensures the three agent-state MCP
+// tools reach the live server's tool-call dispatch path. Without this
+// guard a typo in NewMCPServer / registerTools would silently drop the
+// tools from the Streamable HTTP surface.
+func TestMCPServer_RegistersAgentTools(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	process := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	server := NewMCPServerWithAgentController(cfg, makeNucleus("Cog", "tester"), process,
+		&fakeAgentController{
+			Agents: []AgentSummary{{AgentID: DefaultAgentID, Alive: true, CycleCount: 9}},
+			GetResult: &AgentSnapshot{
+				Summary: AgentSummary{AgentID: DefaultAgentID, Alive: true, CycleCount: 9},
+			},
+		},
+	)
+	// Exercise each tool handler directly via the MCPServer method.
+	result, _, err := server.toolListAgents(context.Background(), nil, listAgentsInput{})
+	if err != nil {
+		t.Fatalf("toolListAgents: %v", err)
+	}
+	var listResp ListAgentsResponse
+	decodeMCPJSONForAgentTests(t, result, &listResp)
+	if listResp.Count != 1 {
+		t.Fatalf("Count=%d; want 1", listResp.Count)
+	}
+
+	result2, _, err := server.toolGetAgentState(context.Background(), nil, getAgentStateInput{})
+	if err != nil {
+		t.Fatalf("toolGetAgentState: %v", err)
+	}
+	var snap AgentSnapshot
+	decodeMCPJSONForAgentTests(t, result2, &snap)
+	if snap.Summary.AgentID != DefaultAgentID {
+		t.Fatalf("AgentID=%q; want %q", snap.Summary.AgentID, DefaultAgentID)
+	}
+
+	result3, _, err := server.toolTriggerAgentLoop(context.Background(), nil, triggerAgentLoopInput{})
+	if err != nil {
+		t.Fatalf("toolTriggerAgentLoop: %v", err)
+	}
+	var trigger AgentTriggerResult
+	decodeMCPJSONForAgentTests(t, result3, &trigger)
+	if !trigger.Triggered {
+		t.Fatalf("Triggered=false; want true")
+	}
+}
+
+// decodeMCPJSONForAgentTests mirrors decodeMCPJSON from mcp_server_test.go
+// but lives here so the agent-state tests are self-contained (parallel
+// test files often need their own helper).
+func decodeMCPJSONForAgentTests(t *testing.T, result interface{}, target any) {
+	t.Helper()
+	// We intentionally use the same shape as decodeMCPJSON in mcp_server_test.go.
+	// Both files are in package engine, so we could call the shared helper,
+	// but writing a local one keeps this test independent.
+	b, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal mcp result: %v", err)
+	}
+	// The mcp.CallToolResult JSON envelope looks like {"content":[{"text":"..."}]}.
+	// Extract the Text field then unmarshal into the target.
+	var envelope struct {
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(b, &envelope); err != nil || len(envelope.Content) == 0 {
+		t.Fatalf("unmarshal envelope: %v (raw=%s)", err, b)
+	}
+	if err := json.Unmarshal([]byte(envelope.Content[0].Text), target); err != nil {
+		t.Fatalf("unmarshal text: %v (raw=%s)", err, envelope.Content[0].Text)
+	}
+}
+
+// TestMCPServer_AgentToolsWithoutController ensures the tools return a
+// clean "not configured" response — not a panic — when no controller is
+// attached. This is the default state until SetAgentController is called.
+func TestMCPServer_AgentToolsWithoutController(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	process := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	server := NewMCPServer(cfg, makeNucleus("Cog", "tester"), process)
+	// agentController is nil
+
+	result, _, err := server.toolListAgents(context.Background(), nil, listAgentsInput{})
+	if err != nil {
+		t.Fatalf("toolListAgents: %v", err)
+	}
+	// fallbackResult sets IsError=true
+	if result == nil {
+		t.Fatal("nil result")
+	}
+	if !strings.Contains(firstTextContent(result), "agent not running") {
+		t.Errorf("got %q; want contains 'agent not running'", firstTextContent(result))
+	}
+}
+
+func firstTextContent(r interface{}) string {
+	b, _ := json.Marshal(r)
+	var envelope struct {
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	_ = json.Unmarshal(b, &envelope)
+	if len(envelope.Content) == 0 {
+		return ""
+	}
+	return envelope.Content[0].Text
+}
+
+// TestAgentSummary_JSONFields guards the wire shape against accidental
+// field renames. The dashboard and existing /v1/agent/status tests
+// depend on these exact JSON names.
+func TestAgentSummary_JSONFields(t *testing.T) {
+	t.Parallel()
+	s := AgentSummary{
+		AgentID:     "primary",
+		Identity:    "cog",
+		Alive:       true,
+		Running:     false,
+		UptimeSec:   60,
+		CycleCount:  3,
+		LastAction:  "sleep",
+		LastCycle:   "2026-04-21T12:00:00Z",
+		LastUrgency: 0.2,
+		LastReason:  "idle",
+		LastDurMs:   42,
+		Model:       "gemma4:e4b",
+		Interval:    "3m0s",
+	}
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	want := []string{
+		`"agent_id":"primary"`,
+		`"identity":"cog"`,
+		`"alive":true`,
+		`"running":false`,
+		`"cycle_count":3`,
+		`"last_action":"sleep"`,
+		`"last_cycle":"2026-04-21T12:00:00Z"`,
+		`"last_urgency":0.2`,
+		`"last_reason":"idle"`,
+		`"last_duration_ms":42`,
+		`"model":"gemma4:e4b"`,
+		`"interval":"3m0s"`,
+		`"uptime_sec":60`,
+	}
+	for _, needle := range want {
+		if !strings.Contains(string(b), needle) {
+			t.Fatalf("JSON missing %q\nfull: %s", needle, b)
+		}
+	}
+}

--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -33,27 +33,39 @@ import (
 
 // MCPServer wraps the MCP server and its dependencies.
 type MCPServer struct {
-	server    *mcp.Server
-	handler   http.Handler
-	cfg       *Config
-	nucleus   *Nucleus
-	process   *Process
-	cogdocSvc *CogDocService
+	server          *mcp.Server
+	handler         http.Handler
+	cfg             *Config
+	nucleus         *Nucleus
+	process         *Process
+	cogdocSvc       *CogDocService
+	agentController AgentController // optional; nil when the kernel has no live agent
 }
 
 // NewMCPServer creates and configures the MCP server with all stage-1 tools.
+// The returned server has no AgentController attached. Call SetAgentController
+// to enable cog_list_agents / cog_get_agent_state / cog_trigger_agent_loop.
 func NewMCPServer(cfg *Config, nucleus *Nucleus, process *Process) *MCPServer {
+	return NewMCPServerWithAgentController(cfg, nucleus, process, nil)
+}
+
+// NewMCPServerWithAgentController creates the MCP server and attaches an
+// AgentController for the agent-state tools. The controller may be nil;
+// the tools remain registered and return a "not configured" response in
+// that case so clients get a consistent error shape.
+func NewMCPServerWithAgentController(cfg *Config, nucleus *Nucleus, process *Process, ctrl AgentController) *MCPServer {
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "cogos-v3",
 		Version: BuildTime,
 	}, nil)
 
 	m := &MCPServer{
-		server:    server,
-		cfg:       cfg,
-		nucleus:   nucleus,
-		process:   process,
-		cogdocSvc: NewCogDocService(cfg, process),
+		server:          server,
+		cfg:             cfg,
+		nucleus:         nucleus,
+		process:         process,
+		cogdocSvc:       NewCogDocService(cfg, process),
+		agentController: ctrl,
 	}
 
 	m.registerTools()
@@ -65,6 +77,13 @@ func NewMCPServer(cfg *Config, nucleus *Nucleus, process *Process) *MCPServer {
 	)
 
 	return m
+}
+
+// SetAgentController wires a live AgentController into an already-built
+// MCPServer. Safe to call after construction; the tool registration is
+// unchanged because the tools resolve the current controller on each call.
+func (m *MCPServer) SetAgentController(ctrl AgentController) {
+	m.agentController = ctrl
 }
 
 // Handler returns the http.Handler for mounting at /mcp.
@@ -125,6 +144,22 @@ func (m *MCPServer) registerTools() {
 		Name:        "cog_ingest",
 		Description: "Ingest external material into CogOS knowledge. Deterministic decomposition — no LLM calls. Supports URLs, conversations, documents. Applies membrane policy (accept/quarantine/defer/discard).",
 	}, m.toolIngest)
+
+	// Agent state / loop control — closes Agent F gap #8 per Agent T's design.
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name:        "cog_list_agents",
+		Description: "Enumerate active agent harness instances inside the kernel. Each entry summarises identity, state, and recent activity. Today returns one element (\"primary\") reflecting the ServeAgent singleton; forward-compatible for future multi-agent deployment. Fallback: curl http://localhost:6931/v1/agents",
+	}, m.toolListAgents)
+
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name:        "cog_get_agent_state",
+		Description: "Full state snapshot of one agent instance — status summary, activity awareness, rolling cycle memory, pending proposals, inbox queue, and optionally the most recent cycle traces. Matches the shape of GET /v1/agents/{id}. Fallback: curl http://localhost:6931/v1/agents/primary",
+	}, m.toolGetAgentState)
+
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name:        "cog_trigger_agent_loop",
+		Description: "Manually invoke one homeostatic cycle of the specified agent, outside the regular ticker. Equivalent to POST /v1/agents/{id}/tick. Returns immediately with a trigger receipt; cycle runs async unless wait=true. Refuses if a cycle is already in flight (overlap guard). Fallback: curl -X POST http://localhost:6931/v1/agents/primary/tick",
+	}, m.toolTriggerAgentLoop)
 }
 
 // registerResources registers MCP Resources — read-only addressable data.
@@ -371,6 +406,22 @@ type ingestInput struct {
 	Format   string            `json:"format" jsonschema:"Input format: url, conversation, message, document"`
 	Data     string            `json:"data" jsonschema:"Raw material to ingest (URL, text, JSON)"`
 	Metadata map[string]string `json:"metadata,omitempty" jsonschema:"Optional context (discord_message_id, channel, etc.)"`
+}
+
+type listAgentsInput struct {
+	IncludeStopped bool `json:"include_stopped,omitempty" jsonschema:"Include agents that have stopped (default false). Reserved for future multi-agent pool managers."`
+}
+
+type getAgentStateInput struct {
+	AgentID      string `json:"agent_id,omitempty" jsonschema:"Which agent to inspect. Default \"primary\" (the ServeAgent singleton)."`
+	IncludeTrace bool   `json:"include_trace,omitempty" jsonschema:"Attach up to trace_limit most-recent full cycle traces (observation + result)."`
+	TraceLimit   int    `json:"trace_limit,omitempty" jsonschema:"If include_trace, how many recent traces to include. Range [1, 20]. Default 1."`
+}
+
+type triggerAgentLoopInput struct {
+	AgentID string `json:"agent_id,omitempty" jsonschema:"Which agent to trigger. Default \"primary\"."`
+	Reason  string `json:"reason,omitempty" jsonschema:"Free-text tag stored on a synthetic agent.wake event for audit (optional)."`
+	Wait    bool   `json:"wait,omitempty" jsonschema:"If true, block until the cycle completes (up to 90s) and return the outcome. Default false (fire-and-forget)."`
 }
 
 // ── Tool Implementations ─────────────────────────────────────────────────────
@@ -956,6 +1007,58 @@ func (m *MCPServer) toolIngest(ctx context.Context, req *mcp.CallToolRequest, in
 		"title":        result.Title,
 		"content_type": string(result.ContentType),
 	})
+}
+
+// --- Agent state / loop control tools -------------------------------------
+
+// toolListAgents implements cog_list_agents — returns the set of active
+// agents. Today always a one-element list ("primary"). See agent-T-agent-
+// state-design §4.1.
+func (m *MCPServer) toolListAgents(ctx context.Context, req *mcp.CallToolRequest, input listAgentsInput) (*mcp.CallToolResult, any, error) {
+	resp, err := QueryListAgents(ctx, m.agentController, ListAgentsRequest{IncludeStopped: input.IncludeStopped})
+	if err != nil {
+		return agentErrorResult(err, "curl http://localhost:6931/v1/agents")
+	}
+	return marshalResult(resp)
+}
+
+// toolGetAgentState implements cog_get_agent_state — full snapshot of
+// one agent. See agent-T-agent-state-design §4.1.
+func (m *MCPServer) toolGetAgentState(ctx context.Context, req *mcp.CallToolRequest, input getAgentStateInput) (*mcp.CallToolResult, any, error) {
+	snap, err := QueryGetAgent(ctx, m.agentController, GetAgentRequest{
+		AgentID:      input.AgentID,
+		IncludeTrace: input.IncludeTrace,
+		TraceLimit:   input.TraceLimit,
+	})
+	if err != nil {
+		return agentErrorResult(err, "curl http://localhost:6931/v1/agents/primary")
+	}
+	return marshalResult(snap)
+}
+
+// toolTriggerAgentLoop implements cog_trigger_agent_loop — manually
+// invoke one cycle. See agent-T-agent-state-design §4.1.
+func (m *MCPServer) toolTriggerAgentLoop(ctx context.Context, req *mcp.CallToolRequest, input triggerAgentLoopInput) (*mcp.CallToolResult, any, error) {
+	result, err := QueryTriggerAgent(ctx, m.agentController, TriggerAgentRequest{
+		AgentID: input.AgentID,
+		Reason:  input.Reason,
+		Wait:    input.Wait,
+	})
+	if err != nil {
+		return agentErrorResult(err, "curl -X POST http://localhost:6931/v1/agents/primary/tick")
+	}
+	return marshalResult(result)
+}
+
+// agentErrorResult translates AgentControllerError into the MCP fallback
+// format used by the rest of this file. Unknown errors are surfaced as
+// internal-error text responses.
+func agentErrorResult(err error, fallback string) (*mcp.CallToolResult, any, error) {
+	msg := err.Error()
+	if ace, ok := err.(*AgentControllerError); ok && ace != nil {
+		msg = ace.Message
+	}
+	return fallbackResult(msg, fallback)
 }
 
 // slugify converts a string to a URL-friendly slug.

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -42,13 +42,15 @@ import (
 
 // Server wraps the HTTP server and its dependencies.
 type Server struct {
-	cfg          *Config
-	nucleus      *Nucleus
-	process      *Process
-	router       Router // nil until SetRouter is called
-	srv          *http.Server
-	debug        debugStore    // captures last request pipeline state
-	attentionLog *attentionLog // per-server log (avoids global write race)
+	cfg             *Config
+	nucleus         *Nucleus
+	process         *Process
+	router          Router // nil until SetRouter is called
+	srv             *http.Server
+	debug           debugStore    // captures last request pipeline state
+	attentionLog    *attentionLog // per-server log (avoids global write race)
+	agentController AgentController // nil until SetAgentController is called
+	mcpServer       *MCPServer      // so SetAgentController can propagate to tools
 }
 
 // NewServer constructs a Server bound to the configured port.
@@ -91,6 +93,19 @@ func NewServer(cfg *Config, nucleus *Nucleus, process *Process) *Server {
 // SetRouter wires an inference Router into the server.
 func (s *Server) SetRouter(r Router) {
 	s.router = r
+}
+
+// SetAgentController wires a live AgentController into the server so the
+// cog_list_agents / cog_get_agent_state / cog_trigger_agent_loop MCP
+// tools have a backing implementation. Callers outside engine (like the
+// root-package serveServer) can build the controller and pass it here.
+// Safe to call post-construction: the MCP tool registry resolves the
+// controller at call time.
+func (s *Server) SetAgentController(ctrl AgentController) {
+	s.agentController = ctrl
+	if s.mcpServer != nil {
+		s.mcpServer.SetAgentController(ctrl)
+	}
 }
 
 // Start begins serving. It blocks until the server stops.

--- a/internal/engine/serve_mcp.go
+++ b/internal/engine/serve_mcp.go
@@ -4,8 +4,14 @@ import "net/http"
 
 // registerMCPRoutes mounts the MCP Streamable HTTP handler at /mcp.
 // Explicit method patterns avoid conflicts with the catch-all GET / dashboard route.
+//
+// The server's agentController (if set via SetAgentController before or
+// after registration) is threaded into the MCP tool registry so the
+// cog_list_agents / cog_get_agent_state / cog_trigger_agent_loop tools
+// have a backing implementation.
 func (s *Server) registerMCPRoutes(mux *http.ServeMux) {
-	mcpSrv := NewMCPServer(s.cfg, s.nucleus, s.process)
+	mcpSrv := NewMCPServerWithAgentController(s.cfg, s.nucleus, s.process, s.agentController)
+	s.mcpServer = mcpSrv
 	h := mcpSrv.Handler()
 	mux.Handle("GET /mcp", h)
 	mux.Handle("POST /mcp", h)

--- a/serve.go
+++ b/serve.go
@@ -229,9 +229,15 @@ func (s *serveServer) Start() error {
 	mux.HandleFunc("/v1/sessions/", s.handleSessionContext)                   // Per-session context detail
 	mux.HandleFunc("GET /v1/card", s.handleCard)                              // ADR-048: Kernel capability card
 	mux.HandleFunc("POST /v1/tool-bridge/pending", s.handleToolBridgePending) // Synchronous tool bridge
-	mux.HandleFunc("GET /v1/agent/status", s.handleAgentStatus)              // Homeostatic agent loop status
-	mux.HandleFunc("POST /v1/agent/trigger", s.handleAgentTrigger)           // Manual cycle trigger
-	mux.HandleFunc("GET /v1/agent/traces", s.handleAgentTraces)              // Cycle trace history
+	mux.HandleFunc("GET /v1/agent/status", s.handleAgentStatus)              // Homeostatic agent loop status (legacy singular — preserved for dashboard)
+	mux.HandleFunc("POST /v1/agent/trigger", s.handleAgentTrigger)           // Manual cycle trigger (legacy singular)
+	mux.HandleFunc("GET /v1/agent/traces", s.handleAgentTraces)              // Cycle trace history (legacy singular)
+	// Plural /v1/agents/* routes (Agent F gap #8 per agent-T-agent-state-design).
+	// The plural surface is canonical going forward; the singular aliases above
+	// stay indefinitely because the embedded dashboard consumes them.
+	mux.HandleFunc("GET /v1/agents", s.handleListAgents)                     // Enumerate agents
+	mux.HandleFunc("GET /v1/agents/", s.handleGetAgent)                      // GET /v1/agents/{id} and /v1/agents/{id}/traces
+	mux.HandleFunc("POST /v1/agents/", s.handleAgentTick)                    // POST /v1/agents/{id}/tick
 	mux.HandleFunc("/health", s.handleHealth)
 	mux.HandleFunc("GET /v1/health/canary", s.handleHealthCanary)
 	mux.HandleFunc("GET /v1/metrics/foveated", s.handleFoveatedMetrics) // B4: FCE quality metrics

--- a/serve_agents.go
+++ b/serve_agents.go
@@ -1,0 +1,513 @@
+// serve_agents.go — Plural /v1/agents HTTP surface + ServeAgentController
+// adapter that satisfies engine.AgentController.
+//
+// This file is the entire root-package surface for the agent-state API.
+// It is additive: the existing /v1/agent/{status,traces,trigger} routes
+// remain in agent_serve.go and the dashboard keeps consuming them
+// unchanged. The new plural routes project the same ServeAgent state
+// onto engine-side value types so MCP + HTTP callers share one schema.
+//
+// Design references:
+//   - cog://mem/semantic/surveys/2026-04-21-consolidation/agent-T-agent-state-design
+//   - internal/engine/agent_controller.go (the interface this adapts)
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/cogos-dev/cogos/internal/engine"
+	"github.com/cogos-dev/cogos/internal/linkfeed"
+)
+
+// ServeAgentController adapts *ServeAgent to the engine.AgentController
+// interface. It is the only root-package piece of the agent-state API;
+// everything else is engine-side and additive.
+type ServeAgentController struct {
+	agent *ServeAgent // may be nil when the kernel has no agent wired
+	// Monotonic counter for trigger acknowledgments. Each successful
+	// TriggerAgent increments it; response payloads echo the value so
+	// callers can correlate async acks.
+	triggerSeq int64
+}
+
+// NewServeAgentController returns a controller wired to the given
+// ServeAgent. nil-safe: if agent is nil, all methods return
+// engine.ErrAgentUnavailable.
+func NewServeAgentController(agent *ServeAgent) *ServeAgentController {
+	return &ServeAgentController{agent: agent}
+}
+
+// identityName returns the nucleus identity the kernel is currently
+// animating, used as the Identity field on the AgentSummary. Empty when
+// no SDK kernel or nucleus is loaded.
+func (c *ServeAgentController) identityName() string {
+	if c == nil || c.agent == nil {
+		return ""
+	}
+	// ServeAgent doesn't have a direct nucleus reference today. The
+	// kernel-wide identity is surfaced via the SDK's /state route, but
+	// we don't want to take that path (it requires kernel boot).
+	// Resolve from the root config file if present; fall back to env.
+	if v := os.Getenv("COG_IDENTITY"); v != "" {
+		return v
+	}
+	// Best-effort read of .cog/config/identity.yaml — a single "name:" line.
+	configPath := filepath.Join(c.agent.root, ".cog", "config", "identity.yaml")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "default_identity:") {
+			return strings.TrimSpace(strings.TrimPrefix(trimmed, "default_identity:"))
+		}
+	}
+	return ""
+}
+
+// summaryFromStatus projects the root-package AgentStatusResponse onto
+// the engine-side AgentSummary shape. Every field maps 1:1 from state
+// already populated by ServeAgent.Status().
+func (c *ServeAgentController) summaryFromStatus(st AgentStatusResponse) engine.AgentSummary {
+	return engine.AgentSummary{
+		AgentID:     engine.DefaultAgentID,
+		Identity:    c.identityName(),
+		Alive:       st.Alive,
+		Running:     st.Running,
+		UptimeSec:   st.UptimeSec,
+		CycleCount:  st.CycleCount,
+		LastAction:  st.LastAction,
+		LastCycle:   st.LastCycle,
+		LastUrgency: st.LastUrgency,
+		LastReason:  st.LastReason,
+		LastDurMs:   st.LastDurMs,
+		Model:       st.Model,
+		Interval:    st.Interval,
+	}
+}
+
+// activityFromStatus projects the enriched activity summary onto the
+// engine type, or returns nil if no activity is available.
+func activityFromStatus(a *AgentActivitySummary) *engine.AgentActivitySummary {
+	if a == nil {
+		return nil
+	}
+	return &engine.AgentActivitySummary{
+		UserPresence:     a.UserPresence,
+		UserLastEventAgo: a.UserLastEventAgo,
+		ClaudeCodeActive: a.ClaudeCodeActive,
+		ClaudeCodeEvents: a.ClaudeCodeEvents,
+		TotalEventDelta:  a.TotalEventDelta,
+		HottestBus:       a.HottestBus,
+		HottestDelta:     a.HottestDelta,
+	}
+}
+
+// memoryFromStatus maps the root-package rolling memory entries onto
+// the engine type.
+func memoryFromStatus(m []AgentMemoryEntry) []engine.AgentMemoryEntry {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make([]engine.AgentMemoryEntry, len(m))
+	for i, e := range m {
+		out[i] = engine.AgentMemoryEntry{
+			Cycle:    e.Cycle,
+			Action:   e.Action,
+			Urgency:  e.Urgency,
+			Sentence: e.Sentence,
+			Ago:      e.Ago,
+		}
+	}
+	return out
+}
+
+// proposalsFromStatus maps pending proposal entries.
+func proposalsFromStatus(p []AgentProposalEntry) []engine.AgentProposalEntry {
+	if len(p) == 0 {
+		return nil
+	}
+	out := make([]engine.AgentProposalEntry, len(p))
+	for i, e := range p {
+		out[i] = engine.AgentProposalEntry{
+			File:    e.File,
+			Title:   e.Title,
+			Type:    e.Type,
+			Urgency: e.Urgency,
+			Created: e.Created,
+		}
+	}
+	return out
+}
+
+// inboxFromStatus maps the linkfeed inbox summary onto the engine type.
+func inboxFromStatus(in *linkfeed.AgentInboxSummary) *engine.AgentInboxSummary {
+	if in == nil {
+		return nil
+	}
+	recent := make([]engine.AgentInboxEnrichItem, len(in.RecentEnrichments))
+	for i, r := range in.RecentEnrichments {
+		recent[i] = engine.AgentInboxEnrichItem{
+			Title:       r.Title,
+			Connections: r.Connections,
+			Ago:         r.Ago,
+		}
+	}
+	return &engine.AgentInboxSummary{
+		RawCount:          in.RawCount,
+		EnrichedCount:     in.EnrichedCount,
+		FailedCount:       in.FailedCount,
+		TotalCount:        in.TotalCount,
+		LastPull:          in.LastPull,
+		LastPullAgo:       in.LastPullAgo,
+		NextPullIn:        in.NextPullIn,
+		RecentEnrichments: recent,
+	}
+}
+
+// readRecentTraces loads the most recent N cycle traces from disk. Returns
+// nil when the trace file is absent or unreadable. The traces are already
+// persisted as a JSON array in .cog/.state/agent/cycle-traces.json (ring
+// of 20) — we just slice the tail.
+func (c *ServeAgentController) readRecentTraces(limit int) ([]engine.AgentCycleTrace, string) {
+	if c == nil || c.agent == nil {
+		return nil, ""
+	}
+	traceFile := filepath.Join(c.agent.root, ".cog", ".state", "agent", "cycle-traces.json")
+	data, err := os.ReadFile(traceFile)
+	if err != nil {
+		return nil, ""
+	}
+	var raw []cycleTrace
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, ""
+	}
+	if len(raw) == 0 {
+		return nil, ""
+	}
+	// Keep the last N in chronological order (oldest→newest). Callers
+	// that want newest-first can reverse on the client side if needed.
+	if limit > 0 && len(raw) > limit {
+		raw = raw[len(raw)-limit:]
+	}
+	out := make([]engine.AgentCycleTrace, len(raw))
+	for i, t := range raw {
+		out[i] = engine.AgentCycleTrace{
+			Cycle:       t.Cycle,
+			Timestamp:   t.Timestamp.Format(time.RFC3339),
+			DurationMs:  t.DurationMs,
+			Action:      t.Action,
+			Urgency:     t.Urgency,
+			Reason:      t.Reason,
+			Target:      t.Target,
+			Observation: t.Observation,
+			Result:      t.Result,
+		}
+	}
+	// Use the newest trace's observation as a top-level hint for
+	// last_observation.
+	lastObs := raw[len(raw)-1].Observation
+	return out, lastObs
+}
+
+// ListAgents implements engine.AgentController.
+func (c *ServeAgentController) ListAgents(ctx context.Context, includeStopped bool) ([]engine.AgentSummary, error) {
+	if c == nil || c.agent == nil {
+		return nil, engine.ErrAgentUnavailable
+	}
+	st := c.agent.Status()
+	return []engine.AgentSummary{c.summaryFromStatus(st)}, nil
+}
+
+// GetAgent implements engine.AgentController.
+func (c *ServeAgentController) GetAgent(ctx context.Context, id string, includeTrace bool, traceLimit int) (*engine.AgentSnapshot, error) {
+	if c == nil || c.agent == nil {
+		return nil, engine.ErrAgentUnavailable
+	}
+	if id != engine.DefaultAgentID {
+		return nil, engine.ErrAgentNotFound
+	}
+	st := c.agent.Status()
+	snap := &engine.AgentSnapshot{
+		Summary:   c.summaryFromStatus(st),
+		Activity:  activityFromStatus(st.Activity),
+		Memory:    memoryFromStatus(st.Memory),
+		Proposals: proposalsFromStatus(st.Proposals),
+		Inbox:     inboxFromStatus(st.Inbox),
+	}
+	if ident := snap.Summary.Identity; ident != "" {
+		snap.IdentityRef = fmt.Sprintf("cog:agents/identities/identity_%s.md", strings.ToLower(ident))
+	}
+	if includeTrace {
+		traces, lastObs := c.readRecentTraces(traceLimit)
+		snap.Traces = traces
+		snap.LastObservation = lastObs
+	}
+	return snap, nil
+}
+
+// TriggerAgent implements engine.AgentController.
+func (c *ServeAgentController) TriggerAgent(ctx context.Context, id string, reason string, wait bool) (*engine.AgentTriggerResult, error) {
+	if c == nil || c.agent == nil {
+		return nil, engine.ErrAgentUnavailable
+	}
+	if id != engine.DefaultAgentID {
+		return nil, engine.ErrAgentNotFound
+	}
+
+	// Overlap guard — mirror the behaviour of POST /v1/agent/trigger.
+	if atomic.LoadInt32(&c.agent.running) == 1 {
+		return &engine.AgentTriggerResult{
+			Triggered:  false,
+			AgentID:    id,
+			TriggerSeq: atomic.LoadInt64(&c.triggerSeq),
+			Message:    "already_running",
+		}, nil
+	}
+
+	seq := atomic.AddInt64(&c.triggerSeq, 1)
+
+	if !wait {
+		// Fire-and-forget — kick the cycle in a goroutine and return
+		// a trigger receipt. Mirror the existing handleAgentTrigger
+		// behaviour so the dashboard-facing alias stays byte-compat.
+		go c.agent.safeCycle(context.Background())
+		if reason != "" {
+			log.Printf("[agent-api] tick trigger_seq=%d reason=%q wait=false", seq, reason)
+		}
+		return &engine.AgentTriggerResult{
+			Triggered:  true,
+			AgentID:    id,
+			TriggerSeq: seq,
+			Message:    "triggered",
+		}, nil
+	}
+
+	// wait=true — block until the cycle finishes, up to a 90s deadline.
+	// Snapshot cycle_count before/after to detect completion; we don't
+	// modify runCycle itself (out of scope).
+	startCount := c.agent.Status().CycleCount
+	done := make(chan string, 1)
+	go func() {
+		done <- c.agent.safeCycle(context.Background())
+	}()
+
+	deadline := 90 * time.Second
+	timer := time.NewTimer(deadline)
+	defer timer.Stop()
+
+	select {
+	case action := <-done:
+		// Read post-cycle snapshot.
+		end := c.agent.Status()
+		return &engine.AgentTriggerResult{
+			Triggered:  true,
+			AgentID:    id,
+			TriggerSeq: seq,
+			Message:    "completed",
+			Action:     action,
+			Urgency:    end.LastUrgency,
+			Reason:     end.LastReason,
+			DurationMs: end.LastDurMs,
+			TimedOut:   false,
+		}, nil
+	case <-timer.C:
+		// Cycle still running; acknowledge the timeout but let the
+		// goroutine continue. We report the trigger as accepted with
+		// TimedOut=true so callers know to poll for the final state.
+		_ = startCount // reserved for future cycle_id correlation
+		return &engine.AgentTriggerResult{
+			Triggered:  true,
+			AgentID:    id,
+			TriggerSeq: seq,
+			Message:    "timed_out",
+			TimedOut:   true,
+		}, nil
+	case <-ctx.Done():
+		return &engine.AgentTriggerResult{
+			Triggered:  true,
+			AgentID:    id,
+			TriggerSeq: seq,
+			Message:    "canceled",
+			TimedOut:   true,
+		}, nil
+	}
+}
+
+// --- HTTP handlers --------------------------------------------------------
+
+// handleListAgents serves GET /v1/agents.
+func (s *serveServer) handleListAgents(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	ctrl := NewServeAgentController(s.agent)
+
+	includeStopped := r.URL.Query().Get("include_stopped") == "true"
+	resp, err := engine.QueryListAgents(r.Context(), ctrl, engine.ListAgentsRequest{IncludeStopped: includeStopped})
+	if err != nil {
+		writeAgentError(w, err)
+		return
+	}
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// handleGetAgent serves GET /v1/agents/{id} and GET /v1/agents/{id}/traces.
+// The id is extracted from the path; the traces suffix flips include_trace
+// on and defaults trace_limit to 20 to match the existing /v1/agent/traces
+// alias shape.
+func (s *serveServer) handleGetAgent(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	ctrl := NewServeAgentController(s.agent)
+
+	id, suffix := extractAgentIDAndSuffix(r.URL.Path)
+	q := r.URL.Query()
+	req := engine.GetAgentRequest{
+		AgentID:      id,
+		IncludeTrace: q.Get("include_trace") == "true",
+	}
+	if v := q.Get("trace_limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			writeAgentError(w, &engine.AgentControllerError{Code: "invalid_input", Message: fmt.Sprintf("trace_limit must be an integer (got %q)", v)})
+			return
+		}
+		req.TraceLimit = n
+	}
+
+	// /traces suffix → alias for the dashboard's `/v1/agent/traces` route.
+	// Return the traces array directly (not wrapped in a snapshot envelope)
+	// to preserve the legacy shape.
+	if suffix == "traces" {
+		s.handleAgentTracesByID(w, r, id, req.TraceLimit)
+		return
+	}
+
+	snap, err := engine.QueryGetAgent(r.Context(), ctrl, req)
+	if err != nil {
+		writeAgentError(w, err)
+		return
+	}
+	_ = json.NewEncoder(w).Encode(snap)
+}
+
+// handleAgentTracesByID serves GET /v1/agents/{id}/traces. Returns the
+// cycle-traces.json array directly (same shape as GET /v1/agent/traces)
+// so existing consumers can swap the URL with no code change.
+func (s *serveServer) handleAgentTracesByID(w http.ResponseWriter, r *http.Request, id string, limit int) {
+	if err := engine.ValidateAgentID(id); err != nil {
+		writeAgentError(w, err)
+		return
+	}
+	if id != engine.DefaultAgentID {
+		writeAgentError(w, engine.ErrAgentNotFound)
+		return
+	}
+	if s.agent == nil {
+		_, _ = w.Write([]byte("[]"))
+		return
+	}
+	traceFile := filepath.Join(s.agent.root, ".cog", ".state", "agent", "cycle-traces.json")
+	data, err := os.ReadFile(traceFile)
+	if err != nil {
+		_, _ = w.Write([]byte("[]"))
+		return
+	}
+	if limit <= 0 || limit > 20 {
+		// Preserve the full ring when the caller did not specify a clamp;
+		// this mirrors the old /v1/agent/traces route (which also returned
+		// the full file verbatim).
+		_, _ = w.Write(data)
+		return
+	}
+	var traces []cycleTrace
+	if err := json.Unmarshal(data, &traces); err != nil {
+		_, _ = w.Write(data)
+		return
+	}
+	if len(traces) > limit {
+		traces = traces[len(traces)-limit:]
+	}
+	_ = json.NewEncoder(w).Encode(traces)
+}
+
+// handleAgentTick serves POST /v1/agents/{id}/tick.
+func (s *serveServer) handleAgentTick(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	ctrl := NewServeAgentController(s.agent)
+
+	id, suffix := extractAgentIDAndSuffix(r.URL.Path)
+	if suffix != "tick" {
+		// Path like POST /v1/agents/primary (no /tick) — still treat as tick
+		// to be lenient on trailing slashes.
+		if suffix != "" {
+			writeAgentError(w, &engine.AgentControllerError{Code: "invalid_input", Message: fmt.Sprintf("unknown POST subpath %q", suffix)})
+			return
+		}
+	}
+
+	q := r.URL.Query()
+	req := engine.TriggerAgentRequest{
+		AgentID: id,
+		Reason:  q.Get("reason"),
+		Wait:    q.Get("wait") == "true",
+	}
+
+	result, err := engine.QueryTriggerAgent(r.Context(), ctrl, req)
+	if err != nil {
+		writeAgentError(w, err)
+		return
+	}
+	// Return 409 when the agent was already running — preserves the
+	// semantics of the legacy POST /v1/agent/trigger route.
+	if !result.Triggered && result.Message == "already_running" {
+		w.WriteHeader(http.StatusConflict)
+	}
+	_ = json.NewEncoder(w).Encode(result)
+}
+
+// extractAgentIDAndSuffix parses /v1/agents/{id}[/suffix] paths. Both
+// the id and the optional suffix are returned; missing values are empty.
+func extractAgentIDAndSuffix(path string) (id, suffix string) {
+	// Expect: /v1/agents, /v1/agents/, /v1/agents/{id}, /v1/agents/{id}/{suffix}
+	trimmed := strings.TrimPrefix(path, "/v1/agents")
+	trimmed = strings.TrimPrefix(trimmed, "/")
+	if trimmed == "" {
+		return "", ""
+	}
+	parts := strings.SplitN(trimmed, "/", 2)
+	id = parts[0]
+	if len(parts) > 1 {
+		suffix = strings.TrimSuffix(parts[1], "/")
+	}
+	return id, suffix
+}
+
+// writeAgentError maps engine errors onto HTTP status + a JSON error body.
+func writeAgentError(w http.ResponseWriter, err error) {
+	w.Header().Set("Content-Type", "application/json")
+	code := http.StatusInternalServerError
+	msg := err.Error()
+	if ace, ok := err.(*engine.AgentControllerError); ok && ace != nil {
+		msg = ace.Message
+		switch ace.Code {
+		case "not_found":
+			code = http.StatusNotFound
+		case "unavailable":
+			code = http.StatusServiceUnavailable
+		case "invalid_input":
+			code = http.StatusBadRequest
+		}
+	}
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/serve_agents_test.go
+++ b/serve_agents_test.go
@@ -1,0 +1,713 @@
+// serve_agents_test.go — HTTP handler tests for the plural /v1/agents
+// surface, the ServeAgentController adapter, and the dashboard-route
+// compatibility guard.
+//
+// All tests are short, race-clean, and use httptest.ResponseRecorder so
+// they can run silently in parallel with the rest of the engine suite.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cogos-dev/cogos/internal/engine"
+	"github.com/cogos-dev/cogos/internal/linkfeed"
+)
+
+// newTestServeAgent returns a ServeAgent with enough fields populated
+// that Status()/getMemoryForAPI()/etc. produce sensible values, but
+// WITHOUT actually starting the Ollama-driven runLoop. Tests assert
+// against the projection not the live loop.
+func newTestServeAgent(t *testing.T) *ServeAgent {
+	t.Helper()
+	root := t.TempDir()
+	// Write a minimal identity config so identityName() resolves.
+	configDir := filepath.Join(root, ".cog", "config")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir identity config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "identity.yaml"),
+		[]byte("default_identity: cog\n"), 0o644); err != nil {
+		t.Fatalf("write identity.yaml: %v", err)
+	}
+	harness := NewAgentHarness(AgentHarnessConfig{
+		OllamaURL: "http://localhost:11434",
+		Model:     "gemma4:e4b",
+	})
+	sa := &ServeAgent{
+		root:                 root,
+		interval:             3 * time.Minute,
+		harness:              harness,
+		stopCh:               make(chan struct{}),
+		wakeCh:               make(chan struct{}, 1),
+		cycleMemory:          newAgentCycleMemory(maxRollingMemory),
+		lastRegistrySnapshot: make(map[string]int64),
+		startedAt:            time.Now().Add(-5 * time.Minute),
+		lastRun:              time.Now().Add(-1 * time.Minute),
+		cycleCount:           7,
+		lastAction:           "execute",
+		lastUrgency:          0.6,
+		lastReason:           "new link arrived",
+		lastDurMs:            1200,
+	}
+	return sa
+}
+
+// newTestServer wraps a ServeAgent in a serveServer so the HTTP handlers
+// have s.agent wired.
+func newTestServer(sa *ServeAgent) *serveServer {
+	return &serveServer{
+		agent: sa,
+	}
+}
+
+// --- Controller-level tests --------------------------------------------
+
+func TestServeAgentController_ListAgents(t *testing.T) {
+	t.Parallel()
+	sa := newTestServeAgent(t)
+	ctrl := NewServeAgentController(sa)
+	list, err := ctrl.ListAgents(context.Background(), false)
+	if err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("len=%d; want 1", len(list))
+	}
+	got := list[0]
+	if got.AgentID != engine.DefaultAgentID {
+		t.Errorf("AgentID=%q; want %q", got.AgentID, engine.DefaultAgentID)
+	}
+	if got.CycleCount != 7 {
+		t.Errorf("CycleCount=%d; want 7", got.CycleCount)
+	}
+	if got.LastAction != "execute" {
+		t.Errorf("LastAction=%q; want execute", got.LastAction)
+	}
+	if got.Model != "gemma4:e4b" {
+		t.Errorf("Model=%q; want gemma4:e4b", got.Model)
+	}
+	if got.Identity != "cog" {
+		t.Errorf("Identity=%q; want cog", got.Identity)
+	}
+}
+
+func TestServeAgentController_ListAgents_NilAgent(t *testing.T) {
+	t.Parallel()
+	ctrl := NewServeAgentController(nil)
+	if _, err := ctrl.ListAgents(context.Background(), false); err == nil {
+		t.Fatal("want ErrAgentUnavailable, got nil")
+	}
+}
+
+func TestServeAgentController_GetAgent_NotFound(t *testing.T) {
+	t.Parallel()
+	sa := newTestServeAgent(t)
+	ctrl := NewServeAgentController(sa)
+	_, err := ctrl.GetAgent(context.Background(), "ghost", false, 0)
+	if err != engine.ErrAgentNotFound {
+		t.Fatalf("err=%v; want ErrAgentNotFound", err)
+	}
+}
+
+func TestServeAgentController_GetAgent_Summary(t *testing.T) {
+	t.Parallel()
+	sa := newTestServeAgent(t)
+	ctrl := NewServeAgentController(sa)
+	snap, err := ctrl.GetAgent(context.Background(), engine.DefaultAgentID, false, 0)
+	if err != nil {
+		t.Fatalf("GetAgent: %v", err)
+	}
+	if snap.Summary.AgentID != engine.DefaultAgentID {
+		t.Errorf("AgentID=%q; want %q", snap.Summary.AgentID, engine.DefaultAgentID)
+	}
+	if snap.IdentityRef == "" {
+		t.Errorf("IdentityRef empty; want cog:agents/identities/identity_cog.md")
+	}
+	if snap.Traces != nil {
+		t.Errorf("Traces=%v; want nil when include_trace=false", snap.Traces)
+	}
+}
+
+func TestServeAgentController_GetAgent_WithTraces(t *testing.T) {
+	t.Parallel()
+	sa := newTestServeAgent(t)
+	// Write three cycle traces to disk so the controller can read them.
+	traceDir := filepath.Join(sa.root, ".cog", ".state", "agent")
+	if err := os.MkdirAll(traceDir, 0o755); err != nil {
+		t.Fatalf("mkdir trace dir: %v", err)
+	}
+	traces := []cycleTrace{
+		{Cycle: 1, Timestamp: time.Now().Add(-3 * time.Minute), DurationMs: 100, Action: "observe", Urgency: 0.1, Reason: "initial", Observation: "obs-1", Result: "res-1"},
+		{Cycle: 2, Timestamp: time.Now().Add(-2 * time.Minute), DurationMs: 200, Action: "execute", Urgency: 0.5, Reason: "new work", Observation: "obs-2", Result: "res-2"},
+		{Cycle: 3, Timestamp: time.Now().Add(-1 * time.Minute), DurationMs: 150, Action: "sleep", Urgency: 0.0, Reason: "idle", Observation: "obs-3", Result: ""},
+	}
+	data, _ := json.MarshalIndent(traces, "", "  ")
+	if err := os.WriteFile(filepath.Join(traceDir, "cycle-traces.json"), data, 0o644); err != nil {
+		t.Fatalf("write traces: %v", err)
+	}
+
+	ctrl := NewServeAgentController(sa)
+	snap, err := ctrl.GetAgent(context.Background(), engine.DefaultAgentID, true, 2)
+	if err != nil {
+		t.Fatalf("GetAgent: %v", err)
+	}
+	if len(snap.Traces) != 2 {
+		t.Fatalf("Traces len=%d; want 2", len(snap.Traces))
+	}
+	// Should be the last two (tail clamp).
+	if snap.Traces[1].Cycle != 3 {
+		t.Errorf("Traces[1].Cycle=%d; want 3", snap.Traces[1].Cycle)
+	}
+	if snap.LastObservation == "" {
+		t.Errorf("LastObservation empty; want populated")
+	}
+}
+
+func TestServeAgentController_TriggerAgent_NilAgent(t *testing.T) {
+	t.Parallel()
+	ctrl := NewServeAgentController(nil)
+	_, err := ctrl.TriggerAgent(context.Background(), engine.DefaultAgentID, "", false)
+	if err != engine.ErrAgentUnavailable {
+		t.Fatalf("err=%v; want ErrAgentUnavailable", err)
+	}
+}
+
+func TestServeAgentController_TriggerAgent_AlreadyRunning(t *testing.T) {
+	t.Parallel()
+	sa := newTestServeAgent(t)
+	// Simulate an in-progress cycle.
+	atomic.StoreInt32(&sa.running, 1)
+	defer atomic.StoreInt32(&sa.running, 0)
+
+	ctrl := NewServeAgentController(sa)
+	result, err := ctrl.TriggerAgent(context.Background(), engine.DefaultAgentID, "", false)
+	if err != nil {
+		t.Fatalf("TriggerAgent: %v", err)
+	}
+	if result.Triggered {
+		t.Errorf("Triggered=true; want false (already_running)")
+	}
+	if result.Message != "already_running" {
+		t.Errorf("Message=%q; want already_running", result.Message)
+	}
+}
+
+// --- HTTP handler tests ------------------------------------------------
+
+func TestHandleListAgents_Roundtrip(t *testing.T) {
+	t.Parallel()
+	sa := newTestServeAgent(t)
+	s := newTestServer(sa)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/agents", nil)
+	w := httptest.NewRecorder()
+	s.handleListAgents(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d; want 200", w.Code)
+	}
+	var resp engine.ListAgentsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, w.Body.String())
+	}
+	if resp.Count != 1 {
+		t.Fatalf("Count=%d; want 1", resp.Count)
+	}
+	if resp.Agents[0].AgentID != engine.DefaultAgentID {
+		t.Errorf("AgentID=%q; want %q", resp.Agents[0].AgentID, engine.DefaultAgentID)
+	}
+}
+
+func TestHandleListAgents_NilAgent_503(t *testing.T) {
+	t.Parallel()
+	s := newTestServer(nil)
+	req := httptest.NewRequest(http.MethodGet, "/v1/agents", nil)
+	w := httptest.NewRecorder()
+	s.handleListAgents(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d; want 503", w.Code)
+	}
+}
+
+func TestHandleGetAgent_Primary(t *testing.T) {
+	t.Parallel()
+	sa := newTestServeAgent(t)
+	s := newTestServer(sa)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/agents/primary", nil)
+	w := httptest.NewRecorder()
+	s.handleGetAgent(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d; body=%s", w.Code, w.Body.String())
+	}
+	var snap engine.AgentSnapshot
+	if err := json.Unmarshal(w.Body.Bytes(), &snap); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if snap.Summary.AgentID != engine.DefaultAgentID {
+		t.Errorf("AgentID=%q; want %q", snap.Summary.AgentID, engine.DefaultAgentID)
+	}
+}
+
+func TestHandleGetAgent_NotFound(t *testing.T) {
+	t.Parallel()
+	sa := newTestServeAgent(t)
+	s := newTestServer(sa)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/agents/ghost", nil)
+	w := httptest.NewRecorder()
+	s.handleGetAgent(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status=%d; want 404", w.Code)
+	}
+}
+
+func TestHandleGetAgent_InvalidID(t *testing.T) {
+	t.Parallel()
+	sa := newTestServeAgent(t)
+	s := newTestServer(sa)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/agents/BAD_ID", nil)
+	w := httptest.NewRecorder()
+	s.handleGetAgent(w, req)
+
+	// Uppercase is rejected by the regex.
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d; want 400", w.Code)
+	}
+}
+
+func TestHandleGetAgent_Traces(t *testing.T) {
+	t.Parallel()
+	sa := newTestServeAgent(t)
+	// Drop two traces on disk.
+	traceDir := filepath.Join(sa.root, ".cog", ".state", "agent")
+	if err := os.MkdirAll(traceDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	traces := []cycleTrace{
+		{Cycle: 1, Timestamp: time.Now(), Action: "observe", Urgency: 0.1},
+		{Cycle: 2, Timestamp: time.Now(), Action: "execute", Urgency: 0.5},
+	}
+	data, _ := json.Marshal(traces)
+	if err := os.WriteFile(filepath.Join(traceDir, "cycle-traces.json"), data, 0o644); err != nil {
+		t.Fatalf("write traces: %v", err)
+	}
+
+	s := newTestServer(sa)
+	req := httptest.NewRequest(http.MethodGet, "/v1/agents/primary/traces", nil)
+	w := httptest.NewRecorder()
+	s.handleGetAgent(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d; body=%s", w.Code, w.Body.String())
+	}
+	var got []cycleTrace
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d; want 2", len(got))
+	}
+}
+
+func TestHandleAgentTick_FireAndForget(t *testing.T) {
+	t.Parallel()
+	sa := newTestServeAgent(t)
+	// Replace Ollama URL with a stub server so safeCycle doesn't hang on
+	// the real network. The goroutine's failure path is acceptable here —
+	// we assert on the trigger-receipt response, not the cycle outcome.
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(stub.Close)
+	sa.harness.ollamaURL = stub.URL
+
+	s := newTestServer(sa)
+	req := httptest.NewRequest(http.MethodPost, "/v1/agents/primary/tick", nil)
+	w := httptest.NewRecorder()
+	s.handleAgentTick(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d; body=%s", w.Code, w.Body.String())
+	}
+	var result engine.AgentTriggerResult
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !result.Triggered {
+		t.Errorf("Triggered=false; want true")
+	}
+	if result.Message != "triggered" {
+		t.Errorf("Message=%q; want triggered", result.Message)
+	}
+	// Wait briefly for the async cycle goroutine to drain so the test
+	// doesn't leak; this exercise doesn't care what the goroutine did.
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestHandleAgentTick_AlreadyRunning_Returns409(t *testing.T) {
+	t.Parallel()
+	sa := newTestServeAgent(t)
+	atomic.StoreInt32(&sa.running, 1)
+	defer atomic.StoreInt32(&sa.running, 0)
+
+	s := newTestServer(sa)
+	req := httptest.NewRequest(http.MethodPost, "/v1/agents/primary/tick", nil)
+	w := httptest.NewRecorder()
+	s.handleAgentTick(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status=%d; want 409", w.Code)
+	}
+	var result engine.AgentTriggerResult
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if result.Triggered {
+		t.Errorf("Triggered=true; want false")
+	}
+	if result.Message != "already_running" {
+		t.Errorf("Message=%q; want already_running", result.Message)
+	}
+}
+
+func TestHandleAgentTick_NoAgent_Returns503(t *testing.T) {
+	t.Parallel()
+	s := newTestServer(nil)
+	req := httptest.NewRequest(http.MethodPost, "/v1/agents/primary/tick", nil)
+	w := httptest.NewRecorder()
+	s.handleAgentTick(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d; want 503", w.Code)
+	}
+}
+
+// --- Dashboard compatibility regression guard ---------------------------
+
+// TestAgentRoutesPreservedForDashboard asserts that the legacy singular
+// routes still return the shapes the embedded dashboard.html consumes.
+// The dashboard issues:
+//   GET  /v1/agent/status   → AgentStatusResponse (`alive`, `running`, `cycle_count`, `last_cycle`, `last_action`, `last_urgency`, `interval`, `model`, `activity`, `memory`, `proposals`, `inbox`)
+//   GET  /v1/agent/traces   → []cycleTrace (each with `cycle`, `action`, `urgency`, `reason`, `target`, `observation`, `result`, `duration_ms`, `timestamp`)
+//   POST /v1/agent/trigger  → {"status":"triggered"} | {"status":"already_running"} (409) | {"error":"agent not running"} (503)
+//
+// If anyone ever breaks these shapes this test fails loudly, and the
+// dashboard at internal/engine/web/dashboard.html:1549/1573/1785 would
+// break in the same way.
+func TestAgentRoutesPreservedForDashboard(t *testing.T) {
+	t.Parallel()
+	sa := newTestServeAgent(t)
+	// Drop a trace on disk so /v1/agent/traces has something to return.
+	traceDir := filepath.Join(sa.root, ".cog", ".state", "agent")
+	if err := os.MkdirAll(traceDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	trace := cycleTrace{
+		Cycle:       9,
+		Timestamp:   time.Now(),
+		DurationMs:  321,
+		Action:      "observe",
+		Urgency:     0.3,
+		Reason:      "dashboard",
+		Target:      "",
+		Observation: "watch",
+		Result:      "",
+	}
+	data, _ := json.Marshal([]cycleTrace{trace})
+	if err := os.WriteFile(filepath.Join(traceDir, "cycle-traces.json"), data, 0o644); err != nil {
+		t.Fatalf("write traces: %v", err)
+	}
+
+	s := newTestServer(sa)
+
+	// --- /v1/agent/status -------------------------------------------------
+	req := httptest.NewRequest(http.MethodGet, "/v1/agent/status", nil)
+	w := httptest.NewRecorder()
+	s.handleAgentStatus(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("/v1/agent/status: status=%d; want 200", w.Code)
+	}
+	// Decode into the root-package shape to guarantee the same field set.
+	var status AgentStatusResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &status); err != nil {
+		t.Fatalf("/v1/agent/status decode: %v", err)
+	}
+	// Dashboard.html:1551-1557 reads these directly.
+	if !status.Alive {
+		t.Errorf("Alive=false; want true")
+	}
+	if status.CycleCount != 7 {
+		t.Errorf("CycleCount=%d; want 7", status.CycleCount)
+	}
+	if status.LastAction != "execute" {
+		t.Errorf("LastAction=%q; want execute", status.LastAction)
+	}
+	if status.Model != "gemma4:e4b" {
+		t.Errorf("Model=%q; want gemma4:e4b", status.Model)
+	}
+	if status.Interval != "3m0s" {
+		t.Errorf("Interval=%q; want 3m0s", status.Interval)
+	}
+
+	// Guard the exact JSON field names the dashboard's renderAgent* helpers use.
+	needBodyFields := []string{
+		`"alive":`, `"running":`, `"cycle_count":`, `"last_cycle":`,
+		`"last_action":`, `"last_urgency":`, `"last_reason":`,
+		`"last_duration_ms":`, `"interval":`, `"model":`,
+	}
+	body := w.Body.String()
+	for _, f := range needBodyFields {
+		if !strings.Contains(body, f) {
+			t.Errorf("/v1/agent/status body missing %q\nfull body: %s", f, body)
+		}
+	}
+
+	// --- /v1/agent/traces --------------------------------------------------
+	req = httptest.NewRequest(http.MethodGet, "/v1/agent/traces", nil)
+	w = httptest.NewRecorder()
+	s.handleAgentTraces(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("/v1/agent/traces: status=%d; want 200", w.Code)
+	}
+	// Dashboard.html:1577 reads `t.cycle + ':' + t.action`; renderAgentTraces uses
+	// t.urgency, t.duration_ms, t.timestamp, t.reason, t.target, t.result, t.observation.
+	var traces []cycleTrace
+	if err := json.Unmarshal(w.Body.Bytes(), &traces); err != nil {
+		t.Fatalf("/v1/agent/traces decode: %v", err)
+	}
+	if len(traces) != 1 {
+		t.Fatalf("traces len=%d; want 1", len(traces))
+	}
+	if traces[0].Cycle != 9 || traces[0].Action != "observe" {
+		t.Errorf("trace mismatch: %+v", traces[0])
+	}
+	tracesBody := w.Body.String()
+	for _, f := range []string{
+		`"cycle":9`, `"action":"observe"`, `"urgency":0.3`,
+		`"reason":"dashboard"`, `"duration_ms":321`, `"observation":"watch"`,
+	} {
+		if !strings.Contains(tracesBody, f) {
+			t.Errorf("/v1/agent/traces body missing %q\nfull body: %s", f, tracesBody)
+		}
+	}
+
+	// --- POST /v1/agent/trigger (success path: 200 {"status":"triggered"}) ---
+	// Point the harness at a stub so safeCycle doesn't hang on real Ollama.
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(stub.Close)
+	sa.harness.ollamaURL = stub.URL
+
+	req = httptest.NewRequest(http.MethodPost, "/v1/agent/trigger", nil)
+	w = httptest.NewRecorder()
+	s.handleAgentTrigger(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("/v1/agent/trigger status=%d; want 200", w.Code)
+	}
+	var triggerResp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &triggerResp); err != nil {
+		t.Fatalf("/v1/agent/trigger decode: %v", err)
+	}
+	if triggerResp["status"] != "triggered" {
+		t.Errorf("/v1/agent/trigger status=%q; want triggered (dashboard.html:1785 sends POST and expects this success shape)", triggerResp["status"])
+	}
+	time.Sleep(50 * time.Millisecond) // let the async cycle goroutine drain
+
+	// --- POST /v1/agent/trigger (conflict path: 409 {"status":"already_running"}) ---
+	atomic.StoreInt32(&sa.running, 1)
+	req = httptest.NewRequest(http.MethodPost, "/v1/agent/trigger", nil)
+	w = httptest.NewRecorder()
+	s.handleAgentTrigger(w, req)
+	atomic.StoreInt32(&sa.running, 0)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("/v1/agent/trigger conflict status=%d; want 409", w.Code)
+	}
+	var conflict map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &conflict); err != nil {
+		t.Fatalf("/v1/agent/trigger conflict decode: %v", err)
+	}
+	if conflict["status"] != "already_running" {
+		t.Errorf("conflict status=%q; want already_running", conflict["status"])
+	}
+
+	// --- POST /v1/agent/trigger (no agent: 503 {"error":"agent not running"}) ---
+	nilSrv := newTestServer(nil)
+	req = httptest.NewRequest(http.MethodPost, "/v1/agent/trigger", nil)
+	w = httptest.NewRecorder()
+	nilSrv.handleAgentTrigger(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("/v1/agent/trigger no-agent status=%d; want 503", w.Code)
+	}
+	var unavail map[string]string
+	_ = json.Unmarshal(w.Body.Bytes(), &unavail)
+	if unavail["error"] != "agent not running" {
+		t.Errorf("no-agent error=%q; want 'agent not running'", unavail["error"])
+	}
+
+	// --- /v1/agent/status with no agent returns the Alive:false shape ---
+	req = httptest.NewRequest(http.MethodGet, "/v1/agent/status", nil)
+	w = httptest.NewRecorder()
+	nilSrv.handleAgentStatus(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("/v1/agent/status no-agent status=%d; want 200", w.Code)
+	}
+	var noAgent AgentStatusResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &noAgent); err != nil {
+		t.Fatalf("no-agent status decode: %v", err)
+	}
+	if noAgent.Alive {
+		t.Errorf("no-agent Alive=true; want false")
+	}
+	if noAgent.Model != "none" {
+		t.Errorf("no-agent Model=%q; want none", noAgent.Model)
+	}
+}
+
+// TestAgentRoutes_PluralAndSingularAgree cross-checks that the plural
+// route's summary field values match the singular route's top-level
+// fields, so callers migrating from one to the other see the same data.
+func TestAgentRoutes_PluralAndSingularAgree(t *testing.T) {
+	t.Parallel()
+	sa := newTestServeAgent(t)
+	s := newTestServer(sa)
+
+	// GET /v1/agent/status
+	r1 := httptest.NewRequest(http.MethodGet, "/v1/agent/status", nil)
+	w1 := httptest.NewRecorder()
+	s.handleAgentStatus(w1, r1)
+	var single AgentStatusResponse
+	_ = json.Unmarshal(w1.Body.Bytes(), &single)
+
+	// GET /v1/agents/primary
+	r2 := httptest.NewRequest(http.MethodGet, "/v1/agents/primary", nil)
+	w2 := httptest.NewRecorder()
+	s.handleGetAgent(w2, r2)
+	var snap engine.AgentSnapshot
+	_ = json.Unmarshal(w2.Body.Bytes(), &snap)
+
+	if snap.Summary.CycleCount != single.CycleCount {
+		t.Errorf("plural CycleCount=%d; singular=%d (must match)", snap.Summary.CycleCount, single.CycleCount)
+	}
+	if snap.Summary.LastAction != single.LastAction {
+		t.Errorf("plural LastAction=%q; singular=%q", snap.Summary.LastAction, single.LastAction)
+	}
+	if snap.Summary.Model != single.Model {
+		t.Errorf("plural Model=%q; singular=%q", snap.Summary.Model, single.Model)
+	}
+	if snap.Summary.Interval != single.Interval {
+		t.Errorf("plural Interval=%q; singular=%q", snap.Summary.Interval, single.Interval)
+	}
+}
+
+// TestExtractAgentIDAndSuffix covers the URL-parsing helper used by the
+// handlers directly.
+func TestExtractAgentIDAndSuffix(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		path     string
+		wantID   string
+		wantSub  string
+	}{
+		{"/v1/agents/primary", "primary", ""},
+		{"/v1/agents/primary/tick", "primary", "tick"},
+		{"/v1/agents/primary/traces", "primary", "traces"},
+		{"/v1/agents/", "", ""},
+		{"/v1/agents", "", ""},
+	}
+	for _, tc := range cases {
+		id, sub := extractAgentIDAndSuffix(tc.path)
+		if id != tc.wantID || sub != tc.wantSub {
+			t.Errorf("extractAgentIDAndSuffix(%q) = (%q, %q); want (%q, %q)",
+				tc.path, id, sub, tc.wantID, tc.wantSub)
+		}
+	}
+}
+
+// TestAgentRoutes_MuxWiring checks that the actual ServeMux wiring
+// dispatches to the correct handlers for both singular and plural routes.
+// This catches regressions from accidentally deleting a HandleFunc call
+// or mis-ordering route registrations.
+func TestAgentRoutes_MuxWiring(t *testing.T) {
+	t.Parallel()
+	sa := newTestServeAgent(t)
+	s := newTestServer(sa)
+
+	mux := http.NewServeMux()
+	// Exactly the route set registered in serve.go.
+	mux.HandleFunc("GET /v1/agent/status", s.handleAgentStatus)
+	mux.HandleFunc("POST /v1/agent/trigger", s.handleAgentTrigger)
+	mux.HandleFunc("GET /v1/agent/traces", s.handleAgentTraces)
+	mux.HandleFunc("GET /v1/agents", s.handleListAgents)
+	mux.HandleFunc("GET /v1/agents/", s.handleGetAgent)
+	mux.HandleFunc("POST /v1/agents/", s.handleAgentTick)
+
+	testCases := []struct {
+		method   string
+		path     string
+		wantCode int
+	}{
+		{"GET", "/v1/agent/status", 200},
+		{"GET", "/v1/agent/traces", 200},
+		{"GET", "/v1/agents", 200},
+		{"GET", "/v1/agents/primary", 200},
+		{"GET", "/v1/agents/ghost", 404},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.method+"_"+strings.ReplaceAll(tc.path, "/", "_"), func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+			if w.Code != tc.wantCode {
+				t.Errorf("%s %s: status=%d; want %d (body=%s)", tc.method, tc.path, w.Code, tc.wantCode, w.Body.String())
+			}
+		})
+	}
+}
+
+// TestInboxSummaryMapping makes sure the linkfeed-type → engine-type
+// adapter doesn't drop fields. This is the only mapping with non-trivial
+// nested slices.
+func TestInboxSummaryMapping(t *testing.T) {
+	t.Parallel()
+	in := &linkfeed.AgentInboxSummary{
+		RawCount:      1,
+		EnrichedCount: 2,
+		FailedCount:   3,
+		TotalCount:    6,
+		LastPull:      "2026-04-21T10:00:00Z",
+		LastPullAgo:   "5m",
+		NextPullIn:    "25m",
+		RecentEnrichments: []linkfeed.RecentEnrichmentItem{
+			{Title: "one", Connections: 1, Ago: "2m"},
+			{Title: "two", Connections: 3, Ago: "4m"},
+		},
+	}
+	out := inboxFromStatus(in)
+	if out.RawCount != 1 || out.EnrichedCount != 2 || out.TotalCount != 6 {
+		t.Errorf("counts mismatch: %+v", out)
+	}
+	if len(out.RecentEnrichments) != 2 {
+		t.Fatalf("RecentEnrichments len=%d; want 2", len(out.RecentEnrichments))
+	}
+	if out.RecentEnrichments[1].Title != "two" {
+		t.Errorf("RecentEnrichments[1].Title=%q; want two", out.RecentEnrichments[1].Title)
+	}
+	if inboxFromStatus(nil) != nil {
+		t.Errorf("inboxFromStatus(nil) should return nil")
+	}
+}
+


### PR DESCRIPTION
## Summary

Agent state + loop-control surface — closes Agent F's gap #8. Additive: three new MCP tools + four new plural HTTP routes at \`/v1/agents[/...]\`. The existing singular routes at \`/v1/agent/{status,traces,trigger}\` (which the dashboard consumes at \`internal/engine/web/dashboard.html:1549,1573,1785\`) are untouched and locked in by regression tests.

Per Agent T's design (\`agent-T-agent-state-design.cog.md\`, 681 lines). Closes gap #8.

## Key architectural move: \`AgentController\` interface

\`\`\`go
type AgentController interface {
    ListAgents(ctx context.Context, includeStopped bool) ([]AgentSummary, error)
    GetAgent(ctx context.Context, id string, includeTrace bool, traceLimit int) (*AgentSnapshot, error)
    TriggerAgent(ctx context.Context, id string, reason string, wait bool) (*AgentTriggerResult, error)
}
\`\`\`

Defined in \`internal/engine/\`; implemented by \`ServeAgentController\` adapter in root \`main\` (\`serve_agents.go\`). This breaks the import cycle (ServeAgent lives in \`package main\`, MCP tools live in \`package engine\`) without relocating ServeAgent. Plus sentinel errors (\`ErrAgentNotFound\`, \`ErrAgentUnavailable\`, \`ErrAgentInvalidInput\`) and wire-compat value types.

## What landed

**engine-side (additive):**
- \`internal/engine/agent_controller.go\` (195 LOC) — interface, sentinel errors, value types.
- \`internal/engine/agent_state_query.go\` (153 LOC) — query helpers: listing, get-by-id, trigger, state projection.
- \`internal/engine/mcp_server.go\` — 3 new tool registrations (\`cog_list_agents\`, \`cog_get_agent_state\`, \`cog_trigger_agent_loop\`), plus \`NewMCPServerWithAgentController\` + \`SetAgentController\` for post-construction injection.
- \`internal/engine/serve.go\`, \`internal/engine/serve_mcp.go\` — wire the controller into the server.

**root-side (minimal):**
- \`serve.go\` — 3 new \`HandleFunc\` entries for the plural routes. Legacy singular routes untouched.
- \`serve_agents.go\` (513 LOC) — \`ServeAgentController\` adapter + 4 HTTP handlers (list / get / tick + the existing singular aliases).

**Tests:**
- \`internal/engine/agent_state_query_test.go\` (695 LOC, 21 tests)
- \`serve_agents_test.go\` (730 LOC, 21 tests including dashboard preservation)

## API pluralizes from day one

N=1 today (the \`ServeAgent\` singleton), but every tool/route accepts \`agent_id\` with \`"primary"\` as the stable handle. When multi-agent pools land, the surface accommodates without version churn.

## Dashboard compatibility — locked

- **\`TestAgentRoutesPreservedForDashboard\`** exercises the exact JSON field names \`dashboard.html:1549-1797\` consumes on happy/409/503 paths.
- **\`TestAgentRoutes_PluralAndSingularAgree\`** cross-checks the plural response's summary fields match the singular route's top-level fields 1:1.
- **\`TestAgentRoutes_MuxWiring\`** exercises actual \`http.ServeMux\` routing with all legacy + new routes.

Before/after for \`GET /v1/agent/status\` is byte-compatible — same JSON shape, same handler (\`agent_serve.go:1460\`, untouched).

## Test plan

- [x] 42 new \`Test*\` functions across 2 test files — all pass
- [x] \`go test ./... -short -race -count=1\` — green (root ~8.8s, engine ~2s)
- [x] \`go build ./...\` + \`go vet ./...\` — silent

## Disambiguation honored (Agent T §2)

- **Identity** = static YAML config (AgentProvider reconciles, doesn't run)
- **Session** = live external-client conversational context (Agent P's lane; Python bridge)
- **Agent** = kernel-internal goroutine (ServeAgent singleton) running the homeostatic loop

These are orthogonal; meet only at the identity catalogue.

## New findings for cogos#22 (scaffolded-infra audit)

1. **Two parallel MCP servers in the kernel.** \`internal/engine/mcp_server.go\` (engine, reached via the \`cogos\` binary's /mcp) and root \`mcp.go\`'s \`MCPSessionManager\` (reached via the \`cog serve\` /mcp). Dashboard-facing \`cog serve\` routes to the root one. Reinforces Agent I2's finding that "installed cogos = ROOT build" extends to MCP dispatch. New engine tools registered here are reachable via \`cogos\` binary; to reach via \`cog\` binary requires root-side re-registration. Scope-gated per Agent T §3.6 option B; will resolve naturally when Track 5 Phase 4 flips the Makefile target.
2. **Engine's \`AgentController\` plumbing is complete but \`cmd/cogos\` Main never builds a \`*ServeAgent\`.** Tools resolve to \`ErrAgentUnavailable\` in that binary unless a controller is wired in. Tests verify clean-error path (not panic). Wiring is ~5 LOC in \`cmd/cogos/main.go\` when the time comes.
3. **\`ServeAgent\` lacks an identity field.** Adapter resolves by reading \`.cog/config/identity.yaml\` \`default_identity:\`. A future \`ServeAgent.identity string\` set at construction time would simplify the adapter and let multi-agent pools differ on identity.

## Design reference

\`cog://mem/semantic/surveys/2026-04-21-consolidation/agent-T-agent-state-design.cog.md\` (681 lines)