### PR TITLE
feat(engine): wire BindAddr config + --bind flag

### DIFF
--- a/internal/engine/cli.go
+++ b/internal/engine/cli.go
@@ -46,7 +46,7 @@ func Main() {
 			runInitCmd(args[1:], *workspace)
 			return
 		case "serve":
-			runServeCmd(args[1:], *workspace, *port)
+			runServeCmd(args[1:], *workspace, *port, "")
 			return
 		case "start":
 			runStartCmd(args[1:], *workspace, *port)
@@ -96,7 +96,7 @@ func Main() {
 	}
 
 	// Compatibility path: plain `cogos-v3` still serves in the foreground.
-	runServe(*workspace, *port)
+	runServe(*workspace, *port, "")
 }
 
 func runInitCmd(args []string, defaultWorkspace string) {
@@ -125,15 +125,16 @@ func setupLogger() {
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})))
 }
 
-func runServeCmd(args []string, defaultWorkspace string, defaultPort int) {
+func runServeCmd(args []string, defaultWorkspace string, defaultPort int, defaultBind string) {
 	fs := flag.NewFlagSet("serve", flag.ExitOnError)
 	workspace := fs.String("workspace", defaultWorkspace, "Workspace root path (auto-detected if empty)")
 	port := fs.Int("port", defaultPort, "HTTP API port (default 6931)")
+	bind := fs.String("bind", defaultBind, "HTTP server bind address (default 127.0.0.1; use 0.0.0.0 for LAN, requires trusted network)")
 	_ = fs.Parse(args)
-	runServe(*workspace, *port)
+	runServe(*workspace, *port, *bind)
 }
 
-func runServe(workspace string, port int) {
+func runServe(workspace string, port int, bindAddr string) {
 	setupLogger()
 	slog.Info("cogos-v3: starting", "build", BuildTime)
 
@@ -143,13 +144,25 @@ func runServe(workspace string, port int) {
 		slog.Error("config load failed", "err", err)
 		os.Exit(1)
 	}
+	// Flag override for bind address (takes precedence over YAML).
+	// LoadConfig cannot accept it as a parameter without breaking many
+	// unrelated call-sites, so we apply it here symmetrically with the
+	// port flag.
+	if bindAddr != "" {
+		cfg.BindAddr = bindAddr
+	}
+	// Defensive fallback: if BindAddr is somehow still empty after load
+	// (older YAML + empty-string flag + missing default), pin to loopback.
+	if cfg.BindAddr == "" {
+		cfg.BindAddr = "127.0.0.1"
+	}
 	// Now that the workspace root is known, upgrade the stderr-only logger
 	// to also fan records to <workspace>/.cog/run/kernel.log.jsonl (Agent U's
 	// kernel-slog-api). Lines logged above go to stderr only; lines below
 	// this call also land in the JSONL sink exposed by /v1/kernel-log and
 	// the cog_tail_kernel_log MCP tool.
 	upgradeLoggerWithFileSink(cfg)
-	slog.Info("config loaded", "workspace", cfg.WorkspaceRoot, "port", cfg.Port)
+	slog.Info("config loaded", "workspace", cfg.WorkspaceRoot, "port", cfg.Port, "bind", cfg.BindAddr)
 
 	if reuse, msg, err := planServeState(cfg, checkDaemonHealth); err != nil {
 		slog.Error("daemon lifecycle failed", "err", err)

--- a/internal/engine/config.go
+++ b/internal/engine/config.go
@@ -28,6 +28,13 @@ type Config struct {
 	// Port the HTTP API listens on. Default: 6931 (ln(2) × 10⁴).
 	Port int
 
+	// BindAddr is the interface the HTTP API binds to.
+	// Default: "127.0.0.1" (loopback-only). Set to "0.0.0.0" to listen
+	// on all interfaces — required for pod/LAN/Tailnet deployments.
+	// Users opting in to non-loopback binds are expected to handle the
+	// network boundary themselves (trusted network, VPN, firewall).
+	BindAddr string
+
 	// ConsolidationInterval is how often the consolidation loop fires (seconds).
 	ConsolidationInterval int
 
@@ -78,6 +85,7 @@ type Config struct {
 // kernelConfigSection holds settings that can appear at the top level or inside v3:.
 type kernelConfigSection struct {
 	Port                  int               `yaml:"port"`
+	BindAddr              string            `yaml:"bind_addr"`
 	ConsolidationInterval int               `yaml:"consolidation_interval"`
 	HeartbeatInterval     int               `yaml:"heartbeat_interval"`
 	SalienceDaysWindow    int               `yaml:"salience_days_window"`
@@ -121,6 +129,7 @@ func LoadConfig(workspaceRoot string, port int) (*Config, error) {
 		WorkspaceRoot:             workspaceRoot,
 		CogDir:                    filepath.Join(workspaceRoot, ".cog"),
 		Port:                      6931,
+		BindAddr:                  "127.0.0.1",
 		ConsolidationInterval:     3600,
 		HeartbeatInterval:         60,
 		SalienceDaysWindow:        90,
@@ -153,6 +162,9 @@ func LoadConfig(workspaceRoot string, port int) (*Config, error) {
 func applyKernelSection(cfg *Config, s kernelConfigSection) {
 	if s.Port != 0 {
 		cfg.Port = s.Port
+	}
+	if s.BindAddr != "" {
+		cfg.BindAddr = s.BindAddr
 	}
 	if s.ConsolidationInterval != 0 {
 		cfg.ConsolidationInterval = s.ConsolidationInterval

--- a/internal/engine/config_test.go
+++ b/internal/engine/config_test.go
@@ -18,6 +18,11 @@ func TestLoadConfigDefaults(t *testing.T) {
 	if cfg.Port != 6931 {
 		t.Errorf("Port = %d; want 6931", cfg.Port)
 	}
+	// Default bind MUST be loopback — security posture for issue #12.
+	// Operators opt into 0.0.0.0 explicitly; never by accident.
+	if cfg.BindAddr != "127.0.0.1" {
+		t.Errorf("BindAddr = %q; want default 127.0.0.1 (loopback-only)", cfg.BindAddr)
+	}
 	if cfg.ConsolidationInterval != 3600 {
 		t.Errorf("ConsolidationInterval = %d; want 3600", cfg.ConsolidationInterval)
 	}
@@ -88,6 +93,69 @@ digest_paths:
 	}
 	if cfg.DigestPaths["openclaw"] != "/tmp/openclaw" {
 		t.Errorf("DigestPaths[openclaw] = %q; want /tmp/openclaw", cfg.DigestPaths["openclaw"])
+	}
+}
+
+// TestLoadConfigBindAddrFromYAML verifies that a `bind_addr: 0.0.0.0`
+// entry in kernel.yaml parses and applies to Config. Regression test for
+// cogos#12 (BindAddr declared but never wired).
+func TestLoadConfigBindAddrFromYAML(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	kernelYAML := "bind_addr: 0.0.0.0\n"
+	writeTestFile(t, filepath.Join(root, ".cog", "config", "kernel.yaml"), kernelYAML)
+
+	cfg, err := LoadConfig(root, 0)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	if cfg.BindAddr != "0.0.0.0" {
+		t.Errorf("BindAddr = %q; want 0.0.0.0 (from YAML)", cfg.BindAddr)
+	}
+	// Port should still default — bind_addr shouldn't affect anything else.
+	if cfg.Port != 6931 {
+		t.Errorf("Port = %d; want default 6931", cfg.Port)
+	}
+}
+
+// TestLoadConfigBindAddrV3SectionOverridesTopLevel mirrors the existing
+// v3-override pattern for the bind_addr field.
+func TestLoadConfigBindAddrV3SectionOverridesTopLevel(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	kernelYAML := `bind_addr: 127.0.0.1
+v3:
+  bind_addr: 0.0.0.0
+`
+	writeTestFile(t, filepath.Join(root, ".cog", "config", "kernel.yaml"), kernelYAML)
+
+	cfg, err := LoadConfig(root, 0)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	if cfg.BindAddr != "0.0.0.0" {
+		t.Errorf("BindAddr = %q; want 0.0.0.0 (v3 section)", cfg.BindAddr)
+	}
+}
+
+// TestLoadConfigBindAddrMissingKeepsLoopback verifies that YAML without a
+// bind_addr key does NOT reset the default to empty — the zero-skip pattern
+// must preserve the loopback default.
+func TestLoadConfigBindAddrMissingKeepsLoopback(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	kernelYAML := "port: 7000\n" // bind_addr absent
+	writeTestFile(t, filepath.Join(root, ".cog", "config", "kernel.yaml"), kernelYAML)
+
+	cfg, err := LoadConfig(root, 0)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	if cfg.BindAddr != "127.0.0.1" {
+		t.Errorf("BindAddr = %q; want default 127.0.0.1 (YAML omitted bind_addr)", cfg.BindAddr)
 	}
 }
 

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -92,8 +92,15 @@ func NewServer(cfg *Config, nucleus *Nucleus, process *Process) *Server {
 	s.registerMCPRoutes(mux)
 	s.registerConfigRoutes(mux)
 
+	// Resolve the bind address. Default stays 127.0.0.1 (loopback-only);
+	// callers may override via Config.BindAddr to listen on all interfaces
+	// ("0.0.0.0") for pod/LAN/Tailnet deployments.
+	bindAddr := cfg.BindAddr
+	if bindAddr == "" {
+		bindAddr = "127.0.0.1"
+	}
 	s.srv = &http.Server{
-		Addr:         fmt.Sprintf(":%d", cfg.Port),
+		Addr:         fmt.Sprintf("%s:%d", bindAddr, cfg.Port),
 		Handler:      mux,
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 300 * time.Second, // 5 min — streaming responses can be long
@@ -126,7 +133,7 @@ func (s *Server) Start() error {
 	if err != nil {
 		return fmt.Errorf("listen %s: %w", s.srv.Addr, err)
 	}
-	slog.Info("server: listening", "addr", s.srv.Addr)
+	slog.Info("server: listening", "addr", s.srv.Addr, "bind", s.cfg.BindAddr)
 	return s.srv.Serve(ln)
 }
 

--- a/internal/engine/serve_test.go
+++ b/internal/engine/serve_test.go
@@ -3,10 +3,13 @@ package engine
 import (
 	"bufio"
 	"encoding/json"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 // newTestServer builds a Server with a healthy nucleus and a fresh process.
@@ -355,4 +358,153 @@ func TestServerHandler(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("status = %d; want 200", resp.StatusCode)
 	}
+}
+
+// ── BindAddr wiring (cogos#12) ─────────────────────────────────────────────
+
+// TestNewServerUsesBindAddr verifies NewServer composes http.Server.Addr
+// from Config.BindAddr so --bind 0.0.0.0 actually listens on all interfaces.
+// This is the regression test for cogos#12: prior to the fix the Addr was
+// always ":<port>" and BindAddr was ignored.
+func TestNewServerUsesBindAddr(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		bind     string
+		wantAddr string
+	}{
+		{"loopback default", "127.0.0.1", "127.0.0.1:0"},
+		{"all interfaces", "0.0.0.0", "0.0.0.0:0"},
+		{"empty falls back to loopback", "", "127.0.0.1:0"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			root := makeWorkspace(t)
+			cfg := makeConfig(t, root)
+			cfg.BindAddr = tc.bind
+			cfg.Port = 0
+			process := NewProcess(cfg, makeNucleus("T", "r"))
+			srv := NewServer(cfg, makeNucleus("T", "r"), process)
+			if srv.srv.Addr != tc.wantAddr {
+				t.Errorf("srv.Addr = %q; want %q", srv.srv.Addr, tc.wantAddr)
+			}
+		})
+	}
+}
+
+// TestServerBindsAllInterfaces spins up a server with BindAddr=0.0.0.0 and
+// probes the reachable address to confirm it actually listens beyond
+// loopback. We cannot easily synthesize a LAN client in unit tests, but a
+// dial to 127.0.0.1:<port> must still succeed when bound to 0.0.0.0
+// (loopback is a subset of "all interfaces"), and the resolved
+// net.Listener addr must NOT be tied to 127.0.0.1 only.
+func TestServerBindsAllInterfaces(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	cfg.BindAddr = "0.0.0.0"
+	cfg.Port = 0
+
+	// Use a raw net.Listen to probe what "0.0.0.0:0" means on this host.
+	// This sanity-checks the platform before the server starts.
+	probe, err := net.Listen("tcp", "0.0.0.0:0")
+	if err != nil {
+		t.Skipf("platform refuses 0.0.0.0 bind: %v", err)
+	}
+	probeAddr := probe.Addr().String()
+	probe.Close()
+	if !strings.HasPrefix(probeAddr, "0.0.0.0:") && !strings.HasPrefix(probeAddr, "[::]:") {
+		t.Fatalf("probe addr %q does not look all-interfaces", probeAddr)
+	}
+
+	process := NewProcess(cfg, makeNucleus("T", "r"))
+	srv := NewServer(cfg, makeNucleus("T", "r"), process)
+	// Override port so we can race-free dial after Start.
+	ln, err := net.Listen("tcp", srv.srv.Addr)
+	if err != nil {
+		t.Fatalf("pre-listen: %v", err)
+	}
+	actualPort := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	srv.srv.Addr = fmt.Sprintf("0.0.0.0:%d", actualPort)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Start() }()
+	defer func() {
+		_ = srv.srv.Close()
+		select {
+		case <-errCh:
+		case <-time.After(2 * time.Second):
+		}
+	}()
+
+	// Poll a loopback dial until the server accepts (or we give up). A
+	// successful dial to 127.0.0.1 when bound to 0.0.0.0 confirms the
+	// socket is open on loopback too, which is the subset we can verify
+	// without spoofing a LAN client in unit tests.
+	deadline := time.Now().Add(2 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", actualPort), 100*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			return // success
+		}
+		lastErr = err
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("could not reach 0.0.0.0-bound server via 127.0.0.1: %v", lastErr)
+}
+
+// TestServerBindsLoopbackOnly verifies that BindAddr=127.0.0.1 (the default)
+// remains reachable via 127.0.0.1 — i.e. we didn't break the loopback path
+// while adding the non-loopback bind option.
+func TestServerBindsLoopbackOnly(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	cfg.BindAddr = "127.0.0.1"
+	cfg.Port = 0
+
+	process := NewProcess(cfg, makeNucleus("T", "r"))
+	srv := NewServer(cfg, makeNucleus("T", "r"), process)
+
+	if !strings.HasPrefix(srv.srv.Addr, "127.0.0.1:") {
+		t.Fatalf("srv.Addr = %q; want 127.0.0.1:<port>", srv.srv.Addr)
+	}
+
+	ln, err := net.Listen("tcp", srv.srv.Addr)
+	if err != nil {
+		t.Fatalf("pre-listen: %v", err)
+	}
+	actualPort := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	srv.srv.Addr = fmt.Sprintf("127.0.0.1:%d", actualPort)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Start() }()
+	defer func() {
+		_ = srv.srv.Close()
+		select {
+		case <-errCh:
+		case <-time.After(2 * time.Second):
+		}
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", actualPort), 100*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			return
+		}
+		lastErr = err
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("could not reach 127.0.0.1-bound server: %v", lastErr)
 }

--- a/serve.go
+++ b/serve.go
@@ -61,6 +61,7 @@ type workspaceContext struct {
 
 type serveServer struct {
 	port          int
+	bindAddr      string                       // bind interface (default 127.0.0.1; "0.0.0.0" for LAN)
 	kernel        *sdk.Kernel                  // default workspace kernel (backward compat)
 	workspaces    map[string]*workspaceContext // name → workspace context
 	defaultWS     string                       // default workspace name
@@ -95,9 +96,20 @@ type serveServer struct {
 }
 
 func newServeServer(port int, kernel *sdk.Kernel) *serveServer {
+	return newServeServerWithBind(port, "127.0.0.1", kernel)
+}
+
+// newServeServerWithBind is like newServeServer but lets the caller specify
+// the bind address. Used by cmdServeForeground when --bind is supplied.
+// An empty bindAddr falls back to the loopback default.
+func newServeServerWithBind(port int, bindAddr string, kernel *sdk.Kernel) *serveServer {
 	root, _, _ := ResolveWorkspace()
+	if bindAddr == "" {
+		bindAddr = "127.0.0.1"
+	}
 	return &serveServer{
 		port:               port,
+		bindAddr:           bindAddr,
 		kernel:             kernel,
 		busBroker:          newBusEventBroker(),
 		toolBridge:         NewToolBridge(),
@@ -306,7 +318,11 @@ func (s *serveServer) Start() error {
 	mux.HandleFunc("GET /dashboard", s.handleDashboardPage) // Embedded web dashboard
 	mux.HandleFunc("/", s.handleRoot)
 
-	addr := fmt.Sprintf("127.0.0.1:%d", s.port)
+	bindAddr := s.bindAddr
+	if bindAddr == "" {
+		bindAddr = "127.0.0.1"
+	}
+	addr := fmt.Sprintf("%s:%d", bindAddr, s.port)
 
 	// Check port availability before printing banner
 	listener, err := net.Listen("tcp", addr)
@@ -372,7 +388,7 @@ func (s *serveServer) Start() error {
 		}
 	}()
 
-	fmt.Printf("CogOS unified server starting on http://localhost:%d\n", s.port)
+	fmt.Printf("CogOS unified server starting on http://%s:%d (bind %s)\n", displayHost(bindAddr), s.port, bindAddr)
 	fmt.Printf("\nAnthropic Messages API Proxy:\n")
 	fmt.Printf("  POST   /v1/messages         - Proxy to Anthropic (ANTHROPIC_BASE_URL=http://localhost:%d)\n", s.port)
 	fmt.Printf("\nInference (OpenAI-compatible):\n")
@@ -554,13 +570,62 @@ func (s *serveServer) checkOCIDigest() {
 	}
 }
 
+// displayHost returns a user-friendly host string for banner printing.
+// Shows "localhost" for loopback binds, or the actual bind address otherwise
+// (so "0.0.0.0" surfaces clearly to operators opting into LAN binds).
+func displayHost(bindAddr string) string {
+	if bindAddr == "" || bindAddr == "127.0.0.1" || bindAddr == "::1" {
+		return "localhost"
+	}
+	return bindAddr
+}
+
+// isLoopbackBind reports whether the given bind address is loopback-only.
+// Used to decide whether to tighten or relax WS/CORS origin patterns.
+func isLoopbackBind(bindAddr string) bool {
+	switch bindAddr {
+	case "", "127.0.0.1", "localhost", "::1":
+		return true
+	}
+	return false
+}
+
+// originPatternsForBind returns the WebSocket OriginPatterns list
+// appropriate for the given bind address. Loopback binds stay tight
+// (localhost + 127.0.0.1 only); non-loopback binds relax to "*" because
+// the origin is no longer predictable (LAN hostnames, Tailscale MagicDNS,
+// pod DNS, etc.). Security of non-loopback binds must be provided at
+// the network boundary (trusted LAN, VPN, firewall).
+func originPatternsForBind(bindAddr string) []string {
+	if isLoopbackBind(bindAddr) {
+		return []string{"localhost:*", "127.0.0.1:*"}
+	}
+	return []string{"*"}
+}
+
 func (s *serveServer) corsMiddleware(next http.Handler) http.Handler {
+	loopback := isLoopbackBind(s.bindAddr)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		origin := r.Header.Get("Origin")
-		if origin == "" || strings.HasPrefix(origin, "http://localhost") || strings.HasPrefix(origin, "http://127.0.0.1") {
+		switch {
+		case origin == "":
+			// No Origin header — non-browser request. Still emit a permissive
+			// wildcard so downstream tooling doesn't choke on missing header.
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+		case loopback:
+			// Tight policy for loopback: only echo back loopback origins;
+			// everything else falls through to a safe default.
+			if strings.HasPrefix(origin, "http://localhost") || strings.HasPrefix(origin, "http://127.0.0.1") {
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+			} else {
+				w.Header().Set("Access-Control-Allow-Origin", "http://localhost:5100")
+			}
+		default:
+			// Non-loopback bind (e.g. 0.0.0.0). The user has opted into a
+			// broader network surface and is responsible for boundary
+			// protection (trusted LAN / VPN / firewall). Echo the origin
+			// back so LAN / Tailnet / pod clients can connect.
 			w.Header().Set("Access-Control-Allow-Origin", origin)
-		} else {
-			w.Header().Set("Access-Control-Allow-Origin", "http://localhost:5100")
 		}
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, Mcp-Session-Id")

--- a/serve_bus.go
+++ b/serve_bus.go
@@ -133,9 +133,11 @@ func (s *serveServer) handleWatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Upgrade to WebSocket
+	// Upgrade to WebSocket. Origin patterns follow the server's bind address:
+	// loopback stays tight, non-loopback relaxes to "*" (security is enforced
+	// at the network boundary when opting into 0.0.0.0).
 	c, err := websocket.Accept(w, r, &websocket.AcceptOptions{
-		OriginPatterns: []string{"localhost:*", "127.0.0.1:*"},
+		OriginPatterns: originPatternsForBind(s.bindAddr),
 	})
 	if err != nil {
 		s.writeError(w, http.StatusInternalServerError, "failed to upgrade: "+err.Error(), "server_error")

--- a/serve_daemon.go
+++ b/serve_daemon.go
@@ -300,6 +300,7 @@ func getStartTimeFromPID(pid int) (time.Time, error) {
 
 func cmdServe(args []string) int {
 	port := defaultServePort
+	bindAddr := ""
 	subCmd := ""
 
 	// Parse arguments to find subcommand and flags
@@ -309,6 +310,11 @@ func cmdServe(args []string) int {
 		case "--port", "-p":
 			if i+1 < len(args) {
 				fmt.Sscanf(args[i+1], "%d", &port)
+				i++
+			}
+		case "--bind":
+			if i+1 < len(args) {
+				bindAddr = args[i+1]
 				i++
 			}
 		case "--debug":
@@ -339,12 +345,15 @@ func cmdServe(args []string) int {
 		return cmdServeDisable()
 	default:
 		// No subcommand = run in foreground (existing behavior)
-		return cmdServeForeground(port)
+		return cmdServeForeground(port, bindAddr)
 	}
 }
 
-// cmdServeForeground runs the server in the foreground
-func cmdServeForeground(port int) int {
+// cmdServeForeground runs the server in the foreground. An empty bindAddr
+// falls back to loopback ("127.0.0.1"); "0.0.0.0" opens all interfaces
+// (opt-in for pod/LAN/Tailnet deployments that handle the network boundary
+// at a lower layer).
+func cmdServeForeground(port int, bindAddr string) int {
 	// When running under launchd (stdout is not a terminal), redirect all output
 	// through a rotating log writer so StandardOutPath doesn't grow unbounded.
 	if !isStdoutTerminal() {
@@ -408,7 +417,7 @@ func cmdServeForeground(port int) int {
 		}
 	}
 
-	server := newServeServer(port, kernel)
+	server := newServeServerWithBind(port, bindAddr, kernel)
 
 	// Initialize OCI auto-reload
 	if root != "" {
@@ -1193,6 +1202,8 @@ Commands:
 
 Options:
   --port, -p <port>   Port to listen on (default: %d)
+  --bind <addr>       HTTP server bind address (default 127.0.0.1; use 0.0.0.0
+                      for LAN, requires trusted network)
   --help, -h          Show this help
 
 Inference Endpoints (OpenAI-compatible):


### PR DESCRIPTION
Closes #12.

Previously the kernel always bound to 127.0.0.1 regardless of the NetworkConfig.BindAddr declaration in node_config.go. This wires the existing field through engine.Config + adds a `--bind` CLI flag.

## Surface
- `cogos serve --bind 0.0.0.0` - binds all interfaces
- `cog serve --bind 0.0.0.0` - same for the root CLI
- `bind_addr: 0.0.0.0` in kernel.yaml - YAML equivalent (top-level or v3: section)
- Default stays `127.0.0.1` (safe)

## Security posture
Default is loopback-only. Users who opt into 0.0.0.0 must handle the network boundary via trusted network (Tailnet, VPC, LAN). No authentication added (consistent with existing kernel API design).

## CORS / WS
- WS `OriginPatterns` selected by `originPatternsForBind(bindAddr)` helper: loopback stays tight (`localhost:*`, `127.0.0.1:*`); non-loopback relaxes to `*`.
- HTTP `corsMiddleware` echoes the request Origin when bind is non-loopback (otherwise falls back to the existing tight policy).
- Strict policy preserved when binding to the loopback default.

## Flag precedence
`--bind` (CLI) > `bind_addr` (YAML, v3: section > top level) > `127.0.0.1` (default). Mirrors the existing `--port` precedence chain.

## Unblocks
Peer session's image-pipeline plan - socat LAN forwarder (launchd `com.slowbro.cogos-lan-forwarder`) can be retired once this lands.

## Test plan
- [x] Unit: YAML `bind_addr: 0.0.0.0` parses (`TestLoadConfigBindAddrFromYAML`)
- [x] Unit: v3: section overrides top-level (`TestLoadConfigBindAddrV3SectionOverridesTopLevel`)
- [x] Unit: missing `bind_addr` preserves loopback default (`TestLoadConfigBindAddrMissingKeepsLoopback`)
- [x] Unit: `Config.BindAddr` default is `127.0.0.1` (`TestLoadConfigDefaults`)
- [x] Integration: `NewServer` composes `http.Server.Addr` from BindAddr (`TestNewServerUsesBindAddr` - 3 cases)
- [x] Integration: 0.0.0.0 bind actually accepts connections (`TestServerBindsAllInterfaces`)
- [x] Integration: 127.0.0.1 bind unchanged (`TestServerBindsLoopbackOnly`)
- [x] `go build ./...`, `go vet ./...`, `go test ./internal/engine/... -short -race -count=1` all pass
- [x] Full root package race test (`go test . -short -race -count=1`) passes