### PR TITLE
fix(serve_daemon): use unix.Dup2 for linux/arm64 compatibility

### DIFF
--- a/serve_daemon.go
+++ b/serve_daemon.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	sdk "github.com/cogos-dev/cogos/sdk"
+	"golang.org/x/sys/unix"
 )
 
 // === LOG ROTATION ===
@@ -126,11 +127,11 @@ func redirectOutputToRotatingLog(logPath string, maxSize int64, maxFiles int) (*
 	}
 
 	// Replace fd 1 (stdout) and fd 2 (stderr) with the pipe's write end
-	if err := syscall.Dup2(int(pw.Fd()), 1); err != nil {
+	if err := unix.Dup2(int(pw.Fd()), 1); err != nil {
 		w.Close()
 		return nil, fmt.Errorf("dup2 stdout: %w", err)
 	}
-	if err := syscall.Dup2(int(pw.Fd()), 2); err != nil {
+	if err := unix.Dup2(int(pw.Fd()), 2); err != nil {
 		w.Close()
 		return nil, fmt.Errorf("dup2 stderr: %w", err)
 	}


### PR DESCRIPTION
Closes #13.

```
GOOS=linux GOARCH=arm64 go build ./...    # was: undefined: syscall.Dup2
```

Swaps `syscall.Dup2` -> `unix.Dup2` (from `golang.org/x/sys/unix`, already in go.mod). On arm64, unix.Dup2 internally calls Dup3(oldfd, newfd, 0) - zero behavior change.

## Test plan
- [x] `go build ./...` silent (amd64)
- [x] `GOOS=linux GOARCH=arm64 go build ./...` succeeds
- [x] `GOOS=linux GOARCH=amd64 go build ./...` succeeds
- [x] `go vet ./...` silent
- [x] `go test ./internal/engine/... -short -race -count=1` passes

Unblocks native linux/arm64 pod image builds (peer session's image pipeline).