### PR TITLE
feat(engine): port /v1/bus/* and /v1/sessions to engine (Track 5 Phase 3)

### DIFF
--- a/internal/engine/bus_consumers.go
+++ b/internal/engine/bus_consumers.go
@@ -1,0 +1,210 @@
+// bus_consumers.go — consumer cursor registry for the bus surface.
+//
+// Track 5 Phase 3: port of the consumer-cursor portion of root's bus_stream.go
+// (ADR-061 server-side consumer position tracking). Kept in a separate file
+// from the SSE broker for readability — the two surfaces cooperate but are
+// decoupled.
+//
+// Persistence layout:
+//   {workspace}/.cog/run/bus/{bus_id}.cursors.jsonl   — append-only log, last
+//                                                       entry per consumer wins
+package engine
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ConsumerCursor tracks a consumer's position in a bus event stream.
+// Persisted to {bus_id}.cursors.jsonl alongside events.
+//
+// JSON field names MUST stay identical to root for byte-compat (the cursor
+// objects are what GET /v1/bus/consumers returns under "consumers").
+type ConsumerCursor struct {
+	ConsumerID   string    `json:"consumer_id"`
+	BusID        string    `json:"bus_id"`
+	LastAckedSeq int64     `json:"last_acked_seq"`
+	ConnectedAt  time.Time `json:"connected_at"`
+	LastAckAt    time.Time `json:"last_ack_at"`
+	Stale        bool      `json:"stale"`
+}
+
+// ConsumerRegistry manages consumer cursors for all buses.
+// Thread-safe — all public methods acquire the mutex.
+type ConsumerRegistry struct {
+	mu      sync.RWMutex
+	cursors map[string]map[string]*ConsumerCursor // busID -> consumerID -> cursor
+	dataDir string                                // persistence directory (.cog/run/bus/)
+}
+
+// NewConsumerRegistry constructs an empty registry that will persist cursor
+// updates to dataDir. If dataDir is empty, persistence is disabled (tests).
+func NewConsumerRegistry(dataDir string) *ConsumerRegistry {
+	return &ConsumerRegistry{
+		cursors: make(map[string]map[string]*ConsumerCursor),
+		dataDir: dataDir,
+	}
+}
+
+// GetOrCreate returns the cursor for a consumer, creating one at position 0
+// if it doesn't exist.
+func (cr *ConsumerRegistry) GetOrCreate(busID, consumerID string) *ConsumerCursor {
+	cr.mu.Lock()
+	defer cr.mu.Unlock()
+	if cr.cursors[busID] == nil {
+		cr.cursors[busID] = make(map[string]*ConsumerCursor)
+	}
+	cursor, ok := cr.cursors[busID][consumerID]
+	if !ok {
+		cursor = &ConsumerCursor{
+			ConsumerID:   consumerID,
+			BusID:        busID,
+			LastAckedSeq: 0,
+			ConnectedAt:  time.Now(),
+			Stale:        false,
+		}
+		cr.cursors[busID][consumerID] = cursor
+		slog.Debug("bus-cursor: created cursor", "consumer", consumerID, "bus", busID)
+	} else {
+		cursor.ConnectedAt = time.Now()
+		cursor.Stale = false
+	}
+	return cursor
+}
+
+// Ack advances a consumer's cursor. Returns the updated cursor. Monotonic —
+// ignores seq <= current LastAckedSeq. Returns error if the bus/consumer is
+// unknown (matches root's semantics for /v1/bus/{id}/ack).
+func (cr *ConsumerRegistry) Ack(busID, consumerID string, seq int64) (*ConsumerCursor, error) {
+	cr.mu.Lock()
+	defer cr.mu.Unlock()
+	if cr.cursors[busID] == nil {
+		return nil, fmt.Errorf("unknown bus: %s", busID)
+	}
+	cursor, ok := cr.cursors[busID][consumerID]
+	if !ok {
+		return nil, fmt.Errorf("unknown consumer: %s on bus %s", consumerID, busID)
+	}
+	if seq <= cursor.LastAckedSeq {
+		return cursor, nil
+	}
+	cursor.LastAckedSeq = seq
+	cursor.LastAckAt = time.Now()
+	cursor.Stale = false
+	cr.persistLocked(busID, cursor)
+	return cursor, nil
+}
+
+// List returns all cursors, optionally filtered by busID (empty = all).
+// Returned cursors are copies; modifying them has no effect on the registry.
+func (cr *ConsumerRegistry) List(busID string) []*ConsumerCursor {
+	cr.mu.RLock()
+	defer cr.mu.RUnlock()
+	var result []*ConsumerCursor
+	for bid, consumers := range cr.cursors {
+		if busID != "" && bid != busID {
+			continue
+		}
+		for _, cursor := range consumers {
+			c := *cursor
+			result = append(result, &c)
+		}
+	}
+	return result
+}
+
+// Remove deletes a consumer's cursor by consumer ID across all buses.
+// Returns true if at least one cursor was removed.
+func (cr *ConsumerRegistry) Remove(consumerID string) bool {
+	cr.mu.Lock()
+	defer cr.mu.Unlock()
+	found := false
+	for busID, consumers := range cr.cursors {
+		if _, ok := consumers[consumerID]; ok {
+			delete(consumers, consumerID)
+			found = true
+			slog.Debug("bus-cursor: removed", "consumer", consumerID, "bus", busID)
+			if len(consumers) == 0 {
+				delete(cr.cursors, busID)
+			}
+		}
+	}
+	return found
+}
+
+// persistLocked writes a cursor snapshot to the cursors.jsonl file.
+// Caller must hold cr.mu.
+func (cr *ConsumerRegistry) persistLocked(busID string, cursor *ConsumerCursor) {
+	if cr.dataDir == "" {
+		return
+	}
+	if err := os.MkdirAll(cr.dataDir, 0755); err != nil {
+		slog.Warn("bus-cursor: mkdir failed", "dir", cr.dataDir, "err", err)
+		return
+	}
+	path := filepath.Join(cr.dataDir, busID+".cursors.jsonl")
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		slog.Warn("bus-cursor: open cursor file failed", "path", path, "err", err)
+		return
+	}
+	defer f.Close()
+	data, _ := json.Marshal(cursor)
+	f.Write(append(data, '\n'))
+}
+
+// LoadFromDisk reads all cursor files and reconstructs the latest state per consumer.
+func (cr *ConsumerRegistry) LoadFromDisk() error {
+	if cr.dataDir == "" {
+		return nil
+	}
+	entries, err := os.ReadDir(cr.dataDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read cursor dir: %w", err)
+	}
+
+	cr.mu.Lock()
+	defer cr.mu.Unlock()
+
+	loaded := 0
+	for _, entry := range entries {
+		if !strings.HasSuffix(entry.Name(), ".cursors.jsonl") {
+			continue
+		}
+		busID := strings.TrimSuffix(entry.Name(), ".cursors.jsonl")
+		path := filepath.Join(cr.dataDir, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			slog.Warn("bus-cursor: read cursor file failed", "path", path, "err", err)
+			continue
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			var cursor ConsumerCursor
+			if err := json.Unmarshal([]byte(line), &cursor); err != nil {
+				continue
+			}
+			if cr.cursors[busID] == nil {
+				cr.cursors[busID] = make(map[string]*ConsumerCursor)
+			}
+			cr.cursors[busID][cursor.ConsumerID] = &cursor
+			loaded++
+		}
+	}
+	if loaded > 0 {
+		slog.Debug("bus-cursor: loaded cursor entries from disk", "count", loaded)
+	}
+	return nil
+}

--- a/internal/engine/bus_session.go
+++ b/internal/engine/bus_session.go
@@ -1,0 +1,376 @@
+// bus_session.go — per-bus session manager + hash-chained event log.
+//
+// Track 5 Phase 3: ported verbatim from the root package's bus_session.go so
+// that the `/v1/bus/*` HTTP surface lives in engine.  The storage layout is
+// identical to root:
+//
+//	{workspace}/.cog/.state/buses/
+//	  registry.json                     — bus metadata catalogue
+//	  {bus_id}/events.jsonl             — append-only hash chain (one CogBlock/line)
+//
+// Bus events use pkg/cogfield.Block as the wire type; the hash chain is
+// per-bus (distinct from the ledger chain in ledger.go — do NOT merge).
+//
+// Byte-compat with root: the canonical form used for hash computation and the
+// event JSON shape must stay identical.  The bridge at
+// cog-sandbox-mcp/src/cog_sandbox_mcp/tools/cogos_bridge.py reads:
+//
+//	{v: 2, bus_id, seq, ts, from, type, payload, prev_hash?, prev?, hash}
+package engine
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/cogos-dev/cogos/pkg/cogfield"
+)
+
+// BusBlock is the wire format for bus events. Alias to the canonical
+// pkg/cogfield.Block so the byte-compat JSON shape is guaranteed — the
+// root package uses the same type.
+type BusBlock = cogfield.Block
+
+// BusRegistryEntry matches registry.json shape — aliased for the same reason.
+type BusRegistryEntry = cogfield.BusRegistryEntry
+
+// busEventHandler is a named handler for bus events.
+type busEventHandler struct {
+	name    string
+	handler func(busID string, block *BusBlock)
+}
+
+// BusSessionManager manages CogBus operations: bus creation, event appending,
+// and reading event history. Direct verbatim port of root's busSessionManager
+// to preserve byte-compat.
+type BusSessionManager struct {
+	mu            sync.Mutex
+	workspaceRoot string
+	eventHandlers []busEventHandler
+}
+
+// NewBusSessionManager constructs a manager rooted at workspaceRoot.
+// Events and registry live under {workspaceRoot}/.cog/.state/buses/.
+func NewBusSessionManager(workspaceRoot string) *BusSessionManager {
+	return &BusSessionManager{workspaceRoot: workspaceRoot}
+}
+
+// WorkspaceRoot returns the workspace path the manager is bound to.
+func (m *BusSessionManager) WorkspaceRoot() string {
+	return m.workspaceRoot
+}
+
+// AddEventHandler registers a named handler for bus events.
+// Handlers are called in registration order when a bus event is appended.
+func (m *BusSessionManager) AddEventHandler(name string, fn func(busID string, block *BusBlock)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.eventHandlers = append(m.eventHandlers, busEventHandler{name: name, handler: fn})
+}
+
+// RemoveEventHandler removes a named handler by name.
+func (m *BusSessionManager) RemoveEventHandler(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i, h := range m.eventHandlers {
+		if h.name == name {
+			m.eventHandlers = append(m.eventHandlers[:i], m.eventHandlers[i+1:]...)
+			return
+		}
+	}
+}
+
+// BusesDir returns the path to the buses state directory.
+func (m *BusSessionManager) BusesDir() string {
+	return filepath.Join(m.workspaceRoot, ".cog", ".state", "buses")
+}
+
+// RegistryPath returns the path to the bus registry file.
+func (m *BusSessionManager) RegistryPath() string {
+	return filepath.Join(m.BusesDir(), "registry.json")
+}
+
+// EventsPath returns the path to a bus's events JSONL file.
+func (m *BusSessionManager) EventsPath(busID string) string {
+	return filepath.Join(m.BusesDir(), busID, "events.jsonl")
+}
+
+// computeBusBlockHash computes the V2 content-addressed hash for a bus block.
+// Hashes the full canonical envelope (all fields except hash and sig). The
+// field set and order MUST stay identical to root's computeBlockHash — the
+// hash is byte-compat observable.
+func computeBusBlockHash(block *BusBlock) string {
+	canonical := struct {
+		V       int                    `json:"v"`
+		BusID   string                 `json:"bus_id,omitempty"`
+		Seq     int                    `json:"seq,omitempty"`
+		Ts      string                 `json:"ts"`
+		From    string                 `json:"from"`
+		To      string                 `json:"to,omitempty"`
+		Type    string                 `json:"type"`
+		Payload map[string]interface{} `json:"payload"`
+		Prev    []string               `json:"prev,omitempty"`
+		Merkle  string                 `json:"merkle,omitempty"`
+		Size    int                    `json:"size,omitempty"`
+	}{
+		V: block.V, BusID: block.BusID, Seq: block.Seq,
+		Ts: block.Ts, From: block.From, To: block.To,
+		Type: block.Type, Payload: block.Payload,
+		Prev: block.Prev, Merkle: block.Merkle, Size: block.Size,
+	}
+	data, _ := json.Marshal(canonical)
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// EnsureBus creates the bus directory + events.jsonl if they don't exist.
+// Safe to call multiple times.
+func (m *BusSessionManager) EnsureBus(busID string) error {
+	busDir := filepath.Join(m.BusesDir(), busID)
+	if err := os.MkdirAll(busDir, 0755); err != nil {
+		return fmt.Errorf("create bus dir: %w", err)
+	}
+	eventsFile := filepath.Join(busDir, "events.jsonl")
+	if _, err := os.Stat(eventsFile); os.IsNotExist(err) {
+		f, err := os.Create(eventsFile)
+		if err != nil {
+			return fmt.Errorf("create events file: %w", err)
+		}
+		f.Close()
+	}
+	return nil
+}
+
+// RegisterBus adds or updates a bus entry in the registry.
+func (m *BusSessionManager) RegisterBus(busID, sessionID, origin string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.registerBusLocked(busID, sessionID, origin)
+}
+
+// registerBusLocked is the locked-variant helper. Caller must hold m.mu.
+func (m *BusSessionManager) registerBusLocked(busID, sessionID, origin string) error {
+	registry := m.loadRegistry()
+
+	for i, entry := range registry {
+		if entry.BusID == busID {
+			registry[i].State = "active"
+			return m.saveRegistry(registry)
+		}
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	entry := BusRegistryEntry{
+		BusID:        busID,
+		State:        "active",
+		Participants: []string{fmt.Sprintf("%s:session:%s", origin, sessionID), "kernel:cogos"},
+		Transport:    "file",
+		Endpoint:     filepath.Join(".cog", ".state", "buses", busID),
+		CreatedAt:    now,
+		LastEventSeq: 0,
+		LastEventAt:  now,
+		EventCount:   0,
+	}
+	registry = append(registry, entry)
+	return m.saveRegistry(registry)
+}
+
+// loadRegistry reads the bus registry from disk. Returns empty slice on error.
+// Caller must hold m.mu.
+func (m *BusSessionManager) loadRegistry() []BusRegistryEntry {
+	data, err := os.ReadFile(m.RegistryPath())
+	if err != nil {
+		return []BusRegistryEntry{}
+	}
+	var entries []BusRegistryEntry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return []BusRegistryEntry{}
+	}
+	return entries
+}
+
+// LoadRegistry is the public, lock-acquiring variant. Returns a copy of the
+// current registry snapshot.
+func (m *BusSessionManager) LoadRegistry() []BusRegistryEntry {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	entries := m.loadRegistry()
+	out := make([]BusRegistryEntry, len(entries))
+	copy(out, entries)
+	return out
+}
+
+// saveRegistry writes the bus registry to disk. Caller must hold m.mu.
+func (m *BusSessionManager) saveRegistry(entries []BusRegistryEntry) error {
+	if err := os.MkdirAll(m.BusesDir(), 0755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(m.RegistryPath(), data, 0644)
+}
+
+// AppendEvent appends a new BusBlock to a bus's event chain.
+// V2 blocks hash the full canonical envelope (all fields except hash and sig).
+// Both prev ([]string) and prev_hash (string) are written for V1 compat.
+// Handlers are dispatched synchronously after the lock is released.
+//
+// The bus directory + events.jsonl are created on demand if they don't yet
+// exist — matches root's behaviour where handleBusSend pre-creates them but
+// downstream callers (e.g. the chat pipeline) can skip that step.
+func (m *BusSessionManager) AppendEvent(busID, eventType, from string, payload map[string]interface{}) (*BusBlock, error) {
+	// EnsureBus is idempotent and takes its own lock-free path; do it
+	// before acquiring m.mu to keep the critical section small.
+	if err := m.EnsureBus(busID); err != nil {
+		return nil, fmt.Errorf("ensure bus: %w", err)
+	}
+
+	m.mu.Lock()
+
+	lastSeq, lastHash := m.getLastEvent(busID)
+	newSeq := lastSeq + 1
+
+	var prev []string
+	if lastHash != "" {
+		prev = []string{lastHash}
+	}
+
+	evt := BusBlock{
+		V:        2,
+		BusID:    busID,
+		Seq:      newSeq,
+		Ts:       time.Now().UTC().Format(time.RFC3339Nano),
+		From:     from,
+		Type:     eventType,
+		Payload:  payload,
+		Prev:     prev,
+		PrevHash: lastHash, // V1 compat — written alongside Prev during transition
+	}
+	evt.Hash = computeBusBlockHash(&evt)
+
+	line, err := json.Marshal(evt)
+	if err != nil {
+		m.mu.Unlock()
+		return nil, fmt.Errorf("marshal event: %w", err)
+	}
+
+	eventsFile := m.EventsPath(busID)
+	f, err := os.OpenFile(eventsFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		m.mu.Unlock()
+		return nil, fmt.Errorf("open events file: %w", err)
+	}
+	if _, err := f.WriteString(string(line) + "\n"); err != nil {
+		f.Close()
+		m.mu.Unlock()
+		return nil, fmt.Errorf("write event: %w", err)
+	}
+	f.Close()
+
+	m.updateRegistrySeqLocked(busID, newSeq, evt.Ts)
+
+	// Snapshot handlers while locked, then dispatch OUTSIDE the lock.
+	handlers := make([]busEventHandler, len(m.eventHandlers))
+	copy(handlers, m.eventHandlers)
+	m.mu.Unlock()
+
+	for _, h := range handlers {
+		h.handler(busID, &evt)
+	}
+
+	return &evt, nil
+}
+
+// getLastEvent reads the last event from a bus to get seq and hash for chaining.
+// Caller must hold m.mu.
+func (m *BusSessionManager) getLastEvent(busID string) (int, string) {
+	eventsFile := m.EventsPath(busID)
+	f, err := os.Open(eventsFile)
+	if err != nil {
+		return 0, ""
+	}
+	defer f.Close()
+
+	var lastLine string
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 256*1024), 256*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line != "" {
+			lastLine = line
+		}
+	}
+
+	if lastLine == "" {
+		return 0, ""
+	}
+
+	var block BusBlock
+	if err := json.Unmarshal([]byte(lastLine), &block); err != nil {
+		return 0, ""
+	}
+	return block.Seq, block.Hash
+}
+
+// updateRegistrySeqLocked updates the last event seq/timestamp in the registry.
+// Caller must hold m.mu.
+func (m *BusSessionManager) updateRegistrySeqLocked(busID string, seq int, ts string) {
+	registry := m.loadRegistry()
+	for i, entry := range registry {
+		if entry.BusID == busID {
+			registry[i].LastEventSeq = seq
+			registry[i].LastEventAt = ts
+			registry[i].EventCount = seq
+			break
+		}
+	}
+	if err := m.saveRegistry(registry); err != nil {
+		slog.Warn("bus: failed to update registry seq", "err", err, "bus_id", busID)
+	}
+}
+
+// ReadEvents reads all events from a bus. De-dups by seq (file may have
+// duplicates from crash recovery).
+func (m *BusSessionManager) ReadEvents(busID string) ([]BusBlock, error) {
+	eventsFile := m.EventsPath(busID)
+	f, err := os.Open(eventsFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("open events file: %w", err)
+	}
+	defer f.Close()
+
+	var events []BusBlock
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 256*1024), 256*1024)
+	seen := make(map[int]bool)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		var block BusBlock
+		if err := json.Unmarshal([]byte(line), &block); err != nil {
+			continue
+		}
+		if seen[block.Seq] {
+			continue
+		}
+		seen[block.Seq] = true
+		events = append(events, block)
+	}
+
+	return events, nil
+}

--- a/internal/engine/bus_session_test.go
+++ b/internal/engine/bus_session_test.go
@@ -1,0 +1,309 @@
+// bus_session_test.go — unit tests for BusSessionManager.
+//
+// Track 5 Phase 3: verifies hash-chain continuity, bus isolation, and the
+// byte-compat storage layout (.cog/.state/buses/{id}/events.jsonl).
+package engine
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestBusSessionAppendAndRead covers the basic seq/hash chain and JSONL
+// storage layout.
+func TestBusSessionAppendAndRead(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mgr := NewBusSessionManager(root)
+
+	if err := mgr.EnsureBus("bus-a"); err != nil {
+		t.Fatalf("EnsureBus: %v", err)
+	}
+
+	e1, err := mgr.AppendEvent("bus-a", "message", "alice", map[string]interface{}{"content": "hello"})
+	if err != nil {
+		t.Fatalf("AppendEvent 1: %v", err)
+	}
+	if e1.Seq != 1 {
+		t.Errorf("seq = %d, want 1", e1.Seq)
+	}
+	if e1.Hash == "" || len(e1.Hash) != 64 {
+		t.Errorf("hash not 64-char hex: %q", e1.Hash)
+	}
+	if _, err := hex.DecodeString(e1.Hash); err != nil {
+		t.Errorf("hash not lowercase hex: %v", err)
+	}
+	if len(e1.Prev) != 0 || e1.PrevHash != "" {
+		t.Errorf("first event should have no prev: prev=%v prev_hash=%q", e1.Prev, e1.PrevHash)
+	}
+
+	e2, err := mgr.AppendEvent("bus-a", "message", "bob", map[string]interface{}{"content": "world"})
+	if err != nil {
+		t.Fatalf("AppendEvent 2: %v", err)
+	}
+	if e2.Seq != 2 {
+		t.Errorf("seq = %d, want 2", e2.Seq)
+	}
+	if len(e2.Prev) != 1 || e2.Prev[0] != e1.Hash {
+		t.Errorf("prev chain broken: got %v, want [%s]", e2.Prev, e1.Hash)
+	}
+	if e2.PrevHash != e1.Hash {
+		t.Errorf("prev_hash = %q, want %q", e2.PrevHash, e1.Hash)
+	}
+
+	// Verify storage layout matches root: .cog/.state/buses/{bus_id}/events.jsonl
+	eventsFile := filepath.Join(root, ".cog", ".state", "buses", "bus-a", "events.jsonl")
+	b, err := os.ReadFile(eventsFile)
+	if err != nil {
+		t.Fatalf("read events.jsonl: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(b)), "\n")
+	if len(lines) != 2 {
+		t.Errorf("events.jsonl has %d lines, want 2", len(lines))
+	}
+
+	// Verify ReadEvents de-dups by seq and preserves order.
+	events, err := mgr.ReadEvents("bus-a")
+	if err != nil {
+		t.Fatalf("ReadEvents: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("len(events) = %d, want 2", len(events))
+	}
+	if events[0].Seq != 1 || events[1].Seq != 2 {
+		t.Errorf("seq order broken: %d, %d", events[0].Seq, events[1].Seq)
+	}
+}
+
+// TestBusSessionHashChainRecompute verifies that re-computing the hash of a
+// read-back event yields the stored hash (byte-compat with root's hash).
+func TestBusSessionHashChainRecompute(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mgr := NewBusSessionManager(root)
+
+	_, _ = mgr.AppendEvent("chain", "event.a", "sender", map[string]interface{}{"k": "v"})
+	_, _ = mgr.AppendEvent("chain", "event.b", "sender", map[string]interface{}{"k": 42.0})
+	_, _ = mgr.AppendEvent("chain", "event.c", "sender", map[string]interface{}{"k": true})
+
+	events, err := mgr.ReadEvents("chain")
+	if err != nil {
+		t.Fatalf("ReadEvents: %v", err)
+	}
+
+	var prevHash string
+	for i, e := range events {
+		// Re-compute the hash from the event and compare.
+		recomputed := computeBusBlockHash(&e)
+		if recomputed != e.Hash {
+			t.Errorf("event %d: recomputed hash %q != stored hash %q", i, recomputed, e.Hash)
+		}
+		// Verify the chain links.
+		if i == 0 {
+			if e.PrevHash != "" {
+				t.Errorf("event 0 PrevHash = %q, want empty", e.PrevHash)
+			}
+		} else if e.PrevHash != prevHash {
+			t.Errorf("event %d PrevHash = %q, want %q", i, e.PrevHash, prevHash)
+		}
+		prevHash = e.Hash
+	}
+}
+
+// TestBusSessionIsolation verifies two buses don't cross-contaminate.
+func TestBusSessionIsolation(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mgr := NewBusSessionManager(root)
+
+	a1, _ := mgr.AppendEvent("bus-a", "m", "x", map[string]interface{}{"v": 1})
+	b1, _ := mgr.AppendEvent("bus-b", "m", "x", map[string]interface{}{"v": 1})
+	a2, _ := mgr.AppendEvent("bus-a", "m", "x", map[string]interface{}{"v": 2})
+
+	if a1.Seq != 1 || b1.Seq != 1 || a2.Seq != 2 {
+		t.Errorf("bus seqs wrong: a1=%d b1=%d a2=%d", a1.Seq, b1.Seq, a2.Seq)
+	}
+	if len(b1.Prev) != 0 {
+		t.Errorf("bus-b first event shouldn't chain from bus-a: prev=%v", b1.Prev)
+	}
+
+	aEvents, _ := mgr.ReadEvents("bus-a")
+	bEvents, _ := mgr.ReadEvents("bus-b")
+	if len(aEvents) != 2 {
+		t.Errorf("bus-a has %d events, want 2", len(aEvents))
+	}
+	if len(bEvents) != 1 {
+		t.Errorf("bus-b has %d events, want 1", len(bEvents))
+	}
+}
+
+// TestBusSessionRegistry covers RegisterBus + LoadRegistry round-trip and
+// verifies the registry.json format matches root.
+func TestBusSessionRegistry(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mgr := NewBusSessionManager(root)
+
+	if err := mgr.EnsureBus("r1"); err != nil {
+		t.Fatalf("EnsureBus: %v", err)
+	}
+	if err := mgr.RegisterBus("r1", "sess1", "test"); err != nil {
+		t.Fatalf("RegisterBus: %v", err)
+	}
+
+	entries := mgr.LoadRegistry()
+	if len(entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1", len(entries))
+	}
+	if entries[0].BusID != "r1" || entries[0].State != "active" {
+		t.Errorf("registry shape wrong: %+v", entries[0])
+	}
+	if entries[0].Transport != "file" {
+		t.Errorf("Transport = %q, want 'file'", entries[0].Transport)
+	}
+	if entries[0].Endpoint != filepath.Join(".cog", ".state", "buses", "r1") {
+		t.Errorf("Endpoint = %q", entries[0].Endpoint)
+	}
+
+	// Append an event, verify registry got updated.
+	_, _ = mgr.AppendEvent("r1", "m", "from", map[string]interface{}{"x": 1})
+	entries = mgr.LoadRegistry()
+	if entries[0].LastEventSeq != 1 || entries[0].EventCount != 1 {
+		t.Errorf("registry not updated after append: %+v", entries[0])
+	}
+
+	// Verify registry.json is valid JSON with the expected field names.
+	regBytes, err := os.ReadFile(mgr.RegistryPath())
+	if err != nil {
+		t.Fatalf("read registry.json: %v", err)
+	}
+	var parsed []map[string]interface{}
+	if err := json.Unmarshal(regBytes, &parsed); err != nil {
+		t.Fatalf("registry.json not valid JSON: %v", err)
+	}
+	wantFields := []string{"bus_id", "state", "participants", "transport", "endpoint", "created_at", "last_event_seq", "last_event_at", "event_count"}
+	for _, f := range wantFields {
+		if _, ok := parsed[0][f]; !ok {
+			t.Errorf("registry.json missing field %q", f)
+		}
+	}
+}
+
+// TestBusSessionByteCompatJSONShape verifies that the JSON encoding of a bus
+// event matches the shape captured from the live cogos-v3 daemon:
+//
+//	{v, bus_id, seq, ts, from, type, payload, prev?, prev_hash?, hash}
+func TestBusSessionByteCompatJSONShape(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mgr := NewBusSessionManager(root)
+
+	// First event — no prev chain.
+	e1, err := mgr.AppendEvent("phase3-test", "message", "phase3-test",
+		map[string]interface{}{"content": "shape-probe"})
+	if err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+
+	raw, _ := json.Marshal(e1)
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// Required fields that the bridge (cogos_bridge.py) reads on every
+	// event. If any of these go missing, the bridge breaks.
+	wantRequired := []string{"v", "bus_id", "seq", "ts", "from", "type", "payload", "hash"}
+	for _, f := range wantRequired {
+		if _, ok := parsed[f]; !ok {
+			t.Errorf("first event missing required field %q", f)
+		}
+	}
+	// On the first event `prev` + `prev_hash` should be omitted (omitempty).
+	if _, has := parsed["prev"]; has {
+		t.Errorf("first event unexpectedly has 'prev': %v", parsed["prev"])
+	}
+	if _, has := parsed["prev_hash"]; has {
+		t.Errorf("first event unexpectedly has 'prev_hash': %v", parsed["prev_hash"])
+	}
+
+	// Second event — should carry prev and prev_hash.
+	e2, _ := mgr.AppendEvent("phase3-test", "message", "phase3-test",
+		map[string]interface{}{"content": "second"})
+	raw2, _ := json.Marshal(e2)
+	var p2 map[string]interface{}
+	_ = json.Unmarshal(raw2, &p2)
+	if _, ok := p2["prev"]; !ok {
+		t.Errorf("second event missing 'prev'")
+	}
+	if _, ok := p2["prev_hash"]; !ok {
+		t.Errorf("second event missing 'prev_hash'")
+	}
+
+	// Value-level checks on the first event.
+	if parsed["v"].(float64) != 2 {
+		t.Errorf("v = %v, want 2", parsed["v"])
+	}
+	if parsed["bus_id"].(string) != "phase3-test" {
+		t.Errorf("bus_id = %v", parsed["bus_id"])
+	}
+	if parsed["seq"].(float64) != 1 {
+		t.Errorf("seq = %v, want 1", parsed["seq"])
+	}
+	if parsed["type"].(string) != "message" {
+		t.Errorf("type = %v", parsed["type"])
+	}
+	// Ts must be RFC3339-nano style.
+	ts, ok := parsed["ts"].(string)
+	if !ok || !strings.Contains(ts, "T") || !strings.HasSuffix(ts, "Z") {
+		t.Errorf("ts shape wrong: %q", ts)
+	}
+	// Hash is lowercase hex, 64 chars.
+	h, ok := parsed["hash"].(string)
+	if !ok || len(h) != 64 {
+		t.Errorf("hash shape wrong: %q", h)
+	}
+	if _, err := hex.DecodeString(h); err != nil {
+		t.Errorf("hash not hex: %v", err)
+	}
+}
+
+// TestBusSessionEventHandlerDispatch verifies that registered handlers
+// fire after AppendEvent, outside the lock.
+func TestBusSessionEventHandlerDispatch(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mgr := NewBusSessionManager(root)
+
+	seen := make(chan *BusBlock, 4)
+	mgr.AddEventHandler("test", func(busID string, block *BusBlock) {
+		seen <- block
+	})
+
+	_, _ = mgr.AppendEvent("bus-h", "m", "x", map[string]interface{}{"v": 1})
+	_, _ = mgr.AppendEvent("bus-h", "m", "x", map[string]interface{}{"v": 2})
+
+	for i := 0; i < 2; i++ {
+		select {
+		case evt := <-seen:
+			if evt.Seq != i+1 {
+				t.Errorf("handler received seq=%d, want %d", evt.Seq, i+1)
+			}
+		default:
+			t.Errorf("handler didn't receive event %d", i+1)
+		}
+	}
+
+	mgr.RemoveEventHandler("test")
+	_, _ = mgr.AppendEvent("bus-h", "m", "x", map[string]interface{}{"v": 3})
+	select {
+	case evt := <-seen:
+		t.Errorf("handler fired after removal: %+v", evt)
+	default:
+		// ok — handler was properly removed
+	}
+}

--- a/internal/engine/bus_stream.go
+++ b/internal/engine/bus_stream.go
@@ -1,0 +1,233 @@
+// bus_stream.go — bus-session-backed SSE broker (parallel to the ledger
+// EventBroker in eventbus.go).
+//
+// Track 5 Phase 3: library-only port of root's bus_stream.go broker so that
+// AppendEvent can fan out to SSE subscribers. No HTTP route is registered in
+// this phase — PR #16 already owns `/v1/events/stream` (ledger-backed). The
+// broker exists here so future work (or a caller that wires its own SSE
+// handler) can subscribe to per-bus events without re-running the port.
+//
+// This surface is intentionally distinct from the ledger EventBroker:
+//
+//	EventBroker  (eventbus.go)      — ledger-append events, hash-chain over all events
+//	BusEventBroker (this file)      — per-bus events from .cog/.state/buses/{id}/events.jsonl
+//
+// Per I2 the two chains stay separate.
+package engine
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// Defaults copied verbatim from root so reapers/limits behave identically.
+const (
+	busSSEMaxPerBus       = 25
+	busSSEIdleTimeout     = 2 * time.Minute
+	busSSEReaperInterval  = 30 * time.Second
+)
+
+// busSSESubscriber tracks per-connection metadata for liveness detection.
+type busSSESubscriber struct {
+	ch         chan *BusBlock
+	ctx        context.Context // request context; Done() = client disconnected
+	lastWrite  time.Time
+	consumerID string // optional consumer identity for dedup
+}
+
+// BusEventBroker manages SSE subscribers for real-time bus event delivery.
+// Per-bus indexed, with a wildcard key "*" for cross-bus subscriptions.
+type BusEventBroker struct {
+	mu          sync.RWMutex
+	subscribers map[string]map[chan *BusBlock]*busSSESubscriber
+}
+
+// NewBusEventBroker constructs an empty broker.
+func NewBusEventBroker() *BusEventBroker {
+	return &BusEventBroker{
+		subscribers: make(map[string]map[chan *BusBlock]*busSSESubscriber),
+	}
+}
+
+// StartReaper launches a background goroutine that periodically sweeps stale
+// SSE connections across all buses. This is the "belt" — catches abandoned
+// connections regardless of whether new ones are arriving.
+func (b *BusEventBroker) StartReaper(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(busSSEReaperInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				reaped := b.sweepAll()
+				if reaped > 0 {
+					slog.Debug("bus-stream: reaper closed stale connections", "count", reaped)
+				}
+			}
+		}
+	}()
+}
+
+// sweepAll sweeps stale/dead subscribers across ALL buses.
+func (b *BusEventBroker) sweepAll() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	total := 0
+	for busID := range b.subscribers {
+		now := time.Now()
+		subs := b.subscribers[busID]
+		for ch, sub := range subs {
+			dead := false
+			select {
+			case <-sub.ctx.Done():
+				dead = true
+			default:
+			}
+			if !dead && now.Sub(sub.lastWrite) > busSSEIdleTimeout {
+				dead = true
+			}
+			if dead {
+				delete(subs, ch)
+				close(ch)
+				total++
+			}
+		}
+		if len(subs) == 0 {
+			delete(b.subscribers, busID)
+		}
+	}
+	return total
+}
+
+// Subscribe registers a channel to receive events for a given bus.
+// If consumerID is non-empty, any existing subscription with the same
+// consumer identity is evicted first. If the bus is at the connection
+// limit, stale/dead subscribers are swept first; returns false if still
+// at capacity afterward.
+func (b *BusEventBroker) Subscribe(busID string, ch chan *BusBlock, ctx context.Context, consumerID string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.subscribers[busID] == nil {
+		b.subscribers[busID] = make(map[chan *BusBlock]*busSSESubscriber)
+	}
+
+	// Consumer-identity dedup: close previous connection from same consumer.
+	if consumerID != "" {
+		for oldCh, sub := range b.subscribers[busID] {
+			if sub.consumerID == consumerID {
+				delete(b.subscribers[busID], oldCh)
+				close(oldCh)
+				slog.Debug("bus-stream: replaced connection for consumer",
+					"consumer", consumerID, "bus", busID)
+				break
+			}
+		}
+	}
+
+	if len(b.subscribers[busID]) >= busSSEMaxPerBus {
+		b.sweepLocked(busID)
+	}
+	if len(b.subscribers[busID]) >= busSSEMaxPerBus {
+		slog.Warn("bus-stream: REJECT at capacity", "bus", busID, "cap", busSSEMaxPerBus)
+		return false
+	}
+
+	b.subscribers[busID][ch] = &busSSESubscriber{
+		ch:         ch,
+		ctx:        ctx,
+		lastWrite:  time.Now(),
+		consumerID: consumerID,
+	}
+	return true
+}
+
+// sweepLocked removes dead or idle subscribers for a bus.
+// Caller must hold b.mu (write lock).
+func (b *BusEventBroker) sweepLocked(busID string) {
+	subs, ok := b.subscribers[busID]
+	if !ok {
+		return
+	}
+	now := time.Now()
+	for ch, sub := range subs {
+		dead := false
+		select {
+		case <-sub.ctx.Done():
+			dead = true
+		default:
+		}
+		if !dead && now.Sub(sub.lastWrite) > busSSEIdleTimeout {
+			dead = true
+		}
+		if dead {
+			slog.Debug("bus-stream: evicting stale subscriber",
+				"bus", busID, "last_write_ago", now.Sub(sub.lastWrite).Round(time.Second))
+			delete(subs, ch)
+			close(ch)
+		}
+	}
+	if len(subs) == 0 {
+		delete(b.subscribers, busID)
+	}
+}
+
+// SubscriberCount returns the number of active subscribers for a bus.
+func (b *BusEventBroker) SubscriberCount(busID string) int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return len(b.subscribers[busID])
+}
+
+// Unsubscribe removes a channel from a bus's subscriber set.
+func (b *BusEventBroker) Unsubscribe(busID string, ch chan *BusBlock) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if subs, ok := b.subscribers[busID]; ok {
+		delete(subs, ch)
+		if len(subs) == 0 {
+			delete(b.subscribers, busID)
+		}
+	}
+}
+
+// TouchWrite updates the lastWrite timestamp for a subscriber.
+func (b *BusEventBroker) TouchWrite(busID string, ch chan *BusBlock) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if subs, ok := b.subscribers[busID]; ok {
+		if sub, ok := subs[ch]; ok {
+			sub.lastWrite = time.Now()
+		}
+	}
+}
+
+// Publish sends an event to all subscribers of a bus AND to wildcard ("*")
+// subscribers. Non-blocking: drops if channel is full.
+func (b *BusEventBroker) Publish(busID string, evt *BusBlock) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	if subs, ok := b.subscribers[busID]; ok {
+		for ch := range subs {
+			select {
+			case ch <- evt:
+			default:
+			}
+		}
+	}
+
+	if busID != "*" {
+		if subs, ok := b.subscribers["*"]; ok {
+			for ch := range subs {
+				select {
+				case ch <- evt:
+				default:
+				}
+			}
+		}
+	}
+}

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -56,11 +56,30 @@ type Server struct {
 	attentionLog    *attentionLog // per-server log (avoids global write race)
 	agentController AgentController // nil until SetAgentController is called
 	mcpServer       *MCPServer      // so SetAgentController can propagate to tools
+
+	// Track 5 Phase 3 surface — per-bus event store, SSE broker, and
+	// consumer cursor registry. Scoped to the server so tests can create
+	// isolated instances.
+	busSessions  *BusSessionManager
+	busBroker    *BusEventBroker
+	busConsumers *ConsumerRegistry
+	sessions     *SessionContextStore
 }
 
 // NewServer constructs a Server bound to the configured port.
 func NewServer(cfg *Config, nucleus *Nucleus, process *Process) *Server {
 	s := &Server{cfg: cfg, nucleus: nucleus, process: process}
+
+	// Phase 3 bus/session surface. Managers are always instantiated so
+	// handlers don't need nil-safety for the common case; tests can
+	// override via the exported fields if they want an isolated fixture.
+	s.busSessions = NewBusSessionManager(cfg.WorkspaceRoot)
+	s.busBroker = NewBusEventBroker()
+	s.busConsumers = NewConsumerRegistry(
+		// Match root's persistence path: .cog/run/bus/{bus_id}.cursors.jsonl
+		filepath.Join(cfg.WorkspaceRoot, ".cog", "run", "bus"),
+	)
+	s.sessions = NewSessionContextStore()
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /", handleDashboard)
@@ -91,6 +110,9 @@ func NewServer(cfg *Config, nucleus *Nucleus, process *Process) *Server {
 	s.registerEventBusRoutes(mux)
 	s.registerMCPRoutes(mux)
 	s.registerConfigRoutes(mux)
+
+	// Track 5 Phase 3: /v1/bus/* and /v1/sessions routes.
+	s.registerBusRoutes(mux)
 
 	// Resolve the bind address. Default stays 127.0.0.1 (loopback-only);
 	// callers may override via Config.BindAddr to listen on all interfaces

--- a/internal/engine/serve_bus.go
+++ b/internal/engine/serve_bus.go
@@ -1,0 +1,541 @@
+// serve_bus.go — HTTP surface for the per-bus event store.
+//
+// Track 5 Phase 3: ported verbatim from the root package's bus_api.go +
+// serve_bus.go. The response shapes are byte-compat with the live v3 daemon
+// so cog-sandbox-mcp's bridge (tools/cogos_bridge.py) keeps working when the
+// installed binary flips to engine in Phase 4.
+//
+// Routes owned by this file:
+//
+//	POST   /v1/bus/send                       — append event to a bus
+//	POST   /v1/bus/open                       — create/register a bus
+//	GET    /v1/bus/list                       — list all registered buses
+//	GET    /v1/bus/events                     — cross-bus event search
+//	GET    /v1/bus/{bus_id}/events            — per-bus events, filtered
+//	GET    /v1/bus/{bus_id}/events/{seq}      — single event by seq
+//	GET    /v1/bus/{bus_id}/stats             — bus statistics
+//	GET    /v1/bus/consumers                  — list consumer cursors (ADR-061)
+//	DELETE /v1/bus/consumers/{consumer_id}    — remove a consumer cursor
+package engine
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/cogos-dev/cogos/pkg/cogfield"
+)
+
+// registerBusRoutes attaches the nine /v1/bus/* routes + the two
+// /v1/sessions routes onto mux. Called from NewServer after the base
+// routes so the specific patterns register cleanly.
+//
+// Route ordering note: the Go 1.22+ mux routes by pattern specificity, so
+// POST /v1/bus/send wins over POST /v1/bus/... even though the latter is a
+// shorter prefix. We still list the specific routes before the bus_id catch
+// for readability.
+func (s *Server) registerBusRoutes(mux *http.ServeMux) {
+	// Specific first, catch-all later — same order as root's serve.go.
+	mux.HandleFunc("POST /v1/bus/send", s.handleBusSend)
+	mux.HandleFunc("POST /v1/bus/open", s.handleBusOpen)
+	mux.HandleFunc("GET /v1/bus/list", s.handleBusList)
+	mux.HandleFunc("GET /v1/bus/events", s.handleBusEventsGlobal) // cross-bus search
+
+	// Consumer cursor API (ADR-061).
+	mux.HandleFunc("GET /v1/bus/consumers", s.handleBusConsumers)
+	mux.HandleFunc("DELETE /v1/bus/consumers/", s.handleBusConsumerDelete)
+
+	// Catch-all for /v1/bus/{bus_id}/events[,/{seq}] and /v1/bus/{bus_id}/stats.
+	mux.HandleFunc("GET /v1/bus/", s.handleBusRoute)
+
+	// Session surface.
+	mux.HandleFunc("GET /v1/sessions", s.handleListSessions)
+	mux.HandleFunc("GET /v1/sessions/", s.handleSessionContext)
+}
+
+// ─── POST /v1/bus/send ───────────────────────────────────────────────────────
+
+// busSendRequest mirrors root's body shape exactly.
+type busSendRequest struct {
+	BusID   string `json:"bus_id"`
+	From    string `json:"from"`
+	To      string `json:"to,omitempty"`
+	Message string `json:"message"`
+	Type    string `json:"type,omitempty"` // event type, defaults to "message"
+}
+
+// busSendResponse is the 200 body.
+type busSendResponse struct {
+	OK   bool   `json:"ok"`
+	Seq  int    `json:"seq"`
+	Hash string `json:"hash"`
+}
+
+// handleBusSend appends a message event to a bus. The engine treats "message"
+// as the default event type and builds the payload identically to root:
+// {"content": message} with an optional "to" field.
+func (s *Server) handleBusSend(w http.ResponseWriter, r *http.Request) {
+	var req busSendRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"error":"invalid JSON body"}`, http.StatusBadRequest)
+		return
+	}
+
+	if req.BusID == "" || req.Message == "" {
+		http.Error(w, `{"error":"bus_id and message are required"}`, http.StatusBadRequest)
+		return
+	}
+
+	if req.From == "" {
+		req.From = "anonymous"
+	}
+	eventType := req.Type
+	if eventType == "" {
+		eventType = "message"
+	}
+
+	mgr := s.busSessions
+	if mgr == nil {
+		http.Error(w, `{"error":"no bus manager available"}`, http.StatusServiceUnavailable)
+		return
+	}
+
+	if err := mgr.EnsureBus(req.BusID); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+
+	payload := map[string]interface{}{
+		"content": req.Message,
+	}
+	if req.To != "" {
+		payload["to"] = req.To
+	}
+
+	evt, err := mgr.AppendEvent(req.BusID, eventType, req.From, payload)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":"append failed: %s"}`, err), http.StatusInternalServerError)
+		return
+	}
+
+	// Publish to the SSE broker so subscribers hear about it. Root wires
+	// publish via an AppendEvent handler registered in serve_daemon.go;
+	// here we do it inline so the broker is optional — if no broker is
+	// attached, sends still succeed.
+	if s.busBroker != nil {
+		s.busBroker.Publish(req.BusID, evt)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(busSendResponse{
+		OK:   true,
+		Seq:  evt.Seq,
+		Hash: evt.Hash,
+	})
+}
+
+// ─── POST /v1/bus/open ───────────────────────────────────────────────────────
+
+// handleBusOpen creates or re-opens a bus for inter-workspace communication.
+// Response shape preserved: {ok, bus_id, state}.
+func (s *Server) handleBusOpen(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		BusID        string   `json:"bus_id"`
+		Participants []string `json:"participants"`
+		Transport    string   `json:"transport"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"error":"invalid JSON body"}`, http.StatusBadRequest)
+		return
+	}
+	if req.BusID == "" {
+		http.Error(w, `{"error":"bus_id is required"}`, http.StatusBadRequest)
+		return
+	}
+
+	mgr := s.busSessions
+	if mgr == nil {
+		http.Error(w, `{"error":"no bus manager available"}`, http.StatusServiceUnavailable)
+		return
+	}
+
+	if err := mgr.EnsureBus(req.BusID); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+
+	origin := "api"
+	if len(req.Participants) > 0 {
+		origin = req.Participants[0]
+	}
+	if err := mgr.RegisterBus(req.BusID, origin, origin); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":"register failed: %s"}`, err), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"ok":     true,
+		"bus_id": req.BusID,
+		"state":  "active",
+	})
+}
+
+// ─── GET /v1/bus/list ────────────────────────────────────────────────────────
+
+// handleBusList returns every registered bus as a JSON array of BusRegistryEntry.
+func (s *Server) handleBusList(w http.ResponseWriter, r *http.Request) {
+	mgr := s.busSessions
+	if mgr == nil {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+		return
+	}
+
+	entries := mgr.LoadRegistry()
+	if entries == nil {
+		entries = []BusRegistryEntry{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(entries)
+}
+
+// ─── Event query filtering (shared) ──────────────────────────────────────────
+
+// busEventQueryParams holds parsed query parameters for event filtering.
+type busEventQueryParams struct {
+	Type   string
+	From   string
+	After  int
+	Before int
+	Limit  int
+	Since  string
+	Until  string
+}
+
+// parseBusEventQuery extracts query params from the request URL.
+// Default limit: 100, capped at 1000.
+func parseBusEventQuery(r *http.Request) busEventQueryParams {
+	q := r.URL.Query()
+	p := busEventQueryParams{
+		Type:  q.Get("type"),
+		From:  q.Get("from"),
+		Since: q.Get("since"),
+		Until: q.Get("until"),
+		Limit: 100,
+	}
+	// Root reads `after` but the bridge's existing query param is also `after`;
+	// honor `from_sender` as a documented alias for readability, though root
+	// didn't define it — we only honor the params root actually parses.
+	if v := q.Get("after"); v != "" {
+		p.After, _ = strconv.Atoi(v)
+	}
+	// after_seq is the cogos-bridge's canonical name for per-bus pagination.
+	// Root accepts `after` only, but the bridge sends `after_seq`. Accept both
+	// for compat — `after_seq` wins if both present.
+	if v := q.Get("after_seq"); v != "" {
+		n, _ := strconv.Atoi(v)
+		p.After = n
+	}
+	if v := q.Get("before"); v != "" {
+		p.Before, _ = strconv.Atoi(v)
+	}
+	if v := q.Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			p.Limit = n
+		}
+	}
+	// from_sender alias (root uses `from` only, but bridge may use the
+	// longer form; honor both).
+	if v := q.Get("from_sender"); v != "" && p.From == "" {
+		p.From = v
+	}
+	if p.Limit > 1000 {
+		p.Limit = 1000
+	}
+	return p
+}
+
+// filterBusEvents applies query params to an event list.
+func filterBusEvents(events []BusBlock, p busEventQueryParams) []BusBlock {
+	result := make([]BusBlock, 0, len(events))
+	for _, e := range events {
+		if p.Type != "" && e.Type != p.Type {
+			continue
+		}
+		if p.From != "" && e.From != p.From {
+			continue
+		}
+		if p.After > 0 && e.Seq <= p.After {
+			continue
+		}
+		if p.Before > 0 && e.Seq >= p.Before {
+			continue
+		}
+		if p.Since != "" && e.Ts < p.Since {
+			continue
+		}
+		if p.Until != "" && e.Ts > p.Until {
+			continue
+		}
+		result = append(result, e)
+		if len(result) >= p.Limit {
+			break
+		}
+	}
+	return result
+}
+
+// ─── GET /v1/bus/{bus_id}/... catch-all ──────────────────────────────────────
+
+// handleBusRoute dispatches GET /v1/bus/{bus_id}/events, .../events/{seq},
+// and .../stats.
+func (s *Server) handleBusRoute(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/v1/bus/")
+	parts := strings.SplitN(path, "/", 3)
+	if len(parts) == 0 || parts[0] == "" {
+		http.Error(w, `{"error":"expected /v1/bus/{bus_id}/{action}"}`, http.StatusBadRequest)
+		return
+	}
+	busID := parts[0]
+	action := ""
+	extra := ""
+	if len(parts) >= 2 {
+		action = parts[1]
+	}
+	if len(parts) >= 3 {
+		extra = parts[2]
+	}
+
+	switch action {
+	case "events":
+		if extra != "" {
+			s.handleBusEventBySeq(w, r, busID, extra)
+		} else {
+			s.handleBusEvents(w, r, busID)
+		}
+	case "stats":
+		s.handleBusStats(w, r, busID)
+	default:
+		http.Error(w, `{"error":"expected /v1/bus/{bus_id}/events or /v1/bus/{bus_id}/stats"}`, http.StatusBadRequest)
+	}
+}
+
+// handleBusEvents serves GET /v1/bus/{bus_id}/events with query params.
+func (s *Server) handleBusEvents(w http.ResponseWriter, r *http.Request, busID string) {
+	mgr := s.busSessions
+	w.Header().Set("Content-Type", "application/json")
+	if mgr == nil {
+		_, _ = w.Write([]byte("[]"))
+		return
+	}
+
+	events, err := mgr.ReadEvents(busID)
+	if err != nil {
+		_, _ = w.Write([]byte("[]"))
+		return
+	}
+
+	params := parseBusEventQuery(r)
+	filtered := filterBusEvents(events, params)
+	// Match root: return "[]" (not null) when empty.
+	if filtered == nil {
+		filtered = []BusBlock{}
+	}
+	_ = json.NewEncoder(w).Encode(filtered)
+}
+
+// handleBusEventBySeq serves GET /v1/bus/{bus_id}/events/{seq}.
+func (s *Server) handleBusEventBySeq(w http.ResponseWriter, r *http.Request, busID, seqStr string) {
+	seq, err := strconv.Atoi(seqStr)
+	if err != nil {
+		http.Error(w, `{"error":"seq must be an integer"}`, http.StatusBadRequest)
+		return
+	}
+	mgr := s.busSessions
+	if mgr == nil {
+		http.Error(w, `{"error":"event not found"}`, http.StatusNotFound)
+		return
+	}
+
+	events, err := mgr.ReadEvents(busID)
+	if err != nil {
+		http.Error(w, `{"error":"event not found"}`, http.StatusNotFound)
+		return
+	}
+
+	for _, e := range events {
+		if e.Seq == seq {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(e)
+			return
+		}
+	}
+
+	http.Error(w, `{"error":"event not found"}`, http.StatusNotFound)
+}
+
+// ─── GET /v1/bus/{bus_id}/stats ──────────────────────────────────────────────
+
+// busStatsResponse is the response shape for /stats. Field set + order
+// matches root exactly (bus_api.go:385).
+type busStatsResponse struct {
+	BusID        string         `json:"bus_id"`
+	EventCount   int            `json:"event_count"`
+	FirstEventAt string         `json:"first_event_at,omitempty"`
+	LastEventAt  string         `json:"last_event_at,omitempty"`
+	Types        map[string]int `json:"types"`
+	Senders      map[string]int `json:"senders"`
+}
+
+// handleBusStats serves GET /v1/bus/{bus_id}/stats.
+func (s *Server) handleBusStats(w http.ResponseWriter, r *http.Request, busID string) {
+	mgr := s.busSessions
+	w.Header().Set("Content-Type", "application/json")
+	if mgr == nil {
+		_ = json.NewEncoder(w).Encode(busStatsResponse{
+			BusID: busID, Types: map[string]int{}, Senders: map[string]int{},
+		})
+		return
+	}
+
+	events, _ := mgr.ReadEvents(busID)
+	stats := busStatsResponse{
+		BusID:      busID,
+		EventCount: len(events),
+		Types:      make(map[string]int),
+		Senders:    make(map[string]int),
+	}
+	for i, e := range events {
+		stats.Types[e.Type]++
+		stats.Senders[e.From]++
+		if i == 0 {
+			stats.FirstEventAt = e.Ts
+		}
+		stats.LastEventAt = e.Ts
+	}
+	_ = json.NewEncoder(w).Encode(stats)
+}
+
+// ─── GET /v1/bus/events (cross-bus search) ───────────────────────────────────
+
+// crossBusEvent wraps a BusBlock with its bus_id explicitly set (so the
+// client always sees a bus_id even when the stored block didn't carry one).
+// Go struct embedding preserves the JSON layout of BusBlock and appends
+// bus_id — this matches root's crossBusEvent shape.
+type crossBusEvent struct {
+	BusBlock
+	BusID string `json:"bus_id"`
+}
+
+// handleBusEventsGlobal serves GET /v1/bus/events — cross-bus event search.
+// Events are sorted by timestamp descending, capped by params.Limit.
+func (s *Server) handleBusEventsGlobal(w http.ResponseWriter, r *http.Request) {
+	mgr := s.busSessions
+	w.Header().Set("Content-Type", "application/json")
+	if mgr == nil {
+		_, _ = w.Write([]byte("[]"))
+		return
+	}
+
+	params := parseBusEventQuery(r)
+	entries := mgr.LoadRegistry()
+	var allEvents []crossBusEvent
+
+	for _, entry := range entries {
+		events, err := mgr.ReadEvents(entry.BusID)
+		if err != nil {
+			continue
+		}
+		filtered := filterBusEvents(events, busEventQueryParams{
+			Type:  params.Type,
+			From:  params.From,
+			Since: params.Since,
+			Until: params.Until,
+			Limit: params.Limit,
+		})
+		for _, e := range filtered {
+			cb := crossBusEvent{BusBlock: e}
+			if cb.BusBlock.BusID != "" {
+				cb.BusID = cb.BusBlock.BusID
+			} else {
+				cb.BusID = entry.BusID
+			}
+			allEvents = append(allEvents, cb)
+		}
+	}
+
+	sort.Slice(allEvents, func(i, j int) bool {
+		return allEvents[i].Ts > allEvents[j].Ts
+	})
+	if len(allEvents) > params.Limit {
+		allEvents = allEvents[:params.Limit]
+	}
+	if allEvents == nil {
+		allEvents = []crossBusEvent{}
+	}
+	_ = json.NewEncoder(w).Encode(allEvents)
+}
+
+// ─── Consumer cursor endpoints (ADR-061) ─────────────────────────────────────
+
+// handleBusConsumers serves GET /v1/bus/consumers — list all consumers.
+// Response shape: {"consumers": [ConsumerCursor...]} — matches root exactly.
+// Optional `bus_id` query filters the list to a single bus.
+func (s *Server) handleBusConsumers(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	if s.busConsumers == nil {
+		// Empty-object body, not an error — consistent with root's behaviour
+		// when the registry hasn't been initialized.
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"consumers": []any{}})
+		return
+	}
+
+	busID := r.URL.Query().Get("bus_id")
+	cursors := s.busConsumers.List(busID)
+	if cursors == nil {
+		cursors = []*ConsumerCursor{}
+	}
+
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"consumers": cursors,
+	})
+}
+
+// handleBusConsumerDelete serves DELETE /v1/bus/consumers/{consumer_id}.
+// 204 on success, 404 if the consumer didn't exist.
+func (s *Server) handleBusConsumerDelete(w http.ResponseWriter, r *http.Request) {
+	consumerID := strings.TrimPrefix(r.URL.Path, "/v1/bus/consumers/")
+	// Strip any trailing slash or additional path segments.
+	if idx := strings.Index(consumerID, "/"); idx >= 0 {
+		consumerID = consumerID[:idx]
+	}
+	if consumerID == "" {
+		http.Error(w, "Consumer ID required", http.StatusBadRequest)
+		return
+	}
+
+	if s.busConsumers == nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "consumer registry not ready"})
+		return
+	}
+
+	if !s.busConsumers.Remove(consumerID) {
+		http.Error(w, "Consumer not found", http.StatusNotFound)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// Ensure cogfield import is used (compiler sanity check — the import is live
+// via BusBlock/BusRegistryEntry aliases in bus_session.go, but re-import here
+// keeps godoc cross-references healthy).
+var _ = cogfield.Block{}

--- a/internal/engine/serve_bus_test.go
+++ b/internal/engine/serve_bus_test.go
@@ -1,0 +1,596 @@
+// serve_bus_test.go — HTTP tests for the /v1/bus/* and /v1/sessions surface.
+//
+// Track 5 Phase 3: byte-compat regression tests against the response shapes
+// captured from the live cogos-v3 daemon on :6931.
+package engine
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestBusSendAndReadEvents hits POST /v1/bus/send followed by GET
+// /v1/bus/{bus_id}/events and verifies the shape matches the live daemon.
+func TestBusSendAndReadEvents(t *testing.T) {
+	t.Parallel()
+	handler, _, _ := newEventsTestServer(t)
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	// Send a message.
+	body := `{"bus_id":"phase3-test","message":"shape-probe","from":"phase3-test"}`
+	resp, err := http.Post(srv.URL+"/v1/bus/send", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /v1/bus/send: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("send status = %d", resp.StatusCode)
+	}
+
+	var sendResp struct {
+		OK   bool   `json:"ok"`
+		Seq  int    `json:"seq"`
+		Hash string `json:"hash"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&sendResp); err != nil {
+		t.Fatalf("decode send resp: %v", err)
+	}
+	if !sendResp.OK {
+		t.Errorf("ok = false")
+	}
+	if sendResp.Seq != 1 {
+		t.Errorf("seq = %d, want 1", sendResp.Seq)
+	}
+	if len(sendResp.Hash) != 64 {
+		t.Errorf("hash wrong len: %q", sendResp.Hash)
+	}
+
+	// Read it back.
+	eventsResp, err := http.Get(srv.URL + "/v1/bus/phase3-test/events")
+	if err != nil {
+		t.Fatalf("GET events: %v", err)
+	}
+	defer eventsResp.Body.Close()
+	if eventsResp.StatusCode != 200 {
+		t.Fatalf("events status = %d", eventsResp.StatusCode)
+	}
+
+	raw, _ := io.ReadAll(eventsResp.Body)
+	// Must be a JSON array.
+	if !bytes.HasPrefix(bytes.TrimSpace(raw), []byte("[")) {
+		t.Fatalf("events response not a JSON array: %s", raw)
+	}
+
+	var events []map[string]interface{}
+	if err := json.Unmarshal(raw, &events); err != nil {
+		t.Fatalf("events decode: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("len(events) = %d, want 1", len(events))
+	}
+
+	// Byte-compat: every field that cog-sandbox-mcp's bridge consumes
+	// must be present with the correct value + type.
+	// Reference fixture: /tmp/phase3-fixture-after-send.json.
+	wantFields := map[string]interface{}{
+		"v":       float64(2),
+		"bus_id":  "phase3-test",
+		"seq":     float64(1),
+		"from":    "phase3-test",
+		"type":    "message",
+	}
+	for k, wantv := range wantFields {
+		got, ok := events[0][k]
+		if !ok {
+			t.Errorf("missing field %q", k)
+			continue
+		}
+		if got != wantv {
+			t.Errorf("field %q = %v, want %v", k, got, wantv)
+		}
+	}
+	// Ts is RFC3339-style ending in Z (or offset).
+	if ts, ok := events[0]["ts"].(string); !ok || ts == "" {
+		t.Errorf("ts not a non-empty string: %v", events[0]["ts"])
+	}
+	// Hash is lowercase hex, 64 chars.
+	if h, ok := events[0]["hash"].(string); !ok || len(h) != 64 {
+		t.Errorf("hash malformed: %v", events[0]["hash"])
+	}
+	// Payload is an object with "content".
+	pl, ok := events[0]["payload"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("payload not an object: %v", events[0]["payload"])
+	}
+	if pl["content"] != "shape-probe" {
+		t.Errorf("payload.content = %v, want 'shape-probe'", pl["content"])
+	}
+}
+
+// TestBusOpenAndList hits POST /v1/bus/open then GET /v1/bus/list and checks
+// the registry shape matches root's.
+func TestBusOpenAndList(t *testing.T) {
+	t.Parallel()
+	handler, _, _ := newEventsTestServer(t)
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	body := `{"bus_id":"open-test","participants":["alice","bob"]}`
+	openResp, err := http.Post(srv.URL+"/v1/bus/open", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST open: %v", err)
+	}
+	defer openResp.Body.Close()
+	if openResp.StatusCode != 200 {
+		t.Fatalf("open status = %d", openResp.StatusCode)
+	}
+
+	var openBody map[string]interface{}
+	_ = json.NewDecoder(openResp.Body).Decode(&openBody)
+	if openBody["ok"] != true || openBody["bus_id"] != "open-test" || openBody["state"] != "active" {
+		t.Errorf("open response shape wrong: %+v", openBody)
+	}
+
+	// Now list.
+	listResp, err := http.Get(srv.URL + "/v1/bus/list")
+	if err != nil {
+		t.Fatalf("GET list: %v", err)
+	}
+	defer listResp.Body.Close()
+	var entries []map[string]interface{}
+	if err := json.NewDecoder(listResp.Body).Decode(&entries); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(entries) < 1 {
+		t.Fatalf("list empty")
+	}
+	found := false
+	for _, e := range entries {
+		if e["bus_id"] == "open-test" {
+			found = true
+			// Shape fields captured from /tmp/phase3-fixture-list.json.
+			wantFields := []string{"state", "participants", "transport", "endpoint", "created_at", "last_event_seq", "last_event_at", "event_count"}
+			for _, f := range wantFields {
+				if _, ok := e[f]; !ok {
+					t.Errorf("list entry missing field %q", f)
+				}
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("open-test not in list: %+v", entries)
+	}
+}
+
+// TestBusStats exercises GET /v1/bus/{bus_id}/stats — fixture:
+// /tmp/phase3-fixture-stats.json.
+func TestBusStats(t *testing.T) {
+	t.Parallel()
+	handler, _, _ := newEventsTestServer(t)
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	// Seed a few events.
+	for i, msg := range []string{"a", "b", "c"} {
+		body := fmt.Sprintf(`{"bus_id":"stats-test","message":%q,"from":"u%d","type":"m%d"}`, msg, i%2, i%2)
+		if _, err := http.Post(srv.URL+"/v1/bus/send", "application/json", strings.NewReader(body)); err != nil {
+			t.Fatalf("send %d: %v", i, err)
+		}
+	}
+
+	resp, err := http.Get(srv.URL + "/v1/bus/stats-test/stats")
+	if err != nil {
+		t.Fatalf("GET stats: %v", err)
+	}
+	defer resp.Body.Close()
+	var stats map[string]interface{}
+	_ = json.NewDecoder(resp.Body).Decode(&stats)
+
+	if stats["bus_id"] != "stats-test" {
+		t.Errorf("bus_id wrong")
+	}
+	if stats["event_count"].(float64) != 3 {
+		t.Errorf("event_count = %v, want 3", stats["event_count"])
+	}
+	if _, ok := stats["first_event_at"].(string); !ok {
+		t.Errorf("first_event_at missing or wrong type")
+	}
+	if _, ok := stats["last_event_at"].(string); !ok {
+		t.Errorf("last_event_at missing")
+	}
+	types, ok := stats["types"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("types not object: %v", stats["types"])
+	}
+	if types["m0"].(float64)+types["m1"].(float64) != 3 {
+		t.Errorf("types aggregate wrong: %v", types)
+	}
+	senders, ok := stats["senders"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("senders not object")
+	}
+	if senders["u0"].(float64)+senders["u1"].(float64) != 3 {
+		t.Errorf("senders aggregate wrong: %v", senders)
+	}
+}
+
+// TestBusEventBySeq exercises GET /v1/bus/{id}/events/{seq}.
+func TestBusEventBySeq(t *testing.T) {
+	t.Parallel()
+	handler, _, _ := newEventsTestServer(t)
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	for i := 0; i < 3; i++ {
+		body := fmt.Sprintf(`{"bus_id":"seq-test","message":"m%d","from":"x"}`, i)
+		_, _ = http.Post(srv.URL+"/v1/bus/send", "application/json", strings.NewReader(body))
+	}
+
+	// Valid seq.
+	resp, err := http.Get(srv.URL + "/v1/bus/seq-test/events/2")
+	if err != nil {
+		t.Fatalf("GET events/2: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	var evt map[string]interface{}
+	_ = json.NewDecoder(resp.Body).Decode(&evt)
+	if evt["seq"].(float64) != 2 {
+		t.Errorf("seq = %v, want 2", evt["seq"])
+	}
+
+	// Invalid seq → 400.
+	resp2, _ := http.Get(srv.URL + "/v1/bus/seq-test/events/nope")
+	resp2.Body.Close()
+	if resp2.StatusCode != 400 {
+		t.Errorf("bad seq status = %d, want 400", resp2.StatusCode)
+	}
+
+	// Missing seq → 404.
+	resp3, _ := http.Get(srv.URL + "/v1/bus/seq-test/events/99")
+	resp3.Body.Close()
+	if resp3.StatusCode != 404 {
+		t.Errorf("missing seq status = %d, want 404", resp3.StatusCode)
+	}
+}
+
+// TestBusEventsGlobal exercises cross-bus search (GET /v1/bus/events).
+func TestBusEventsGlobal(t *testing.T) {
+	t.Parallel()
+	handler, _, _ := newEventsTestServer(t)
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	// Register each bus first — byte-compat with root: the global
+	// /v1/bus/events endpoint iterates the registry, so buses that were
+	// only ever sent-to (never opened) do NOT appear. This mirrors root's
+	// bus_api.go:handleBusEventsGlobal exactly.
+	for _, bus := range []string{"g-a", "g-b", "g-c"} {
+		openBody := fmt.Sprintf(`{"bus_id":%q}`, bus)
+		_, _ = http.Post(srv.URL+"/v1/bus/open", "application/json", strings.NewReader(openBody))
+		body := fmt.Sprintf(`{"bus_id":%q,"message":"hi","from":"x"}`, bus)
+		_, _ = http.Post(srv.URL+"/v1/bus/send", "application/json", strings.NewReader(body))
+	}
+
+	resp, err := http.Get(srv.URL + "/v1/bus/events?limit=10")
+	if err != nil {
+		t.Fatalf("GET /v1/bus/events: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var events []map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&events); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// Each event must carry bus_id.
+	seenBuses := map[string]bool{}
+	for _, e := range events {
+		bid, ok := e["bus_id"].(string)
+		if !ok || bid == "" {
+			t.Errorf("event missing bus_id: %+v", e)
+			continue
+		}
+		seenBuses[bid] = true
+	}
+	for _, want := range []string{"g-a", "g-b", "g-c"} {
+		if !seenBuses[want] {
+			t.Errorf("global events missing bus %q", want)
+		}
+	}
+}
+
+// TestBusConsumers covers GET /v1/bus/consumers + DELETE /v1/bus/consumers/{id}.
+func TestBusConsumers(t *testing.T) {
+	t.Parallel()
+	handler, _, _ := newEventsTestServer(t)
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	// The empty-registry case should return the {"consumers": []} shape
+	// (fixture: /tmp/phase3-fixture-consumers.json).
+	resp, err := http.Get(srv.URL + "/v1/bus/consumers")
+	if err != nil {
+		t.Fatalf("GET consumers: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	var body map[string]interface{}
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if _, ok := body["consumers"]; !ok {
+		t.Errorf("missing 'consumers' key: %+v", body)
+	}
+
+	// DELETE unknown consumer → 404.
+	req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/v1/bus/consumers/nope", nil)
+	delResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE consumer: %v", err)
+	}
+	delResp.Body.Close()
+	if delResp.StatusCode != 404 {
+		t.Errorf("delete unknown consumer status = %d, want 404", delResp.StatusCode)
+	}
+}
+
+// TestBusSendValidation verifies that missing required fields yield 400.
+func TestBusSendValidation(t *testing.T) {
+	t.Parallel()
+	handler, _, _ := newEventsTestServer(t)
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	cases := []struct {
+		name string
+		body string
+		code int
+	}{
+		{"missing-busid", `{"message":"hi"}`, 400},
+		{"missing-message", `{"bus_id":"x"}`, 400},
+		{"bad-json", `{not json}`, 400},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, _ := http.Post(srv.URL+"/v1/bus/send", "application/json", strings.NewReader(tc.body))
+			resp.Body.Close()
+			if resp.StatusCode != tc.code {
+				t.Errorf("status = %d, want %d", resp.StatusCode, tc.code)
+			}
+		})
+	}
+}
+
+// TestBusEventsAfterSeq verifies that after_seq (the bridge's canonical
+// pagination param) filters correctly. This is the hot path for
+// cogos_bridge.py @ line 266.
+func TestBusEventsAfterSeq(t *testing.T) {
+	t.Parallel()
+	handler, _, _ := newEventsTestServer(t)
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	for i := 0; i < 5; i++ {
+		body := fmt.Sprintf(`{"bus_id":"paging","message":"m%d","from":"x"}`, i)
+		_, _ = http.Post(srv.URL+"/v1/bus/send", "application/json", strings.NewReader(body))
+	}
+
+	resp, err := http.Get(srv.URL + "/v1/bus/paging/events?after_seq=2&limit=10")
+	if err != nil {
+		t.Fatalf("GET events: %v", err)
+	}
+	defer resp.Body.Close()
+	var events []map[string]interface{}
+	_ = json.NewDecoder(resp.Body).Decode(&events)
+	if len(events) != 3 {
+		t.Errorf("len(events) = %d, want 3 (seq 3,4,5 after seq>2)", len(events))
+	}
+	for _, e := range events {
+		if e["seq"].(float64) <= 2 {
+			t.Errorf("got event seq=%v which should be filtered out", e["seq"])
+		}
+	}
+}
+
+// TestSessionsListAndDetail exercises /v1/sessions + /v1/sessions/{id}.
+func TestSessionsListAndDetail(t *testing.T) {
+	t.Parallel()
+	handler, _, _ := newEventsTestServer(t)
+
+	// Seed the session store. We need a handle on the Server to Record —
+	// the helper only returns the handler, so we re-build the server here.
+	// newEventsTestServer uses NewServer internally; for test purposes we
+	// just mutate the real route by poking at the Server via the exposed
+	// handler's context. Simpler: create our own Server side-by-side.
+	_ = handler
+	root := t.TempDir()
+	cfg := &Config{WorkspaceRoot: root, CogDir: root + "/.cog", Port: 0}
+	nucleus := &Nucleus{Name: "test-sessions"}
+	proc := NewProcess(cfg, nucleus)
+	server := NewServer(cfg, nucleus, proc)
+	t.Cleanup(func() { _ = proc.Broker().Close() })
+
+	server.sessions.Record(&SessionContextState{
+		SessionID:      "sess-abc",
+		Profile:        "agent_harness",
+		TurnNumber:     448,
+		IrisPressure:   0.25,
+		TotalTokens:    37,
+		BlockCount:     4,
+		CoherenceScore: 0.5,
+		LastRequestAt:  time.Now(),
+	})
+
+	srv := httptest.NewServer(server.Handler())
+	t.Cleanup(srv.Close)
+
+	// List.
+	listResp, err := http.Get(srv.URL + "/v1/sessions")
+	if err != nil {
+		t.Fatalf("GET sessions: %v", err)
+	}
+	defer listResp.Body.Close()
+
+	var listBody struct {
+		Count    int                      `json:"count"`
+		Sessions []map[string]interface{} `json:"sessions"`
+	}
+	_ = json.NewDecoder(listResp.Body).Decode(&listBody)
+	if listBody.Count != 1 {
+		t.Errorf("count = %d, want 1", listBody.Count)
+	}
+	if len(listBody.Sessions) != 1 {
+		t.Fatalf("sessions len = %d", len(listBody.Sessions))
+	}
+	// Byte-compat fields captured from /tmp/phase3-fixture-sessions.json.
+	wantFields := []string{"session_id", "profile", "turn_number", "iris_pressure", "total_tokens", "block_count", "coherence_score", "last_request_at"}
+	for _, f := range wantFields {
+		if _, ok := listBody.Sessions[0][f]; !ok {
+			t.Errorf("list response missing %q", f)
+		}
+	}
+
+	// Detail.
+	detResp, err := http.Get(srv.URL + "/v1/sessions/sess-abc")
+	if err != nil {
+		t.Fatalf("GET detail: %v", err)
+	}
+	defer detResp.Body.Close()
+	if detResp.StatusCode != 200 {
+		t.Fatalf("detail status = %d", detResp.StatusCode)
+	}
+	var detail map[string]interface{}
+	_ = json.NewDecoder(detResp.Body).Decode(&detail)
+	if detail["session_id"] != "sess-abc" {
+		t.Errorf("session_id = %v", detail["session_id"])
+	}
+
+	// Also supports /context alias.
+	ctxResp, err := http.Get(srv.URL + "/v1/sessions/sess-abc/context")
+	if err != nil {
+		t.Fatalf("GET detail/context: %v", err)
+	}
+	defer ctxResp.Body.Close()
+	if ctxResp.StatusCode != 200 {
+		t.Fatalf("context alias status = %d", ctxResp.StatusCode)
+	}
+
+	// Missing session → 404.
+	missResp, _ := http.Get(srv.URL + "/v1/sessions/nope")
+	missResp.Body.Close()
+	if missResp.StatusCode != 404 {
+		t.Errorf("missing session status = %d, want 404", missResp.StatusCode)
+	}
+}
+
+// TestBusStreamBrokerPublishSubscribe verifies that AppendEvent fans out to
+// a subscribed channel (library-level test — the port doesn't register an
+// HTTP route for bus SSE because PR #16 owns /v1/events/stream).
+func TestBusStreamBrokerPublishSubscribe(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mgr := NewBusSessionManager(root)
+	broker := NewBusEventBroker()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	ch := make(chan *BusBlock, 4)
+	if !broker.Subscribe("bus-s", ch, ctx, "consumer-1") {
+		t.Fatal("Subscribe returned false")
+	}
+
+	// Wire the broker into the manager so AppendEvent publishes.
+	mgr.AddEventHandler("bus-publisher", func(busID string, block *BusBlock) {
+		broker.Publish(busID, block)
+	})
+
+	_, _ = mgr.AppendEvent("bus-s", "m", "x", map[string]interface{}{"v": 1})
+
+	select {
+	case evt := <-ch:
+		if evt == nil {
+			t.Fatal("got nil event")
+		}
+		if evt.Seq != 1 {
+			t.Errorf("seq = %d", evt.Seq)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for broker publish")
+	}
+
+	// Unsubscribe cleans up.
+	broker.Unsubscribe("bus-s", ch)
+	if broker.SubscriberCount("bus-s") != 0 {
+		t.Errorf("subscriber count = %d after unsubscribe, want 0", broker.SubscriberCount("bus-s"))
+	}
+}
+
+// TestConsumerRegistryAckAndList covers the consumer cursor ack + list path
+// — orthogonal to the HTTP surface but exercising the same code handleBus*
+// handlers call.
+func TestConsumerRegistryAckAndList(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	reg := NewConsumerRegistry(root)
+
+	// Unknown bus → error.
+	if _, err := reg.Ack("nope", "c1", 1); err == nil {
+		t.Error("Ack on unknown bus should error")
+	}
+
+	// GetOrCreate establishes the cursor.
+	cur := reg.GetOrCreate("bus-c", "c1")
+	if cur.LastAckedSeq != 0 {
+		t.Errorf("initial LastAckedSeq = %d", cur.LastAckedSeq)
+	}
+
+	// Ack advances.
+	ack, err := reg.Ack("bus-c", "c1", 5)
+	if err != nil {
+		t.Fatalf("Ack: %v", err)
+	}
+	if ack.LastAckedSeq != 5 {
+		t.Errorf("after ack(5): %d", ack.LastAckedSeq)
+	}
+
+	// Monotonic — older seq ignored.
+	ack2, _ := reg.Ack("bus-c", "c1", 3)
+	if ack2.LastAckedSeq != 5 {
+		t.Errorf("after lower ack: %d, want 5", ack2.LastAckedSeq)
+	}
+
+	// List (all / by bus).
+	all := reg.List("")
+	if len(all) != 1 {
+		t.Errorf("list(all): %d", len(all))
+	}
+	filtered := reg.List("bus-c")
+	if len(filtered) != 1 {
+		t.Errorf("list(bus-c): %d", len(filtered))
+	}
+	empty := reg.List("other-bus")
+	if len(empty) != 0 {
+		t.Errorf("list(other-bus): %d", len(empty))
+	}
+
+	// Remove.
+	if !reg.Remove("c1") {
+		t.Error("Remove should return true")
+	}
+	if reg.Remove("c1") {
+		t.Error("Remove twice should return false")
+	}
+}

--- a/internal/engine/serve_sessions.go
+++ b/internal/engine/serve_sessions.go
@@ -1,0 +1,176 @@
+// serve_sessions.go — per-session context observability endpoints.
+//
+// Track 5 Phase 3: ported from root's serve_context.go (handleListSessions +
+// handleSessionContext). Preserves the byte-compat response shape:
+//
+//	GET /v1/sessions           → { count, sessions: [sessionSummary ...] }
+//	GET /v1/sessions/{id}      → SessionContextState (full detail)
+//	GET /v1/sessions/{id}/context → SessionContextState (alias)
+//
+// The store is kept as a struct field on Server so tests can instantiate
+// isolated instances; root's singleton-style map is equivalent in single-
+// server deployments.
+package engine
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// SessionContextState captures the context state for a single session's most
+// recent foveated request. Mirrors root's type (serve_context.go) exactly so
+// the JSON payload is byte-compatible.
+type SessionContextState struct {
+	SessionID      string         `json:"session_id"`
+	Profile        string         `json:"profile"`
+	TurnNumber     int            `json:"turn_number"`
+	IrisSize       int            `json:"iris_size"`
+	IrisUsed       int            `json:"iris_used"`
+	IrisPressure   float64        `json:"iris_pressure"`
+	TotalTokens    int            `json:"total_tokens"`
+	Blocks         []SessionBlock `json:"blocks"`
+	BlockCount     int            `json:"block_count"`
+	CacheHits      int            `json:"cache_hits"`
+	LastRequestAt  time.Time      `json:"last_request_at"`
+	CoherenceScore float64        `json:"coherence_score,omitempty"`
+}
+
+// SessionBlock is the block shape embedded inside SessionContextState.
+// Matches root's ContextBlock JSON shape (serve_context.go ContextBlock).
+type SessionBlock struct {
+	Hash    string  `json:"hash"`
+	Kind    string  `json:"kind,omitempty"`
+	Tokens  int     `json:"tokens"`
+	Score   float64 `json:"score,omitempty"`
+	Source  string  `json:"source,omitempty"`
+	Tier    string  `json:"tier,omitempty"`
+	Content string  `json:"content,omitempty"`
+}
+
+// SessionContextStore is the in-memory index of session → latest context
+// state. Methods are goroutine-safe.
+type SessionContextStore struct {
+	mu    sync.RWMutex
+	store map[string]*SessionContextState
+}
+
+// NewSessionContextStore constructs an empty store.
+func NewSessionContextStore() *SessionContextStore {
+	return &SessionContextStore{store: make(map[string]*SessionContextState)}
+}
+
+// Record replaces the state for a session.
+func (s *SessionContextStore) Record(state *SessionContextState) {
+	if state == nil || state.SessionID == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.store[state.SessionID] = state
+}
+
+// Get returns the state for a session.
+func (s *SessionContextStore) Get(sessionID string) (*SessionContextState, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	st, ok := s.store[sessionID]
+	return st, ok
+}
+
+// Snapshot returns a copy of every session's state. Slice order is not
+// guaranteed — matches root (iteration over map).
+func (s *SessionContextStore) Snapshot() []*SessionContextState {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]*SessionContextState, 0, len(s.store))
+	for _, st := range s.store {
+		out = append(out, st)
+	}
+	return out
+}
+
+// handleListSessions returns summary metadata for all known sessions.
+//
+//	GET /v1/sessions
+//	200 → { count, sessions: [sessionSummary] }
+func (s *Server) handleListSessions(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	type sessionSummary struct {
+		SessionID      string    `json:"session_id"`
+		Profile        string    `json:"profile"`
+		TurnNumber     int       `json:"turn_number"`
+		IrisPressure   float64   `json:"iris_pressure"`
+		TotalTokens    int       `json:"total_tokens"`
+		BlockCount     int       `json:"block_count"`
+		CoherenceScore float64   `json:"coherence_score,omitempty"`
+		LastRequestAt  time.Time `json:"last_request_at"`
+	}
+
+	snap := s.sessions.Snapshot()
+	sessions := make([]sessionSummary, 0, len(snap))
+	for _, state := range snap {
+		sessions = append(sessions, sessionSummary{
+			SessionID:      state.SessionID,
+			Profile:        state.Profile,
+			TurnNumber:     state.TurnNumber,
+			IrisPressure:   state.IrisPressure,
+			TotalTokens:    state.TotalTokens,
+			BlockCount:     state.BlockCount,
+			CoherenceScore: state.CoherenceScore,
+			LastRequestAt:  state.LastRequestAt,
+		})
+	}
+
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"sessions": sessions,
+		"count":    len(sessions),
+	})
+}
+
+// handleSessionContext returns the full context state for a specific session.
+//
+//	GET /v1/sessions/{session_id}
+//	GET /v1/sessions/{session_id}/context
+//	200 → SessionContextState
+//	400 → missing session_id
+//	404 → session not found
+func (s *Server) handleSessionContext(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	// Extract session_id from URL path: /v1/sessions/{session_id}[/context]
+	path := strings.TrimPrefix(r.URL.Path, "/v1/sessions/")
+	sessionID := strings.TrimSuffix(path, "/context")
+	sessionID = strings.TrimSuffix(sessionID, "/")
+
+	if sessionID == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]string{
+				"type":    "invalid_request",
+				"message": "session_id is required in path: /v1/sessions/{session_id}",
+			},
+		})
+		return
+	}
+
+	state, ok := s.sessions.Get(sessionID)
+	if !ok {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]string{
+				"type": "not_found",
+				"message": fmt.Sprintf(
+					"No context found for session %q. Use GET /v1/sessions to list known sessions.",
+					sessionID),
+			},
+		})
+		return
+	}
+
+	_ = json.NewEncoder(w).Encode(state)
+}


### PR DESCRIPTION
Phase 3 of the Track 5 migration plan (Agent I2).

## What this lands
- 9 /v1/bus/* routes + 2 /v1/sessions routes now implemented in engine
- busSessionManager ported verbatim (~376 LoC)
- Bus SSE broker ported (distinct from PR #16's ledger broker)
- Consumer cursor registry ported (ADR-061)
- Byte-compat JSON shape preserved (CogBlock {v:2, seq, ts, from, type, payload, prev_hash, hash} — tested against live fixtures from cogos-v3 :6931)
- ~2,463 LoC new engine code + tests

## Additive-only
Root still serves these routes. Installed binary (per Makefile:44) remains root-backed until Phase 4 flips the build target. No user-visible change.

## Shape verification
Captured live responses from cogos-v3 :6931 into /tmp/phase3-fixture-*.json, then ran the engine server through httptest and diff'd the top-level key sets:
- POST /v1/bus/send — MATCH (ok, seq, hash)
- GET /v1/bus/{id}/events — MATCH (v, bus_id, seq, ts, from, type, payload, hash)
- GET /v1/bus/list — MATCH (bus_id, state, participants, transport, endpoint, created_at, last_event_seq, last_event_at, event_count)
- GET /v1/bus/{id}/stats — MATCH (bus_id, event_count, first_event_at, last_event_at, types, senders)
- GET /v1/bus/consumers — MATCH outer + inner ConsumerCursor shape (consumer_id, bus_id, last_acked_seq, connected_at, last_ack_at, stale)

## Unblocks
Phase 4 Makefile cutover. After Phase 4 lands, running \`cogos serve\` from the installed binary will serve these routes via engine; rebuilding cogos-v3 will no longer break cog-sandbox-mcp bridge.

## Not in scope
- Phase 4 Makefile flip
- Phase 5 dormant-subcommand audit
- Sweep deletion of 25 serveServer files
- /v1/agent/* routes (already handled by PR #27)
- Ledger-based event bus (PR #16; orthogonal surface)
- Bus SSE HTTP route — deferred. PR #16 already owns /v1/events/stream (ledger-backed). The bus SSE broker is ported as a library so AppendEvent can fan out, but no new HTTP route is registered in this phase.

## Test plan
- [x] byte-compat diff against captured cogos-v3 :6931 responses (fixture-diff probe, described above)
- [x] hash chain continuity (TestBusSessionHashChainRecompute)
- [x] bus isolation (TestBusSessionIsolation)
- [x] consumer cursors (TestConsumerRegistryAckAndList + TestBusConsumers)
- [x] SSE subscribe (TestBusStreamBrokerPublishSubscribe)
- [x] session list + detail (TestSessionsListAndDetail)
- [x] engine test suite green -race -count=1 (ok 3.093s)
- [x] build + vet silent (full repo)
- [x] TestServeBusAckRemoved regression — still passes (no ack route added)