### PR TITLE
feat: kernel-native session management (hybrid) — closes last Agent F gap

### DIFF
--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -40,6 +40,13 @@ type MCPServer struct {
 	process         *Process
 	cogdocSvc       *CogDocService
 	agentController AgentController // optional; nil when the kernel has no live agent
+
+	// Session management backends (see SetSessionsBackend). Optional —
+	// NewMCPServer without a live HTTP server skips wiring and the
+	// session tools return a graceful "not configured" error.
+	busSessions     *BusSessionManager
+	sessionRegistry *SessionRegistry
+	handoffRegistry *HandoffRegistry
 }
 
 // NewMCPServer creates and configures the MCP server with all stage-1 tools.
@@ -228,6 +235,12 @@ func (m *MCPServer) registerTools() {
 		Name:        "cog_search_traces",
 		Description: "Search kernel trace JSONL streams in .cog/run/ (attention, proprioceptive, internal_requests). Filter by source, session_id, level, case-insensitive substring, and time range (since/until accept RFC3339 or duration like 5m/1h). Returns unified chronological results with per-source scan diagnostics. Fallback: ls .cog/run/*.jsonl && jq -c . .cog/run/<name>.jsonl | head",
 	}, m.toolSearchTraces)
+
+	// Kernel-native session/handoff tools (mcp_sessions.go). The 8 tools
+	// complement the 8 cogos_* bridge tools living in cog-sandbox-mcp:
+	// both surfaces coexist by design — same kernel truth, two MCP
+	// doorways (amendment #5 of the Agent P hybrid plan).
+	m.registerSessionTools()
 }
 
 // registerResources registers MCP Resources — read-only addressable data.

--- a/internal/engine/mcp_sessions.go
+++ b/internal/engine/mcp_sessions.go
@@ -46,7 +46,7 @@ func (m *MCPServer) registerSessionTools() {
 		Name: "cog_register_session",
 		Description: "Register (or idempotently update) a session on " +
 			"bus_sessions. Validates the session_id format " +
-			"(lowercase, hyphen-separated, ≥2 components). Required: " +
+			"(lowercase, hyphen-separated, 3-component required). Required: " +
 			"session_id, workspace, role. Optional: task, model, hostname, " +
 			"status, current_task, context_usage.",
 	}, withToolObserver(m, "cog_register_session", m.toolRegisterSession))
@@ -189,25 +189,27 @@ func (m *MCPServer) toolRegisterSession(ctx context.Context, req *mcp.CallToolRe
 		ContextUsage: in.ContextUsage, Status: in.Status, CurrentTask: in.CurrentTask,
 		Extras: in.Extras, RegisteredAt: now, LastSeen: now,
 	}
-	stored, created, err := m.sessionRegistry.ApplyRegister(
-		state, time.Duration(defaultActiveWithinSeconds)*time.Second, now,
-	)
-	if err != nil {
-		return textResult(err.Error())
-	}
 	payload := map[string]interface{}{
 		"session_id": in.SessionID, "workspace": in.Workspace, "role": in.Role,
 		"task": in.Task, "model": in.Model, "hostname": in.Hostname,
 		"status": in.Status, "current_task": in.CurrentTask,
 		"context_usage": in.ContextUsage,
-		"registered_at": stored.RegisteredAt.Format(time.RFC3339Nano),
+		"registered_at": now.Format(time.RFC3339Nano),
 	}
 	for k, v := range in.Extras {
 		if _, exists := payload[k]; !exists {
 			payload[k] = v
 		}
 	}
-	evt, err := m.busSessions.AppendEvent(BusSessions, EvtSessionRegister, in.SessionID, payload)
+	var evt *BusBlock
+	appendFn := func() error {
+		var err error
+		evt, err = m.busSessions.AppendEvent(BusSessions, EvtSessionRegister, in.SessionID, payload)
+		return err
+	}
+	stored, created, err := m.sessionRegistry.ApplyRegister(
+		state, time.Duration(defaultActiveWithinSeconds)*time.Second, now, appendFn,
+	)
 	if err != nil {
 		return fallbackResult(fmt.Sprintf("bus append failed: %v", err), "")
 	}
@@ -226,20 +228,29 @@ func (m *MCPServer) toolHeartbeatSession(ctx context.Context, req *mcp.CallToolR
 		return textResult(err.Error())
 	}
 	now := time.Now().UTC()
-	stored, ok := m.sessionRegistry.ApplyHeartbeat(in.SessionID, in.ContextUsage, in.Status, in.CurrentTask, now)
-	if !ok {
-		return textResult(fmt.Sprintf("session %q is not registered", in.SessionID))
-	}
-	if stored.Ended {
-		return textResult(fmt.Sprintf("session %q is already ended", in.SessionID))
-	}
 	payload := map[string]interface{}{
 		"session_id": in.SessionID, "status": in.Status,
 		"context_usage": in.ContextUsage, "current_task": in.CurrentTask,
 		"at": now.Format(time.RFC3339Nano),
 	}
-	evt, err := m.busSessions.AppendEvent(BusSessions, EvtSessionHeartbeat, in.SessionID, payload)
+	var evt *BusBlock
+	appendFn := func() error {
+		var err error
+		evt, err = m.busSessions.AppendEvent(BusSessions, EvtSessionHeartbeat, in.SessionID, payload)
+		return err
+	}
+	stored, ok, err := m.sessionRegistry.ApplyHeartbeat(
+		in.SessionID, in.ContextUsage, in.Status, in.CurrentTask, now, appendFn,
+	)
+	if !ok {
+		return textResult(fmt.Sprintf("session %q is not registered", in.SessionID))
+	}
 	if err != nil {
+		// Ended-session rejection or append failure. Ended is recognised
+		// by the unchanged stored.Ended flag and evt==nil.
+		if stored != nil && stored.Ended && evt == nil {
+			return textResult(fmt.Sprintf("session %q is already ended", in.SessionID))
+		}
 		return fallbackResult(fmt.Sprintf("bus append failed: %v", err), "")
 	}
 	return marshalResult(map[string]any{
@@ -256,21 +267,26 @@ func (m *MCPServer) toolEndSession(ctx context.Context, req *mcp.CallToolRequest
 		return textResult(err.Error())
 	}
 	now := time.Now().UTC()
-	stored, known, err := m.sessionRegistry.ApplyEnd(in.SessionID, in.Reason, in.HandoffID, now)
-	if !known {
-		return textResult(fmt.Sprintf("session %q is not registered", in.SessionID))
-	}
-	if err != nil {
-		return textResult(err.Error())
-	}
 	payload := map[string]interface{}{
 		"session_id": in.SessionID, "reason": in.Reason,
 		"handoff_id": in.HandoffID,
 		"ended_at":   now.Format(time.RFC3339Nano),
 	}
-	evt, errEmit := m.busSessions.AppendEvent(BusSessions, EvtSessionEnd, in.SessionID, payload)
-	if errEmit != nil {
-		return fallbackResult(fmt.Sprintf("bus append failed: %v", errEmit), "")
+	var evt *BusBlock
+	appendFn := func() error {
+		var err error
+		evt, err = m.busSessions.AppendEvent(BusSessions, EvtSessionEnd, in.SessionID, payload)
+		return err
+	}
+	stored, known, err := m.sessionRegistry.ApplyEnd(in.SessionID, in.Reason, in.HandoffID, now, appendFn)
+	if !known {
+		return textResult(fmt.Sprintf("session %q is not registered", in.SessionID))
+	}
+	if err != nil {
+		if evt == nil && stored != nil && stored.Ended {
+			return textResult(err.Error())
+		}
+		return fallbackResult(fmt.Sprintf("bus append failed: %v", err), "")
 	}
 	return marshalResult(map[string]any{
 		"ok": true, "session_id": in.SessionID,
@@ -331,6 +347,9 @@ func (m *MCPServer) toolOfferHandoff(ctx context.Context, req *mcp.CallToolReque
 	if steps, ok := in.Task["next_steps"].([]interface{}); !ok || len(steps) == 0 {
 		return textResult("task.next_steps must be a non-empty list")
 	}
+	if in.TTLSeconds < 0 {
+		return textResult("ttl_seconds must be >= 0")
+	}
 	if in.TTLSeconds == 0 {
 		in.TTLSeconds = 3600
 	}
@@ -356,9 +375,14 @@ func (m *MCPServer) toolOfferHandoff(ctx context.Context, req *mcp.CallToolReque
 		"memory_refs":      in.MemoryRefs,
 	}
 	state.OfferPayload = payload
-	stored := m.handoffRegistry.ApplyOffer(state, now)
 
-	evt, err := m.busSessions.AppendEvent(BusHandoffs, EvtHandoffOffer, in.FromSession, payload)
+	var evt *BusBlock
+	appendFn := func() error {
+		var err error
+		evt, err = m.busSessions.AppendEvent(BusHandoffs, EvtHandoffOffer, in.FromSession, payload)
+		return err
+	}
+	stored, err := m.handoffRegistry.ApplyOffer(state, now, appendFn)
 	if err != nil {
 		return fallbackResult(fmt.Sprintf("bus append failed: %v", err), "")
 	}
@@ -406,29 +430,33 @@ func (m *MCPServer) toolClaimHandoff(ctx context.Context, req *mcp.CallToolReque
 		return textResult("claiming_session: " + err.Error())
 	}
 	now := time.Now().UTC()
-	result := m.handoffRegistry.ApplyClaim(in.HandoffID, in.ClaimingSession, now)
-	if result.Rejection != "" {
-		// Emit the claim_rejected event for observability (amendment #4).
-		payload := map[string]interface{}{
-			"handoff_id":         in.HandoffID,
-			"attempting_session": in.ClaimingSession,
-			"reason":             string(result.Rejection),
-			"rejected_at":        now.Format(time.RFC3339Nano),
-		}
-		if result.ConflictingSession != "" {
-			payload["conflicting_session"] = result.ConflictingSession
-		}
-		_, _ = m.busSessions.AppendEvent(BusHandoffs, EvtHandoffClaimRejected, in.ClaimingSession, payload)
-		return textResult(fmt.Sprintf("claim rejected: %s", result.Rejection))
-	}
 	claimPayload := map[string]interface{}{
 		"handoff_id":       in.HandoffID,
 		"claiming_session": in.ClaimingSession,
 		"claimed_at":       now.Format(time.RFC3339Nano),
 	}
-	evt, err := m.busSessions.AppendEvent(BusHandoffs, EvtHandoffClaim, in.ClaimingSession, claimPayload)
-	if err != nil {
-		return fallbackResult(fmt.Sprintf("bus append failed: %v", err), "")
+	var evt *BusBlock
+	appendFn := func() error {
+		var err error
+		evt, err = m.busSessions.AppendEvent(BusHandoffs, EvtHandoffClaim, in.ClaimingSession, claimPayload)
+		return err
+	}
+	result, appendErr := m.handoffRegistry.ApplyClaim(in.HandoffID, in.ClaimingSession, now, appendFn)
+	if appendErr != nil {
+		return fallbackResult(fmt.Sprintf("bus append failed: %v", appendErr), "")
+	}
+	if result.Rejection != "" {
+		// Emit claim_rejected (amendment #4). Always include
+		// conflicting_session even when empty — stable schema for audit.
+		payload := map[string]interface{}{
+			"handoff_id":          in.HandoffID,
+			"attempting_session":  in.ClaimingSession,
+			"conflicting_session": result.ConflictingSession,
+			"reason":              string(result.Rejection),
+			"rejected_at":         now.Format(time.RFC3339Nano),
+		}
+		_, _ = m.busSessions.AppendEvent(BusHandoffs, EvtHandoffClaimRejected, in.ClaimingSession, payload)
+		return textResult(fmt.Sprintf("claim rejected: %s", result.Rejection))
 	}
 	return marshalResult(map[string]any{
 		"ok":         true,
@@ -454,15 +482,6 @@ func (m *MCPServer) toolCompleteHandoff(ctx context.Context, req *mcp.CallToolRe
 		return textResult("outcome is required")
 	}
 	now := time.Now().UTC()
-	stored, reason := m.handoffRegistry.ApplyComplete(
-		in.HandoffID, in.CompletingSession, in.Outcome, in.Notes, in.NextHandoffID, now,
-	)
-	if reason == ClaimRejectedOfferNotFound {
-		return textResult(fmt.Sprintf("handoff %q not found", in.HandoffID))
-	}
-	if reason == ClaimRejectedOutOfOrder {
-		return textResult(fmt.Sprintf("handoff %q cannot complete in state %q", in.HandoffID, stored.State))
-	}
 	payload := map[string]interface{}{
 		"handoff_id":         in.HandoffID,
 		"completing_session": in.CompletingSession,
@@ -471,9 +490,23 @@ func (m *MCPServer) toolCompleteHandoff(ctx context.Context, req *mcp.CallToolRe
 		"next_handoff_id":    in.NextHandoffID,
 		"completed_at":       now.Format(time.RFC3339Nano),
 	}
-	evt, err := m.busSessions.AppendEvent(BusHandoffs, EvtHandoffComplete, in.CompletingSession, payload)
-	if err != nil {
-		return fallbackResult(fmt.Sprintf("bus append failed: %v", err), "")
+	var evt *BusBlock
+	appendFn := func() error {
+		var err error
+		evt, err = m.busSessions.AppendEvent(BusHandoffs, EvtHandoffComplete, in.CompletingSession, payload)
+		return err
+	}
+	stored, reason, appendErr := m.handoffRegistry.ApplyComplete(
+		in.HandoffID, in.CompletingSession, in.Outcome, in.Notes, in.NextHandoffID, now, appendFn,
+	)
+	if appendErr != nil {
+		return fallbackResult(fmt.Sprintf("bus append failed: %v", appendErr), "")
+	}
+	if reason == ClaimRejectedOfferNotFound {
+		return textResult(fmt.Sprintf("handoff %q not found", in.HandoffID))
+	}
+	if reason == ClaimRejectedOutOfOrder {
+		return textResult(fmt.Sprintf("handoff %q cannot complete in state %q", in.HandoffID, stored.State))
 	}
 	return marshalResult(map[string]any{
 		"ok":         true,

--- a/internal/engine/mcp_sessions.go
+++ b/internal/engine/mcp_sessions.go
@@ -1,0 +1,485 @@
+// mcp_sessions.go — 8 native MCP tools over the kernel session/handoff
+// registries. Complement (not replacement) to the 8 `cogos_*` Python bridge
+// tools that live in cog-sandbox-mcp: per amendment #5 both surfaces coexist
+// by design — bridge tools keep MCP-level ergonomics for agents already
+// wired to the Python sandbox; these expose the same kernel truth with no
+// Python dependency so a future native client (Wave widget, desktop app,
+// direct `cog` CLI) can just speak MCP.
+//
+// Tool naming mirrors the rest of the kernel MCP surface: snake_case under
+// the `cog_*` prefix. Input/output types live in this file so mcp_server.go
+// stays focused on registration.
+package engine
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// SetSessionsBackend wires the bus manager + registries so the kernel-side
+// MCP tools can serve traffic. Safe to call post-construction.
+func (m *MCPServer) SetSessionsBackend(
+	bus *BusSessionManager,
+	sessions *SessionRegistry,
+	handoffs *HandoffRegistry,
+) {
+	m.busSessions = bus
+	m.sessionRegistry = sessions
+	m.handoffRegistry = handoffs
+}
+
+// sessionsBackendReady is true when SetSessionsBackend has been called.
+func (m *MCPServer) sessionsBackendReady() bool {
+	return m.busSessions != nil && m.sessionRegistry != nil && m.handoffRegistry != nil
+}
+
+// ─── registerSessionTools — called from registerTools ────────────────────────
+
+// registerSessionTools installs the 8 cog_* session/handoff tools. Kept in
+// its own method so mcp_server.go stays tidy; the registration site in
+// registerTools calls this last.
+func (m *MCPServer) registerSessionTools() {
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name: "cog_register_session",
+		Description: "Register (or idempotently update) a session on " +
+			"bus_sessions. Validates the session_id format " +
+			"(lowercase, hyphen-separated, ≥2 components). Required: " +
+			"session_id, workspace, role. Optional: task, model, hostname, " +
+			"status, current_task, context_usage.",
+	}, withToolObserver(m, "cog_register_session", m.toolRegisterSession))
+
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name: "cog_heartbeat_session",
+		Description: "Emit a periodic keep-alive heartbeat for a session. " +
+			"Updates LastSeen and optional status/context fields. Rejects " +
+			"if the session is unregistered (404) or already ended (409).",
+	}, withToolObserver(m, "cog_heartbeat_session", m.toolHeartbeatSession))
+
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name: "cog_end_session",
+		Description: "Mark a session as ended. Optional handoff_id " +
+			"references the outgoing handoff, if any. Rejects if the " +
+			"session is unknown (404) or already ended (409).",
+	}, withToolObserver(m, "cog_end_session", m.toolEndSession))
+
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name: "cog_list_sessions",
+		Description: "List the roster of tracked sessions with an " +
+			"is-active flag computed from the freshness window " +
+			"(default 600s, override via active_within_seconds). Set " +
+			"include_ended=true to also see sessions that exited.",
+	}, withToolObserver(m, "cog_list_sessions", m.toolListSessions))
+
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name: "cog_offer_handoff",
+		Description: "Post a handoff.offer to bus_handoffs. Mints a new " +
+			"handoff_id (ho-<ms>-<hex>). task.title, task.goal, and a " +
+			"non-empty task.next_steps list are required. TTL defaults to " +
+			"3600s; expired offers are 409 on claim. Returns the full " +
+			"offer payload so the caller can inspect what was written.",
+	}, withToolObserver(m, "cog_offer_handoff", m.toolOfferHandoff))
+
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name: "cog_list_handoffs",
+		Description: "List tracked handoffs with optional filters: " +
+			"state (open|claimed|completed|expired) and for_session. The " +
+			"kernel maintains the derived view; the bus remains ground " +
+			"truth.",
+	}, withToolObserver(m, "cog_list_handoffs", m.toolListHandoffs))
+
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name: "cog_claim_handoff",
+		Description: "Atomically claim an open handoff offer. First-wins " +
+			"by kernel mutex: concurrent claims produce exactly one 200 " +
+			"and N-1 409 responses, each of which emits a " +
+			"handoff.claim_rejected event on bus_handoffs for audit. " +
+			"Returns the full offer payload on success.",
+	}, withToolObserver(m, "cog_claim_handoff", m.toolClaimHandoff))
+
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name: "cog_complete_handoff",
+		Description: "Mark a claimed handoff as completed. Rejected with " +
+			"409 if the handoff has not been claimed yet or is already " +
+			"complete. Optional outcome, notes, and next_handoff_id.",
+	}, withToolObserver(m, "cog_complete_handoff", m.toolCompleteHandoff))
+}
+
+// ─── input/output types ──────────────────────────────────────────────────────
+
+type registerSessionInput struct {
+	SessionID    string                 `json:"session_id"`
+	Workspace    string                 `json:"workspace"`
+	Role         string                 `json:"role"`
+	Task         string                 `json:"task,omitempty"`
+	Model        string                 `json:"model,omitempty"`
+	Hostname     string                 `json:"hostname,omitempty"`
+	Status       string                 `json:"status,omitempty"`
+	CurrentTask  string                 `json:"current_task,omitempty"`
+	ContextUsage float64                `json:"context_usage,omitempty"`
+	Extras       map[string]interface{} `json:"extras,omitempty"`
+}
+
+type heartbeatSessionInput struct {
+	SessionID    string  `json:"session_id"`
+	Status       string  `json:"status,omitempty"`
+	ContextUsage float64 `json:"context_usage,omitempty"`
+	CurrentTask  string  `json:"current_task,omitempty"`
+}
+
+type endSessionInput struct {
+	SessionID string `json:"session_id"`
+	Reason    string `json:"reason,omitempty"`
+	HandoffID string `json:"handoff_id,omitempty"`
+}
+
+type listSessionsInput struct {
+	ActiveWithinSeconds int  `json:"active_within_seconds,omitempty"`
+	IncludeEnded        bool `json:"include_ended,omitempty"`
+}
+
+type offerHandoffInput struct {
+	FromSession     string                   `json:"from_session"`
+	ToSession       string                   `json:"to_session,omitempty"`
+	Reason          string                   `json:"reason,omitempty"`
+	TTLSeconds      int                      `json:"ttl_seconds,omitempty"`
+	Task            map[string]interface{}   `json:"task"`
+	BootstrapPrompt string                   `json:"bootstrap_prompt"`
+	BusContextRefs  []map[string]interface{} `json:"bus_context_refs,omitempty"`
+	MemoryRefs      []string                 `json:"memory_refs,omitempty"`
+}
+
+type listHandoffsInput struct {
+	State      string `json:"state,omitempty"`
+	ForSession string `json:"for_session,omitempty"`
+}
+
+type claimHandoffInput struct {
+	HandoffID       string `json:"handoff_id"`
+	ClaimingSession string `json:"claiming_session"`
+}
+
+type completeHandoffInput struct {
+	HandoffID         string `json:"handoff_id"`
+	CompletingSession string `json:"completing_session"`
+	Outcome           string `json:"outcome"`
+	Notes             string `json:"notes,omitempty"`
+	NextHandoffID     string `json:"next_handoff_id,omitempty"`
+}
+
+// ─── handlers ────────────────────────────────────────────────────────────────
+
+func (m *MCPServer) toolRegisterSession(ctx context.Context, req *mcp.CallToolRequest, in registerSessionInput) (*mcp.CallToolResult, any, error) {
+	if !m.sessionsBackendReady() {
+		return fallbackResult("sessions backend not configured",
+			"curl -X POST http://localhost:6931/v1/sessions/register -d '{...}'")
+	}
+	if err := ValidateSessionID(in.SessionID); err != nil {
+		return textResult(err.Error())
+	}
+	if in.Workspace == "" || in.Role == "" {
+		return textResult("workspace and role are required")
+	}
+	now := time.Now().UTC()
+	state := SessionState{
+		SessionID: in.SessionID, Workspace: in.Workspace, Role: in.Role,
+		Task: in.Task, Model: in.Model, Hostname: in.Hostname,
+		ContextUsage: in.ContextUsage, Status: in.Status, CurrentTask: in.CurrentTask,
+		Extras: in.Extras, RegisteredAt: now, LastSeen: now,
+	}
+	stored, created, err := m.sessionRegistry.ApplyRegister(
+		state, time.Duration(defaultActiveWithinSeconds)*time.Second, now,
+	)
+	if err != nil {
+		return textResult(err.Error())
+	}
+	payload := map[string]interface{}{
+		"session_id": in.SessionID, "workspace": in.Workspace, "role": in.Role,
+		"task": in.Task, "model": in.Model, "hostname": in.Hostname,
+		"status": in.Status, "current_task": in.CurrentTask,
+		"context_usage": in.ContextUsage,
+		"registered_at": stored.RegisteredAt.Format(time.RFC3339Nano),
+	}
+	for k, v := range in.Extras {
+		if _, exists := payload[k]; !exists {
+			payload[k] = v
+		}
+	}
+	evt, err := m.busSessions.AppendEvent(BusSessions, EvtSessionRegister, in.SessionID, payload)
+	if err != nil {
+		return fallbackResult(fmt.Sprintf("bus append failed: %v", err), "")
+	}
+	return marshalResult(map[string]any{
+		"ok": true, "session_id": in.SessionID,
+		"seq": evt.Seq, "hash": evt.Hash,
+		"created": created, "session": stored,
+	})
+}
+
+func (m *MCPServer) toolHeartbeatSession(ctx context.Context, req *mcp.CallToolRequest, in heartbeatSessionInput) (*mcp.CallToolResult, any, error) {
+	if !m.sessionsBackendReady() {
+		return fallbackResult("sessions backend not configured", "")
+	}
+	if err := ValidateSessionID(in.SessionID); err != nil {
+		return textResult(err.Error())
+	}
+	now := time.Now().UTC()
+	stored, ok := m.sessionRegistry.ApplyHeartbeat(in.SessionID, in.ContextUsage, in.Status, in.CurrentTask, now)
+	if !ok {
+		return textResult(fmt.Sprintf("session %q is not registered", in.SessionID))
+	}
+	if stored.Ended {
+		return textResult(fmt.Sprintf("session %q is already ended", in.SessionID))
+	}
+	payload := map[string]interface{}{
+		"session_id": in.SessionID, "status": in.Status,
+		"context_usage": in.ContextUsage, "current_task": in.CurrentTask,
+		"at": now.Format(time.RFC3339Nano),
+	}
+	evt, err := m.busSessions.AppendEvent(BusSessions, EvtSessionHeartbeat, in.SessionID, payload)
+	if err != nil {
+		return fallbackResult(fmt.Sprintf("bus append failed: %v", err), "")
+	}
+	return marshalResult(map[string]any{
+		"ok": true, "session_id": in.SessionID,
+		"seq": evt.Seq, "hash": evt.Hash, "session": stored,
+	})
+}
+
+func (m *MCPServer) toolEndSession(ctx context.Context, req *mcp.CallToolRequest, in endSessionInput) (*mcp.CallToolResult, any, error) {
+	if !m.sessionsBackendReady() {
+		return fallbackResult("sessions backend not configured", "")
+	}
+	if err := ValidateSessionID(in.SessionID); err != nil {
+		return textResult(err.Error())
+	}
+	now := time.Now().UTC()
+	stored, known, err := m.sessionRegistry.ApplyEnd(in.SessionID, in.Reason, in.HandoffID, now)
+	if !known {
+		return textResult(fmt.Sprintf("session %q is not registered", in.SessionID))
+	}
+	if err != nil {
+		return textResult(err.Error())
+	}
+	payload := map[string]interface{}{
+		"session_id": in.SessionID, "reason": in.Reason,
+		"handoff_id": in.HandoffID,
+		"ended_at":   now.Format(time.RFC3339Nano),
+	}
+	evt, errEmit := m.busSessions.AppendEvent(BusSessions, EvtSessionEnd, in.SessionID, payload)
+	if errEmit != nil {
+		return fallbackResult(fmt.Sprintf("bus append failed: %v", errEmit), "")
+	}
+	return marshalResult(map[string]any{
+		"ok": true, "session_id": in.SessionID,
+		"seq": evt.Seq, "hash": evt.Hash, "session": stored,
+	})
+}
+
+func (m *MCPServer) toolListSessions(ctx context.Context, req *mcp.CallToolRequest, in listSessionsInput) (*mcp.CallToolResult, any, error) {
+	if !m.sessionsBackendReady() {
+		return fallbackResult("sessions backend not configured", "")
+	}
+	now := time.Now().UTC()
+	window := time.Duration(defaultActiveWithinSeconds) * time.Second
+	if in.ActiveWithinSeconds > 0 {
+		window = time.Duration(in.ActiveWithinSeconds) * time.Second
+	}
+	snap := m.sessionRegistry.Snapshot()
+	entries := make([]sessionPresenceEntry, 0, len(snap))
+	for _, row := range snap {
+		if !in.IncludeEnded && row.Ended {
+			continue
+		}
+		entries = append(entries, sessionPresenceEntry{
+			SessionState: row,
+			Active:       row.IsActive(window, now),
+		})
+	}
+	return marshalResult(map[string]any{
+		"sessions": entries,
+		"count":    len(entries),
+	})
+}
+
+func (m *MCPServer) toolOfferHandoff(ctx context.Context, req *mcp.CallToolRequest, in offerHandoffInput) (*mcp.CallToolResult, any, error) {
+	if !m.sessionsBackendReady() {
+		return fallbackResult("sessions backend not configured", "")
+	}
+	if err := ValidateSessionID(in.FromSession); err != nil {
+		return textResult("from_session: " + err.Error())
+	}
+	if in.ToSession != "" {
+		if err := ValidateSessionID(in.ToSession); err != nil {
+			return textResult("to_session: " + err.Error())
+		}
+	}
+	if in.BootstrapPrompt == "" {
+		return textResult("bootstrap_prompt is required")
+	}
+	if in.Task == nil {
+		return textResult("task is required")
+	}
+	if title, _ := in.Task["title"].(string); title == "" {
+		return textResult("task.title is required")
+	}
+	if goal, _ := in.Task["goal"].(string); goal == "" {
+		return textResult("task.goal is required")
+	}
+	if steps, ok := in.Task["next_steps"].([]interface{}); !ok || len(steps) == 0 {
+		return textResult("task.next_steps must be a non-empty list")
+	}
+	if in.TTLSeconds == 0 {
+		in.TTLSeconds = 3600
+	}
+
+	now := time.Now().UTC()
+	handoffID := mintHandoffID(now)
+	state := HandoffState{
+		HandoffID: handoffID, FromSession: in.FromSession,
+		ToSession: in.ToSession, Reason: in.Reason,
+		TTLSeconds: in.TTLSeconds, CreatedAt: now,
+		ExpiresAt: now.Add(time.Duration(in.TTLSeconds) * time.Second),
+	}
+	payload := map[string]interface{}{
+		"handoff_id":       handoffID,
+		"from_session":     in.FromSession,
+		"to_session":       in.ToSession,
+		"reason":           in.Reason,
+		"ttl_seconds":      in.TTLSeconds,
+		"created_at":       now.Format(time.RFC3339Nano),
+		"task":             in.Task,
+		"bootstrap_prompt": in.BootstrapPrompt,
+		"bus_context_refs": in.BusContextRefs,
+		"memory_refs":      in.MemoryRefs,
+	}
+	state.OfferPayload = payload
+	stored := m.handoffRegistry.ApplyOffer(state, now)
+
+	evt, err := m.busSessions.AppendEvent(BusHandoffs, EvtHandoffOffer, in.FromSession, payload)
+	if err != nil {
+		return fallbackResult(fmt.Sprintf("bus append failed: %v", err), "")
+	}
+	return marshalResult(map[string]any{
+		"ok": true, "handoff_id": handoffID,
+		"seq": evt.Seq, "hash": evt.Hash,
+		"handoff": stored,
+	})
+}
+
+func (m *MCPServer) toolListHandoffs(ctx context.Context, req *mcp.CallToolRequest, in listHandoffsInput) (*mcp.CallToolResult, any, error) {
+	if !m.sessionsBackendReady() {
+		return fallbackResult("sessions backend not configured", "")
+	}
+	now := time.Now().UTC()
+	snap := m.handoffRegistry.Snapshot()
+	out := make([]*HandoffState, 0, len(snap))
+	for _, h := range snap {
+		effective := h.State
+		if effective == HandoffStateOpen && h.IsExpired(now) {
+			effective = "expired"
+		}
+		if in.State != "" && effective != in.State {
+			continue
+		}
+		if in.ForSession != "" && h.ToSession != "" && h.ToSession != in.ForSession {
+			continue
+		}
+		out = append(out, h)
+	}
+	return marshalResult(map[string]any{
+		"handoffs": out,
+		"count":    len(out),
+	})
+}
+
+func (m *MCPServer) toolClaimHandoff(ctx context.Context, req *mcp.CallToolRequest, in claimHandoffInput) (*mcp.CallToolResult, any, error) {
+	if !m.sessionsBackendReady() {
+		return fallbackResult("sessions backend not configured", "")
+	}
+	if in.HandoffID == "" {
+		return textResult("handoff_id is required")
+	}
+	if err := ValidateSessionID(in.ClaimingSession); err != nil {
+		return textResult("claiming_session: " + err.Error())
+	}
+	now := time.Now().UTC()
+	result := m.handoffRegistry.ApplyClaim(in.HandoffID, in.ClaimingSession, now)
+	if result.Rejection != "" {
+		// Emit the claim_rejected event for observability (amendment #4).
+		payload := map[string]interface{}{
+			"handoff_id":         in.HandoffID,
+			"attempting_session": in.ClaimingSession,
+			"reason":             string(result.Rejection),
+			"rejected_at":        now.Format(time.RFC3339Nano),
+		}
+		if result.ConflictingSession != "" {
+			payload["conflicting_session"] = result.ConflictingSession
+		}
+		_, _ = m.busSessions.AppendEvent(BusHandoffs, EvtHandoffClaimRejected, in.ClaimingSession, payload)
+		return textResult(fmt.Sprintf("claim rejected: %s", result.Rejection))
+	}
+	claimPayload := map[string]interface{}{
+		"handoff_id":       in.HandoffID,
+		"claiming_session": in.ClaimingSession,
+		"claimed_at":       now.Format(time.RFC3339Nano),
+	}
+	evt, err := m.busSessions.AppendEvent(BusHandoffs, EvtHandoffClaim, in.ClaimingSession, claimPayload)
+	if err != nil {
+		return fallbackResult(fmt.Sprintf("bus append failed: %v", err), "")
+	}
+	return marshalResult(map[string]any{
+		"ok":         true,
+		"handoff_id": in.HandoffID,
+		"seq":        evt.Seq,
+		"hash":       evt.Hash,
+		"handoff":    result.Offer,
+		"offer":      result.Offer.OfferPayload,
+	})
+}
+
+func (m *MCPServer) toolCompleteHandoff(ctx context.Context, req *mcp.CallToolRequest, in completeHandoffInput) (*mcp.CallToolResult, any, error) {
+	if !m.sessionsBackendReady() {
+		return fallbackResult("sessions backend not configured", "")
+	}
+	if in.HandoffID == "" {
+		return textResult("handoff_id is required")
+	}
+	if err := ValidateSessionID(in.CompletingSession); err != nil {
+		return textResult("completing_session: " + err.Error())
+	}
+	if in.Outcome == "" {
+		return textResult("outcome is required")
+	}
+	now := time.Now().UTC()
+	stored, reason := m.handoffRegistry.ApplyComplete(
+		in.HandoffID, in.CompletingSession, in.Outcome, in.Notes, in.NextHandoffID, now,
+	)
+	if reason == ClaimRejectedOfferNotFound {
+		return textResult(fmt.Sprintf("handoff %q not found", in.HandoffID))
+	}
+	if reason == ClaimRejectedOutOfOrder {
+		return textResult(fmt.Sprintf("handoff %q cannot complete in state %q", in.HandoffID, stored.State))
+	}
+	payload := map[string]interface{}{
+		"handoff_id":         in.HandoffID,
+		"completing_session": in.CompletingSession,
+		"outcome":            in.Outcome,
+		"notes":              in.Notes,
+		"next_handoff_id":    in.NextHandoffID,
+		"completed_at":       now.Format(time.RFC3339Nano),
+	}
+	evt, err := m.busSessions.AppendEvent(BusHandoffs, EvtHandoffComplete, in.CompletingSession, payload)
+	if err != nil {
+		return fallbackResult(fmt.Sprintf("bus append failed: %v", err), "")
+	}
+	return marshalResult(map[string]any{
+		"ok":         true,
+		"handoff_id": in.HandoffID,
+		"seq":        evt.Seq,
+		"hash":       evt.Hash,
+		"handoff":    stored,
+	})
+}

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -64,6 +64,13 @@ type Server struct {
 	busBroker    *BusEventBroker
 	busConsumers *ConsumerRegistry
 	sessions     *SessionContextStore
+
+	// Kernel-native session-management registries (hybrid design —
+	// cog://mem/semantic/surveys/2026-04-21-consolidation/
+	// agent-P-session-management-evaluation). The bus is ground truth;
+	// these are derived views rebuilt from bus replay at startup.
+	sessionRegistry *SessionRegistry
+	handoffRegistry *HandoffRegistry
 }
 
 // NewServer constructs a Server bound to the configured port.
@@ -80,6 +87,12 @@ func NewServer(cfg *Config, nucleus *Nucleus, process *Process) *Server {
 		filepath.Join(cfg.WorkspaceRoot, ".cog", "run", "bus"),
 	)
 	s.sessions = NewSessionContextStore()
+
+	// Kernel-native session + handoff registries. Replay from bus is done
+	// below, after the bus manager + its handlers are wired up, so that
+	// the warm cache is ready before any HTTP request lands.
+	s.sessionRegistry = NewSessionRegistry()
+	s.handoffRegistry = NewHandoffRegistry()
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /", handleDashboard)
@@ -113,6 +126,18 @@ func NewServer(cfg *Config, nucleus *Nucleus, process *Process) *Server {
 
 	// Track 5 Phase 3: /v1/bus/* and /v1/sessions routes.
 	s.registerBusRoutes(mux)
+
+	// Kernel-native session & handoff management routes — the hybrid
+	// design's invariance layer. Registered AFTER registerBusRoutes so
+	// the specific patterns (POST /v1/sessions/register, etc.) coexist
+	// cleanly with the pre-existing GET /v1/sessions[/{id}] surface.
+	s.registerSessionMgmtRoutes(mux)
+
+	// Replay bus_sessions + bus_handoffs into the in-memory registries so
+	// the kernel starts with an accurate derived view. Bus is authoritative
+	// either way; this just warms the read path.
+	_ = ReplaySessionRegistry(s.busSessions, s.sessionRegistry)
+	_ = ReplayHandoffRegistry(s.busSessions, s.handoffRegistry)
 
 	// Resolve the bind address. Default stays 127.0.0.1 (loopback-only);
 	// callers may override via Config.BindAddr to listen on all interfaces

--- a/internal/engine/serve_mcp.go
+++ b/internal/engine/serve_mcp.go
@@ -11,6 +11,12 @@ import "net/http"
 // have a backing implementation.
 func (s *Server) registerMCPRoutes(mux *http.ServeMux) {
 	mcpSrv := NewMCPServerWithAgentController(s.cfg, s.nucleus, s.process, s.agentController)
+	// Wire session-management deps so the cog_register_session /
+	// cog_offer_handoff / etc. tools can hit the same in-memory registries
+	// the HTTP surface uses. The tools fall back to an error message if
+	// these are nil — NewMCPServer (used by tests that only care about
+	// memory tools) doesn't call this, which is fine.
+	mcpSrv.SetSessionsBackend(s.busSessions, s.sessionRegistry, s.handoffRegistry)
 	s.mcpServer = mcpSrv
 	h := mcpSrv.Handler()
 	mux.Handle("GET /mcp", h)

--- a/internal/engine/serve_sessions_mgmt.go
+++ b/internal/engine/serve_sessions_mgmt.go
@@ -136,16 +136,13 @@ func (s *Server) handleSessionRegister(w http.ResponseWriter, r *http.Request) {
 		RegisteredAt: now,
 		LastSeen:     now,
 	}
-	stored, created, err := s.sessionRegistry.ApplyRegister(
-		state,
-		time.Duration(defaultActiveWithinSeconds)*time.Second,
-		now,
-	)
-	if err != nil {
-		writeJSONError(w, http.StatusBadRequest, "invalid_request", err.Error())
-		return
-	}
-	// Mirror to the bus.
+	// Build the bus payload up front so the appendFn closure can reference
+	// it. The registered_at field is derived from the final stored state's
+	// RegisteredAt (which may have been preserved from a prior re-register
+	// by ApplyRegister); since we don't yet know if this is a new row vs
+	// an update, we use `now` here and let ApplyRegister correct lineage
+	// internally. The bus event's ts field is authoritative for ordering
+	// anyway.
 	payload := map[string]interface{}{
 		"session_id":    req.SessionID,
 		"workspace":     req.Workspace,
@@ -156,7 +153,7 @@ func (s *Server) handleSessionRegister(w http.ResponseWriter, r *http.Request) {
 		"status":        req.Status,
 		"current_task":  req.CurrentTask,
 		"context_usage": req.ContextUsage,
-		"registered_at": stored.RegisteredAt.Format(time.RFC3339Nano),
+		"registered_at": now.Format(time.RFC3339Nano),
 	}
 	if req.Extras != nil {
 		for k, v := range req.Extras {
@@ -165,7 +162,21 @@ func (s *Server) handleSessionRegister(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-	evt, err := s.busSessions.AppendEvent(BusSessions, EvtSessionRegister, req.SessionID, payload)
+	// Validation has already happened above (ValidateSessionID + required
+	// fields), so the only error ApplyRegister can return now is from
+	// appendFn — i.e. bus-append failure, which is always a 500.
+	var evt *BusBlock
+	appendFn := func() error {
+		var err error
+		evt, err = s.busSessions.AppendEvent(BusSessions, EvtSessionRegister, req.SessionID, payload)
+		return err
+	}
+	stored, created, err := s.sessionRegistry.ApplyRegister(
+		state,
+		time.Duration(defaultActiveWithinSeconds)*time.Second,
+		now,
+		appendFn,
+	)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "bus_append_failed", err.Error())
 		return
@@ -199,19 +210,6 @@ func (s *Server) handleSessionHeartbeat(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 	now := time.Now().UTC()
-	stored, ok := s.sessionRegistry.ApplyHeartbeat(
-		id, req.ContextUsage, req.Status, req.CurrentTask, now,
-	)
-	if !ok {
-		writeJSONError(w, http.StatusNotFound, "not_found",
-			fmt.Sprintf("session %q is not registered", id))
-		return
-	}
-	if stored.Ended {
-		writeJSONError(w, http.StatusConflict, "conflict",
-			fmt.Sprintf("session %q is already ended", id))
-		return
-	}
 	payload := map[string]interface{}{
 		"session_id":    id,
 		"status":        req.Status,
@@ -219,8 +217,31 @@ func (s *Server) handleSessionHeartbeat(w http.ResponseWriter, r *http.Request) 
 		"current_task":  req.CurrentTask,
 		"at":            now.Format(time.RFC3339Nano),
 	}
-	evt, err := s.busSessions.AppendEvent(BusSessions, EvtSessionHeartbeat, id, payload)
+	var evt *BusBlock
+	appendFn := func() error {
+		var err error
+		evt, err = s.busSessions.AppendEvent(BusSessions, EvtSessionHeartbeat, id, payload)
+		return err
+	}
+	stored, ok, err := s.sessionRegistry.ApplyHeartbeat(
+		id, req.ContextUsage, req.Status, req.CurrentTask, now, appendFn,
+	)
+	if !ok {
+		writeJSONError(w, http.StatusNotFound, "not_found",
+			fmt.Sprintf("session %q is not registered", id))
+		return
+	}
 	if err != nil {
+		// Two shapes of err land here:
+		//   1. "session already ended" — the registry was NOT mutated
+		//      (LastSeen unchanged) and no bus event was appended.
+		//      Return 409.
+		//   2. bus append failure — also no mutation. Return 500.
+		if stored != nil && stored.Ended && evt == nil {
+			writeJSONError(w, http.StatusConflict, "conflict",
+				fmt.Sprintf("session %q is already ended", id))
+			return
+		}
 		writeJSONError(w, http.StatusInternalServerError, "bus_append_failed", err.Error())
 		return
 	}
@@ -251,25 +272,32 @@ func (s *Server) handleSessionEnd(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	now := time.Now().UTC()
-	stored, known, err := s.sessionRegistry.ApplyEnd(id, req.Reason, req.HandoffID, now)
-	if !known {
-		writeJSONError(w, http.StatusNotFound, "not_found",
-			fmt.Sprintf("session %q is not registered", id))
-		return
-	}
-	if err != nil {
-		writeJSONError(w, http.StatusConflict, "conflict", err.Error())
-		return
-	}
 	payload := map[string]interface{}{
 		"session_id": id,
 		"reason":     req.Reason,
 		"handoff_id": req.HandoffID,
 		"ended_at":   now.Format(time.RFC3339Nano),
 	}
-	evt, errEmit := s.busSessions.AppendEvent(BusSessions, EvtSessionEnd, id, payload)
-	if errEmit != nil {
-		writeJSONError(w, http.StatusInternalServerError, "bus_append_failed", errEmit.Error())
+	var evt *BusBlock
+	appendFn := func() error {
+		var err error
+		evt, err = s.busSessions.AppendEvent(BusSessions, EvtSessionEnd, id, payload)
+		return err
+	}
+	stored, known, err := s.sessionRegistry.ApplyEnd(id, req.Reason, req.HandoffID, now, appendFn)
+	if !known {
+		writeJSONError(w, http.StatusNotFound, "not_found",
+			fmt.Sprintf("session %q is not registered", id))
+		return
+	}
+	if err != nil {
+		// "already ended" sentinel → 409. Bus-append failure → 500.
+		// Disambiguate by whether evt was populated.
+		if evt == nil && stored != nil && stored.Ended {
+			writeJSONError(w, http.StatusConflict, "conflict", err.Error())
+			return
+		}
+		writeJSONError(w, http.StatusInternalServerError, "bus_append_failed", err.Error())
 		return
 	}
 	writeJSONResp(w, http.StatusOK, sessionWriteResponse{
@@ -340,6 +368,14 @@ func (s *Server) handleHandoffOffer(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, "invalid_request", "body must be JSON")
 		return
 	}
+	// Per design spec, the kernel ALWAYS mints handoff_id. A caller-
+	// supplied value is rejected so path-based claim/complete routes can
+	// rely on the canonical ho-<ms>-<hex> shape.
+	if req.HandoffID != "" {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request",
+			"handoff_id must not be provided; kernel mints it server-side")
+		return
+	}
 	if err := ValidateSessionID(req.FromSession); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid_request",
 			"from_session: "+err.Error())
@@ -378,17 +414,21 @@ func (s *Server) handleHandoffOffer(w http.ResponseWriter, r *http.Request) {
 			"task.next_steps must be a non-empty list")
 		return
 	}
-
-	if req.HandoffID == "" {
-		req.HandoffID = mintHandoffID(time.Now())
+	if req.TTLSeconds < 0 {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request",
+			"ttl_seconds must be >= 0")
+		return
 	}
 	if req.TTLSeconds == 0 {
 		req.TTLSeconds = 3600
 	}
 
+	// Single `now` for the whole operation — no skew between the minted
+	// handoff_id's embedded timestamp and the stored created_at.
 	now := time.Now().UTC()
+	handoffID := mintHandoffID(now)
 	state := HandoffState{
-		HandoffID:   req.HandoffID,
+		HandoffID:   handoffID,
 		FromSession: req.FromSession,
 		ToSession:   req.ToSession,
 		Reason:      req.Reason,
@@ -399,7 +439,7 @@ func (s *Server) handleHandoffOffer(w http.ResponseWriter, r *http.Request) {
 	// The full payload we put on the bus is the canonical offer — mirror it
 	// to OfferPayload so claimants can read it verbatim.
 	payload := map[string]interface{}{
-		"handoff_id":       req.HandoffID,
+		"handoff_id":       handoffID,
 		"from_session":     req.FromSession,
 		"to_session":       req.ToSession,
 		"reason":           req.Reason,
@@ -411,15 +451,20 @@ func (s *Server) handleHandoffOffer(w http.ResponseWriter, r *http.Request) {
 		"memory_refs":      req.MemoryRefs,
 	}
 	state.OfferPayload = payload
-	stored := s.handoffRegistry.ApplyOffer(state, now)
 
-	evt, err := s.busSessions.AppendEvent(BusHandoffs, EvtHandoffOffer, req.FromSession, payload)
+	var evt *BusBlock
+	appendFn := func() error {
+		var err error
+		evt, err = s.busSessions.AppendEvent(BusHandoffs, EvtHandoffOffer, req.FromSession, payload)
+		return err
+	}
+	stored, err := s.handoffRegistry.ApplyOffer(state, now, appendFn)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "bus_append_failed", err.Error())
 		return
 	}
 	writeJSONResp(w, http.StatusOK, handoffWriteResponse{
-		OK: true, HandoffID: req.HandoffID,
+		OK: true, HandoffID: handoffID,
 		Seq: evt.Seq, Hash: evt.Hash, Handoff: stored,
 	})
 }
@@ -487,7 +532,25 @@ func (s *Server) handleHandoffClaim(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	now := time.Now().UTC()
-	result := s.handoffRegistry.ApplyClaim(id, req.ClaimingSession, now)
+	// The bus append for the winning claim runs WHILE the handoff lock
+	// is held inside ApplyClaim, so first-wins is enforced on the
+	// authoritative bus, not just the in-memory registry.
+	claimPayload := map[string]interface{}{
+		"handoff_id":       id,
+		"claiming_session": req.ClaimingSession,
+		"claimed_at":       now.Format(time.RFC3339Nano),
+	}
+	var evt *BusBlock
+	appendFn := func() error {
+		var err error
+		evt, err = s.busSessions.AppendEvent(BusHandoffs, EvtHandoffClaim, req.ClaimingSession, claimPayload)
+		return err
+	}
+	result, appendErr := s.handoffRegistry.ApplyClaim(id, req.ClaimingSession, now, appendFn)
+	if appendErr != nil {
+		writeJSONError(w, http.StatusInternalServerError, "bus_append_failed", appendErr.Error())
+		return
+	}
 	if result.Rejection != "" {
 		s.emitClaimRejected(id, req.ClaimingSession, result, now)
 		status := http.StatusConflict
@@ -498,17 +561,6 @@ func (s *Server) handleHandoffClaim(w http.ResponseWriter, r *http.Request) {
 		}
 		writeJSONError(w, status, kind, fmt.Sprintf(
 			"claim rejected: %s", result.Rejection))
-		return
-	}
-	// Successful claim — emit and return offer payload.
-	claimPayload := map[string]interface{}{
-		"handoff_id":       id,
-		"claiming_session": req.ClaimingSession,
-		"claimed_at":       now.Format(time.RFC3339Nano),
-	}
-	evt, err := s.busSessions.AppendEvent(BusHandoffs, EvtHandoffClaim, req.ClaimingSession, claimPayload)
-	if err != nil {
-		writeJSONError(w, http.StatusInternalServerError, "bus_append_failed", err.Error())
 		return
 	}
 	writeJSONResp(w, http.StatusOK, map[string]any{
@@ -524,16 +576,19 @@ func (s *Server) handleHandoffClaim(w http.ResponseWriter, r *http.Request) {
 // emitClaimRejected writes a handoff.claim_rejected event to bus_handoffs so
 // observers can audit failed claim attempts (amendment #4). Emission failure
 // is logged but non-fatal — the handler already returned the HTTP error.
+//
+// Per the amendment the payload ALWAYS includes reason, attempting_session,
+// and conflicting_session (empty string when inapplicable, e.g. the offer
+// never existed or TTL expired). This gives audit consumers a stable schema
+// to query against.
 func (s *Server) emitClaimRejected(handoffID, attemptingSession string,
 	result ClaimResult, now time.Time) {
 	payload := map[string]interface{}{
-		"handoff_id":         handoffID,
-		"attempting_session": attemptingSession,
-		"reason":             string(result.Rejection),
-		"rejected_at":        now.Format(time.RFC3339Nano),
-	}
-	if result.ConflictingSession != "" {
-		payload["conflicting_session"] = result.ConflictingSession
+		"handoff_id":          handoffID,
+		"attempting_session":  attemptingSession,
+		"conflicting_session": result.ConflictingSession, // "" when N/A
+		"reason":              string(result.Rejection),
+		"rejected_at":         now.Format(time.RFC3339Nano),
 	}
 	if _, err := s.busSessions.AppendEvent(BusHandoffs, EvtHandoffClaimRejected, attemptingSession, payload); err != nil {
 		slog.Warn("handoff: claim_rejected emit failed",
@@ -571,19 +626,6 @@ func (s *Server) handleHandoffComplete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	now := time.Now().UTC()
-	stored, reason := s.handoffRegistry.ApplyComplete(
-		id, req.CompletingSession, req.Outcome, req.Notes, req.NextHandoffID, now,
-	)
-	if reason == ClaimRejectedOfferNotFound {
-		writeJSONError(w, http.StatusNotFound, "not_found",
-			fmt.Sprintf("handoff %q not found", id))
-		return
-	}
-	if reason == ClaimRejectedOutOfOrder {
-		writeJSONError(w, http.StatusConflict, "conflict",
-			fmt.Sprintf("handoff %q cannot complete in state %q", id, stored.State))
-		return
-	}
 	payload := map[string]interface{}{
 		"handoff_id":         id,
 		"completing_session": req.CompletingSession,
@@ -592,9 +634,27 @@ func (s *Server) handleHandoffComplete(w http.ResponseWriter, r *http.Request) {
 		"next_handoff_id":    req.NextHandoffID,
 		"completed_at":       now.Format(time.RFC3339Nano),
 	}
-	evt, err := s.busSessions.AppendEvent(BusHandoffs, EvtHandoffComplete, req.CompletingSession, payload)
-	if err != nil {
-		writeJSONError(w, http.StatusInternalServerError, "bus_append_failed", err.Error())
+	var evt *BusBlock
+	appendFn := func() error {
+		var err error
+		evt, err = s.busSessions.AppendEvent(BusHandoffs, EvtHandoffComplete, req.CompletingSession, payload)
+		return err
+	}
+	stored, reason, appendErr := s.handoffRegistry.ApplyComplete(
+		id, req.CompletingSession, req.Outcome, req.Notes, req.NextHandoffID, now, appendFn,
+	)
+	if appendErr != nil {
+		writeJSONError(w, http.StatusInternalServerError, "bus_append_failed", appendErr.Error())
+		return
+	}
+	if reason == ClaimRejectedOfferNotFound {
+		writeJSONError(w, http.StatusNotFound, "not_found",
+			fmt.Sprintf("handoff %q not found", id))
+		return
+	}
+	if reason == ClaimRejectedOutOfOrder {
+		writeJSONError(w, http.StatusConflict, "conflict",
+			fmt.Sprintf("handoff %q cannot complete in state %q", id, stored.State))
 		return
 	}
 	writeJSONResp(w, http.StatusOK, handoffWriteResponse{

--- a/internal/engine/serve_sessions_mgmt.go
+++ b/internal/engine/serve_sessions_mgmt.go
@@ -1,0 +1,603 @@
+// serve_sessions_mgmt.go — kernel-native HTTP surface for session & handoff
+// management. The 8 routes below are the "invariance layer" of the hybrid
+// design: they validate inputs, enforce the state machine via
+// SessionRegistry / HandoffRegistry, and only then append to the bus.
+//
+// Routes registered here:
+//
+//	POST /v1/sessions/register                — register (or idempotently
+//	                                            update) a session
+//	POST /v1/sessions/{id}/heartbeat          — bump last_seen + optional
+//	                                            status fields
+//	POST /v1/sessions/{id}/end                — mark ended; optional
+//	                                            handoff_id hand-off-ref
+//	GET  /v1/sessions/presence                — roster of tracked sessions
+//	                                            (optional active_within_seconds)
+//
+//	POST /v1/handoffs/offer                   — post an offer (kernel mints
+//	                                            handoff_id if missing)
+//	GET  /v1/handoffs                         — list handoffs, optional
+//	                                            state / for_session filters
+//	POST /v1/handoffs/{id}/claim              — atomic first-wins claim;
+//	                                            emits handoff.claim_rejected
+//	                                            on failure (amendment #4)
+//	POST /v1/handoffs/{id}/complete           — mark claimed offer completed
+//
+// Note: the existing routes `/v1/sessions` and `/v1/sessions/{id}[/context]`
+// registered by serve_bus.go are preserved untouched (they serve per-turn
+// TAA inference context, a different concern). Go 1.22 pattern precedence
+// resolves `POST /v1/sessions/register` before `GET /v1/sessions/` because
+// the method+pattern is more specific.
+package engine
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// registerSessionMgmtRoutes attaches the 8 new routes onto mux. Called from
+// NewServer after registerBusRoutes so specific patterns land cleanly
+// alongside the pre-existing `/v1/sessions` GET surface.
+func (s *Server) registerSessionMgmtRoutes(mux *http.ServeMux) {
+	// Sessions (specific-method first).
+	mux.HandleFunc("POST /v1/sessions/register", s.handleSessionRegister)
+	mux.HandleFunc("GET /v1/sessions/presence", s.handleSessionPresence)
+	mux.HandleFunc("POST /v1/sessions/{id}/heartbeat", s.handleSessionHeartbeat)
+	mux.HandleFunc("POST /v1/sessions/{id}/end", s.handleSessionEnd)
+
+	// Handoffs.
+	mux.HandleFunc("POST /v1/handoffs/offer", s.handleHandoffOffer)
+	mux.HandleFunc("GET /v1/handoffs", s.handleHandoffList)
+	mux.HandleFunc("POST /v1/handoffs/{id}/claim", s.handleHandoffClaim)
+	mux.HandleFunc("POST /v1/handoffs/{id}/complete", s.handleHandoffComplete)
+}
+
+// ─── error helpers ───────────────────────────────────────────────────────────
+
+// writeJSONError mirrors the existing /v1/sessions/{id}[/context] error shape
+// so clients see a uniform envelope across the whole /v1/sessions family.
+func writeJSONError(w http.ResponseWriter, status int, kind, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"error": map[string]string{
+			"type":    kind,
+			"message": msg,
+		},
+	})
+}
+
+// writeJSONResp writes a JSON body with the given status. Kept distinct from
+// writeJSON in tests to avoid collision with test-file helpers.
+func writeJSONResp(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// ─── POST /v1/sessions/register ──────────────────────────────────────────────
+
+type sessionRegisterRequest struct {
+	SessionID    string                 `json:"session_id"`
+	Workspace    string                 `json:"workspace"`
+	Role         string                 `json:"role"`
+	Task         string                 `json:"task,omitempty"`
+	Model        string                 `json:"model,omitempty"`
+	Hostname     string                 `json:"hostname,omitempty"`
+	ContextUsage float64                `json:"context_usage,omitempty"`
+	Status       string                 `json:"status,omitempty"`
+	CurrentTask  string                 `json:"current_task,omitempty"`
+	Extras       map[string]interface{} `json:"extras,omitempty"`
+}
+
+type sessionWriteResponse struct {
+	OK        bool          `json:"ok"`
+	SessionID string        `json:"session_id,omitempty"`
+	Seq       int           `json:"seq,omitempty"`
+	Hash      string        `json:"hash,omitempty"`
+	Created   bool          `json:"created,omitempty"`
+	Session   *SessionState `json:"session,omitempty"`
+}
+
+func (s *Server) handleSessionRegister(w http.ResponseWriter, r *http.Request) {
+	var req sessionRegisterRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", "body must be JSON")
+		return
+	}
+	if err := ValidateSessionID(req.SessionID); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	if req.Workspace == "" || req.Role == "" {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request",
+			"workspace and role are required")
+		return
+	}
+	now := time.Now().UTC()
+	state := SessionState{
+		SessionID:    req.SessionID,
+		Workspace:    req.Workspace,
+		Role:         req.Role,
+		Task:         req.Task,
+		Model:        req.Model,
+		Hostname:     req.Hostname,
+		ContextUsage: req.ContextUsage,
+		Status:       req.Status,
+		CurrentTask:  req.CurrentTask,
+		Extras:       req.Extras,
+		RegisteredAt: now,
+		LastSeen:     now,
+	}
+	stored, created, err := s.sessionRegistry.ApplyRegister(
+		state,
+		time.Duration(defaultActiveWithinSeconds)*time.Second,
+		now,
+	)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	// Mirror to the bus.
+	payload := map[string]interface{}{
+		"session_id":    req.SessionID,
+		"workspace":     req.Workspace,
+		"role":          req.Role,
+		"task":          req.Task,
+		"model":         req.Model,
+		"hostname":      req.Hostname,
+		"status":        req.Status,
+		"current_task":  req.CurrentTask,
+		"context_usage": req.ContextUsage,
+		"registered_at": stored.RegisteredAt.Format(time.RFC3339Nano),
+	}
+	if req.Extras != nil {
+		for k, v := range req.Extras {
+			if _, exists := payload[k]; !exists {
+				payload[k] = v
+			}
+		}
+	}
+	evt, err := s.busSessions.AppendEvent(BusSessions, EvtSessionRegister, req.SessionID, payload)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "bus_append_failed", err.Error())
+		return
+	}
+	writeJSONResp(w, http.StatusOK, sessionWriteResponse{
+		OK: true, SessionID: req.SessionID,
+		Seq: evt.Seq, Hash: evt.Hash,
+		Created: created, Session: stored,
+	})
+}
+
+// ─── POST /v1/sessions/{id}/heartbeat ────────────────────────────────────────
+
+type sessionHeartbeatRequest struct {
+	Status       string  `json:"status,omitempty"`
+	ContextUsage float64 `json:"context_usage,omitempty"`
+	CurrentTask  string  `json:"current_task,omitempty"`
+}
+
+func (s *Server) handleSessionHeartbeat(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if err := ValidateSessionID(id); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	var req sessionHeartbeatRequest
+	if r.ContentLength > 0 {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSONError(w, http.StatusBadRequest, "invalid_request", "body must be JSON")
+			return
+		}
+	}
+	now := time.Now().UTC()
+	stored, ok := s.sessionRegistry.ApplyHeartbeat(
+		id, req.ContextUsage, req.Status, req.CurrentTask, now,
+	)
+	if !ok {
+		writeJSONError(w, http.StatusNotFound, "not_found",
+			fmt.Sprintf("session %q is not registered", id))
+		return
+	}
+	if stored.Ended {
+		writeJSONError(w, http.StatusConflict, "conflict",
+			fmt.Sprintf("session %q is already ended", id))
+		return
+	}
+	payload := map[string]interface{}{
+		"session_id":    id,
+		"status":        req.Status,
+		"context_usage": req.ContextUsage,
+		"current_task":  req.CurrentTask,
+		"at":            now.Format(time.RFC3339Nano),
+	}
+	evt, err := s.busSessions.AppendEvent(BusSessions, EvtSessionHeartbeat, id, payload)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "bus_append_failed", err.Error())
+		return
+	}
+	writeJSONResp(w, http.StatusOK, sessionWriteResponse{
+		OK: true, SessionID: id,
+		Seq: evt.Seq, Hash: evt.Hash, Session: stored,
+	})
+}
+
+// ─── POST /v1/sessions/{id}/end ──────────────────────────────────────────────
+
+type sessionEndRequest struct {
+	Reason    string `json:"reason,omitempty"`
+	HandoffID string `json:"handoff_id,omitempty"`
+}
+
+func (s *Server) handleSessionEnd(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if err := ValidateSessionID(id); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	var req sessionEndRequest
+	if r.ContentLength > 0 {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSONError(w, http.StatusBadRequest, "invalid_request", "body must be JSON")
+			return
+		}
+	}
+	now := time.Now().UTC()
+	stored, known, err := s.sessionRegistry.ApplyEnd(id, req.Reason, req.HandoffID, now)
+	if !known {
+		writeJSONError(w, http.StatusNotFound, "not_found",
+			fmt.Sprintf("session %q is not registered", id))
+		return
+	}
+	if err != nil {
+		writeJSONError(w, http.StatusConflict, "conflict", err.Error())
+		return
+	}
+	payload := map[string]interface{}{
+		"session_id": id,
+		"reason":     req.Reason,
+		"handoff_id": req.HandoffID,
+		"ended_at":   now.Format(time.RFC3339Nano),
+	}
+	evt, errEmit := s.busSessions.AppendEvent(BusSessions, EvtSessionEnd, id, payload)
+	if errEmit != nil {
+		writeJSONError(w, http.StatusInternalServerError, "bus_append_failed", errEmit.Error())
+		return
+	}
+	writeJSONResp(w, http.StatusOK, sessionWriteResponse{
+		OK: true, SessionID: id, Seq: evt.Seq, Hash: evt.Hash, Session: stored,
+	})
+}
+
+// ─── GET /v1/sessions/presence ───────────────────────────────────────────────
+
+type sessionPresenceEntry struct {
+	*SessionState
+	Active bool `json:"active"`
+}
+
+func (s *Server) handleSessionPresence(w http.ResponseWriter, r *http.Request) {
+	now := time.Now().UTC()
+	window := time.Duration(defaultActiveWithinSeconds) * time.Second
+	if raw := r.URL.Query().Get("active_within_seconds"); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			window = time.Duration(n) * time.Second
+		}
+	}
+	includeEnded := r.URL.Query().Get("include_ended") == "true"
+
+	snap := s.sessionRegistry.Snapshot()
+	out := make([]sessionPresenceEntry, 0, len(snap))
+	for _, row := range snap {
+		if !includeEnded && row.Ended {
+			continue
+		}
+		entry := sessionPresenceEntry{
+			SessionState: row,
+			Active:       row.IsActive(window, now),
+		}
+		out = append(out, entry)
+	}
+	writeJSONResp(w, http.StatusOK, map[string]any{
+		"sessions": out,
+		"count":    len(out),
+	})
+}
+
+// ─── POST /v1/handoffs/offer ─────────────────────────────────────────────────
+
+type handoffOfferRequest struct {
+	HandoffID       string                   `json:"handoff_id,omitempty"`
+	FromSession     string                   `json:"from_session"`
+	ToSession       string                   `json:"to_session,omitempty"`
+	Reason          string                   `json:"reason,omitempty"`
+	TTLSeconds      int                      `json:"ttl_seconds,omitempty"`
+	Task            map[string]interface{}   `json:"task"`
+	BootstrapPrompt string                   `json:"bootstrap_prompt"`
+	BusContextRefs  []map[string]interface{} `json:"bus_context_refs,omitempty"`
+	MemoryRefs      []string                 `json:"memory_refs,omitempty"`
+}
+
+type handoffWriteResponse struct {
+	OK        bool          `json:"ok"`
+	HandoffID string        `json:"handoff_id,omitempty"`
+	Seq       int           `json:"seq,omitempty"`
+	Hash      string        `json:"hash,omitempty"`
+	Handoff   *HandoffState `json:"handoff,omitempty"`
+}
+
+func (s *Server) handleHandoffOffer(w http.ResponseWriter, r *http.Request) {
+	var req handoffOfferRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", "body must be JSON")
+		return
+	}
+	if err := ValidateSessionID(req.FromSession); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request",
+			"from_session: "+err.Error())
+		return
+	}
+	if req.ToSession != "" {
+		if err := ValidateSessionID(req.ToSession); err != nil {
+			writeJSONError(w, http.StatusBadRequest, "invalid_request",
+				"to_session: "+err.Error())
+			return
+		}
+	}
+	if req.BootstrapPrompt == "" {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request",
+			"bootstrap_prompt is required")
+		return
+	}
+	if req.Task == nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request",
+			"task is required")
+		return
+	}
+	if _, ok := req.Task["title"].(string); !ok || req.Task["title"].(string) == "" {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request",
+			"task.title is required")
+		return
+	}
+	if _, ok := req.Task["goal"].(string); !ok || req.Task["goal"].(string) == "" {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request",
+			"task.goal is required")
+		return
+	}
+	nextSteps, ok := req.Task["next_steps"].([]interface{})
+	if !ok || len(nextSteps) == 0 {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request",
+			"task.next_steps must be a non-empty list")
+		return
+	}
+
+	if req.HandoffID == "" {
+		req.HandoffID = mintHandoffID(time.Now())
+	}
+	if req.TTLSeconds == 0 {
+		req.TTLSeconds = 3600
+	}
+
+	now := time.Now().UTC()
+	state := HandoffState{
+		HandoffID:   req.HandoffID,
+		FromSession: req.FromSession,
+		ToSession:   req.ToSession,
+		Reason:      req.Reason,
+		TTLSeconds:  req.TTLSeconds,
+		CreatedAt:   now,
+		ExpiresAt:   now.Add(time.Duration(req.TTLSeconds) * time.Second),
+	}
+	// The full payload we put on the bus is the canonical offer — mirror it
+	// to OfferPayload so claimants can read it verbatim.
+	payload := map[string]interface{}{
+		"handoff_id":       req.HandoffID,
+		"from_session":     req.FromSession,
+		"to_session":       req.ToSession,
+		"reason":           req.Reason,
+		"ttl_seconds":      req.TTLSeconds,
+		"created_at":       now.Format(time.RFC3339Nano),
+		"task":             req.Task,
+		"bootstrap_prompt": req.BootstrapPrompt,
+		"bus_context_refs": req.BusContextRefs,
+		"memory_refs":      req.MemoryRefs,
+	}
+	state.OfferPayload = payload
+	stored := s.handoffRegistry.ApplyOffer(state, now)
+
+	evt, err := s.busSessions.AppendEvent(BusHandoffs, EvtHandoffOffer, req.FromSession, payload)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "bus_append_failed", err.Error())
+		return
+	}
+	writeJSONResp(w, http.StatusOK, handoffWriteResponse{
+		OK: true, HandoffID: req.HandoffID,
+		Seq: evt.Seq, Hash: evt.Hash, Handoff: stored,
+	})
+}
+
+// mintHandoffID mirrors the bridge's format: ho-<unix-ms>-<hex suffix>.
+func mintHandoffID(now time.Time) string {
+	var b [6]byte
+	_, _ = rand.Read(b[:])
+	return fmt.Sprintf("ho-%d-%s", now.UnixMilli(), hex.EncodeToString(b[:]))
+}
+
+// ─── GET /v1/handoffs ────────────────────────────────────────────────────────
+
+func (s *Server) handleHandoffList(w http.ResponseWriter, r *http.Request) {
+	filterState := strings.ToLower(r.URL.Query().Get("state"))
+	forSession := r.URL.Query().Get("for_session")
+	now := time.Now().UTC()
+
+	snap := s.handoffRegistry.Snapshot()
+	out := make([]*HandoffState, 0, len(snap))
+	for _, h := range snap {
+		// Treat TTL-expired open handoffs as expired in the filter view: a
+		// caller looking for "open" offers shouldn't see stale rows the
+		// kernel would reject anyway.
+		effective := h.State
+		if effective == HandoffStateOpen && h.IsExpired(now) {
+			effective = "expired"
+		}
+		if filterState != "" && effective != filterState {
+			continue
+		}
+		if forSession != "" {
+			if h.ToSession != "" && h.ToSession != forSession {
+				continue
+			}
+		}
+		out = append(out, h)
+	}
+	writeJSONResp(w, http.StatusOK, map[string]any{
+		"handoffs": out,
+		"count":    len(out),
+	})
+}
+
+// ─── POST /v1/handoffs/{id}/claim ────────────────────────────────────────────
+
+type handoffClaimRequest struct {
+	ClaimingSession string `json:"claiming_session"`
+}
+
+func (s *Server) handleHandoffClaim(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", "handoff_id required in path")
+		return
+	}
+	var req handoffClaimRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", "body must be JSON")
+		return
+	}
+	if err := ValidateSessionID(req.ClaimingSession); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request",
+			"claiming_session: "+err.Error())
+		return
+	}
+	now := time.Now().UTC()
+	result := s.handoffRegistry.ApplyClaim(id, req.ClaimingSession, now)
+	if result.Rejection != "" {
+		s.emitClaimRejected(id, req.ClaimingSession, result, now)
+		status := http.StatusConflict
+		kind := "conflict"
+		if result.Rejection == ClaimRejectedOfferNotFound {
+			status = http.StatusNotFound
+			kind = "not_found"
+		}
+		writeJSONError(w, status, kind, fmt.Sprintf(
+			"claim rejected: %s", result.Rejection))
+		return
+	}
+	// Successful claim — emit and return offer payload.
+	claimPayload := map[string]interface{}{
+		"handoff_id":       id,
+		"claiming_session": req.ClaimingSession,
+		"claimed_at":       now.Format(time.RFC3339Nano),
+	}
+	evt, err := s.busSessions.AppendEvent(BusHandoffs, EvtHandoffClaim, req.ClaimingSession, claimPayload)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "bus_append_failed", err.Error())
+		return
+	}
+	writeJSONResp(w, http.StatusOK, map[string]any{
+		"ok":         true,
+		"handoff_id": id,
+		"seq":        evt.Seq,
+		"hash":       evt.Hash,
+		"handoff":    result.Offer,
+		"offer":      result.Offer.OfferPayload, // the canonical offer payload
+	})
+}
+
+// emitClaimRejected writes a handoff.claim_rejected event to bus_handoffs so
+// observers can audit failed claim attempts (amendment #4). Emission failure
+// is logged but non-fatal — the handler already returned the HTTP error.
+func (s *Server) emitClaimRejected(handoffID, attemptingSession string,
+	result ClaimResult, now time.Time) {
+	payload := map[string]interface{}{
+		"handoff_id":         handoffID,
+		"attempting_session": attemptingSession,
+		"reason":             string(result.Rejection),
+		"rejected_at":        now.Format(time.RFC3339Nano),
+	}
+	if result.ConflictingSession != "" {
+		payload["conflicting_session"] = result.ConflictingSession
+	}
+	if _, err := s.busSessions.AppendEvent(BusHandoffs, EvtHandoffClaimRejected, attemptingSession, payload); err != nil {
+		slog.Warn("handoff: claim_rejected emit failed",
+			"handoff_id", handoffID, "reason", string(result.Rejection), "err", err)
+	}
+}
+
+// ─── POST /v1/handoffs/{id}/complete ─────────────────────────────────────────
+
+type handoffCompleteRequest struct {
+	CompletingSession string `json:"completing_session"`
+	Outcome           string `json:"outcome"`
+	Notes             string `json:"notes,omitempty"`
+	NextHandoffID     string `json:"next_handoff_id,omitempty"`
+}
+
+func (s *Server) handleHandoffComplete(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", "handoff_id required in path")
+		return
+	}
+	var req handoffCompleteRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", "body must be JSON")
+		return
+	}
+	if err := ValidateSessionID(req.CompletingSession); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request",
+			"completing_session: "+err.Error())
+		return
+	}
+	if req.Outcome == "" {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", "outcome is required")
+		return
+	}
+	now := time.Now().UTC()
+	stored, reason := s.handoffRegistry.ApplyComplete(
+		id, req.CompletingSession, req.Outcome, req.Notes, req.NextHandoffID, now,
+	)
+	if reason == ClaimRejectedOfferNotFound {
+		writeJSONError(w, http.StatusNotFound, "not_found",
+			fmt.Sprintf("handoff %q not found", id))
+		return
+	}
+	if reason == ClaimRejectedOutOfOrder {
+		writeJSONError(w, http.StatusConflict, "conflict",
+			fmt.Sprintf("handoff %q cannot complete in state %q", id, stored.State))
+		return
+	}
+	payload := map[string]interface{}{
+		"handoff_id":         id,
+		"completing_session": req.CompletingSession,
+		"outcome":            req.Outcome,
+		"notes":              req.Notes,
+		"next_handoff_id":    req.NextHandoffID,
+		"completed_at":       now.Format(time.RFC3339Nano),
+	}
+	evt, err := s.busSessions.AppendEvent(BusHandoffs, EvtHandoffComplete, req.CompletingSession, payload)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "bus_append_failed", err.Error())
+		return
+	}
+	writeJSONResp(w, http.StatusOK, handoffWriteResponse{
+		OK: true, HandoffID: id, Seq: evt.Seq, Hash: evt.Hash, Handoff: stored,
+	})
+}

--- a/internal/engine/sessions.go
+++ b/internal/engine/sessions.go
@@ -32,6 +32,7 @@ import (
 	"fmt"
 	"log/slog"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -63,12 +64,19 @@ const (
 )
 
 // sessionIDPattern enforces the three-component hyphen-separated lowercase
-// format the handoff protocol recommends. Same regex the design doc calls out.
+// format the handoff protocol design spec requires. Three components —
+// <machine>-<role>-<nonce> — or more. The first component is a single
+// non-empty token; the second and third may themselves contain hyphens, which
+// is why the pattern is written as "token-hyphenable-hyphenable" rather than
+// "exactly three tokens."
+//
 // Example: slowbro-laptop-cogos-gap-closure → passes.
-var sessionIDPattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)+$`)
+//          alpha-beta-gamma                 → passes (exactly 3 tokens).
+//          a-b                              → REJECTED (only 2 tokens).
+var sessionIDPattern = regexp.MustCompile(`^[a-z0-9]+-[a-z0-9-]+-[a-z0-9-]+$`)
 
 // ValidateSessionID returns nil iff id matches the lowercase-hyphen format
-// with at least two components. Exported so tests and the HTTP handlers can
+// with at least three components. Exported so tests and the HTTP handlers can
 // share the single source of truth.
 func ValidateSessionID(id string) error {
 	if id == "" {
@@ -76,8 +84,15 @@ func ValidateSessionID(id string) error {
 	}
 	if !sessionIDPattern.MatchString(id) {
 		return fmt.Errorf(
-			"session_id %q must be ascii-lowercase with at least two "+
+			"session_id %q must be ascii-lowercase with at least three "+
 				"hyphen-separated components", id)
+	}
+	// Reject trailing/leading hyphens on inner components — the regex
+	// alone would accept "a--b-c" which is visually confusing. A
+	// single explicit double-hyphen check catches the common typos.
+	if strings.Contains(id, "--") {
+		return fmt.Errorf(
+			"session_id %q must not contain consecutive hyphens", id)
 	}
 	return nil
 }
@@ -125,6 +140,12 @@ func (s *SessionState) IsActive(window time.Duration, now time.Time) bool {
 
 // SessionRegistry is the in-memory, RWMutex-guarded map of session_id →
 // SessionState. The bus is ground truth; this map is a derived, warm cache.
+//
+// The mutating methods take an optional `appendFn` callback that writes the
+// corresponding event to the bus WHILE the registry lock is held. On
+// appendFn() error, the in-memory row is left untouched so the derived view
+// can never run ahead of the authoritative ledger. This fixes the inverted
+// write-path critical raised in codex's PR#43 review.
 type SessionRegistry struct {
 	mu   sync.RWMutex
 	rows map[string]*SessionState
@@ -171,12 +192,18 @@ func (r *SessionRegistry) Snapshot() []*SessionState {
 // after end is allowed only if the prior session is ended or its heartbeat is
 // outside the active window.
 //
-// Returns the resulting state (copy) and a flag indicating whether the
-// registry row was newly created vs updated.
+// If appendFn is non-nil it is invoked AFTER validation but BEFORE the
+// registry mutation is committed, while the registry lock is held. An error
+// from appendFn aborts the mutation and is returned verbatim — the registry
+// is left unchanged, preserving the bus-is-ground-truth invariant.
+//
+// Returns the resulting state (copy), a flag indicating whether the registry
+// row was newly created vs updated, and an error.
 func (r *SessionRegistry) ApplyRegister(
 	state SessionState,
 	activeWindow time.Duration,
 	now time.Time,
+	appendFn func() error,
 ) (*SessionState, bool, error) {
 	if err := ValidateSessionID(state.SessionID); err != nil {
 		return nil, false, err
@@ -203,27 +230,53 @@ func (r *SessionRegistry) ApplyRegister(
 	state.EndedAt = time.Time{}
 	state.EndReason = ""
 	state.EndHandoffID = ""
+	// Append to the bus FIRST — if that fails, the registry is unchanged.
+	if appendFn != nil {
+		if err := appendFn(); err != nil {
+			return nil, false, err
+		}
+	}
 	row := state
 	r.rows[state.SessionID] = &row
 	cp := row
 	return &cp, !found, nil
 }
 
-// ApplyHeartbeat bumps LastSeen + optional fields. Returns (state, ok).
-//   - ok=false when session is unknown.
-//   - ok=true but Ended=true when the session was already ended — the caller
-//     should translate that to a 409 before emitting to the bus.
+// ApplyHeartbeat bumps LastSeen + optional fields. Returns (state, ok, err).
+//   - ok=false when session is unknown → caller returns 404.
+//   - ok=true with non-nil err when the session was already ended. In that
+//     case the registry is NOT mutated (no LastSeen update, no status bump)
+//     and no appendFn is invoked — the caller translates to 409.
+//   - ok=true, err=nil on success — the mutation and (optional) bus append
+//     both happened atomically under the registry lock.
+//
+// appendFn, if non-nil, is invoked AFTER validation/ended-check but BEFORE
+// the LastSeen mutation commits. An appendFn error aborts the mutation and
+// is returned verbatim so the registry stays in lockstep with the bus.
 func (r *SessionRegistry) ApplyHeartbeat(
 	id string,
 	contextUsage float64,
 	status, currentTask string,
 	now time.Time,
-) (*SessionState, bool) {
+	appendFn func() error,
+) (*SessionState, bool, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	row, ok := r.rows[id]
 	if !ok {
-		return nil, false
+		return nil, false, nil
+	}
+	if row.Ended {
+		// Return the CURRENT (unmutated) state so the caller can still
+		// surface fields like EndedAt if needed, but signal the rejection.
+		cp := *row
+		return &cp, true, errors.New("session already ended")
+	}
+	// Append FIRST — if that fails, LastSeen is NOT bumped.
+	if appendFn != nil {
+		if err := appendFn(); err != nil {
+			return nil, true, err
+		}
 	}
 	row.LastSeen = now
 	if contextUsage > 0 {
@@ -236,16 +289,21 @@ func (r *SessionRegistry) ApplyHeartbeat(
 		row.CurrentTask = currentTask
 	}
 	cp := *row
-	return &cp, true
+	return &cp, true, nil
 }
 
 // ApplyEnd transitions a session to ended. Returns:
 //   - (nil, false, nil)            when the session is unknown → 404.
 //   - (&state, true, errAlready)   when the session was already ended → 409.
 //   - (&state, true, nil)          on success.
+//   - (nil, true, appendErr)       if appendFn failed — registry unchanged.
+//
+// appendFn runs AFTER validation but BEFORE the Ended transition commits,
+// under the registry lock. If it errors, no mutation is applied.
 func (r *SessionRegistry) ApplyEnd(
 	id, reason, handoffID string,
 	now time.Time,
+	appendFn func() error,
 ) (*SessionState, bool, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -256,6 +314,11 @@ func (r *SessionRegistry) ApplyEnd(
 	if row.Ended {
 		cp := *row
 		return &cp, true, errors.New("session already ended")
+	}
+	if appendFn != nil {
+		if err := appendFn(); err != nil {
+			return nil, true, err
+		}
 	}
 	row.Ended = true
 	row.EndedAt = now
@@ -311,8 +374,15 @@ func (h *HandoffState) IsExpired(now time.Time) bool {
 // HandoffRegistry guards in-memory handoff state. The bus is still the
 // source of truth; this struct is how we atomically enforce first-wins on
 // claim and state-order on complete.
+//
+// The mutex is held across the bus append in mutating methods (via the
+// appendFn callback). Yes this serializes concurrent offers/claims/completes
+// against disk I/O, but: (a) these operations are low-rate, (b) the append
+// is local disk — typical <10ms — and (c) correctness demands the bus-append
+// and registry mutation commit as one atomic unit so the derived view can't
+// run ahead of the ground-truth ledger.
 type HandoffRegistry struct {
-	mu   sync.Mutex // write-mostly; snapshot also takes the lock briefly
+	mu   sync.RWMutex // write-heavy callers take Lock(); read paths use RLock()
 	rows map[string]*HandoffState
 }
 
@@ -323,15 +393,15 @@ func NewHandoffRegistry() *HandoffRegistry {
 
 // Len returns the number of tracked handoffs (open + claimed + completed).
 func (r *HandoffRegistry) Len() int {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	return len(r.rows)
 }
 
 // Get returns a copy, or (nil, false).
 func (r *HandoffRegistry) Get(id string) (*HandoffState, bool) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	row, ok := r.rows[id]
 	if !ok {
 		return nil, false
@@ -342,8 +412,8 @@ func (r *HandoffRegistry) Get(id string) (*HandoffState, bool) {
 
 // Snapshot returns a copy of every handoff row.
 func (r *HandoffRegistry) Snapshot() []*HandoffState {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	out := make([]*HandoffState, 0, len(r.rows))
 	for _, row := range r.rows {
 		cp := *row
@@ -356,7 +426,13 @@ func (r *HandoffRegistry) Snapshot() []*HandoffState {
 // the row; this shouldn't happen in normal flow (IDs are unique) but mirrors
 // the bus semantics (re-emitting the same offer would just append another
 // event).
-func (r *HandoffRegistry) ApplyOffer(h HandoffState, now time.Time) *HandoffState {
+//
+// appendFn, if non-nil, runs under the registry lock BEFORE the mutation is
+// committed. An error aborts the mutation and is returned; on nil-error the
+// in-memory row is installed atomically with the bus append.
+func (r *HandoffRegistry) ApplyOffer(
+	h HandoffState, now time.Time, appendFn func() error,
+) (*HandoffState, error) {
 	if h.CreatedAt.IsZero() {
 		h.CreatedAt = now
 	}
@@ -366,10 +442,15 @@ func (r *HandoffRegistry) ApplyOffer(h HandoffState, now time.Time) *HandoffStat
 	h.State = HandoffStateOpen
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if appendFn != nil {
+		if err := appendFn(); err != nil {
+			return nil, err
+		}
+	}
 	row := h
 	r.rows[h.HandoffID] = &row
 	cp := row
-	return &cp
+	return &cp, nil
 }
 
 // ClaimRejection reasons for the handoff.claim_rejected event (amendment #4).
@@ -389,53 +470,84 @@ type ClaimResult struct {
 	ConflictingSession string         // set on already_claimed
 }
 
-// ApplyClaim is the ATOMIC first-wins check. Returns a ClaimResult whose
-// Rejection is non-empty if the claim should be rejected (and a
-// claim_rejected event emitted). On success, updates the in-memory row and
-// returns the full offer copy with State=claimed.
+// ApplyClaim is the ATOMIC first-wins check + bus-append path. Semantics:
+//
+//   - If the offer is missing, already claimed/completed, or TTL-expired,
+//     returns a ClaimResult with a non-empty Rejection; NO mutation, and
+//     appendFn is NOT invoked (the caller emits handoff.claim_rejected
+//     independently for audit).
+//   - Otherwise appendFn is invoked WHILE THE LOCK IS HELD. If it errors,
+//     the claim is aborted — the in-memory row stays open and the error is
+//     returned on the second return value. The "losing" session thus sees
+//     an internal error, not a conflict, and can retry.
+//   - On appendFn success, the row transitions to Claimed and the second
+//     return value is nil. This makes the claim first-wins on the bus as
+//     well as in memory — the whole point of the PR.
+//
+// Holding a lock across disk I/O is deliberate. Claims are rare, appends are
+// local (<10ms typical), and correctness here beats throughput. See codex
+// review of PR#43.
 func (r *HandoffRegistry) ApplyClaim(
 	id, claimingSession string,
 	now time.Time,
-) ClaimResult {
+	appendFn func() error,
+) (ClaimResult, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	row, ok := r.rows[id]
 	if !ok {
-		return ClaimResult{Rejection: ClaimRejectedOfferNotFound}
+		return ClaimResult{Rejection: ClaimRejectedOfferNotFound}, nil
 	}
 	if row.State == HandoffStateClaimed || row.State == HandoffStateCompleted {
 		return ClaimResult{
 			Rejection:          ClaimRejectedAlreadyClaimed,
 			ConflictingSession: row.ClaimingSession,
-		}
+		}, nil
 	}
 	if row.IsExpired(now) {
-		return ClaimResult{Rejection: ClaimRejectedTTLExpired}
+		return ClaimResult{Rejection: ClaimRejectedTTLExpired}, nil
+	}
+	// All invariants pass — write to the bus FIRST, under the lock, so the
+	// winning claim is durable before the derived view reflects it.
+	if appendFn != nil {
+		if err := appendFn(); err != nil {
+			return ClaimResult{}, err
+		}
 	}
 	row.State = HandoffStateClaimed
 	row.ClaimingSession = claimingSession
 	row.ClaimedAt = now
 	cp := *row
-	return ClaimResult{Offer: &cp}
+	return ClaimResult{Offer: &cp}, nil
 }
 
-// ApplyComplete transitions a claimed handoff to completed. Returns
-// (&state, true) on success; returns (&state, false) with reason
-// ClaimRejectedOutOfOrder if called before claim; returns (nil, false) if
-// unknown (caller translates to 404 vs 409).
+// ApplyComplete transitions a claimed handoff to completed. Returns:
+//   - (nil,   ClaimRejectedOfferNotFound, nil)      when unknown     → 404.
+//   - (&row,  ClaimRejectedOutOfOrder,    nil)      not claimed yet  → 409.
+//   - (nil,   "",                         appendErr) append failed.
+//   - (&row,  "",                         nil)      success.
+//
+// appendFn runs under the lock AFTER the state-order check but BEFORE the
+// Completed transition commits; an error aborts the mutation.
 func (r *HandoffRegistry) ApplyComplete(
 	id, completingSession, outcome, notes, nextHandoffID string,
 	now time.Time,
-) (*HandoffState, ClaimRejection) {
+	appendFn func() error,
+) (*HandoffState, ClaimRejection, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	row, ok := r.rows[id]
 	if !ok {
-		return nil, ClaimRejectedOfferNotFound
+		return nil, ClaimRejectedOfferNotFound, nil
 	}
 	if row.State != HandoffStateClaimed {
 		cp := *row
-		return &cp, ClaimRejectedOutOfOrder
+		return &cp, ClaimRejectedOutOfOrder, nil
+	}
+	if appendFn != nil {
+		if err := appendFn(); err != nil {
+			return nil, "", err
+		}
 	}
 	row.State = HandoffStateCompleted
 	row.CompletingSession = completingSession
@@ -444,7 +556,7 @@ func (r *HandoffRegistry) ApplyComplete(
 	row.CompletionNotes = notes
 	row.NextHandoffID = nextHandoffID
 	cp := *row
-	return &cp, ""
+	return &cp, "", nil
 }
 
 // ─── Replay-from-bus warmers ─────────────────────────────────────────────────
@@ -454,6 +566,12 @@ func (r *HandoffRegistry) ApplyComplete(
 // function just gets the derived view ready for read-traffic before the HTTP
 // server starts serving. Errors are logged but non-fatal — an empty registry
 // is a safe degraded start.
+//
+// Events are sorted ascending by Seq before replay so the reconstructed
+// state is deterministic regardless of on-disk line order. ReadEvents
+// already de-dupes by Seq; a seq collision with conflicting payloads keeps
+// the FIRST occurrence (insertion order). Callers that need "last-write-wins
+// within a seq" semantics should not rely on replay ordering beyond Seq.
 func ReplaySessionRegistry(mgr *BusSessionManager, reg *SessionRegistry) error {
 	if mgr == nil || reg == nil {
 		return nil
@@ -463,6 +581,9 @@ func ReplaySessionRegistry(mgr *BusSessionManager, reg *SessionRegistry) error {
 		slog.Warn("sessions: replay read failed", "bus", BusSessions, "err", err)
 		return err
 	}
+	sort.SliceStable(events, func(i, j int) bool {
+		return events[i].Seq < events[j].Seq
+	})
 	// bridge-v0.1 payload shape: the entire session dict lives at the top
 	// level of the bus event's payload map. Some bridge code writes a
 	// nested "content" (the message text) plus flat fields; we tolerate
@@ -551,6 +672,9 @@ func ReplaySessionRegistry(mgr *BusSessionManager, reg *SessionRegistry) error {
 }
 
 // ReplayHandoffRegistry replays bus_handoffs into the handoff registry.
+// Events are sorted by Seq ascending before consumption so replay is
+// deterministic even if the on-disk file has out-of-order lines (e.g. from
+// a resumed write after crash). See also ReplaySessionRegistry.
 func ReplayHandoffRegistry(mgr *BusSessionManager, reg *HandoffRegistry) error {
 	if mgr == nil || reg == nil {
 		return nil
@@ -560,6 +684,9 @@ func ReplayHandoffRegistry(mgr *BusSessionManager, reg *HandoffRegistry) error {
 		slog.Warn("handoffs: replay read failed", "bus", BusHandoffs, "err", err)
 		return err
 	}
+	sort.SliceStable(events, func(i, j int) bool {
+		return events[i].Seq < events[j].Seq
+	})
 	for _, evt := range events {
 		payload := evt.Payload
 		if payload == nil {

--- a/internal/engine/sessions.go
+++ b/internal/engine/sessions.go
@@ -1,0 +1,731 @@
+// sessions.go — kernel-native session & handoff registries.
+//
+// This is the "invariance layer" of the hybrid design sketched in
+// cog://mem/semantic/surveys/2026-04-21-consolidation/agent-P-session-management-evaluation.
+// The bus (BusSessionManager) remains ground truth; everything in this file is
+// a derived view rebuilt from bus replay at startup. The registries' job is to
+// enforce the state-machine invariants the bridge-only implementation was
+// doing by convention:
+//
+//   • session_id format validation (regex) on register
+//   • idempotent re-register = update-semantics (re-register a live session
+//     updates the in-memory row; re-register after end is allowed only if the
+//     prior session is ended or its heartbeat is outside the active window)
+//   • heartbeat/end refused against unknown sessions
+//   • end refused against already-ended sessions
+//   • handoff.offer → claim → complete state machine with:
+//       - first-wins claim (atomic check under handoff mutex)
+//       - TTL enforcement (offer rejected if now - created_at > ttl_seconds)
+//       - claim-before-offer rejection (phantom offers) as 404
+//       - complete-before-claim rejected as 409
+//   • on every rejected claim, emit a handoff.claim_rejected event on
+//     bus_handoffs so operators have an audit trail (amendment #4 of the
+//     user-approved plan).
+//
+// Everything is flushed to the bus via BusSessionManager.AppendEvent so the
+// seq/hash chain remains the authoritative ledger. The in-memory maps only
+// speed up reads and guard writes against out-of-order transitions.
+package engine
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ─── well-known buses + event types ──────────────────────────────────────────
+//
+// These constants mirror the bridge-layer constants in
+// cog-sandbox-mcp/src/cog_sandbox_mcp/tools/cogos_bridge.py. Keep them in sync.
+
+const (
+	BusSessions  = "bus_sessions"
+	BusHandoffs  = "bus_handoffs"
+	BusBroadcast = "bus_broadcast"
+
+	EvtSessionRegister  = "session.register"
+	EvtSessionHeartbeat = "session.heartbeat"
+	EvtSessionEnd       = "session.end"
+
+	EvtHandoffOffer         = "handoff.offer"
+	EvtHandoffClaim         = "handoff.claim"
+	EvtHandoffComplete      = "handoff.complete"
+	EvtHandoffClaimRejected = "handoff.claim_rejected" // amendment #4
+
+	// Default freshness window for "is this session still present" checks.
+	// 600s matches the bridge's default; both are tunable per-call via the
+	// active_within_seconds query param.
+	defaultActiveWithinSeconds = 600
+)
+
+// sessionIDPattern enforces the three-component hyphen-separated lowercase
+// format the handoff protocol recommends. Same regex the design doc calls out.
+// Example: slowbro-laptop-cogos-gap-closure → passes.
+var sessionIDPattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)+$`)
+
+// ValidateSessionID returns nil iff id matches the lowercase-hyphen format
+// with at least two components. Exported so tests and the HTTP handlers can
+// share the single source of truth.
+func ValidateSessionID(id string) error {
+	if id == "" {
+		return errors.New("session_id is required")
+	}
+	if !sessionIDPattern.MatchString(id) {
+		return fmt.Errorf(
+			"session_id %q must be ascii-lowercase with at least two "+
+				"hyphen-separated components", id)
+	}
+	return nil
+}
+
+// ─── Session registry ────────────────────────────────────────────────────────
+
+// SessionState is the in-memory row for a session. Fields mirror the payload
+// shape the bridge writes to bus_sessions so presence responses are
+// byte-compat for external consumers.
+type SessionState struct {
+	SessionID    string                 `json:"session_id"`
+	Workspace    string                 `json:"workspace"`
+	Role         string                 `json:"role"`
+	Task         string                 `json:"task,omitempty"`
+	Model        string                 `json:"model,omitempty"`
+	Hostname     string                 `json:"hostname,omitempty"`
+	ContextUsage float64                `json:"context_usage,omitempty"`
+	CurrentTask  string                 `json:"current_task,omitempty"`
+	Status       string                 `json:"status,omitempty"`
+	Extras       map[string]interface{} `json:"extras,omitempty"`
+
+	// Lifecycle.
+	RegisteredAt time.Time `json:"registered_at"`
+	LastSeen     time.Time `json:"last_seen"`
+	EndedAt      time.Time `json:"ended_at,omitempty"`
+	EndReason    string    `json:"end_reason,omitempty"`
+	EndHandoffID string    `json:"end_handoff_id,omitempty"`
+
+	// Lifecycle flag, computed from EndedAt. Kept as its own JSON field so
+	// presence responses don't need derivation on the client side.
+	Ended bool `json:"ended"`
+}
+
+// IsActive returns true iff the session has been heard from within the given
+// window AND has not been ended. Window ≤ 0 falls back to the protocol default.
+func (s *SessionState) IsActive(window time.Duration, now time.Time) bool {
+	if s.Ended {
+		return false
+	}
+	if window <= 0 {
+		window = time.Duration(defaultActiveWithinSeconds) * time.Second
+	}
+	return !s.LastSeen.IsZero() && now.Sub(s.LastSeen) <= window
+}
+
+// SessionRegistry is the in-memory, RWMutex-guarded map of session_id →
+// SessionState. The bus is ground truth; this map is a derived, warm cache.
+type SessionRegistry struct {
+	mu   sync.RWMutex
+	rows map[string]*SessionState
+}
+
+// NewSessionRegistry returns an empty registry.
+func NewSessionRegistry() *SessionRegistry {
+	return &SessionRegistry{rows: make(map[string]*SessionState)}
+}
+
+// Len returns the number of tracked sessions.
+func (r *SessionRegistry) Len() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.rows)
+}
+
+// Get returns a copy of the session row, or (nil, false) if unknown.
+func (r *SessionRegistry) Get(id string) (*SessionState, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	row, ok := r.rows[id]
+	if !ok {
+		return nil, false
+	}
+	cp := *row
+	return &cp, true
+}
+
+// Snapshot returns a copy of every session row. Order is not guaranteed.
+func (r *SessionRegistry) Snapshot() []*SessionState {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]*SessionState, 0, len(r.rows))
+	for _, row := range r.rows {
+		cp := *row
+		out = append(out, &cp)
+	}
+	return out
+}
+
+// ApplyRegister records a session.register event into the map. Idempotent per
+// amendment #2: same session_id updates the in-memory row; re-registration
+// after end is allowed only if the prior session is ended or its heartbeat is
+// outside the active window.
+//
+// Returns the resulting state (copy) and a flag indicating whether the
+// registry row was newly created vs updated.
+func (r *SessionRegistry) ApplyRegister(
+	state SessionState,
+	activeWindow time.Duration,
+	now time.Time,
+) (*SessionState, bool, error) {
+	if err := ValidateSessionID(state.SessionID); err != nil {
+		return nil, false, err
+	}
+	if state.RegisteredAt.IsZero() {
+		state.RegisteredAt = now
+	}
+	if state.LastSeen.IsZero() {
+		state.LastSeen = state.RegisteredAt
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	existing, found := r.rows[state.SessionID]
+	if found && !existing.Ended {
+		// Live prior row — allow re-register only if heartbeat is stale.
+		if existing.IsActive(activeWindow, now) {
+			// Still active; accept as update. Preserve the original
+			// RegisteredAt to keep lineage.
+			state.RegisteredAt = existing.RegisteredAt
+		}
+	}
+	// Clear ended flags if re-registering (fresh lifecycle).
+	state.Ended = false
+	state.EndedAt = time.Time{}
+	state.EndReason = ""
+	state.EndHandoffID = ""
+	row := state
+	r.rows[state.SessionID] = &row
+	cp := row
+	return &cp, !found, nil
+}
+
+// ApplyHeartbeat bumps LastSeen + optional fields. Returns (state, ok).
+//   - ok=false when session is unknown.
+//   - ok=true but Ended=true when the session was already ended — the caller
+//     should translate that to a 409 before emitting to the bus.
+func (r *SessionRegistry) ApplyHeartbeat(
+	id string,
+	contextUsage float64,
+	status, currentTask string,
+	now time.Time,
+) (*SessionState, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	row, ok := r.rows[id]
+	if !ok {
+		return nil, false
+	}
+	row.LastSeen = now
+	if contextUsage > 0 {
+		row.ContextUsage = contextUsage
+	}
+	if status != "" {
+		row.Status = status
+	}
+	if currentTask != "" {
+		row.CurrentTask = currentTask
+	}
+	cp := *row
+	return &cp, true
+}
+
+// ApplyEnd transitions a session to ended. Returns:
+//   - (nil, false, nil)            when the session is unknown → 404.
+//   - (&state, true, errAlready)   when the session was already ended → 409.
+//   - (&state, true, nil)          on success.
+func (r *SessionRegistry) ApplyEnd(
+	id, reason, handoffID string,
+	now time.Time,
+) (*SessionState, bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	row, ok := r.rows[id]
+	if !ok {
+		return nil, false, nil
+	}
+	if row.Ended {
+		cp := *row
+		return &cp, true, errors.New("session already ended")
+	}
+	row.Ended = true
+	row.EndedAt = now
+	row.EndReason = reason
+	row.EndHandoffID = handoffID
+	row.LastSeen = now // treat end as implicit last contact
+	cp := *row
+	return &cp, true, nil
+}
+
+// ─── Handoff registry ────────────────────────────────────────────────────────
+
+// HandoffLifecycle values.
+const (
+	HandoffStateOpen      = "open"
+	HandoffStateClaimed   = "claimed"
+	HandoffStateCompleted = "completed"
+)
+
+// HandoffState is the in-memory row for a handoff.
+type HandoffState struct {
+	HandoffID   string `json:"handoff_id"`
+	FromSession string `json:"from_session"`
+	ToSession   string `json:"to_session,omitempty"`
+	Reason      string `json:"reason,omitempty"`
+
+	// Full offer payload (mirror of what went on the bus). Kept verbatim so
+	// claimants can read it back without a separate bus fetch.
+	OfferPayload map[string]interface{} `json:"offer,omitempty"`
+
+	CreatedAt  time.Time `json:"created_at"`
+	TTLSeconds int       `json:"ttl_seconds,omitempty"`
+	ExpiresAt  time.Time `json:"expires_at,omitempty"`
+
+	State             string    `json:"state"`
+	ClaimingSession   string    `json:"claiming_session,omitempty"`
+	ClaimedAt         time.Time `json:"claimed_at,omitempty"`
+	CompletingSession string    `json:"completing_session,omitempty"`
+	CompletedAt       time.Time `json:"completed_at,omitempty"`
+	CompletionOutcome string    `json:"outcome,omitempty"`
+	CompletionNotes   string    `json:"notes,omitempty"`
+	NextHandoffID    string    `json:"next_handoff_id,omitempty"`
+}
+
+// IsExpired is true when TTL > 0 and now is past ExpiresAt.
+func (h *HandoffState) IsExpired(now time.Time) bool {
+	if h.TTLSeconds <= 0 || h.ExpiresAt.IsZero() {
+		return false
+	}
+	return now.After(h.ExpiresAt)
+}
+
+// HandoffRegistry guards in-memory handoff state. The bus is still the
+// source of truth; this struct is how we atomically enforce first-wins on
+// claim and state-order on complete.
+type HandoffRegistry struct {
+	mu   sync.Mutex // write-mostly; snapshot also takes the lock briefly
+	rows map[string]*HandoffState
+}
+
+// NewHandoffRegistry returns an empty registry.
+func NewHandoffRegistry() *HandoffRegistry {
+	return &HandoffRegistry{rows: make(map[string]*HandoffState)}
+}
+
+// Len returns the number of tracked handoffs (open + claimed + completed).
+func (r *HandoffRegistry) Len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.rows)
+}
+
+// Get returns a copy, or (nil, false).
+func (r *HandoffRegistry) Get(id string) (*HandoffState, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	row, ok := r.rows[id]
+	if !ok {
+		return nil, false
+	}
+	cp := *row
+	return &cp, true
+}
+
+// Snapshot returns a copy of every handoff row.
+func (r *HandoffRegistry) Snapshot() []*HandoffState {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]*HandoffState, 0, len(r.rows))
+	for _, row := range r.rows {
+		cp := *row
+		out = append(out, &cp)
+	}
+	return out
+}
+
+// ApplyOffer records a handoff offer. Idempotent on duplicate IDs — replaces
+// the row; this shouldn't happen in normal flow (IDs are unique) but mirrors
+// the bus semantics (re-emitting the same offer would just append another
+// event).
+func (r *HandoffRegistry) ApplyOffer(h HandoffState, now time.Time) *HandoffState {
+	if h.CreatedAt.IsZero() {
+		h.CreatedAt = now
+	}
+	if h.TTLSeconds > 0 && h.ExpiresAt.IsZero() {
+		h.ExpiresAt = h.CreatedAt.Add(time.Duration(h.TTLSeconds) * time.Second)
+	}
+	h.State = HandoffStateOpen
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	row := h
+	r.rows[h.HandoffID] = &row
+	cp := row
+	return &cp
+}
+
+// ClaimRejection reasons for the handoff.claim_rejected event (amendment #4).
+type ClaimRejection string
+
+const (
+	ClaimRejectedOfferNotFound ClaimRejection = "offer_not_found"
+	ClaimRejectedAlreadyClaimed ClaimRejection = "already_claimed"
+	ClaimRejectedTTLExpired     ClaimRejection = "ttl_expired"
+	ClaimRejectedOutOfOrder     ClaimRejection = "out_of_order"
+)
+
+// ClaimResult is what the handler returns after an atomic claim attempt.
+type ClaimResult struct {
+	Offer              *HandoffState
+	Rejection          ClaimRejection // empty on success
+	ConflictingSession string         // set on already_claimed
+}
+
+// ApplyClaim is the ATOMIC first-wins check. Returns a ClaimResult whose
+// Rejection is non-empty if the claim should be rejected (and a
+// claim_rejected event emitted). On success, updates the in-memory row and
+// returns the full offer copy with State=claimed.
+func (r *HandoffRegistry) ApplyClaim(
+	id, claimingSession string,
+	now time.Time,
+) ClaimResult {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	row, ok := r.rows[id]
+	if !ok {
+		return ClaimResult{Rejection: ClaimRejectedOfferNotFound}
+	}
+	if row.State == HandoffStateClaimed || row.State == HandoffStateCompleted {
+		return ClaimResult{
+			Rejection:          ClaimRejectedAlreadyClaimed,
+			ConflictingSession: row.ClaimingSession,
+		}
+	}
+	if row.IsExpired(now) {
+		return ClaimResult{Rejection: ClaimRejectedTTLExpired}
+	}
+	row.State = HandoffStateClaimed
+	row.ClaimingSession = claimingSession
+	row.ClaimedAt = now
+	cp := *row
+	return ClaimResult{Offer: &cp}
+}
+
+// ApplyComplete transitions a claimed handoff to completed. Returns
+// (&state, true) on success; returns (&state, false) with reason
+// ClaimRejectedOutOfOrder if called before claim; returns (nil, false) if
+// unknown (caller translates to 404 vs 409).
+func (r *HandoffRegistry) ApplyComplete(
+	id, completingSession, outcome, notes, nextHandoffID string,
+	now time.Time,
+) (*HandoffState, ClaimRejection) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	row, ok := r.rows[id]
+	if !ok {
+		return nil, ClaimRejectedOfferNotFound
+	}
+	if row.State != HandoffStateClaimed {
+		cp := *row
+		return &cp, ClaimRejectedOutOfOrder
+	}
+	row.State = HandoffStateCompleted
+	row.CompletingSession = completingSession
+	row.CompletedAt = now
+	row.CompletionOutcome = outcome
+	row.CompletionNotes = notes
+	row.NextHandoffID = nextHandoffID
+	cp := *row
+	return &cp, ""
+}
+
+// ─── Replay-from-bus warmers ─────────────────────────────────────────────────
+
+// ReplaySessionRegistry reads bus_sessions events through the given manager
+// and reconstructs the in-memory session map. The bus is ground truth; this
+// function just gets the derived view ready for read-traffic before the HTTP
+// server starts serving. Errors are logged but non-fatal — an empty registry
+// is a safe degraded start.
+func ReplaySessionRegistry(mgr *BusSessionManager, reg *SessionRegistry) error {
+	if mgr == nil || reg == nil {
+		return nil
+	}
+	events, err := mgr.ReadEvents(BusSessions)
+	if err != nil {
+		slog.Warn("sessions: replay read failed", "bus", BusSessions, "err", err)
+		return err
+	}
+	// bridge-v0.1 payload shape: the entire session dict lives at the top
+	// level of the bus event's payload map. Some bridge code writes a
+	// nested "content" (the message text) plus flat fields; we tolerate
+	// both by preferring explicit top-level keys and falling back to
+	// reasonable defaults.
+	for _, evt := range events {
+		switch evt.Type {
+		case EvtSessionRegister:
+			state := parseSessionPayload(evt.From, evt.Payload)
+			if state == nil {
+				continue
+			}
+			if ts, err := parseBusTS(evt.Ts); err == nil {
+				state.RegisteredAt = ts
+				if state.LastSeen.IsZero() {
+					state.LastSeen = ts
+				}
+			}
+			// Replay bypasses the "refuse re-register when live" check —
+			// we're reconstructing history, not enforcing invariants.
+			reg.mu.Lock()
+			row := *state
+			reg.rows[state.SessionID] = &row
+			reg.mu.Unlock()
+
+		case EvtSessionHeartbeat:
+			payload := evt.Payload
+			if payload == nil {
+				continue
+			}
+			id, _ := payload["session_id"].(string)
+			if id == "" {
+				id = evt.From
+			}
+			if id == "" {
+				continue
+			}
+			reg.mu.Lock()
+			row, ok := reg.rows[id]
+			if ok {
+				if ts, err := parseBusTS(evt.Ts); err == nil {
+					row.LastSeen = ts
+				}
+				if v, ok := payload["context_usage"].(float64); ok && v > 0 {
+					row.ContextUsage = v
+				}
+				if s, _ := payload["status"].(string); s != "" {
+					row.Status = s
+				}
+				if t, _ := payload["current_task"].(string); t != "" {
+					row.CurrentTask = t
+				}
+			}
+			reg.mu.Unlock()
+
+		case EvtSessionEnd:
+			payload := evt.Payload
+			if payload == nil {
+				continue
+			}
+			id, _ := payload["session_id"].(string)
+			if id == "" {
+				id = evt.From
+			}
+			if id == "" {
+				continue
+			}
+			reason, _ := payload["reason"].(string)
+			handoffID, _ := payload["handoff_id"].(string)
+			reg.mu.Lock()
+			row, ok := reg.rows[id]
+			if ok {
+				row.Ended = true
+				if ts, err := parseBusTS(evt.Ts); err == nil {
+					row.EndedAt = ts
+					row.LastSeen = ts
+				}
+				row.EndReason = reason
+				row.EndHandoffID = handoffID
+			}
+			reg.mu.Unlock()
+		}
+	}
+	slog.Info("sessions: replay complete", "sessions", reg.Len(), "events", len(events))
+	return nil
+}
+
+// ReplayHandoffRegistry replays bus_handoffs into the handoff registry.
+func ReplayHandoffRegistry(mgr *BusSessionManager, reg *HandoffRegistry) error {
+	if mgr == nil || reg == nil {
+		return nil
+	}
+	events, err := mgr.ReadEvents(BusHandoffs)
+	if err != nil {
+		slog.Warn("handoffs: replay read failed", "bus", BusHandoffs, "err", err)
+		return err
+	}
+	for _, evt := range events {
+		payload := evt.Payload
+		if payload == nil {
+			continue
+		}
+		switch evt.Type {
+		case EvtHandoffOffer:
+			h := parseHandoffOffer(evt.Payload)
+			if h == nil {
+				continue
+			}
+			if ts, err := parseBusTS(evt.Ts); err == nil && h.CreatedAt.IsZero() {
+				h.CreatedAt = ts
+				if h.TTLSeconds > 0 && h.ExpiresAt.IsZero() {
+					h.ExpiresAt = ts.Add(time.Duration(h.TTLSeconds) * time.Second)
+				}
+			}
+			h.State = HandoffStateOpen
+			reg.mu.Lock()
+			row := *h
+			reg.rows[h.HandoffID] = &row
+			reg.mu.Unlock()
+
+		case EvtHandoffClaim:
+			id, _ := payload["handoff_id"].(string)
+			claimant, _ := payload["claiming_session"].(string)
+			if id == "" {
+				continue
+			}
+			reg.mu.Lock()
+			row, ok := reg.rows[id]
+			// On replay, honor first-wins by seq: only the first claim
+			// for a given id transitions state.
+			if ok && row.State == HandoffStateOpen {
+				row.State = HandoffStateClaimed
+				row.ClaimingSession = claimant
+				if ts, err := parseBusTS(evt.Ts); err == nil {
+					row.ClaimedAt = ts
+				}
+			}
+			reg.mu.Unlock()
+
+		case EvtHandoffComplete:
+			id, _ := payload["handoff_id"].(string)
+			session, _ := payload["completing_session"].(string)
+			outcome, _ := payload["outcome"].(string)
+			notes, _ := payload["notes"].(string)
+			nextID, _ := payload["next_handoff_id"].(string)
+			if id == "" {
+				continue
+			}
+			reg.mu.Lock()
+			row, ok := reg.rows[id]
+			if ok && row.State == HandoffStateClaimed {
+				row.State = HandoffStateCompleted
+				row.CompletingSession = session
+				row.CompletionOutcome = outcome
+				row.CompletionNotes = notes
+				row.NextHandoffID = nextID
+				if ts, err := parseBusTS(evt.Ts); err == nil {
+					row.CompletedAt = ts
+				}
+			}
+			reg.mu.Unlock()
+		}
+	}
+	slog.Info("handoffs: replay complete", "handoffs", reg.Len(), "events", len(events))
+	return nil
+}
+
+// ─── payload helpers ─────────────────────────────────────────────────────────
+
+// parseSessionPayload reconstructs a SessionState from a bus event's payload.
+// The bridge writes nearly everything to the top level. Unknown keys are
+// copied to Extras so no information is lost.
+func parseSessionPayload(fromField string, p map[string]interface{}) *SessionState {
+	if p == nil {
+		return nil
+	}
+	id, _ := p["session_id"].(string)
+	if id == "" {
+		id = fromField
+	}
+	if id == "" {
+		return nil
+	}
+	state := &SessionState{SessionID: id}
+	pickString(&state.Workspace, p, "workspace")
+	pickString(&state.Role, p, "role")
+	pickString(&state.Task, p, "task")
+	pickString(&state.Model, p, "model")
+	pickString(&state.Hostname, p, "hostname")
+	pickString(&state.Status, p, "status")
+	pickString(&state.CurrentTask, p, "current_task")
+	if v, ok := p["context_usage"].(float64); ok {
+		state.ContextUsage = v
+	}
+	// Stash any other fields for debuggability.
+	known := map[string]bool{
+		"session_id": true, "workspace": true, "role": true, "task": true,
+		"model": true, "hostname": true, "status": true,
+		"current_task": true, "context_usage": true, "content": true,
+	}
+	for k, v := range p {
+		if known[k] {
+			continue
+		}
+		if state.Extras == nil {
+			state.Extras = map[string]interface{}{}
+		}
+		state.Extras[k] = v
+	}
+	return state
+}
+
+// parseHandoffOffer reconstructs a HandoffState from a bus.offer payload.
+// The bridge writes the whole offer dict verbatim to the payload.
+func parseHandoffOffer(p map[string]interface{}) *HandoffState {
+	if p == nil {
+		return nil
+	}
+	id, _ := p["handoff_id"].(string)
+	if id == "" {
+		return nil
+	}
+	h := &HandoffState{HandoffID: id}
+	pickString(&h.FromSession, p, "from_session")
+	pickString(&h.ToSession, p, "to_session")
+	pickString(&h.Reason, p, "reason")
+	if v, ok := p["ttl_seconds"].(float64); ok {
+		h.TTLSeconds = int(v)
+	}
+	if s, _ := p["created_at"].(string); s != "" {
+		if ts, err := parseBusTS(s); err == nil {
+			h.CreatedAt = ts
+		}
+	}
+	// Keep the whole payload verbatim so claimants can read it back.
+	h.OfferPayload = copyMap(p)
+	return h
+}
+
+func pickString(dst *string, p map[string]interface{}, key string) {
+	if v, ok := p[key].(string); ok {
+		*dst = v
+	}
+}
+
+func copyMap(src map[string]interface{}) map[string]interface{} {
+	if src == nil {
+		return nil
+	}
+	out := make(map[string]interface{}, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+	return out
+}
+
+func parseBusTS(ts string) (time.Time, error) {
+	// The bus writes RFC3339Nano; tolerate RFC3339 too.
+	if ts == "" {
+		return time.Time{}, errors.New("empty ts")
+	}
+	if t, err := time.Parse(time.RFC3339Nano, ts); err == nil {
+		return t, nil
+	}
+	return time.Parse(time.RFC3339, strings.TrimSpace(ts))
+}

--- a/internal/engine/sessions_test.go
+++ b/internal/engine/sessions_test.go
@@ -1,0 +1,745 @@
+// sessions_test.go — unit tests for the kernel-native session / handoff
+// hybrid (cog://mem/semantic/surveys/2026-04-21-consolidation/
+// agent-P-session-management-evaluation §"Tests to add").
+//
+// 14 tests total:
+//
+//  1. TestSessionRegister_ValidID         — happy path
+//  2. TestSessionRegister_InvalidFormat   — regex rejects malformed IDs
+//  3. TestSessionRegister_ReRegistration  — idempotent UPDATE semantics
+//  4. TestHeartbeat_UnknownSession        — 404
+//  5. TestEnd_UnknownSession              — 404
+//  6. TestEnd_AlreadyEnded                — 409
+//  7. TestPresence_ActiveWindow           — stale heartbeats marked inactive
+//  8. TestHandoffOffer_MissingTaskFields  — 400 validation
+//  9. TestHandoffClaim_Atomicity          — concurrent claims, first wins
+// 10. TestHandoffClaim_TTLExpired         — expired offer rejected with 409
+// 11. TestHandoffClaim_PhantomOffer       — 404
+// 12. TestHandoffComplete_WithoutClaim    — 409
+// 13. TestReplayOnStartup                 — registry rebuilds from bus
+// 14. TestClaimRejectedEventEmitted       — amendment #4 observability
+
+package engine
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// ─── HTTP fixtures ───────────────────────────────────────────────────────────
+
+// newSessionsTestServer reuses the generic events fixture and returns the
+// Server struct alongside an httptest base URL so tests can poke both the
+// public HTTP surface and the in-memory registries directly.
+func newSessionsTestServer(t *testing.T) (*Server, *httptest.Server) {
+	t.Helper()
+	root := t.TempDir()
+	cfg := &Config{WorkspaceRoot: root, CogDir: root + "/.cog", Port: 0}
+	nucleus := &Nucleus{Name: "test"}
+	proc := NewProcess(cfg, nucleus)
+	srv := NewServer(cfg, nucleus, proc)
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(func() {
+		ts.Close()
+		_ = proc.Broker().Close()
+	})
+	return srv, ts
+}
+
+func postJSON(t *testing.T, url string, body any) *http.Response {
+	t.Helper()
+	b, _ := json.Marshal(body)
+	resp, err := http.Post(url, "application/json", bytes.NewReader(b))
+	if err != nil {
+		t.Fatalf("POST %s: %v", url, err)
+	}
+	return resp
+}
+
+func decodeJSON(t *testing.T, resp *http.Response, into any) {
+	t.Helper()
+	defer resp.Body.Close()
+	if err := json.NewDecoder(resp.Body).Decode(into); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+}
+
+// ─── 1. TestSessionRegister_ValidID ──────────────────────────────────────────
+
+func TestSessionRegister_ValidID(t *testing.T) {
+	t.Parallel()
+	srv, ts := newSessionsTestServer(t)
+
+	body := map[string]any{
+		"session_id": "alpha-beta-gamma",
+		"workspace":  "demo",
+		"role":       "author",
+	}
+	resp := postJSON(t, ts.URL+"/v1/sessions/register", body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var out sessionWriteResponse
+	decodeJSON(t, resp, &out)
+	if !out.OK || out.SessionID != "alpha-beta-gamma" {
+		t.Errorf("bad response: %+v", out)
+	}
+	if out.Seq != 1 {
+		t.Errorf("seq = %d, want 1", out.Seq)
+	}
+	if got := srv.sessionRegistry.Len(); got != 1 {
+		t.Errorf("registry len = %d, want 1", got)
+	}
+}
+
+// ─── 2. TestSessionRegister_InvalidFormat ────────────────────────────────────
+
+func TestSessionRegister_InvalidFormat(t *testing.T) {
+	t.Parallel()
+	_, ts := newSessionsTestServer(t)
+
+	cases := []string{
+		"",            // empty
+		"single",      // only one component
+		"BAD-ID-HERE", // uppercase
+		"has spaces-x-y",
+		"trailing-dash-",
+	}
+	for _, id := range cases {
+		body := map[string]any{"session_id": id, "workspace": "w", "role": "r"}
+		resp := postJSON(t, ts.URL+"/v1/sessions/register", body)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("%q: status = %d, want 400", id, resp.StatusCode)
+		}
+		resp.Body.Close()
+	}
+}
+
+// ─── 3. TestSessionRegister_ReRegistration ───────────────────────────────────
+
+func TestSessionRegister_ReRegistration(t *testing.T) {
+	t.Parallel()
+	srv, ts := newSessionsTestServer(t)
+
+	body := map[string]any{
+		"session_id": "same-id-twice",
+		"workspace":  "demo",
+		"role":       "author",
+		"task":       "first",
+	}
+	r1 := postJSON(t, ts.URL+"/v1/sessions/register", body)
+	r1.Body.Close()
+	if r1.StatusCode != http.StatusOK {
+		t.Fatalf("first register = %d", r1.StatusCode)
+	}
+
+	// Second call updates the row — should not be rejected.
+	body["task"] = "second"
+	r2 := postJSON(t, ts.URL+"/v1/sessions/register", body)
+	if r2.StatusCode != http.StatusOK {
+		t.Fatalf("re-register = %d, want 200 (update)", r2.StatusCode)
+	}
+	var resp2 sessionWriteResponse
+	decodeJSON(t, r2, &resp2)
+	if resp2.Created {
+		t.Errorf("second register reported created=true")
+	}
+	if resp2.Session == nil || resp2.Session.Task != "second" {
+		t.Errorf("task not updated: %+v", resp2.Session)
+	}
+	if got := srv.sessionRegistry.Len(); got != 1 {
+		t.Errorf("len = %d, want 1 after update", got)
+	}
+	// Both events should be on the bus.
+	events, _ := srv.busSessions.ReadEvents(BusSessions)
+	if len(events) < 2 {
+		t.Errorf("bus has %d events, want >=2", len(events))
+	}
+}
+
+// ─── 4. TestHeartbeat_UnknownSession ─────────────────────────────────────────
+
+func TestHeartbeat_UnknownSession(t *testing.T) {
+	t.Parallel()
+	_, ts := newSessionsTestServer(t)
+
+	resp := postJSON(t, ts.URL+"/v1/sessions/ghost-session-id/heartbeat",
+		map[string]any{"status": "live"})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+// ─── 5. TestEnd_UnknownSession ───────────────────────────────────────────────
+
+func TestEnd_UnknownSession(t *testing.T) {
+	t.Parallel()
+	_, ts := newSessionsTestServer(t)
+
+	resp := postJSON(t, ts.URL+"/v1/sessions/ghost-session-id/end",
+		map[string]any{"reason": "test"})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+// ─── 6. TestEnd_AlreadyEnded ─────────────────────────────────────────────────
+
+func TestEnd_AlreadyEnded(t *testing.T) {
+	t.Parallel()
+	_, ts := newSessionsTestServer(t)
+
+	body := map[string]any{"session_id": "once-and-done", "workspace": "w", "role": "r"}
+	postJSON(t, ts.URL+"/v1/sessions/register", body).Body.Close()
+
+	endURL := ts.URL + "/v1/sessions/once-and-done/end"
+	r1 := postJSON(t, endURL, map[string]any{"reason": "first"})
+	r1.Body.Close()
+	if r1.StatusCode != http.StatusOK {
+		t.Fatalf("first end = %d", r1.StatusCode)
+	}
+	r2 := postJSON(t, endURL, map[string]any{"reason": "second"})
+	defer r2.Body.Close()
+	if r2.StatusCode != http.StatusConflict {
+		t.Errorf("second end = %d, want 409", r2.StatusCode)
+	}
+}
+
+// ─── 7. TestPresence_ActiveWindow ────────────────────────────────────────────
+
+func TestPresence_ActiveWindow(t *testing.T) {
+	t.Parallel()
+	srv, ts := newSessionsTestServer(t)
+
+	// Register two sessions. Then manually backdate one's LastSeen.
+	postJSON(t, ts.URL+"/v1/sessions/register", map[string]any{
+		"session_id": "fresh-session-here", "workspace": "w", "role": "r",
+	}).Body.Close()
+	postJSON(t, ts.URL+"/v1/sessions/register", map[string]any{
+		"session_id": "stale-session-here", "workspace": "w", "role": "r",
+	}).Body.Close()
+
+	// Rewind the stale session's LastSeen well past the default window.
+	srv.sessionRegistry.mu.Lock()
+	srv.sessionRegistry.rows["stale-session-here"].LastSeen =
+		time.Now().UTC().Add(-2 * time.Hour)
+	srv.sessionRegistry.mu.Unlock()
+
+	resp, err := http.Get(ts.URL + "/v1/sessions/presence?active_within_seconds=300")
+	if err != nil {
+		t.Fatalf("GET presence: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var body struct {
+		Sessions []struct {
+			SessionID string `json:"session_id"`
+			Active    bool   `json:"active"`
+		} `json:"sessions"`
+		Count int `json:"count"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Count != 2 {
+		t.Fatalf("count = %d, want 2", body.Count)
+	}
+	for _, s := range body.Sessions {
+		switch s.SessionID {
+		case "fresh-session-here":
+			if !s.Active {
+				t.Errorf("%s: active=false, want true", s.SessionID)
+			}
+		case "stale-session-here":
+			if s.Active {
+				t.Errorf("%s: active=true, want false", s.SessionID)
+			}
+		}
+	}
+}
+
+// ─── 8. TestHandoffOffer_MissingTaskFields ───────────────────────────────────
+
+func TestHandoffOffer_MissingTaskFields(t *testing.T) {
+	t.Parallel()
+	_, ts := newSessionsTestServer(t)
+
+	// No task at all.
+	r1 := postJSON(t, ts.URL+"/v1/handoffs/offer", map[string]any{
+		"from_session":     "src-session-abc",
+		"bootstrap_prompt": "x",
+	})
+	r1.Body.Close()
+	if r1.StatusCode != http.StatusBadRequest {
+		t.Errorf("no-task: status = %d, want 400", r1.StatusCode)
+	}
+
+	// task without next_steps.
+	r2 := postJSON(t, ts.URL+"/v1/handoffs/offer", map[string]any{
+		"from_session":     "src-session-abc",
+		"bootstrap_prompt": "x",
+		"task":             map[string]any{"title": "T", "goal": "G"},
+	})
+	r2.Body.Close()
+	if r2.StatusCode != http.StatusBadRequest {
+		t.Errorf("no next_steps: status = %d, want 400", r2.StatusCode)
+	}
+
+	// Empty next_steps list.
+	r3 := postJSON(t, ts.URL+"/v1/handoffs/offer", map[string]any{
+		"from_session":     "src-session-abc",
+		"bootstrap_prompt": "x",
+		"task":             map[string]any{"title": "T", "goal": "G", "next_steps": []any{}},
+	})
+	r3.Body.Close()
+	if r3.StatusCode != http.StatusBadRequest {
+		t.Errorf("empty next_steps: status = %d, want 400", r3.StatusCode)
+	}
+
+	// Happy path.
+	r4 := postJSON(t, ts.URL+"/v1/handoffs/offer", map[string]any{
+		"from_session":     "src-session-abc",
+		"bootstrap_prompt": "x",
+		"task":             map[string]any{"title": "T", "goal": "G", "next_steps": []any{"step1"}},
+	})
+	defer r4.Body.Close()
+	if r4.StatusCode != http.StatusOK {
+		t.Errorf("valid offer: status = %d, want 200", r4.StatusCode)
+	}
+}
+
+// ─── 9. TestHandoffClaim_Atomicity ───────────────────────────────────────────
+
+func TestHandoffClaim_Atomicity(t *testing.T) {
+	t.Parallel()
+	srv, ts := newSessionsTestServer(t)
+
+	// Post an offer first.
+	offerResp := postJSON(t, ts.URL+"/v1/handoffs/offer", map[string]any{
+		"from_session":     "offering-session-x",
+		"bootstrap_prompt": "bp",
+		"task":             map[string]any{"title": "T", "goal": "G", "next_steps": []any{"s1"}},
+	})
+	var offer handoffWriteResponse
+	decodeJSON(t, offerResp, &offer)
+	if !offer.OK {
+		t.Fatalf("offer failed: %+v", offer)
+	}
+	claimURL := ts.URL + "/v1/handoffs/" + offer.HandoffID + "/claim"
+
+	// Spin up 8 concurrent claims from 8 different sessions.
+	const N = 8
+	var wg sync.WaitGroup
+	results := make([]int, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			sess := []byte("claimant-session-0")
+			sess[len(sess)-1] = byte('0' + idx)
+			resp := postJSON(t, claimURL, map[string]any{"claiming_session": string(sess)})
+			resp.Body.Close()
+			results[idx] = resp.StatusCode
+		}(i)
+	}
+	wg.Wait()
+
+	wins := 0
+	losses := 0
+	for _, code := range results {
+		switch code {
+		case http.StatusOK:
+			wins++
+		case http.StatusConflict:
+			losses++
+		default:
+			t.Errorf("unexpected status %d", code)
+		}
+	}
+	if wins != 1 {
+		t.Errorf("wins = %d, want 1", wins)
+	}
+	if losses != N-1 {
+		t.Errorf("losses = %d, want %d", losses, N-1)
+	}
+
+	// Confirm the claim_rejected events landed for each loser.
+	events, _ := srv.busSessions.ReadEvents(BusHandoffs)
+	rejCount := 0
+	for _, e := range events {
+		if e.Type == EvtHandoffClaimRejected {
+			rejCount++
+		}
+	}
+	if rejCount != N-1 {
+		t.Errorf("claim_rejected events = %d, want %d", rejCount, N-1)
+	}
+}
+
+// ─── 10. TestHandoffClaim_TTLExpired ─────────────────────────────────────────
+
+func TestHandoffClaim_TTLExpired(t *testing.T) {
+	t.Parallel()
+	srv, ts := newSessionsTestServer(t)
+
+	// Offer with 1s TTL, then backdate CreatedAt + ExpiresAt to force expiry.
+	offerResp := postJSON(t, ts.URL+"/v1/handoffs/offer", map[string]any{
+		"from_session":     "offering-session-y",
+		"bootstrap_prompt": "bp",
+		"ttl_seconds":      1,
+		"task":             map[string]any{"title": "T", "goal": "G", "next_steps": []any{"s"}},
+	})
+	var offer handoffWriteResponse
+	decodeJSON(t, offerResp, &offer)
+
+	// Age the row.
+	srv.handoffRegistry.mu.Lock()
+	srv.handoffRegistry.rows[offer.HandoffID].CreatedAt =
+		time.Now().Add(-1 * time.Hour)
+	srv.handoffRegistry.rows[offer.HandoffID].ExpiresAt =
+		time.Now().Add(-59 * time.Minute)
+	srv.handoffRegistry.mu.Unlock()
+
+	claimResp := postJSON(t, ts.URL+"/v1/handoffs/"+offer.HandoffID+"/claim",
+		map[string]any{"claiming_session": "would-be-claimant"})
+	defer claimResp.Body.Close()
+	if claimResp.StatusCode != http.StatusConflict {
+		t.Errorf("status = %d, want 409", claimResp.StatusCode)
+	}
+	body, _ := jsonReadAll(claimResp)
+	if !strings.Contains(body, "ttl_expired") {
+		t.Errorf("expected ttl_expired in body: %q", body)
+	}
+}
+
+// ─── 11. TestHandoffClaim_PhantomOffer ───────────────────────────────────────
+
+func TestHandoffClaim_PhantomOffer(t *testing.T) {
+	t.Parallel()
+	srv, ts := newSessionsTestServer(t)
+
+	resp := postJSON(t, ts.URL+"/v1/handoffs/ho-0-deadbeef/claim",
+		map[string]any{"claiming_session": "phantom-claimant-abc"})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+	// claim_rejected event should still have been emitted for observability.
+	events, _ := srv.busSessions.ReadEvents(BusHandoffs)
+	found := false
+	for _, e := range events {
+		if e.Type == EvtHandoffClaimRejected {
+			if r, _ := e.Payload["reason"].(string); r == string(ClaimRejectedOfferNotFound) {
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		t.Errorf("no claim_rejected/offer_not_found event on bus")
+	}
+}
+
+// ─── 12. TestHandoffComplete_WithoutClaim ────────────────────────────────────
+
+func TestHandoffComplete_WithoutClaim(t *testing.T) {
+	t.Parallel()
+	_, ts := newSessionsTestServer(t)
+
+	offerResp := postJSON(t, ts.URL+"/v1/handoffs/offer", map[string]any{
+		"from_session":     "offering-session-z",
+		"bootstrap_prompt": "bp",
+		"task":             map[string]any{"title": "T", "goal": "G", "next_steps": []any{"s"}},
+	})
+	var offer handoffWriteResponse
+	decodeJSON(t, offerResp, &offer)
+
+	resp := postJSON(t, ts.URL+"/v1/handoffs/"+offer.HandoffID+"/complete",
+		map[string]any{
+			"completing_session": "premature-completer-xyz",
+			"outcome":            "done",
+		})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Errorf("status = %d, want 409", resp.StatusCode)
+	}
+}
+
+// ─── 13. TestReplayOnStartup ─────────────────────────────────────────────────
+
+func TestReplayOnStartup(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	cfg := &Config{WorkspaceRoot: root, CogDir: root + "/.cog", Port: 0}
+	nucleus := &Nucleus{Name: "test"}
+	proc := NewProcess(cfg, nucleus)
+	srv1 := NewServer(cfg, nucleus, proc)
+	ts1 := httptest.NewServer(srv1.Handler())
+	t.Cleanup(func() { ts1.Close() })
+
+	// Register two sessions, end one, leave the other live.
+	postJSON(t, ts1.URL+"/v1/sessions/register", map[string]any{
+		"session_id": "replay-live-session", "workspace": "w", "role": "r",
+	}).Body.Close()
+	postJSON(t, ts1.URL+"/v1/sessions/register", map[string]any{
+		"session_id": "replay-ended-session", "workspace": "w", "role": "r",
+	}).Body.Close()
+	postJSON(t, ts1.URL+"/v1/sessions/replay-ended-session/end",
+		map[string]any{"reason": "test-end"}).Body.Close()
+
+	// And a handoff.
+	offerResp := postJSON(t, ts1.URL+"/v1/handoffs/offer", map[string]any{
+		"from_session":     "replay-live-session",
+		"bootstrap_prompt": "bp",
+		"task":             map[string]any{"title": "T", "goal": "G", "next_steps": []any{"s"}},
+	})
+	var offer handoffWriteResponse
+	decodeJSON(t, offerResp, &offer)
+
+	ts1.Close()
+
+	// Boot a fresh Server rooted at the same workspace — replay should
+	// reconstruct the same state from the bus.
+	srv2 := NewServer(cfg, nucleus, proc)
+	if got := srv2.sessionRegistry.Len(); got != 2 {
+		t.Errorf("replay session count = %d, want 2", got)
+	}
+	s1, ok := srv2.sessionRegistry.Get("replay-live-session")
+	if !ok || s1.Ended {
+		t.Errorf("live session not replayed correctly: ok=%v ended=%v", ok, s1 != nil && s1.Ended)
+	}
+	s2, ok := srv2.sessionRegistry.Get("replay-ended-session")
+	var endReason string
+	if s2 != nil {
+		endReason = s2.EndReason
+	}
+	if !ok || s2 == nil || !s2.Ended || endReason != "test-end" {
+		t.Errorf("ended session not replayed: ok=%v ended=%v reason=%q",
+			ok, s2 != nil && s2.Ended, endReason)
+	}
+	if got := srv2.handoffRegistry.Len(); got != 1 {
+		t.Errorf("replay handoff count = %d, want 1", got)
+	}
+	h, ok := srv2.handoffRegistry.Get(offer.HandoffID)
+	var hState string
+	if h != nil {
+		hState = h.State
+	}
+	if !ok || h == nil || hState != HandoffStateOpen {
+		t.Errorf("handoff not replayed as open: ok=%v state=%q", ok, hState)
+	}
+}
+
+// ─── 14. TestClaimRejectedEventEmitted (amendment #4) ────────────────────────
+
+func TestClaimRejectedEventEmitted(t *testing.T) {
+	t.Parallel()
+	srv, ts := newSessionsTestServer(t)
+
+	// Post an offer; claim it once; then try to claim again. The second
+	// attempt must 409 AND write a handoff.claim_rejected event with the
+	// conflicting_session field populated.
+	offerResp := postJSON(t, ts.URL+"/v1/handoffs/offer", map[string]any{
+		"from_session":     "first-offerer-here",
+		"bootstrap_prompt": "bp",
+		"task":             map[string]any{"title": "T", "goal": "G", "next_steps": []any{"s"}},
+	})
+	var offer handoffWriteResponse
+	decodeJSON(t, offerResp, &offer)
+
+	// First claim wins.
+	r1 := postJSON(t, ts.URL+"/v1/handoffs/"+offer.HandoffID+"/claim",
+		map[string]any{"claiming_session": "first-winner-abc"})
+	r1.Body.Close()
+	if r1.StatusCode != http.StatusOK {
+		t.Fatalf("first claim: %d", r1.StatusCode)
+	}
+
+	// Second attempt loses.
+	r2 := postJSON(t, ts.URL+"/v1/handoffs/"+offer.HandoffID+"/claim",
+		map[string]any{"claiming_session": "second-loser-xyz"})
+	r2.Body.Close()
+	if r2.StatusCode != http.StatusConflict {
+		t.Fatalf("second claim: %d, want 409", r2.StatusCode)
+	}
+
+	events, _ := srv.busSessions.ReadEvents(BusHandoffs)
+	var rej *BusBlock
+	for i := range events {
+		if events[i].Type == EvtHandoffClaimRejected {
+			rej = &events[i]
+			break
+		}
+	}
+	if rej == nil {
+		t.Fatal("no claim_rejected event emitted")
+	}
+	if r, _ := rej.Payload["reason"].(string); r != string(ClaimRejectedAlreadyClaimed) {
+		t.Errorf("reason = %q, want %q", r, ClaimRejectedAlreadyClaimed)
+	}
+	if cs, _ := rej.Payload["conflicting_session"].(string); cs != "first-winner-abc" {
+		t.Errorf("conflicting_session = %q, want first-winner-abc", cs)
+	}
+	if as, _ := rej.Payload["attempting_session"].(string); as != "second-loser-xyz" {
+		t.Errorf("attempting_session = %q, want second-loser-xyz", as)
+	}
+}
+
+// ─── 15. TestMCP_HandoffRoundTrip — integration test (Phase 2) ─────────────
+
+// TestMCP_HandoffRoundTrip exercises the 8 cog_* MCP tools end-to-end:
+// register two sessions → one offers a handoff → the other claims it →
+// claim emits the offer payload back → complete cycles the state to
+// HandoffStateCompleted. Round trips the actual bus through the same
+// registries the HTTP surface uses.
+func TestMCP_HandoffRoundTrip(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	cfg := &Config{WorkspaceRoot: root, CogDir: root + "/.cog", Port: 0}
+	proc := NewProcess(cfg, &Nucleus{Name: "test"})
+	mcpSrv := NewMCPServer(cfg, &Nucleus{Name: "test"}, proc)
+	bus := NewBusSessionManager(root)
+	sessions := NewSessionRegistry()
+	handoffs := NewHandoffRegistry()
+	mcpSrv.SetSessionsBackend(bus, sessions, handoffs)
+
+	ctx := mcpTestCtx(t)
+
+	// 1. Register two sessions via the MCP tool.
+	reg1Result, _, err := mcpSrv.toolRegisterSession(ctx, nil, registerSessionInput{
+		SessionID: "mcp-src-session", Workspace: "w", Role: "r",
+	})
+	if err != nil || reg1Result == nil {
+		t.Fatalf("register src: %v", err)
+	}
+	reg2Result, _, err := mcpSrv.toolRegisterSession(ctx, nil, registerSessionInput{
+		SessionID: "mcp-dst-session", Workspace: "w", Role: "r",
+	})
+	if err != nil || reg2Result == nil {
+		t.Fatalf("register dst: %v", err)
+	}
+
+	// 2. src offers a handoff.
+	offerResult, _, err := mcpSrv.toolOfferHandoff(ctx, nil, offerHandoffInput{
+		FromSession: "mcp-src-session",
+		BootstrapPrompt: "bp",
+		Task: map[string]interface{}{
+			"title": "T", "goal": "G", "next_steps": []interface{}{"step1"},
+		},
+	})
+	if err != nil || offerResult == nil {
+		t.Fatalf("offer: %v", err)
+	}
+	var offerResp struct {
+		OK        bool   `json:"ok"`
+		HandoffID string `json:"handoff_id"`
+	}
+	decodeMCPJSON(t, offerResult, &offerResp)
+	if !offerResp.OK || offerResp.HandoffID == "" {
+		t.Fatalf("offer payload: %+v", offerResp)
+	}
+
+	// 3. dst claims it.
+	claimResult, _, err := mcpSrv.toolClaimHandoff(ctx, nil, claimHandoffInput{
+		HandoffID: offerResp.HandoffID, ClaimingSession: "mcp-dst-session",
+	})
+	if err != nil || claimResult == nil {
+		t.Fatalf("claim: %v", err)
+	}
+	var claimResp struct {
+		OK        bool                   `json:"ok"`
+		HandoffID string                 `json:"handoff_id"`
+		Offer     map[string]interface{} `json:"offer"`
+	}
+	decodeMCPJSON(t, claimResult, &claimResp)
+	if !claimResp.OK || claimResp.HandoffID != offerResp.HandoffID {
+		t.Fatalf("claim resp: %+v", claimResp)
+	}
+	if claimResp.Offer == nil || claimResp.Offer["bootstrap_prompt"] != "bp" {
+		t.Errorf("claim did not surface bootstrap_prompt: %+v", claimResp.Offer)
+	}
+
+	// 4. dst completes the handoff.
+	compResult, _, err := mcpSrv.toolCompleteHandoff(ctx, nil, completeHandoffInput{
+		HandoffID: offerResp.HandoffID, CompletingSession: "mcp-dst-session",
+		Outcome: "success", Notes: "roundtrip done",
+	})
+	if err != nil || compResult == nil {
+		t.Fatalf("complete: %v", err)
+	}
+	var compResp struct {
+		OK bool `json:"ok"`
+	}
+	decodeMCPJSON(t, compResult, &compResp)
+	if !compResp.OK {
+		t.Errorf("complete not ok: %+v", compResp)
+	}
+
+	// Verify bus has the full chain: 1 offer + 1 claim + 1 complete.
+	events, _ := bus.ReadEvents(BusHandoffs)
+	var types []string
+	for _, e := range events {
+		types = append(types, e.Type)
+	}
+	wantSeq := []string{EvtHandoffOffer, EvtHandoffClaim, EvtHandoffComplete}
+	if len(events) != 3 {
+		t.Fatalf("bus chain length = %d, want 3: %v", len(events), types)
+	}
+	for i, e := range events {
+		if e.Type != wantSeq[i] {
+			t.Errorf("event[%d].type = %q, want %q", i, e.Type, wantSeq[i])
+		}
+	}
+
+	// In-memory state: handoff should be in completed state.
+	h, ok := handoffs.Get(offerResp.HandoffID)
+	if !ok || h.State != HandoffStateCompleted {
+		var state string
+		if h != nil {
+			state = h.State
+		}
+		t.Errorf("final handoff state = %q (ok=%v), want completed", state, ok)
+	}
+}
+
+// mcpTestCtx returns a background context with t.Deadline if set.
+func mcpTestCtx(t *testing.T) context.Context {
+	ctx := t.Context()
+	return ctx
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+func jsonReadAll(resp *http.Response) (string, error) {
+	defer resp.Body.Close()
+	b, err := readAll(resp.Body)
+	return string(b), err
+}
+
+func readAll(r interface {
+	Read(p []byte) (int, error)
+}) ([]byte, error) {
+	buf := make([]byte, 0, 1024)
+	tmp := make([]byte, 512)
+	for {
+		n, err := r.Read(tmp)
+		if n > 0 {
+			buf = append(buf, tmp[:n]...)
+		}
+		if err != nil {
+			if err.Error() == "EOF" {
+				return buf, nil
+			}
+			return buf, err
+		}
+	}
+}

--- a/internal/engine/sessions_test.go
+++ b/internal/engine/sessions_test.go
@@ -2,22 +2,37 @@
 // hybrid (cog://mem/semantic/surveys/2026-04-21-consolidation/
 // agent-P-session-management-evaluation §"Tests to add").
 //
-// 14 tests total:
+// 26 tests total (15 original + 11 added post-codex-review):
 //
-//  1. TestSessionRegister_ValidID         — happy path
-//  2. TestSessionRegister_InvalidFormat   — regex rejects malformed IDs
-//  3. TestSessionRegister_ReRegistration  — idempotent UPDATE semantics
-//  4. TestHeartbeat_UnknownSession        — 404
-//  5. TestEnd_UnknownSession              — 404
-//  6. TestEnd_AlreadyEnded                — 409
-//  7. TestPresence_ActiveWindow           — stale heartbeats marked inactive
-//  8. TestHandoffOffer_MissingTaskFields  — 400 validation
-//  9. TestHandoffClaim_Atomicity          — concurrent claims, first wins
-// 10. TestHandoffClaim_TTLExpired         — expired offer rejected with 409
-// 11. TestHandoffClaim_PhantomOffer       — 404
-// 12. TestHandoffComplete_WithoutClaim    — 409
-// 13. TestReplayOnStartup                 — registry rebuilds from bus
-// 14. TestClaimRejectedEventEmitted       — amendment #4 observability
+//  1. TestSessionRegister_ValidID                     — happy path
+//  2. TestSessionRegister_InvalidFormat               — regex rejects malformed IDs
+//  3. TestSessionRegister_ReRegistration              — idempotent UPDATE semantics
+//  4. TestHeartbeat_UnknownSession                    — 404
+//  5. TestEnd_UnknownSession                          — 404
+//  6. TestEnd_AlreadyEnded                            — 409
+//  7. TestPresence_ActiveWindow                       — stale heartbeats marked inactive
+//  8. TestHandoffOffer_MissingTaskFields              — 400 validation
+//  9. TestHandoffClaim_Atomicity                      — concurrent claims, first wins
+// 10. TestHandoffClaim_TTLExpired                     — expired offer rejected with 409
+// 11. TestHandoffClaim_PhantomOffer                   — 404
+// 12. TestHandoffComplete_WithoutClaim                — 409
+// 13. TestReplayOnStartup                             — registry rebuilds from bus
+// 14. TestClaimRejectedEventEmitted                   — amendment #4 observability
+// 15. TestMCP_HandoffRoundTrip                        — MCP end-to-end
+//
+// Added post PR#43 codex review:
+//
+// 16. TestRegistryUnchangedOnBusAppendFailure         — critical #1: append-first
+// 17. TestHeartbeatOnEndedSessionDoesNotMutate        — critical #2: no-mutation 409
+// 18. TestReplay_EmptyBuses                           — empty replay is safe
+// 19. TestReplay_UnknownEventType                     — unknown types skipped
+// 20. TestReplay_OutOfOrderSeq                        — sort-by-seq determinism
+// 21. TestReplay_DuplicateSeqWithConflictingPayload   — first-write-wins policy
+// 22. TestReplay_CompleteWithoutClaim                 — orphaned complete tolerated
+// 23. TestSessionRegister_TwoComponentIDRejected      — spec-required 3-tuple
+// 24. TestHandoffOffer_NegativeTTLRejected            — 400 on ttl_seconds:-1
+// 25. TestHandoffOffer_CallerSuppliedIDRejected       — kernel always mints
+// 26. TestRoutes_PresenceDoesNotShadowContext         — /presence vs /{id}/context
 
 package engine
 
@@ -25,8 +40,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -740,6 +758,625 @@ func readAll(r interface {
 				return buf, nil
 			}
 			return buf, err
+		}
+	}
+}
+
+// ─── 16. TestRegistryUnchangedOnBusAppendFailure ─────────────────────────────
+//
+// Critical #1 from the codex review: the bus is ground truth, so a failed
+// AppendEvent must leave the derived in-memory registry untouched. We verify
+// this at the registry level for every mutating path: register, heartbeat,
+// end, offer, claim, complete. Each calls the Apply* method with an appendFn
+// that always errors; we then assert the registry state is identical to what
+// it was before the call.
+func TestRegistryUnchangedOnBusAppendFailure(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	appendErr := errors.New("simulated bus append failure")
+	failFn := func() error { return appendErr }
+
+	t.Run("register on empty registry stays empty", func(t *testing.T) {
+		reg := NewSessionRegistry()
+		state := SessionState{
+			SessionID: "bus-fail-register", Workspace: "w", Role: "r",
+			RegisteredAt: now, LastSeen: now,
+		}
+		stored, created, err := reg.ApplyRegister(state, time.Minute, now, failFn)
+		if err == nil {
+			t.Fatal("ApplyRegister returned nil err despite failing appendFn")
+		}
+		if stored != nil || created {
+			t.Errorf("ApplyRegister leaked state on error: stored=%v created=%v", stored, created)
+		}
+		if reg.Len() != 0 {
+			t.Errorf("registry has %d rows after failed register, want 0", reg.Len())
+		}
+	})
+
+	t.Run("register update on existing row preserves prior state", func(t *testing.T) {
+		reg := NewSessionRegistry()
+		state := SessionState{
+			SessionID: "bus-fail-reupdate", Workspace: "w", Role: "r", Task: "first",
+			RegisteredAt: now, LastSeen: now,
+		}
+		if _, _, err := reg.ApplyRegister(state, time.Minute, now, nil); err != nil {
+			t.Fatalf("seed register: %v", err)
+		}
+		before, _ := reg.Get("bus-fail-reupdate")
+
+		state.Task = "second"
+		_, _, err := reg.ApplyRegister(state, time.Minute, now, failFn)
+		if err == nil {
+			t.Fatal("expected error from failFn")
+		}
+		after, _ := reg.Get("bus-fail-reupdate")
+		if after.Task != before.Task {
+			t.Errorf("task mutated on failed re-register: before=%q after=%q", before.Task, after.Task)
+		}
+	})
+
+	t.Run("heartbeat does not bump LastSeen on append failure", func(t *testing.T) {
+		reg := NewSessionRegistry()
+		state := SessionState{
+			SessionID: "bus-fail-heartbeat", Workspace: "w", Role: "r",
+			RegisteredAt: now, LastSeen: now,
+		}
+		if _, _, err := reg.ApplyRegister(state, time.Minute, now, nil); err != nil {
+			t.Fatalf("seed register: %v", err)
+		}
+		before, _ := reg.Get("bus-fail-heartbeat")
+		later := now.Add(30 * time.Second)
+		_, ok, err := reg.ApplyHeartbeat("bus-fail-heartbeat", 0.42, "busy", "task", later, failFn)
+		if !ok {
+			t.Fatal("heartbeat saw unregistered session")
+		}
+		if err == nil {
+			t.Fatal("expected err from failFn")
+		}
+		after, _ := reg.Get("bus-fail-heartbeat")
+		if !after.LastSeen.Equal(before.LastSeen) {
+			t.Errorf("LastSeen mutated on failed heartbeat: before=%v after=%v",
+				before.LastSeen, after.LastSeen)
+		}
+		if after.Status != "" || after.CurrentTask != "" || after.ContextUsage != 0 {
+			t.Errorf("status/task/usage mutated on failed heartbeat: %+v", after)
+		}
+	})
+
+	t.Run("end does not set Ended on append failure", func(t *testing.T) {
+		reg := NewSessionRegistry()
+		state := SessionState{
+			SessionID: "bus-fail-endsess", Workspace: "w", Role: "r",
+			RegisteredAt: now, LastSeen: now,
+		}
+		if _, _, err := reg.ApplyRegister(state, time.Minute, now, nil); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		_, known, err := reg.ApplyEnd("bus-fail-endsess", "because", "", now.Add(time.Second), failFn)
+		if !known {
+			t.Fatal("end saw unknown session")
+		}
+		if err == nil {
+			t.Fatal("expected err from failFn")
+		}
+		after, _ := reg.Get("bus-fail-endsess")
+		if after.Ended {
+			t.Error("session was marked Ended despite failed append")
+		}
+	})
+
+	t.Run("offer does not install row on append failure", func(t *testing.T) {
+		hreg := NewHandoffRegistry()
+		h := HandoffState{
+			HandoffID: "ho-fail-offer-1", FromSession: "a-b-c",
+			TTLSeconds: 60, CreatedAt: now,
+		}
+		_, err := hreg.ApplyOffer(h, now, failFn)
+		if err == nil {
+			t.Fatal("expected err from failFn")
+		}
+		if hreg.Len() != 0 {
+			t.Errorf("handoff registry has %d rows after failed offer, want 0", hreg.Len())
+		}
+	})
+
+	t.Run("claim does not transition state on append failure", func(t *testing.T) {
+		hreg := NewHandoffRegistry()
+		h := HandoffState{
+			HandoffID: "ho-fail-claim-1", FromSession: "a-b-c",
+			TTLSeconds: 60, CreatedAt: now,
+		}
+		if _, err := hreg.ApplyOffer(h, now, nil); err != nil {
+			t.Fatalf("seed offer: %v", err)
+		}
+		result, err := hreg.ApplyClaim("ho-fail-claim-1", "claimant-x-y", now, failFn)
+		if err == nil {
+			t.Fatal("expected appendErr from failFn")
+		}
+		if result.Rejection != "" {
+			t.Errorf("unexpected rejection reason: %q", result.Rejection)
+		}
+		after, _ := hreg.Get("ho-fail-claim-1")
+		if after.State != HandoffStateOpen {
+			t.Errorf("handoff state = %q, want %q (unchanged on failed claim)",
+				after.State, HandoffStateOpen)
+		}
+		if after.ClaimingSession != "" {
+			t.Errorf("ClaimingSession set to %q on failed claim", after.ClaimingSession)
+		}
+	})
+
+	t.Run("complete does not transition state on append failure", func(t *testing.T) {
+		hreg := NewHandoffRegistry()
+		h := HandoffState{
+			HandoffID: "ho-fail-complete-1", FromSession: "a-b-c",
+			TTLSeconds: 60, CreatedAt: now,
+		}
+		if _, err := hreg.ApplyOffer(h, now, nil); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		if _, err := hreg.ApplyClaim("ho-fail-complete-1", "claimant-x-y", now, nil); err != nil {
+			t.Fatalf("seed claim: %v", err)
+		}
+		_, reason, err := hreg.ApplyComplete("ho-fail-complete-1",
+			"claimant-x-y", "ok", "notes", "", now.Add(time.Second), failFn)
+		if err == nil {
+			t.Fatal("expected appendErr from failFn")
+		}
+		if reason != "" {
+			t.Errorf("got rejection reason %q on append-failure path", reason)
+		}
+		after, _ := hreg.Get("ho-fail-complete-1")
+		if after.State != HandoffStateClaimed {
+			t.Errorf("handoff state = %q, want %q (unchanged on failed complete)",
+				after.State, HandoffStateClaimed)
+		}
+		if after.CompletingSession != "" {
+			t.Errorf("CompletingSession set on failed complete: %q", after.CompletingSession)
+		}
+	})
+}
+
+// ─── 17. TestHeartbeatOnEndedSessionDoesNotMutate ────────────────────────────
+//
+// Critical #2 from the codex review: a heartbeat against an ended session
+// must 409 AND leave LastSeen + optional fields untouched. HTTP surface path.
+func TestHeartbeatOnEndedSessionDoesNotMutate(t *testing.T) {
+	t.Parallel()
+	srv, ts := newSessionsTestServer(t)
+
+	// Register, then end.
+	postJSON(t, ts.URL+"/v1/sessions/register", map[string]any{
+		"session_id": "ended-nohb-session", "workspace": "w", "role": "r",
+	}).Body.Close()
+	postJSON(t, ts.URL+"/v1/sessions/ended-nohb-session/end",
+		map[string]any{"reason": "goodbye"}).Body.Close()
+
+	before, ok := srv.sessionRegistry.Get("ended-nohb-session")
+	if !ok {
+		t.Fatal("post-end registry lookup failed")
+	}
+	lastSeenBefore := before.LastSeen
+
+	// Count bus events before the heartbeat attempt so we can verify none
+	// were appended.
+	eventsBefore, _ := srv.busSessions.ReadEvents(BusSessions)
+	heartbeatCountBefore := 0
+	for _, e := range eventsBefore {
+		if e.Type == EvtSessionHeartbeat {
+			heartbeatCountBefore++
+		}
+	}
+
+	// Heartbeat against the ended session.
+	resp := postJSON(t, ts.URL+"/v1/sessions/ended-nohb-session/heartbeat",
+		map[string]any{
+			"status": "definitely-not-dead", "context_usage": 0.99,
+			"current_task": "ghost-task",
+		})
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Errorf("status = %d, want 409", resp.StatusCode)
+	}
+
+	after, _ := srv.sessionRegistry.Get("ended-nohb-session")
+	if !after.LastSeen.Equal(lastSeenBefore) {
+		t.Errorf("LastSeen mutated on 409 heartbeat: before=%v after=%v",
+			lastSeenBefore, after.LastSeen)
+	}
+	if after.Status == "definitely-not-dead" {
+		t.Errorf("Status was mutated to %q on 409 heartbeat", after.Status)
+	}
+	if after.ContextUsage == 0.99 {
+		t.Errorf("ContextUsage was mutated to %v on 409 heartbeat", after.ContextUsage)
+	}
+	if after.CurrentTask == "ghost-task" {
+		t.Errorf("CurrentTask was mutated on 409 heartbeat")
+	}
+
+	// And no heartbeat event should have made it to the bus.
+	eventsAfter, _ := srv.busSessions.ReadEvents(BusSessions)
+	heartbeatCountAfter := 0
+	for _, e := range eventsAfter {
+		if e.Type == EvtSessionHeartbeat {
+			heartbeatCountAfter++
+		}
+	}
+	if heartbeatCountAfter != heartbeatCountBefore {
+		t.Errorf("heartbeat event appended on 409 path: before=%d after=%d",
+			heartbeatCountBefore, heartbeatCountAfter)
+	}
+}
+
+// ─── 18. TestReplay_EmptyBuses ───────────────────────────────────────────────
+//
+// Edge: startup against a workspace whose bus_sessions and bus_handoffs
+// files don't exist yet. Replay should succeed with empty registries and
+// log "events=0" rather than crashing.
+func TestReplay_EmptyBuses(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mgr := NewBusSessionManager(root)
+	sreg := NewSessionRegistry()
+	hreg := NewHandoffRegistry()
+
+	if err := ReplaySessionRegistry(mgr, sreg); err != nil {
+		t.Errorf("ReplaySessionRegistry on empty bus: %v", err)
+	}
+	if err := ReplayHandoffRegistry(mgr, hreg); err != nil {
+		t.Errorf("ReplayHandoffRegistry on empty bus: %v", err)
+	}
+	if sreg.Len() != 0 {
+		t.Errorf("session registry len = %d, want 0", sreg.Len())
+	}
+	if hreg.Len() != 0 {
+		t.Errorf("handoff registry len = %d, want 0", hreg.Len())
+	}
+}
+
+// ─── 19. TestReplay_UnknownEventType ─────────────────────────────────────────
+//
+// Edge: bus contains an event with a type the replay loop doesn't recognise
+// (e.g. from a future schema). Replay must skip it without error and
+// continue processing known types.
+func TestReplay_UnknownEventType(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mgr := NewBusSessionManager(root)
+
+	// Emit a known session.register event, a forward-compat unknown event,
+	// then end the same session. Replay should produce a consistent row
+	// with Ended=true, treating the unknown event as a no-op.
+	_, err := mgr.AppendEvent(BusSessions, EvtSessionRegister, "repl-unk-session", map[string]interface{}{
+		"session_id": "repl-unk-session", "workspace": "w", "role": "r",
+	})
+	if err != nil {
+		t.Fatalf("append register: %v", err)
+	}
+	_, err = mgr.AppendEvent(BusSessions, "session.future.mystery-event", "repl-unk-session", map[string]interface{}{
+		"session_id": "repl-unk-session", "mystery": "field",
+	})
+	if err != nil {
+		t.Fatalf("append unknown: %v", err)
+	}
+	_, err = mgr.AppendEvent(BusSessions, EvtSessionEnd, "repl-unk-session", map[string]interface{}{
+		"session_id": "repl-unk-session", "reason": "done",
+	})
+	if err != nil {
+		t.Fatalf("append end: %v", err)
+	}
+
+	reg := NewSessionRegistry()
+	if err := ReplaySessionRegistry(mgr, reg); err != nil {
+		t.Errorf("replay: %v", err)
+	}
+	got, ok := reg.Get("repl-unk-session")
+	if !ok {
+		t.Fatal("registry did not rebuild session")
+	}
+	if !got.Ended {
+		t.Error("session not marked ended after replay with intervening unknown event")
+	}
+}
+
+// ─── 20. TestReplay_OutOfOrderSeq ────────────────────────────────────────────
+//
+// Substantive concern from the review: ReadEvents preserves file order.
+// This test writes the events.jsonl file with lines in seq order [3,1,2]
+// and verifies replay sorts by seq ascending so the final state matches
+// what a normal monotonic append produces.
+func TestReplay_OutOfOrderSeq(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mgr := NewBusSessionManager(root)
+
+	// Hand-craft 3 events with explicit seqs and write them in reversed-ish
+	// order to the jsonl file. Then invoke replay and verify the final
+	// state is as though events had been consumed in seq order.
+	if err := mgr.EnsureBus(BusSessions); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	evts := []BusBlock{
+		{ // seq 3 — end
+			V: 2, BusID: BusSessions, Seq: 3,
+			Ts: time.Now().UTC().Add(2 * time.Second).Format(time.RFC3339Nano),
+			From: "order-test-session", Type: EvtSessionEnd,
+			Payload: map[string]interface{}{"session_id": "order-test-session", "reason": "r3"},
+		},
+		{ // seq 1 — register
+			V: 2, BusID: BusSessions, Seq: 1,
+			Ts: time.Now().UTC().Format(time.RFC3339Nano),
+			From: "order-test-session", Type: EvtSessionRegister,
+			Payload: map[string]interface{}{"session_id": "order-test-session", "workspace": "w", "role": "r"},
+		},
+		{ // seq 2 — heartbeat
+			V: 2, BusID: BusSessions, Seq: 2,
+			Ts: time.Now().UTC().Add(time.Second).Format(time.RFC3339Nano),
+			From: "order-test-session", Type: EvtSessionHeartbeat,
+			Payload: map[string]interface{}{"session_id": "order-test-session", "status": "working"},
+		},
+	}
+	writeBusLinesForTest(t, mgr.EventsPath(BusSessions), evts)
+
+	reg := NewSessionRegistry()
+	if err := ReplaySessionRegistry(mgr, reg); err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	got, ok := reg.Get("order-test-session")
+	if !ok {
+		t.Fatal("session not replayed")
+	}
+	// If replay consumed in file order (end before register), the row
+	// wouldn't exist. Sort-by-seq means register is applied first, then
+	// heartbeat updates status, then end marks Ended.
+	if !got.Ended {
+		t.Error("final state should be ended after sort-by-seq replay")
+	}
+	if got.Status != "working" {
+		t.Errorf("status = %q, want %q (from heartbeat seq=2)", got.Status, "working")
+	}
+}
+
+// ─── 21. TestReplay_DuplicateSeqWithConflictingPayload ───────────────────────
+//
+// Design decision being codified: ReadEvents de-dupes by seq using
+// first-occurrence wins (see seen[block.Seq] check in bus_session.go).
+// Even if the file contains two different payloads for the same seq,
+// replay should consume exactly one of them — specifically the first.
+func TestReplay_DuplicateSeqWithConflictingPayload(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mgr := NewBusSessionManager(root)
+
+	if err := mgr.EnsureBus(BusSessions); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	evts := []BusBlock{
+		{ // seq 1, first occurrence — wins per first-write-wins de-dup
+			V: 2, BusID: BusSessions, Seq: 1,
+			Ts: time.Now().UTC().Format(time.RFC3339Nano),
+			From: "dup-test-session", Type: EvtSessionRegister,
+			Payload: map[string]interface{}{
+				"session_id": "dup-test-session", "workspace": "w", "role": "r",
+				"task": "FIRST",
+			},
+		},
+		{ // seq 1, second occurrence with conflicting payload — should be ignored
+			V: 2, BusID: BusSessions, Seq: 1,
+			Ts: time.Now().UTC().Add(time.Second).Format(time.RFC3339Nano),
+			From: "dup-test-session", Type: EvtSessionRegister,
+			Payload: map[string]interface{}{
+				"session_id": "dup-test-session", "workspace": "w2", "role": "r2",
+				"task": "SECOND",
+			},
+		},
+	}
+	writeBusLinesForTest(t, mgr.EventsPath(BusSessions), evts)
+
+	reg := NewSessionRegistry()
+	if err := ReplaySessionRegistry(mgr, reg); err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	got, _ := reg.Get("dup-test-session")
+	if got == nil {
+		t.Fatal("session not replayed")
+	}
+	if got.Task != "FIRST" {
+		t.Errorf("duplicate-seq policy: task = %q, want FIRST (first-occurrence wins)", got.Task)
+	}
+	if got.Workspace != "w" {
+		t.Errorf("duplicate-seq policy: workspace = %q, want w", got.Workspace)
+	}
+}
+
+// ─── 22. TestReplay_CompleteWithoutClaim ─────────────────────────────────────
+//
+// Edge: bus_handoffs contains an orphaned complete with no prior claim
+// (possible after a crash between claim and complete — bus append of claim
+// landed, complete landed, but some intermediate state was truncated). The
+// replay state machine should reject the complete (it sees state != claimed)
+// and leave the handoff in its earlier state.
+func TestReplay_CompleteWithoutClaim(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mgr := NewBusSessionManager(root)
+
+	_, _ = mgr.AppendEvent(BusHandoffs, EvtHandoffOffer, "from-a-b-c", map[string]interface{}{
+		"handoff_id":   "ho-orphan-1",
+		"from_session": "from-a-b-c",
+		"ttl_seconds":  600.0,
+	})
+	// Skip claim on purpose.
+	_, _ = mgr.AppendEvent(BusHandoffs, EvtHandoffComplete, "completer-x-y-z", map[string]interface{}{
+		"handoff_id":         "ho-orphan-1",
+		"completing_session": "completer-x-y-z",
+		"outcome":            "orphan",
+	})
+
+	reg := NewHandoffRegistry()
+	if err := ReplayHandoffRegistry(mgr, reg); err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	got, ok := reg.Get("ho-orphan-1")
+	if !ok {
+		t.Fatal("handoff not replayed at all")
+	}
+	if got.State != HandoffStateOpen {
+		t.Errorf("state = %q, want %q (orphan complete should not transition)",
+			got.State, HandoffStateOpen)
+	}
+	if got.CompletingSession != "" {
+		t.Errorf("CompletingSession = %q, should be empty on orphan-complete skip",
+			got.CompletingSession)
+	}
+}
+
+// ─── 23. TestSessionRegister_TwoComponentIDRejected ──────────────────────────
+//
+// Spec drift fix: the regex must reject 2-component IDs like "a-b", per
+// the design doc's ^[a-z0-9]+-[a-z0-9-]+-[a-z0-9-]+$.
+func TestSessionRegister_TwoComponentIDRejected(t *testing.T) {
+	t.Parallel()
+	_, ts := newSessionsTestServer(t)
+
+	resp := postJSON(t, ts.URL+"/v1/sessions/register", map[string]any{
+		"session_id": "a-b", "workspace": "w", "role": "r",
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("2-component id: status = %d, want 400", resp.StatusCode)
+	}
+
+	// And the direct validator check, belt-and-suspenders.
+	if err := ValidateSessionID("a-b"); err == nil {
+		t.Error("ValidateSessionID(\"a-b\") returned nil; want error")
+	}
+	if err := ValidateSessionID("a-b-c"); err != nil {
+		t.Errorf("ValidateSessionID(\"a-b-c\") returned err %v; want nil", err)
+	}
+	if err := ValidateSessionID("slowbro-laptop-cogos-gap-closure"); err != nil {
+		t.Errorf("ValidateSessionID on 5-component id: %v", err)
+	}
+}
+
+// ─── 24. TestHandoffOffer_NegativeTTLRejected ────────────────────────────────
+//
+// Validation gap: ttl_seconds: -1 should return 400, not silently apply
+// (which in the prior code path meant "no TTL enforcement" — a potential
+// footgun where an offer never expires).
+func TestHandoffOffer_NegativeTTLRejected(t *testing.T) {
+	t.Parallel()
+	_, ts := newSessionsTestServer(t)
+
+	resp := postJSON(t, ts.URL+"/v1/handoffs/offer", map[string]any{
+		"from_session":     "neg-ttl-offer-a",
+		"bootstrap_prompt": "bp",
+		"ttl_seconds":      -1,
+		"task": map[string]any{
+			"title": "T", "goal": "G", "next_steps": []any{"s"},
+		},
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("negative ttl: status = %d, want 400", resp.StatusCode)
+	}
+}
+
+// ─── 25. TestHandoffOffer_CallerSuppliedIDRejected ───────────────────────────
+//
+// Design-doc divergence fix: the kernel ALWAYS mints the handoff_id. A
+// caller-supplied one is a 400 — this prevents malformed IDs landing in
+// path-based claim/complete routes.
+func TestHandoffOffer_CallerSuppliedIDRejected(t *testing.T) {
+	t.Parallel()
+	_, ts := newSessionsTestServer(t)
+
+	resp := postJSON(t, ts.URL+"/v1/handoffs/offer", map[string]any{
+		"handoff_id":       "callersupplied-12345",
+		"from_session":     "caller-id-offer-a",
+		"bootstrap_prompt": "bp",
+		"task": map[string]any{
+			"title": "T", "goal": "G", "next_steps": []any{"s"},
+		},
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("caller-supplied id: status = %d, want 400", resp.StatusCode)
+	}
+}
+
+// ─── 26. TestRoutes_PresenceDoesNotShadowContext ─────────────────────────────
+//
+// Route-coexistence proof: POST /v1/sessions/register, GET
+// /v1/sessions/presence, and the legacy GET /v1/sessions/{id}/context all
+// coexist on the same mux. Fire them back-to-back and check each returns
+// its expected semantics without cross-contamination.
+func TestRoutes_PresenceDoesNotShadowContext(t *testing.T) {
+	t.Parallel()
+	_, ts := newSessionsTestServer(t)
+
+	// 1. Register a session on the new route.
+	reg := postJSON(t, ts.URL+"/v1/sessions/register", map[string]any{
+		"session_id": "route-coexist-session", "workspace": "w", "role": "r",
+	})
+	reg.Body.Close()
+	if reg.StatusCode != http.StatusOK {
+		t.Fatalf("register: %d", reg.StatusCode)
+	}
+
+	// 2. GET /v1/sessions/presence — the new route.
+	respP, err := http.Get(ts.URL + "/v1/sessions/presence")
+	if err != nil {
+		t.Fatalf("GET presence: %v", err)
+	}
+	respP.Body.Close()
+	if respP.StatusCode != http.StatusOK {
+		t.Errorf("presence: %d, want 200", respP.StatusCode)
+	}
+
+	// 3. GET /v1/sessions/{id}/context — the legacy TAA-inference route
+	//    registered by serve_bus.go / serve_sessions.go. This should still
+	//    resolve to the legacy handler even though /presence sits on the
+	//    same prefix. Expect 404 for an unknown session (context store is
+	//    independent of the kernel-native registry) — the important thing
+	//    is the handler RESPONDS rather than the path being shadowed by
+	//    /presence.
+	respC, err := http.Get(ts.URL + "/v1/sessions/route-coexist-session/context")
+	if err != nil {
+		t.Fatalf("GET context: %v", err)
+	}
+	defer respC.Body.Close()
+	if respC.StatusCode >= 500 {
+		t.Errorf("context route shadowed/broken: status = %d", respC.StatusCode)
+	}
+	// Accept any 2xx/4xx — the legacy context handler has its own body
+	// format; we're only proving the route is still dispatched to it.
+}
+
+// writeBusLinesForTest writes hash-chained BusBlocks to the events file in
+// the slice's order, computing each block's Hash so that ReadEvents will
+// parse them. Used by replay tests that need to plant deliberately-
+// out-of-order or duplicate-seq lines on disk.
+func writeBusLinesForTest(t *testing.T, path string, evts []BusBlock) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer f.Close()
+	for i := range evts {
+		evts[i].V = 2
+		evts[i].Hash = computeBusBlockHash(&evts[i])
+		line, err := json.Marshal(&evts[i])
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if _, err := f.Write(append(line, '\n')); err != nil {
+			t.Fatalf("write: %v", err)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Closes **Agent F gap #3 (session management, CRITICAL)** — the last of the eight critical MCP surface gaps. Implements the hybrid design from [Agent P's survey](cog://mem/semantic/surveys/2026-04-21-consolidation/agent-P-session-management-evaluation) with four user-approved amendments (scope reduction; see below).

The kernel now owns session/handoff invariants (id-format validation, lifecycle state machine, atomic first-wins claim, TTL enforcement, presence aggregation). The Python bridge (on a paired local branch, not pushed) keeps the same MCP signatures but shims over the new kernel routes. Two MCP surfaces coexist by design — `cogos_*` bridge tools for current clients, `cog_*` native tools for future ones — both hitting the same kernel truth.

## Amendments vs the survey

1. **No parallel coexistence** (dropped Open Question #1). All consumers are in-tree, atomic migration.
2. **Idempotent register = update-semantics** (Open Question #2).
3. **`handoff.claim_rejected` event** emitted on every rejected claim (`reason` ∈ `already_claimed | ttl_expired | offer_not_found | out_of_order` + `attempting_session` + `conflicting_session`). Big audit value for cheap.
4. **Two MCP surfaces coexist** — documented in `HANDOFF_PROTOCOL.md` v0.2.

Budget was ~10h (vs the survey's 14-18h — saved by dropping the coexistence ceremony).

## What lands

### Kernel

| File | Purpose | LOC |
|---|---|---|
| `internal/engine/sessions.go` | Typed registries, validation, replay-from-bus | ~530 |
| `internal/engine/serve_sessions_mgmt.go` | 8 HTTP handlers | ~360 |
| `internal/engine/mcp_sessions.go` | 8 `cog_*` MCP tool wrappers | ~400 |
| `internal/engine/sessions_test.go` | 15 unit + integration tests | ~600 |
| `internal/engine/{serve,serve_mcp,mcp_server}.go` | Wiring (registries, MCP backend setter, route registration) | ~+45 |

**New HTTP routes:**
```
POST /v1/sessions/register
POST /v1/sessions/{id}/heartbeat
POST /v1/sessions/{id}/end
GET  /v1/sessions/presence            (?active_within_seconds, ?include_ended)

POST /v1/handoffs/offer
GET  /v1/handoffs                     (?state, ?for_session)
POST /v1/handoffs/{id}/claim
POST /v1/handoffs/{id}/complete
```

Existing `/v1/sessions` (TAA inference context, regression-locked) is untouched. Go 1.22 method-aware routing resolves `POST /v1/sessions/register` before the `GET /v1/sessions/{id}` catch-all.

**New MCP tools:** `cog_register_session`, `cog_heartbeat_session`, `cog_end_session`, `cog_list_sessions`, `cog_offer_handoff`, `cog_list_handoffs`, `cog_claim_handoff`, `cog_complete_handoff`.

### Bridge (local branch only — NOT pushed)

Paired branch `feat/sessions-kernel-native-bridge` on `chazmaniandinkle/cog-sandbox-mcp`. Refactors the 8 `cogos_*` tools to POST to the new kernel routes instead of `/v1/bus/send`. MCP signatures unchanged; never-raise `{"success": False, "error": ..., "bus_id": ...}` envelope preserved; back-compat `handoff_id + emit_result` / `claim_emitted + offer` shapes preserved.

Also updates `docs/HANDOFF_PROTOCOL.md` to v0.2 (two MCP surfaces, atomic claim, `claim_rejected` event).

## Test coverage

- **15 new Go tests** in `sessions_test.go`, all green under `-race`:
  - `TestSessionRegister_ValidID` — happy path
  - `TestSessionRegister_InvalidFormat` — regex rejects malformed IDs
  - `TestSessionRegister_ReRegistration` — idempotent update semantics
  - `TestHeartbeat_UnknownSession` → 404
  - `TestEnd_UnknownSession` → 404
  - `TestEnd_AlreadyEnded` → 409
  - `TestPresence_ActiveWindow` — stale heartbeat marked inactive
  - `TestHandoffOffer_MissingTaskFields` → 400 (3 shapes)
  - `TestHandoffClaim_Atomicity` — 8 concurrent claimants, exactly 1 win / 7 × 409, each emits a `claim_rejected` event
  - `TestHandoffClaim_TTLExpired` → 409
  - `TestHandoffClaim_PhantomOffer` → 404 + `claim_rejected/offer_not_found` event
  - `TestHandoffComplete_WithoutClaim` → 409
  - `TestReplayOnStartup` — fresh Server rebuilds state from bus
  - `TestClaimRejectedEventEmitted` — payload fields (amendment #4)
  - `TestMCP_HandoffRoundTrip` — full register → offer → claim → complete through the MCP tool handlers
- **Full `internal/engine` suite** remains green under `-race -count=1`.
- **Bridge**: 16 new unit tests in `tests/test_session_handoff.py` (monkeypatched HTTP); full bridge suite 77/77 passing.

## End-to-end smoke

Build: `go build -o /tmp/cogos-v3-sessions ./cmd/cogos/`

Ephemeral kernel on port 6932 (not 6931 — running production kernel untouched throughout):

```
register src → ok seq=1
register dst → ok
heartbeat src (context_usage=0.55) → ok
offer       → handoff_id=ho-1776860339550-f371b69c89f2
list state=open → 1 entry
claim (dst) → ok, offer.bootstrap_prompt returned
claim (other) → HTTP 409 "already_claimed", claim_rejected event on bus
complete    → handoff.state=completed
```

bus_sessions chain: 3 events. bus_handoffs chain: 4 events — offer, claim, claim_rejected, complete. Bridge tools against the same kernel exercised every path and preserved back-compat response shapes.

## Invariants held

- No restart of the running kernel (PID 53761, port 6931) during development.
- `/v1/sessions/{id}/context` (TAA inference context) untouched.
- `/v1/bus/*` byte-compat preserved (regression tests still green).
- No `Co-Authored-By` trailers.
- No push of the bridge branch to origin.

## Reference

Agent P's survey (canonical design): `cog://mem/semantic/surveys/2026-04-21-consolidation/agent-P-session-management-evaluation`

## Test plan

- [x] `go build ./...` silent
- [x] `go vet ./...` silent
- [x] `go test ./internal/engine/... -short -race -count=1` green
- [x] End-to-end smoke against ephemeral :6932 kernel
- [x] Bridge tests green on local branch (77 passing)
- [x] Running :6931 kernel untouched