### PR TITLE
fix(engine): stabilize ledger + sync-watcher tests on -count>=2

### DIFF
--- a/internal/engine/cli_emit_test.go
+++ b/internal/engine/cli_emit_test.go
@@ -49,6 +49,7 @@ func readLedger(t *testing.T, root, sessionID string) []*EventEnvelope {
 // via AppendEvent, with hash chaining intact.
 func TestRunEmitCmd_EmitsToLedger(t *testing.T) {
 	t.Parallel()
+	t.Cleanup(resetLedgerCacheForTest)
 	root := newTestWorkspace(t)
 	sessionID := "test-session-emit-ledger"
 

--- a/internal/engine/ledger.go
+++ b/internal/engine/ledger.go
@@ -216,6 +216,18 @@ func getCachedLastEvent(sessionID string) *EventEnvelope {
 	return lastEventCache.bySession[sessionID]
 }
 
+// resetLedgerCacheForTest clears the package-level lastEventCache. Only intended
+// for tests: when -count>=2 reuses the same sessionID across fresh workspace
+// roots, the cache from the prior iteration's root leaks into the new one and
+// computes a wrong prior_hash (breaking chain-integrity assertions). Callers
+// should invoke this via t.Cleanup at the start of any test that pins a
+// sessionID literal.
+func resetLedgerCacheForTest() {
+	lastEventCache.mu.Lock()
+	defer lastEventCache.mu.Unlock()
+	lastEventCache.bySession = make(map[string]*EventEnvelope)
+}
+
 func setCachedLastEvent(sessionID string, env *EventEnvelope) {
 	lastEventCache.mu.Lock()
 	defer lastEventCache.mu.Unlock()

--- a/internal/engine/ledger_query_test.go
+++ b/internal/engine/ledger_query_test.go
@@ -22,6 +22,9 @@ import (
 // supplied via ts.
 func appendTestEvent(t *testing.T, root, sessionID, evtType string, data map[string]interface{}, ts string) *EventEnvelope {
 	t.Helper()
+	// Guard against stale entries leaking across -count iterations when the
+	// same sessionID literal reappears under a fresh workspace root.
+	t.Cleanup(resetLedgerCacheForTest)
 	env := &EventEnvelope{
 		HashedPayload: EventPayload{
 			Type:      evtType,

--- a/internal/engine/ledger_test.go
+++ b/internal/engine/ledger_test.go
@@ -124,6 +124,7 @@ func TestCanonicalizeEventWithData(t *testing.T) {
 
 func TestAppendEventChainIntegrity(t *testing.T) {
 	t.Parallel()
+	t.Cleanup(resetLedgerCacheForTest)
 	root := t.TempDir()
 	sessionID := "chain-test-session"
 
@@ -182,6 +183,7 @@ func TestAppendEventChainIntegrity(t *testing.T) {
 
 func TestAppendEventConcurrent(t *testing.T) {
 	t.Parallel()
+	t.Cleanup(resetLedgerCacheForTest)
 	root := t.TempDir()
 	sessionID := "concurrent-session"
 
@@ -267,6 +269,7 @@ func TestGetLastGlobalEventNoPriorSession(t *testing.T) {
 
 func TestGetLastGlobalEventFindsNewest(t *testing.T) {
 	t.Parallel()
+	t.Cleanup(resetLedgerCacheForTest)
 	root := t.TempDir()
 
 	// Write events into two prior sessions.
@@ -299,6 +302,7 @@ func TestGetLastGlobalEventFindsNewest(t *testing.T) {
 
 func TestCrossSessionChain(t *testing.T) {
 	t.Parallel()
+	t.Cleanup(resetLedgerCacheForTest)
 	root := t.TempDir()
 
 	// Session A: one event.

--- a/internal/engine/sync_watcher.go
+++ b/internal/engine/sync_watcher.go
@@ -101,14 +101,37 @@ func (w *SyncWatcher) pollInterval() time.Duration {
 func (w *SyncWatcher) inspectFile(path string) SyncEvent {
 	event := SyncEvent{FilePath: path}
 
-	data, err := os.ReadFile(path)
-	if err != nil {
-		event.ValidationError = fmt.Sprintf("read envelope: %v", err)
-		return event
+	// Envelope files are created with Syncthing's rename-into-place or the
+	// tests' os.WriteFile — both of which briefly expose a zero-length or
+	// partial file to ReadDir before the content is flushed. A single read
+	// attempt is enough in production's 5s poll interval, but test setups
+	// using 10-50ms polls can race mid-write and see truncated JSON. Retry
+	// the read+parse a few times with a short backoff before giving up.
+	const maxAttempts = 3
+	const backoff = 20 * time.Millisecond
+
+	var data []byte
+	var readErr, parseErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		data, readErr = os.ReadFile(path)
+		if readErr != nil {
+			break
+		}
+		parseErr = json.Unmarshal(data, &event.Envelope)
+		if parseErr == nil {
+			break
+		}
+		if attempt+1 < maxAttempts {
+			time.Sleep(backoff)
+		}
 	}
 
-	if err := json.Unmarshal(data, &event.Envelope); err != nil {
-		event.ValidationError = fmt.Sprintf("parse envelope: %v", err)
+	if readErr != nil {
+		event.ValidationError = fmt.Sprintf("read envelope: %v", readErr)
+		return event
+	}
+	if parseErr != nil {
+		event.ValidationError = fmt.Sprintf("parse envelope: %v", parseErr)
 		return event
 	}
 


### PR DESCRIPTION
Closes #18.

Reproducer (before): `go test ./internal/engine/... -short -race -count=5 -timeout 300s` fails 5/5 runs with the ledger subset failing deterministically and `TestSyncWatcherDetectsNewEnvelopeFile` flaking intermittently.

## Two fixes

### 1. Ledger package-state leak

`lastEventCache.bySession` (`internal/engine/ledger.go:36`) is a process-wide `map[sessionID]*EventEnvelope`. Tests reuse sessionID literals (`"chain-test-session"`, `"concurrent-session"`, `"session-alpha"`, etc.) but each run gets a fresh `t.TempDir()` — so the second `-count` iteration reads cached envelopes from the prior iteration's (now-gone) workspace, computes a `prior_hash` that references events no longer on disk, and fails chain-integrity assertions.

Fix: added `resetLedgerCacheForTest()` which clears the cache under its mutex. Wired via `t.Cleanup` in every test that calls `AppendEvent` with a fixed sessionID — the `appendTestEvent` helper (used by all `TestQueryLedger*` + `TestToolReadLedgerRoundtrip`), plus the four tests that call `AppendEvent` directly: `TestAppendEventChainIntegrity`, `TestAppendEventConcurrent`, `TestCrossSessionChain`, `TestGetLastGlobalEventFindsNewest`, and `TestRunEmitCmd_EmitsToLedger`.

Alternative considered: scoping the cache to `(workspaceRoot, sessionID)`. That's the better long-term fix but a bigger diff — deferred.

### 2. Sync-watcher mid-write race

`TestSyncWatcherDetectsNewEnvelopeFile` et al. poll at 10ms and write envelopes with `os.WriteFile`, which briefly exposes a zero-length or partially-flushed file to `ReadDir` before the write completes. `inspectFile`'s single-shot `os.ReadFile` + `json.Unmarshal` saw truncated JSON and returned a `ValidationError` from the wrong path.

Fix: wrapped the read+parse inside `inspectFile` in a 3-attempt retry with 20ms backoff. Chose this over bumping the poll interval because it also hardens production against the same race — Syncthing's atomic rename is safer than `os.WriteFile` but not immune on every filesystem, and the retry cost is zero on the happy path.

## Test plan

- [x] Reproduced before: ledger subset fails 5/5 runs on `-count=5 -race`
- [x] Passes after: 5/5 consecutive runs of `go test ./internal/engine/... -short -race -count=5 -timeout 300s` pass cleanly
- [x] `go build ./...` and `go vet ./...` clean
- [x] `resetLedgerCacheForTest` is test-only (doc comment states so); production hot paths untouched
- [x] Sync-watcher retry is transparent on the happy path (first attempt succeeds)