### PR TITLE
feat(identity): Identity CRD + IdentityProvider reconciler (Wave 6a)

### DIFF
--- a/identity_crd.go
+++ b/identity_crd.go
@@ -44,18 +44,34 @@ type IdentityCRDMeta struct {
 
 // IdentityCRDSpec holds the OIDC-shaped identity body.
 //
-//	Issuer   — OIDC `iss`; who minted this identity (e.g., "cogos-dev",
-//	           "https://accounts.google.com", "node:<hostname>", or a
-//	           federation URL). Required.
-//	Subject  — OIDC `sub`; globally stable identifier for the principal.
-//	           Required. Conventionally matches metadata.name for
-//	           self-minted identities, but may differ for federated ones.
-//	Type     — agent | human | service. Governs downstream semantics
-//	           (e.g., humans don't need presence expectation heartbeats).
-//	PublicKey — optional PEM-encoded public key. When present, the
-//	            reconciler records it for signature-verified attestations.
-//	            Layer-1 node keys live separately in the constellation
-//	            repo — this is Layer-2 principal identity.
+//	Issuer     — OIDC `iss`; who minted this identity (e.g., "cogos-dev",
+//	             "https://accounts.google.com", "node:<hostname>", or a
+//	             federation URL). Required.
+//	Subject    — OIDC `sub`; globally stable identifier for the principal.
+//	             Required. Conventionally matches metadata.name for
+//	             self-minted identities, but may differ for federated ones.
+//	Type       — agent | human | service. Governs downstream semantics
+//	             (e.g., humans don't need presence expectation heartbeats).
+//	PublicKey  — optional PEM-encoded public key. Inlined because the public
+//	             half is not secret; committing it to the manifest is the
+//	             point. When present, the reconciler records it for
+//	             signature-verified attestations. Layer-1 node keys live
+//	             separately in the constellation repo — this is Layer-2
+//	             principal identity.
+//	PrivateKey — optional reference to the private-key material. The ref
+//	             URI is location-independent (file://, vault://, s3://,
+//	             keychain://, env://, etc.) and is paired with an integrity
+//	             hash. Moving the key between storage media keeps the
+//	             identity stable as long as the hash matches — the
+//	             cryptographic material itself is the identity, its
+//	             location is ephemeral.
+//	AuthFactors — optional multi-factor requirements for operations that
+//	              modify this identity (apply, deregister). The reconciler
+//	              is the enforcement point because it is the source of
+//	              truth; everything downstream trusts its output. Evaluated
+//	              at ApplyPlan, not at read-time. (Wiring this to real
+//	              MFA providers is a later wave — the field is declared
+//	              now so the schema is stable.)
 //	Expressions — how this identity is projected into audiences. The
 //	              reconciler's "collapse operation" picks the entry whose
 //	              aud matches the current context.
@@ -64,7 +80,66 @@ type IdentityCRDSpec struct {
 	Subject     string               `yaml:"sub"`
 	Type        string               `yaml:"type"`
 	PublicKey   string               `yaml:"public_key,omitempty"`
+	PrivateKey  *KeyRef              `yaml:"private_key,omitempty"`
+	AuthFactors []AuthFactor         `yaml:"auth_factors,omitempty"`
 	Expressions []IdentityExpression `yaml:"expressions"`
+}
+
+// KeyRef points at key material stored outside the manifest. The ref is
+// resolved at ApplyPlan time through a pluggable KeyResolver (see
+// identity_provider.go); IntegrityHash is verified after resolution. If
+// the bytes at `ref` ever hash to a different value, the reconciler
+// refuses to apply and surfaces the mismatch in Health.
+//
+// Supported ref URI schemes (extensible — each registered with the
+// provider's KeyResolver):
+//
+//	file://<absolute-path>           — plain-PEM file on disk
+//	vault://<path>                   — HashiCorp Vault secret path
+//	s3://<bucket>/<key>              — S3 object
+//	keychain://<service>/<account>   — macOS keychain entry
+//	env://<VAR_NAME>                 — environment variable (dev only)
+//	kms://<provider>/<arn>           — cloud KMS reference
+//	inline://pem                     — base64 bytes inline (testing; avoid)
+//
+// IntegrityHash is `<algo>:<hex>` (e.g., "sha256:a1b2..."). The reconciler
+// enforces algo ∈ {sha256, sha512}.
+type KeyRef struct {
+	Ref           string `yaml:"ref"`
+	IntegrityHash string `yaml:"integrity_hash"`
+}
+
+// AuthFactor declares a multi-factor requirement. At least one factor per
+// entry must be satisfied (OR semantics within an entry); each entry in
+// the AuthFactors slice adds an AND requirement (entry1 AND entry2 AND …).
+// Example: require either TOTP or a hardware key, AND also require a
+// signed challenge from the Layer-1 node:
+//
+//	auth_factors:
+//	  - kind: any-of
+//	    factors:
+//	      - type: totp
+//	        ref: vault://secret/cogos/identities/cog/totp-seed
+//	      - type: webauthn
+//	        ref: keychain://cogos/cog-yubikey
+//	  - kind: required
+//	    factors:
+//	      - type: node-signed-challenge
+//	        ref: ""  # uses the current node's Layer-1 key
+//
+// The schema is declared now so manifests are stable; enforcement
+// (prompting/verifying the factor) is a follow-up wave.
+type AuthFactor struct {
+	Kind    string            `yaml:"kind"` // "required" | "any-of"
+	Factors []AuthFactorEntry `yaml:"factors"`
+}
+
+// AuthFactorEntry is one factor within an AuthFactor group.
+type AuthFactorEntry struct {
+	Type string `yaml:"type"` // totp | webauthn | node-signed-challenge | oidc-step-up | ...
+	Ref  string `yaml:"ref,omitempty"`
+	// Claims carries factor-specific config (e.g., TOTP period, WebAuthn RP ID).
+	Claims map[string]any `yaml:"claims,omitempty"`
 }
 
 // IdentityExpression is one projection of an identity into a specific audience.
@@ -217,7 +292,128 @@ func validateIdentityCRD(crd *IdentityCRD) error {
 		}
 		seenAud[exp.Audience] = struct{}{}
 	}
+	if err := validateKeyRef(crd.Spec.PrivateKey, "spec.private_key"); err != nil {
+		return err
+	}
+	for i, factor := range crd.Spec.AuthFactors {
+		if err := validateAuthFactor(&factor, fmt.Sprintf("spec.auth_factors[%d]", i)); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+// validateKeyRef enforces the structural invariants on a key reference.
+// Nil is valid (optional field). When present, both ref and integrity_hash
+// are required, the ref must have a recognized scheme, and the hash must
+// be a known algorithm.
+func validateKeyRef(k *KeyRef, path string) error {
+	if k == nil {
+		return nil
+	}
+	if strings.TrimSpace(k.Ref) == "" {
+		return fmt.Errorf("%s.ref is required when private_key is set", path)
+	}
+	scheme, ok := parseKeyRefScheme(k.Ref)
+	if !ok {
+		return fmt.Errorf("%s.ref = %q: expected scheme://... (one of: %s)",
+			path, k.Ref, strings.Join(knownKeyRefSchemes(), ", "))
+	}
+	if _, allowed := allowedKeyRefSchemes[scheme]; !allowed {
+		return fmt.Errorf("%s.ref scheme %q is not recognized; allowed: %s",
+			path, scheme, strings.Join(knownKeyRefSchemes(), ", "))
+	}
+	if strings.TrimSpace(k.IntegrityHash) == "" {
+		return fmt.Errorf("%s.integrity_hash is required when private_key is set", path)
+	}
+	algo, _, ok := strings.Cut(k.IntegrityHash, ":")
+	if !ok {
+		return fmt.Errorf("%s.integrity_hash = %q: expected \"<algo>:<hex>\"", path, k.IntegrityHash)
+	}
+	if _, allowed := allowedHashAlgos[algo]; !allowed {
+		return fmt.Errorf("%s.integrity_hash algo %q not allowed; allowed: sha256, sha512", path, algo)
+	}
+	return nil
+}
+
+// validateAuthFactor enforces the structural invariants on an auth-factor
+// group. Each group must have a kind and at least one factor entry.
+func validateAuthFactor(f *AuthFactor, path string) error {
+	if f == nil {
+		return nil
+	}
+	if _, ok := validAuthFactorKinds[f.Kind]; !ok {
+		return fmt.Errorf("%s.kind = %q, want one of {required, any-of}", path, f.Kind)
+	}
+	if len(f.Factors) == 0 {
+		return fmt.Errorf("%s.factors must contain at least one entry", path)
+	}
+	for i, entry := range f.Factors {
+		if strings.TrimSpace(entry.Type) == "" {
+			return fmt.Errorf("%s.factors[%d].type is required", path, i)
+		}
+	}
+	return nil
+}
+
+// parseKeyRefScheme extracts the scheme from a ref URI. Returns (scheme, true)
+// on success. Does not validate that the scheme is allowed — that's a
+// separate check so the error message can distinguish "malformed URI" from
+// "scheme not recognized."
+func parseKeyRefScheme(ref string) (string, bool) {
+	idx := strings.Index(ref, "://")
+	if idx <= 0 {
+		return "", false
+	}
+	return ref[:idx], true
+}
+
+// knownKeyRefSchemes returns a sorted slice of allowed schemes for error
+// messages. The allow-list is declared so downstream provider code can
+// implement resolvers with predictable coverage.
+func knownKeyRefSchemes() []string {
+	out := make([]string, 0, len(allowedKeyRefSchemes))
+	for s := range allowedKeyRefSchemes {
+		out = append(out, s)
+	}
+	// Sort for deterministic error messages.
+	sortStrings(out)
+	return out
+}
+
+// Known schemes for KeyRef.Ref. New schemes are added here as resolvers
+// are implemented in identity_provider.go.
+var allowedKeyRefSchemes = map[string]struct{}{
+	"file":     {},
+	"vault":    {},
+	"s3":       {},
+	"keychain": {},
+	"env":      {},
+	"kms":      {},
+	"inline":   {},
+}
+
+// Allowed integrity-hash algorithms.
+var allowedHashAlgos = map[string]struct{}{
+	"sha256": {},
+	"sha512": {},
+}
+
+// Allowed AuthFactor.Kind values.
+var validAuthFactorKinds = map[string]struct{}{
+	"required": {},
+	"any-of":   {},
+}
+
+// sortStrings is a tiny stable-sort helper so identity_crd.go does not
+// have to import "sort" just for the error-message path. Insertion sort
+// is fine at len ≤ ~10.
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j-1] > s[j]; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
 }
 
 // ─── Collapse Operation ─────────────────────────────────────────────────────────

--- a/identity_crd.go
+++ b/identity_crd.go
@@ -1,0 +1,246 @@
+// identity_crd.go
+// Loads Identity CRD definitions from .cog/config/identities/*.yaml.
+//
+// Identity is a CRD managed by the CogOS reconciliation loop (pkg/reconcile).
+// The spec on disk is one leg of the (Spec, Projections, Reconciler) triple
+// that defines an identity at runtime — see
+// project_cogos_identity_as_crd.md in user memory for the architecture.
+//
+// Shape is OIDC-compatible: each identity has a stable (iss, sub) anchor and
+// a list of expressions keyed by audience (workspace, channel, resource).
+// The reconciler picks the expression matching the current audience when
+// projecting — that's the "collapse operation" that maps global identity
+// down to its contextual local expression.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ─── CRD Types ──────────────────────────────────────────────────────────────────
+
+// IdentityCRD is the top-level Kubernetes-style identity definition.
+type IdentityCRD struct {
+	APIVersion string          `yaml:"apiVersion"`
+	Kind       string          `yaml:"kind"`
+	Metadata   IdentityCRDMeta `yaml:"metadata"`
+	Spec       IdentityCRDSpec `yaml:"spec"`
+}
+
+// IdentityCRDMeta matches the standard CRD metadata shape.
+type IdentityCRDMeta struct {
+	Name        string            `yaml:"name"`
+	Namespace   string            `yaml:"namespace,omitempty"`
+	Labels      map[string]string `yaml:"labels,omitempty"`
+	Annotations map[string]string `yaml:"annotations,omitempty"`
+}
+
+// IdentityCRDSpec holds the OIDC-shaped identity body.
+//
+//	Issuer   — OIDC `iss`; who minted this identity (e.g., "cogos-dev",
+//	           "https://accounts.google.com", "node:<hostname>", or a
+//	           federation URL). Required.
+//	Subject  — OIDC `sub`; globally stable identifier for the principal.
+//	           Required. Conventionally matches metadata.name for
+//	           self-minted identities, but may differ for federated ones.
+//	Type     — agent | human | service. Governs downstream semantics
+//	           (e.g., humans don't need presence expectation heartbeats).
+//	PublicKey — optional PEM-encoded public key. When present, the
+//	            reconciler records it for signature-verified attestations.
+//	            Layer-1 node keys live separately in the constellation
+//	            repo — this is Layer-2 principal identity.
+//	Expressions — how this identity is projected into audiences. The
+//	              reconciler's "collapse operation" picks the entry whose
+//	              aud matches the current context.
+type IdentityCRDSpec struct {
+	Issuer      string               `yaml:"iss"`
+	Subject     string               `yaml:"sub"`
+	Type        string               `yaml:"type"`
+	PublicKey   string               `yaml:"public_key,omitempty"`
+	Expressions []IdentityExpression `yaml:"expressions"`
+}
+
+// IdentityExpression is one projection of an identity into a specific audience.
+// At least one expression per Identity. The reconciler matches by `aud`:
+//
+//	workspace:<name>     — project into a workspace's view
+//	channel:<channel_id> — project into a specific channel (mod3 room, etc.)
+//	resource:<uri>       — project against an arbitrary cog:// URI
+//	*                    — catch-all (used as fallback when no audience matches)
+type IdentityExpression struct {
+	Audience    string   `yaml:"aud"`
+	DisplayName string   `yaml:"display_name,omitempty"`
+	Role        string   `yaml:"role,omitempty"`
+	Skills      []string `yaml:"skills,omitempty"`
+	Voice       string   `yaml:"voice,omitempty"`
+	Sudo        bool     `yaml:"sudo,omitempty"`
+	// MemoryNamespace optionally scopes this expression's memory reads/writes
+	// (e.g., "cog://" for root, "cog://agents/sandy/" for a scoped agent).
+	MemoryNamespace string `yaml:"memory_namespace,omitempty"`
+	// Claims is an OIDC-style free-form claim bag. The reconciler preserves
+	// unknown claims verbatim — future tooling can read them without the
+	// spec needing a schema bump.
+	Claims map[string]any `yaml:"claims,omitempty"`
+}
+
+// Valid identity types accepted by the loader.
+var validIdentityTypes = map[string]struct{}{
+	"agent":   {},
+	"human":   {},
+	"service": {},
+}
+
+// Valid apiVersion/kind — validated on load to catch typos early.
+const (
+	IdentityAPIVersion = "cog.os/v1alpha1"
+	IdentityKind       = "Identity"
+)
+
+// ─── Loader ─────────────────────────────────────────────────────────────────────
+
+// identityCRDDir returns the path to the identity definitions directory.
+// Matches the `.cog/config/<provider>/` convention used by services.
+func identityCRDDir(root string) string {
+	return filepath.Join(root, ".cog", "config", "identities")
+}
+
+// LoadIdentityCRD loads a single identity CRD by subject slug.
+// Looks for {root}/.cog/config/identities/{sub}.yaml.
+func LoadIdentityCRD(root, sub string) (*IdentityCRD, error) {
+	if sub == "" {
+		return nil, errors.New("load identity CRD: empty subject")
+	}
+	path := filepath.Join(identityCRDDir(root), sub+".yaml")
+	return loadIdentityCRDFile(path)
+}
+
+// LoadIdentityCRDs loads every identity CRD under
+// {root}/.cog/config/identities/*.yaml. Returns an empty slice (not an
+// error) when the directory does not exist — identity is optional.
+//
+// The returned slice is deterministically ordered by filename so plan
+// diffs stay stable.
+func LoadIdentityCRDs(root string) ([]*IdentityCRD, error) {
+	dir := identityCRDDir(root)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read identities dir %q: %w", dir, err)
+	}
+
+	var out []*IdentityCRD
+	var loadErrs []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".yaml") && !strings.HasSuffix(name, ".yml") {
+			continue
+		}
+		crd, err := loadIdentityCRDFile(filepath.Join(dir, name))
+		if err != nil {
+			loadErrs = append(loadErrs, fmt.Sprintf("%s: %v", name, err))
+			continue
+		}
+		out = append(out, crd)
+	}
+
+	if len(loadErrs) > 0 {
+		return out, fmt.Errorf("load identities: %d error(s): %s",
+			len(loadErrs), strings.Join(loadErrs, "; "))
+	}
+	return out, nil
+}
+
+// loadIdentityCRDFile reads + parses + validates one CRD file.
+func loadIdentityCRDFile(path string) (*IdentityCRD, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %q: %w", path, err)
+	}
+
+	var crd IdentityCRD
+	if err := yaml.Unmarshal(data, &crd); err != nil {
+		return nil, fmt.Errorf("parse %q: %w", path, err)
+	}
+
+	if err := validateIdentityCRD(&crd); err != nil {
+		return nil, fmt.Errorf("validate %q: %w", path, err)
+	}
+	return &crd, nil
+}
+
+// validateIdentityCRD enforces the invariants the reconciler depends on.
+// Fail fast at load time so the plan/apply loop never sees malformed specs.
+func validateIdentityCRD(crd *IdentityCRD) error {
+	if crd == nil {
+		return errors.New("nil CRD")
+	}
+	if crd.APIVersion != IdentityAPIVersion {
+		return fmt.Errorf("apiVersion = %q, want %q", crd.APIVersion, IdentityAPIVersion)
+	}
+	if crd.Kind != IdentityKind {
+		return fmt.Errorf("kind = %q, want %q", crd.Kind, IdentityKind)
+	}
+	if strings.TrimSpace(crd.Metadata.Name) == "" {
+		return errors.New("metadata.name is required")
+	}
+	if strings.TrimSpace(crd.Spec.Issuer) == "" {
+		return errors.New("spec.iss is required")
+	}
+	if strings.TrimSpace(crd.Spec.Subject) == "" {
+		return errors.New("spec.sub is required")
+	}
+	if _, ok := validIdentityTypes[crd.Spec.Type]; !ok {
+		return fmt.Errorf("spec.type = %q, want one of {agent, human, service}", crd.Spec.Type)
+	}
+	if len(crd.Spec.Expressions) == 0 {
+		return errors.New("spec.expressions must contain at least one entry")
+	}
+	seenAud := make(map[string]struct{}, len(crd.Spec.Expressions))
+	for i, exp := range crd.Spec.Expressions {
+		if strings.TrimSpace(exp.Audience) == "" {
+			return fmt.Errorf("spec.expressions[%d].aud is required", i)
+		}
+		if _, dup := seenAud[exp.Audience]; dup {
+			return fmt.Errorf("spec.expressions[%d].aud = %q is duplicated; each audience must appear at most once", i, exp.Audience)
+		}
+		seenAud[exp.Audience] = struct{}{}
+	}
+	return nil
+}
+
+// ─── Collapse Operation ─────────────────────────────────────────────────────────
+
+// ExpressionFor returns the expression matching `aud`, or the catch-all `*`
+// expression when no exact match exists. Returns nil when neither is present.
+// This is the "collapse operation" — global identity collapsing down to a
+// local expression based on the caller's context. Pure function; the
+// reconciler calls it both at ComputePlan (to decide what to project) and
+// at runtime (to resolve an identity's contextual view for a tool call).
+func (s *IdentityCRDSpec) ExpressionFor(aud string) *IdentityExpression {
+	if s == nil {
+		return nil
+	}
+	var wildcard *IdentityExpression
+	for i := range s.Expressions {
+		exp := &s.Expressions[i]
+		if exp.Audience == aud {
+			return exp
+		}
+		if exp.Audience == "*" && wildcard == nil {
+			wildcard = exp
+		}
+	}
+	return wildcard
+}

--- a/identity_crd_test.go
+++ b/identity_crd_test.go
@@ -1,0 +1,334 @@
+// identity_crd_test.go
+// Covers: CRD YAML parsing, validation invariants, LoadIdentityCRDs
+// directory enumeration, and the ExpressionFor collapse operation.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// ─── YAML parsing + validation ──────────────────────────────────────────────────
+
+const minimalValidIdentityYAML = `
+apiVersion: cog.os/v1alpha1
+kind: Identity
+metadata:
+  name: cog
+spec:
+  iss: cogos-dev
+  sub: cog-pattern
+  type: agent
+  expressions:
+    - aud: workspace:cog-workspace
+      display_name: "Cog — Workspace Guardian"
+`
+
+func writeTempCRD(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+func TestLoadIdentityCRD_MinimalValid(t *testing.T) {
+	dir := t.TempDir()
+	idDir := filepath.Join(dir, ".cog", "config", "identities")
+	if err := os.MkdirAll(idDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeTempCRD(t, idDir, "cog.yaml", minimalValidIdentityYAML)
+
+	crd, err := LoadIdentityCRD(dir, "cog")
+	if err != nil {
+		t.Fatalf("LoadIdentityCRD: %v", err)
+	}
+	if crd.APIVersion != IdentityAPIVersion {
+		t.Errorf("APIVersion = %q, want %q", crd.APIVersion, IdentityAPIVersion)
+	}
+	if crd.Spec.Issuer != "cogos-dev" {
+		t.Errorf("iss = %q", crd.Spec.Issuer)
+	}
+	if crd.Spec.Subject != "cog-pattern" {
+		t.Errorf("sub = %q", crd.Spec.Subject)
+	}
+	if len(crd.Spec.Expressions) != 1 {
+		t.Fatalf("expressions len = %d, want 1", len(crd.Spec.Expressions))
+	}
+	if crd.Spec.Expressions[0].Audience != "workspace:cog-workspace" {
+		t.Errorf("aud = %q", crd.Spec.Expressions[0].Audience)
+	}
+}
+
+func TestLoadIdentityCRD_RejectsBadKind(t *testing.T) {
+	dir := t.TempDir()
+	idDir := filepath.Join(dir, ".cog", "config", "identities")
+	_ = os.MkdirAll(idDir, 0o755)
+	writeTempCRD(t, idDir, "bad.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: Widget
+metadata:
+  name: bad
+spec:
+  iss: cogos-dev
+  sub: bad
+  type: agent
+  expressions:
+    - aud: "*"
+`)
+	if _, err := LoadIdentityCRD(dir, "bad"); err == nil {
+		t.Fatal("expected error for wrong kind, got nil")
+	}
+}
+
+func TestLoadIdentityCRD_RejectsMissingIssOrSub(t *testing.T) {
+	cases := map[string]string{
+		"missing iss": `
+apiVersion: cog.os/v1alpha1
+kind: Identity
+metadata:
+  name: x
+spec:
+  sub: x
+  type: agent
+  expressions:
+    - aud: "*"
+`,
+		"missing sub": `
+apiVersion: cog.os/v1alpha1
+kind: Identity
+metadata:
+  name: x
+spec:
+  iss: cogos-dev
+  type: agent
+  expressions:
+    - aud: "*"
+`,
+	}
+	for label, body := range cases {
+		t.Run(label, func(t *testing.T) {
+			dir := t.TempDir()
+			idDir := filepath.Join(dir, ".cog", "config", "identities")
+			_ = os.MkdirAll(idDir, 0o755)
+			writeTempCRD(t, idDir, "x.yaml", body)
+			if _, err := LoadIdentityCRD(dir, "x"); err == nil {
+				t.Fatalf("expected error for %s, got nil", label)
+			}
+		})
+	}
+}
+
+func TestLoadIdentityCRD_RejectsBadType(t *testing.T) {
+	dir := t.TempDir()
+	idDir := filepath.Join(dir, ".cog", "config", "identities")
+	_ = os.MkdirAll(idDir, 0o755)
+	writeTempCRD(t, idDir, "x.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: Identity
+metadata:
+  name: x
+spec:
+  iss: cogos-dev
+  sub: x
+  type: robot
+  expressions:
+    - aud: "*"
+`)
+	if _, err := LoadIdentityCRD(dir, "x"); err == nil {
+		t.Fatal("expected error for bad type, got nil")
+	}
+}
+
+func TestLoadIdentityCRD_RejectsEmptyExpressions(t *testing.T) {
+	dir := t.TempDir()
+	idDir := filepath.Join(dir, ".cog", "config", "identities")
+	_ = os.MkdirAll(idDir, 0o755)
+	writeTempCRD(t, idDir, "x.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: Identity
+metadata:
+  name: x
+spec:
+  iss: cogos-dev
+  sub: x
+  type: agent
+  expressions: []
+`)
+	if _, err := LoadIdentityCRD(dir, "x"); err == nil {
+		t.Fatal("expected error for empty expressions, got nil")
+	}
+}
+
+func TestLoadIdentityCRD_RejectsDuplicateAudience(t *testing.T) {
+	dir := t.TempDir()
+	idDir := filepath.Join(dir, ".cog", "config", "identities")
+	_ = os.MkdirAll(idDir, 0o755)
+	writeTempCRD(t, idDir, "x.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: Identity
+metadata:
+  name: x
+spec:
+  iss: cogos-dev
+  sub: x
+  type: agent
+  expressions:
+    - aud: workspace:foo
+      display_name: first
+    - aud: workspace:foo
+      display_name: second
+`)
+	if _, err := LoadIdentityCRD(dir, "x"); err == nil {
+		t.Fatal("expected error for duplicate aud, got nil")
+	}
+}
+
+// ─── Directory enumeration ──────────────────────────────────────────────────────
+
+func TestLoadIdentityCRDs_EmptyWhenDirMissing(t *testing.T) {
+	out, err := LoadIdentityCRDs(t.TempDir())
+	if err != nil {
+		t.Fatalf("LoadIdentityCRDs: %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("expected empty slice, got %d entries", len(out))
+	}
+}
+
+func TestLoadIdentityCRDs_MultipleFiles(t *testing.T) {
+	dir := t.TempDir()
+	idDir := filepath.Join(dir, ".cog", "config", "identities")
+	_ = os.MkdirAll(idDir, 0o755)
+
+	writeTempCRD(t, idDir, "cog.yaml", minimalValidIdentityYAML)
+	writeTempCRD(t, idDir, "sandy.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: Identity
+metadata:
+  name: sandy
+spec:
+  iss: cogos-dev
+  sub: sandy
+  type: agent
+  expressions:
+    - aud: workspace:cog-workspace
+      display_name: "Sandy — Lab Engineer"
+`)
+	// A .yml alias should also be picked up.
+	writeTempCRD(t, idDir, "chaz.yml", `
+apiVersion: cog.os/v1alpha1
+kind: Identity
+metadata:
+  name: chaz
+spec:
+  iss: cogos-dev
+  sub: chaz
+  type: human
+  expressions:
+    - aud: "*"
+      display_name: Chaz
+`)
+	// A non-yaml file should be ignored.
+	writeTempCRD(t, idDir, "README.md", "# ignore me\n")
+
+	out, err := LoadIdentityCRDs(dir)
+	if err != nil {
+		t.Fatalf("LoadIdentityCRDs: %v", err)
+	}
+	if len(out) != 3 {
+		t.Fatalf("got %d CRDs, want 3", len(out))
+	}
+	// Deterministic order (sorted by filename).
+	wantOrder := []string{"chaz", "cog", "sandy"}
+	for i, crd := range out {
+		if crd.Metadata.Name != wantOrder[i] {
+			t.Errorf("out[%d].Name = %q, want %q", i, crd.Metadata.Name, wantOrder[i])
+		}
+	}
+}
+
+func TestLoadIdentityCRDs_CollectsErrorsContinuesLoading(t *testing.T) {
+	dir := t.TempDir()
+	idDir := filepath.Join(dir, ".cog", "config", "identities")
+	_ = os.MkdirAll(idDir, 0o755)
+
+	writeTempCRD(t, idDir, "good.yaml", minimalValidIdentityYAML)
+	writeTempCRD(t, idDir, "bad.yaml", `apiVersion: cog.os/v1alpha1
+kind: Identity
+spec:
+  iss: cogos-dev
+`) // missing metadata.name, missing sub, missing type, empty expressions
+
+	out, err := LoadIdentityCRDs(dir)
+	if err == nil {
+		t.Fatal("expected error for bad.yaml, got nil")
+	}
+	if len(out) != 1 {
+		t.Errorf("expected 1 good CRD loaded, got %d", len(out))
+	}
+}
+
+// ─── Collapse operation (ExpressionFor) ─────────────────────────────────────────
+
+func TestExpressionFor_ExactMatch(t *testing.T) {
+	spec := &IdentityCRDSpec{
+		Expressions: []IdentityExpression{
+			{Audience: "workspace:a", DisplayName: "A"},
+			{Audience: "workspace:b", DisplayName: "B"},
+		},
+	}
+	got := spec.ExpressionFor("workspace:b")
+	if got == nil || got.DisplayName != "B" {
+		t.Fatalf("got %+v, want DisplayName=B", got)
+	}
+}
+
+func TestExpressionFor_WildcardFallback(t *testing.T) {
+	spec := &IdentityCRDSpec{
+		Expressions: []IdentityExpression{
+			{Audience: "workspace:a", DisplayName: "A"},
+			{Audience: "*", DisplayName: "Fallback"},
+		},
+	}
+	got := spec.ExpressionFor("channel:xyz")
+	if got == nil || got.DisplayName != "Fallback" {
+		t.Fatalf("got %+v, want DisplayName=Fallback", got)
+	}
+}
+
+func TestExpressionFor_ExactBeatsWildcard(t *testing.T) {
+	spec := &IdentityCRDSpec{
+		Expressions: []IdentityExpression{
+			{Audience: "*", DisplayName: "Fallback"},
+			{Audience: "workspace:a", DisplayName: "A"},
+		},
+	}
+	got := spec.ExpressionFor("workspace:a")
+	if got == nil || got.DisplayName != "A" {
+		t.Fatalf("got %+v, want DisplayName=A (exact should beat *)", got)
+	}
+}
+
+func TestExpressionFor_NoMatchNoWildcard(t *testing.T) {
+	spec := &IdentityCRDSpec{
+		Expressions: []IdentityExpression{
+			{Audience: "workspace:a", DisplayName: "A"},
+		},
+	}
+	got := spec.ExpressionFor("workspace:b")
+	if got != nil {
+		t.Fatalf("got %+v, want nil", got)
+	}
+}
+
+func TestExpressionFor_NilSpec(t *testing.T) {
+	var spec *IdentityCRDSpec
+	if got := spec.ExpressionFor("anything"); got != nil {
+		t.Errorf("nil spec should return nil, got %+v", got)
+	}
+}

--- a/identity_crd_test.go
+++ b/identity_crd_test.go
@@ -5,8 +5,10 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -330,5 +332,278 @@ func TestExpressionFor_NilSpec(t *testing.T) {
 	var spec *IdentityCRDSpec
 	if got := spec.ExpressionFor("anything"); got != nil {
 		t.Errorf("nil spec should return nil, got %+v", got)
+	}
+}
+
+// ─── KeyRef validation (spec.private_key) ───────────────────────────────────────
+
+func TestLoadIdentityCRD_PrivateKeyRef_ValidFileScheme(t *testing.T) {
+	dir := t.TempDir()
+	idDir := filepath.Join(dir, ".cog", "config", "identities")
+	_ = os.MkdirAll(idDir, 0o755)
+	writeTempCRD(t, idDir, "cog.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: Identity
+metadata:
+  name: cog
+spec:
+  iss: cogos-dev
+  sub: cog
+  type: agent
+  public_key: |-
+    -----BEGIN PUBLIC KEY-----
+    MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEstub...
+    -----END PUBLIC KEY-----
+  private_key:
+    ref: "file:///Users/slowbro/.cogos/keys/cog-priv.pem"
+    integrity_hash: "sha256:a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2"
+  expressions:
+    - aud: "*"
+      display_name: Cog
+`)
+	crd, err := LoadIdentityCRD(dir, "cog")
+	if err != nil {
+		t.Fatalf("LoadIdentityCRD: %v", err)
+	}
+	if crd.Spec.PrivateKey == nil {
+		t.Fatal("PrivateKey is nil; expected populated")
+	}
+	if crd.Spec.PrivateKey.Ref != "file:///Users/slowbro/.cogos/keys/cog-priv.pem" {
+		t.Errorf("Ref = %q", crd.Spec.PrivateKey.Ref)
+	}
+	if !strings.HasPrefix(crd.Spec.PrivateKey.IntegrityHash, "sha256:") {
+		t.Errorf("IntegrityHash = %q", crd.Spec.PrivateKey.IntegrityHash)
+	}
+}
+
+func TestLoadIdentityCRD_PrivateKeyRef_AllSchemes(t *testing.T) {
+	// Every scheme in allowedKeyRefSchemes should parse successfully.
+	for scheme := range allowedKeyRefSchemes {
+		t.Run(scheme, func(t *testing.T) {
+			dir := t.TempDir()
+			idDir := filepath.Join(dir, ".cog", "config", "identities")
+			_ = os.MkdirAll(idDir, 0o755)
+			ref := scheme + "://some/path"
+			writeTempCRD(t, idDir, "x.yaml", fmt.Sprintf(`
+apiVersion: cog.os/v1alpha1
+kind: Identity
+metadata:
+  name: x
+spec:
+  iss: cogos-dev
+  sub: x
+  type: agent
+  private_key:
+    ref: %q
+    integrity_hash: "sha256:deadbeef"
+  expressions:
+    - aud: "*"
+`, ref))
+			if _, err := LoadIdentityCRD(dir, "x"); err != nil {
+				t.Fatalf("scheme %q: %v", scheme, err)
+			}
+		})
+	}
+}
+
+func TestLoadIdentityCRD_PrivateKeyRef_RejectsUnknownScheme(t *testing.T) {
+	dir := t.TempDir()
+	idDir := filepath.Join(dir, ".cog", "config", "identities")
+	_ = os.MkdirAll(idDir, 0o755)
+	writeTempCRD(t, idDir, "x.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: Identity
+metadata:
+  name: x
+spec:
+  iss: cogos-dev
+  sub: x
+  type: agent
+  private_key:
+    ref: "ftp://legacy.example.com/key.pem"
+    integrity_hash: "sha256:deadbeef"
+  expressions:
+    - aud: "*"
+`)
+	if _, err := LoadIdentityCRD(dir, "x"); err == nil {
+		t.Fatal("expected error for unknown scheme, got nil")
+	}
+}
+
+func TestLoadIdentityCRD_PrivateKeyRef_RejectsMalformedURI(t *testing.T) {
+	dir := t.TempDir()
+	idDir := filepath.Join(dir, ".cog", "config", "identities")
+	_ = os.MkdirAll(idDir, 0o755)
+	writeTempCRD(t, idDir, "x.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: Identity
+metadata:
+  name: x
+spec:
+  iss: cogos-dev
+  sub: x
+  type: agent
+  private_key:
+    ref: "not-a-uri"
+    integrity_hash: "sha256:deadbeef"
+  expressions:
+    - aud: "*"
+`)
+	if _, err := LoadIdentityCRD(dir, "x"); err == nil {
+		t.Fatal("expected error for malformed ref, got nil")
+	}
+}
+
+func TestLoadIdentityCRD_PrivateKeyRef_RejectsMissingHash(t *testing.T) {
+	dir := t.TempDir()
+	idDir := filepath.Join(dir, ".cog", "config", "identities")
+	_ = os.MkdirAll(idDir, 0o755)
+	writeTempCRD(t, idDir, "x.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: Identity
+metadata:
+  name: x
+spec:
+  iss: cogos-dev
+  sub: x
+  type: agent
+  private_key:
+    ref: "file:///tmp/k.pem"
+  expressions:
+    - aud: "*"
+`)
+	if _, err := LoadIdentityCRD(dir, "x"); err == nil {
+		t.Fatal("expected error for missing integrity_hash, got nil")
+	}
+}
+
+func TestLoadIdentityCRD_PrivateKeyRef_RejectsUnknownHashAlgo(t *testing.T) {
+	dir := t.TempDir()
+	idDir := filepath.Join(dir, ".cog", "config", "identities")
+	_ = os.MkdirAll(idDir, 0o755)
+	writeTempCRD(t, idDir, "x.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: Identity
+metadata:
+  name: x
+spec:
+  iss: cogos-dev
+  sub: x
+  type: agent
+  private_key:
+    ref: "file:///tmp/k.pem"
+    integrity_hash: "md5:deadbeef"
+  expressions:
+    - aud: "*"
+`)
+	if _, err := LoadIdentityCRD(dir, "x"); err == nil {
+		t.Fatal("expected error for md5 hash algo, got nil")
+	}
+}
+
+func TestLoadIdentityCRD_PrivateKeyOptional(t *testing.T) {
+	// No private_key field at all — should still load successfully.
+	dir := t.TempDir()
+	idDir := filepath.Join(dir, ".cog", "config", "identities")
+	_ = os.MkdirAll(idDir, 0o755)
+	writeTempCRD(t, idDir, "x.yaml", minimalValidIdentityYAML)
+	crd, err := LoadIdentityCRD(dir, "x")
+	if err != nil {
+		t.Fatalf("LoadIdentityCRD: %v", err)
+	}
+	if crd.Spec.PrivateKey != nil {
+		t.Errorf("PrivateKey = %+v, want nil when unset", crd.Spec.PrivateKey)
+	}
+}
+
+// ─── AuthFactors validation ─────────────────────────────────────────────────────
+
+func TestLoadIdentityCRD_AuthFactors_ValidAnyOfGroup(t *testing.T) {
+	dir := t.TempDir()
+	idDir := filepath.Join(dir, ".cog", "config", "identities")
+	_ = os.MkdirAll(idDir, 0o755)
+	writeTempCRD(t, idDir, "x.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: Identity
+metadata:
+  name: x
+spec:
+  iss: cogos-dev
+  sub: x
+  type: agent
+  auth_factors:
+    - kind: any-of
+      factors:
+        - type: totp
+          ref: "vault://secret/cogos/x/totp"
+        - type: webauthn
+          ref: "keychain://cogos/x-yubikey"
+    - kind: required
+      factors:
+        - type: node-signed-challenge
+  expressions:
+    - aud: "*"
+`)
+	crd, err := LoadIdentityCRD(dir, "x")
+	if err != nil {
+		t.Fatalf("LoadIdentityCRD: %v", err)
+	}
+	if len(crd.Spec.AuthFactors) != 2 {
+		t.Fatalf("AuthFactors len = %d, want 2", len(crd.Spec.AuthFactors))
+	}
+	if crd.Spec.AuthFactors[0].Kind != "any-of" {
+		t.Errorf("first kind = %q", crd.Spec.AuthFactors[0].Kind)
+	}
+	if len(crd.Spec.AuthFactors[0].Factors) != 2 {
+		t.Errorf("first factors len = %d, want 2", len(crd.Spec.AuthFactors[0].Factors))
+	}
+}
+
+func TestLoadIdentityCRD_AuthFactors_RejectsBadKind(t *testing.T) {
+	dir := t.TempDir()
+	idDir := filepath.Join(dir, ".cog", "config", "identities")
+	_ = os.MkdirAll(idDir, 0o755)
+	writeTempCRD(t, idDir, "x.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: Identity
+metadata:
+  name: x
+spec:
+  iss: cogos-dev
+  sub: x
+  type: agent
+  auth_factors:
+    - kind: one-of-many
+      factors:
+        - type: totp
+  expressions:
+    - aud: "*"
+`)
+	if _, err := LoadIdentityCRD(dir, "x"); err == nil {
+		t.Fatal("expected error for unknown factor kind, got nil")
+	}
+}
+
+func TestLoadIdentityCRD_AuthFactors_RejectsEmptyFactors(t *testing.T) {
+	dir := t.TempDir()
+	idDir := filepath.Join(dir, ".cog", "config", "identities")
+	_ = os.MkdirAll(idDir, 0o755)
+	writeTempCRD(t, idDir, "x.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: Identity
+metadata:
+  name: x
+spec:
+  iss: cogos-dev
+  sub: x
+  type: agent
+  auth_factors:
+    - kind: required
+      factors: []
+  expressions:
+    - aud: "*"
+`)
+	if _, err := LoadIdentityCRD(dir, "x"); err == nil {
+		t.Fatal("expected error for empty factors list, got nil")
 	}
 }

--- a/identity_provider.go
+++ b/identity_provider.go
@@ -1,0 +1,899 @@
+// identity_provider.go
+// IdentityProvider implements pkg/reconcile.Reconcilable for the Identity CRD.
+//
+// Responsibility split (per the project_cogos_identity_as_crd triple):
+//   - identity_crd.go    — Spec: on-disk YAML at .cog/config/identities/<sub>.yaml
+//   - identity_provider.go — Reconciler + Projections: what writes to DB + cogdoc
+//
+// This file is the second leg of the triple. It consumes the Spec from
+// identity_crd.go, produces Projections into:
+//
+//   - the Constellation memory-graph (participants table + identity cogdocs)
+//   - a short projection path .cog/id/<sub>.cog.md (Layer-2 principal card)
+//
+// and emits an `identity.*` event for every Apply action so the ledger tells
+// the truth about what happened.
+//
+// All side-effects are reached through narrow dependencies (ConstellationDB,
+// KeyResolver, busEmit) so the provider is testable without standing up a
+// real SQLite file, a real key vault, or a real ledger.
+//
+// Not covered in this wave:
+//   - concrete wiring to sdk/constellation/db.go (that is a later wave —
+//     the interface here is the integration point)
+//   - live enforcement of AuthFactors (the spec-shape lives in identity_crd.go
+//     now; evaluating a challenge is a follow-up)
+
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	stdhash "hash"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"gopkg.in/yaml.v3"
+)
+
+// ─── DB surface ─────────────────────────────────────────────────────────────────
+
+// ConstellationDB is the narrow dependency-injection surface the
+// IdentityProvider needs to read/write projections. A concrete implementation
+// wraps *sdk/constellation.DB (out of scope for this wave). Tests supply an
+// in-memory fake.
+//
+// Design: projections (identity cogdocs) and the participants table are
+// two tables in the same store. A single interface keeps the boundary clear
+// and lets the provider atomically coordinate both when real transactions
+// land later.
+type ConstellationDB interface {
+	UpsertIdentityCogDoc(ctx context.Context, doc IdentityProjection) error
+	DeleteIdentityCogDoc(ctx context.Context, sub string) error
+	UpsertParticipant(ctx context.Context, row ParticipantRow) error
+	DeleteParticipant(ctx context.Context, id string) error
+	GetProjection(ctx context.Context, sub string) (*IdentityProjection, error)
+	ListProjections(ctx context.Context) ([]IdentityProjection, error)
+}
+
+// IdentityProjection is the data the provider writes per reconciled identity.
+// Mirrors the spec's identity-relevant fields plus provenance so downstream
+// consumers (e.g. dashboards, the agent runtime) can answer "where did this
+// identity come from?" without re-reading the YAML.
+type IdentityProjection struct {
+	Sub         string               `json:"sub"`
+	Iss         string               `json:"iss"`
+	Type        string               `json:"type"`
+	ProjectedAt time.Time            `json:"projected_at"`
+	SpecHash    string               `json:"spec_hash"`
+	Expressions []IdentityExpression `json:"expressions"`
+	ContentPath string               `json:"content_path"`
+}
+
+// ParticipantRow matches the kernel's existing `participants` table schema
+// (see docs/architecture/the-constellation.md). Per convention the row id
+// is "<type>:<sub>", with type ∈ {agent, human, service}.
+type ParticipantRow struct {
+	ID           string    `json:"id"`
+	Type         string    `json:"type"`
+	Name         string    `json:"name"`
+	IdentityPath string    `json:"identity_path"`
+	SessionID    string    `json:"session_id"`
+	Active       bool      `json:"active"`
+	LastSeen     time.Time `json:"last_seen"`
+	RegisteredAt time.Time `json:"registered_at"`
+	NodeHash     string    `json:"node_hash"`
+}
+
+// ─── Key resolution ─────────────────────────────────────────────────────────────
+
+// ErrSchemeNotImplemented is returned when a KeyRef uses a scheme that is
+// declared in the CRD allow-list but not yet wired up (vault://, s3://, etc.).
+var ErrSchemeNotImplemented = errors.New("identity: key-ref scheme not implemented")
+
+// KeyResolver resolves key-ref URIs to raw key bytes. Each scheme
+// (file://, inline://, vault://, s3://, …) has its own resolver; the
+// provider multiplexes them through resolverRegistry.
+//
+// Resolvers MUST NOT verify the integrity hash — that is the provider's job,
+// so that misimplemented resolvers cannot launder bad bytes.
+type KeyResolver interface {
+	ResolveKey(ctx context.Context, ref string) ([]byte, error)
+}
+
+// fileKeyResolver reads key bytes from a local file path (file://<abs>).
+type fileKeyResolver struct{}
+
+func (fileKeyResolver) ResolveKey(_ context.Context, ref string) ([]byte, error) {
+	path := strings.TrimPrefix(ref, "file://")
+	if path == "" {
+		return nil, fmt.Errorf("identity: file:// ref missing path")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("identity: read file key %q: %w", path, err)
+	}
+	return data, nil
+}
+
+// inlineKeyResolver decodes base64 payloads embedded directly in the ref.
+// Form: inline://<base64-std-padded>. Intended for tests and tiny dev keys;
+// the CRD loader allows it but operators should avoid it in production.
+type inlineKeyResolver struct{}
+
+func (inlineKeyResolver) ResolveKey(_ context.Context, ref string) ([]byte, error) {
+	payload := strings.TrimPrefix(ref, "inline://")
+	if payload == "" {
+		return nil, fmt.Errorf("identity: inline:// ref missing payload")
+	}
+	data, err := base64.StdEncoding.DecodeString(payload)
+	if err != nil {
+		return nil, fmt.Errorf("identity: decode inline key: %w", err)
+	}
+	return data, nil
+}
+
+// notImplementedResolver is a placeholder for scheme-allowed-but-unwired
+// schemes. Keeping a single struct reduces boilerplate.
+type notImplementedResolver struct{ scheme string }
+
+func (r notImplementedResolver) ResolveKey(_ context.Context, _ string) ([]byte, error) {
+	return nil, fmt.Errorf("%w: %s", ErrSchemeNotImplemented, r.scheme)
+}
+
+// defaultKeyResolvers returns the scheme→resolver map used when the provider
+// is constructed without an explicit resolver registry. Tests may override
+// specific schemes via NewIdentityProvider's resolvers argument.
+func defaultKeyResolvers() map[string]KeyResolver {
+	return map[string]KeyResolver{
+		"file":     fileKeyResolver{},
+		"inline":   inlineKeyResolver{},
+		"vault":    notImplementedResolver{scheme: "vault"},
+		"s3":       notImplementedResolver{scheme: "s3"},
+		"keychain": notImplementedResolver{scheme: "keychain"},
+		"env":      notImplementedResolver{scheme: "env"},
+		"kms":      notImplementedResolver{scheme: "kms"},
+	}
+}
+
+// verifyKeyIntegrity checks that sha256/sha512 of key bytes matches the
+// CRD's declared integrity hash. Returns an error (not just a bool) so the
+// caller can surface algorithm errors distinctly.
+func verifyKeyIntegrity(keyBytes []byte, integrityHash string) error {
+	algo, expected, ok := strings.Cut(integrityHash, ":")
+	if !ok {
+		return fmt.Errorf("identity: malformed integrity_hash %q", integrityHash)
+	}
+	var h stdhash.Hash
+	switch algo {
+	case "sha256":
+		h = sha256.New()
+	case "sha512":
+		h = sha512.New()
+	default:
+		return fmt.Errorf("identity: unsupported hash algorithm %q", algo)
+	}
+	h.Write(keyBytes)
+	got := hex.EncodeToString(h.Sum(nil))
+	if got != expected {
+		return fmt.Errorf("identity: key integrity mismatch: want %s, got %s", expected, got)
+	}
+	return nil
+}
+
+// ─── Event emission ─────────────────────────────────────────────────────────────
+
+// BusEmit is the callback shape the provider uses to emit events. Passing
+// it as a function (rather than importing AppendEvent directly) keeps the
+// provider unit-testable: tests capture into a slice, production wires to
+// engine.AppendEvent (or any equivalent transport).
+type BusEmit func(eventType string, data map[string]any) error
+
+// Identity event-type constants. Dot-separated lowercase per event-schema
+// convention. Source metadata is always "reconciler/identity".
+const (
+	EventIdentityReconciled        = "identity.reconciled"
+	EventIdentityProjected         = "identity.projected"
+	EventIdentityExpressionUpdated = "identity.expression.updated"
+	EventIdentityDeregistered      = "identity.deregistered"
+	EventIdentityKeyRotated        = "identity.key.rotated"
+	EventIdentityKeyMismatch       = "identity.key.mismatch"
+	EventIdentityAuthRequired      = "identity.auth.required"
+)
+
+const identityEventSource = "reconciler/identity"
+
+// ─── Provider ───────────────────────────────────────────────────────────────────
+
+// IdentityProvider implements Reconcilable for the Identity CRD.
+//
+// Construction is explicit (see NewIdentityProvider) because DB and event-bus
+// wiring are external concerns — the kernel's reconcile harness wires them
+// at startup, tests wire fakes. There is no init()-style RegisterProvider
+// here; that is the kernel's wiring step in a later wave.
+type IdentityProvider struct {
+	mu sync.Mutex
+
+	db        ConstellationDB
+	resolvers map[string]KeyResolver
+	emit      BusEmit
+
+	// State populated during the reconcile loop and surfaced in Health.
+	root             string
+	lastPlanSummary  ReconcileSummary
+	lastMismatchSubs map[string]struct{} // sub → present means "bad hash"
+	missingSpecSubs  map[string]struct{} // sub → present means "projection without spec"
+	operation        OperationPhase
+}
+
+// NewIdentityProvider constructs a provider with explicit dependencies. A
+// nil resolvers map falls back to defaultKeyResolvers. A nil emit silently
+// drops events (safe default for tests that don't assert on events).
+func NewIdentityProvider(db ConstellationDB, resolvers map[string]KeyResolver, emit BusEmit) *IdentityProvider {
+	if resolvers == nil {
+		resolvers = defaultKeyResolvers()
+	}
+	if emit == nil {
+		emit = func(string, map[string]any) error { return nil }
+	}
+	return &IdentityProvider{
+		db:               db,
+		resolvers:        resolvers,
+		emit:             emit,
+		lastMismatchSubs: make(map[string]struct{}),
+		missingSpecSubs:  make(map[string]struct{}),
+		operation:        OperationIdle,
+	}
+}
+
+// Type returns the provider identifier. Matches CRD kind lowercase per
+// reconciler convention.
+func (p *IdentityProvider) Type() string { return "identity" }
+
+// ─── LoadConfig ─────────────────────────────────────────────────────────────────
+
+// identityConfig is the provider's internal config bundle. We keep raw CRDs
+// plus a precomputed per-sub spec hash so ComputePlan can diff cheaply.
+type identityConfig struct {
+	Root      string
+	CRDs      []*IdentityCRD
+	SpecHash  map[string]string // sub → "sha256:<hex>" of the canonicalized spec
+	ConfigDir string
+}
+
+// LoadConfig reads all identity CRDs from .cog/config/identities/ and
+// computes a spec hash per identity for drift detection. The spec hash is
+// sha256 of the canonical YAML of spec (not the whole file) so a cosmetic
+// comment edit does not trigger a projection update.
+func (p *IdentityProvider) LoadConfig(root string) (any, error) {
+	p.mu.Lock()
+	p.root = root
+	p.mu.Unlock()
+
+	crds, err := LoadIdentityCRDs(root)
+	if err != nil {
+		return nil, fmt.Errorf("identity provider: load config: %w", err)
+	}
+	if crds == nil {
+		crds = []*IdentityCRD{}
+	}
+
+	cfg := &identityConfig{
+		Root:      root,
+		CRDs:      crds,
+		SpecHash:  make(map[string]string, len(crds)),
+		ConfigDir: identityCRDDir(root),
+	}
+	for _, crd := range crds {
+		hash, err := hashIdentitySpec(&crd.Spec)
+		if err != nil {
+			return nil, fmt.Errorf("identity provider: hash spec %q: %w", crd.Spec.Subject, err)
+		}
+		cfg.SpecHash[crd.Spec.Subject] = hash
+	}
+	return cfg, nil
+}
+
+// hashIdentitySpec produces a stable "sha256:<hex>" over the YAML-marshaled
+// spec. Using yaml.Marshal with default sort order keeps the hash stable for
+// equivalent specs without pulling in a dedicated RFC-8785 canonicalizer.
+func hashIdentitySpec(spec *IdentityCRDSpec) (string, error) {
+	b, err := yaml.Marshal(spec)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(b)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+// ─── FetchLive ──────────────────────────────────────────────────────────────────
+
+// identityLive is the provider's snapshot of the current projection state.
+type identityLive struct {
+	Projections map[string]IdentityProjection // sub → projection
+}
+
+// FetchLive reads all identity projections from the database. Missing DB
+// is a hard error — we cannot reconcile without knowing current state. An
+// empty projection set (no rows) is not an error.
+func (p *IdentityProvider) FetchLive(ctx context.Context, _ any) (any, error) {
+	if p.db == nil {
+		return nil, fmt.Errorf("identity provider: no ConstellationDB configured")
+	}
+	rows, err := p.db.ListProjections(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("identity provider: list projections: %w", err)
+	}
+	live := &identityLive{Projections: make(map[string]IdentityProjection, len(rows))}
+	for _, row := range rows {
+		live.Projections[row.Sub] = row
+	}
+	return live, nil
+}
+
+// ─── ComputePlan ────────────────────────────────────────────────────────────────
+
+// ComputePlan compares the declared specs against the live projections:
+//   - spec present, projection absent  → create
+//   - spec present, projection present, spec-hash differs → update
+//   - spec absent, projection present  → delete
+//   - spec present, projection present, spec-hash matches → skip
+//
+// Actions are sorted by (action-class, sub) for deterministic output.
+func (p *IdentityProvider) ComputePlan(config any, live any, _ *ReconcileState) (*ReconcilePlan, error) {
+	cfg, ok := config.(*identityConfig)
+	if !ok {
+		return nil, fmt.Errorf("identity provider: expected *identityConfig, got %T", config)
+	}
+	liveState, ok := live.(*identityLive)
+	if !ok {
+		return nil, fmt.Errorf("identity provider: expected *identityLive, got %T", live)
+	}
+
+	plan := &ReconcilePlan{
+		ResourceType: "identity",
+		GeneratedAt:  nowISO(),
+		ConfigPath:   cfg.ConfigDir,
+		Metadata:     map[string]any{},
+	}
+
+	seen := make(map[string]struct{}, len(cfg.CRDs))
+
+	// Walk declared specs.
+	for _, crd := range cfg.CRDs {
+		sub := crd.Spec.Subject
+		seen[sub] = struct{}{}
+		specHash := cfg.SpecHash[sub]
+		existing, hasProjection := liveState.Projections[sub]
+
+		switch {
+		case !hasProjection:
+			plan.Actions = append(plan.Actions, ReconcileAction{
+				Action:       ActionCreate,
+				ResourceType: "identity",
+				Name:         sub,
+				Details: map[string]any{
+					"iss":       crd.Spec.Issuer,
+					"type":      crd.Spec.Type,
+					"spec_hash": specHash,
+				},
+			})
+			plan.Summary.Creates++
+
+		case existing.SpecHash != specHash:
+			plan.Actions = append(plan.Actions, ReconcileAction{
+				Action:       ActionUpdate,
+				ResourceType: "identity",
+				Name:         sub,
+				Details: map[string]any{
+					"iss":                crd.Spec.Issuer,
+					"type":               crd.Spec.Type,
+					"spec_hash":          specHash,
+					"previous_spec_hash": existing.SpecHash,
+				},
+			})
+			plan.Summary.Updates++
+
+		default:
+			plan.Actions = append(plan.Actions, ReconcileAction{
+				Action:       ActionSkip,
+				ResourceType: "identity",
+				Name:         sub,
+				Details: map[string]any{
+					"reason":    "in sync",
+					"spec_hash": specHash,
+				},
+			})
+			plan.Summary.Skipped++
+		}
+	}
+
+	// Any projection without a matching spec is a delete.
+	for sub, proj := range liveState.Projections {
+		if _, ok := seen[sub]; ok {
+			continue
+		}
+		plan.Actions = append(plan.Actions, ReconcileAction{
+			Action:       ActionDelete,
+			ResourceType: "identity",
+			Name:         sub,
+			Details: map[string]any{
+				"iss":                proj.Iss,
+				"type":               proj.Type,
+				"previous_spec_hash": proj.SpecHash,
+			},
+		})
+		plan.Summary.Deletes++
+	}
+
+	// Deterministic order so test assertions and diff viewers are stable.
+	sort.Slice(plan.Actions, func(i, j int) bool {
+		if plan.Actions[i].Action != plan.Actions[j].Action {
+			return plan.Actions[i].Action < plan.Actions[j].Action
+		}
+		return plan.Actions[i].Name < plan.Actions[j].Name
+	})
+
+	// Remember summary for Health() — OutOfSync is simply "plan had any
+	// non-skip action".
+	p.mu.Lock()
+	p.lastPlanSummary = plan.Summary
+	p.missingSpecSubs = make(map[string]struct{}, plan.Summary.Deletes)
+	for _, a := range plan.Actions {
+		if a.Action == ActionDelete {
+			p.missingSpecSubs[a.Name] = struct{}{}
+		}
+	}
+	p.mu.Unlock()
+
+	return plan, nil
+}
+
+// ─── ApplyPlan ──────────────────────────────────────────────────────────────────
+
+// ApplyPlan executes every non-skip action in order, emitting exactly one
+// event per action. Key-hash mismatches produce ApplyFailed + an
+// identity.key.mismatch event; the provider does NOT abort the whole plan
+// on a single mismatch (other identities can still reconcile).
+func (p *IdentityProvider) ApplyPlan(ctx context.Context, plan *ReconcilePlan) ([]ReconcileResult, error) {
+	if plan == nil {
+		return nil, fmt.Errorf("identity provider: nil plan")
+	}
+	if p.db == nil {
+		return nil, fmt.Errorf("identity provider: no ConstellationDB configured")
+	}
+
+	p.mu.Lock()
+	p.operation = OperationSyncing
+	root := p.root
+	p.lastMismatchSubs = make(map[string]struct{})
+	p.mu.Unlock()
+	defer func() {
+		p.mu.Lock()
+		p.operation = OperationIdle
+		p.mu.Unlock()
+	}()
+
+	// Reload CRDs keyed by sub so Apply can access the full spec. (The plan
+	// only carries summary details — the ApplyPlan contract says we can
+	// trust the on-disk spec at apply time.)
+	crds, err := LoadIdentityCRDs(root)
+	if err != nil {
+		return nil, fmt.Errorf("identity provider: reload specs: %w", err)
+	}
+	crdBySub := make(map[string]*IdentityCRD, len(crds))
+	for _, c := range crds {
+		crdBySub[c.Spec.Subject] = c
+	}
+
+	var results []ReconcileResult
+	for _, action := range plan.Actions {
+		if action.Action == ActionSkip {
+			continue
+		}
+
+		res := ReconcileResult{
+			Phase:  "identity",
+			Action: string(action.Action),
+			Name:   action.Name,
+		}
+
+		switch action.Action {
+		case ActionCreate, ActionUpdate:
+			crd, ok := crdBySub[action.Name]
+			if !ok {
+				res.Status = ApplyFailed
+				res.Error = fmt.Sprintf("spec for %q disappeared between plan and apply", action.Name)
+				results = append(results, res)
+				continue
+			}
+			applied, err := p.applyUpsert(ctx, root, crd, action)
+			if err != nil {
+				res.Status = ApplyFailed
+				res.Error = err.Error()
+				results = append(results, res)
+				continue
+			}
+			res.Status = ApplySucceeded
+			res.CreatedID = applied.Sub
+			results = append(results, res)
+
+		case ActionDelete:
+			if err := p.applyDelete(ctx, action); err != nil {
+				res.Status = ApplyFailed
+				res.Error = err.Error()
+				results = append(results, res)
+				continue
+			}
+			res.Status = ApplySucceeded
+			results = append(results, res)
+
+		default:
+			res.Status = ApplySkipped
+			results = append(results, res)
+		}
+	}
+
+	return results, nil
+}
+
+// applyUpsert handles both create and update. Sequence:
+//  1. If private_key set: resolve + verify integrity. Mismatch → mismatch event, error.
+//  2. Write projection cogdoc at .cog/id/<sub>.cog.md.
+//  3. Upsert DB row.
+//  4. Upsert participants row.
+//  5. Emit the appropriate identity.* event.
+func (p *IdentityProvider) applyUpsert(ctx context.Context, root string, crd *IdentityCRD, action ReconcileAction) (*IdentityProjection, error) {
+	sub := crd.Spec.Subject
+	specHash := stringDetail(action.Details, "spec_hash")
+
+	if crd.Spec.PrivateKey != nil {
+		keyBytes, err := p.resolveKey(ctx, crd.Spec.PrivateKey.Ref)
+		if err != nil {
+			// Resolver failure is distinct from hash mismatch — surface as
+			// a plain error, no mismatch event.
+			return nil, fmt.Errorf("resolve key for %q: %w", sub, err)
+		}
+		if err := verifyKeyIntegrity(keyBytes, crd.Spec.PrivateKey.IntegrityHash); err != nil {
+			p.mu.Lock()
+			p.lastMismatchSubs[sub] = struct{}{}
+			p.mu.Unlock()
+			p.emitIdentityEvent(EventIdentityKeyMismatch, map[string]any{
+				"iss":       crd.Spec.Issuer,
+				"sub":       sub,
+				"spec_hash": specHash,
+				"error":     err.Error(),
+			})
+			return nil, err
+		}
+	}
+
+	now := time.Now().UTC()
+	projectionPath := filepath.Join(".cog", "id", sub+".cog.md")
+	absProjection := filepath.Join(root, projectionPath)
+
+	proj := IdentityProjection{
+		Sub:         sub,
+		Iss:         crd.Spec.Issuer,
+		Type:        crd.Spec.Type,
+		ProjectedAt: now,
+		SpecHash:    specHash,
+		Expressions: append([]IdentityExpression(nil), crd.Spec.Expressions...),
+		ContentPath: projectionPath,
+	}
+
+	// Write projection cogdoc first — if it fails we haven't touched the DB.
+	if err := writeIdentityProjectionCogDoc(absProjection, crd, specHash, now); err != nil {
+		return nil, fmt.Errorf("write projection cogdoc %q: %w", absProjection, err)
+	}
+
+	if err := p.db.UpsertIdentityCogDoc(ctx, proj); err != nil {
+		return nil, fmt.Errorf("upsert identity cogdoc: %w", err)
+	}
+
+	row := participantRowForCRD(crd, now, projectionPath)
+	if err := p.db.UpsertParticipant(ctx, row); err != nil {
+		return nil, fmt.Errorf("upsert participant: %w", err)
+	}
+
+	eventType := EventIdentityProjected
+	if action.Action == ActionUpdate {
+		eventType = EventIdentityExpressionUpdated
+	}
+	p.emitIdentityEvent(eventType, map[string]any{
+		"iss":             crd.Spec.Issuer,
+		"sub":             sub,
+		"aud":             primaryAudience(&crd.Spec),
+		"action":          string(action.Action),
+		"spec_hash":       specHash,
+		"projection_path": projectionPath,
+		"applied_at":      now.Format(time.RFC3339),
+	})
+
+	return &proj, nil
+}
+
+// applyDelete removes both the participants row and the projection cogdoc
+// from the DB, and emits identity.deregistered.
+func (p *IdentityProvider) applyDelete(ctx context.Context, action ReconcileAction) error {
+	sub := action.Name
+	iss := stringDetail(action.Details, "iss")
+	typ := stringDetail(action.Details, "type")
+
+	if err := p.db.DeleteIdentityCogDoc(ctx, sub); err != nil {
+		return fmt.Errorf("delete identity cogdoc: %w", err)
+	}
+	if err := p.db.DeleteParticipant(ctx, participantID(typ, sub)); err != nil {
+		return fmt.Errorf("delete participant: %w", err)
+	}
+
+	// Remove the disk projection if we have a root. Missing file is fine.
+	p.mu.Lock()
+	root := p.root
+	p.mu.Unlock()
+	if root != "" {
+		_ = os.Remove(filepath.Join(root, ".cog", "id", sub+".cog.md"))
+	}
+
+	p.emitIdentityEvent(EventIdentityDeregistered, map[string]any{
+		"iss":        iss,
+		"sub":        sub,
+		"action":     string(ActionDelete),
+		"spec_hash":  stringDetail(action.Details, "previous_spec_hash"),
+		"applied_at": time.Now().UTC().Format(time.RFC3339),
+	})
+	return nil
+}
+
+// resolveKey dispatches to the registered resolver for the ref's scheme.
+// Returns ErrSchemeNotImplemented for registered-but-unwired schemes.
+func (p *IdentityProvider) resolveKey(ctx context.Context, ref string) ([]byte, error) {
+	scheme, ok := parseKeyRefScheme(ref)
+	if !ok {
+		return nil, fmt.Errorf("identity: malformed key ref %q", ref)
+	}
+	resolver, ok := p.resolvers[scheme]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrSchemeNotImplemented, scheme)
+	}
+	return resolver.ResolveKey(ctx, ref)
+}
+
+// emitIdentityEvent is a thin wrapper that logs but does not fail on emit
+// errors — the projection has already happened, losing the event is a
+// reliability concern for the bus, not a correctness concern for reconcile.
+func (p *IdentityProvider) emitIdentityEvent(eventType string, data map[string]any) {
+	if p.emit == nil {
+		return
+	}
+	if err := p.emit(eventType, data); err != nil {
+		log.Printf("[identity] emit %s: %v", eventType, err)
+	}
+}
+
+// ─── BuildState ─────────────────────────────────────────────────────────────────
+
+// BuildState constructs a Terraform-style reconcile state from live
+// projections. Lineage is preserved across calls (so operators can track a
+// continuous history); serial is incremented each time.
+func (p *IdentityProvider) BuildState(_ any, live any, existing *ReconcileState) (*ReconcileState, error) {
+	liveState, ok := live.(*identityLive)
+	if !ok {
+		return nil, fmt.Errorf("identity provider: expected *identityLive, got %T", live)
+	}
+
+	state := &ReconcileState{
+		Version:      1,
+		ResourceType: "identity",
+		GeneratedAt:  nowISO(),
+		Resources:    []ReconcileResource{},
+		Metadata:     map[string]any{},
+	}
+
+	if existing != nil && existing.Lineage != "" {
+		state.Lineage = existing.Lineage
+		state.Serial = existing.Serial + 1
+	} else {
+		state.Lineage = "identity-" + uuid.New().String()
+		state.Serial = 1
+	}
+
+	subs := make([]string, 0, len(liveState.Projections))
+	for sub := range liveState.Projections {
+		subs = append(subs, sub)
+	}
+	sort.Strings(subs)
+
+	now := nowISO()
+	for _, sub := range subs {
+		proj := liveState.Projections[sub]
+		state.Resources = append(state.Resources, ReconcileResource{
+			Address:       "identity." + sub,
+			Type:          "identity",
+			Mode:          ModeManaged,
+			ExternalID:    participantID(proj.Type, sub),
+			Name:          sub,
+			LastRefreshed: now,
+			Attributes: map[string]any{
+				"iss":             proj.Iss,
+				"type":            proj.Type,
+				"spec_hash":       proj.SpecHash,
+				"projection_path": proj.ContentPath,
+				"projected_at":    proj.ProjectedAt.Format(time.RFC3339),
+			},
+		})
+	}
+
+	return state, nil
+}
+
+// ─── Health ─────────────────────────────────────────────────────────────────────
+
+// Health returns the three-axis status:
+//
+//	Sync      — Synced when last plan had zero non-skip actions; OutOfSync otherwise.
+//	Health    — Missing when any projection lacks a spec (delete pending);
+//	            Degraded when any identity hit a key-hash mismatch;
+//	            Healthy otherwise.
+//	Operation — Syncing while ApplyPlan is running; Idle otherwise.
+func (p *IdentityProvider) Health() ResourceStatus {
+	p.mu.Lock()
+	summary := p.lastPlanSummary
+	mismatches := len(p.lastMismatchSubs)
+	missing := len(p.missingSpecSubs)
+	op := p.operation
+	p.mu.Unlock()
+
+	sync := SyncStatusSynced
+	if summary.HasChanges() {
+		sync = SyncStatusOutOfSync
+	}
+
+	health := HealthHealthy
+	msg := ""
+	switch {
+	case mismatches > 0:
+		health = HealthDegraded
+		msg = fmt.Sprintf("%d identity key-hash mismatch(es)", mismatches)
+	case missing > 0:
+		health = HealthMissing
+		msg = fmt.Sprintf("%d projection(s) without matching spec", missing)
+	}
+
+	return ResourceStatus{
+		Sync:      sync,
+		Health:    health,
+		Operation: op,
+		Message:   msg,
+	}
+}
+
+// ─── Projection cogdoc writer ───────────────────────────────────────────────────
+
+// writeIdentityProjectionCogDoc writes the Layer-2 principal card markdown
+// file with provenance frontmatter. Directory is created if missing.
+func writeIdentityProjectionCogDoc(absPath string, crd *IdentityCRD, specHash string, appliedAt time.Time) error {
+	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
+		return err
+	}
+
+	exp := crd.Spec.ExpressionFor("*")
+	if exp == nil && len(crd.Spec.Expressions) > 0 {
+		exp = &crd.Spec.Expressions[0]
+	}
+
+	displayName := crd.Spec.Subject
+	if exp != nil && exp.DisplayName != "" {
+		displayName = exp.DisplayName
+	}
+
+	specPath := filepath.Join(".cog", "config", "identities", crd.Spec.Subject+".yaml")
+
+	var buf strings.Builder
+	buf.WriteString("---\n")
+	buf.WriteString("type: identity\n")
+	fmt.Fprintf(&buf, "id: %s\n", crd.Spec.Subject)
+	fmt.Fprintf(&buf, "iss: %s\n", crd.Spec.Issuer)
+	fmt.Fprintf(&buf, "title: %q\n", displayName)
+	buf.WriteString("derived_from:\n")
+	fmt.Fprintf(&buf, "  spec_path: %q\n", specPath)
+	fmt.Fprintf(&buf, "  spec_hash: %q\n", specHash)
+	buf.WriteString("  reconciler: IdentityProvider\n")
+	fmt.Fprintf(&buf, "  applied_at: %q\n", appliedAt.UTC().Format(time.RFC3339))
+	buf.WriteString("---\n\n")
+
+	fmt.Fprintf(&buf, "# %s\n\n", displayName)
+	if exp != nil {
+		if exp.Role != "" {
+			fmt.Fprintf(&buf, "**Role:** %s\n\n", exp.Role)
+		}
+		if exp.Voice != "" {
+			fmt.Fprintf(&buf, "**Voice:** %s\n\n", exp.Voice)
+		}
+		if len(exp.Skills) > 0 {
+			buf.WriteString("**Skills:**\n")
+			for _, s := range exp.Skills {
+				fmt.Fprintf(&buf, "- %s\n", s)
+			}
+			buf.WriteString("\n")
+		}
+		if exp.MemoryNamespace != "" {
+			fmt.Fprintf(&buf, "**Memory namespace:** `%s`\n\n", exp.MemoryNamespace)
+		}
+	}
+	fmt.Fprintf(&buf, "_Generated by IdentityProvider from `%s` (%s)._\n", specPath, specHash)
+
+	return os.WriteFile(absPath, []byte(buf.String()), 0o644)
+}
+
+// ─── Small helpers ──────────────────────────────────────────────────────────────
+
+// participantID returns the "<type>:<sub>" identifier used as participants.id.
+// Unknown types fall back to "<type>:<sub>" as-is — validation upstream
+// should have caught the bad type.
+func participantID(typ, sub string) string {
+	return typ + ":" + sub
+}
+
+// participantRowForCRD projects a CRD into a participants-table row.
+func participantRowForCRD(crd *IdentityCRD, now time.Time, projectionPath string) ParticipantRow {
+	name := crd.Metadata.Name
+	// Prefer a display_name from the catch-all / first expression when present;
+	// keep metadata.name as the ID fallback.
+	if exp := crd.Spec.ExpressionFor("*"); exp != nil && exp.DisplayName != "" {
+		name = exp.DisplayName
+	} else if len(crd.Spec.Expressions) > 0 && crd.Spec.Expressions[0].DisplayName != "" {
+		name = crd.Spec.Expressions[0].DisplayName
+	}
+	return ParticipantRow{
+		ID:           participantID(crd.Spec.Type, crd.Spec.Subject),
+		Type:         crd.Spec.Type,
+		Name:         name,
+		IdentityPath: projectionPath,
+		SessionID:    "",
+		Active:       true,
+		LastSeen:     now,
+		RegisteredAt: now,
+		NodeHash:     "",
+	}
+}
+
+// primaryAudience picks the audience used for an event's `aud` field —
+// prefers the catch-all `*` expression, falls back to the first one. The
+// audience is informational on the event; downstream consumers that care
+// about per-audience projection pull the full expression list from the DB.
+func primaryAudience(spec *IdentityCRDSpec) string {
+	if spec == nil {
+		return ""
+	}
+	if exp := spec.ExpressionFor("*"); exp != nil {
+		return exp.Audience
+	}
+	if len(spec.Expressions) > 0 {
+		return spec.Expressions[0].Audience
+	}
+	return ""
+}
+
+// stringDetail fetches a string value from an Action.Details map with a
+// zero-value default. Keeps the apply code clean of repeated type asserts.
+func stringDetail(d map[string]any, key string) string {
+	if d == nil {
+		return ""
+	}
+	if v, ok := d[key].(string); ok {
+		return v
+	}
+	return ""
+}

--- a/identity_provider.go
+++ b/identity_provider.go
@@ -518,6 +518,27 @@ func (p *IdentityProvider) ApplyPlan(ctx context.Context, plan *ReconcilePlan) (
 				results = append(results, res)
 				continue
 			}
+
+			// Idempotency short-circuit (Wave 6a-4): if an existing projection
+			// already matches this action's spec_hash AND the cogdoc file is on
+			// disk, skip the whole apply — no DB write, no file write, no event.
+			// Keeps scheduler-driven re-ticks (kernel-interior reconciler cadence)
+			// from churning files, participant rows, and the bus on every tick
+			// when nothing has changed. See project_cogos_reconciler_is_agent.md:
+			// ApplyPlan must be provably idempotent for the kernel-interior
+			// harness to call reconcilers on a schedule safely.
+			if specHash := stringDetail(action.Details, "spec_hash"); specHash != "" {
+				if existing, gerr := p.db.GetProjection(ctx, action.Name); gerr == nil && existing != nil && existing.SpecHash == specHash {
+					absProjection := filepath.Join(root, existing.ContentPath)
+					if _, serr := os.Stat(absProjection); serr == nil {
+						res.Status = ApplySkipped
+						res.CreatedID = existing.Sub
+						results = append(results, res)
+						continue
+					}
+				}
+			}
+
 			applied, err := p.applyUpsert(ctx, root, crd, action)
 			if err != nil {
 				res.Status = ApplyFailed

--- a/identity_provider_test.go
+++ b/identity_provider_test.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"crypto/sha512"
@@ -470,6 +471,231 @@ func TestIdentityProvider_ApplyPlan_KeyHashMismatch_RefusesApply_EmitsMismatchEv
 	if _, ok := fx.db.projections["cog"]; ok {
 		t.Errorf("projection in DB despite mismatch")
 	}
+}
+
+// ─── Wave 6a-4 idempotency tests ────────────────────────────────────────────────
+//
+// These cover the ApplyPlan idempotency contract required by the scheduler-
+// driven interior harness: calling ApplyPlan twice with the same plan must
+// produce zero new events, zero DB writes, and leave the cogdoc file
+// byte-identical on the second call. See project_cogos_reconciler_is_agent.md
+// for the framing: the reconciler tick IS the agent's cognitive loop, and an
+// agent that can't re-tick without churning its own substrate is broken.
+
+// TestIdentityProvider_ApplyPlan_DoubleApply_IsIdempotent is the core
+// idempotency contract: same plan applied twice → first creates, second
+// skips entirely (no writes, no events, file unchanged).
+func TestIdentityProvider_ApplyPlan_DoubleApply_IsIdempotent(t *testing.T) {
+	fx := setupProvider(t)
+	writeIdentityCRD(t, fx.root, "cog", "cogos-dev", "Cog", "")
+
+	cfg, _ := fx.prov.LoadConfig(fx.root)
+	live, _ := fx.prov.FetchLive(context.Background(), cfg)
+	plan, _ := fx.prov.ComputePlan(cfg, live, nil)
+
+	// First apply: creates.
+	results1, err := fx.prov.ApplyPlan(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("first ApplyPlan: %v", err)
+	}
+	if len(results1) != 1 || results1[0].Status != ApplySucceeded {
+		t.Fatalf("first apply = %+v, want 1 succeeded", results1)
+	}
+
+	// Snapshot state.
+	fx.evMu.Lock()
+	eventsBefore := len(*fx.events)
+	fx.evMu.Unlock()
+
+	projBefore, _ := fx.db.GetProjection(context.Background(), "cog")
+	partBefore := fx.db.participants["agent:cog"]
+
+	cogdocPath := filepath.Join(fx.root, ".cog", "id", "cog.cog.md")
+	contentBefore, err := os.ReadFile(cogdocPath)
+	if err != nil {
+		t.Fatalf("read cogdoc: %v", err)
+	}
+
+	// Second apply of identical plan.
+	results2, err := fx.prov.ApplyPlan(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("second ApplyPlan: %v", err)
+	}
+	if len(results2) != 1 || results2[0].Status != ApplySkipped {
+		t.Fatalf("second apply = %+v, want 1 skipped", results2)
+	}
+
+	// Zero new events.
+	fx.evMu.Lock()
+	eventsAfter := len(*fx.events)
+	fx.evMu.Unlock()
+	if eventsAfter != eventsBefore {
+		t.Errorf("second apply emitted %d new events, want 0", eventsAfter-eventsBefore)
+	}
+
+	// Projection row unchanged (including timestamp — signature of no upsert).
+	projAfter, _ := fx.db.GetProjection(context.Background(), "cog")
+	if projBefore == nil || projAfter == nil {
+		t.Fatalf("projection missing: before=%v after=%v", projBefore, projAfter)
+	}
+	if !projBefore.ProjectedAt.Equal(projAfter.ProjectedAt) {
+		t.Errorf("ProjectedAt mutated on re-apply: %v → %v", projBefore.ProjectedAt, projAfter.ProjectedAt)
+	}
+	if projBefore.SpecHash != projAfter.SpecHash {
+		t.Errorf("SpecHash mutated: %q → %q", projBefore.SpecHash, projAfter.SpecHash)
+	}
+
+	// Participant row unchanged (timestamps stable).
+	partAfter := fx.db.participants["agent:cog"]
+	if !partBefore.LastSeen.Equal(partAfter.LastSeen) {
+		t.Errorf("participant LastSeen mutated: %v → %v", partBefore.LastSeen, partAfter.LastSeen)
+	}
+	if !partBefore.RegisteredAt.Equal(partAfter.RegisteredAt) {
+		t.Errorf("participant RegisteredAt mutated: %v → %v", partBefore.RegisteredAt, partAfter.RegisteredAt)
+	}
+
+	// Cogdoc file byte-identical (the applied_at churn fix).
+	contentAfter, err := os.ReadFile(cogdocPath)
+	if err != nil {
+		t.Fatalf("read cogdoc after: %v", err)
+	}
+	if !bytes.Equal(contentBefore, contentAfter) {
+		t.Errorf("cogdoc rewritten on re-apply\nbefore:\n%s\nafter:\n%s", string(contentBefore), string(contentAfter))
+	}
+}
+
+// TestIdentityProvider_ApplyPlan_ReapplyAfterFileDelete_RewritesFile ensures
+// the idempotency short-circuit respects disk state — if the cogdoc file is
+// manually deleted between applies, the re-apply must rewrite it, not blindly
+// skip based on DB row alone. This is what keeps the reconciler actually
+// reconciling rather than silently drifting off disk.
+func TestIdentityProvider_ApplyPlan_ReapplyAfterFileDelete_RewritesFile(t *testing.T) {
+	fx := setupProvider(t)
+	writeIdentityCRD(t, fx.root, "cog", "cogos-dev", "Cog", "")
+
+	cfg, _ := fx.prov.LoadConfig(fx.root)
+	live, _ := fx.prov.FetchLive(context.Background(), cfg)
+	plan, _ := fx.prov.ComputePlan(cfg, live, nil)
+
+	if _, err := fx.prov.ApplyPlan(context.Background(), plan); err != nil {
+		t.Fatalf("first ApplyPlan: %v", err)
+	}
+
+	// Simulate drift: remove the cogdoc file out from under the reconciler.
+	cogdocPath := filepath.Join(fx.root, ".cog", "id", "cog.cog.md")
+	if err := os.Remove(cogdocPath); err != nil {
+		t.Fatalf("remove cogdoc: %v", err)
+	}
+
+	// Re-apply — should detect missing file and rewrite, NOT skip.
+	results, err := fx.prov.ApplyPlan(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("second ApplyPlan: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("second apply: got %d results, want 1", len(results))
+	}
+	if results[0].Status != ApplySucceeded {
+		t.Errorf("re-apply after file delete: Status = %v, want ApplySucceeded (should rewrite, not skip)", results[0].Status)
+	}
+	if _, err := os.Stat(cogdocPath); err != nil {
+		t.Errorf("cogdoc not rewritten after delete: %v", err)
+	}
+}
+
+// TestIdentityProvider_ApplyPlan_FullReconcileCycle_DoubleApply_IsIdempotent
+// runs the full reconcile cycle twice (LoadConfig → FetchLive → ComputePlan →
+// ApplyPlan) and asserts the second cycle produces no new events. This matches
+// the scheduler-driven pattern: every tick re-runs the full cycle from disk
+// state, so the full cycle must be idempotent end-to-end.
+func TestIdentityProvider_ApplyPlan_FullReconcileCycle_DoubleApply_IsIdempotent(t *testing.T) {
+	fx := setupProvider(t)
+	writeIdentityCRD(t, fx.root, "alice", "cogos-dev", "Alice", "")
+	writeIdentityCRD(t, fx.root, "bob", "cogos-dev", "Bob", "")
+
+	// Cycle 1 — both creates.
+	cfg1, _ := fx.prov.LoadConfig(fx.root)
+	live1, _ := fx.prov.FetchLive(context.Background(), cfg1)
+	plan1, _ := fx.prov.ComputePlan(cfg1, live1, nil)
+	results1, _ := fx.prov.ApplyPlan(context.Background(), plan1)
+	if len(results1) != 2 {
+		t.Fatalf("cycle 1: got %d results, want 2", len(results1))
+	}
+	for _, r := range results1 {
+		if r.Status != ApplySucceeded {
+			t.Fatalf("cycle 1 result %+v, want succeeded", r)
+		}
+	}
+
+	fx.evMu.Lock()
+	cycle1Events := len(*fx.events)
+	fx.evMu.Unlock()
+
+	// Cycle 2 — fresh full reload. ComputePlan should return all-skip.
+	cfg2, _ := fx.prov.LoadConfig(fx.root)
+	live2, _ := fx.prov.FetchLive(context.Background(), cfg2)
+	plan2, _ := fx.prov.ComputePlan(cfg2, live2, nil)
+
+	if plan2.Summary.HasChanges() {
+		t.Errorf("cycle 2 plan has changes: %+v, want all-skip", plan2.Summary)
+	}
+	if plan2.Summary.Skipped != 2 {
+		t.Errorf("cycle 2 Skipped = %d, want 2", plan2.Summary.Skipped)
+	}
+
+	// Apply the all-skip plan — all actions have ActionSkip, which ApplyPlan
+	// filters with `continue` at the top of the loop, so results should be empty.
+	results2, _ := fx.prov.ApplyPlan(context.Background(), plan2)
+	if len(results2) != 0 {
+		t.Errorf("cycle 2 apply produced %d results, want 0 (all actions skip)", len(results2))
+	}
+
+	// Zero new events across the entire second cycle.
+	fx.evMu.Lock()
+	cycle2Events := len(*fx.events)
+	fx.evMu.Unlock()
+	if cycle2Events != cycle1Events {
+		t.Errorf("cycle 2 emitted %d new events, want 0", cycle2Events-cycle1Events)
+	}
+}
+
+// TestIdentityProvider_ApplyPlan_RepeatedSamePlan_AllSkippedAfterFirst is the
+// strictest form of the contract: applying the same plan object N times in a
+// row produces exactly one effective apply. Every subsequent call returns
+// ApplySkipped, and exactly one identity.projected event is emitted total.
+func TestIdentityProvider_ApplyPlan_RepeatedSamePlan_AllSkippedAfterFirst(t *testing.T) {
+	fx := setupProvider(t)
+	writeIdentityCRD(t, fx.root, "cog", "cogos-dev", "Cog", "")
+
+	cfg, _ := fx.prov.LoadConfig(fx.root)
+	live, _ := fx.prov.FetchLive(context.Background(), cfg)
+	plan, _ := fx.prov.ComputePlan(cfg, live, nil)
+
+	// First apply — creates.
+	r0, err := fx.prov.ApplyPlan(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("apply 0: %v", err)
+	}
+	if len(r0) != 1 || r0[0].Status != ApplySucceeded {
+		t.Fatalf("apply 0 = %+v, want 1 succeeded", r0)
+	}
+
+	// Five more applies — every one should be skipped.
+	for i := 1; i <= 5; i++ {
+		ri, err := fx.prov.ApplyPlan(context.Background(), plan)
+		if err != nil {
+			t.Fatalf("apply %d: %v", i, err)
+		}
+		if len(ri) != 1 {
+			t.Fatalf("apply %d: got %d results, want 1", i, len(ri))
+		}
+		if ri[0].Status != ApplySkipped {
+			t.Errorf("apply %d: Status = %v, want ApplySkipped", i, ri[0].Status)
+		}
+	}
+
+	// Exactly one identity.projected event across all six applies.
+	assertEmitted(t, fx, EventIdentityProjected, 1)
 }
 
 func TestIdentityProvider_KeyResolvers_FileScheme(t *testing.T) {

--- a/identity_provider_test.go
+++ b/identity_provider_test.go
@@ -1,0 +1,666 @@
+// identity_provider_test.go
+// Covers IdentityProvider's full reconcile lifecycle (LoadConfig → FetchLive →
+// ComputePlan → ApplyPlan → BuildState → Health) against an in-memory
+// ConstellationDB fake and a captured event bus. Also exercises key
+// resolvers, integrity-hash verification, and the three-axis health surface.
+
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// ─── In-memory fakes ─────────────────────────────────────────────────────────────
+
+// memDB is a thread-safe in-memory ConstellationDB implementation for tests.
+// The provider only depends on the six methods of ConstellationDB, so this
+// single struct is enough to drive the whole reconcile lifecycle.
+type memDB struct {
+	mu           sync.Mutex
+	projections  map[string]IdentityProjection
+	participants map[string]ParticipantRow
+}
+
+func newMemDB() *memDB {
+	return &memDB{
+		projections:  make(map[string]IdentityProjection),
+		participants: make(map[string]ParticipantRow),
+	}
+}
+
+func (m *memDB) UpsertIdentityCogDoc(_ context.Context, doc IdentityProjection) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.projections[doc.Sub] = doc
+	return nil
+}
+
+func (m *memDB) DeleteIdentityCogDoc(_ context.Context, sub string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.projections, sub)
+	return nil
+}
+
+func (m *memDB) UpsertParticipant(_ context.Context, row ParticipantRow) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.participants[row.ID] = row
+	return nil
+}
+
+func (m *memDB) DeleteParticipant(_ context.Context, id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.participants, id)
+	return nil
+}
+
+func (m *memDB) GetProjection(_ context.Context, sub string) (*IdentityProjection, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if p, ok := m.projections[sub]; ok {
+		cp := p
+		return &cp, nil
+	}
+	return nil, nil
+}
+
+func (m *memDB) ListProjections(_ context.Context) ([]IdentityProjection, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]IdentityProjection, 0, len(m.projections))
+	for _, p := range m.projections {
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+// capturedEvent is one entry in the test event bus.
+type capturedEvent struct {
+	Type string
+	Data map[string]any
+}
+
+// eventRecorder is a BusEmit that appends into a slice under a mutex.
+func eventRecorder(out *[]capturedEvent, mu *sync.Mutex) BusEmit {
+	return func(t string, d map[string]any) error {
+		mu.Lock()
+		defer mu.Unlock()
+		// Copy the map so test mutations don't affect history.
+		cp := make(map[string]any, len(d))
+		for k, v := range d {
+			cp[k] = v
+		}
+		*out = append(*out, capturedEvent{Type: t, Data: cp})
+		return nil
+	}
+}
+
+// ─── Fixture builders ────────────────────────────────────────────────────────────
+
+// writeIdentityCRD materializes a minimal valid identity YAML in the given
+// workspace root. `extra` is appended to the spec block verbatim (trailing
+// newline included) for tests that need to add private_key or auth_factors.
+func writeIdentityCRD(t *testing.T, root, sub, iss, displayName, extra string) {
+	t.Helper()
+	dir := identityCRDDir(root)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	body := fmt.Sprintf(`apiVersion: cog.os/v1alpha1
+kind: Identity
+metadata:
+  name: %s
+spec:
+  iss: %s
+  sub: %s
+  type: agent
+%s  expressions:
+    - aud: "*"
+      display_name: %q
+`, sub, iss, sub, extra, displayName)
+	path := filepath.Join(dir, sub+".yaml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// setupProvider builds a fresh provider with a fresh in-memory DB and event
+// recorder. Returns everything the tests commonly need.
+type providerFixture struct {
+	root   string
+	db     *memDB
+	prov   *IdentityProvider
+	events *[]capturedEvent
+	evMu   *sync.Mutex
+}
+
+func setupProvider(t *testing.T) *providerFixture {
+	t.Helper()
+	root := t.TempDir()
+	db := newMemDB()
+	var events []capturedEvent
+	var mu sync.Mutex
+	prov := NewIdentityProvider(db, nil, eventRecorder(&events, &mu))
+	return &providerFixture{
+		root:   root,
+		db:     db,
+		prov:   prov,
+		events: &events,
+		evMu:   &mu,
+	}
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────────
+
+func TestIdentityProvider_Type(t *testing.T) {
+	p := NewIdentityProvider(nil, nil, nil)
+	if got := p.Type(); got != "identity" {
+		t.Errorf("Type() = %q, want %q", got, "identity")
+	}
+}
+
+func TestIdentityProvider_LoadConfig_Empty(t *testing.T) {
+	fx := setupProvider(t)
+
+	cfg, err := fx.prov.LoadConfig(fx.root)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	idCfg, ok := cfg.(*identityConfig)
+	if !ok {
+		t.Fatalf("LoadConfig returned %T, want *identityConfig", cfg)
+	}
+	if len(idCfg.CRDs) != 0 {
+		t.Errorf("CRDs len = %d, want 0", len(idCfg.CRDs))
+	}
+}
+
+func TestIdentityProvider_LoadConfig_Multiple(t *testing.T) {
+	fx := setupProvider(t)
+	writeIdentityCRD(t, fx.root, "cog", "cogos-dev", "Cog", "")
+	writeIdentityCRD(t, fx.root, "claude", "cogos-dev", "Claude", "")
+	writeIdentityCRD(t, fx.root, "sandy", "cogos-dev", "Sandy", "")
+
+	cfg, err := fx.prov.LoadConfig(fx.root)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	idCfg := cfg.(*identityConfig)
+	if len(idCfg.CRDs) != 3 {
+		t.Fatalf("CRDs len = %d, want 3", len(idCfg.CRDs))
+	}
+	for _, sub := range []string{"cog", "claude", "sandy"} {
+		h, ok := idCfg.SpecHash[sub]
+		if !ok || !strings.HasPrefix(h, "sha256:") {
+			t.Errorf("SpecHash[%q] = %q, want sha256:...", sub, h)
+		}
+	}
+}
+
+func TestIdentityProvider_FetchLive_EmptyDB(t *testing.T) {
+	fx := setupProvider(t)
+
+	live, err := fx.prov.FetchLive(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("FetchLive: %v", err)
+	}
+	snap := live.(*identityLive)
+	if len(snap.Projections) != 0 {
+		t.Errorf("Projections = %d, want 0", len(snap.Projections))
+	}
+}
+
+func TestIdentityProvider_FetchLive_ExistingProjections(t *testing.T) {
+	fx := setupProvider(t)
+	// Prime the DB directly so FetchLive has something to read back.
+	_ = fx.db.UpsertIdentityCogDoc(context.Background(), IdentityProjection{
+		Sub: "cog", Iss: "cogos-dev", Type: "agent", SpecHash: "sha256:deadbeef",
+	})
+
+	live, err := fx.prov.FetchLive(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("FetchLive: %v", err)
+	}
+	snap := live.(*identityLive)
+	if got, ok := snap.Projections["cog"]; !ok || got.SpecHash != "sha256:deadbeef" {
+		t.Errorf("Projections[cog] = %+v, want spec_hash sha256:deadbeef", got)
+	}
+}
+
+func TestIdentityProvider_ComputePlan_AllCreates(t *testing.T) {
+	fx := setupProvider(t)
+	writeIdentityCRD(t, fx.root, "cog", "cogos-dev", "Cog", "")
+	writeIdentityCRD(t, fx.root, "claude", "cogos-dev", "Claude", "")
+
+	cfg, _ := fx.prov.LoadConfig(fx.root)
+	live, _ := fx.prov.FetchLive(context.Background(), cfg)
+
+	plan, err := fx.prov.ComputePlan(cfg, live, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if plan.Summary.Creates != 2 {
+		t.Errorf("Creates = %d, want 2", plan.Summary.Creates)
+	}
+	if plan.Summary.Updates != 0 || plan.Summary.Deletes != 0 {
+		t.Errorf("Updates/Deletes = %d/%d, want 0/0", plan.Summary.Updates, plan.Summary.Deletes)
+	}
+}
+
+func TestIdentityProvider_ComputePlan_NoChanges(t *testing.T) {
+	fx := setupProvider(t)
+	writeIdentityCRD(t, fx.root, "cog", "cogos-dev", "Cog", "")
+
+	// First pass: create.
+	cfg, _ := fx.prov.LoadConfig(fx.root)
+	live, _ := fx.prov.FetchLive(context.Background(), cfg)
+	plan, _ := fx.prov.ComputePlan(cfg, live, nil)
+	if _, err := fx.prov.ApplyPlan(context.Background(), plan); err != nil {
+		t.Fatalf("ApplyPlan (create): %v", err)
+	}
+
+	// Second pass: re-compute, should be all-skip.
+	live2, _ := fx.prov.FetchLive(context.Background(), cfg)
+	plan2, err := fx.prov.ComputePlan(cfg, live2, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if plan2.Summary.HasChanges() {
+		t.Errorf("expected no changes, got %+v", plan2.Summary)
+	}
+	if plan2.Summary.Skipped != 1 {
+		t.Errorf("Skipped = %d, want 1", plan2.Summary.Skipped)
+	}
+}
+
+func TestIdentityProvider_ComputePlan_ExpressionUpdate(t *testing.T) {
+	fx := setupProvider(t)
+	writeIdentityCRD(t, fx.root, "cog", "cogos-dev", "Cog", "")
+
+	cfg, _ := fx.prov.LoadConfig(fx.root)
+	live, _ := fx.prov.FetchLive(context.Background(), cfg)
+	plan, _ := fx.prov.ComputePlan(cfg, live, nil)
+	if _, err := fx.prov.ApplyPlan(context.Background(), plan); err != nil {
+		t.Fatalf("ApplyPlan (create): %v", err)
+	}
+
+	// Change display_name.
+	writeIdentityCRD(t, fx.root, "cog", "cogos-dev", "Cog v2", "")
+
+	cfg2, _ := fx.prov.LoadConfig(fx.root)
+	live2, _ := fx.prov.FetchLive(context.Background(), cfg2)
+	plan2, err := fx.prov.ComputePlan(cfg2, live2, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if plan2.Summary.Updates != 1 {
+		t.Errorf("Updates = %d, want 1", plan2.Summary.Updates)
+	}
+}
+
+func TestIdentityProvider_ComputePlan_Delete(t *testing.T) {
+	fx := setupProvider(t)
+	writeIdentityCRD(t, fx.root, "cog", "cogos-dev", "Cog", "")
+
+	// Apply create.
+	cfg, _ := fx.prov.LoadConfig(fx.root)
+	live, _ := fx.prov.FetchLive(context.Background(), cfg)
+	plan, _ := fx.prov.ComputePlan(cfg, live, nil)
+	if _, err := fx.prov.ApplyPlan(context.Background(), plan); err != nil {
+		t.Fatalf("ApplyPlan (create): %v", err)
+	}
+
+	// Remove the spec file.
+	if err := os.Remove(filepath.Join(identityCRDDir(fx.root), "cog.yaml")); err != nil {
+		t.Fatalf("remove spec: %v", err)
+	}
+
+	cfg2, _ := fx.prov.LoadConfig(fx.root)
+	live2, _ := fx.prov.FetchLive(context.Background(), cfg2)
+	plan2, err := fx.prov.ComputePlan(cfg2, live2, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if plan2.Summary.Deletes != 1 {
+		t.Errorf("Deletes = %d, want 1", plan2.Summary.Deletes)
+	}
+}
+
+func TestIdentityProvider_ApplyPlan_Create_EmitsProjectedEvent(t *testing.T) {
+	fx := setupProvider(t)
+	writeIdentityCRD(t, fx.root, "cog", "cogos-dev", "Cog", "")
+
+	cfg, _ := fx.prov.LoadConfig(fx.root)
+	live, _ := fx.prov.FetchLive(context.Background(), cfg)
+	plan, _ := fx.prov.ComputePlan(cfg, live, nil)
+	results, err := fx.prov.ApplyPlan(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("ApplyPlan: %v", err)
+	}
+	if len(results) != 1 || results[0].Status != ApplySucceeded {
+		t.Fatalf("results = %+v, want 1 succeeded", results)
+	}
+
+	// The projection cogdoc must exist on disk.
+	if _, err := os.Stat(filepath.Join(fx.root, ".cog", "id", "cog.cog.md")); err != nil {
+		t.Errorf("projection cogdoc not written: %v", err)
+	}
+	// DB has the participant row.
+	if _, ok := fx.db.participants["agent:cog"]; !ok {
+		t.Errorf("participants[agent:cog] missing")
+	}
+	// Event emitted.
+	assertEmitted(t, fx, EventIdentityProjected, 1)
+}
+
+func TestIdentityProvider_ApplyPlan_UpdateEmitsExpressionUpdatedEvent(t *testing.T) {
+	fx := setupProvider(t)
+	writeIdentityCRD(t, fx.root, "cog", "cogos-dev", "Cog", "")
+
+	cfg, _ := fx.prov.LoadConfig(fx.root)
+	live, _ := fx.prov.FetchLive(context.Background(), cfg)
+	plan, _ := fx.prov.ComputePlan(cfg, live, nil)
+	if _, err := fx.prov.ApplyPlan(context.Background(), plan); err != nil {
+		t.Fatalf("ApplyPlan (create): %v", err)
+	}
+	// Reset events so the update assertion is unambiguous.
+	fx.evMu.Lock()
+	*fx.events = nil
+	fx.evMu.Unlock()
+
+	// Change the spec, re-plan, apply as update.
+	writeIdentityCRD(t, fx.root, "cog", "cogos-dev", "Cog v2", "")
+	cfg2, _ := fx.prov.LoadConfig(fx.root)
+	live2, _ := fx.prov.FetchLive(context.Background(), cfg2)
+	plan2, _ := fx.prov.ComputePlan(cfg2, live2, nil)
+	if _, err := fx.prov.ApplyPlan(context.Background(), plan2); err != nil {
+		t.Fatalf("ApplyPlan (update): %v", err)
+	}
+
+	assertEmitted(t, fx, EventIdentityExpressionUpdated, 1)
+}
+
+func TestIdentityProvider_ApplyPlan_DeleteEmitsDeregisteredEvent(t *testing.T) {
+	fx := setupProvider(t)
+	writeIdentityCRD(t, fx.root, "cog", "cogos-dev", "Cog", "")
+
+	cfg, _ := fx.prov.LoadConfig(fx.root)
+	live, _ := fx.prov.FetchLive(context.Background(), cfg)
+	plan, _ := fx.prov.ComputePlan(cfg, live, nil)
+	if _, err := fx.prov.ApplyPlan(context.Background(), plan); err != nil {
+		t.Fatalf("ApplyPlan (create): %v", err)
+	}
+	fx.evMu.Lock()
+	*fx.events = nil
+	fx.evMu.Unlock()
+
+	// Remove the spec, re-plan, apply as delete.
+	if err := os.Remove(filepath.Join(identityCRDDir(fx.root), "cog.yaml")); err != nil {
+		t.Fatalf("remove spec: %v", err)
+	}
+	cfg2, _ := fx.prov.LoadConfig(fx.root)
+	live2, _ := fx.prov.FetchLive(context.Background(), cfg2)
+	plan2, _ := fx.prov.ComputePlan(cfg2, live2, nil)
+	if _, err := fx.prov.ApplyPlan(context.Background(), plan2); err != nil {
+		t.Fatalf("ApplyPlan (delete): %v", err)
+	}
+
+	assertEmitted(t, fx, EventIdentityDeregistered, 1)
+	// Participant row removed.
+	if _, ok := fx.db.participants["agent:cog"]; ok {
+		t.Errorf("participants[agent:cog] still present after delete")
+	}
+	// Projection cogdoc removed from disk.
+	if _, err := os.Stat(filepath.Join(fx.root, ".cog", "id", "cog.cog.md")); !os.IsNotExist(err) {
+		t.Errorf("projection cogdoc still on disk after delete: err=%v", err)
+	}
+}
+
+func TestIdentityProvider_ApplyPlan_KeyHashMismatch_RefusesApply_EmitsMismatchEvent(t *testing.T) {
+	fx := setupProvider(t)
+
+	// Write a real key bytes file, but state a bogus hash in the CRD.
+	keyBytes := []byte("fake-pem-bytes")
+	keyPath := filepath.Join(fx.root, "key.pem")
+	if err := os.WriteFile(keyPath, keyBytes, 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	extra := fmt.Sprintf(`  private_key:
+    ref: "file://%s"
+    integrity_hash: "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+`, keyPath)
+	writeIdentityCRD(t, fx.root, "cog", "cogos-dev", "Cog", extra)
+
+	cfg, _ := fx.prov.LoadConfig(fx.root)
+	live, _ := fx.prov.FetchLive(context.Background(), cfg)
+	plan, _ := fx.prov.ComputePlan(cfg, live, nil)
+	results, err := fx.prov.ApplyPlan(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("ApplyPlan returned top-level error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(results))
+	}
+	if results[0].Status != ApplyFailed {
+		t.Errorf("Status = %q, want %q", results[0].Status, ApplyFailed)
+	}
+	if !strings.Contains(results[0].Error, "mismatch") {
+		t.Errorf("Error = %q, want substring 'mismatch'", results[0].Error)
+	}
+
+	assertEmitted(t, fx, EventIdentityKeyMismatch, 1)
+	// Projection cogdoc must NOT have been written.
+	if _, err := os.Stat(filepath.Join(fx.root, ".cog", "id", "cog.cog.md")); !os.IsNotExist(err) {
+		t.Errorf("projection cogdoc written despite mismatch: err=%v", err)
+	}
+	// DB must NOT have a row.
+	if _, ok := fx.db.projections["cog"]; ok {
+		t.Errorf("projection in DB despite mismatch")
+	}
+}
+
+func TestIdentityProvider_KeyResolvers_FileScheme(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "k.pem")
+	want := []byte("hello")
+	if err := os.WriteFile(keyPath, want, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := (fileKeyResolver{}).ResolveKey(context.Background(), "file://"+keyPath)
+	if err != nil {
+		t.Fatalf("ResolveKey: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestIdentityProvider_KeyResolvers_InlineScheme(t *testing.T) {
+	payload := []byte("inline-data")
+	ref := "inline://" + base64.StdEncoding.EncodeToString(payload)
+	got, err := (inlineKeyResolver{}).ResolveKey(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("ResolveKey: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Errorf("got %q, want %q", got, payload)
+	}
+}
+
+func TestIdentityProvider_KeyResolvers_UnsupportedScheme_Errors(t *testing.T) {
+	p := NewIdentityProvider(nil, nil, nil)
+	for _, scheme := range []string{"vault", "s3", "keychain", "env", "kms"} {
+		ref := scheme + "://whatever"
+		if _, err := p.resolveKey(context.Background(), ref); !errors.Is(err, ErrSchemeNotImplemented) {
+			t.Errorf("%s://: err = %v, want ErrSchemeNotImplemented", scheme, err)
+		}
+	}
+}
+
+func TestIdentityProvider_IntegrityHash_SHA256(t *testing.T) {
+	data := []byte("some-key-bytes")
+	sum := sha256.Sum256(data)
+	hash := "sha256:" + hex.EncodeToString(sum[:])
+	if err := verifyKeyIntegrity(data, hash); err != nil {
+		t.Errorf("verifyKeyIntegrity passed-case: %v", err)
+	}
+
+	// sha512 passes too.
+	sum5 := sha512.Sum512(data)
+	hash5 := "sha512:" + hex.EncodeToString(sum5[:])
+	if err := verifyKeyIntegrity(data, hash5); err != nil {
+		t.Errorf("verifyKeyIntegrity sha512: %v", err)
+	}
+}
+
+func TestIdentityProvider_IntegrityHash_Mismatch(t *testing.T) {
+	data := []byte("some-key-bytes")
+	bogus := "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+	if err := verifyKeyIntegrity(data, bogus); err == nil {
+		t.Errorf("verifyKeyIntegrity(mismatch) returned nil, want error")
+	}
+}
+
+func TestIdentityProvider_Health_ThreeAxes(t *testing.T) {
+	// Scenario 1: fresh provider with no config → Synced / Healthy / Idle.
+	p := NewIdentityProvider(newMemDB(), nil, nil)
+	got := p.Health()
+	if got.Sync != SyncStatusSynced || got.Health != HealthHealthy || got.Operation != OperationIdle {
+		t.Errorf("scenario 1: %+v, want Synced/Healthy/Idle", got)
+	}
+
+	// Scenario 2: plan has pending creates → OutOfSync / Healthy / Idle.
+	fx := setupProvider(t)
+	writeIdentityCRD(t, fx.root, "cog", "cogos-dev", "Cog", "")
+	cfg, _ := fx.prov.LoadConfig(fx.root)
+	live, _ := fx.prov.FetchLive(context.Background(), cfg)
+	if _, err := fx.prov.ComputePlan(cfg, live, nil); err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	got = fx.prov.Health()
+	if got.Sync != SyncStatusOutOfSync {
+		t.Errorf("scenario 2: Sync = %q, want OutOfSync", got.Sync)
+	}
+	if got.Health != HealthHealthy {
+		t.Errorf("scenario 2: Health = %q, want Healthy", got.Health)
+	}
+
+	// Scenario 3: projection present but spec deleted → Health = Missing.
+	fx3 := setupProvider(t)
+	writeIdentityCRD(t, fx3.root, "cog", "cogos-dev", "Cog", "")
+	cfg3, _ := fx3.prov.LoadConfig(fx3.root)
+	live3, _ := fx3.prov.FetchLive(context.Background(), cfg3)
+	plan3, _ := fx3.prov.ComputePlan(cfg3, live3, nil)
+	if _, err := fx3.prov.ApplyPlan(context.Background(), plan3); err != nil {
+		t.Fatalf("ApplyPlan: %v", err)
+	}
+	// Remove spec, re-plan; projection now orphaned.
+	_ = os.Remove(filepath.Join(identityCRDDir(fx3.root), "cog.yaml"))
+	cfg3b, _ := fx3.prov.LoadConfig(fx3.root)
+	live3b, _ := fx3.prov.FetchLive(context.Background(), cfg3b)
+	if _, err := fx3.prov.ComputePlan(cfg3b, live3b, nil); err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	got = fx3.prov.Health()
+	if got.Health != HealthMissing {
+		t.Errorf("scenario 3: Health = %q, want Missing", got.Health)
+	}
+
+	// Scenario 4: key-hash mismatch → Health = Degraded.
+	fx4 := setupProvider(t)
+	keyBytes := []byte("fake-pem-bytes")
+	keyPath := filepath.Join(fx4.root, "k.pem")
+	_ = os.WriteFile(keyPath, keyBytes, 0o600)
+	extra := fmt.Sprintf(`  private_key:
+    ref: "file://%s"
+    integrity_hash: "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+`, keyPath)
+	writeIdentityCRD(t, fx4.root, "cog", "cogos-dev", "Cog", extra)
+	cfg4, _ := fx4.prov.LoadConfig(fx4.root)
+	live4, _ := fx4.prov.FetchLive(context.Background(), cfg4)
+	plan4, _ := fx4.prov.ComputePlan(cfg4, live4, nil)
+	_, _ = fx4.prov.ApplyPlan(context.Background(), plan4)
+	got = fx4.prov.Health()
+	if got.Health != HealthDegraded {
+		t.Errorf("scenario 4: Health = %q, want Degraded", got.Health)
+	}
+}
+
+func TestIdentityProvider_BuildState_LineageSurvives(t *testing.T) {
+	fx := setupProvider(t)
+	writeIdentityCRD(t, fx.root, "cog", "cogos-dev", "Cog", "")
+
+	cfg, _ := fx.prov.LoadConfig(fx.root)
+	live, _ := fx.prov.FetchLive(context.Background(), cfg)
+	plan, _ := fx.prov.ComputePlan(cfg, live, nil)
+	if _, err := fx.prov.ApplyPlan(context.Background(), plan); err != nil {
+		t.Fatalf("ApplyPlan: %v", err)
+	}
+
+	live1, _ := fx.prov.FetchLive(context.Background(), cfg)
+	state1, err := fx.prov.BuildState(cfg, live1, nil)
+	if err != nil {
+		t.Fatalf("BuildState #1: %v", err)
+	}
+	if state1.Lineage == "" {
+		t.Fatalf("state1.Lineage empty")
+	}
+	if state1.Serial != 1 {
+		t.Errorf("state1.Serial = %d, want 1", state1.Serial)
+	}
+
+	// Rebuild with the previous state as existing.
+	state2, err := fx.prov.BuildState(cfg, live1, state1)
+	if err != nil {
+		t.Fatalf("BuildState #2: %v", err)
+	}
+	if state2.Lineage != state1.Lineage {
+		t.Errorf("Lineage changed: %q → %q", state1.Lineage, state2.Lineage)
+	}
+	if state2.Serial != state1.Serial+1 {
+		t.Errorf("Serial = %d, want %d", state2.Serial, state1.Serial+1)
+	}
+	if len(state2.Resources) != 1 {
+		t.Errorf("Resources len = %d, want 1", len(state2.Resources))
+	}
+}
+
+// ─── helpers ────────────────────────────────────────────────────────────────────
+
+// assertEmitted verifies that exactly `want` events of type `eventType` were
+// captured by the fixture's recorder.
+func assertEmitted(t *testing.T, fx *providerFixture, eventType string, want int) {
+	t.Helper()
+	fx.evMu.Lock()
+	defer fx.evMu.Unlock()
+	got := 0
+	for _, e := range *fx.events {
+		if e.Type == eventType {
+			got++
+		}
+	}
+	if got != want {
+		t.Errorf("event %q: got %d, want %d (all events: %v)", eventType, got, want, eventTypes(*fx.events))
+	}
+}
+
+func eventTypes(evs []capturedEvent) []string {
+	out := make([]string, len(evs))
+	for i, e := range evs {
+		out[i] = e.Type
+	}
+	return out
+}

--- a/internal/engine/config.go
+++ b/internal/engine/config.go
@@ -77,6 +77,16 @@ type Config struct {
 	// at .cog/run/kernel.log.jsonl. Leave empty for the default.
 	KernelLogPath string
 
+	// Mod3URL is the base URL (scheme + host + port) of the mod3 voice service
+	// that owns per-channel communication state (voice, output device, queue)
+	// keyed on kernel-issued session IDs. The kernel forwards channel-session
+	// registration to this URL; mod3 remains the per-channel state owner while
+	// the kernel retains identity authority (ADR-082 split).
+	//
+	// Default: http://localhost:7860. Override via `mod3_url` in kernel.yaml
+	// (top-level or under v3:) or via the COGOS_MOD3_URL env var.
+	Mod3URL string
+
 	LocalModel string
 
 	localModelConfigured bool
@@ -99,6 +109,7 @@ type kernelConfigSection struct {
 	LocalModel            string            `yaml:"local_model"`
 	DigestPaths           map[string]string `yaml:"digest_paths"`
 	KernelLogPath         string            `yaml:"kernel_log_path"`
+	Mod3URL               string            `yaml:"mod3_url"`
 }
 
 // kernelConfig is the on-disk YAML shape of .cog/config/kernel.yaml.
@@ -137,6 +148,7 @@ func LoadConfig(workspaceRoot string, port int) (*Config, error) {
 		ToolCallValidationEnabled: true,
 		LocalModel:                defaultOllamaModel,
 		DigestPaths:               make(map[string]string),
+		Mod3URL:                   "http://localhost:7860",
 	}
 
 	// Load from file if present.
@@ -148,6 +160,12 @@ func LoadConfig(workspaceRoot string, port int) (*Config, error) {
 			applyKernelSection(cfg, kc.kernelConfigSection)
 			applyKernelSection(cfg, kc.V3)
 		}
+	}
+
+	// Env override for the mod3 URL. Env wins over file; flags stay flag-only
+	// (we don't surface `--mod3-url` in CLI; one env var + YAML is enough).
+	if v := os.Getenv("COGOS_MOD3_URL"); v != "" {
+		cfg.Mod3URL = v
 	}
 
 	// Flag override.
@@ -210,6 +228,9 @@ func applyKernelSection(cfg *Config, s kernelConfigSection) {
 	}
 	if s.KernelLogPath != "" {
 		cfg.KernelLogPath = s.KernelLogPath
+	}
+	if s.Mod3URL != "" {
+		cfg.Mod3URL = s.Mod3URL
 	}
 }
 

--- a/internal/engine/mcp_modality_proxy.go
+++ b/internal/engine/mcp_modality_proxy.go
@@ -83,6 +83,14 @@ type modalityProxy struct {
 	// this when they want to assert "we got the bytes" without spawning a
 	// real player. Production code leaves it false.
 	disablePlayback bool
+
+	// subscriberCheck, when non-nil, is consulted before spawning the local
+	// player in mod3_speak. If it returns (true, nil) the kernel skips
+	// afplay — mod3's /ws/audio/{session_id} WebSocket is already pushing
+	// the WAV to a dashboard subscriber (Wave 4.3). Errors and false return
+	// values fall through to the normal playback path. Nil means "use the
+	// default HTTP implementation" (GET {Mod3URL}/v1/sessions/{id}/subscribers).
+	subscriberCheck func(ctx context.Context, sessionID string) (bool, error)
 }
 
 // defaultMod3ProxyTimeout is the per-request timeout for mod3 forwards. 30s
@@ -279,6 +287,25 @@ func (m *MCPServer) toolMod3Speak(ctx context.Context, req *mcp.CallToolRequest,
 		return marshalResult(result)
 	}
 
+	// Wave 4.3 — if the session has a live dashboard WebSocket subscriber,
+	// mod3 is already routing the WAV there. Skip the kernel's local player
+	// so we don't double-play. The check is scoped to sessions that were
+	// actually named on the speak call; session_id="" always falls through
+	// to the normal afplay path so CLI invocations keep working.
+	if in.SessionID != "" {
+		subscribed, checkErr := m.checkSessionSubscriber(ctx, in.SessionID)
+		if checkErr != nil {
+			// Log-worthy but not fatal — fall back to local playback.
+			slog.Debug("mod3 proxy: subscriber check failed",
+				"session_id", in.SessionID, "err", checkErr)
+			result["subscriber_check_error"] = checkErr.Error()
+		}
+		if subscribed {
+			result["playback_status"] = "routed_ws"
+			return marshalResult(result)
+		}
+	}
+
 	playErr := p.playAudio(audio, in.Blocking)
 	switch {
 	case playErr == nil && in.Blocking:
@@ -290,6 +317,43 @@ func (m *MCPServer) toolMod3Speak(ctx context.Context, req *mcp.CallToolRequest,
 		result["playback_error"] = playErr.Error()
 	}
 	return marshalResult(result)
+}
+
+// checkSessionSubscriber asks mod3 whether ``sessionID`` has at least one
+// active dashboard WebSocket subscriber for audio playback. Returns
+// ``(subscribed, nil)`` on success, ``(false, err)`` on transport failure.
+// ``(false, nil)`` — the default when the proxy has no check configured —
+// also suppresses the routing path, so legacy callers see the exact same
+// afplay behavior as before.
+//
+// Injectable via modalityProxy.subscriberCheck for tests. The default is a
+// GET against mod3's /v1/sessions/{id}/subscribers endpoint with a 1.5s
+// timeout inherited from defaultMod3ProxyTimeout.
+func (m *MCPServer) checkSessionSubscriber(ctx context.Context, sessionID string) (bool, error) {
+	p := m.getModalityProxy()
+	if p.subscriberCheck != nil {
+		return p.subscriberCheck(ctx, sessionID)
+	}
+	// Default implementation — HTTP GET. Scoped to 1.5s so a wedged mod3
+	// can't block a speak for more than that; falls back to afplay on timeout.
+	checkCtx, cancel := context.WithTimeout(ctx, 1500*time.Millisecond)
+	defer cancel()
+	raw, _, status, err := m.proxyMod3Bytes(checkCtx, http.MethodGet,
+		"/v1/sessions/"+url.PathEscape(sessionID)+"/subscribers", nil, "")
+	if err != nil {
+		return false, err
+	}
+	if status < 200 || status >= 300 {
+		return false, fmt.Errorf("mod3 returned %d: %s", status, truncate(string(raw), 200))
+	}
+	var body struct {
+		Subscribed bool `json:"subscribed"`
+		Count      int  `json:"count"`
+	}
+	if unmarshalErr := json.Unmarshal(raw, &body); unmarshalErr != nil {
+		return false, fmt.Errorf("decode subscribers response: %w", unmarshalErr)
+	}
+	return body.Subscribed, nil
 }
 
 func (m *MCPServer) toolMod3Stop(ctx context.Context, req *mcp.CallToolRequest, in mod3StopInput) (*mcp.CallToolResult, any, error) {

--- a/internal/engine/mcp_modality_proxy.go
+++ b/internal/engine/mcp_modality_proxy.go
@@ -1,0 +1,551 @@
+// mcp_modality_proxy.go — kernel-side MCP proxy for mod3 voice tools.
+//
+// Wave 3 of the mod3-kernel integration (ADR-082 + channel-provider RFC).
+// The kernel becomes the MCP front door for mod3; the previous OpenClaw
+// gateway pattern in the installed binary read metrics but discarded audio
+// bytes. This proxy fixes that: it forwards HTTP calls to mod3, captures the
+// audio/wav payload, plays it locally via afplay/aplay (fire-and-forget by
+// default), and returns mod3's metric headers (X-Mod3-*) to the MCP caller.
+//
+// Design locks:
+//
+//  1. MCP transport = HTTP proxy. Every tool handler here POSTs/GETs against
+//     cfg.Mod3URL + "/v1/*". Mod3 is NOT an MCP server to the kernel. The
+//     installed binary's OpenClaw gateway is a separate concern — we are the
+//     next kernel build and will supersede it when deployed.
+//  2. Session authority = kernel-owned. session_id is threaded through every
+//     proxied call. Callers pass it as an optional field; absent → proxy
+//     omits it and mod3 routes to its default session. Present → proxy
+//     includes it in the request body (synthesize) or query string (stop).
+//  3. Playback strategy = Option (A), server-side. Kernel receives audio/wav,
+//     writes to a tempfile, execs `afplay` (macOS) or `aplay` (Linux),
+//     fire-and-forget. Callers can opt in to blocking with blocking=true.
+//     Forward-compatible with Option (B) session-routed playback once the
+//     Wave 4 dashboard WebSocket lands — a future session-router check can
+//     gate this path when a browser subscriber exists.
+//
+// Tools registered (prefix `mod3_` to namespace against cog_* kernel tools):
+//
+//   - mod3_speak                — synthesize + (optionally) play
+//   - mod3_stop                 — cancel current/queued speech
+//   - mod3_voices               — list available voices
+//   - mod3_status               — mod3 /health probe + build info
+//   - mod3_register_session     — proxy to mod3 session register (future)
+//   - mod3_deregister_session   — proxy to mod3 session deregister
+//   - mod3_list_sessions        — proxy to mod3 session list
+//
+// Note: the session-registry family forwards to mod3's /v1/sessions/* routes
+// which are not yet live on every mod3 instance (see openapi.json). They
+// return a clean 502 "mod3_unreachable" in that case; once mod3 implements
+// the routes (ADR-082 Wave 2 target), these tools become useful.
+package engine
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// ─── proxy wiring on MCPServer ───────────────────────────────────────────────
+
+// modalityProxy holds the HTTP client and playback helper used by the mod3_*
+// MCP tools. Fields are exported-by-convention (capitalized where needed for
+// tests) so test code can override the HTTP client and the player command.
+type modalityProxy struct {
+	// client is the HTTP client used for all mod3 forwards. Nil falls back
+	// to defaultMod3ProxyClient.
+	client *http.Client
+
+	// player is the OS command executed for server-side audio playback.
+	// Overridable in tests to a stub binary / /usr/bin/true. Empty means
+	// "autodetect via runtime.GOOS" (afplay on darwin, aplay elsewhere).
+	player string
+
+	// playerArgs, when non-nil, are passed as additional command args
+	// before the tempfile path. Useful for tests to pipe the wav through
+	// a counting script. Nil means no extra args.
+	playerArgs []string
+
+	// disablePlayback short-circuits the player exec entirely. Tests set
+	// this when they want to assert "we got the bytes" without spawning a
+	// real player. Production code leaves it false.
+	disablePlayback bool
+}
+
+// defaultMod3ProxyTimeout is the per-request timeout for mod3 forwards. 30s
+// covers the longest-plausible synthesis on the current Kokoro voice stack
+// (~5-10s for multi-sentence input, with headroom for cold starts).
+const defaultMod3ProxyTimeout = 30 * time.Second
+
+// defaultMod3ProxyClient is the shared http.Client used when modalityProxy.client
+// is nil. Lazily initialised; safe for concurrent use.
+var defaultMod3ProxyClient = &http.Client{Timeout: defaultMod3ProxyTimeout}
+
+// getModalityProxy returns the MCPServer's modality proxy, lazily creating
+// one with sane defaults on first access. Tests can pre-seed m.mod3Proxy with
+// their own instance before calling this.
+func (m *MCPServer) getModalityProxy() *modalityProxy {
+	if m.mod3Proxy == nil {
+		m.mod3Proxy = &modalityProxy{}
+	}
+	return m.mod3Proxy
+}
+
+// ─── tool registration ───────────────────────────────────────────────────────
+
+// registerMod3Tools installs the 7 mod3_* MCP tools. Called from
+// MCPServer.registerTools after the cog_* tools so the tool index stays
+// stable at the front.
+func (m *MCPServer) registerMod3Tools() {
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name: "mod3_speak",
+		Description: "Synthesize text to speech via mod3 and play the audio " +
+			"locally. Required: text. Optional: session_id, voice, speed, " +
+			"emotion, blocking (wait for playback to finish). Returns mod3 " +
+			"metrics (job_id, duration_sec, rtf, voice) and a playback_status " +
+			"flag. Fallback: curl -X POST http://localhost:7860/v1/synthesize " +
+			"-d '{\"text\":\"...\"}' -o out.wav && afplay out.wav",
+	}, withToolObserver(m, "mod3_speak", m.toolMod3Speak))
+
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name: "mod3_stop",
+		Description: "Stop current mod3 speech and/or cancel queued jobs. " +
+			"Optional: session_id, job_id (cancel one specific job). Empty " +
+			"cancels current playback and clears the queue. Returns mod3's " +
+			"barge-in interruption context. Fallback: curl -X POST " +
+			"http://localhost:7860/v1/stop",
+	}, withToolObserver(m, "mod3_stop", m.toolMod3Stop))
+
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name: "mod3_voices",
+		Description: "List available mod3 voices, optionally scoped to a " +
+			"session. Optional: session_id. Returns the voice catalogue mod3 " +
+			"exposes (id, name, language, gender metadata per voice). " +
+			"Fallback: curl http://localhost:7860/v1/voices",
+	}, withToolObserver(m, "mod3_voices", m.toolMod3Voices))
+
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name: "mod3_status",
+		Description: "Probe mod3's /health endpoint. Returns the raw health " +
+			"payload (model_loaded, engine info, queue_depth, etc). 502 if " +
+			"mod3 is unreachable. Fallback: curl http://localhost:7860/health",
+	}, withToolObserver(m, "mod3_status", m.toolMod3Status))
+
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name: "mod3_register_session",
+		Description: "Proxy to mod3's POST /v1/sessions/register. Required: " +
+			"participant_id. Optional: session_id (caller-supplied; kernel " +
+			"does NOT mint here — use /v1/channel-sessions/register for that), " +
+			"participant_type, preferred_voice, preferred_output_device, " +
+			"priority. Returns mod3's full SessionRegisterResponse (assigned_" +
+			"voice, voice_conflict, output_device, queue_depth).",
+	}, withToolObserver(m, "mod3_register_session", m.toolMod3RegisterSession))
+
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name: "mod3_deregister_session",
+		Description: "Proxy to mod3's POST /v1/sessions/{session_id}/deregister. " +
+			"Required: session_id. Returns mod3's deregister acknowledgment " +
+			"(released_voice, dropped_jobs).",
+	}, withToolObserver(m, "mod3_deregister_session", m.toolMod3DeregisterSession))
+
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name: "mod3_list_sessions",
+		Description: "Proxy to mod3's GET /v1/sessions. Returns the live " +
+			"mod3 session roster (sessions, voice_pool, voice_holders, " +
+			"serializer policy). No kernel-side filtering — mod3 is source " +
+			"of truth for per-channel state.",
+	}, withToolObserver(m, "mod3_list_sessions", m.toolMod3ListSessions))
+}
+
+// ─── input / output types ────────────────────────────────────────────────────
+
+type mod3SpeakInput struct {
+	Text      string  `json:"text"`
+	SessionID string  `json:"session_id,omitempty"`
+	Voice     string  `json:"voice,omitempty"`
+	Speed     float64 `json:"speed,omitempty"`
+	Emotion   float64 `json:"emotion,omitempty"`
+	// Blocking waits for the spawned player to exit before returning the
+	// tool result. Default false — fire-and-forget so multi-second audio
+	// doesn't block the MCP call.
+	Blocking bool `json:"blocking,omitempty"`
+	// SkipPlayback returns the wav bytes (base64) without attempting local
+	// playback. Useful for callers routing audio elsewhere (dashboard WS,
+	// file write, etc). Default false.
+	SkipPlayback bool `json:"skip_playback,omitempty"`
+}
+
+type mod3StopInput struct {
+	SessionID string `json:"session_id,omitempty"`
+	JobID     string `json:"job_id,omitempty"`
+}
+
+type mod3VoicesInput struct {
+	SessionID string `json:"session_id,omitempty"`
+}
+
+type mod3StatusInput struct{}
+
+type mod3RegisterSessionInput struct {
+	SessionID             string `json:"session_id,omitempty"`
+	ParticipantID         string `json:"participant_id"`
+	ParticipantType       string `json:"participant_type,omitempty"`
+	PreferredVoice        string `json:"preferred_voice,omitempty"`
+	PreferredOutputDevice string `json:"preferred_output_device,omitempty"`
+	Priority              int    `json:"priority,omitempty"`
+}
+
+type mod3DeregisterSessionInput struct {
+	SessionID string `json:"session_id"`
+}
+
+type mod3ListSessionsInput struct{}
+
+// ─── handlers ────────────────────────────────────────────────────────────────
+
+func (m *MCPServer) toolMod3Speak(ctx context.Context, req *mcp.CallToolRequest, in mod3SpeakInput) (*mcp.CallToolResult, any, error) {
+	if strings.TrimSpace(in.Text) == "" {
+		return textResult("text is required")
+	}
+	body := map[string]any{"text": in.Text}
+	if in.Voice != "" {
+		body["voice"] = in.Voice
+	}
+	if in.Speed > 0 {
+		body["speed"] = in.Speed
+	}
+	if in.Emotion > 0 {
+		body["emotion"] = in.Emotion
+	}
+	if in.SessionID != "" {
+		// Session threading: mod3 ignores unknown fields on SynthesizeRequest
+		// today; once multi-session synthesis lands, this is the channel.
+		body["session_id"] = in.SessionID
+	}
+	raw, _ := json.Marshal(body)
+
+	audio, headers, status, err := m.proxyMod3Bytes(ctx, http.MethodPost,
+		"/v1/synthesize", bytes.NewReader(raw), "application/json")
+	if err != nil {
+		return mod3ErrorResult(fmt.Sprintf("mod3 unreachable: %v", err))
+	}
+	if status < 200 || status >= 300 {
+		return mod3ErrorResult(fmt.Sprintf("mod3 returned %d: %s", status, truncate(string(audio), 400)))
+	}
+
+	metrics := extractMod3Metrics(headers)
+	result := map[string]any{
+		"ok":         true,
+		"bytes":      len(audio),
+		"metrics":    metrics,
+		"session_id": in.SessionID, // may be empty; echoed for observability
+	}
+
+	// If the caller asked for raw bytes (no server-side playback), base64-
+	// encode and return. Forward-compatible with session-routed playback.
+	if in.SkipPlayback {
+		result["audio_base64"] = base64.StdEncoding.EncodeToString(audio)
+		result["playback_status"] = "skipped"
+		return marshalResult(result)
+	}
+
+	p := m.getModalityProxy()
+	if p.disablePlayback {
+		result["playback_status"] = "disabled"
+		return marshalResult(result)
+	}
+
+	playErr := p.playAudio(audio, in.Blocking)
+	switch {
+	case playErr == nil && in.Blocking:
+		result["playback_status"] = "played"
+	case playErr == nil:
+		result["playback_status"] = "spawned"
+	default:
+		result["playback_status"] = "error"
+		result["playback_error"] = playErr.Error()
+	}
+	return marshalResult(result)
+}
+
+func (m *MCPServer) toolMod3Stop(ctx context.Context, req *mcp.CallToolRequest, in mod3StopInput) (*mcp.CallToolResult, any, error) {
+	path := "/v1/stop"
+	q := url.Values{}
+	if in.JobID != "" {
+		q.Set("job_id", in.JobID)
+	}
+	if in.SessionID != "" {
+		q.Set("session_id", in.SessionID)
+	}
+	if encoded := q.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+	return m.proxyMod3JSONAsMCP(ctx, http.MethodPost, path, nil)
+}
+
+func (m *MCPServer) toolMod3Voices(ctx context.Context, req *mcp.CallToolRequest, in mod3VoicesInput) (*mcp.CallToolResult, any, error) {
+	path := "/v1/voices"
+	if in.SessionID != "" {
+		path += "?session_id=" + url.QueryEscape(in.SessionID)
+	}
+	return m.proxyMod3JSONAsMCP(ctx, http.MethodGet, path, nil)
+}
+
+func (m *MCPServer) toolMod3Status(ctx context.Context, req *mcp.CallToolRequest, in mod3StatusInput) (*mcp.CallToolResult, any, error) {
+	return m.proxyMod3JSONAsMCP(ctx, http.MethodGet, "/health", nil)
+}
+
+func (m *MCPServer) toolMod3RegisterSession(ctx context.Context, req *mcp.CallToolRequest, in mod3RegisterSessionInput) (*mcp.CallToolResult, any, error) {
+	if in.ParticipantID == "" {
+		return textResult("participant_id is required")
+	}
+	body := map[string]any{
+		"participant_id": in.ParticipantID,
+	}
+	if in.SessionID != "" {
+		body["session_id"] = in.SessionID
+	}
+	if in.ParticipantType != "" {
+		body["participant_type"] = in.ParticipantType
+	}
+	if in.PreferredVoice != "" {
+		body["preferred_voice"] = in.PreferredVoice
+	}
+	if in.PreferredOutputDevice != "" {
+		body["preferred_output_device"] = in.PreferredOutputDevice
+	}
+	if in.Priority != 0 {
+		body["priority"] = in.Priority
+	}
+	raw, _ := json.Marshal(body)
+	return m.proxyMod3JSONAsMCP(ctx, http.MethodPost, "/v1/sessions/register", bytes.NewReader(raw))
+}
+
+func (m *MCPServer) toolMod3DeregisterSession(ctx context.Context, req *mcp.CallToolRequest, in mod3DeregisterSessionInput) (*mcp.CallToolResult, any, error) {
+	if in.SessionID == "" {
+		return textResult("session_id is required")
+	}
+	return m.proxyMod3JSONAsMCP(ctx, http.MethodPost,
+		"/v1/sessions/"+url.PathEscape(in.SessionID)+"/deregister", nil)
+}
+
+func (m *MCPServer) toolMod3ListSessions(ctx context.Context, req *mcp.CallToolRequest, in mod3ListSessionsInput) (*mcp.CallToolResult, any, error) {
+	return m.proxyMod3JSONAsMCP(ctx, http.MethodGet, "/v1/sessions", nil)
+}
+
+// ─── HTTP forwarder primitives ───────────────────────────────────────────────
+
+// proxyMod3Bytes issues an HTTP request to mod3 and returns the raw body,
+// response headers, HTTP status, and a transport error. Caller owns the body
+// bytes; they may be audio/wav (mod3_speak) or JSON (everything else).
+func (m *MCPServer) proxyMod3Bytes(ctx context.Context, method, path string, body io.Reader, contentType string) ([]byte, http.Header, int, error) {
+	if m.cfg == nil {
+		return nil, nil, 0, errors.New("Mod3URL not configured (cfg nil)")
+	}
+	base := strings.TrimRight(m.cfg.Mod3URL, "/")
+	if base == "" {
+		return nil, nil, 0, errors.New("Mod3URL not configured")
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, defaultMod3ProxyTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, method, base+path, body)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("build request: %w", err)
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	// Accept both audio and JSON so a single client path covers synthesize
+	// (audio/wav) and the rest (application/json).
+	req.Header.Set("Accept", "audio/wav, application/json")
+
+	client := m.getModalityProxy().client
+	if client == nil {
+		client = defaultMod3ProxyClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	defer resp.Body.Close()
+
+	// 16 MB cap — more than enough for multi-minute Kokoro wav at 24kHz
+	// (~2 MB per 30s), safety net against an upstream that never closes.
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 16<<20))
+	if err != nil {
+		return nil, resp.Header, resp.StatusCode, fmt.Errorf("read response body: %w", err)
+	}
+	return raw, resp.Header, resp.StatusCode, nil
+}
+
+// proxyMod3JSONAsMCP is a convenience wrapper for tools whose response is
+// JSON (everything except mod3_speak). Reads the body, parses it as JSON if
+// possible, and returns an mcp.CallToolResult; on non-2xx status returns a
+// mod3-error marshalled result so the caller sees the mod3 body intact.
+func (m *MCPServer) proxyMod3JSONAsMCP(ctx context.Context, method, path string, body io.Reader) (*mcp.CallToolResult, any, error) {
+	contentType := ""
+	if body != nil {
+		contentType = "application/json"
+	}
+	raw, _, status, err := m.proxyMod3Bytes(ctx, method, path, body, contentType)
+	if err != nil {
+		return mod3ErrorResult(fmt.Sprintf("mod3 unreachable: %v", err))
+	}
+	// Try to parse as JSON; if parse fails, surface the body as text so the
+	// caller at least sees what mod3 said.
+	var parsed any
+	if len(raw) > 0 {
+		if jsonErr := json.Unmarshal(raw, &parsed); jsonErr != nil {
+			parsed = map[string]any{"raw": string(raw)}
+		}
+	}
+	if status < 200 || status >= 300 {
+		return mod3ErrorResult(fmt.Sprintf("mod3 returned %d: %v", status, parsed))
+	}
+	return marshalResult(parsed)
+}
+
+// mod3ErrorResult returns an IsError=true CallToolResult so the observer
+// wrapper records the tool invocation as a failure in the ledger.
+func mod3ErrorResult(msg string) (*mcp.CallToolResult, any, error) {
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: msg}},
+		IsError: true,
+	}, nil, nil
+}
+
+// extractMod3Metrics pulls the X-Mod3-* headers into a metrics map. Numeric
+// fields are parsed when possible; unknown headers pass through as strings
+// so future mod3 headers surface without code changes.
+func extractMod3Metrics(h http.Header) map[string]any {
+	out := map[string]any{}
+	for key, values := range h {
+		lk := strings.ToLower(key)
+		if !strings.HasPrefix(lk, "x-mod3-") || len(values) == 0 {
+			continue
+		}
+		short := strings.TrimPrefix(lk, "x-mod3-")
+		v := values[0]
+		// Try numeric parse for the common metric headers.
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			// Preserve integers as int for nicer JSON output.
+			if i, ierr := strconv.ParseInt(v, 10, 64); ierr == nil {
+				out[short] = i
+			} else {
+				out[short] = f
+			}
+			continue
+		}
+		out[short] = v
+	}
+	return out
+}
+
+// ─── playback helper ─────────────────────────────────────────────────────────
+
+// playAudio writes the wav bytes to a tempfile and spawns the platform's
+// default player. When blocking==false the function returns immediately
+// after the process starts; a goroutine waits for exit so the tempfile can
+// be cleaned up. When blocking==true the function waits for exit and
+// surfaces any non-zero return as an error.
+//
+// In tests, set modalityProxy.player to "/usr/bin/true" (or similar) to
+// avoid actually playing audio.
+func (p *modalityProxy) playAudio(wav []byte, blocking bool) error {
+	if p.disablePlayback {
+		return nil
+	}
+	f, err := os.CreateTemp("", "mod3-speak-*.wav")
+	if err != nil {
+		return fmt.Errorf("tempfile: %w", err)
+	}
+	path := f.Name()
+	if _, err := f.Write(wav); err != nil {
+		f.Close()
+		os.Remove(path)
+		return fmt.Errorf("write tempfile: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(path)
+		return fmt.Errorf("close tempfile: %w", err)
+	}
+
+	player := p.player
+	if player == "" {
+		player = defaultPlayerCommand()
+	}
+	if player == "" {
+		os.Remove(path)
+		return fmt.Errorf("no audio player available for GOOS=%s", runtime.GOOS)
+	}
+
+	args := append([]string{}, p.playerArgs...)
+	args = append(args, path)
+	cmd := exec.Command(player, args...)
+
+	if err := cmd.Start(); err != nil {
+		os.Remove(path)
+		return fmt.Errorf("start %s: %w", player, err)
+	}
+
+	if blocking {
+		err := cmd.Wait()
+		_ = os.Remove(path)
+		if err != nil {
+			return fmt.Errorf("player %s exited: %w", player, err)
+		}
+		return nil
+	}
+	// Fire-and-forget: reap the child so the tempfile gets cleaned and the
+	// process isn't a zombie. Log errors; don't propagate (the MCP call
+	// already returned successfully).
+	go func() {
+		if werr := cmd.Wait(); werr != nil {
+			slog.Debug("mod3 proxy: player exited non-zero",
+				"player", player, "path", path, "err", werr)
+		}
+		_ = os.Remove(path)
+	}()
+	return nil
+}
+
+// defaultPlayerCommand returns the preferred platform player, or "" when
+// none is available in PATH. Resolved lazily per call so tests that change
+// PATH take effect.
+func defaultPlayerCommand() string {
+	candidates := map[string][]string{
+		"darwin":  {"afplay"},
+		"linux":   {"aplay", "paplay"},
+		"freebsd": {"aplay"},
+	}
+	for _, name := range candidates[runtime.GOOS] {
+		if _, err := exec.LookPath(name); err == nil {
+			return name
+		}
+	}
+	// Final fallback: if neither platform default is present, see if the
+	// caller has exposed one via PATH under its canonical name.
+	for _, name := range []string{"afplay", "aplay", "paplay", "ffplay"} {
+		if _, err := exec.LookPath(name); err == nil {
+			return name
+		}
+	}
+	return ""
+}

--- a/internal/engine/mcp_modality_proxy.go
+++ b/internal/engine/mcp_modality_proxy.go
@@ -118,7 +118,7 @@ func (m *MCPServer) getModalityProxy() *modalityProxy {
 // MCPServer.registerTools after the cog_* tools so the tool index stays
 // stable at the front.
 func (m *MCPServer) registerMod3Tools() {
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name: "mod3_speak",
 		Description: "Synthesize text to speech via mod3 and play the audio " +
 			"locally. Required: text. Optional: session_id, voice, speed, " +
@@ -126,33 +126,33 @@ func (m *MCPServer) registerMod3Tools() {
 			"metrics (job_id, duration_sec, rtf, voice) and a playback_status " +
 			"flag. Fallback: curl -X POST http://localhost:7860/v1/synthesize " +
 			"-d '{\"text\":\"...\"}' -o out.wav && afplay out.wav",
-	}, withToolObserver(m, "mod3_speak", m.toolMod3Speak))
+	}), withToolObserver(m, "mod3_speak", m.toolMod3Speak))
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name: "mod3_stop",
 		Description: "Stop current mod3 speech and/or cancel queued jobs. " +
 			"Optional: session_id, job_id (cancel one specific job). Empty " +
 			"cancels current playback and clears the queue. Returns mod3's " +
 			"barge-in interruption context. Fallback: curl -X POST " +
 			"http://localhost:7860/v1/stop",
-	}, withToolObserver(m, "mod3_stop", m.toolMod3Stop))
+	}), withToolObserver(m, "mod3_stop", m.toolMod3Stop))
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name: "mod3_voices",
 		Description: "List available mod3 voices, optionally scoped to a " +
 			"session. Optional: session_id. Returns the voice catalogue mod3 " +
 			"exposes (id, name, language, gender metadata per voice). " +
 			"Fallback: curl http://localhost:7860/v1/voices",
-	}, withToolObserver(m, "mod3_voices", m.toolMod3Voices))
+	}), withToolObserver(m, "mod3_voices", m.toolMod3Voices))
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name: "mod3_status",
 		Description: "Probe mod3's /health endpoint. Returns the raw health " +
 			"payload (model_loaded, engine info, queue_depth, etc). 502 if " +
 			"mod3 is unreachable. Fallback: curl http://localhost:7860/health",
-	}, withToolObserver(m, "mod3_status", m.toolMod3Status))
+	}), withToolObserver(m, "mod3_status", m.toolMod3Status))
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name: "mod3_register_session",
 		Description: "Register a channel-participant session. Routes through " +
 			"the kernel's /v1/channel-sessions/register endpoint so " +
@@ -165,24 +165,24 @@ func (m *MCPServer) registerMod3Tools() {
 			"mod3} block: kernel identity record + mod3's full " +
 			"SessionRegisterResponse (assigned_voice, voice_conflict, " +
 			"output_device, queue_depth).",
-	}, withToolObserver(m, "mod3_register_session", m.toolMod3RegisterSession))
+	}), withToolObserver(m, "mod3_register_session", m.toolMod3RegisterSession))
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name: "mod3_deregister_session",
 		Description: "Deregister a channel-participant session. Routes " +
 			"through the kernel's /v1/channel-sessions/{id}/deregister " +
 			"endpoint so the kernel drops its identity record in sync with " +
 			"mod3. Required: session_id. Returns mod3's deregister " +
 			"acknowledgment (released_voice, dropped_jobs).",
-	}, withToolObserver(m, "mod3_deregister_session", m.toolMod3DeregisterSession))
+	}), withToolObserver(m, "mod3_deregister_session", m.toolMod3DeregisterSession))
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name: "mod3_list_sessions",
 		Description: "List channel-participant sessions via the kernel's " +
 			"/v1/channel-sessions endpoint. Returns a merged {kernel, mod3} " +
 			"block: kernel identity records + mod3's live per-channel state " +
 			"(voice_pool, voice_holders, serializer policy).",
-	}, withToolObserver(m, "mod3_list_sessions", m.toolMod3ListSessions))
+	}), withToolObserver(m, "mod3_list_sessions", m.toolMod3ListSessions))
 }
 
 // ─── input / output types ────────────────────────────────────────────────────

--- a/internal/engine/mcp_modality_proxy.go
+++ b/internal/engine/mcp_modality_proxy.go
@@ -1,6 +1,7 @@
 // mcp_modality_proxy.go — kernel-side MCP proxy for mod3 voice tools.
 //
-// Wave 3 of the mod3-kernel integration (ADR-082 + channel-provider RFC).
+// Wave 3 of the mod3-kernel integration (ADR-082 + channel-provider RFC),
+// consolidated in Wave 3.5 with Wave 2's session-ID authority.
 // The kernel becomes the MCP front door for mod3; the previous OpenClaw
 // gateway pattern in the installed binary read metrics but discarded audio
 // bytes. This proxy fixes that: it forwards HTTP calls to mod3, captures the
@@ -9,14 +10,16 @@
 //
 // Design locks:
 //
-//  1. MCP transport = HTTP proxy. Every tool handler here POSTs/GETs against
-//     cfg.Mod3URL + "/v1/*". Mod3 is NOT an MCP server to the kernel. The
-//     installed binary's OpenClaw gateway is a separate concern — we are the
-//     next kernel build and will supersede it when deployed.
-//  2. Session authority = kernel-owned. session_id is threaded through every
-//     proxied call. Callers pass it as an optional field; absent → proxy
-//     omits it and mod3 routes to its default session. Present → proxy
-//     includes it in the request body (synthesize) or query string (stop).
+//  1. MCP transport = HTTP proxy. Synthesis/control tool handlers here
+//     POST/GET against cfg.Mod3URL + "/v1/*". Mod3 is NOT an MCP server to
+//     the kernel. The installed binary's OpenClaw gateway is a separate
+//     concern — we are the next kernel build and will supersede it when
+//     deployed.
+//  2. Session authority = kernel-owned (Wave 3.5). The session-family tools
+//     (register/deregister/list) do NOT call mod3 directly — they call the
+//     kernel's RegisterChannelSession / DeregisterChannelSession /
+//     ListChannelSessions methods on the Server, which mint the session_id
+//     and forward to mod3. Session ID minting happens in exactly one place.
 //  3. Playback strategy = Option (A), server-side. Kernel receives audio/wav,
 //     writes to a tempfile, execs `afplay` (macOS) or `aplay` (Linux),
 //     fire-and-forget. Callers can opt in to blocking with blocking=true.
@@ -26,18 +29,13 @@
 //
 // Tools registered (prefix `mod3_` to namespace against cog_* kernel tools):
 //
-//   - mod3_speak                — synthesize + (optionally) play
-//   - mod3_stop                 — cancel current/queued speech
-//   - mod3_voices               — list available voices
-//   - mod3_status               — mod3 /health probe + build info
-//   - mod3_register_session     — proxy to mod3 session register (future)
-//   - mod3_deregister_session   — proxy to mod3 session deregister
-//   - mod3_list_sessions        — proxy to mod3 session list
-//
-// Note: the session-registry family forwards to mod3's /v1/sessions/* routes
-// which are not yet live on every mod3 instance (see openapi.json). They
-// return a clean 502 "mod3_unreachable" in that case; once mod3 implements
-// the routes (ADR-082 Wave 2 target), these tools become useful.
+//   - mod3_speak                — synthesize + (optionally) play      (direct to mod3)
+//   - mod3_stop                 — cancel current/queued speech        (direct to mod3)
+//   - mod3_voices               — list available voices               (direct to mod3)
+//   - mod3_status               — mod3 /health probe + build info     (direct to mod3)
+//   - mod3_register_session     — kernel-minted session registration  (via kernel)
+//   - mod3_deregister_session   — session deregister                  (via kernel)
+//   - mod3_list_sessions        — merged kernel+mod3 session roster   (via kernel)
 package engine
 
 import (
@@ -148,27 +146,34 @@ func (m *MCPServer) registerMod3Tools() {
 
 	mcp.AddTool(m.server, &mcp.Tool{
 		Name: "mod3_register_session",
-		Description: "Proxy to mod3's POST /v1/sessions/register. Required: " +
-			"participant_id. Optional: session_id (caller-supplied; kernel " +
-			"does NOT mint here — use /v1/channel-sessions/register for that), " +
-			"participant_type, preferred_voice, preferred_output_device, " +
-			"priority. Returns mod3's full SessionRegisterResponse (assigned_" +
-			"voice, voice_conflict, output_device, queue_depth).",
+		Description: "Register a channel-participant session. Routes through " +
+			"the kernel's /v1/channel-sessions/register endpoint so " +
+			"session_id minting stays centralized (ADR-082 Wave 3.5). " +
+			"Required: participant_id. Optional: session_id (kernel mints " +
+			"a cs-* short UUID when absent), participant_type " +
+			"(agent|user|provider), preferred_voice, preferred_output_device, " +
+			"priority, kinds (e.g. [\"audio\"] per channel-provider RFC), " +
+			"metadata (opaque pass-through). Returns the merged {kernel, " +
+			"mod3} block: kernel identity record + mod3's full " +
+			"SessionRegisterResponse (assigned_voice, voice_conflict, " +
+			"output_device, queue_depth).",
 	}, withToolObserver(m, "mod3_register_session", m.toolMod3RegisterSession))
 
 	mcp.AddTool(m.server, &mcp.Tool{
 		Name: "mod3_deregister_session",
-		Description: "Proxy to mod3's POST /v1/sessions/{session_id}/deregister. " +
-			"Required: session_id. Returns mod3's deregister acknowledgment " +
-			"(released_voice, dropped_jobs).",
+		Description: "Deregister a channel-participant session. Routes " +
+			"through the kernel's /v1/channel-sessions/{id}/deregister " +
+			"endpoint so the kernel drops its identity record in sync with " +
+			"mod3. Required: session_id. Returns mod3's deregister " +
+			"acknowledgment (released_voice, dropped_jobs).",
 	}, withToolObserver(m, "mod3_deregister_session", m.toolMod3DeregisterSession))
 
 	mcp.AddTool(m.server, &mcp.Tool{
 		Name: "mod3_list_sessions",
-		Description: "Proxy to mod3's GET /v1/sessions. Returns the live " +
-			"mod3 session roster (sessions, voice_pool, voice_holders, " +
-			"serializer policy). No kernel-side filtering — mod3 is source " +
-			"of truth for per-channel state.",
+		Description: "List channel-participant sessions via the kernel's " +
+			"/v1/channel-sessions endpoint. Returns a merged {kernel, mod3} " +
+			"block: kernel identity records + mod3's live per-channel state " +
+			"(voice_pool, voice_holders, serializer policy).",
 	}, withToolObserver(m, "mod3_list_sessions", m.toolMod3ListSessions))
 }
 
@@ -208,6 +213,10 @@ type mod3RegisterSessionInput struct {
 	PreferredVoice        string `json:"preferred_voice,omitempty"`
 	PreferredOutputDevice string `json:"preferred_output_device,omitempty"`
 	Priority              int    `json:"priority,omitempty"`
+	// Kinds / Metadata are the channel-provider RFC fields that flow
+	// through to mod3 unchanged. See cogos_session_register primitive.
+	Kinds    []string       `json:"kinds,omitempty"`
+	Metadata map[string]any `json:"metadata,omitempty"`
 }
 
 type mod3DeregisterSessionInput struct {
@@ -310,42 +319,90 @@ func (m *MCPServer) toolMod3Status(ctx context.Context, req *mcp.CallToolRequest
 	return m.proxyMod3JSONAsMCP(ctx, http.MethodGet, "/health", nil)
 }
 
+// toolMod3RegisterSession routes through the kernel's shared
+// RegisterChannelSession so session_id minting happens in exactly one place
+// (ADR-082 Wave 3.5). The previous Wave 3 implementation called mod3's
+// /v1/sessions/register directly, which bypassed Wave 2's kernel-owned
+// minting authority; that path is now gone.
 func (m *MCPServer) toolMod3RegisterSession(ctx context.Context, req *mcp.CallToolRequest, in mod3RegisterSessionInput) (*mcp.CallToolResult, any, error) {
 	if in.ParticipantID == "" {
 		return textResult("participant_id is required")
 	}
-	body := map[string]any{
-		"participant_id": in.ParticipantID,
+	if m.channelSessionBackend == nil {
+		return mod3ErrorResult("channel-session backend not configured")
 	}
-	if in.SessionID != "" {
-		body["session_id"] = in.SessionID
+	resp, ferr := m.channelSessionBackend.RegisterChannelSession(ctx, channelSessionRegisterRequest{
+		SessionID:             in.SessionID,
+		ParticipantID:         in.ParticipantID,
+		ParticipantType:       in.ParticipantType,
+		PreferredVoice:        in.PreferredVoice,
+		PreferredOutputDevice: in.PreferredOutputDevice,
+		Priority:              in.Priority,
+		Kinds:                 in.Kinds,
+		Metadata:              in.Metadata,
+	})
+	if ferr != nil {
+		return mod3ErrorResult(channelSessionForwardErrorText(ferr))
 	}
-	if in.ParticipantType != "" {
-		body["participant_type"] = in.ParticipantType
-	}
-	if in.PreferredVoice != "" {
-		body["preferred_voice"] = in.PreferredVoice
-	}
-	if in.PreferredOutputDevice != "" {
-		body["preferred_output_device"] = in.PreferredOutputDevice
-	}
-	if in.Priority != 0 {
-		body["priority"] = in.Priority
-	}
-	raw, _ := json.Marshal(body)
-	return m.proxyMod3JSONAsMCP(ctx, http.MethodPost, "/v1/sessions/register", bytes.NewReader(raw))
+	return marshalResult(resp)
 }
 
 func (m *MCPServer) toolMod3DeregisterSession(ctx context.Context, req *mcp.CallToolRequest, in mod3DeregisterSessionInput) (*mcp.CallToolResult, any, error) {
 	if in.SessionID == "" {
 		return textResult("session_id is required")
 	}
-	return m.proxyMod3JSONAsMCP(ctx, http.MethodPost,
-		"/v1/sessions/"+url.PathEscape(in.SessionID)+"/deregister", nil)
+	if m.channelSessionBackend == nil {
+		return mod3ErrorResult("channel-session backend not configured")
+	}
+	mod3Resp, status, ferr := m.channelSessionBackend.DeregisterChannelSession(ctx, in.SessionID)
+	if ferr != nil {
+		return mod3ErrorResult(channelSessionForwardErrorText(ferr))
+	}
+	// Parse mod3's JSON body; surface mod3's non-2xx bodies intact as
+	// tool errors. The HTTP handler passes these through verbatim; the
+	// MCP tool wraps them so the caller sees the mod3 body text.
+	var parsed any
+	if len(mod3Resp) > 0 {
+		if jsonErr := json.Unmarshal(mod3Resp, &parsed); jsonErr != nil {
+			parsed = map[string]any{"raw": string(mod3Resp)}
+		}
+	}
+	if status < 200 || status >= 300 {
+		return mod3ErrorResult(fmt.Sprintf("mod3 returned %d: %v", status, parsed))
+	}
+	return marshalResult(parsed)
 }
 
 func (m *MCPServer) toolMod3ListSessions(ctx context.Context, req *mcp.CallToolRequest, in mod3ListSessionsInput) (*mcp.CallToolResult, any, error) {
-	return m.proxyMod3JSONAsMCP(ctx, http.MethodGet, "/v1/sessions", nil)
+	if m.channelSessionBackend == nil {
+		return mod3ErrorResult("channel-session backend not configured")
+	}
+	resp, _, ferr := m.channelSessionBackend.ListChannelSessions(ctx)
+	if ferr != nil {
+		return mod3ErrorResult(channelSessionForwardErrorText(ferr))
+	}
+	return marshalResult(resp)
+}
+
+// channelSessionForwardErrorText renders a *channelSessionForwardError into
+// the "mod3 unreachable" / "mod3 returned N: body" shape the legacy MCP
+// tool paths used, keeping error surfaces stable for callers that previously
+// matched on those strings.
+func channelSessionForwardErrorText(ferr *channelSessionForwardError) string {
+	switch ferr.Kind {
+	case "mod3_unreachable":
+		return ferr.Message
+	case "mod3_rejected":
+		var parsed any
+		if len(ferr.Mod3Body) > 0 {
+			if jsonErr := json.Unmarshal(ferr.Mod3Body, &parsed); jsonErr != nil {
+				parsed = map[string]any{"raw": string(ferr.Mod3Body)}
+			}
+		}
+		return fmt.Sprintf("mod3 returned %d: %v", ferr.HTTPStatus, parsed)
+	default:
+		return ferr.Message
+	}
 }
 
 // ─── HTTP forwarder primitives ───────────────────────────────────────────────

--- a/internal/engine/mcp_modality_proxy_test.go
+++ b/internal/engine/mcp_modality_proxy_test.go
@@ -10,6 +10,7 @@ package engine
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -868,4 +869,240 @@ sleep 5
 	case <-time.After(2 * time.Second):
 		t.Fatal("playAudio(blocking=false) did not return within 2s")
 	}
+}
+
+// ─── Wave 4.3 — subscriber-check / afplay skip ───────────────────────────────
+
+// TestMod3Speak_NoSessionAlwaysSpawnsPlayer — session_id="" bypasses the
+// subscriber check entirely so CLI invocations of mod3_speak still play
+// audio through afplay as they always did.
+func TestMod3Speak_NoSessionAlwaysSpawnsPlayer(t *testing.T) {
+	fm := newFakeMod3Proxy(t)
+	m := newProxyMCP(t, fm)
+
+	stubPath, count := writeStubPlayer(t)
+	m.mod3Proxy = &modalityProxy{player: stubPath}
+
+	res, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{
+		Text:     "no session",
+		Blocking: true, // wait for stub to finish so the test can assert invocation count
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected success, got %v", res.Content)
+	}
+	out := decodeToolText(t, res)
+	if got, _ := out["playback_status"].(string); got != "played" {
+		t.Fatalf("expected playback_status=played, got %v", out["playback_status"])
+	}
+	if got := count(); got != 1 {
+		t.Fatalf("expected stub player invoked once, got %d", got)
+	}
+}
+
+// TestMod3Speak_SessionWithSubscriberSkipsPlayer — when the injected
+// subscriber-check returns true, the kernel skips afplay entirely and
+// returns playback_status=routed_ws. The stub player must NOT be invoked.
+func TestMod3Speak_SessionWithSubscriberSkipsPlayer(t *testing.T) {
+	fm := newFakeMod3Proxy(t)
+	m := newProxyMCP(t, fm)
+
+	stubPath, count := writeStubPlayer(t)
+	m.mod3Proxy = &modalityProxy{
+		player: stubPath,
+		subscriberCheck: func(ctx context.Context, sessionID string) (bool, error) {
+			if sessionID != "cs-with-sub" {
+				t.Errorf("unexpected session_id=%q", sessionID)
+			}
+			return true, nil
+		},
+	}
+
+	res, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{
+		Text:      "skip me",
+		SessionID: "cs-with-sub",
+		Blocking:  true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected success, got %v", res.Content)
+	}
+	out := decodeToolText(t, res)
+	if got, _ := out["playback_status"].(string); got != "routed_ws" {
+		t.Fatalf("expected playback_status=routed_ws, got %v", out["playback_status"])
+	}
+	// Give any stray goroutine a moment to trip the stub — proving non-invocation.
+	time.Sleep(100 * time.Millisecond)
+	if got := count(); got != 0 {
+		t.Fatalf("expected stub player NOT invoked, got %d", got)
+	}
+}
+
+// TestMod3Speak_SessionWithoutSubscriberSpawnsPlayer — subscriber-check
+// returns false: kernel falls back to the normal afplay path and the stub
+// player IS invoked.
+func TestMod3Speak_SessionWithoutSubscriberSpawnsPlayer(t *testing.T) {
+	fm := newFakeMod3Proxy(t)
+	m := newProxyMCP(t, fm)
+
+	stubPath, count := writeStubPlayer(t)
+	m.mod3Proxy = &modalityProxy{
+		player: stubPath,
+		subscriberCheck: func(ctx context.Context, sessionID string) (bool, error) {
+			return false, nil
+		},
+	}
+
+	res, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{
+		Text:      "no subscriber",
+		SessionID: "cs-no-sub",
+		Blocking:  true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected success, got %v", res.Content)
+	}
+	out := decodeToolText(t, res)
+	if got, _ := out["playback_status"].(string); got != "played" {
+		t.Fatalf("expected playback_status=played, got %v", out["playback_status"])
+	}
+	if got := count(); got != 1 {
+		t.Fatalf("expected stub player invoked once, got %d", got)
+	}
+}
+
+// TestMod3Speak_SubscriberCheckErrorFallsBackToPlayer — transient
+// check error (mod3 flaky, timeout, etc.) must not orphan the audio.
+// The kernel logs the error, records subscriber_check_error in the result,
+// and still spawns the player so the user hears the reply.
+func TestMod3Speak_SubscriberCheckErrorFallsBackToPlayer(t *testing.T) {
+	fm := newFakeMod3Proxy(t)
+	m := newProxyMCP(t, fm)
+
+	stubPath, count := writeStubPlayer(t)
+	m.mod3Proxy = &modalityProxy{
+		player: stubPath,
+		subscriberCheck: func(ctx context.Context, sessionID string) (bool, error) {
+			return false, fmt.Errorf("mod3 probe timed out")
+		},
+	}
+
+	res, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{
+		Text:      "check failed",
+		SessionID: "cs-flaky",
+		Blocking:  true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected success despite check error, got %v", res.Content)
+	}
+	out := decodeToolText(t, res)
+	if got, _ := out["playback_status"].(string); got != "played" {
+		t.Fatalf("expected playback_status=played, got %v", out["playback_status"])
+	}
+	if checkErr, _ := out["subscriber_check_error"].(string); !strings.Contains(checkErr, "probe timed out") {
+		t.Fatalf("expected subscriber_check_error to surface, got %v", out["subscriber_check_error"])
+	}
+	if got := count(); got != 1 {
+		t.Fatalf("expected stub player invoked once on check error, got %d", got)
+	}
+}
+
+// TestCheckSessionSubscriber_DefaultImplementationHitsMod3 — wire up a
+// stand-alone fake HTTP server that answers the
+// /v1/sessions/{id}/subscribers probe and verify the default implementation
+// (no injected subscriberCheck) parses its response correctly.
+func TestCheckSessionSubscriber_DefaultImplementationHitsMod3(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /v1/sessions/cs-yes/subscribers", func(w http.ResponseWriter, r *http.Request) {
+		writeFakeJSON(w, http.StatusOK, map[string]any{
+			"session_id": "cs-yes", "subscribed": true, "count": 1,
+		})
+	})
+	mux.HandleFunc("GET /v1/sessions/cs-no/subscribers", func(w http.ResponseWriter, r *http.Request) {
+		writeFakeJSON(w, http.StatusOK, map[string]any{
+			"session_id": "cs-no", "subscribed": false, "count": 0,
+		})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	m := &MCPServer{
+		cfg:       &Config{Mod3URL: srv.URL},
+		mod3Proxy: &modalityProxy{disablePlayback: true},
+	}
+
+	yes, err := m.checkSessionSubscriber(context.Background(), "cs-yes")
+	if err != nil {
+		t.Fatalf("cs-yes: %v", err)
+	}
+	if !yes {
+		t.Fatal("cs-yes: expected subscribed=true")
+	}
+
+	no, err := m.checkSessionSubscriber(context.Background(), "cs-no")
+	if err != nil {
+		t.Fatalf("cs-no: %v", err)
+	}
+	if no {
+		t.Fatal("cs-no: expected subscribed=false")
+	}
+}
+
+// TestCheckSessionSubscriber_Mod3UnreachableReturnsError — transport
+// error (connection refused, timeout) must surface as a non-nil error so
+// toolMod3Speak records subscriber_check_error and falls back to afplay.
+func TestCheckSessionSubscriber_Mod3UnreachableReturnsError(t *testing.T) {
+	// Bind a port, close it so dials get ECONNREFUSED.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := l.Addr().String()
+	_ = l.Close()
+
+	m := &MCPServer{
+		cfg:       &Config{Mod3URL: "http://" + addr},
+		mod3Proxy: &modalityProxy{disablePlayback: true},
+	}
+	subscribed, err := m.checkSessionSubscriber(context.Background(), "cs-anything")
+	if err == nil {
+		t.Fatal("expected transport error")
+	}
+	if subscribed {
+		t.Fatal("expected subscribed=false on error")
+	}
+}
+
+// writeStubPlayer builds a temp shell script that records each invocation
+// by appending to a log file. Returns the path of the executable AND a
+// getter that returns the current invocation count. The stub exits
+// immediately so blocking=true still works in tests.
+func writeStubPlayer(t *testing.T) (stubPath string, count func() int) {
+	t.Helper()
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "invocations.log")
+	stubPath = filepath.Join(dir, "stub-player.sh")
+	stubBody := `#!/bin/sh
+echo "invoked" >> "` + logPath + `"
+`
+	if err := os.WriteFile(stubPath, []byte(stubBody), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	count = func() int {
+		data, err := os.ReadFile(logPath)
+		if err != nil {
+			return 0
+		}
+		return strings.Count(string(data), "invoked\n")
+	}
+	return stubPath, count
 }

--- a/internal/engine/mcp_modality_proxy_test.go
+++ b/internal/engine/mcp_modality_proxy_test.go
@@ -185,14 +185,41 @@ func (fm *fakeMod3Proxy) last() capturedProxyRequest {
 }
 
 // newProxyMCP builds a minimal MCPServer whose proxy points at fm, with
-// playback fully disabled so tests don't touch the audio stack.
+// playback fully disabled so tests don't touch the audio stack. A live
+// Server is wired in as the channel-session backend so the session-family
+// MCP tools (register/deregister/list) flow through the kernel's shared
+// minting logic — matching production (ADR-082 Wave 3.5). Synthesis /
+// control tools continue calling mod3 directly via the proxy.
 func newProxyMCP(t *testing.T, fm *fakeMod3Proxy) *MCPServer {
 	t.Helper()
+	cfg := &Config{Mod3URL: fm.srv.URL}
+	srv := &Server{
+		cfg:                    cfg,
+		channelSessionRegistry: NewChannelSessionRegistry(),
+	}
 	m := &MCPServer{
-		cfg:       &Config{Mod3URL: fm.srv.URL},
-		mod3Proxy: &modalityProxy{disablePlayback: true},
+		cfg:                   cfg,
+		mod3Proxy:             &modalityProxy{disablePlayback: true},
+		channelSessionBackend: srv,
 	}
 	return m
+}
+
+// newProxyMCPWithServer is like newProxyMCP but returns the wired-in Server
+// so tests that want to assert on the kernel-side registry state can do so.
+func newProxyMCPWithServer(t *testing.T, fm *fakeMod3Proxy) (*MCPServer, *Server) {
+	t.Helper()
+	cfg := &Config{Mod3URL: fm.srv.URL}
+	srv := &Server{
+		cfg:                    cfg,
+		channelSessionRegistry: NewChannelSessionRegistry(),
+	}
+	m := &MCPServer{
+		cfg:                   cfg,
+		mod3Proxy:             &modalityProxy{disablePlayback: true},
+		channelSessionBackend: srv,
+	}
+	return m, srv
 }
 
 // decodeToolText parses the JSON text content of a CallToolResult.
@@ -487,9 +514,13 @@ func TestMod3Status_Mod3DownClean(t *testing.T) {
 	}
 }
 
-func TestMod3RegisterSession_ForwardsBody(t *testing.T) {
+// TestMod3RegisterSession_RoutesThroughKernel verifies that the MCP tool
+// goes through the kernel's shared RegisterChannelSession backend — not
+// directly to mod3 — and that the response is the merged {kernel, mod3}
+// block produced by that shared code path (ADR-082 Wave 3.5).
+func TestMod3RegisterSession_RoutesThroughKernel(t *testing.T) {
 	fm := newFakeMod3Proxy(t)
-	m := newProxyMCP(t, fm)
+	m, srv := newProxyMCPWithServer(t, fm)
 
 	res, _, err := m.toolMod3RegisterSession(context.Background(), nil, mod3RegisterSessionInput{
 		SessionID:             "cs-regtest",
@@ -503,7 +534,110 @@ func TestMod3RegisterSession_ForwardsBody(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if res.IsError {
-		t.Fatal("expected success")
+		t.Fatalf("expected success, got IsError: %v", res.Content)
+	}
+
+	// The forward to mod3 must have happened via the kernel's shared
+	// method — verify the request body mod3 saw carries the caller-
+	// supplied session_id and participant_id unchanged.
+	cap := fm.last()
+	if cap.Path != "/v1/sessions/register" {
+		t.Fatalf("expected mod3 /v1/sessions/register, got %q", cap.Path)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(cap.Body, &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["session_id"] != "cs-regtest" {
+		t.Fatalf("bad session_id forwarded: %v", body["session_id"])
+	}
+	if body["participant_id"] != "cog" {
+		t.Fatalf("bad participant_id forwarded: %v", body["participant_id"])
+	}
+	if body["preferred_voice"] != "bm_lewis" {
+		t.Fatalf("bad preferred_voice forwarded: %v", body["preferred_voice"])
+	}
+
+	// The merged {kernel, mod3} shape must land — verify the kernel's
+	// identity record is present in the response.
+	out := decodeToolText(t, res)
+	kernel, ok := out["kernel"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected kernel block in response, got %v", out)
+	}
+	if kernel["session_id"] != "cs-regtest" {
+		t.Fatalf("expected kernel.session_id=cs-regtest, got %v", kernel["session_id"])
+	}
+	if kernel["id_source"] != "caller" {
+		t.Fatalf("expected id_source=caller, got %v", kernel["id_source"])
+	}
+
+	// Kernel registry must hold the committed record — proves we went
+	// through the shared backend and not straight to mod3.
+	if _, held := srv.channelSessionRegistry.Get("cs-regtest"); !held {
+		t.Fatal("expected kernel registry to hold record after register")
+	}
+}
+
+// TestMod3RegisterSession_KernelMintsWhenAbsent exercises the minting
+// path — caller omits session_id, kernel mints one, mod3 receives it.
+func TestMod3RegisterSession_KernelMintsWhenAbsent(t *testing.T) {
+	fm := newFakeMod3Proxy(t)
+	m, srv := newProxyMCPWithServer(t, fm)
+
+	res, _, err := m.toolMod3RegisterSession(context.Background(), nil, mod3RegisterSessionInput{
+		ParticipantID: "cog",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected success, got IsError: %v", res.Content)
+	}
+
+	out := decodeToolText(t, res)
+	kernel, _ := out["kernel"].(map[string]any)
+	sid, _ := kernel["session_id"].(string)
+	if !strings.HasPrefix(sid, "cs-") {
+		t.Fatalf("expected minted cs-* session_id, got %q", sid)
+	}
+	if kernel["id_source"] != "minted" {
+		t.Fatalf("expected id_source=minted, got %v", kernel["id_source"])
+	}
+
+	// Mod3 must have seen the kernel-minted ID verbatim.
+	cap := fm.last()
+	var body map[string]any
+	_ = json.Unmarshal(cap.Body, &body)
+	if body["session_id"] != sid {
+		t.Fatalf("mod3 got session_id=%v, expected %q", body["session_id"], sid)
+	}
+
+	if _, held := srv.channelSessionRegistry.Get(sid); !held {
+		t.Fatalf("expected kernel registry to hold minted record %q", sid)
+	}
+}
+
+// TestMod3RegisterSession_ForwardsKindsAndMetadata verifies the Wave 3.5
+// schema alignment with the channel-provider RFC — `kinds` and `metadata`
+// flow through the kernel's register endpoint and land in mod3's request
+// body unchanged.
+func TestMod3RegisterSession_ForwardsKindsAndMetadata(t *testing.T) {
+	fm := newFakeMod3Proxy(t)
+	m, _ := newProxyMCPWithServer(t, fm)
+
+	_, _, err := m.toolMod3RegisterSession(context.Background(), nil, mod3RegisterSessionInput{
+		SessionID:       "cs-kinds",
+		ParticipantID:   "mod3-provider",
+		ParticipantType: "provider",
+		Kinds:           []string{"audio"},
+		Metadata: map[string]any{
+			"provider_id": "mod3-local",
+			"build":       "0.5.0",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	cap := fm.last()
@@ -511,14 +645,19 @@ func TestMod3RegisterSession_ForwardsBody(t *testing.T) {
 	if err := json.Unmarshal(cap.Body, &body); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if body["session_id"] != "cs-regtest" {
-		t.Fatalf("bad session_id: %v", body["session_id"])
+	kinds, ok := body["kinds"].([]any)
+	if !ok || len(kinds) != 1 || kinds[0] != "audio" {
+		t.Fatalf("expected kinds=[\"audio\"] forwarded, got %v", body["kinds"])
 	}
-	if body["participant_id"] != "cog" {
-		t.Fatalf("bad participant_id: %v", body["participant_id"])
+	md, ok := body["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected metadata object forwarded, got %v (%T)", body["metadata"], body["metadata"])
 	}
-	if body["preferred_voice"] != "bm_lewis" {
-		t.Fatalf("bad preferred_voice: %v", body["preferred_voice"])
+	if md["provider_id"] != "mod3-local" {
+		t.Fatalf("expected metadata.provider_id=mod3-local, got %v", md["provider_id"])
+	}
+	if body["participant_type"] != "provider" {
+		t.Fatalf("expected participant_type=provider, got %v", body["participant_type"])
 	}
 }
 
@@ -536,9 +675,38 @@ func TestMod3RegisterSession_RejectsWithoutParticipant(t *testing.T) {
 	}
 }
 
-func TestMod3DeregisterSession_PathEscape(t *testing.T) {
+func TestMod3RegisterSession_NoBackendReturnsCleanError(t *testing.T) {
+	// An MCPServer with no channel-session backend wired in must surface
+	// a clean "not configured" error rather than a nil deref — important
+	// because NewMCPServer (used by tests that only care about memory
+	// tools) doesn't wire the backend.
+	m := &MCPServer{cfg: &Config{Mod3URL: "http://unused"}}
+	res, _, err := m.toolMod3RegisterSession(context.Background(), nil, mod3RegisterSessionInput{
+		ParticipantID: "cog",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected IsError=true when backend is nil")
+	}
+	tc := res.Content[0].(*mcp.TextContent)
+	if !strings.Contains(tc.Text, "backend not configured") {
+		t.Fatalf("expected backend-not-configured message, got %q", tc.Text)
+	}
+}
+
+// TestMod3DeregisterSession_RoutesThroughKernel verifies the deregister
+// tool forwards via the kernel's shared path and the kernel drops its
+// identity record on success.
+func TestMod3DeregisterSession_RoutesThroughKernel(t *testing.T) {
 	fm := newFakeMod3Proxy(t)
-	m := newProxyMCP(t, fm)
+	m, srv := newProxyMCPWithServer(t, fm)
+
+	// Seed the kernel registry so we can see it get dropped.
+	srv.channelSessionRegistry.Put(ChannelSessionRecord{
+		SessionID: "cs-drop", ParticipantID: "cog",
+	})
 
 	res, _, err := m.toolMod3DeregisterSession(context.Background(), nil, mod3DeregisterSessionInput{
 		SessionID: "cs-drop",
@@ -547,11 +715,14 @@ func TestMod3DeregisterSession_PathEscape(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if res.IsError {
-		t.Fatal("expected success")
+		t.Fatalf("expected success, got IsError: %v", res.Content)
 	}
 	cap := fm.last()
 	if cap.Path != "/v1/sessions/cs-drop/deregister" {
-		t.Fatalf("expected /v1/sessions/cs-drop/deregister, got %q", cap.Path)
+		t.Fatalf("expected /v1/sessions/cs-drop/deregister at mod3, got %q", cap.Path)
+	}
+	if _, held := srv.channelSessionRegistry.Get("cs-drop"); held {
+		t.Fatal("expected kernel registry to drop record after successful deregister")
 	}
 }
 
@@ -567,21 +738,35 @@ func TestMod3DeregisterSession_RequiresID(t *testing.T) {
 	}
 }
 
-func TestMod3ListSessions_ReturnsRaw(t *testing.T) {
+// TestMod3ListSessions_RoutesThroughKernel verifies list merges the
+// kernel snapshot with mod3's per-channel state (the new Wave 3.5
+// merged shape, not mod3's raw payload).
+func TestMod3ListSessions_RoutesThroughKernel(t *testing.T) {
 	fm := newFakeMod3Proxy(t)
-	m := newProxyMCP(t, fm)
+	m, srv := newProxyMCPWithServer(t, fm)
+
+	srv.channelSessionRegistry.Put(ChannelSessionRecord{
+		SessionID: "cs-seed", ParticipantID: "cog",
+	})
 
 	res, _, err := m.toolMod3ListSessions(context.Background(), nil, mod3ListSessionsInput{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if res.IsError {
-		t.Fatal("expected success")
+		t.Fatalf("expected success, got IsError: %v", res.Content)
 	}
 	out := decodeToolText(t, res)
-	vp, _ := out["voice_pool"].([]any)
-	if len(vp) != 2 {
-		t.Fatalf("expected 2 voices in pool, got %d", len(vp))
+	kernel, ok := out["kernel"].([]any)
+	if !ok {
+		t.Fatalf("expected kernel array in merged response, got %v", out)
+	}
+	if len(kernel) != 1 {
+		t.Fatalf("expected 1 kernel record, got %d", len(kernel))
+	}
+	// Mod3 block must be present (from the fake list handler).
+	if _, present := out["mod3"]; !present {
+		t.Fatal("expected mod3 block in merged response")
 	}
 }
 

--- a/internal/engine/mcp_modality_proxy_test.go
+++ b/internal/engine/mcp_modality_proxy_test.go
@@ -1,0 +1,686 @@
+// mcp_modality_proxy_test.go — coverage for the mod3 MCP proxy tools.
+//
+// Strategy: stand up a fake mod3 via httptest.NewServer, point an MCPServer's
+// proxy at it, exercise each tool handler directly (handler function +
+// typed input, bypassing the MCP SDK's JSON marshal layer). Playback is
+// stubbed via disablePlayback or the injectable player field so tests don't
+// spawn afplay.
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// ─── fake mod3 with synthesize + session routes ──────────────────────────────
+
+type fakeMod3Proxy struct {
+	t        *testing.T
+	srv      *httptest.Server
+	mu       sync.Mutex
+	captured []capturedProxyRequest
+
+	// Overrides for per-endpoint behavior.
+	synthesizeHandler  http.HandlerFunc
+	stopHandler        http.HandlerFunc
+	voicesHandler      http.HandlerFunc
+	healthHandler      http.HandlerFunc
+	regHandler         http.HandlerFunc
+	deregHandler       http.HandlerFunc
+	listSessionHandler http.HandlerFunc
+}
+
+type capturedProxyRequest struct {
+	Method string
+	Path   string
+	Query  string
+	Body   []byte
+}
+
+// synthWav is a tiny valid-ish WAV header + ~1KB of silence. Not a real
+// audio file — the proxy doesn't parse it, it just forwards/plays bytes.
+var synthWav = func() []byte {
+	b := make([]byte, 1024)
+	copy(b, []byte("RIFF\x00\x00\x00\x00WAVEfmt "))
+	return b
+}()
+
+func newFakeMod3Proxy(t *testing.T) *fakeMod3Proxy {
+	t.Helper()
+	fm := &fakeMod3Proxy{t: t}
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("POST /v1/synthesize", func(w http.ResponseWriter, r *http.Request) {
+		fm.capture(r)
+		if fm.synthesizeHandler != nil {
+			fm.synthesizeHandler(w, r)
+			return
+		}
+		// Emit the full mod3 header surface so the proxy can extract it.
+		w.Header().Set("X-Mod3-Job-Id", "job-test-0001")
+		w.Header().Set("X-Mod3-Voice", "bm_lewis")
+		w.Header().Set("X-Mod3-Duration-Sec", "1.23")
+		w.Header().Set("X-Mod3-Sample-Rate", "24000")
+		w.Header().Set("X-Mod3-Rtf", "9.29")
+		w.Header().Set("X-Mod3-Chunks", "1")
+		w.Header().Set("Content-Type", "audio/wav")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(synthWav)
+	})
+
+	mux.HandleFunc("POST /v1/stop", func(w http.ResponseWriter, r *http.Request) {
+		fm.capture(r)
+		if fm.stopHandler != nil {
+			fm.stopHandler(w, r)
+			return
+		}
+		writeFakeJSON(w, http.StatusOK, map[string]any{
+			"status":        "stopped",
+			"dropped_jobs":  0,
+			"interrupted":   true,
+			"session_id":    r.URL.Query().Get("session_id"),
+			"job_id_target": r.URL.Query().Get("job_id"),
+		})
+	})
+
+	mux.HandleFunc("GET /v1/voices", func(w http.ResponseWriter, r *http.Request) {
+		fm.capture(r)
+		if fm.voicesHandler != nil {
+			fm.voicesHandler(w, r)
+			return
+		}
+		writeFakeJSON(w, http.StatusOK, map[string]any{
+			"voices": []map[string]any{
+				{"id": "bm_lewis", "language": "en-GB"},
+				{"id": "af_bella", "language": "en-US"},
+			},
+		})
+	})
+
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
+		fm.capture(r)
+		if fm.healthHandler != nil {
+			fm.healthHandler(w, r)
+			return
+		}
+		writeFakeJSON(w, http.StatusOK, map[string]any{
+			"status":       "ok",
+			"model_loaded": true,
+			"engine":       "kokoro",
+		})
+	})
+
+	mux.HandleFunc("POST /v1/sessions/register", func(w http.ResponseWriter, r *http.Request) {
+		fm.capture(r)
+		if fm.regHandler != nil {
+			fm.regHandler(w, r)
+			return
+		}
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		writeFakeJSON(w, http.StatusOK, map[string]any{
+			"session_id":     body["session_id"],
+			"participant_id": body["participant_id"],
+			"assigned_voice": "bm_lewis",
+		})
+	})
+
+	mux.HandleFunc("POST /v1/sessions/{id}/deregister", func(w http.ResponseWriter, r *http.Request) {
+		fm.capture(r)
+		if fm.deregHandler != nil {
+			fm.deregHandler(w, r)
+			return
+		}
+		writeFakeJSON(w, http.StatusOK, map[string]any{
+			"status":     "ok",
+			"session_id": r.PathValue("id"),
+		})
+	})
+
+	mux.HandleFunc("GET /v1/sessions", func(w http.ResponseWriter, r *http.Request) {
+		fm.capture(r)
+		if fm.listSessionHandler != nil {
+			fm.listSessionHandler(w, r)
+			return
+		}
+		writeFakeJSON(w, http.StatusOK, map[string]any{
+			"sessions":   []any{},
+			"voice_pool": []string{"bm_lewis", "af_bella"},
+		})
+	})
+
+	fm.srv = httptest.NewServer(mux)
+	t.Cleanup(func() { fm.srv.Close() })
+	return fm
+}
+
+func (fm *fakeMod3Proxy) capture(r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+	fm.captured = append(fm.captured, capturedProxyRequest{
+		Method: r.Method, Path: r.URL.Path, Query: r.URL.RawQuery, Body: body,
+	})
+}
+
+func (fm *fakeMod3Proxy) last() capturedProxyRequest {
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+	if len(fm.captured) == 0 {
+		fm.t.Fatalf("no captured requests")
+	}
+	return fm.captured[len(fm.captured)-1]
+}
+
+// newProxyMCP builds a minimal MCPServer whose proxy points at fm, with
+// playback fully disabled so tests don't touch the audio stack.
+func newProxyMCP(t *testing.T, fm *fakeMod3Proxy) *MCPServer {
+	t.Helper()
+	m := &MCPServer{
+		cfg:       &Config{Mod3URL: fm.srv.URL},
+		mod3Proxy: &modalityProxy{disablePlayback: true},
+	}
+	return m
+}
+
+// decodeToolText parses the JSON text content of a CallToolResult.
+func decodeToolText(t *testing.T, res *mcp.CallToolResult) map[string]any {
+	t.Helper()
+	if res == nil || len(res.Content) == 0 {
+		t.Fatalf("empty result")
+	}
+	tc, ok := res.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected *mcp.TextContent, got %T", res.Content[0])
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(tc.Text), &out); err != nil {
+		t.Fatalf("decode result text: %v (raw=%q)", err, tc.Text)
+	}
+	return out
+}
+
+// ─── mod3_speak ──────────────────────────────────────────────────────────────
+
+func TestMod3Speak_SuccessPath(t *testing.T) {
+	fm := newFakeMod3Proxy(t)
+	m := newProxyMCP(t, fm)
+
+	res, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{
+		Text: "hello world",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected success, got IsError=true: %v", res.Content)
+	}
+
+	out := decodeToolText(t, res)
+	if ok, _ := out["ok"].(bool); !ok {
+		t.Fatalf("expected ok=true, got %v", out["ok"])
+	}
+	if bytes, _ := out["bytes"].(float64); bytes < 100 {
+		t.Fatalf("expected bytes > 100, got %v", out["bytes"])
+	}
+
+	metrics, _ := out["metrics"].(map[string]any)
+	if metrics == nil {
+		t.Fatal("expected metrics map")
+	}
+	if jobID, _ := metrics["job-id"].(string); jobID != "job-test-0001" {
+		t.Fatalf("expected job-id=job-test-0001, got %v", metrics["job-id"])
+	}
+	if dur, _ := metrics["duration-sec"].(float64); dur != 1.23 {
+		t.Fatalf("expected duration-sec=1.23, got %v", metrics["duration-sec"])
+	}
+	// Integer parse path — sample-rate comes as "24000".
+	if sr, ok := metrics["sample-rate"].(float64); !ok || sr != 24000 {
+		t.Fatalf("expected sample-rate=24000, got %v (%T)", metrics["sample-rate"], metrics["sample-rate"])
+	}
+	if got, _ := out["playback_status"].(string); got != "disabled" {
+		t.Fatalf("expected playback_status=disabled, got %v", out["playback_status"])
+	}
+}
+
+func TestMod3Speak_ForwardsSessionID(t *testing.T) {
+	fm := newFakeMod3Proxy(t)
+	m := newProxyMCP(t, fm)
+
+	_, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{
+		Text:      "hello",
+		SessionID: "cs-abc123",
+		Voice:     "af_bella",
+		Speed:     1.1,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cap := fm.last()
+	var forwarded map[string]any
+	if err := json.Unmarshal(cap.Body, &forwarded); err != nil {
+		t.Fatalf("decode forwarded body: %v", err)
+	}
+	if forwarded["session_id"] != "cs-abc123" {
+		t.Fatalf("expected session_id=cs-abc123, got %v", forwarded["session_id"])
+	}
+	if forwarded["voice"] != "af_bella" {
+		t.Fatalf("expected voice=af_bella, got %v", forwarded["voice"])
+	}
+	if speed, _ := forwarded["speed"].(float64); speed != 1.1 {
+		t.Fatalf("expected speed=1.1, got %v", forwarded["speed"])
+	}
+}
+
+func TestMod3Speak_OmitsSessionIDWhenAbsent(t *testing.T) {
+	fm := newFakeMod3Proxy(t)
+	m := newProxyMCP(t, fm)
+
+	_, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{Text: "plain"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cap := fm.last()
+	var forwarded map[string]any
+	if err := json.Unmarshal(cap.Body, &forwarded); err != nil {
+		t.Fatalf("decode forwarded body: %v", err)
+	}
+	if _, present := forwarded["session_id"]; present {
+		t.Fatalf("expected no session_id key, got %v", forwarded["session_id"])
+	}
+}
+
+func TestMod3Speak_EmptyTextRejects(t *testing.T) {
+	m := &MCPServer{cfg: &Config{Mod3URL: "http://unused"}}
+	res, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{Text: "   "})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// textResult — IsError is false because it's a validation message, but
+	// the content must mention the required field.
+	if len(res.Content) == 0 {
+		t.Fatal("expected content")
+	}
+	tc := res.Content[0].(*mcp.TextContent)
+	if !strings.Contains(tc.Text, "required") {
+		t.Fatalf("expected 'required' in message, got %q", tc.Text)
+	}
+}
+
+func TestMod3Speak_Mod3DownReturnsCleanError(t *testing.T) {
+	// Port that refuses connections.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := l.Addr().String()
+	_ = l.Close() // release the port so dials get ECONNREFUSED
+
+	m := &MCPServer{
+		cfg:       &Config{Mod3URL: "http://" + addr},
+		mod3Proxy: &modalityProxy{disablePlayback: true},
+	}
+	res, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{Text: "hi"})
+	if err != nil {
+		t.Fatalf("handler should not return Go error, got %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected IsError=true when mod3 is unreachable")
+	}
+	tc := res.Content[0].(*mcp.TextContent)
+	if !strings.Contains(strings.ToLower(tc.Text), "mod3 unreachable") {
+		t.Fatalf("expected 'mod3 unreachable' message, got %q", tc.Text)
+	}
+}
+
+func TestMod3Speak_PreservesMod3ErrorBody(t *testing.T) {
+	fm := newFakeMod3Proxy(t)
+	fm.synthesizeHandler = func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"detail":"text must not be empty"}`))
+	}
+	m := newProxyMCP(t, fm)
+
+	res, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{Text: "bad"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected IsError=true on mod3 422")
+	}
+	tc := res.Content[0].(*mcp.TextContent)
+	if !strings.Contains(tc.Text, "422") {
+		t.Fatalf("expected '422' in error text, got %q", tc.Text)
+	}
+	if !strings.Contains(tc.Text, "text must not be empty") {
+		t.Fatalf("expected mod3 body preserved, got %q", tc.Text)
+	}
+}
+
+func TestMod3Speak_SkipPlaybackReturnsBase64(t *testing.T) {
+	fm := newFakeMod3Proxy(t)
+	m := newProxyMCP(t, fm)
+
+	res, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{
+		Text:         "skip",
+		SkipPlayback: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := decodeToolText(t, res)
+	if got, _ := out["playback_status"].(string); got != "skipped" {
+		t.Fatalf("expected playback_status=skipped, got %v", out["playback_status"])
+	}
+	if b64, _ := out["audio_base64"].(string); b64 == "" {
+		t.Fatal("expected audio_base64 populated when skip_playback=true")
+	}
+}
+
+// ─── mod3_stop / voices / status / sessions ──────────────────────────────────
+
+func TestMod3Stop_ForwardsSessionAndJob(t *testing.T) {
+	fm := newFakeMod3Proxy(t)
+	m := newProxyMCP(t, fm)
+
+	res, _, err := m.toolMod3Stop(context.Background(), nil, mod3StopInput{
+		SessionID: "cs-abc",
+		JobID:     "job-xyz",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatal("expected success")
+	}
+
+	cap := fm.last()
+	if !strings.Contains(cap.Query, "session_id=cs-abc") {
+		t.Fatalf("expected session_id in query, got %q", cap.Query)
+	}
+	if !strings.Contains(cap.Query, "job_id=job-xyz") {
+		t.Fatalf("expected job_id in query, got %q", cap.Query)
+	}
+
+	out := decodeToolText(t, res)
+	if out["status"] != "stopped" {
+		t.Fatalf("expected status=stopped, got %v", out["status"])
+	}
+}
+
+func TestMod3Voices_ReturnsRawList(t *testing.T) {
+	fm := newFakeMod3Proxy(t)
+	m := newProxyMCP(t, fm)
+
+	res, _, err := m.toolMod3Voices(context.Background(), nil, mod3VoicesInput{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatal("expected success")
+	}
+	out := decodeToolText(t, res)
+	voices, _ := out["voices"].([]any)
+	if len(voices) != 2 {
+		t.Fatalf("expected 2 voices, got %d", len(voices))
+	}
+}
+
+func TestMod3Voices_ThreadsSessionID(t *testing.T) {
+	fm := newFakeMod3Proxy(t)
+	m := newProxyMCP(t, fm)
+
+	_, _, _ = m.toolMod3Voices(context.Background(), nil, mod3VoicesInput{SessionID: "cs-qq"})
+	cap := fm.last()
+	if !strings.Contains(cap.Query, "session_id=cs-qq") {
+		t.Fatalf("expected session_id in query, got %q", cap.Query)
+	}
+}
+
+func TestMod3Status_HitsHealth(t *testing.T) {
+	fm := newFakeMod3Proxy(t)
+	m := newProxyMCP(t, fm)
+
+	res, _, err := m.toolMod3Status(context.Background(), nil, mod3StatusInput{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatal("expected success")
+	}
+	out := decodeToolText(t, res)
+	if out["status"] != "ok" {
+		t.Fatalf("expected status=ok, got %v", out["status"])
+	}
+
+	cap := fm.last()
+	if cap.Path != "/health" {
+		t.Fatalf("expected /health, got %q", cap.Path)
+	}
+}
+
+func TestMod3Status_Mod3DownClean(t *testing.T) {
+	l, _ := net.Listen("tcp", "127.0.0.1:0")
+	addr := l.Addr().String()
+	_ = l.Close()
+
+	m := &MCPServer{cfg: &Config{Mod3URL: "http://" + addr}}
+	res, _, err := m.toolMod3Status(context.Background(), nil, mod3StatusInput{})
+	if err != nil {
+		t.Fatalf("handler should not Go-error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected IsError=true")
+	}
+}
+
+func TestMod3RegisterSession_ForwardsBody(t *testing.T) {
+	fm := newFakeMod3Proxy(t)
+	m := newProxyMCP(t, fm)
+
+	res, _, err := m.toolMod3RegisterSession(context.Background(), nil, mod3RegisterSessionInput{
+		SessionID:             "cs-regtest",
+		ParticipantID:         "cog",
+		ParticipantType:       "agent",
+		PreferredVoice:        "bm_lewis",
+		PreferredOutputDevice: "system-default",
+		Priority:              2,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatal("expected success")
+	}
+
+	cap := fm.last()
+	var body map[string]any
+	if err := json.Unmarshal(cap.Body, &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["session_id"] != "cs-regtest" {
+		t.Fatalf("bad session_id: %v", body["session_id"])
+	}
+	if body["participant_id"] != "cog" {
+		t.Fatalf("bad participant_id: %v", body["participant_id"])
+	}
+	if body["preferred_voice"] != "bm_lewis" {
+		t.Fatalf("bad preferred_voice: %v", body["preferred_voice"])
+	}
+}
+
+func TestMod3RegisterSession_RejectsWithoutParticipant(t *testing.T) {
+	fm := newFakeMod3Proxy(t)
+	m := newProxyMCP(t, fm)
+
+	res, _, err := m.toolMod3RegisterSession(context.Background(), nil, mod3RegisterSessionInput{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	tc := res.Content[0].(*mcp.TextContent)
+	if !strings.Contains(tc.Text, "participant_id") {
+		t.Fatalf("expected validation message, got %q", tc.Text)
+	}
+}
+
+func TestMod3DeregisterSession_PathEscape(t *testing.T) {
+	fm := newFakeMod3Proxy(t)
+	m := newProxyMCP(t, fm)
+
+	res, _, err := m.toolMod3DeregisterSession(context.Background(), nil, mod3DeregisterSessionInput{
+		SessionID: "cs-drop",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatal("expected success")
+	}
+	cap := fm.last()
+	if cap.Path != "/v1/sessions/cs-drop/deregister" {
+		t.Fatalf("expected /v1/sessions/cs-drop/deregister, got %q", cap.Path)
+	}
+}
+
+func TestMod3DeregisterSession_RequiresID(t *testing.T) {
+	m := &MCPServer{cfg: &Config{Mod3URL: "http://unused"}}
+	res, _, err := m.toolMod3DeregisterSession(context.Background(), nil, mod3DeregisterSessionInput{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	tc := res.Content[0].(*mcp.TextContent)
+	if !strings.Contains(tc.Text, "session_id") {
+		t.Fatalf("expected session_id message, got %q", tc.Text)
+	}
+}
+
+func TestMod3ListSessions_ReturnsRaw(t *testing.T) {
+	fm := newFakeMod3Proxy(t)
+	m := newProxyMCP(t, fm)
+
+	res, _, err := m.toolMod3ListSessions(context.Background(), nil, mod3ListSessionsInput{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatal("expected success")
+	}
+	out := decodeToolText(t, res)
+	vp, _ := out["voice_pool"].([]any)
+	if len(vp) != 2 {
+		t.Fatalf("expected 2 voices in pool, got %d", len(vp))
+	}
+}
+
+// ─── metric extraction unit test ─────────────────────────────────────────────
+
+func TestExtractMod3Metrics_TypesByValue(t *testing.T) {
+	h := http.Header{}
+	h.Set("X-Mod3-Job-Id", "abc123")
+	h.Set("X-Mod3-Duration-Sec", "2.50")
+	h.Set("X-Mod3-Sample-Rate", "24000")
+	h.Set("X-Mod3-Rtf", "8.1")
+	h.Set("Content-Type", "audio/wav") // should be skipped
+
+	out := extractMod3Metrics(h)
+	if len(out) != 4 {
+		t.Fatalf("expected 4 metrics, got %d: %v", len(out), out)
+	}
+	if got, _ := out["job-id"].(string); got != "abc123" {
+		t.Fatalf("job-id: got %v", out["job-id"])
+	}
+	if got, ok := out["duration-sec"].(float64); !ok || got != 2.5 {
+		t.Fatalf("duration-sec: got %v (%T)", out["duration-sec"], out["duration-sec"])
+	}
+	if got, ok := out["sample-rate"].(int64); !ok || got != 24000 {
+		t.Fatalf("sample-rate should parse to int64, got %v (%T)",
+			out["sample-rate"], out["sample-rate"])
+	}
+	if _, present := out["content-type"]; present {
+		t.Fatal("content-type should be skipped")
+	}
+}
+
+// ─── playback injection test ─────────────────────────────────────────────────
+
+// TestPlayAudio_StubPlayer — validate the playback plumbing by injecting a
+// small shell-script player that records the file it received. Proves the
+// audio bytes reach the player (the bug the installed binary has today is
+// that they don't). Only runs on OSes where a shell is available.
+func TestPlayAudio_StubPlayer(t *testing.T) {
+	dir := t.TempDir()
+	recPath := filepath.Join(dir, "received.log")
+	stubPath := filepath.Join(dir, "stub-player.sh")
+
+	// Player writes its last-arg path and the first 4 bytes of the wav to
+	// received.log; proves (a) the player got a path, (b) the file exists
+	// at that path with our bytes.
+	stubBody := `#!/bin/sh
+path="$1"
+hdr=$(dd if="$path" bs=4 count=1 2>/dev/null)
+printf 'path=%s hdr=%s\n' "$path" "$hdr" > "` + recPath + `"
+`
+	if err := os.WriteFile(stubPath, []byte(stubBody), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+
+	p := &modalityProxy{player: stubPath}
+	if err := p.playAudio(synthWav, true); err != nil {
+		t.Fatalf("playAudio: %v", err)
+	}
+
+	got, err := os.ReadFile(recPath)
+	if err != nil {
+		t.Fatalf("read record: %v", err)
+	}
+	line := string(got)
+	if !strings.Contains(line, "hdr=RIFF") {
+		t.Fatalf("player did not see RIFF header; got %q", line)
+	}
+	if !strings.Contains(line, "path=") {
+		t.Fatalf("player did not get a path arg; got %q", line)
+	}
+}
+
+// TestPlayAudio_NonBlockingSpawn — fire-and-forget. Use a sleep-style stub
+// and assert playAudio returns before the stub would finish. Prevents the
+// regression where speech synthesis blocks the MCP response on playback.
+func TestPlayAudio_NonBlockingSpawn(t *testing.T) {
+	dir := t.TempDir()
+	stubPath := filepath.Join(dir, "sleeper.sh")
+	stubBody := `#!/bin/sh
+sleep 5
+`
+	if err := os.WriteFile(stubPath, []byte(stubBody), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	p := &modalityProxy{player: stubPath}
+
+	done := make(chan struct{})
+	go func() {
+		if err := p.playAudio(synthWav, false); err != nil {
+			t.Errorf("playAudio: %v", err)
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Expected: playAudio returns immediately in non-blocking mode.
+	case <-time.After(2 * time.Second):
+		t.Fatal("playAudio(blocking=false) did not return within 2s")
+	}
+}

--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -47,6 +47,11 @@ type MCPServer struct {
 	busSessions     *BusSessionManager
 	sessionRegistry *SessionRegistry
 	handoffRegistry *HandoffRegistry
+
+	// mod3Proxy backs the mod3_* MCP tools (Wave 3 of the mod3-kernel
+	// integration). Lazily initialised — tests can pre-seed it with a
+	// custom HTTP client + stub player to avoid real network + audio.
+	mod3Proxy *modalityProxy
 }
 
 // NewMCPServer creates and configures the MCP server with all stage-1 tools.
@@ -241,6 +246,12 @@ func (m *MCPServer) registerTools() {
 	// both surfaces coexist by design — same kernel truth, two MCP
 	// doorways (amendment #5 of the Agent P hybrid plan).
 	m.registerSessionTools()
+
+	// Wave 3: mod3 proxy tools (mcp_modality_proxy.go). The kernel becomes
+	// the MCP front door for mod3 — HTTP-forwards synthesis/stop/voices/
+	// status and plays the returned audio/wav locally. Supersedes the
+	// installed binary's OpenClaw gateway which silently drops audio bytes.
+	m.registerMod3Tools()
 }
 
 // registerResources registers MCP Resources — read-only addressable data.

--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -61,6 +61,12 @@ type MCPServer struct {
 	// place. Nil when the MCP server is built outside a live kernel —
 	// the tools return a clean "not configured" error in that case.
 	channelSessionBackend channelSessionBackend
+
+	// toolMeta is the manifest-introspection registry for MCP tools.
+	// Populated by trackTool at registration time (see serve_manifest.go);
+	// read by handleManifest. Frozen after registerTools returns, so
+	// lock-free reads are safe.
+	toolMeta []mcpToolMeta
 }
 
 // channelSessionBackend is the narrow surface the mod3 session-family MCP
@@ -140,134 +146,134 @@ func (m *MCPServer) Handler() http.Handler {
 // closes Agent F gap #6 and activates the gate.go:94 recognizer that has
 // been waiting for a producer.
 func (m *MCPServer) registerTools() {
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name:        "cog_search_memory",
 		Description: "Full-text and semantic search over the CogDoc memory corpus. Returns ranked results with salience scores. Fallback: ./scripts/cog memory search \"query\"",
-	}, withToolObserver(m, "cog_search_memory", m.toolSearchMemory))
+	}), withToolObserver(m, "cog_search_memory", m.toolSearchMemory))
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name:        "cog_read_cogdoc",
 		Description: "Read a CogDoc by URI or path. Resolves cog: URIs automatically. Returns full content with parsed frontmatter and optional section extraction via #fragment. Fallback: ./scripts/cog memory read <path>",
-	}, withToolObserver(m, "cog_read_cogdoc", m.toolReadCogdoc))
+	}), withToolObserver(m, "cog_read_cogdoc", m.toolReadCogdoc))
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name:        "cog_write_cogdoc",
 		Description: "Write or update a CogDoc at the specified memory path. Creates the file with proper frontmatter if it doesn't exist. Fallback: ./scripts/cog memory write <path> \"Title\"",
-	}, withToolObserver(m, "cog_write_cogdoc", m.toolWriteCogdoc))
+	}), withToolObserver(m, "cog_write_cogdoc", m.toolWriteCogdoc))
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name:        "cog_patch_frontmatter",
 		Description: "Merge description, tags, or type patches into a CogDoc frontmatter block.",
-	}, withToolObserver(m, "cog_patch_frontmatter", m.toolPatchFrontmatter))
+	}), withToolObserver(m, "cog_patch_frontmatter", m.toolPatchFrontmatter))
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name:        "cog_check_coherence",
 		Description: "Run coherence validation against the workspace. Checks URI resolution, frontmatter validity, and reference integrity. Fallback: ./scripts/cog coherence check",
-	}, withToolObserver(m, "cog_check_coherence", m.toolCheckCoherence))
+	}), withToolObserver(m, "cog_check_coherence", m.toolCheckCoherence))
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name:        "cog_get_state",
 		Description: "Get kernel state: process status, uptime, trust, node health (sibling services), field size, and heartbeat info. Includes identity and coherence metadata. Fallback: curl http://localhost:6931/health",
-	}, withToolObserver(m, "cog_get_state", m.toolGetState))
+	}), withToolObserver(m, "cog_get_state", m.toolGetState))
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name:        "cog_query_field",
 		Description: "Query the attentional field — the salience-scored map of all tracked CogDocs. Returns top-N items, optionally filtered by sector. Shows what the kernel considers most relevant right now.",
-	}, withToolObserver(m, "cog_query_field", m.toolQueryField))
+	}), withToolObserver(m, "cog_query_field", m.toolQueryField))
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name:        "cog_assemble_context",
 		Description: "Build a context package for a given token budget with an explicit focus topic. Use this for intentional context assembly (subtasks, specific investigations). The automatic foveated-context hook handles ambient context on every prompt.",
-	}, withToolObserver(m, "cog_assemble_context", m.toolAssembleContext))
+	}), withToolObserver(m, "cog_assemble_context", m.toolAssembleContext))
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name:        "cog_emit_event",
 		Description: "Emit a typed event to the workspace ledger. Events: attention.boost (uri + weight), session.marker (label), insight.captured (summary), decision.made (decision + rationale). Fallback: events are JSONL in .cog/ledger/",
-	}, withToolObserver(m, "cog_emit_event", m.toolEmitEvent))
+	}), withToolObserver(m, "cog_emit_event", m.toolEmitEvent))
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name:        "cog_read_ledger",
 		Description: "Read the hash-chained event ledger. Filter by session_id, event_type (exact or 'prefix.*' wildcard), after_seq (requires session_id), since_timestamp (RFC3339), or limit (default 100, max 1000). Set verify_chain=true to recompute hashes and validate prior_hash links. Fallback: cat .cog/ledger/<session_id>/events.jsonl",
-	}, m.toolReadLedger)
+	}), m.toolReadLedger)
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name:        "cog_read_events",
 		Description: "Query recent kernel events for observability. Returns historical events from the ledger without chain verification (use cog_read_ledger for audit). Filters: session_id, event_type (exact or 'attention.*' wildcard), source ('kernel-v3' / 'mcp-client'), since/until (RFC3339 or duration shorthand like '5m'), limit (default 100, max 1000), order ('desc' newest-first default, 'asc' oldest-first). Fallback: ls .cog/ledger/ && cat .cog/ledger/*/events.jsonl",
-	}, m.toolReadEvents)
+	}), m.toolReadEvents)
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name:        "cog_tail_events",
 		Description: "Tail kernel events as they are appended to the ledger, like 'tail -f'. Blocks until max_events or max_duration reached. Same filters as cog_read_events plus since= for replay before going live. Bounded by max_events (default 100, max 1000) and max_duration (default 60s, max 10m). Fallback: curl -N http://localhost:6931/v1/events/stream",
-	}, m.toolTailEvents)
+	}), m.toolTailEvents)
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name:        "cog_ingest",
 		Description: "Ingest external material into CogOS knowledge. Deterministic decomposition — no LLM calls. Supports URLs, conversations, documents. Applies membrane policy (accept/quarantine/defer/discard).",
-	}, withToolObserver(m, "cog_ingest", m.toolIngest))
+	}), withToolObserver(m, "cog_ingest", m.toolIngest))
 
 	// Tool-call observability — reads the paired tool.call/tool.result events
 	// the wrapper above emits. Self-reflective: these two tools also go
 	// through withToolObserver and end up in their own query results.
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name:        "cog_read_tool_calls",
 		Description: "Query recent tool invocations and their outcomes. Returns call+result pairs from the ledger, filterable by tool_name, status (pending/success/error/rejected/timeout), source, ownership, call_id, or time window. Default limit 100, max 500. Arguments and output are opt-in via include_args/include_output. Fallback: grep '\"type\":\"tool\\.' .cog/ledger/<sid>/events.jsonl",
-	}, withToolObserver(m, "cog_read_tool_calls", m.toolReadToolCalls))
+	}), withToolObserver(m, "cog_read_tool_calls", m.toolReadToolCalls))
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name:        "cog_tail_tool_calls",
 		Description: "Tail tool-call events live. Replays recent tool.call / tool.result events (up to max_events, default 50), applying the same filters as cog_read_tool_calls. When Agent N's event bus lands, this will stream new events live; until then it returns a snapshot of the latest matching rows. Fallback: tail -f .cog/ledger/<sid>/events.jsonl | grep '\"type\":\"tool\\.'",
-	}, withToolObserver(m, "cog_tail_tool_calls", m.toolTailToolCalls))
+	}), withToolObserver(m, "cog_tail_tool_calls", m.toolTailToolCalls))
 
 	// Agent state / loop control — closes Agent F gap #8 per Agent T's design.
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name:        "cog_list_agents",
 		Description: "Enumerate active agent harness instances inside the kernel. Each entry summarises identity, state, and recent activity. Today returns one element (\"primary\") reflecting the ServeAgent singleton; forward-compatible for future multi-agent deployment. Fallback: curl http://localhost:6931/v1/agents",
-	}, m.toolListAgents)
+	}), m.toolListAgents)
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name:        "cog_get_agent_state",
 		Description: "Full state snapshot of one agent instance — status summary, activity awareness, rolling cycle memory, pending proposals, inbox queue, and optionally the most recent cycle traces. Matches the shape of GET /v1/agents/{id}. Fallback: curl http://localhost:6931/v1/agents/primary",
-	}, m.toolGetAgentState)
+	}), m.toolGetAgentState)
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name:        "cog_trigger_agent_loop",
 		Description: "Manually invoke one homeostatic cycle of the specified agent, outside the regular ticker. Equivalent to POST /v1/agents/{id}/tick. Returns immediately with a trigger receipt; cycle runs async unless wait=true. Refuses if a cycle is already in flight (overlap guard). Fallback: curl -X POST http://localhost:6931/v1/agents/primary/tick",
-	}, m.toolTriggerAgentLoop)
+	}), m.toolTriggerAgentLoop)
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name:        "cog_tail_kernel_log",
 		Description: "Read recent entries from the kernel's own diagnostic log (slog JSON at .cog/run/kernel.log.jsonl). Returns newest-first, optionally filtered by level, substring, and time range. This is the OPERATOR/DEBUG surface — for hash-chained event history use cog_read_ledger (when available); for client metabolites (turn metrics, attention, proprioceptive) use cog_search_traces. Fallback: tail -n 100 .cog/run/kernel.log.jsonl | jq -c .",
-	}, m.toolTailKernelLog)
+	}), m.toolTailKernelLog)
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name: "cog_read_conversation",
 		Description: "Read conversation turns (prompt + response pairs) from a session's chat history. " +
 			"Each turn is a complete user-to-assistant exchange; kernel tool calls are inlined when include_tools=true. " +
 			"Backed by the turn.completed ledger event + per-session sidecar (.cog/run/turns/<sid>.jsonl). " +
 			"Use after_turn / before_turn for pagination. Default: current process session, 20 turns, ascending. " +
 			"Fallback (kernel unavailable): jq -c . .cog/run/turns/<sid>.jsonl",
-	}, m.toolReadConversation)
+	}), m.toolReadConversation)
 
 	// Config mutation API (Agent O design — closes Agent F gaps #5 + #19).
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name:        "cog_read_config",
 		Description: "Read the kernel config (.cog/config/kernel.yaml). Returns the effective resolved config (defaults + file overrides). Optional include_raw_yaml returns the raw file bytes; include_defaults also returns the hardcoded defaults for diffing. kernel.yaml only — sibling configs (providers.yaml, secrets.yaml) are out of scope.",
-	}, m.toolReadConfig)
+	}), m.toolReadConfig)
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name:        "cog_write_config",
 		Description: "Merge a patch into the kernel config (.cog/config/kernel.yaml) using RFC 7396 JSON merge-patch semantics: fields omitted from the patch are left unchanged; explicit null removes a field and restores the default on next boot. Validated before persisting — returns violations without writing on failure. Atomic write + rotating .bak-<timestamp> backups (keeps 10). Takes effect on next daemon restart (requires_restart: true in response). Fallback: edit .cog/config/kernel.yaml and run `./scripts/cog restart`. No authentication — the kernel assumes a trusted local caller.",
-	}, m.toolWriteConfig)
+	}), m.toolWriteConfig)
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name:        "cog_rollback_config",
 		Description: "Restore kernel.yaml from a prior .bak-<timestamp> backup. Pass list_only=true to enumerate available backups without restoring. If backup is empty, the most recent backup is used. Atomic restore; response carries updated backup list.",
-	}, m.toolRollbackConfig)
+	}), m.toolRollbackConfig)
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name:        "cog_search_traces",
 		Description: "Search kernel trace JSONL streams in .cog/run/ (attention, proprioceptive, internal_requests). Filter by source, session_id, level, case-insensitive substring, and time range (since/until accept RFC3339 or duration like 5m/1h). Returns unified chronological results with per-source scan diagnostics. Fallback: ls .cog/run/*.jsonl && jq -c . .cog/run/<name>.jsonl | head",
-	}, m.toolSearchTraces)
+	}), m.toolSearchTraces)
 
 	// Kernel-native session/handoff tools (mcp_sessions.go). The 8 tools
 	// complement the 8 cogos_* bridge tools living in cog-sandbox-mcp:

--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -52,6 +52,25 @@ type MCPServer struct {
 	// integration). Lazily initialised — tests can pre-seed it with a
 	// custom HTTP client + stub player to avoid real network + audio.
 	mod3Proxy *modalityProxy
+
+	// channelSessionBackend is the kernel Server whose
+	// RegisterChannelSession / DeregisterChannelSession /
+	// ListChannelSessions methods own session-ID authority (ADR-082
+	// Wave 2). Wave 3.5 routes the three mod3 session-family MCP tools
+	// through these shared methods so minting happens in exactly one
+	// place. Nil when the MCP server is built outside a live kernel —
+	// the tools return a clean "not configured" error in that case.
+	channelSessionBackend channelSessionBackend
+}
+
+// channelSessionBackend is the narrow surface the mod3 session-family MCP
+// tools need to forward through the kernel's shared minting/forwarding
+// logic. Interface rather than concrete *Server so tests can inject a fake
+// without building a whole Server.
+type channelSessionBackend interface {
+	RegisterChannelSession(ctx context.Context, req channelSessionRegisterRequest) (*channelSessionResponse, *channelSessionForwardError)
+	DeregisterChannelSession(ctx context.Context, sessionID string) (json.RawMessage, int, *channelSessionForwardError)
+	ListChannelSessions(ctx context.Context) (*channelSessionListResponse, int, *channelSessionForwardError)
 }
 
 // NewMCPServer creates and configures the MCP server with all stage-1 tools.
@@ -96,6 +115,15 @@ func NewMCPServerWithAgentController(cfg *Config, nucleus *Nucleus, process *Pro
 // unchanged because the tools resolve the current controller on each call.
 func (m *MCPServer) SetAgentController(ctrl AgentController) {
 	m.agentController = ctrl
+}
+
+// SetChannelSessionBackend wires the kernel-owned channel-session minting
+// logic into the MCP server so the mod3_register_session / _deregister /
+// _list tools call through the same shared methods the HTTP surface uses
+// (ADR-082 Wave 3.5). Safe to pass nil; the tools surface a clean "not
+// configured" error in that case.
+func (m *MCPServer) SetChannelSessionBackend(b channelSessionBackend) {
+	m.channelSessionBackend = b
 }
 
 // Handler returns the http.Handler for mounting at /mcp.

--- a/internal/engine/mcp_sessions.go
+++ b/internal/engine/mcp_sessions.go
@@ -42,69 +42,69 @@ func (m *MCPServer) sessionsBackendReady() bool {
 // its own method so mcp_server.go stays tidy; the registration site in
 // registerTools calls this last.
 func (m *MCPServer) registerSessionTools() {
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name: "cog_register_session",
 		Description: "Register (or idempotently update) a session on " +
 			"bus_sessions. Validates the session_id format " +
 			"(lowercase, hyphen-separated, 3-component required). Required: " +
 			"session_id, workspace, role. Optional: task, model, hostname, " +
 			"status, current_task, context_usage.",
-	}, withToolObserver(m, "cog_register_session", m.toolRegisterSession))
+	}), withToolObserver(m, "cog_register_session", m.toolRegisterSession))
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name: "cog_heartbeat_session",
 		Description: "Emit a periodic keep-alive heartbeat for a session. " +
 			"Updates LastSeen and optional status/context fields. Rejects " +
 			"if the session is unregistered (404) or already ended (409).",
-	}, withToolObserver(m, "cog_heartbeat_session", m.toolHeartbeatSession))
+	}), withToolObserver(m, "cog_heartbeat_session", m.toolHeartbeatSession))
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name: "cog_end_session",
 		Description: "Mark a session as ended. Optional handoff_id " +
 			"references the outgoing handoff, if any. Rejects if the " +
 			"session is unknown (404) or already ended (409).",
-	}, withToolObserver(m, "cog_end_session", m.toolEndSession))
+	}), withToolObserver(m, "cog_end_session", m.toolEndSession))
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name: "cog_list_sessions",
 		Description: "List the roster of tracked sessions with an " +
 			"is-active flag computed from the freshness window " +
 			"(default 600s, override via active_within_seconds). Set " +
 			"include_ended=true to also see sessions that exited.",
-	}, withToolObserver(m, "cog_list_sessions", m.toolListSessions))
+	}), withToolObserver(m, "cog_list_sessions", m.toolListSessions))
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name: "cog_offer_handoff",
 		Description: "Post a handoff.offer to bus_handoffs. Mints a new " +
 			"handoff_id (ho-<ms>-<hex>). task.title, task.goal, and a " +
 			"non-empty task.next_steps list are required. TTL defaults to " +
 			"3600s; expired offers are 409 on claim. Returns the full " +
 			"offer payload so the caller can inspect what was written.",
-	}, withToolObserver(m, "cog_offer_handoff", m.toolOfferHandoff))
+	}), withToolObserver(m, "cog_offer_handoff", m.toolOfferHandoff))
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name: "cog_list_handoffs",
 		Description: "List tracked handoffs with optional filters: " +
 			"state (open|claimed|completed|expired) and for_session. The " +
 			"kernel maintains the derived view; the bus remains ground " +
 			"truth.",
-	}, withToolObserver(m, "cog_list_handoffs", m.toolListHandoffs))
+	}), withToolObserver(m, "cog_list_handoffs", m.toolListHandoffs))
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name: "cog_claim_handoff",
 		Description: "Atomically claim an open handoff offer. First-wins " +
 			"by kernel mutex: concurrent claims produce exactly one 200 " +
 			"and N-1 409 responses, each of which emits a " +
 			"handoff.claim_rejected event on bus_handoffs for audit. " +
 			"Returns the full offer payload on success.",
-	}, withToolObserver(m, "cog_claim_handoff", m.toolClaimHandoff))
+	}), withToolObserver(m, "cog_claim_handoff", m.toolClaimHandoff))
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name: "cog_complete_handoff",
 		Description: "Mark a claimed handoff as completed. Rejected with " +
 			"409 if the handoff has not been claimed yet or is already " +
 			"complete. Optional outcome, notes, and next_handoff_id.",
-	}, withToolObserver(m, "cog_complete_handoff", m.toolCompleteHandoff))
+	}), withToolObserver(m, "cog_complete_handoff", m.toolCompleteHandoff))
 }
 
 // ─── input/output types ──────────────────────────────────────────────────────

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -184,9 +184,15 @@ func NewServer(cfg *Config, nucleus *Nucleus, process *Process) *Server {
 	if bindAddr == "" {
 		bindAddr = "127.0.0.1"
 	}
+	// Wrap the mux with CORS middleware so browser origins (e.g. the mod3
+	// dashboard at http://localhost:7860) can POST to /v1/* without the
+	// preflight failing. See serve_cors.go for the policy rationale —
+	// loopback origins are echoed, everything else gets "*".
+	handler := corsMiddleware(mux)
+
 	s.srv = &http.Server{
 		Addr:         fmt.Sprintf("%s:%d", bindAddr, cfg.Port),
-		Handler:      mux,
+		Handler:      handler,
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 300 * time.Second, // 5 min — streaming responses can be long
 		IdleTimeout:  120 * time.Second,

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -92,6 +92,12 @@ type Server struct {
 	// to mod3. Nil in production (falls back to the package-level
 	// mod3HTTPClient); tests set this to an httptest-backed client.
 	mod3Client *http.Client
+
+	// httpRoutes is the manifest-introspection registry. Every route added
+	// via s.route / s.routeH appends here; /v1/manifest serialises this
+	// slice. Populated at startup only — reads are lock-free because the
+	// slice is frozen by the time Start returns.
+	httpRoutes []routeMeta
 }
 
 // NewServer constructs a Server bound to the configured port.
@@ -119,24 +125,25 @@ func NewServer(cfg *Config, nucleus *Nucleus, process *Process) *Server {
 	s.channelSessionRegistry = NewChannelSessionRegistry()
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /", handleDashboard)
-	mux.HandleFunc("GET /canvas", handleCanvas)
-	mux.HandleFunc("GET /health", s.handleHealth)
-	mux.HandleFunc("GET /v1/context", s.handleContext)
-	mux.HandleFunc("GET /v1/resolve", s.handleResolve)
-	mux.HandleFunc("GET /v1/cogdoc/read", s.handleCogDocRead)
-	mux.HandleFunc("GET /v1/debug/last", s.handleDebugLast)
-	mux.HandleFunc("GET /v1/debug/context", s.handleDebugContext)
-	mux.HandleFunc("POST /v1/chat/completions", s.handleChat)
-	mux.HandleFunc("POST /v1/messages", s.handleAnthropicMessages)
-	mux.HandleFunc("GET /v1/proprioceptive", s.handleProprioceptive)
-	mux.HandleFunc("GET /v1/ledger", s.handleLedger)
-	mux.HandleFunc("GET /v1/traces", s.handleTraces)
-	mux.HandleFunc("GET /v1/lightcone", s.handleLightCone)
-	mux.HandleFunc("POST /v1/context/foveated", s.handleFoveatedContext)
-	mux.HandleFunc("GET /v1/kernel-log", s.handleKernelLog)
-	mux.HandleFunc("GET /v1/tool-calls", s.handleToolCalls)
-	mux.HandleFunc("GET /v1/conversation", s.handleConversation)
+	s.route(mux, "GET /", handleDashboard)
+	s.route(mux, "GET /canvas", handleCanvas)
+	s.route(mux, "GET /health", s.handleHealth)
+	s.route(mux, "GET /v1/context", s.handleContext)
+	s.route(mux, "GET /v1/resolve", s.handleResolve)
+	s.route(mux, "GET /v1/cogdoc/read", s.handleCogDocRead)
+	s.route(mux, "GET /v1/debug/last", s.handleDebugLast)
+	s.route(mux, "GET /v1/debug/context", s.handleDebugContext)
+	s.route(mux, "POST /v1/chat/completions", s.handleChat)
+	s.route(mux, "POST /v1/messages", s.handleAnthropicMessages)
+	s.route(mux, "GET /v1/proprioceptive", s.handleProprioceptive)
+	s.route(mux, "GET /v1/ledger", s.handleLedger)
+	s.route(mux, "GET /v1/traces", s.handleTraces)
+	s.route(mux, "GET /v1/lightcone", s.handleLightCone)
+	s.route(mux, "POST /v1/context/foveated", s.handleFoveatedContext)
+	s.route(mux, "GET /v1/kernel-log", s.handleKernelLog)
+	s.route(mux, "GET /v1/tool-calls", s.handleToolCalls)
+	s.route(mux, "GET /v1/conversation", s.handleConversation)
+	s.route(mux, "GET /v1/manifest", s.handleManifest)
 
 	// Constellation / attention endpoints (Phase 3)
 	s.registerAttentionRoutes(mux)

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -19,6 +19,15 @@
 //	GET  /v1/constellation/fovea           — current fovea state
 //	GET  /v1/constellation/adjacent?uri=… — adjacent nodes by attentional proximity
 //
+// Channel-session forwarder (ADR-082 Wave 2, see serve_sessions_channel.go):
+//
+//	POST /v1/channel-sessions/register             — kernel mints session_id
+//	                                                  and forwards to mod3;
+//	                                                  returns merged response
+//	POST /v1/channel-sessions/{id}/deregister      — proxy to mod3, drop record
+//	GET  /v1/channel-sessions                      — kernel view + mod3 list
+//	GET  /v1/channel-sessions/{id}                 — single-session detail
+//
 // The chat endpoint routes through the inference Router when one is set,
 // otherwise returns 501.
 package engine
@@ -52,8 +61,8 @@ type Server struct {
 	process         *Process
 	router          Router // nil until SetRouter is called
 	srv             *http.Server
-	debug           debugStore    // captures last request pipeline state
-	attentionLog    *attentionLog // per-server log (avoids global write race)
+	debug           debugStore      // captures last request pipeline state
+	attentionLog    *attentionLog   // per-server log (avoids global write race)
 	agentController AgentController // nil until SetAgentController is called
 	mcpServer       *MCPServer      // so SetAgentController can propagate to tools
 
@@ -71,6 +80,18 @@ type Server struct {
 	// these are derived views rebuilt from bus replay at startup.
 	sessionRegistry *SessionRegistry
 	handoffRegistry *HandoffRegistry
+
+	// ADR-082 Wave 2: kernel-owned identity registry for channel-participant
+	// sessions. The kernel mints session_id, mod3 stores per-channel state
+	// keyed on the kernel-issued ID. Distinct from sessionRegistry above,
+	// which enforces strict 3-component hyphen IDs for the agent/handoff
+	// protocol. See serve_sessions_channel.go for the full rationale.
+	channelSessionRegistry *ChannelSessionRegistry
+
+	// mod3Client is the HTTP client used to forward channel-session calls
+	// to mod3. Nil in production (falls back to the package-level
+	// mod3HTTPClient); tests set this to an httptest-backed client.
+	mod3Client *http.Client
 }
 
 // NewServer constructs a Server bound to the configured port.
@@ -93,6 +114,9 @@ func NewServer(cfg *Config, nucleus *Nucleus, process *Process) *Server {
 	// the warm cache is ready before any HTTP request lands.
 	s.sessionRegistry = NewSessionRegistry()
 	s.handoffRegistry = NewHandoffRegistry()
+
+	// ADR-082 Wave 2 kernel-owned channel-session identity.
+	s.channelSessionRegistry = NewChannelSessionRegistry()
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /", handleDashboard)
@@ -132,6 +156,13 @@ func NewServer(cfg *Config, nucleus *Nucleus, process *Process) *Server {
 	// the specific patterns (POST /v1/sessions/register, etc.) coexist
 	// cleanly with the pre-existing GET /v1/sessions[/{id}] surface.
 	s.registerSessionMgmtRoutes(mux)
+
+	// ADR-082 Wave 2: kernel-side channel-session forwarder. The four
+	// /v1/channel-sessions/* routes mint session_ids, record identity
+	// locally, and forward to mod3 at cfg.Mod3URL. Namespaced under
+	// /v1/channel-sessions/* to coexist with the agent-session surface
+	// above (incompatible session_id formats — see serve_sessions_channel.go).
+	s.registerChannelSessionRoutes(mux)
 
 	// Replay bus_sessions + bus_handoffs into the in-memory registries so
 	// the kernel starts with an accurate derived view. Bus is authoritative

--- a/internal/engine/serve_attention.go
+++ b/internal/engine/serve_attention.go
@@ -88,10 +88,10 @@ func (l *attentionLog) recentSignals(n int) []attentionSignal {
 func (s *Server) registerAttentionRoutes(mux *http.ServeMux) {
 	s.attentionLog = newAttentionLog(s.cfg.WorkspaceRoot)
 
-	mux.HandleFunc("POST /v1/attention", s.handleAttention)
-	mux.HandleFunc("GET /v1/constellation/adjacent", s.handleConstellationAdjacent)
-	mux.HandleFunc("GET /v1/constellation/fovea", s.handleConstellationFovea)
-	mux.HandleFunc("GET /v1/observer/state", s.handleObserverState)
+	s.route(mux, "POST /v1/attention", s.handleAttention)
+	s.route(mux, "GET /v1/constellation/adjacent", s.handleConstellationAdjacent)
+	s.route(mux, "GET /v1/constellation/fovea", s.handleConstellationFovea)
+	s.route(mux, "GET /v1/observer/state", s.handleObserverState)
 }
 
 // handleAttention stores an attention signal and applies a recency boost to the field.

--- a/internal/engine/serve_blocks.go
+++ b/internal/engine/serve_blocks.go
@@ -29,10 +29,10 @@ import (
 
 // registerBlockRoutes wires the block sync endpoints into the mux.
 func (s *Server) registerBlockRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("GET /v1/blocks/manifest", s.handleBlocksManifest)
-	mux.HandleFunc("POST /v1/blocks/verify", s.handleBlocksVerify)
-	mux.HandleFunc("GET /v1/blocks/{hash}", s.handleBlockGet)
-	mux.HandleFunc("PUT /v1/blocks/{hash}", s.handleBlockPut)
+	s.route(mux, "GET /v1/blocks/manifest", s.handleBlocksManifest)
+	s.route(mux, "POST /v1/blocks/verify", s.handleBlocksVerify)
+	s.route(mux, "GET /v1/blocks/{hash}", s.handleBlockGet)
+	s.route(mux, "PUT /v1/blocks/{hash}", s.handleBlockPut)
 }
 
 // handleBlockGet returns blob content by hash.

--- a/internal/engine/serve_bus.go
+++ b/internal/engine/serve_bus.go
@@ -39,21 +39,21 @@ import (
 // for readability.
 func (s *Server) registerBusRoutes(mux *http.ServeMux) {
 	// Specific first, catch-all later — same order as root's serve.go.
-	mux.HandleFunc("POST /v1/bus/send", s.handleBusSend)
-	mux.HandleFunc("POST /v1/bus/open", s.handleBusOpen)
-	mux.HandleFunc("GET /v1/bus/list", s.handleBusList)
-	mux.HandleFunc("GET /v1/bus/events", s.handleBusEventsGlobal) // cross-bus search
+	s.route(mux, "POST /v1/bus/send", s.handleBusSend)
+	s.route(mux, "POST /v1/bus/open", s.handleBusOpen)
+	s.route(mux, "GET /v1/bus/list", s.handleBusList)
+	s.route(mux, "GET /v1/bus/events", s.handleBusEventsGlobal) // cross-bus search
 
 	// Consumer cursor API (ADR-061).
-	mux.HandleFunc("GET /v1/bus/consumers", s.handleBusConsumers)
-	mux.HandleFunc("DELETE /v1/bus/consumers/", s.handleBusConsumerDelete)
+	s.route(mux, "GET /v1/bus/consumers", s.handleBusConsumers)
+	s.route(mux, "DELETE /v1/bus/consumers/", s.handleBusConsumerDelete)
 
 	// Catch-all for /v1/bus/{bus_id}/events[,/{seq}] and /v1/bus/{bus_id}/stats.
-	mux.HandleFunc("GET /v1/bus/", s.handleBusRoute)
+	s.route(mux, "GET /v1/bus/", s.handleBusRoute)
 
 	// Session surface.
-	mux.HandleFunc("GET /v1/sessions", s.handleListSessions)
-	mux.HandleFunc("GET /v1/sessions/", s.handleSessionContext)
+	s.route(mux, "GET /v1/sessions", s.handleListSessions)
+	s.route(mux, "GET /v1/sessions/", s.handleSessionContext)
 }
 
 // ─── POST /v1/bus/send ───────────────────────────────────────────────────────

--- a/internal/engine/serve_compat.go
+++ b/internal/engine/serve_compat.go
@@ -42,19 +42,19 @@ func (s *Server) logCompatDeprecated(r *http.Request) {
 // Called from NewServer after all v3 routes are registered.
 func (s *Server) registerCompatRoutes(mux *http.ServeMux) {
 	// Tier A: blocking for OpenClaw plugin
-	mux.HandleFunc("GET /v1/card", s.handleCard)
-	mux.HandleFunc("GET /v1/models", s.handleModels)
+	s.route(mux, "GET /v1/card", s.handleCard)
+	s.route(mux, "GET /v1/models", s.handleModels)
 
 	// Tier B: event stream + bus ack — now real, registered in serve.go
 	// (handleEvents + handleEventsStream). handleBusAck deleted — no
 	// consumer relied on it and the new SSE resume uses Last-Event-ID.
 
 	// Tier C: operational stability
-	mux.HandleFunc("GET /v1/providers", s.handleProviders)
-	mux.HandleFunc("GET /v1/taa", s.handleTAA)
-	mux.HandleFunc("GET /memory/search", s.handleMemorySearch)
-	mux.HandleFunc("GET /memory/read", s.handleMemoryRead)
-	mux.HandleFunc("GET /coherence/check", s.handleCoherenceCheck)
+	s.route(mux, "GET /v1/providers", s.handleProviders)
+	s.route(mux, "GET /v1/taa", s.handleTAA)
+	s.route(mux, "GET /memory/search", s.handleMemorySearch)
+	s.route(mux, "GET /memory/read", s.handleMemoryRead)
+	s.route(mux, "GET /coherence/check", s.handleCoherenceCheck)
 }
 
 // ── Tier A: OpenClaw plugin ────────────────────────────────────────────────────

--- a/internal/engine/serve_config.go
+++ b/internal/engine/serve_config.go
@@ -15,9 +15,9 @@ import (
 
 // registerConfigRoutes mounts the config read/write/rollback endpoints.
 func (s *Server) registerConfigRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("GET /v1/config", s.handleConfigGet)
-	mux.HandleFunc("PATCH /v1/config", s.handleConfigPatch)
-	mux.HandleFunc("POST /v1/config/rollback", s.handleConfigRollback)
+	s.route(mux, "GET /v1/config", s.handleConfigGet)
+	s.route(mux, "PATCH /v1/config", s.handleConfigPatch)
+	s.route(mux, "POST /v1/config/rollback", s.handleConfigRollback)
 }
 
 // handleConfigGet returns the effective kernel config. Query params:

--- a/internal/engine/serve_cors.go
+++ b/internal/engine/serve_cors.go
@@ -1,0 +1,141 @@
+// serve_cors.go — permissive CORS middleware for the kernel HTTP server.
+//
+// Rationale (Wave 5a, 2026-04-23):
+//
+// The browser-served dashboard (mod3 at http://localhost:7860) calls the
+// kernel at http://127.0.0.1:6931 to register a channel-session via
+// /v1/channel-sessions/register. Cross-origin POSTs from the dashboard
+// trigger a CORS preflight (OPTIONS) that the kernel previously rejected —
+// no Access-Control-* headers were emitted, the browser blocked the
+// request, and the dashboard fell back to calling mod3 directly. That
+// fallback works but leaves an ugly console error and defeats the point of
+// kernel authority over session_id minting.
+//
+// This middleware wraps the entire mux. It:
+//
+//   - Short-circuits OPTIONS preflight with 204 No Content + the required
+//     Access-Control-* headers.
+//   - On every response, sets Access-Control-Allow-Origin based on the
+//     request Origin header (echo for loopback origins, otherwise "*").
+//   - Declares a permissive method/header set sufficient for the mod3
+//     dashboard, MCP /mcp endpoint, and anything else currently calling
+//     the kernel. Include Mcp-Session-Id because the MCP streamable-HTTP
+//     transport relies on it.
+//
+// Policy choice — echo-for-loopback with star fallback:
+//
+// The kernel binds 127.0.0.1:6931 by default (loopback-only), so
+// Allow-Origin: * is not a security boundary — any local process can hit
+// the socket regardless. But echoing the Origin header when it matches
+// a loopback scheme (http://localhost:* or http://127.0.0.1:*) is friendly
+// to credentialed requests (if Allow-Origin is "*" the browser refuses to
+// send cookies). Future auth layers may want that, so we do the echo now.
+// For non-loopback origins we fall back to "*" so the middleware stays
+// compatible with pod / Tailnet deployments when cfg.BindAddr widens.
+//
+// Request whose Origin header is missing (same-origin fetches, curl, the
+// MCP CLI, etc.) are untouched — the middleware only adds headers when an
+// Origin is present or the method is OPTIONS.
+package engine
+
+import (
+	"net/http"
+	"strings"
+)
+
+// corsMiddleware wraps an http.Handler with permissive CORS policy. It
+// handles OPTIONS preflight directly (returning 204 with the allow-list
+// headers) and delegates every other method to `next`, decorating the
+// response with Access-Control-Allow-Origin.
+//
+// The allowed method/header set is intentionally broad: GET/POST are the
+// common cases, PATCH/PUT/DELETE are permitted for future REST-ful
+// endpoints, and the accepted headers cover Content-Type, the MCP session
+// identifier, the Claude Code workspace root override, and Authorization
+// so downstream authenticated clients can send bearer tokens without
+// another round-trip of configuration.
+func corsMiddleware(next http.Handler) http.Handler {
+	const allowMethods = "GET, POST, PATCH, PUT, DELETE, OPTIONS"
+	const allowHeaders = "Content-Type, Mcp-Session-Id, X-Workspace-Root, Authorization"
+	const maxAge = "86400"
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		origin := r.Header.Get("Origin")
+
+		// Echo loopback origins so credentialed requests can round-trip;
+		// fall back to "*" for anything else. Empty Origin → same-origin
+		// (or non-browser client) → nothing to add.
+		if origin != "" {
+			w.Header().Set("Access-Control-Allow-Origin", originAllowValue(origin))
+			w.Header().Set("Vary", "Origin")
+		}
+
+		if r.Method == http.MethodOptions {
+			// Preflight short-circuit: reply with the allow-list headers
+			// and 204 No Content. Do not call `next` — the mux would
+			// return 405 Method Not Allowed for most routes.
+			w.Header().Set("Access-Control-Allow-Methods", allowMethods)
+			w.Header().Set("Access-Control-Allow-Headers", allowHeaders)
+			w.Header().Set("Access-Control-Max-Age", maxAge)
+			// If the request asked to send credentials (Cookie, auth
+			// header), advertise support when we're echoing a specific
+			// origin. Star-origin + credentials is not legal per spec.
+			if origin != "" && origin != "*" && originAllowValue(origin) == origin {
+				w.Header().Set("Access-Control-Allow-Credentials", "true")
+			}
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		// Non-preflight: still expose the allow-list headers so browsers
+		// treating a non-simple response as cacheable know the shape.
+		if origin != "" {
+			w.Header().Set("Access-Control-Allow-Methods", allowMethods)
+			w.Header().Set("Access-Control-Allow-Headers", allowHeaders)
+			if origin != "*" && originAllowValue(origin) == origin {
+				w.Header().Set("Access-Control-Allow-Credentials", "true")
+			}
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// originAllowValue returns the value to place in Access-Control-Allow-Origin
+// for a given request Origin. Loopback schemes echo; anything else gets "*".
+//
+// Accepted loopback shapes:
+//
+//	http://localhost          http://localhost:PORT
+//	http://127.0.0.1          http://127.0.0.1:PORT
+//	https://localhost[:PORT]  https://127.0.0.1[:PORT]
+//
+// Anything else (null origin, file://, remote) is widened to "*". We do not
+// attempt to parse the URL in full — a cheap prefix check is enough because
+// the Origin header is a serialized tuple defined by the Fetch spec and has
+// no path/query component.
+func originAllowValue(origin string) string {
+	if isLoopbackOrigin(origin) {
+		return origin
+	}
+	return "*"
+}
+
+func isLoopbackOrigin(origin string) bool {
+	// Strip scheme so we can do a simple host check.
+	var rest string
+	switch {
+	case strings.HasPrefix(origin, "http://"):
+		rest = strings.TrimPrefix(origin, "http://")
+	case strings.HasPrefix(origin, "https://"):
+		rest = strings.TrimPrefix(origin, "https://")
+	default:
+		return false
+	}
+	// rest is "host[:port]" (no path — Fetch spec forbids it on Origin).
+	host := rest
+	if i := strings.IndexByte(rest, ':'); i >= 0 {
+		host = rest[:i]
+	}
+	return host == "localhost" || host == "127.0.0.1"
+}

--- a/internal/engine/serve_cors_test.go
+++ b/internal/engine/serve_cors_test.go
@@ -1,0 +1,170 @@
+package engine
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestCORSPreflight_OKStatus verifies that an OPTIONS preflight returns
+// 204 No Content with the expected Access-Control-* headers. The handler
+// under test is the wrapped server handler (mux + CORS middleware).
+func TestCORSPreflight_OKStatus(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodOptions, "/v1/channel-sessions/register", nil)
+	req.Header.Set("Origin", "http://localhost:7860")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	req.Header.Set("Access-Control-Request-Headers", "Content-Type")
+
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("preflight status = %d; want 204", w.Code)
+	}
+	// All allow-* headers should be present on the preflight response.
+	wantHeaders := map[string]string{
+		"Access-Control-Allow-Methods": "GET, POST, PATCH, PUT, DELETE, OPTIONS",
+		"Access-Control-Allow-Headers": "Content-Type, Mcp-Session-Id, X-Workspace-Root, Authorization",
+		"Access-Control-Max-Age":       "86400",
+	}
+	for h, want := range wantHeaders {
+		if got := w.Header().Get(h); got != want {
+			t.Errorf("%s = %q; want %q", h, got, want)
+		}
+	}
+}
+
+// TestCORSPreflight_AllowsBrowserOrigin verifies that a preflight from a
+// loopback dashboard origin echoes the Origin header (not "*") so
+// credentialed requests can round-trip, and sets Allow-Credentials.
+func TestCORSPreflight_AllowsBrowserOrigin(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+
+	for _, origin := range []string{
+		"http://localhost:7860",
+		"http://127.0.0.1:6931",
+		"http://localhost",
+	} {
+		origin := origin
+		t.Run(origin, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(http.MethodOptions, "/v1/manifest", nil)
+			req.Header.Set("Origin", origin)
+			req.Header.Set("Access-Control-Request-Method", "GET")
+
+			w := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(w, req)
+
+			if got := w.Header().Get("Access-Control-Allow-Origin"); got != origin {
+				t.Errorf("Allow-Origin = %q; want %q (echo for loopback)", got, origin)
+			}
+			if got := w.Header().Get("Access-Control-Allow-Credentials"); got != "true" {
+				t.Errorf("Allow-Credentials = %q; want %q (echo origin enables credentials)", got, "true")
+			}
+			if got := w.Header().Get("Vary"); got != "Origin" {
+				t.Errorf("Vary = %q; want %q", got, "Origin")
+			}
+		})
+	}
+}
+
+// TestCORSPreflight_NonLoopbackOriginGetsStar verifies the widening
+// fallback for non-loopback origins (future pod/Tailnet deployments).
+// Note: the kernel binds loopback by default, so this path is mostly
+// about not breaking future non-dev deployments.
+func TestCORSPreflight_NonLoopbackOriginGetsStar(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodOptions, "/v1/manifest", nil)
+	req.Header.Set("Origin", "http://evil.example.com")
+
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("Allow-Origin = %q; want %q (widen for non-loopback)", got, "*")
+	}
+	// Allow-Credentials must not be set for star origin.
+	if got := w.Header().Get("Access-Control-Allow-Credentials"); got != "" {
+		t.Errorf("Allow-Credentials = %q; want empty (star + credentials is illegal)", got)
+	}
+}
+
+// TestCORSHeaders_OnRealGET verifies that a real (non-preflight) GET
+// response still carries Access-Control-Allow-Origin when an Origin
+// header is present. Uses /v1/manifest which is known to return 200.
+func TestCORSHeaders_OnRealGET(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/manifest", nil)
+	req.Header.Set("Origin", "http://localhost:7860")
+
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200", w.Code)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "http://localhost:7860" {
+		t.Errorf("Allow-Origin = %q; want echo of loopback origin", got)
+	}
+	if !strings.HasPrefix(w.Header().Get("Content-Type"), "application/json") {
+		t.Errorf("Content-Type = %q; want application/json (handler must still run)",
+			w.Header().Get("Content-Type"))
+	}
+}
+
+// TestCORSHeaders_NoOriginNoChange verifies that requests without an
+// Origin header (curl, MCP CLI, same-origin fetches) are untouched —
+// no CORS headers are added, and the underlying handler still runs.
+func TestCORSHeaders_NoOriginNoChange(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/manifest", nil)
+	// Deliberately no Origin header.
+
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200", w.Code)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("Allow-Origin = %q; want empty (no Origin header should skip CORS)", got)
+	}
+}
+
+// TestIsLoopbackOrigin_Table unit-tests the pure helper so any future
+// change to the allow-policy is easy to catch.
+func TestIsLoopbackOrigin_Table(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		origin string
+		want   bool
+	}{
+		{"http://localhost", true},
+		{"http://localhost:7860", true},
+		{"http://127.0.0.1", true},
+		{"http://127.0.0.1:6931", true},
+		{"https://localhost:8443", true},
+		{"https://127.0.0.1:8443", true},
+		{"http://evil.example.com", false},
+		{"http://192.168.1.2:7860", false},
+		{"", false},
+		{"null", false},
+		{"file://", false},
+	}
+	for _, tc := range cases {
+		if got := isLoopbackOrigin(tc.origin); got != tc.want {
+			t.Errorf("isLoopbackOrigin(%q) = %v; want %v", tc.origin, got, tc.want)
+		}
+	}
+}

--- a/internal/engine/serve_events.go
+++ b/internal/engine/serve_events.go
@@ -37,8 +37,8 @@ const (
 // stale stub registrations (the stubs have been deleted, but this keeps the
 // ordering future-proof against re-introductions).
 func (s *Server) registerEventBusRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("GET /v1/events", s.handleEvents)
-	mux.HandleFunc("GET /v1/events/stream", s.handleEventsStream)
+	s.route(mux, "GET /v1/events", s.handleEvents)
+	s.route(mux, "GET /v1/events/stream", s.handleEventsStream)
 }
 
 // handleEvents is the non-streaming historical query. Mirrors handleLedger

--- a/internal/engine/serve_manifest.go
+++ b/internal/engine/serve_manifest.go
@@ -1,0 +1,259 @@
+// serve_manifest.go — self-describing kernel manifest endpoint.
+//
+//	GET /v1/manifest → JSON describing this kernel's full surface
+//
+// The manifest enumerates every HTTP route and MCP tool at runtime by walking
+// registries populated during startup — no hardcoded lists. If a future wave
+// adds a new route or tool, the manifest reflects it without touching this
+// file.
+//
+// Design:
+//   - HTTP routes are captured at mux-registration time via Server.route and
+//     Server.routeH, which forward to http.ServeMux and also append to
+//     s.httpRoutes.
+//   - MCP tools are captured via MCPServer.trackTool, which records the
+//     *mcp.Tool metadata into m.toolMeta and then returns the pointer so the
+//     caller threads it through to mcp.AddTool unchanged.
+//
+// Why not extend /v1/card? The existing /v1/card endpoint is an OpenClaw v2
+// compatibility stub with a specific contract (models list, capabilities
+// booleans, `endpoints` string map). Reshaping it would break that
+// contract. /v1/manifest lives alongside as the CogOS-native surface for
+// kernel introspection.
+package engine
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// routeMeta records one HTTP route registration.
+type routeMeta struct {
+	Method string `json:"method"`
+	Path   string `json:"path"`
+	Family string `json:"family"`
+}
+
+// mcpToolMeta records one MCP tool registration.
+type mcpToolMeta struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Family      string `json:"family"`
+}
+
+// route registers a handler on mux and records the (method, path) tuple onto
+// s.httpRoutes. The pattern follows http.ServeMux's method-prefixed form,
+// e.g. "GET /v1/health" or "POST /v1/sessions/{id}/heartbeat".
+func (s *Server) route(mux *http.ServeMux, pattern string, handler http.HandlerFunc) {
+	mux.HandleFunc(pattern, handler)
+	s.recordRoute(pattern)
+}
+
+// routeH is like route but takes an http.Handler (used for /mcp which is
+// backed by the streamable HTTP handler from the MCP library).
+func (s *Server) routeH(mux *http.ServeMux, pattern string, handler http.Handler) {
+	mux.Handle(pattern, handler)
+	s.recordRoute(pattern)
+}
+
+// recordRoute parses "METHOD /path" and appends a routeMeta entry.
+func (s *Server) recordRoute(pattern string) {
+	method, path := splitRoutePattern(pattern)
+	s.httpRoutes = append(s.httpRoutes, routeMeta{
+		Method: method,
+		Path:   path,
+		Family: classifyHTTPFamily(path),
+	})
+}
+
+// splitRoutePattern parses "GET /foo" into ("GET", "/foo"). Patterns without
+// a method prefix ("/foo") degrade to method="" path="/foo" — the http.ServeMux
+// accepts that form too but the kernel uses method-prefixed form everywhere.
+func splitRoutePattern(pattern string) (method, path string) {
+	p := strings.TrimSpace(pattern)
+	if i := strings.IndexByte(p, ' '); i > 0 {
+		return p[:i], strings.TrimSpace(p[i+1:])
+	}
+	return "", p
+}
+
+// classifyHTTPFamily maps an HTTP path prefix to a family tag. The map is
+// kept compact; ordering matters because longer prefixes win. New routes that
+// don't match fall into "misc".
+func classifyHTTPFamily(path string) string {
+	// Prefix table, scanned in order. Longer prefixes first so /v1/bus beats
+	// any hypothetical /v1 fallback.
+	prefixes := []struct {
+		prefix, family string
+	}{
+		{"/mcp", "mcp"},
+		{"/v1/chat/completions", "openai"},
+		{"/v1/models", "openai"},
+		{"/v1/messages", "anthropic"},
+		{"/v1/bus", "bus"},
+		{"/v1/events", "bus"},
+		{"/v1/blocks", "bus"},
+		{"/v1/channel-sessions", "sessions"},
+		{"/v1/sessions", "sessions"},
+		{"/v1/handoffs", "sessions"},
+		{"/v1/cogdoc", "memory"},
+		{"/v1/context", "memory"},
+		{"/v1/resolve", "memory"},
+		{"/memory", "memory"},
+		{"/v1/ledger", "observability"},
+		{"/v1/traces", "observability"},
+		{"/v1/tool-calls", "observability"},
+		{"/v1/kernel-log", "observability"},
+		{"/v1/conversation", "observability"},
+		{"/v1/proprioceptive", "observability"},
+		{"/v1/debug", "observability"},
+		{"/v1/attention", "attention"},
+		{"/v1/constellation", "attention"},
+		{"/v1/observer", "attention"},
+		{"/v1/lightcone", "attention"},
+		{"/v1/card", "compat"},
+		{"/v1/providers", "compat"},
+		{"/v1/taa", "compat"},
+		{"/coherence", "kernel"},
+		{"/v1/config", "config"},
+		{"/v1/manifest", "kernel"},
+		{"/health", "kernel"},
+		{"/canvas", "kernel"},
+	}
+	for _, p := range prefixes {
+		if strings.HasPrefix(path, p.prefix) {
+			return p.family
+		}
+	}
+	if path == "/" {
+		return "kernel"
+	}
+	return "misc"
+}
+
+// classifyMCPFamily takes the prefix before the first underscore as the
+// family. Tools without an underscore return "misc".
+func classifyMCPFamily(name string) string {
+	if i := strings.IndexByte(name, '_'); i > 0 {
+		return name[:i]
+	}
+	return "misc"
+}
+
+// trackTool records the tool metadata into m.toolMeta and returns the input
+// pointer unchanged. Typical usage:
+//
+//	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{Name: "cog_search_memory", ...}), handler)
+//
+// Returning the pointer means each existing registration changes by one
+// wrapping call — no separate metadata list, no risk of drift.
+func (m *MCPServer) trackTool(t *mcp.Tool) *mcp.Tool {
+	m.toolMeta = append(m.toolMeta, mcpToolMeta{
+		Name:        t.Name,
+		Description: t.Description,
+		Family:      classifyMCPFamily(t.Name),
+	})
+	return t
+}
+
+// handleManifest returns the kernel self-describing manifest as JSON. Read-
+// only, side-effect-free. Enumeration is cheap (a couple of slice copies plus
+// a sort) so we recompute per request rather than caching — this keeps the
+// endpoint honest if tools or routes are added dynamically after startup.
+//
+//	GET /v1/manifest
+//	200 → {service, version, build_time, node_id, transports, http_routes,
+//	       mcp_tools}
+func (s *Server) handleManifest(w http.ResponseWriter, r *http.Request) {
+	// Copy + sort HTTP routes for stable output. Sort key: family then path
+	// then method, which groups related endpoints visually in jq output.
+	routes := make([]routeMeta, len(s.httpRoutes))
+	copy(routes, s.httpRoutes)
+	sort.Slice(routes, func(i, j int) bool {
+		if routes[i].Family != routes[j].Family {
+			return routes[i].Family < routes[j].Family
+		}
+		if routes[i].Path != routes[j].Path {
+			return routes[i].Path < routes[j].Path
+		}
+		return routes[i].Method < routes[j].Method
+	})
+
+	// MCP tool metadata comes from the MCPServer instance wired up in
+	// registerMCPRoutes. Sorted by name for stable output.
+	var tools []mcpToolMeta
+	if s.mcpServer != nil {
+		tools = make([]mcpToolMeta, len(s.mcpServer.toolMeta))
+		copy(tools, s.mcpServer.toolMeta)
+		sort.Slice(tools, func(i, j int) bool {
+			return tools[i].Name < tools[j].Name
+		})
+	}
+
+	// Transports section — each protocol entry enumerates the routes that
+	// carry it, counted off s.httpRoutes so we don't repeat the source of
+	// truth. The MCP entry also reports tool_count.
+	openaiEndpoints := pathsForFamily(s.httpRoutes, "openai")
+	anthropicEndpoints := pathsForFamily(s.httpRoutes, "anthropic")
+	mcpEndpoints := pathsForFamily(s.httpRoutes, "mcp")
+
+	nodeID := ""
+	if s.process != nil {
+		nodeID = s.process.NodeID
+	}
+
+	resp := map[string]any{
+		"service":    "cogos-kernel",
+		"version":    Version,
+		"build_time": BuildTime,
+		"node_id":    nodeID,
+		"transports": map[string]any{
+			"mcp": map[string]any{
+				"protocol":        "mcp",
+				"version":         "2025-03-26", // Streamable HTTP spec version
+				"endpoints":       mcpEndpoints,
+				"streamable_http": true,
+				"tool_count":      len(tools),
+			},
+			"openai": map[string]any{
+				"protocol":  "openai-compat",
+				"endpoints": openaiEndpoints,
+			},
+			"anthropic": map[string]any{
+				"protocol":  "anthropic-compat",
+				"endpoints": anthropicEndpoints,
+			},
+		},
+		"http_routes": routes,
+		"mcp_tools":   tools,
+		"generated":   time.Now().UTC().Format(time.RFC3339),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(resp)
+}
+
+// pathsForFamily returns a sorted, deduplicated list of paths for routes in
+// the given family. Used to populate the transports.{proto}.endpoints slices
+// in the manifest.
+func pathsForFamily(routes []routeMeta, family string) []string {
+	seen := map[string]struct{}{}
+	for _, r := range routes {
+		if r.Family == family {
+			seen[r.Path] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for p := range seen {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/engine/serve_manifest_test.go
+++ b/internal/engine/serve_manifest_test.go
@@ -1,0 +1,198 @@
+package engine
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestHandleManifestShape verifies the manifest response is well-formed and
+// contains the expected top-level fields.
+func TestHandleManifestShape(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/manifest", nil)
+	w := httptest.NewRecorder()
+	srv.handleManifest(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type = %q; want application/json", ct)
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+
+	wantKeys := []string{"service", "version", "build_time", "node_id", "transports", "http_routes", "mcp_tools"}
+	for _, k := range wantKeys {
+		if _, ok := body[k]; !ok {
+			t.Errorf("missing top-level key %q", k)
+		}
+	}
+	if body["service"] != "cogos-kernel" {
+		t.Errorf("service = %v; want cogos-kernel", body["service"])
+	}
+}
+
+// TestHandleManifestHTTPRoutesByFamily verifies that at least one route per
+// expected family appears in the manifest. This is the headline invariant
+// from the plan: the manifest reflects what's actually registered.
+func TestHandleManifestHTTPRoutesByFamily(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/manifest", nil)
+	w := httptest.NewRecorder()
+	srv.handleManifest(w, req)
+
+	var body struct {
+		HTTPRoutes []routeMeta `json:"http_routes"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+
+	// Families we expect at least one route for after NewServer wires the
+	// full mux. Drops "kernel" in for the / and /health sanity checks.
+	// "observability" families from /v1/ledger etc. should be present.
+	wantFamilies := []string{
+		"kernel",
+		"mcp",
+		"openai",
+		"anthropic",
+		"bus",
+		"sessions",
+		"memory",
+		"observability",
+		"attention",
+		"config",
+		"compat",
+	}
+	got := map[string]bool{}
+	for _, r := range body.HTTPRoutes {
+		got[r.Family] = true
+	}
+	for _, fam := range wantFamilies {
+		if !got[fam] {
+			t.Errorf("family %q not present among %d routes (got families: %v)",
+				fam, len(body.HTTPRoutes), keys(got))
+		}
+	}
+}
+
+// TestHandleManifestMCPToolClassification verifies that a known tool
+// (mod3_speak) gets classified under the expected family (mod3), and that at
+// least the core cog_* family is represented.
+func TestHandleManifestMCPToolClassification(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/manifest", nil)
+	w := httptest.NewRecorder()
+	srv.handleManifest(w, req)
+
+	var body struct {
+		MCPTools []mcpToolMeta `json:"mcp_tools"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+
+	if len(body.MCPTools) == 0 {
+		t.Fatal("mcp_tools is empty; NewServer should have wired at least a handful of cog_* tools")
+	}
+
+	// Verify mod3_speak is classified under family "mod3".
+	var foundMod3, foundCog bool
+	for _, tool := range body.MCPTools {
+		if tool.Name == "mod3_speak" {
+			foundMod3 = true
+			if tool.Family != "mod3" {
+				t.Errorf("mod3_speak family = %q; want mod3", tool.Family)
+			}
+		}
+		if tool.Family == "cog" {
+			foundCog = true
+		}
+	}
+	if !foundMod3 {
+		t.Error("mod3_speak not present among registered tools")
+	}
+	if !foundCog {
+		t.Error("no cog_* family tools found; at least a handful should exist")
+	}
+}
+
+// TestClassifyHTTPFamily covers the prefix map directly.
+func TestClassifyHTTPFamily(t *testing.T) {
+	t.Parallel()
+	cases := []struct{ path, want string }{
+		{"/health", "kernel"},
+		{"/", "kernel"},
+		{"/canvas", "kernel"},
+		{"/v1/chat/completions", "openai"},
+		{"/v1/models", "openai"},
+		{"/v1/messages", "anthropic"},
+		{"/v1/bus/send", "bus"},
+		{"/v1/events", "bus"},
+		{"/v1/sessions", "sessions"},
+		{"/v1/handoffs", "sessions"},
+		{"/v1/channel-sessions", "sessions"},
+		{"/v1/cogdoc/read", "memory"},
+		{"/v1/resolve", "memory"},
+		{"/v1/context", "memory"},
+		{"/memory/search", "memory"},
+		{"/v1/ledger", "observability"},
+		{"/v1/traces", "observability"},
+		{"/v1/tool-calls", "observability"},
+		{"/v1/kernel-log", "observability"},
+		{"/v1/debug/last", "observability"},
+		{"/v1/attention", "attention"},
+		{"/v1/constellation/fovea", "attention"},
+		{"/v1/lightcone", "attention"},
+		{"/mcp", "mcp"},
+		{"/v1/card", "compat"},
+		{"/v1/providers", "compat"},
+		{"/v1/taa", "compat"},
+		{"/coherence/check", "kernel"},
+		{"/v1/config", "config"},
+		{"/totally/made/up", "misc"},
+	}
+	for _, tc := range cases {
+		if got := classifyHTTPFamily(tc.path); got != tc.want {
+			t.Errorf("classifyHTTPFamily(%q) = %q; want %q", tc.path, got, tc.want)
+		}
+	}
+}
+
+// TestClassifyMCPFamily covers the prefix-before-underscore rule.
+func TestClassifyMCPFamily(t *testing.T) {
+	t.Parallel()
+	cases := []struct{ name, want string }{
+		{"cog_search_memory", "cog"},
+		{"mod3_speak", "mod3"},
+		{"cogos_status", "cogos"},
+		{"noprefix", "misc"},
+	}
+	for _, tc := range cases {
+		if got := classifyMCPFamily(tc.name); got != tc.want {
+			t.Errorf("classifyMCPFamily(%q) = %q; want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+// keys is a local helper to extract map keys for test diagnostics.
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/engine/serve_mcp.go
+++ b/internal/engine/serve_mcp.go
@@ -17,6 +17,11 @@ func (s *Server) registerMCPRoutes(mux *http.ServeMux) {
 	// these are nil — NewMCPServer (used by tests that only care about
 	// memory tools) doesn't call this, which is fine.
 	mcpSrv.SetSessionsBackend(s.busSessions, s.sessionRegistry, s.handoffRegistry)
+	// ADR-082 Wave 3.5: route the mod3 session-family MCP tools through
+	// the kernel's shared channel-session methods so session-ID minting
+	// happens in exactly one place (this Server). Handlers dispatching
+	// to mod3 directly was the Wave 3 divergence this removes.
+	mcpSrv.SetChannelSessionBackend(s)
 	s.mcpServer = mcpSrv
 	h := mcpSrv.Handler()
 	mux.Handle("GET /mcp", h)

--- a/internal/engine/serve_mcp.go
+++ b/internal/engine/serve_mcp.go
@@ -24,7 +24,7 @@ func (s *Server) registerMCPRoutes(mux *http.ServeMux) {
 	mcpSrv.SetChannelSessionBackend(s)
 	s.mcpServer = mcpSrv
 	h := mcpSrv.Handler()
-	mux.Handle("GET /mcp", h)
-	mux.Handle("POST /mcp", h)
-	mux.Handle("DELETE /mcp", h)
+	s.routeH(mux, "GET /mcp", h)
+	s.routeH(mux, "POST /mcp", h)
+	s.routeH(mux, "DELETE /mcp", h)
 }

--- a/internal/engine/serve_sessions_channel.go
+++ b/internal/engine/serve_sessions_channel.go
@@ -165,10 +165,10 @@ var mod3HTTPClient = &http.Client{Timeout: defaultMod3ForwardTimeout}
 // registerChannelSessionRoutes attaches the 4 channel-session routes onto mux.
 // Called from NewServer.
 func (s *Server) registerChannelSessionRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("POST /v1/channel-sessions/register", s.handleChannelSessionRegister)
-	mux.HandleFunc("POST /v1/channel-sessions/{id}/deregister", s.handleChannelSessionDeregister)
-	mux.HandleFunc("GET /v1/channel-sessions", s.handleChannelSessionList)
-	mux.HandleFunc("GET /v1/channel-sessions/{id}", s.handleChannelSessionGet)
+	s.route(mux, "POST /v1/channel-sessions/register", s.handleChannelSessionRegister)
+	s.route(mux, "POST /v1/channel-sessions/{id}/deregister", s.handleChannelSessionDeregister)
+	s.route(mux, "GET /v1/channel-sessions", s.handleChannelSessionList)
+	s.route(mux, "GET /v1/channel-sessions/{id}", s.handleChannelSessionGet)
 }
 
 // ─── wire types ──────────────────────────────────────────────────────────────

--- a/internal/engine/serve_sessions_channel.go
+++ b/internal/engine/serve_sessions_channel.go
@@ -1,0 +1,445 @@
+// serve_sessions_channel.go — kernel-side HTTP forwarder for channel-session
+// registration (ADR-082, Wave 2 of the mod3-kernel integration).
+//
+// Design locks (Wave 2 handoff):
+//
+//  1. Session authority = kernel-owned. The kernel mints `session_id` if the
+//     caller doesn't supply one. Mod3's SessionRegistry stores per-channel
+//     state (voice, queue, device) keyed on the kernel-issued ID. If mod3
+//     crashes, the kernel knows which sessions existed; mod3 rebuilds on
+//     re-register.
+//  2. MCP transport = HTTP proxy. Kernel reaches mod3 over plain HTTP at
+//     Config.Mod3URL (default http://localhost:7860), not stdio MCP.
+//
+// Path namespace choice: these routes live under `/v1/channel-sessions/*`,
+// NOT `/v1/sessions/*`. The kernel's existing `/v1/sessions/*` family
+// (serve_sessions_mgmt.go) serves agent-session state (3-component hyphen-
+// validated session IDs, workspace/role required, tied to the handoff
+// protocol). Channel-participant registration has an incompatible shape
+// (short UUID session IDs, participant_id/participant_type/voice/device
+// fields). Rather than weaken ValidateSessionID (which would cascade into
+// handoff claim semantics) we namespace the new concern. The channel-provider
+// RFC's guidance to "use the same cogos_session_register primitive with a
+// participant_type discriminator" remains aspirational at the MCP tool layer
+// (Wave 3); at the HTTP layer the two surfaces coexist cleanly.
+//
+// Routes owned by this file:
+//
+//	POST /v1/channel-sessions/register             — mint+forward to mod3
+//	POST /v1/channel-sessions/{id}/deregister      — forward deregister
+//	GET  /v1/channel-sessions                      — list (kernel view + mod3 list)
+//	GET  /v1/channel-sessions/{id}                 — single-session detail
+package engine
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ─── in-memory registry for kernel-owned channel-session identity ────────────
+
+// ChannelSessionRecord is the kernel's identity-authority record for a
+// channel-participant session. Distinct from SessionState in sessions.go
+// (which tracks agent sessions with strict 3-component hyphen IDs); the
+// channel-session concern uses short UUIDs and caller-supplied participant
+// metadata that the kernel passes through to mod3.
+type ChannelSessionRecord struct {
+	// SessionID is the kernel-authoritative ID. Either caller-supplied or
+	// minted by the kernel (uuid short form).
+	SessionID string `json:"session_id"`
+
+	// ParticipantID / ParticipantType / PreferredVoice / PreferredOutputDevice
+	// / Priority mirror the mod3 SessionRegisterRequest shape. The kernel
+	// stores them so a post-crash re-register can replay identity cleanly.
+	ParticipantID         string `json:"participant_id,omitempty"`
+	ParticipantType       string `json:"participant_type,omitempty"`
+	PreferredVoice        string `json:"preferred_voice,omitempty"`
+	PreferredOutputDevice string `json:"preferred_output_device,omitempty"`
+	Priority              int    `json:"priority,omitempty"`
+
+	RegisteredAt time.Time `json:"registered_at"`
+	LastSeen     time.Time `json:"last_seen"`
+
+	// Source records whether the session_id came from the caller or was
+	// minted. Useful for audit; no functional impact.
+	IDSource string `json:"id_source,omitempty"` // "caller" | "minted"
+}
+
+// ChannelSessionRegistry is the in-memory map keyed by session_id. It holds
+// kernel-owned identity only; per-channel state (assigned_voice, queue,
+// device) lives in mod3 and is returned as part of the merged forward
+// response. If mod3 crashes the kernel knows which sessions existed and
+// callers can re-register to rebuild.
+type ChannelSessionRegistry struct {
+	mu   sync.RWMutex
+	rows map[string]*ChannelSessionRecord
+}
+
+// NewChannelSessionRegistry returns an empty registry.
+func NewChannelSessionRegistry() *ChannelSessionRegistry {
+	return &ChannelSessionRegistry{rows: make(map[string]*ChannelSessionRecord)}
+}
+
+// Put stores (or overwrites) a record by session_id.
+func (r *ChannelSessionRegistry) Put(rec ChannelSessionRecord) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cp := rec
+	r.rows[rec.SessionID] = &cp
+}
+
+// Get returns a copy of the record for id, or (nil, false).
+func (r *ChannelSessionRegistry) Get(id string) (*ChannelSessionRecord, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	row, ok := r.rows[id]
+	if !ok {
+		return nil, false
+	}
+	cp := *row
+	return &cp, true
+}
+
+// Delete removes the record for id. No-op if absent; returns whether the row
+// was present before removal (handy for logging / telemetry).
+func (r *ChannelSessionRegistry) Delete(id string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	_, ok := r.rows[id]
+	delete(r.rows, id)
+	return ok
+}
+
+// Snapshot returns a copy of every record.
+func (r *ChannelSessionRegistry) Snapshot() []*ChannelSessionRecord {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]*ChannelSessionRecord, 0, len(r.rows))
+	for _, row := range r.rows {
+		cp := *row
+		out = append(out, &cp)
+	}
+	return out
+}
+
+// Len returns the number of tracked channel sessions.
+func (r *ChannelSessionRegistry) Len() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.rows)
+}
+
+// ─── route registration ──────────────────────────────────────────────────────
+
+// defaultMod3ForwardTimeout is the per-request timeout for channel-session
+// HTTP forwards. 8s is deliberately shorter than WriteTimeout (300s) so a
+// stalled mod3 doesn't block a kernel request the whole way through.
+const defaultMod3ForwardTimeout = 8 * time.Second
+
+// mod3HTTPClient is the shared net/http client for forwards. Tests override
+// Server.mod3Client for isolation; when nil, handlers fall back to this.
+var mod3HTTPClient = &http.Client{Timeout: defaultMod3ForwardTimeout}
+
+// registerChannelSessionRoutes attaches the 4 channel-session routes onto mux.
+// Called from NewServer.
+func (s *Server) registerChannelSessionRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("POST /v1/channel-sessions/register", s.handleChannelSessionRegister)
+	mux.HandleFunc("POST /v1/channel-sessions/{id}/deregister", s.handleChannelSessionDeregister)
+	mux.HandleFunc("GET /v1/channel-sessions", s.handleChannelSessionList)
+	mux.HandleFunc("GET /v1/channel-sessions/{id}", s.handleChannelSessionGet)
+}
+
+// ─── wire types ──────────────────────────────────────────────────────────────
+
+// channelSessionRegisterRequest is the kernel-facing request body. Shape
+// mirrors mod3's SessionRegisterRequest (see mod3/http_api.py line ~278) plus
+// an optional session_id — when omitted, the kernel mints one.
+type channelSessionRegisterRequest struct {
+	SessionID             string `json:"session_id,omitempty"`
+	ParticipantID         string `json:"participant_id"`
+	ParticipantType       string `json:"participant_type,omitempty"`
+	PreferredVoice        string `json:"preferred_voice,omitempty"`
+	PreferredOutputDevice string `json:"preferred_output_device,omitempty"`
+	Priority              int    `json:"priority,omitempty"`
+}
+
+// channelSessionResponse is the merged shape returned from the kernel. The
+// `kernel` block is the identity record (authoritative owner); `mod3` is the
+// live channel state (voice pool, queue, device). Callers get everything in
+// one round trip. Unknown fields from mod3 are preserved under `mod3` as a
+// raw JSON object.
+type channelSessionResponse struct {
+	Kernel *ChannelSessionRecord `json:"kernel"`
+	Mod3   json.RawMessage       `json:"mod3,omitempty"`
+}
+
+// channelSessionListResponse is the shape of GET /v1/channel-sessions. The
+// kernel list is always present; the mod3 block is an opaque pass-through so
+// clients don't need to know mod3's schema.
+type channelSessionListResponse struct {
+	Kernel []*ChannelSessionRecord `json:"kernel"`
+	Mod3   json.RawMessage         `json:"mod3,omitempty"`
+}
+
+// ─── POST /v1/channel-sessions/register ──────────────────────────────────────
+
+func (s *Server) handleChannelSessionRegister(w http.ResponseWriter, r *http.Request) {
+	var req channelSessionRegisterRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", "body must be JSON")
+		return
+	}
+	if req.ParticipantID == "" {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request",
+			"participant_id is required")
+		return
+	}
+
+	// Mint when absent — kernel is the session-ID authority (ADR-082).
+	idSource := "caller"
+	if req.SessionID == "" {
+		req.SessionID = mintChannelSessionID()
+		idSource = "minted"
+	}
+	if req.ParticipantType == "" {
+		req.ParticipantType = "agent" // matches mod3's default
+	}
+	if req.PreferredOutputDevice == "" {
+		req.PreferredOutputDevice = "system-default"
+	}
+
+	now := time.Now().UTC()
+	record := ChannelSessionRecord{
+		SessionID:             req.SessionID,
+		ParticipantID:         req.ParticipantID,
+		ParticipantType:       req.ParticipantType,
+		PreferredVoice:        req.PreferredVoice,
+		PreferredOutputDevice: req.PreferredOutputDevice,
+		Priority:              req.Priority,
+		RegisteredAt:          now,
+		LastSeen:              now,
+		IDSource:              idSource,
+	}
+
+	// Forward to mod3 with the kernel-issued session_id. Mod3's body is the
+	// same shape modulo the optional session_id field (mod3 requires it; we
+	// always supply one).
+	forwardBody := map[string]any{
+		"session_id":              req.SessionID,
+		"participant_id":          req.ParticipantID,
+		"participant_type":        req.ParticipantType,
+		"preferred_voice":         req.PreferredVoice,
+		"preferred_output_device": req.PreferredOutputDevice,
+		"priority":                req.Priority,
+	}
+	body, _ := json.Marshal(forwardBody)
+
+	mod3Resp, status, err := s.forwardMod3(r.Context(), http.MethodPost,
+		"/v1/sessions/register", bytes.NewReader(body))
+	if err != nil {
+		slog.Warn("channel-sessions: forward to mod3 failed",
+			"session_id", req.SessionID, "err", err)
+		writeJSONError(w, http.StatusBadGateway, "mod3_unreachable",
+			fmt.Sprintf("mod3 unreachable: %v", err))
+		return
+	}
+
+	// Preserve non-success status bodies so the caller can surface mod3's
+	// diagnostic text. Any 4xx/5xx from mod3 becomes the response status
+	// with the raw body attached — the kernel does NOT write its identity
+	// record in that case (mod3 rejected the registration).
+	if status < 200 || status >= 300 {
+		slog.Warn("channel-sessions: mod3 returned non-2xx",
+			"session_id", req.SessionID, "status", status)
+		writeJSONPassThrough(w, status, mod3Resp)
+		return
+	}
+
+	// Mod3 accepted — commit the kernel-side identity record.
+	s.channelSessionRegistry.Put(record)
+	slog.Info("channel-sessions: registered",
+		"session_id", req.SessionID, "participant_id", req.ParticipantID,
+		"id_source", idSource)
+
+	// Return merged response. The `mod3` field is the raw body from mod3 so
+	// callers get the exact {assigned_voice, voice_conflict, output_device,
+	// queue_depth, ...} shape mod3 emits.
+	resp := channelSessionResponse{
+		Kernel: &record,
+		Mod3:   mod3Resp,
+	}
+	writeJSONResp(w, http.StatusOK, resp)
+}
+
+// ─── POST /v1/channel-sessions/{id}/deregister ───────────────────────────────
+
+func (s *Server) handleChannelSessionDeregister(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request",
+			"session_id required in path")
+		return
+	}
+
+	mod3Resp, status, err := s.forwardMod3(r.Context(), http.MethodPost,
+		"/v1/sessions/"+id+"/deregister", nil)
+	if err != nil {
+		slog.Warn("channel-sessions: deregister forward failed",
+			"session_id", id, "err", err)
+		writeJSONError(w, http.StatusBadGateway, "mod3_unreachable",
+			fmt.Sprintf("mod3 unreachable: %v", err))
+		return
+	}
+
+	// Kernel drops its identity record whenever mod3 successfully
+	// acknowledges, including 404 ("never registered" is equivalent to
+	// "not tracked"; clean slate in kernel matches clean slate in mod3).
+	if status >= 200 && status < 500 {
+		s.channelSessionRegistry.Delete(id)
+	}
+
+	writeJSONPassThrough(w, status, mod3Resp)
+}
+
+// ─── GET /v1/channel-sessions ────────────────────────────────────────────────
+
+func (s *Server) handleChannelSessionList(w http.ResponseWriter, r *http.Request) {
+	mod3Resp, status, err := s.forwardMod3(r.Context(), http.MethodGet,
+		"/v1/sessions", nil)
+	if err != nil {
+		slog.Warn("channel-sessions: list forward failed", "err", err)
+		writeJSONError(w, http.StatusBadGateway, "mod3_unreachable",
+			fmt.Sprintf("mod3 unreachable: %v", err))
+		return
+	}
+	if status < 200 || status >= 300 {
+		writeJSONPassThrough(w, status, mod3Resp)
+		return
+	}
+	resp := channelSessionListResponse{
+		Kernel: s.channelSessionRegistry.Snapshot(),
+		Mod3:   mod3Resp,
+	}
+	writeJSONResp(w, http.StatusOK, resp)
+}
+
+// ─── GET /v1/channel-sessions/{id} ───────────────────────────────────────────
+
+func (s *Server) handleChannelSessionGet(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request",
+			"session_id required in path")
+		return
+	}
+
+	mod3Resp, status, err := s.forwardMod3(r.Context(), http.MethodGet,
+		"/v1/sessions/"+id, nil)
+	if err != nil {
+		slog.Warn("channel-sessions: get forward failed",
+			"session_id", id, "err", err)
+		writeJSONError(w, http.StatusBadGateway, "mod3_unreachable",
+			fmt.Sprintf("mod3 unreachable: %v", err))
+		return
+	}
+	if status < 200 || status >= 300 {
+		writeJSONPassThrough(w, status, mod3Resp)
+		return
+	}
+
+	kernelRec, _ := s.channelSessionRegistry.Get(id)
+	resp := channelSessionResponse{
+		Kernel: kernelRec,
+		Mod3:   mod3Resp,
+	}
+	writeJSONResp(w, http.StatusOK, resp)
+}
+
+// ─── forwarder + helpers ─────────────────────────────────────────────────────
+
+// forwardMod3 is the single HTTP egress point to mod3. Returns the raw
+// response body, HTTP status, and a transport error (non-nil only when the
+// request never got a status back — connection refused, DNS, TLS, timeout).
+// Mod3 error bodies (4xx/5xx) come back with err == nil and caller decides
+// how to surface them.
+func (s *Server) forwardMod3(ctx context.Context, method, path string, body io.Reader) (json.RawMessage, int, error) {
+	base := strings.TrimRight(s.cfg.Mod3URL, "/")
+	if base == "" {
+		return nil, 0, errors.New("Mod3URL not configured")
+	}
+	url := base + path
+
+	// Scope a per-request timeout on top of the shared client's. The ambient
+	// request context may have a longer deadline; we want the forward to
+	// fail fast if mod3 stalls.
+	reqCtx, cancel := context.WithTimeout(ctx, defaultMod3ForwardTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, method, url, body)
+	if err != nil {
+		return nil, 0, fmt.Errorf("build request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+
+	client := s.mod3Client
+	if client == nil {
+		client = mod3HTTPClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1 MB cap
+	if err != nil {
+		return nil, resp.StatusCode, fmt.Errorf("read response body: %w", err)
+	}
+	if len(raw) == 0 {
+		// Mod3's deregister can return a JSON object; other endpoints
+		// always return JSON; if the body is empty we substitute null so
+		// json.RawMessage doesn't marshal an empty string (invalid JSON).
+		raw = []byte("null")
+	}
+	if !json.Valid(raw) {
+		// Surface as a synthetic JSON string; don't propagate raw bytes.
+		wrapped, _ := json.Marshal(map[string]string{"raw": string(raw)})
+		return json.RawMessage(wrapped), resp.StatusCode, nil
+	}
+	return json.RawMessage(raw), resp.StatusCode, nil
+}
+
+// mintChannelSessionID returns a 12-char lowercase-hex short UUID. Short
+// enough to be human-readable in logs, unique enough to avoid collisions
+// across a single mod3 instance's lifetime.
+func mintChannelSessionID() string {
+	u := uuid.New()
+	hex := strings.ReplaceAll(u.String(), "-", "")
+	return "cs-" + hex[:12]
+}
+
+// writeJSONPassThrough writes the given status + raw JSON body verbatim. Used
+// when mod3's response (especially errors) should flow to the caller intact.
+func writeJSONPassThrough(w http.ResponseWriter, status int, body json.RawMessage) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if len(body) == 0 {
+		_, _ = w.Write([]byte("null"))
+		return
+	}
+	_, _ = w.Write(body)
+}

--- a/internal/engine/serve_sessions_channel.go
+++ b/internal/engine/serve_sessions_channel.go
@@ -68,6 +68,17 @@ type ChannelSessionRecord struct {
 	PreferredOutputDevice string `json:"preferred_output_device,omitempty"`
 	Priority              int    `json:"priority,omitempty"`
 
+	// Kinds mirrors the channel-provider RFC's `kinds` metadata field
+	// (e.g. ["audio"] for a mod3-provider registration). Mod3 ignores it
+	// today; kept on the kernel record for downstream consumers that want
+	// to filter by capability.
+	Kinds []string `json:"kinds,omitempty"`
+
+	// Metadata is an opaque pass-through map the RFC describes as
+	// "provider_id/kinds in the metadata" — preserved verbatim on the
+	// kernel record and forwarded to mod3 (which ignores unknown fields).
+	Metadata map[string]any `json:"metadata,omitempty"`
+
 	RegisteredAt time.Time `json:"registered_at"`
 	LastSeen     time.Time `json:"last_seen"`
 
@@ -165,13 +176,22 @@ func (s *Server) registerChannelSessionRoutes(mux *http.ServeMux) {
 // channelSessionRegisterRequest is the kernel-facing request body. Shape
 // mirrors mod3's SessionRegisterRequest (see mod3/http_api.py line ~278) plus
 // an optional session_id — when omitted, the kernel mints one.
+//
+// Wave 3.5 schema alignment with the channel-provider RFC's
+// `cogos_session_register` primitive: `kinds` (array of adapter kinds the
+// registrant participates in, e.g. ["audio"]) and `metadata` (opaque
+// pass-through blob — RFC calls for provider_id/kinds to live in metadata)
+// are both optional and flow through to mod3 unchanged (mod3 ignores
+// unknown fields).
 type channelSessionRegisterRequest struct {
-	SessionID             string `json:"session_id,omitempty"`
-	ParticipantID         string `json:"participant_id"`
-	ParticipantType       string `json:"participant_type,omitempty"`
-	PreferredVoice        string `json:"preferred_voice,omitempty"`
-	PreferredOutputDevice string `json:"preferred_output_device,omitempty"`
-	Priority              int    `json:"priority,omitempty"`
+	SessionID             string         `json:"session_id,omitempty"`
+	ParticipantID         string         `json:"participant_id"`
+	ParticipantType       string         `json:"participant_type,omitempty"`
+	PreferredVoice        string         `json:"preferred_voice,omitempty"`
+	PreferredOutputDevice string         `json:"preferred_output_device,omitempty"`
+	Priority              int            `json:"priority,omitempty"`
+	Kinds                 []string       `json:"kinds,omitempty"`
+	Metadata              map[string]any `json:"metadata,omitempty"`
 }
 
 // channelSessionResponse is the merged shape returned from the kernel. The
@@ -192,18 +212,52 @@ type channelSessionListResponse struct {
 	Mod3   json.RawMessage         `json:"mod3,omitempty"`
 }
 
-// ─── POST /v1/channel-sessions/register ──────────────────────────────────────
+// ─── shared register/deregister/list logic (Wave 3.5) ────────────────────────
+//
+// These methods are the single place session-ID minting, kernel registry
+// commits, and mod3 forwarding happen. Both the HTTP handlers below and the
+// mod3_register_session / mod3_deregister_session / mod3_list_sessions MCP
+// tools (see mcp_modality_proxy.go) call through here so session-ID
+// authority stays centralized — nobody reaches mod3's /v1/sessions/* surface
+// directly except this one codepath.
 
-func (s *Server) handleChannelSessionRegister(w http.ResponseWriter, r *http.Request) {
-	var req channelSessionRegisterRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSONError(w, http.StatusBadRequest, "invalid_request", "body must be JSON")
-		return
-	}
+// channelSessionForwardError classifies a failure in RegisterChannelSession /
+// DeregisterChannelSession / ListChannelSessions so the caller (HTTP handler
+// or MCP tool) can surface the right status/message without re-parsing.
+type channelSessionForwardError struct {
+	// Kind: "invalid_request" | "mod3_unreachable" | "mod3_rejected"
+	Kind string
+	// HTTPStatus is the status the caller should emit (400 for
+	// invalid_request, 502 for mod3_unreachable, mod3's own status for
+	// mod3_rejected).
+	HTTPStatus int
+	// Message is a human-readable description, safe to surface to callers.
+	Message string
+	// Mod3Body carries the raw JSON body mod3 returned when Kind ==
+	// "mod3_rejected", so the HTTP handler can pass it through verbatim.
+	Mod3Body json.RawMessage
+}
+
+func (e *channelSessionForwardError) Error() string { return e.Message }
+
+// RegisterChannelSession is the Wave 2+3.5 shared entry point for channel-
+// session registration. It mints a session_id when absent, forwards to mod3,
+// and commits the kernel-side identity record on success.
+//
+// Callers:
+//   - HTTP:  POST /v1/channel-sessions/register  (handleChannelSessionRegister)
+//   - MCP:   mod3_register_session tool          (toolMod3RegisterSession)
+//
+// Returning a (resp, nil) pair means the caller should surface the merged
+// response with 200 OK. Returning a non-nil *channelSessionForwardError
+// tells the caller which status + body shape to surface.
+func (s *Server) RegisterChannelSession(ctx context.Context, req channelSessionRegisterRequest) (*channelSessionResponse, *channelSessionForwardError) {
 	if req.ParticipantID == "" {
-		writeJSONError(w, http.StatusBadRequest, "invalid_request",
-			"participant_id is required")
-		return
+		return nil, &channelSessionForwardError{
+			Kind:       "invalid_request",
+			HTTPStatus: http.StatusBadRequest,
+			Message:    "participant_id is required",
+		}
 	}
 
 	// Mint when absent — kernel is the session-ID authority (ADR-082).
@@ -227,6 +281,8 @@ func (s *Server) handleChannelSessionRegister(w http.ResponseWriter, r *http.Req
 		PreferredVoice:        req.PreferredVoice,
 		PreferredOutputDevice: req.PreferredOutputDevice,
 		Priority:              req.Priority,
+		Kinds:                 req.Kinds,
+		Metadata:              req.Metadata,
 		RegisteredAt:          now,
 		LastSeen:              now,
 		IDSource:              idSource,
@@ -234,7 +290,9 @@ func (s *Server) handleChannelSessionRegister(w http.ResponseWriter, r *http.Req
 
 	// Forward to mod3 with the kernel-issued session_id. Mod3's body is the
 	// same shape modulo the optional session_id field (mod3 requires it; we
-	// always supply one).
+	// always supply one). `kinds` and `metadata` are RFC-level fields mod3
+	// currently ignores; we still forward them so mod3 can start consuming
+	// them without a kernel change when it's ready.
 	forwardBody := map[string]any{
 		"session_id":              req.SessionID,
 		"participant_id":          req.ParticipantID,
@@ -243,27 +301,35 @@ func (s *Server) handleChannelSessionRegister(w http.ResponseWriter, r *http.Req
 		"preferred_output_device": req.PreferredOutputDevice,
 		"priority":                req.Priority,
 	}
+	if len(req.Kinds) > 0 {
+		forwardBody["kinds"] = req.Kinds
+	}
+	if len(req.Metadata) > 0 {
+		forwardBody["metadata"] = req.Metadata
+	}
 	body, _ := json.Marshal(forwardBody)
 
-	mod3Resp, status, err := s.forwardMod3(r.Context(), http.MethodPost,
+	mod3Resp, status, err := s.forwardMod3(ctx, http.MethodPost,
 		"/v1/sessions/register", bytes.NewReader(body))
 	if err != nil {
 		slog.Warn("channel-sessions: forward to mod3 failed",
 			"session_id", req.SessionID, "err", err)
-		writeJSONError(w, http.StatusBadGateway, "mod3_unreachable",
-			fmt.Sprintf("mod3 unreachable: %v", err))
-		return
+		return nil, &channelSessionForwardError{
+			Kind:       "mod3_unreachable",
+			HTTPStatus: http.StatusBadGateway,
+			Message:    fmt.Sprintf("mod3 unreachable: %v", err),
+		}
 	}
 
-	// Preserve non-success status bodies so the caller can surface mod3's
-	// diagnostic text. Any 4xx/5xx from mod3 becomes the response status
-	// with the raw body attached — the kernel does NOT write its identity
-	// record in that case (mod3 rejected the registration).
 	if status < 200 || status >= 300 {
 		slog.Warn("channel-sessions: mod3 returned non-2xx",
 			"session_id", req.SessionID, "status", status)
-		writeJSONPassThrough(w, status, mod3Resp)
-		return
+		return nil, &channelSessionForwardError{
+			Kind:       "mod3_rejected",
+			HTTPStatus: status,
+			Message:    fmt.Sprintf("mod3 returned %d", status),
+			Mod3Body:   mod3Resp,
+		}
 	}
 
 	// Mod3 accepted — commit the kernel-side identity record.
@@ -272,12 +338,101 @@ func (s *Server) handleChannelSessionRegister(w http.ResponseWriter, r *http.Req
 		"session_id", req.SessionID, "participant_id", req.ParticipantID,
 		"id_source", idSource)
 
-	// Return merged response. The `mod3` field is the raw body from mod3 so
-	// callers get the exact {assigned_voice, voice_conflict, output_device,
-	// queue_depth, ...} shape mod3 emits.
-	resp := channelSessionResponse{
-		Kernel: &record,
+	return &channelSessionResponse{Kernel: &record, Mod3: mod3Resp}, nil
+}
+
+// DeregisterChannelSession is the shared entry point for deregistration.
+// Forwards to mod3 and drops the kernel registry row on any non-5xx mod3
+// response (including 404 — "mod3 forgot" is equivalent to "kernel should
+// forget too"). On transport failure the kernel keeps the record so the
+// caller can retry.
+//
+// Returns the raw mod3 body + status on success. Callers should surface
+// both verbatim (writeJSONPassThrough on the HTTP side; the MCP tool
+// wraps it as a JSON result).
+func (s *Server) DeregisterChannelSession(ctx context.Context, sessionID string) (json.RawMessage, int, *channelSessionForwardError) {
+	if sessionID == "" {
+		return nil, 0, &channelSessionForwardError{
+			Kind:       "invalid_request",
+			HTTPStatus: http.StatusBadRequest,
+			Message:    "session_id is required",
+		}
+	}
+
+	mod3Resp, status, err := s.forwardMod3(ctx, http.MethodPost,
+		"/v1/sessions/"+sessionID+"/deregister", nil)
+	if err != nil {
+		slog.Warn("channel-sessions: deregister forward failed",
+			"session_id", sessionID, "err", err)
+		return nil, 0, &channelSessionForwardError{
+			Kind:       "mod3_unreachable",
+			HTTPStatus: http.StatusBadGateway,
+			Message:    fmt.Sprintf("mod3 unreachable: %v", err),
+		}
+	}
+
+	// Kernel drops its identity record whenever mod3 successfully
+	// acknowledges, including 404 ("never registered" is equivalent to
+	// "not tracked"; clean slate in kernel matches clean slate in mod3).
+	if status >= 200 && status < 500 {
+		s.channelSessionRegistry.Delete(sessionID)
+	}
+
+	return mod3Resp, status, nil
+}
+
+// ListChannelSessions is the shared entry point for the merged list query.
+// Returns the kernel snapshot plus mod3's raw `GET /v1/sessions` body.
+//
+// On mod3 transport failure: error (502). On mod3 non-2xx: returns the
+// raw mod3 body with its status attached so the caller can surface intact.
+func (s *Server) ListChannelSessions(ctx context.Context) (*channelSessionListResponse, int, *channelSessionForwardError) {
+	mod3Resp, status, err := s.forwardMod3(ctx, http.MethodGet,
+		"/v1/sessions", nil)
+	if err != nil {
+		slog.Warn("channel-sessions: list forward failed", "err", err)
+		return nil, 0, &channelSessionForwardError{
+			Kind:       "mod3_unreachable",
+			HTTPStatus: http.StatusBadGateway,
+			Message:    fmt.Sprintf("mod3 unreachable: %v", err),
+		}
+	}
+	if status < 200 || status >= 300 {
+		return nil, status, &channelSessionForwardError{
+			Kind:       "mod3_rejected",
+			HTTPStatus: status,
+			Message:    fmt.Sprintf("mod3 returned %d", status),
+			Mod3Body:   mod3Resp,
+		}
+	}
+	return &channelSessionListResponse{
+		Kernel: s.channelSessionRegistry.Snapshot(),
 		Mod3:   mod3Resp,
+	}, http.StatusOK, nil
+}
+
+// ─── POST /v1/channel-sessions/register ──────────────────────────────────────
+
+func (s *Server) handleChannelSessionRegister(w http.ResponseWriter, r *http.Request) {
+	var req channelSessionRegisterRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", "body must be JSON")
+		return
+	}
+
+	resp, ferr := s.RegisterChannelSession(r.Context(), req)
+	if ferr != nil {
+		switch ferr.Kind {
+		case "invalid_request":
+			writeJSONError(w, ferr.HTTPStatus, "invalid_request", ferr.Message)
+		case "mod3_unreachable":
+			writeJSONError(w, ferr.HTTPStatus, "mod3_unreachable", ferr.Message)
+		case "mod3_rejected":
+			writeJSONPassThrough(w, ferr.HTTPStatus, ferr.Mod3Body)
+		default:
+			writeJSONError(w, http.StatusInternalServerError, "internal", ferr.Message)
+		}
+		return
 	}
 	writeJSONResp(w, http.StatusOK, resp)
 }
@@ -292,46 +447,34 @@ func (s *Server) handleChannelSessionDeregister(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	mod3Resp, status, err := s.forwardMod3(r.Context(), http.MethodPost,
-		"/v1/sessions/"+id+"/deregister", nil)
-	if err != nil {
-		slog.Warn("channel-sessions: deregister forward failed",
-			"session_id", id, "err", err)
-		writeJSONError(w, http.StatusBadGateway, "mod3_unreachable",
-			fmt.Sprintf("mod3 unreachable: %v", err))
+	mod3Resp, status, ferr := s.DeregisterChannelSession(r.Context(), id)
+	if ferr != nil {
+		if ferr.Kind == "mod3_unreachable" {
+			writeJSONError(w, ferr.HTTPStatus, "mod3_unreachable", ferr.Message)
+			return
+		}
+		writeJSONError(w, ferr.HTTPStatus, ferr.Kind, ferr.Message)
 		return
 	}
-
-	// Kernel drops its identity record whenever mod3 successfully
-	// acknowledges, including 404 ("never registered" is equivalent to
-	// "not tracked"; clean slate in kernel matches clean slate in mod3).
-	if status >= 200 && status < 500 {
-		s.channelSessionRegistry.Delete(id)
-	}
-
 	writeJSONPassThrough(w, status, mod3Resp)
 }
 
 // ─── GET /v1/channel-sessions ────────────────────────────────────────────────
 
 func (s *Server) handleChannelSessionList(w http.ResponseWriter, r *http.Request) {
-	mod3Resp, status, err := s.forwardMod3(r.Context(), http.MethodGet,
-		"/v1/sessions", nil)
-	if err != nil {
-		slog.Warn("channel-sessions: list forward failed", "err", err)
-		writeJSONError(w, http.StatusBadGateway, "mod3_unreachable",
-			fmt.Sprintf("mod3 unreachable: %v", err))
+	resp, status, ferr := s.ListChannelSessions(r.Context())
+	if ferr != nil {
+		switch ferr.Kind {
+		case "mod3_unreachable":
+			writeJSONError(w, ferr.HTTPStatus, "mod3_unreachable", ferr.Message)
+		case "mod3_rejected":
+			writeJSONPassThrough(w, ferr.HTTPStatus, ferr.Mod3Body)
+		default:
+			writeJSONError(w, http.StatusInternalServerError, "internal", ferr.Message)
+		}
 		return
 	}
-	if status < 200 || status >= 300 {
-		writeJSONPassThrough(w, status, mod3Resp)
-		return
-	}
-	resp := channelSessionListResponse{
-		Kernel: s.channelSessionRegistry.Snapshot(),
-		Mod3:   mod3Resp,
-	}
-	writeJSONResp(w, http.StatusOK, resp)
+	writeJSONResp(w, status, resp)
 }
 
 // ─── GET /v1/channel-sessions/{id} ───────────────────────────────────────────

--- a/internal/engine/serve_sessions_channel_test.go
+++ b/internal/engine/serve_sessions_channel_test.go
@@ -1,0 +1,566 @@
+// serve_sessions_channel_test.go — end-to-end tests for the kernel-side
+// channel-session forwarder. Each test stands up a fake mod3 via
+// httptest.NewServer and exercises the kernel handler against it.
+package engine
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// ─── fakeMod3 — a tiny stub that canonically mirrors mod3's responses ────────
+
+type fakeMod3 struct {
+	t        *testing.T
+	srv      *httptest.Server
+	mu       sync.Mutex
+	captured []capturedRequest
+
+	// Overrides — tests set these to control per-endpoint behavior.
+	registerHandler   http.HandlerFunc
+	deregisterHandler http.HandlerFunc
+	listHandler       http.HandlerFunc
+	getHandler        http.HandlerFunc
+}
+
+type capturedRequest struct {
+	Method string
+	Path   string
+	Body   []byte
+}
+
+func newFakeMod3(t *testing.T) *fakeMod3 {
+	t.Helper()
+	fm := &fakeMod3{t: t}
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("POST /v1/sessions/register", func(w http.ResponseWriter, r *http.Request) {
+		fm.capture(r)
+		if fm.registerHandler != nil {
+			fm.registerHandler(w, r)
+			return
+		}
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		sid, _ := body["session_id"].(string)
+		resp := map[string]any{
+			"session_id":     sid,
+			"participant_id": body["participant_id"],
+			"assigned_voice": "bm_lewis",
+			"voice_conflict": false,
+			"output_device":  map[string]any{"name": "system-default", "live": true},
+			"queue_depth":    0,
+			"created":        true,
+		}
+		writeFakeJSON(w, http.StatusOK, resp)
+	})
+
+	mux.HandleFunc("POST /v1/sessions/{id}/deregister", func(w http.ResponseWriter, r *http.Request) {
+		fm.capture(r)
+		if fm.deregisterHandler != nil {
+			fm.deregisterHandler(w, r)
+			return
+		}
+		writeFakeJSON(w, http.StatusOK, map[string]any{
+			"status":         "ok",
+			"session_id":     r.PathValue("id"),
+			"released_voice": "bm_lewis",
+			"dropped_jobs":   0,
+		})
+	})
+
+	mux.HandleFunc("GET /v1/sessions", func(w http.ResponseWriter, r *http.Request) {
+		fm.capture(r)
+		if fm.listHandler != nil {
+			fm.listHandler(w, r)
+			return
+		}
+		writeFakeJSON(w, http.StatusOK, map[string]any{
+			"sessions":      []any{},
+			"serializer":    map[string]any{"policy": "round-robin"},
+			"voice_pool":    []any{"bm_lewis", "af_bella"},
+			"voice_holders": map[string]any{},
+		})
+	})
+
+	mux.HandleFunc("GET /v1/sessions/{id}", func(w http.ResponseWriter, r *http.Request) {
+		fm.capture(r)
+		if fm.getHandler != nil {
+			fm.getHandler(w, r)
+			return
+		}
+		writeFakeJSON(w, http.StatusOK, map[string]any{
+			"session_id":     r.PathValue("id"),
+			"assigned_voice": "bm_lewis",
+			"output_device":  map[string]any{"name": "system-default"},
+		})
+	})
+
+	fm.srv = httptest.NewServer(mux)
+	t.Cleanup(func() { fm.srv.Close() })
+	return fm
+}
+
+func (fm *fakeMod3) capture(r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+	fm.captured = append(fm.captured, capturedRequest{
+		Method: r.Method, Path: r.URL.Path, Body: body,
+	})
+}
+
+func (fm *fakeMod3) lastCaptured() capturedRequest {
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+	if len(fm.captured) == 0 {
+		fm.t.Fatalf("expected at least one captured request")
+	}
+	return fm.captured[len(fm.captured)-1]
+}
+
+func writeFakeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// ─── newChannelServer — a Server wired just enough to exercise the routes ────
+
+// newChannelServer builds a Server with only the fields needed by the
+// channel-session handlers: cfg.Mod3URL pointing at fake mod3, a fresh
+// ChannelSessionRegistry, and mux routes registered. The httptest.Client
+// used by the kernel is overridden so every call targets fake mod3 regardless
+// of the Mod3URL's scheme (handy for tests that want to inject network
+// failures without depending on DNS).
+func newChannelServer(t *testing.T, fm *fakeMod3) (*Server, *httptest.Server) {
+	t.Helper()
+	cfg := &Config{Mod3URL: fm.srv.URL}
+	s := &Server{
+		cfg:                    cfg,
+		channelSessionRegistry: NewChannelSessionRegistry(),
+	}
+	mux := http.NewServeMux()
+	s.registerChannelSessionRoutes(mux)
+	front := httptest.NewServer(mux)
+	t.Cleanup(func() { front.Close() })
+	return s, front
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+func TestChannelSessionRegister_MintsIDWhenOmitted(t *testing.T) {
+	fm := newFakeMod3(t)
+	s, front := newChannelServer(t, fm)
+
+	body, _ := json.Marshal(map[string]any{
+		"participant_id": "cog",
+	})
+	resp, err := http.Post(front.URL+"/v1/channel-sessions/register",
+		"application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST register: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d; body: %s", resp.StatusCode, raw)
+	}
+
+	var decoded channelSessionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if decoded.Kernel == nil {
+		t.Fatalf("expected kernel block, got nil")
+	}
+	if decoded.Kernel.SessionID == "" {
+		t.Fatal("expected minted session_id, got empty string")
+	}
+	if !strings.HasPrefix(decoded.Kernel.SessionID, "cs-") {
+		t.Fatalf("expected minted ID to carry cs- prefix, got %q", decoded.Kernel.SessionID)
+	}
+	if decoded.Kernel.IDSource != "minted" {
+		t.Fatalf("expected id_source=minted, got %q", decoded.Kernel.IDSource)
+	}
+
+	// Mod3 should have seen the kernel-minted ID.
+	cap := fm.lastCaptured()
+	var forwarded map[string]any
+	if err := json.Unmarshal(cap.Body, &forwarded); err != nil {
+		t.Fatalf("unmarshal forwarded body: %v", err)
+	}
+	if forwarded["session_id"] != decoded.Kernel.SessionID {
+		t.Fatalf("expected mod3 to receive minted session_id %q, got %v",
+			decoded.Kernel.SessionID, forwarded["session_id"])
+	}
+
+	// Kernel registry should hold the record.
+	if _, ok := s.channelSessionRegistry.Get(decoded.Kernel.SessionID); !ok {
+		t.Fatal("expected kernel registry to retain record after success")
+	}
+}
+
+func TestChannelSessionRegister_UsesCallerSuppliedID(t *testing.T) {
+	fm := newFakeMod3(t)
+	_, front := newChannelServer(t, fm)
+
+	body, _ := json.Marshal(map[string]any{
+		"session_id":              "vox-42",
+		"participant_id":          "sandy",
+		"participant_type":        "agent",
+		"preferred_voice":         "af_bella",
+		"preferred_output_device": "AirPods",
+		"priority":                3,
+	})
+	resp, err := http.Post(front.URL+"/v1/channel-sessions/register",
+		"application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST register: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d; body: %s", resp.StatusCode, raw)
+	}
+
+	var decoded channelSessionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if decoded.Kernel.SessionID != "vox-42" {
+		t.Fatalf("expected caller session_id preserved, got %q", decoded.Kernel.SessionID)
+	}
+	if decoded.Kernel.IDSource != "caller" {
+		t.Fatalf("expected id_source=caller, got %q", decoded.Kernel.IDSource)
+	}
+
+	// Verify all caller-supplied fields made it through the forward.
+	cap := fm.lastCaptured()
+	var forwarded map[string]any
+	_ = json.Unmarshal(cap.Body, &forwarded)
+	if forwarded["session_id"] != "vox-42" ||
+		forwarded["participant_id"] != "sandy" ||
+		forwarded["participant_type"] != "agent" ||
+		forwarded["preferred_voice"] != "af_bella" ||
+		forwarded["preferred_output_device"] != "AirPods" {
+		t.Fatalf("forwarded fields mismatch: %v", forwarded)
+	}
+	// Priority is a number in JSON; compare via float64.
+	if p, _ := forwarded["priority"].(float64); int(p) != 3 {
+		t.Fatalf("expected priority=3 forwarded, got %v", forwarded["priority"])
+	}
+}
+
+func TestChannelSessionRegister_MergesMod3Response(t *testing.T) {
+	fm := newFakeMod3(t)
+	fm.registerHandler = func(w http.ResponseWriter, r *http.Request) {
+		writeFakeJSON(w, http.StatusOK, map[string]any{
+			"session_id":     "cs-fixed",
+			"assigned_voice": "bm_oxford",
+			"voice_conflict": true,
+			"queue_depth":    5,
+			"created":        false,
+		})
+	}
+	_, front := newChannelServer(t, fm)
+
+	body, _ := json.Marshal(map[string]any{
+		"session_id":     "cs-fixed",
+		"participant_id": "cog",
+	})
+	resp, err := http.Post(front.URL+"/v1/channel-sessions/register",
+		"application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST register: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// The merged response should carry mod3's assigned_voice and
+	// voice_conflict fields intact.
+	var decoded map[string]json.RawMessage
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	var mod3 map[string]any
+	if err := json.Unmarshal(decoded["mod3"], &mod3); err != nil {
+		t.Fatalf("decode mod3 block: %v", err)
+	}
+	if mod3["assigned_voice"] != "bm_oxford" {
+		t.Fatalf("expected assigned_voice=bm_oxford in merge, got %v", mod3["assigned_voice"])
+	}
+	if mod3["voice_conflict"] != true {
+		t.Fatalf("expected voice_conflict=true in merge, got %v", mod3["voice_conflict"])
+	}
+}
+
+func TestChannelSessionRegister_ReturnsBadGatewayWhenMod3Down(t *testing.T) {
+	// Build a fakeMod3 and immediately close it so the URL refuses connections.
+	fm := newFakeMod3(t)
+	fm.srv.Close()
+	s, front := newChannelServer(t, fm)
+
+	body, _ := json.Marshal(map[string]any{"participant_id": "cog"})
+	resp, err := http.Post(front.URL+"/v1/channel-sessions/register",
+		"application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST register: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadGateway {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 502, got %d; body: %s", resp.StatusCode, raw)
+	}
+	// Kernel must NOT hold a record for a failed forward.
+	if s.channelSessionRegistry.Len() != 0 {
+		t.Fatalf("expected empty kernel registry after 502, got %d rows",
+			s.channelSessionRegistry.Len())
+	}
+}
+
+func TestChannelSessionRegister_PropagatesMod3Error(t *testing.T) {
+	fm := newFakeMod3(t)
+	fm.registerHandler = func(w http.ResponseWriter, r *http.Request) {
+		writeFakeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": "participant_type must be agent|user",
+		})
+	}
+	s, front := newChannelServer(t, fm)
+
+	body, _ := json.Marshal(map[string]any{
+		"participant_id":   "cog",
+		"participant_type": "alien",
+	})
+	resp, err := http.Post(front.URL+"/v1/channel-sessions/register",
+		"application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST register: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 400 passthrough, got %d; body: %s", resp.StatusCode, raw)
+	}
+	var decoded map[string]string
+	_ = json.NewDecoder(resp.Body).Decode(&decoded)
+	if !strings.Contains(decoded["error"], "participant_type") {
+		t.Fatalf("expected mod3 error body preserved, got %v", decoded)
+	}
+	if s.channelSessionRegistry.Len() != 0 {
+		t.Fatal("expected kernel registry empty when mod3 rejected registration")
+	}
+}
+
+func TestChannelSessionRegister_RequiresParticipantID(t *testing.T) {
+	fm := newFakeMod3(t)
+	_, front := newChannelServer(t, fm)
+
+	body, _ := json.Marshal(map[string]any{})
+	resp, err := http.Post(front.URL+"/v1/channel-sessions/register",
+		"application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST register: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+	// No forward should have happened.
+	fm.mu.Lock()
+	if len(fm.captured) != 0 {
+		t.Fatalf("expected no forward to mod3 when participant_id missing, got %d", len(fm.captured))
+	}
+	fm.mu.Unlock()
+}
+
+func TestChannelSessionDeregister_Forwards(t *testing.T) {
+	fm := newFakeMod3(t)
+	s, front := newChannelServer(t, fm)
+
+	// Pre-populate the kernel registry so we can verify deletion.
+	s.channelSessionRegistry.Put(ChannelSessionRecord{
+		SessionID: "cs-to-drop", ParticipantID: "cog",
+	})
+
+	req, _ := http.NewRequest(http.MethodPost,
+		front.URL+"/v1/channel-sessions/cs-to-drop/deregister", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("deregister: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d; body: %s", resp.StatusCode, raw)
+	}
+	if _, ok := s.channelSessionRegistry.Get("cs-to-drop"); ok {
+		t.Fatal("expected kernel registry to drop record after successful deregister")
+	}
+	cap := fm.lastCaptured()
+	if cap.Path != "/v1/sessions/cs-to-drop/deregister" || cap.Method != http.MethodPost {
+		t.Fatalf("unexpected forward: %+v", cap)
+	}
+}
+
+func TestChannelSessionDeregister_Returns502WhenMod3Down(t *testing.T) {
+	fm := newFakeMod3(t)
+	fm.srv.Close()
+	s, front := newChannelServer(t, fm)
+
+	s.channelSessionRegistry.Put(ChannelSessionRecord{SessionID: "keeper"})
+
+	req, _ := http.NewRequest(http.MethodPost,
+		front.URL+"/v1/channel-sessions/keeper/deregister", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("deregister: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d", resp.StatusCode)
+	}
+	// On transport failure the kernel keeps the record — nothing authoritative
+	// changed. The caller can retry.
+	if _, ok := s.channelSessionRegistry.Get("keeper"); !ok {
+		t.Fatal("expected kernel to preserve record on transport failure")
+	}
+}
+
+func TestChannelSessionList_MergesSnapshots(t *testing.T) {
+	fm := newFakeMod3(t)
+	s, front := newChannelServer(t, fm)
+
+	// Seed kernel registry so we can see the kernel block in the merged response.
+	s.channelSessionRegistry.Put(ChannelSessionRecord{
+		SessionID: "cs-seed", ParticipantID: "cog",
+	})
+
+	resp, err := http.Get(front.URL + "/v1/channel-sessions")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var decoded channelSessionListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(decoded.Kernel) != 1 || decoded.Kernel[0].SessionID != "cs-seed" {
+		t.Fatalf("expected kernel snapshot of 1, got %+v", decoded.Kernel)
+	}
+	if len(decoded.Mod3) == 0 {
+		t.Fatal("expected mod3 block populated from fake mod3")
+	}
+}
+
+func TestChannelSessionGet_MergesKernelAndMod3(t *testing.T) {
+	fm := newFakeMod3(t)
+	s, front := newChannelServer(t, fm)
+	s.channelSessionRegistry.Put(ChannelSessionRecord{
+		SessionID: "cs-detail", ParticipantID: "cog", PreferredVoice: "bm_lewis",
+	})
+
+	resp, err := http.Get(front.URL + "/v1/channel-sessions/cs-detail")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var decoded channelSessionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if decoded.Kernel == nil || decoded.Kernel.SessionID != "cs-detail" {
+		t.Fatalf("expected kernel record returned, got %+v", decoded.Kernel)
+	}
+	if len(decoded.Mod3) == 0 {
+		t.Fatal("expected mod3 block populated from fake mod3")
+	}
+}
+
+func TestChannelSessionGet_Returns404WhenMod3NotFound(t *testing.T) {
+	fm := newFakeMod3(t)
+	fm.getHandler = func(w http.ResponseWriter, r *http.Request) {
+		writeFakeJSON(w, http.StatusNotFound, map[string]string{"error": "not found"})
+	}
+	_, front := newChannelServer(t, fm)
+
+	resp, err := http.Get(front.URL + "/v1/channel-sessions/does-not-exist")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 passthrough, got %d", resp.StatusCode)
+	}
+}
+
+// ─── forwardMod3 direct tests ────────────────────────────────────────────────
+
+func TestForwardMod3_ErrorsWhenURLUnset(t *testing.T) {
+	s := &Server{cfg: &Config{Mod3URL: ""}}
+	_, _, err := s.forwardMod3(context.Background(), http.MethodGet, "/v1/sessions", nil)
+	if err == nil {
+		t.Fatal("expected error when Mod3URL is empty")
+	}
+}
+
+func TestForwardMod3_TimeoutYieldsTransportError(t *testing.T) {
+	// A listener that accepts connections but never writes — guarantees the
+	// 8s per-request timeout fires. Use a short deadline so the test runs
+	// quickly.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { l.Close() })
+
+	s := &Server{
+		cfg:        &Config{Mod3URL: "http://" + l.Addr().String()},
+		mod3Client: &http.Client{Timeout: 50 * 1e6}, // 50ms
+	}
+	_, _, err = s.forwardMod3(context.Background(), http.MethodGet, "/v1/sessions", nil)
+	if err == nil {
+		t.Fatal("expected transport error on stalled server")
+	}
+	// Deadline exceeded / i/o timeout / context canceled are all acceptable shapes.
+	msg := err.Error()
+	if !strings.Contains(strings.ToLower(msg), "timeout") &&
+		!strings.Contains(strings.ToLower(msg), "deadline") &&
+		!errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected timeout-ish error, got %v", err)
+	}
+}
+
+// ─── minor sanity tests for minting + helpers ────────────────────────────────
+
+func TestMintChannelSessionID_ShapeAndUniqueness(t *testing.T) {
+	seen := map[string]bool{}
+	for i := 0; i < 100; i++ {
+		id := mintChannelSessionID()
+		if !strings.HasPrefix(id, "cs-") {
+			t.Fatalf("expected cs- prefix, got %q", id)
+		}
+		if len(id) != 3+12 {
+			t.Fatalf("expected 15-char ID (cs- + 12 hex), got len=%d (%q)", len(id), id)
+		}
+		if seen[id] {
+			t.Fatalf("mint collision after %d iterations: %q", i, id)
+		}
+		seen[id] = true
+	}
+}

--- a/internal/engine/serve_sessions_channel_test.go
+++ b/internal/engine/serve_sessions_channel_test.go
@@ -361,6 +361,67 @@ func TestChannelSessionRegister_PropagatesMod3Error(t *testing.T) {
 	}
 }
 
+// TestChannelSessionRegister_ForwardsKindsAndMetadata verifies the Wave 3.5
+// schema alignment: the optional `kinds` array and `metadata` object from
+// the channel-provider RFC's cogos_session_register primitive flow through
+// Wave 2's register endpoint and land in mod3's request body unchanged.
+func TestChannelSessionRegister_ForwardsKindsAndMetadata(t *testing.T) {
+	fm := newFakeMod3(t)
+	s, front := newChannelServer(t, fm)
+
+	body, _ := json.Marshal(map[string]any{
+		"session_id":       "cs-kinds-http",
+		"participant_id":   "mod3-provider",
+		"participant_type": "provider",
+		"kinds":            []string{"audio"},
+		"metadata": map[string]any{
+			"provider_id": "mod3-local",
+			"build":       "0.5.0",
+		},
+	})
+	resp, err := http.Post(front.URL+"/v1/channel-sessions/register",
+		"application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST register: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d; body: %s", resp.StatusCode, raw)
+	}
+
+	cap := fm.lastCaptured()
+	var forwarded map[string]any
+	if err := json.Unmarshal(cap.Body, &forwarded); err != nil {
+		t.Fatalf("decode forwarded body: %v", err)
+	}
+	kinds, ok := forwarded["kinds"].([]any)
+	if !ok || len(kinds) != 1 || kinds[0] != "audio" {
+		t.Fatalf("expected mod3 to receive kinds=[\"audio\"], got %v", forwarded["kinds"])
+	}
+	md, ok := forwarded["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected mod3 to receive metadata object, got %v (%T)",
+			forwarded["metadata"], forwarded["metadata"])
+	}
+	if md["provider_id"] != "mod3-local" {
+		t.Fatalf("expected metadata.provider_id=mod3-local forwarded, got %v", md["provider_id"])
+	}
+
+	// Kernel record must retain the RFC fields so downstream consumers
+	// can filter by capability even when mod3 ignores them.
+	rec, ok := s.channelSessionRegistry.Get("cs-kinds-http")
+	if !ok {
+		t.Fatal("expected kernel registry to hold record")
+	}
+	if len(rec.Kinds) != 1 || rec.Kinds[0] != "audio" {
+		t.Fatalf("expected record.Kinds=[audio], got %v", rec.Kinds)
+	}
+	if rec.Metadata["provider_id"] != "mod3-local" {
+		t.Fatalf("expected record.Metadata.provider_id=mod3-local, got %v", rec.Metadata)
+	}
+}
+
 func TestChannelSessionRegister_RequiresParticipantID(t *testing.T) {
 	fm := newFakeMod3(t)
 	_, front := newChannelServer(t, fm)

--- a/internal/engine/serve_sessions_mgmt.go
+++ b/internal/engine/serve_sessions_mgmt.go
@@ -47,16 +47,16 @@ import (
 // alongside the pre-existing `/v1/sessions` GET surface.
 func (s *Server) registerSessionMgmtRoutes(mux *http.ServeMux) {
 	// Sessions (specific-method first).
-	mux.HandleFunc("POST /v1/sessions/register", s.handleSessionRegister)
-	mux.HandleFunc("GET /v1/sessions/presence", s.handleSessionPresence)
-	mux.HandleFunc("POST /v1/sessions/{id}/heartbeat", s.handleSessionHeartbeat)
-	mux.HandleFunc("POST /v1/sessions/{id}/end", s.handleSessionEnd)
+	s.route(mux, "POST /v1/sessions/register", s.handleSessionRegister)
+	s.route(mux, "GET /v1/sessions/presence", s.handleSessionPresence)
+	s.route(mux, "POST /v1/sessions/{id}/heartbeat", s.handleSessionHeartbeat)
+	s.route(mux, "POST /v1/sessions/{id}/end", s.handleSessionEnd)
 
 	// Handoffs.
-	mux.HandleFunc("POST /v1/handoffs/offer", s.handleHandoffOffer)
-	mux.HandleFunc("GET /v1/handoffs", s.handleHandoffList)
-	mux.HandleFunc("POST /v1/handoffs/{id}/claim", s.handleHandoffClaim)
-	mux.HandleFunc("POST /v1/handoffs/{id}/complete", s.handleHandoffComplete)
+	s.route(mux, "POST /v1/handoffs/offer", s.handleHandoffOffer)
+	s.route(mux, "GET /v1/handoffs", s.handleHandoffList)
+	s.route(mux, "POST /v1/handoffs/{id}/claim", s.handleHandoffClaim)
+	s.route(mux, "POST /v1/handoffs/{id}/complete", s.handleHandoffComplete)
 }
 
 // ─── error helpers ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Wave 6a lands Identity as a first-class CRD in CogOS, reconciled by `pkg/reconcile` alongside existing providers. Four commits:

- **6a-1** (13a00bf) — Identity CRD type, YAML loader, and `ExpressionFor` projection
- **6a-2** (0e360c5) — `KeyRef` indirection for private keys (ref URI + integrity_hash) and declarative `AuthFactors` on the spec
- **6a-3** (4e6206f) — `IdentityProvider` implementing `Reconcilable`, with 20 tests backed by an in-memory DB fake
- **6a-4** (bca4aa0) — ApplyPlan idempotency short-circuit + 4 regression tests; required for scheduler-driven reconciler ticks

## Architecture notes

Three-layer model now explicit in the codebase:

- **Node** (L1): constellation repo, unchanged
- **Identity** (L2): this CRD. OIDC-compatible shape (`iss` / `sub` / `aud` + `expressions[]`). Workspace expressions are projections of a single global identity, not separate identity rows
- **Presence** (L3): emergent from attention table + bus events — deliberately *not* a stored CRD

`KeyRef` keeps private keys portable across storage media; integrity is verified by `integrity_hash`. `AuthFactors` are declared on the CRD; the reconciler is the MFA trust anchor rather than any runtime path.

Wave 6a-4's idempotency short-circuit is load-bearing for the future kernel-interior agent harness that ticks reconcilers on a schedule: before the fix, the `applied_at` timestamp baked into the cogdoc frontmatter caused the file to re-write on every re-apply, polluting git and emitting duplicate events. Now: if the existing projection's `spec_hash` matches AND the cogdoc file is on disk, the apply is a clean no-op (ApplySkipped in results, zero events, zero DB writes). File-delete drift still triggers a rewrite.

## Test plan

- [x] `go test -tags fts5 ./...` — all 24 IdentityProvider tests green (20 existing + 4 new idempotency tests)
- [x] `gofmt -l .` — no new drift from this branch
- [ ] Manual: load sample identity YAML through the reconciler on a dev constellation
- [ ] Follow-up wave: wire SessionStart hook to emit presence bus events (Wave 5b')
- [ ] Follow-up wave: migrate existing 12 identity cards into CRD format (Wave 6b)