### PR TITLE
feat(engine): session-scoped activity channel publish in handleTailerBlock (Phase 1A)

### DIFF
--- a/internal/engine/cli.go
+++ b/internal/engine/cli.go
@@ -212,6 +212,15 @@ func runServe(workspace string, port int, bindAddr string) {
 	server := NewServer(cfg, nucleus, process)
 	server.SetRouter(router)
 
+	// Wire the session-activity publisher so handleTailerBlock can fan
+	// tailer blocks onto per-session bus channels (Phase 1A of the 4E
+	// cognitive-observer loop). server.busSessions is always non-nil by
+	// NewServer's contract; AppendEvent's signature matches
+	// SessionActivityPublisher by construction.
+	if server.busSessions != nil {
+		process.SetSessionActivityPublisher(server.busSessions.AppendEvent)
+	}
+
 	// Initialize telemetry (traces + metrics). No-op if no collector is available.
 	ctx0 := context.Background()
 	shutdownTelemetry := initTelemetry(ctx0)

--- a/internal/engine/process.go
+++ b/internal/engine/process.go
@@ -181,7 +181,21 @@ type Process struct {
 	// initialized on first registerPendingToolCall; swept by
 	// RunPendingToolCallSweeper. See tool_observer.go.
 	pendingToolCalls *pendingToolCallRegistry
+
+	// sessionActivityPublisher fans tailer blocks out to session-scoped bus
+	// channels (channel.<sid>.activity) in addition to the global ledger —
+	// Phase 1A of the 4E cognitive-observer loop closure. Set by the main
+	// serve wire-up (see cli.go) to *BusSessionManager.AppendEvent. Nil when
+	// the process is constructed without a bus (e.g. benchmarks, some tests);
+	// handleTailerBlock degrades gracefully in that case.
+	sessionActivityPublisher SessionActivityPublisher
 }
+
+// SessionActivityPublisher is the bus-append signature used by
+// handleTailerBlock to fan tailer blocks onto per-session activity channels.
+// It matches *BusSessionManager.AppendEvent so main can wire the method
+// value directly without an adapter.
+type SessionActivityPublisher func(busID, eventType, from string, payload map[string]interface{}) (*BusBlock, error)
 
 // NewProcess constructs and initialises the process.
 func NewProcess(cfg *Config, nucleus *Nucleus) *Process {
@@ -355,6 +369,22 @@ func (p *Process) SetTRM(trm *MambaTRM, idx *EmbeddingIndex) {
 	p.trm = trm
 	p.embeddingIndex = idx
 	p.lightCones = NewLightConeManager(trm)
+}
+
+// SetSessionActivityPublisher installs the bus-append hook used by
+// handleTailerBlock to publish normalized tailer blocks onto per-session
+// activity channels (Phase 1A of the 4E cognitive-observer loop). The
+// expected value in production is (*BusSessionManager).AppendEvent wired
+// in at serve startup; tests inject a fake to observe publishes.
+// Passing nil disables the channel-publish side-effect while leaving the
+// ledger write intact.
+func (p *Process) SetSessionActivityPublisher(pub SessionActivityPublisher) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.sessionActivityPublisher = pub
 }
 
 // Send delivers an external event to the process loop (non-blocking).
@@ -531,8 +561,76 @@ func (p *Process) handleTailerBlock(block CogBlock) {
 		b.Timestamp = time.Now().UTC()
 	}
 
+	// Capture the originating session id BEFORE RecordBlock — RecordBlock
+	// substitutes the kernel's own sessionID when the block is missing one,
+	// and for the activity channel we only care about externally-sourced
+	// session identifiers. For Claude Code blocks this is the per-
+	// conversation UUID carried on every JSONL line (see
+	// normalizeClaudeCodeLine — CogBlock.SessionID and
+	// BlockProvenance.OriginSession are both populated from entry.sessionId).
+	// OpenClaw and other tailers that don't stamp a session id fall through
+	// to the graceful-skip branch below.
+	sid := strings.TrimSpace(b.SessionID)
+	if sid == "" {
+		sid = strings.TrimSpace(b.Provenance.OriginSession)
+	}
+
 	ref := p.RecordBlock(&b)
 	slog.Info("process: tailer block ingested", "source_channel", b.SourceChannel, "kind", b.Kind, "ledger_ref", ref)
+
+	p.publishSessionActivity(sid, &b, ref)
+}
+
+// publishSessionActivity fans a tailer block onto the session-scoped bus
+// channel channel.<sid>.activity (ADR-084 dot-separated lowercase event
+// naming). Phase 1A of the 4E cognitive-observer loop — downstream
+// UserPromptSubmit hooks query this channel to render peer-awareness
+// packets (Phase 1B). The payload is a minimal summary rather than the
+// full block content: the ledger remains authoritative for payload, the
+// channel is only for downstream query-driven notifications.
+//
+// Skips with a debug log when the originating session id is missing
+// (e.g. OpenClaw blocks, or Claude Code lines lacking the sessionId
+// field) or when no publisher has been wired — tailer ingestion never
+// fails on a missing side-channel.
+func (p *Process) publishSessionActivity(sid string, b *CogBlock, ref string) {
+	if b == nil {
+		return
+	}
+	if sid == "" {
+		slog.Debug("process: session activity publish skipped — no session id on block",
+			"source_channel", b.SourceChannel, "kind", b.Kind)
+		return
+	}
+
+	p.mu.RLock()
+	pub := p.sessionActivityPublisher
+	p.mu.RUnlock()
+	if pub == nil {
+		slog.Debug("process: session activity publish skipped — no publisher wired",
+			"sid", sid, "source_channel", b.SourceChannel)
+		return
+	}
+
+	busID := "channel." + sid + ".activity"
+	payload := map[string]interface{}{
+		"kind":           string(b.Kind),
+		"source_channel": b.SourceChannel,
+		"timestamp":      b.Timestamp.UTC().Format(time.RFC3339Nano),
+		"ref":            ref,
+	}
+	from := b.SourceChannel
+	if from == "" {
+		from = "kernel:tailer"
+	}
+
+	if _, err := pub(busID, "tailer.block", from, payload); err != nil {
+		slog.Warn("process: session activity publish failed",
+			"bus_id", busID, "source_channel", b.SourceChannel, "err", err)
+		return
+	}
+	slog.Debug("process: session activity published",
+		"bus_id", busID, "source_channel", b.SourceChannel, "kind", b.Kind)
 }
 
 // handleExternal processes an external perturbation.

--- a/internal/engine/process_tailer_channel_test.go
+++ b/internal/engine/process_tailer_channel_test.go
@@ -1,0 +1,233 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// fakeBusPublisher captures bus AppendEvent calls for assertion.
+// Mimics BusSessionManager.AppendEvent's signature so it can be handed to
+// Process.SetSessionActivityPublisher directly.
+type fakeBusPublisher struct {
+	mu    sync.Mutex
+	calls []fakeBusCall
+}
+
+type fakeBusCall struct {
+	BusID   string
+	Type    string
+	From    string
+	Payload map[string]interface{}
+}
+
+func (f *fakeBusPublisher) Append(busID, eventType, from string, payload map[string]interface{}) (*BusBlock, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, fakeBusCall{
+		BusID:   busID,
+		Type:    eventType,
+		From:    from,
+		Payload: payload,
+	})
+	// Return a minimal non-nil BusBlock so callers that inspect the result
+	// don't nil-deref. We don't need a real seq/hash here.
+	return &BusBlock{V: 2, BusID: busID, Seq: len(f.calls), Type: eventType, From: from, Payload: payload}, nil
+}
+
+func (f *fakeBusPublisher) Calls() []fakeBusCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]fakeBusCall, len(f.calls))
+	copy(out, f.calls)
+	return out
+}
+
+// TestHandleTailerBlockPublishesToSessionChannel exercises the Phase 1A
+// contract: every tailer block is recorded on the ledger AND, when the
+// block carries a session id, fanned out to channel.<sid>.activity.
+func TestHandleTailerBlockPublishesToSessionChannel(t *testing.T) {
+	t.Parallel()
+
+	type want struct {
+		ledgerWritten bool
+		busCallCount  int
+		expectedBusID string // empty when no publish expected
+	}
+
+	claudeCodeSID := uuid.New().String()
+
+	cases := []struct {
+		name  string
+		block CogBlock
+		want  want
+	}{
+		{
+			name: "claude-code block with sessionId fans to channel.<sid>.activity",
+			block: CogBlock{
+				ID:            uuid.New().String(),
+				SessionID:     claudeCodeSID,
+				SourceChannel: claudeCodeSourceChannel,
+				Kind:          BlockMessage,
+				Provenance: BlockProvenance{
+					OriginSession: claudeCodeSID,
+					OriginChannel: claudeCodeSourceChannel,
+					NormalizedBy:  claudeCodeNormalizedBy,
+				},
+			},
+			want: want{
+				ledgerWritten: true,
+				busCallCount:  1,
+				expectedBusID: "channel." + claudeCodeSID + ".activity",
+			},
+		},
+		{
+			name: "block without session id writes ledger but skips publish",
+			block: CogBlock{
+				ID:            uuid.New().String(),
+				SourceChannel: "openclaw",
+				Kind:          BlockToolCall,
+				Provenance: BlockProvenance{
+					OriginChannel: "openclaw",
+					NormalizedBy:  "tailer-openclaw",
+				},
+			},
+			want: want{
+				ledgerWritten: true,
+				busCallCount:  0,
+				expectedBusID: "",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := makeConfig(t, t.TempDir())
+			p := NewProcess(cfg, makeNucleus("T", "r"))
+
+			fake := &fakeBusPublisher{}
+			p.SetSessionActivityPublisher(fake.Append)
+
+			// handleTailerBlock drops blocks when the process is not in a
+			// receptive state. NewProcess initialises to StateReceptive, so
+			// no explicit transition is required; if that contract ever
+			// changes, add an explicit setState here so the test stays
+			// targeted at the publish path.
+			if got := p.State(); got != StateReceptive && got != StateActive {
+				t.Fatalf("precondition: process state = %q; want receptive or active",
+					got.String())
+			}
+
+			// Snapshot the per-session ledger file size before/after. The
+			// ledger lives at
+			//   WorkspaceRoot/.cog/ledger/<sessionID>/events.jsonl
+			// (see RecordBlock → AppendEvent). When the incoming block has
+			// a session id, RecordBlock preserves it; otherwise it uses the
+			// kernel's own sessionID — we read both candidates so we
+			// detect the append regardless of which bucket it lands in.
+			ledgerSize := func() int64 {
+				sids := []string{tc.block.SessionID, p.SessionID()}
+				var total int64
+				for _, sid := range sids {
+					if sid == "" {
+						continue
+					}
+					info, err := os.Stat(filepath.Join(
+						cfg.WorkspaceRoot, ".cog", "ledger", sid, "events.jsonl"))
+					if err == nil {
+						total += info.Size()
+					}
+				}
+				return total
+			}
+
+			before := ledgerSize()
+			p.handleTailerBlock(tc.block)
+			after := ledgerSize()
+			if tc.want.ledgerWritten && after <= before {
+				t.Fatalf("ledger: expected append (before=%d after=%d)",
+					before, after)
+			}
+
+			// Bus publish assertion — must match expected shape.
+			calls := fake.Calls()
+			if len(calls) != tc.want.busCallCount {
+				t.Fatalf("bus publish count = %d; want %d (calls=%+v)",
+					len(calls), tc.want.busCallCount, calls)
+			}
+			if tc.want.busCallCount == 0 {
+				return
+			}
+
+			call := calls[0]
+			if call.BusID != tc.want.expectedBusID {
+				t.Fatalf("bus_id = %q; want %q", call.BusID, tc.want.expectedBusID)
+			}
+			if call.Type != "tailer.block" {
+				t.Fatalf("type = %q; want tailer.block", call.Type)
+			}
+			if call.From == "" {
+				t.Fatalf("from is empty; want source_channel or kernel:tailer fallback")
+			}
+			if call.Payload == nil {
+				t.Fatalf("payload is nil; want summary with kind/source_channel/timestamp/ref")
+			}
+			if got, _ := call.Payload["kind"].(string); got != string(tc.block.Kind) {
+				t.Fatalf("payload.kind = %q; want %q", got, string(tc.block.Kind))
+			}
+			if got, _ := call.Payload["source_channel"].(string); got != tc.block.SourceChannel {
+				t.Fatalf("payload.source_channel = %q; want %q", got, tc.block.SourceChannel)
+			}
+			if _, ok := call.Payload["timestamp"].(string); !ok {
+				t.Fatalf("payload.timestamp missing or not a string; payload=%+v", call.Payload)
+			}
+			// ref is the ledger reference. RecordBlock returns the event
+			// hash (may be empty in edge cases); we only assert the field
+			// exists and is a string.
+			if _, ok := call.Payload["ref"].(string); !ok {
+				t.Fatalf("payload.ref missing or not a string; payload=%+v", call.Payload)
+			}
+		})
+	}
+}
+
+// TestHandleTailerBlockNoPublisherWiredIsNoop confirms that a process
+// constructed without a session-activity publisher still ingests tailer
+// blocks (the ledger write is preserved; only the channel publish is
+// skipped). This is the OpenClaw / headless-benchmark path.
+func TestHandleTailerBlockNoPublisherWiredIsNoop(t *testing.T) {
+	t.Parallel()
+
+	cfg := makeConfig(t, t.TempDir())
+	p := NewProcess(cfg, makeNucleus("T", "r"))
+	// Intentionally do NOT call SetSessionActivityPublisher.
+
+	sid := uuid.New().String()
+	block := CogBlock{
+		ID:            uuid.New().String(),
+		SessionID:     sid,
+		SourceChannel: claudeCodeSourceChannel,
+		Kind:          BlockMessage,
+	}
+
+	ledgerPath := filepath.Join(cfg.WorkspaceRoot, ".cog", "ledger", sid, "events.jsonl")
+	var before int64
+	if info, err := os.Stat(ledgerPath); err == nil {
+		before = info.Size()
+	}
+	p.handleTailerBlock(block)
+	var after int64
+	if info, err := os.Stat(ledgerPath); err == nil {
+		after = info.Size()
+	}
+	if after <= before {
+		t.Fatalf("ledger: expected append even when publisher is nil (before=%d after=%d path=%s)",
+			before, after, ledgerPath)
+	}
+}

--- a/internal/engine/tailer_claudecode.go
+++ b/internal/engine/tailer_claudecode.go
@@ -63,6 +63,12 @@ type claudeCodeLogLine struct {
 	ToolUse    json.RawMessage `json:"tool_use"`
 	ToolResult json.RawMessage `json:"tool_result"`
 	Type       string          `json:"type"`
+	// SessionID is Claude Code's per-conversation UUID. Every JSONL line
+	// carries it as the top-level `sessionId` field and it matches the
+	// filename stem of the JSONL log. We propagate it onto the normalized
+	// CogBlock so handleTailerBlock can publish to channel.<sid>.activity
+	// (Phase 1A of the 4E cognitive-observer loop).
+	SessionID string `json:"sessionId"`
 }
 
 func normalizeClaudeCodeLine(line []byte) (CogBlock, error) {
@@ -80,9 +86,12 @@ func normalizeClaudeCodeLine(line []byte) (CogBlock, error) {
 	content := parseClaudeCodeContent(entry.Content)
 	role := strings.TrimSpace(entry.Role)
 
+	sessionID := strings.TrimSpace(entry.SessionID)
+
 	block := CogBlock{
 		ID:              uuid.New().String(),
 		Timestamp:       blockTime,
+		SessionID:       sessionID,
 		SourceChannel:   claudeCodeSourceChannel,
 		SourceTransport: "jsonl",
 		SourceIdentity:  role,
@@ -93,6 +102,7 @@ func normalizeClaudeCodeLine(line []byte) (CogBlock, error) {
 			Content: content,
 		}},
 		Provenance: BlockProvenance{
+			OriginSession: sessionID,
 			OriginChannel: claudeCodeSourceChannel,
 			IngestedAt:    now,
 			NormalizedBy:  claudeCodeNormalizedBy,


### PR DESCRIPTION
## Summary

Phase 1A of the 4E ambient-awareness loop closure. Tailer blocks now fan out to `channel.<sid>.activity` in addition to the global ledger write, giving downstream `UserPromptSubmit` hooks a session-addressable stream to query for per-session peer-awareness packets (Phase 1B follows).

## Change summary (4 files, +350 LoC)

- `internal/engine/tailer_claudecode.go` (+10 LoC) — `claudeCodeLogLine` gains `SessionID` field, propagated from the JSONL `sessionId` onto `CogBlock.SessionID` and `Provenance.OriginSession`
- `internal/engine/process.go` (+98 LoC) — `SessionActivityPublisher` type + setter on `Process`; `handleTailerBlock` extracts `sid` before `RecordBlock` (which would otherwise substitute the kernel's own sessionID on empty), then calls the publisher hook with a minimal summary payload
- `internal/engine/cli.go` (+9 LoC) — wires `process.SetSessionActivityPublisher(server.busSessions.AppendEvent)` after `NewServer`
- `internal/engine/process_tailer_channel_test.go` (+233 LoC) — new test file, 3 tests covering fan-out + skip-on-missing-sid + no-publisher-wired

## Design

- **Channel name**: `channel.<sid>.activity` (dot-separated lowercase per ADR-084)
- **Event type**: `tailer.block`; **payload**: `{kind, source_channel, timestamp, ref}` (ledger remains authoritative for full content)
- **Sid extraction**: `CogBlock.SessionID` primary, `Provenance.OriginSession` fallback; missing sid is a graceful skip (ledger write still happens, debug log emitted)
- **Publisher wiring**: `*BusSessionManager.AppendEvent` — same downstream method `serve_bus.go:handleBusSend` uses; auto-bus-create preserved via `EnsureBus`
- **Field-with-setter pattern** (over package-level global) for test isolation, matching the `Process.SetTRM` precedent

## Test plan

- [x] `go build -tags fts5 ./...` — clean
- [x] `go test -tags fts5 -v -count=1 ./...` — 1295 passed, 0 failed (full tree)
- [x] `gofmt -l` on changed files — clean
- [ ] Follow-up: Phase 1B peer-awareness query surface consumes `channel.<sid>.activity`; hook in cog-workspace (owned by rfc003) renders the packet at `UserPromptSubmit`

## Known follow-ups (not blocking)

- `channel.<sid>.activity` buses accumulate one per observed Claude Code conversation; a later pass should add lifecycle (TTL, prune-on-session-end)
- `ClaudeCodeTailer` single-file vs. directory mode is orthogonal; no dependency