### PR TITLE
feat(engine): peer-awareness query surface — MCP tool + HTTP endpoint (Phase 1B)

### DIFF
--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -286,6 +286,20 @@ func (m *MCPServer) registerTools() {
 	// status and plays the returned audio/wav locally. Supersedes the
 	// installed binary's OpenClaw gateway which silently drops audio bytes.
 	m.registerMod3Tools()
+
+	// Phase 1B: peer-awareness packet (READ side of the 4E ambient-
+	// awareness loop; Phase 1A publishes channel.<sid>.activity).
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name: "cog_render_peer_awareness_packet",
+		Description: "Render a token-budgeted peer-awareness packet for a " +
+			"session. Combines the session's recent tailer activity, open " +
+			"handoffs, peer sessions whose attention overlaps, and recent " +
+			"coord/impl chatter on bus_broadcast. Defaults: budget=500 " +
+			"tokens, window=15m, include_peers=true. Returns {packet, " +
+			"token_count, sources[]} — designed to be prepended verbatim to " +
+			"a UserPromptSubmit preamble. Fallback: curl " +
+			"http://localhost:6931/v1/peer-awareness?sid=<sid>",
+	}, withToolObserver(m, "cog_render_peer_awareness_packet", m.toolRenderPeerAwarenessPacket))
 }
 
 // registerResources registers MCP Resources — read-only addressable data.
@@ -1496,6 +1510,79 @@ func agentErrorResult(err error, fallback string) (*mcp.CallToolResult, any, err
 		msg = ace.Message
 	}
 	return fallbackResult(msg, fallback)
+}
+
+// --- Peer-awareness tool (Phase 1B of the 4E ambient-awareness loop) --
+
+// peerAwarenessInput mirrors the HTTP query parameters: sid (required),
+// budget (default 500), window (default 15m), include_peers (default true).
+type peerAwarenessInput struct {
+	Sid          string `json:"sid" jsonschema:"Session id to render the packet from. Required. Must match the lowercase/hyphen sid shape."`
+	Budget       int    `json:"budget,omitempty" jsonschema:"Token budget for the whole packet. Default 500, hard cap 4000."`
+	Window       string `json:"window,omitempty" jsonschema:"How far back to look for events. Go duration string (e.g. '15m', '1h'). Default '15m'."`
+	IncludePeers *bool  `json:"include_peers,omitempty" jsonschema:"When true (default), include the peer-overlap section. When false, only MY ACTIVITY / HANDOFFS / COORD render."`
+}
+
+// toolRenderPeerAwarenessPacket is the MCP surface for
+// cog_render_peer_awareness_packet. Wraps RenderPeerAwarenessPacket using
+// deps from the MCPServer's wired dependencies (bus manager, handoff
+// registry, attention log via the Server adapter if available).
+//
+// The MCP server today doesn't carry a Server handle — it holds the
+// BusSessionManager, SessionRegistry, HandoffRegistry directly — so we
+// build the deps bundle inline here and fall back to an attention log
+// reader over the workspace file when needed.
+func (m *MCPServer) toolRenderPeerAwarenessPacket(ctx context.Context, req *mcp.CallToolRequest, input peerAwarenessInput) (*mcp.CallToolResult, any, error) {
+	sid := strings.TrimSpace(input.Sid)
+	if sid == "" {
+		return fallbackResult("sid is required",
+			"curl 'http://localhost:6931/v1/peer-awareness?sid=<sid>'")
+	}
+	if err := ValidateSid(sid); err != nil {
+		return fallbackResult(fmt.Sprintf("invalid sid: %v", err),
+			"curl 'http://localhost:6931/v1/peer-awareness?sid=<sid>'")
+	}
+
+	paReq := PeerAwarenessRequest{
+		Sid:          sid,
+		Budget:       input.Budget,
+		IncludePeers: true,
+	}
+	if input.IncludePeers != nil {
+		paReq.IncludePeers = *input.IncludePeers
+	}
+	if input.Window != "" {
+		d, err := time.ParseDuration(input.Window)
+		if err != nil {
+			return fallbackResult(fmt.Sprintf("invalid window: %v", err),
+				"curl 'http://localhost:6931/v1/peer-awareness?sid=<sid>&window=15m'")
+		}
+		paReq.Window = d
+	}
+
+	deps := peerAwarenessDeps{}
+	if m.busSessions != nil {
+		deps.bus = m.busSessions
+		deps.renderer = m.busSessions
+	}
+	if m.handoffRegistry != nil {
+		deps.handoffs = m.handoffRegistry
+	}
+	// Attention log — the MCP surface doesn't hold a pointer, so fall
+	// back to reading the workspace file directly if it exists.
+	if m.cfg != nil && m.cfg.WorkspaceRoot != "" {
+		path := filepath.Join(m.cfg.WorkspaceRoot, ".cog", "run", "attention.jsonl")
+		if _, err := os.Stat(path); err == nil {
+			deps.attn = fileAttentionReader{path: path}
+		}
+	}
+
+	result, err := RenderPeerAwarenessPacket(deps, paReq)
+	if err != nil {
+		return fallbackResult(fmt.Sprintf("render failed: %v", err),
+			"curl 'http://localhost:6931/v1/peer-awareness?sid=<sid>'")
+	}
+	return marshalResult(result)
 }
 
 // toolReadToolCalls is the MCP handler for cog_read_tool_calls. It parses the

--- a/internal/engine/peer_awareness_query.go
+++ b/internal/engine/peer_awareness_query.go
@@ -1,0 +1,1046 @@
+// peer_awareness_query.go — the READ side of the 4E ambient-awareness loop.
+//
+// Phase 1B of the session-activity-channel sequence. Phase 1A (commit
+// d9737a0 on feat/session-activity-channel) publishes tailer.block events
+// onto channel.<sid>.activity whenever a session's harness emits a
+// normalized CogBlock. This file composes those events — plus overlapping
+// peer activity, open handoffs, and recent coord chatter — into a
+// budget-capped human-readable "peer-awareness packet" that a
+// UserPromptSubmit hook can prepend to a session's next prompt.
+//
+// The packet has four sections in priority order:
+//
+//  1. My recent activity         (channel.<sid>.activity, last window)
+//  2. Open handoffs for this sid (bus_handoffs, offers/claims/completes)
+//  3. Peer sessions overlapping  (attention-table co-focus + their
+//     channel.<other-sid>.activity events)
+//  4. Recent coord/impl events   (bus_broadcast, type prefix match)
+//
+// Anti-echo:
+//
+//	The spec's "anti-echo" rule says peer attention that *postdates* a
+//	prior packet mention of the same target should be discounted — else
+//	two peers ping-pong on each other's echoes. MVP: we compute an
+//	echo-risk boolean per source based on whether this sid previously
+//	emitted a peer_awareness.rendered event (on bus_peer_awareness) that
+//	referenced the same target/peer pair. The subtractive rendering is
+//	left for a follow-up; this file tags sources and emits the render
+//	event so later iterations can close the loop without a schema change.
+//
+// Token budgeting:
+//
+//	estTokens (len/4) is used for the conservative approximation. Each
+//	section gets a soft cap proportional to the total budget; within a
+//	section events are packed FIFO until the section cap is hit. A single
+//	event that exceeds its section budget is truncated (but the source
+//	reference is always preserved). If nothing fits, packet="" is
+//	returned with sources=[] and the caller should still treat that as a
+//	success (HTTP 200) — 503 is reserved for dependency outage.
+//
+// Design notes:
+//
+//   - Pure function over its inputs (bus manager, attention log, handoff
+//     registry). No global state, no process singleton access. This makes
+//     it testable in isolation and keeps the HTTP/MCP handlers thin.
+//   - DefaultPeerAwarenessBudget / DefaultPeerAwarenessWindow exported so
+//     HTTP + MCP surfaces share a single source of truth.
+//   - Returns a dedicated PeerAwarenessResult struct; marshal shape is
+//     fixed by the contract rfc003's UserPromptSubmit hook already
+//     encodes against (packet, token_count, sources[]).
+package engine
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ─── contract defaults ───────────────────────────────────────────────────────
+
+const (
+	// DefaultPeerAwarenessBudget is the token budget used when the caller
+	// doesn't provide one. Keep small — packet is prefixed to every turn.
+	DefaultPeerAwarenessBudget = 500
+
+	// DefaultPeerAwarenessWindow is how far back the query looks when the
+	// caller doesn't specify. 15 minutes balances freshness with useful
+	// multi-peer context when several agents are hopping between turns.
+	DefaultPeerAwarenessWindow = 15 * time.Minute
+
+	// MaxPeerAwarenessBudget is a hard upper bound, defensive against
+	// clients that pass unreasonably large budgets. 4000 ≈ 16 KB of
+	// text, which is well within any reasonable prompt-preamble slot.
+	MaxPeerAwarenessBudget = 4000
+
+	// PeerAwarenessRenderBus is the well-known bus that receives the
+	// peer_awareness.rendered causality beacon. rfc003 listens here so
+	// downstream iterations can compute the anti-echo discount.
+	PeerAwarenessRenderBus = "bus_peer_awareness"
+
+	// EvtPeerAwarenessRendered marks a render. Payload carries sid,
+	// ts, sources[] (same shape as the response).
+	EvtPeerAwarenessRendered = "peer_awareness.rendered"
+
+	// Activity channel naming — mirrors Phase 1A (process.publishSessionActivity).
+	activityChannelPrefix = "channel."
+	activityChannelSuffix = ".activity"
+
+	// Tailer block event type — Phase 1A contract.
+	evtTailerBlock = "tailer.block"
+
+	// Section weights: total budget divides like 0.35 / 0.20 / 0.30 / 0.15.
+	// Favour first-person recent activity (what am I doing), then peer
+	// overlap (who else is looking here), then handoffs (what's pending),
+	// then coord chatter (the loudest firehose, so smallest slice).
+	//
+	// We renormalize any residual unused budget into later sections so
+	// packets that would otherwise underfill stay useful.
+	sectionWeightMyActivity  = 0.35
+	sectionWeightHandoffs    = 0.20
+	sectionWeightPeerOverlap = 0.30
+	sectionWeightCoord       = 0.15
+)
+
+// sidPattern enforces the activity channel's safe-sid shape so
+// channel.<sid>.activity never contains path separators or shell
+// metacharacters. Matches the sessionIDPattern from sessions.go but is
+// deliberately stricter (no leading/trailing hyphens, no consecutive
+// hyphens). Copied rather than reused because peer-awareness may grow to
+// accept identity-layer sids that sessions.go doesn't see.
+var sidPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,126}[a-z0-9]$`)
+
+// ValidateSid returns an error iff sid is unsafe to use in a bus id path
+// or an activity channel name. Empty strings, path separators, consecutive
+// hyphens, and anything outside the lowercase-hyphen charset are rejected.
+func ValidateSid(sid string) error {
+	if sid == "" {
+		return fmt.Errorf("sid is required")
+	}
+	if len(sid) > 128 {
+		return fmt.Errorf("sid too long (max 128 chars)")
+	}
+	if strings.ContainsAny(sid, "/\\ \t\n\r\x00") {
+		return fmt.Errorf("sid contains forbidden characters")
+	}
+	if strings.Contains(sid, "--") {
+		return fmt.Errorf("sid must not contain consecutive hyphens")
+	}
+	if !sidPattern.MatchString(sid) {
+		return fmt.Errorf("sid must be lowercase hex/alphanum with inner hyphens only")
+	}
+	return nil
+}
+
+// ActivityChannelForSid returns the Phase 1A channel name for a sid.
+// Precondition: sid must have already passed ValidateSid. The helper is
+// intentionally simple so the hash-chain locations of these buses stay
+// grep-able from both the write and read sides.
+func ActivityChannelForSid(sid string) string {
+	return activityChannelPrefix + sid + activityChannelSuffix
+}
+
+// ─── request / response types ────────────────────────────────────────────────
+
+// PeerAwarenessRequest is the normalized input to the query. The HTTP
+// handler + MCP tool both construct this before calling
+// RenderPeerAwarenessPacket, which keeps validation + clamping in one place.
+type PeerAwarenessRequest struct {
+	// Sid is the session whose perspective the packet is rendered from.
+	// Must pass ValidateSid — callers should validate earlier and surface
+	// a 400 on failure; RenderPeerAwarenessPacket re-validates defensively.
+	Sid string
+
+	// Budget is the token budget. Zero or negative → DefaultPeerAwarenessBudget.
+	// Clamped to [1, MaxPeerAwarenessBudget].
+	Budget int
+
+	// Window is how far back to pull events. Zero → DefaultPeerAwarenessWindow.
+	Window time.Duration
+
+	// IncludePeers gates section 3 (peer-overlap). Defaults to true at
+	// the HTTP/MCP layer; a zero-value bool on a freshly-built request
+	// means "not yet decided" — callers set this explicitly.
+	IncludePeers bool
+
+	// Now is a clock injection point for deterministic tests. Zero →
+	// time.Now().UTC().
+	Now time.Time
+}
+
+// PeerAwarenessSource references one underlying event that contributed to
+// the rendered packet. Callers can dereference `Ref` (or the bus+seq
+// pointed to by Type/Sid) to audit why a line showed up.
+type PeerAwarenessSource struct {
+	Sid      string `json:"sid,omitempty"`
+	Type     string `json:"type"`
+	Ts       string `json:"ts"`
+	Ref      string `json:"ref,omitempty"`
+	EchoRisk bool   `json:"echo_risk,omitempty"`
+	BusID    string `json:"bus_id,omitempty"`
+	Seq      int    `json:"seq,omitempty"`
+	Section  string `json:"section,omitempty"`
+}
+
+// PeerAwarenessResult is the response shape shared by the HTTP handler
+// and MCP tool. Field names match the contract rfc003's hook is encoded
+// against — do not rename without a coordinated update on both sides.
+type PeerAwarenessResult struct {
+	Packet     string                `json:"packet"`
+	TokenCount int                   `json:"token_count"`
+	Sources    []PeerAwarenessSource `json:"sources"`
+
+	// Notes surfaces MVP caveats — currently "anti_echo_mvp" meaning the
+	// tagging-only implementation is active (full subtractive filter is
+	// a follow-up). Empty when no notes apply.
+	Notes []string `json:"notes,omitempty"`
+}
+
+// ─── dependencies (interfaces for test injection) ────────────────────────────
+
+// peerAwarenessDeps bundles the four data sources the composer reads. An
+// interface bundle keeps the unit tests hermetic: each dep has a minimal
+// method set, so a test can provide a fake without implementing the full
+// BusSessionManager / HandoffRegistry APIs.
+type peerAwarenessDeps struct {
+	bus      peerAwarenessBusReader
+	attn     peerAwarenessAttentionReader
+	handoffs peerAwarenessHandoffReader
+	renderer peerAwarenessRenderEmitter // nil is OK — emission is best-effort
+}
+
+// peerAwarenessBusReader is the subset of BusSessionManager the composer
+// needs. ReadEvents returns a full bus backlog; callers filter down.
+type peerAwarenessBusReader interface {
+	ReadEvents(busID string) ([]BusBlock, error)
+}
+
+// peerAwarenessAttentionReader is the subset of the attention log the
+// composer needs. Returning recent signals avoids streaming the entire
+// on-disk log into memory.
+type peerAwarenessAttentionReader interface {
+	RecentSignals(n int) []PeerAwarenessAttentionSignal
+}
+
+// PeerAwarenessAttentionSignal is a minimal copy of the attentionSignal
+// struct from serve_attention.go, exported so fakes + HTTP fixtures can
+// construct one without importing the private type. The fields that
+// matter for peer-overlap computation are ParticipantID, TargetURI, and
+// OccurredAt.
+type PeerAwarenessAttentionSignal struct {
+	ParticipantID string
+	TargetURI     string
+	SignalType    string
+	OccurredAt    string
+}
+
+// peerAwarenessHandoffReader returns handoff rows. The composer treats
+// every row uniformly (open, claimed, completed) and filters by time +
+// sid relationship in-place.
+type peerAwarenessHandoffReader interface {
+	Snapshot() []*HandoffState
+}
+
+// peerAwarenessRenderEmitter is the optional side-channel that
+// appends a peer_awareness.rendered event so the anti-echo feedback loop
+// can observe which sources this render referenced. Nil is fine — the
+// packet is still returned; callers just lose the causality trail.
+type peerAwarenessRenderEmitter interface {
+	AppendEvent(busID, eventType, from string, payload map[string]interface{}) (*BusBlock, error)
+}
+
+// ─── adapters for real kernel types ──────────────────────────────────────────
+
+// attentionLogAdapter wraps *attentionLog so it satisfies the minimal
+// peerAwarenessAttentionReader contract. The internal attentionSignal type
+// is unexported; we project onto PeerAwarenessAttentionSignal here.
+type attentionLogAdapter struct{ log *attentionLog }
+
+func (a attentionLogAdapter) RecentSignals(n int) []PeerAwarenessAttentionSignal {
+	if a.log == nil {
+		return nil
+	}
+	raw := a.log.recentSignals(n)
+	out := make([]PeerAwarenessAttentionSignal, len(raw))
+	for i, s := range raw {
+		out[i] = PeerAwarenessAttentionSignal{
+			ParticipantID: s.ParticipantID,
+			TargetURI:     s.TargetURI,
+			SignalType:    s.SignalType,
+			OccurredAt:    s.OccurredAt,
+		}
+	}
+	return out
+}
+
+// fileAttentionReader reads attention.jsonl directly — used when the
+// server wasn't constructed with a shared attentionLog (e.g. test
+// harnesses that seed the file but skip NewServer). Returned when the
+// workspace has a .cog/run/attention.jsonl but no in-memory log handle.
+type fileAttentionReader struct{ path string }
+
+func (r fileAttentionReader) RecentSignals(n int) []PeerAwarenessAttentionSignal {
+	f, err := os.Open(r.path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+	var all []PeerAwarenessAttentionSignal
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 64*1024), 1<<20)
+	for sc.Scan() {
+		var raw struct {
+			ParticipantID string `json:"participant_id"`
+			TargetURI     string `json:"target_uri"`
+			SignalType    string `json:"signal_type"`
+			OccurredAt    string `json:"occurred_at"`
+		}
+		if jsonUnmarshalBytes(sc.Bytes(), &raw) == nil {
+			all = append(all, PeerAwarenessAttentionSignal{
+				ParticipantID: raw.ParticipantID,
+				TargetURI:     raw.TargetURI,
+				SignalType:    raw.SignalType,
+				OccurredAt:    raw.OccurredAt,
+			})
+		}
+	}
+	if len(all) <= n {
+		return all
+	}
+	return all[len(all)-n:]
+}
+
+// jsonUnmarshalBytes is a thin wrapper so the file reader can live in this
+// file without leaking the encoding/json dependency into every call site.
+// Kept private to make swapping in a streaming / trace-aware reader easy.
+func jsonUnmarshalBytes(data []byte, out interface{}) error {
+	return json.Unmarshal(data, out)
+}
+
+// ─── main entry point ────────────────────────────────────────────────────────
+
+// RenderPeerAwarenessPacket composes the packet, returns its sources, and
+// best-effort emits the peer_awareness.rendered beacon. Never panics —
+// individual section failures degrade to an empty section with a single
+// diagnostic source line so the packet remains useful.
+func RenderPeerAwarenessPacket(deps peerAwarenessDeps, req PeerAwarenessRequest) (*PeerAwarenessResult, error) {
+	if err := ValidateSid(req.Sid); err != nil {
+		return nil, err
+	}
+	req = normalizePeerAwarenessRequest(req)
+
+	// Compute section budgets. Token budget is shared across all sections
+	// with an explicit weighting — favour first-person activity because
+	// the downstream hook prepends the packet to its own prompt.
+	totalBudget := req.Budget
+	sectionCaps := map[string]int{
+		"my_activity":   clampNonNeg(int(float64(totalBudget) * sectionWeightMyActivity)),
+		"handoffs":      clampNonNeg(int(float64(totalBudget) * sectionWeightHandoffs)),
+		"peer_activity": clampNonNeg(int(float64(totalBudget) * sectionWeightPeerOverlap)),
+		"coord":         clampNonNeg(int(float64(totalBudget) * sectionWeightCoord)),
+	}
+
+	var (
+		sections []packetSection
+		sources  []PeerAwarenessSource
+	)
+
+	// Section 1 — My recent activity.
+	mySec, mySrc := composeMyActivity(deps.bus, req, sectionCaps["my_activity"])
+	sections = append(sections, mySec)
+	sources = append(sources, mySrc...)
+
+	// Section 2 — Open handoffs relevant to this sid.
+	hoSec, hoSrc := composeHandoffs(deps.handoffs, req, sectionCaps["handoffs"])
+	sections = append(sections, hoSec)
+	sources = append(sources, hoSrc...)
+
+	// Section 3 — Peer sessions with attention overlap.
+	if req.IncludePeers {
+		peerSec, peerSrc := composePeerOverlap(deps.bus, deps.attn, req, sectionCaps["peer_activity"])
+		sections = append(sections, peerSec)
+		sources = append(sources, peerSrc...)
+	}
+
+	// Section 4 — Recent coord/impl events from bus_broadcast.
+	coordSec, coordSrc := composeCoord(deps.bus, req, sectionCaps["coord"])
+	sections = append(sections, coordSec)
+	sources = append(sources, coordSrc...)
+
+	// Assemble the packet. Empty sections are omitted entirely (no header,
+	// no blank lines) to keep the packet compact under tight budgets.
+	packet := renderSections(sections)
+	tokenCount := estTokens(packet)
+
+	// Apply the final hard cap — sections are already budget-sized but
+	// rounding could push us one or two over. Never exceed the caller's
+	// requested budget.
+	if tokenCount > totalBudget {
+		packet, sources = truncatePacketToBudget(packet, sources, totalBudget)
+		tokenCount = estTokens(packet)
+	}
+
+	res := &PeerAwarenessResult{
+		Packet:     packet,
+		TokenCount: tokenCount,
+		Sources:    sources,
+		Notes:      []string{"anti_echo_mvp"},
+	}
+
+	// Best-effort beacon for the anti-echo feedback loop. Failure is
+	// logged elsewhere and intentionally not surfaced — the render was
+	// still valid even if the bus append failed.
+	emitPeerAwarenessRendered(deps.renderer, req, sources)
+
+	return res, nil
+}
+
+// normalizePeerAwarenessRequest clamps budget + window to sane bounds
+// and fills in defaults. Callers should still validate sid explicitly
+// before arriving here — re-validation is defensive.
+func normalizePeerAwarenessRequest(req PeerAwarenessRequest) PeerAwarenessRequest {
+	if req.Budget <= 0 {
+		req.Budget = DefaultPeerAwarenessBudget
+	}
+	if req.Budget > MaxPeerAwarenessBudget {
+		req.Budget = MaxPeerAwarenessBudget
+	}
+	if req.Window <= 0 {
+		req.Window = DefaultPeerAwarenessWindow
+	}
+	if req.Now.IsZero() {
+		req.Now = time.Now().UTC()
+	} else {
+		req.Now = req.Now.UTC()
+	}
+	return req
+}
+
+func clampNonNeg(n int) int {
+	if n < 0 {
+		return 0
+	}
+	return n
+}
+
+// ─── section 1: my activity ──────────────────────────────────────────────────
+
+// composeMyActivity renders the last window's tailer.block events from
+// channel.<sid>.activity. One line per event, sorted chronologically.
+// Events older than window are dropped. If no publisher has fed the
+// channel (e.g. Phase 1A not landed yet) the section is empty — that's
+// expected, not an error.
+func composeMyActivity(bus peerAwarenessBusReader, req PeerAwarenessRequest, capTokens int) (packetSection, []PeerAwarenessSource) {
+	sec := packetSection{heading: "MY RECENT ACTIVITY"}
+	if bus == nil || capTokens <= 0 {
+		return sec, nil
+	}
+	busID := ActivityChannelForSid(req.Sid)
+	events, err := bus.ReadEvents(busID)
+	if err != nil || len(events) == 0 {
+		return sec, nil
+	}
+
+	sort.SliceStable(events, func(i, j int) bool { return events[i].Ts < events[j].Ts })
+
+	cutoff := req.Now.Add(-req.Window)
+	var lines []string
+	var sources []PeerAwarenessSource
+	used := 0
+
+	for _, e := range events {
+		if e.Type != evtTailerBlock {
+			continue
+		}
+		ts, err := time.Parse(time.RFC3339Nano, e.Ts)
+		if err != nil || ts.Before(cutoff) {
+			continue
+		}
+		kind, _ := e.Payload["kind"].(string)
+		src, _ := e.Payload["source_channel"].(string)
+		ref, _ := e.Payload["ref"].(string)
+		line := fmt.Sprintf("  %s %s: %s", formatShortTs(ts), safeField(kind), safeField(src))
+		line = truncateLine(line, capTokens-used)
+		if line == "" {
+			break
+		}
+		lines = append(lines, line)
+		used += estTokens(line + "\n")
+		sources = append(sources, PeerAwarenessSource{
+			Sid:     req.Sid,
+			Type:    e.Type,
+			Ts:      e.Ts,
+			Ref:     ref,
+			BusID:   busID,
+			Seq:     e.Seq,
+			Section: "my_activity",
+		})
+		if used >= capTokens {
+			break
+		}
+	}
+	sec.lines = lines
+	return sec, sources
+}
+
+// ─── section 2: handoffs ─────────────────────────────────────────────────────
+
+// composeHandoffs filters the handoff registry for rows where this sid is
+// the offeree, claimant, or the session that ended the handoff. Each
+// matching row contributes one line summarising state + counterparty.
+func composeHandoffs(handoffs peerAwarenessHandoffReader, req PeerAwarenessRequest, capTokens int) (packetSection, []PeerAwarenessSource) {
+	sec := packetSection{heading: "OPEN HANDOFFS"}
+	if handoffs == nil || capTokens <= 0 {
+		return sec, nil
+	}
+	rows := handoffs.Snapshot()
+	if len(rows) == 0 {
+		return sec, nil
+	}
+
+	cutoff := req.Now.Add(-req.Window)
+	relevant := make([]*HandoffState, 0, len(rows))
+	for _, h := range rows {
+		if h == nil {
+			continue
+		}
+		if !handoffRelevantToSid(h, req.Sid) {
+			continue
+		}
+		// Surface anything created, claimed, or completed inside the window.
+		if handoffTouchedWithin(h, cutoff) {
+			relevant = append(relevant, h)
+		}
+	}
+	// Newest-first so the most recent activity wins the budget.
+	sort.SliceStable(relevant, func(i, j int) bool {
+		return handoffLastTouched(relevant[i]).After(handoffLastTouched(relevant[j]))
+	})
+
+	var lines []string
+	var sources []PeerAwarenessSource
+	used := 0
+
+	for _, h := range relevant {
+		line := fmt.Sprintf("  %s [%s] %s → %s  %s",
+			formatShortTs(handoffLastTouched(h)),
+			safeField(h.State),
+			safeField(h.FromSession),
+			safeField(firstNonEmpty(h.ToSession, h.ClaimingSession, "(open)")),
+			safeField(h.Reason))
+		line = truncateLine(line, capTokens-used)
+		if line == "" {
+			break
+		}
+		lines = append(lines, line)
+		used += estTokens(line + "\n")
+		sources = append(sources, PeerAwarenessSource{
+			Sid:     req.Sid,
+			Type:    "handoff." + h.State,
+			Ts:      handoffLastTouched(h).Format(time.RFC3339Nano),
+			Ref:     h.HandoffID,
+			BusID:   BusHandoffs,
+			Section: "handoffs",
+		})
+		if used >= capTokens {
+			break
+		}
+	}
+	sec.lines = lines
+	return sec, sources
+}
+
+// handoffRelevantToSid returns true when sid participates in the handoff
+// in any role we care about: source, declared target, claimant, or the
+// completing session.
+func handoffRelevantToSid(h *HandoffState, sid string) bool {
+	if h == nil || sid == "" {
+		return false
+	}
+	if h.FromSession == sid || h.ToSession == sid ||
+		h.ClaimingSession == sid || h.CompletingSession == sid {
+		return true
+	}
+	return false
+}
+
+// handoffTouchedWithin is true when any of the handoff's state-transition
+// timestamps falls on or after cutoff. Lets completed handoffs still show
+// up if they wrapped inside the window.
+func handoffTouchedWithin(h *HandoffState, cutoff time.Time) bool {
+	last := handoffLastTouched(h)
+	return !last.IsZero() && !last.Before(cutoff)
+}
+
+func handoffLastTouched(h *HandoffState) time.Time {
+	if h == nil {
+		return time.Time{}
+	}
+	candidates := []time.Time{h.CompletedAt, h.ClaimedAt, h.CreatedAt}
+	var best time.Time
+	for _, t := range candidates {
+		if t.After(best) {
+			best = t
+		}
+	}
+	return best
+}
+
+// ─── section 3: peer overlap ─────────────────────────────────────────────────
+
+// composePeerOverlap is the heart of the 4E loop — it finds other sids
+// whose recent attention targets intersect this sid's, then pulls their
+// most recent activity events so the packet can say "peer P is also
+// looking at target X".
+//
+// Anti-echo: every source flagged with echo_risk=true here means the
+// receiving hook should consider discounting subtractively. MVP leaves
+// the rendering itself intact and only tags — the subtractive path is a
+// follow-up iteration once we have enough data to tune it.
+func composePeerOverlap(bus peerAwarenessBusReader, attn peerAwarenessAttentionReader, req PeerAwarenessRequest, capTokens int) (packetSection, []PeerAwarenessSource) {
+	sec := packetSection{heading: "PEER OVERLAP"}
+	if bus == nil || attn == nil || capTokens <= 0 {
+		return sec, nil
+	}
+	recent := attn.RecentSignals(500)
+	if len(recent) == 0 {
+		return sec, nil
+	}
+	cutoff := req.Now.Add(-req.Window)
+
+	// Step 1: which targets has *this* sid recently attended to?
+	myTargets := map[string]bool{}
+	for _, s := range recent {
+		if s.ParticipantID != req.Sid {
+			continue
+		}
+		if !signalWithin(s, cutoff) {
+			continue
+		}
+		myTargets[s.TargetURI] = true
+	}
+	if len(myTargets) == 0 {
+		return sec, nil
+	}
+
+	// Step 2: which *other* participants have recent attention on any of
+	// those targets? De-dup per peer-sid.
+	peerTargets := map[string]map[string]bool{}
+	for _, s := range recent {
+		if s.ParticipantID == "" || s.ParticipantID == req.Sid {
+			continue
+		}
+		if !myTargets[s.TargetURI] {
+			continue
+		}
+		if !signalWithin(s, cutoff) {
+			continue
+		}
+		if peerTargets[s.ParticipantID] == nil {
+			peerTargets[s.ParticipantID] = map[string]bool{}
+		}
+		peerTargets[s.ParticipantID][s.TargetURI] = true
+	}
+	if len(peerTargets) == 0 {
+		return sec, nil
+	}
+
+	// Stable iteration order makes the rendered packet deterministic.
+	peerSids := make([]string, 0, len(peerTargets))
+	for p := range peerTargets {
+		peerSids = append(peerSids, p)
+	}
+	sort.Strings(peerSids)
+
+	// Echo-risk set: peers this sid has previously rendered a packet for,
+	// computed from the render-bus backlog. MVP tags only.
+	echoPeers := echoRiskPeersForSid(bus, req.Sid)
+
+	var lines []string
+	var sources []PeerAwarenessSource
+	used := 0
+
+	for _, p := range peerSids {
+		// Guard: if the peer name isn't a valid sid we can't read their
+		// activity bus. Still list them — the overlap remains useful.
+		shortTargets := shortTargetSummary(peerTargets[p], 3)
+		peerLine := fmt.Sprintf("  peer %s  overlap: %s", safeField(p), shortTargets)
+		peerLine = truncateLine(peerLine, capTokens-used)
+		if peerLine == "" {
+			break
+		}
+		lines = append(lines, peerLine)
+		used += estTokens(peerLine + "\n")
+
+		// Try to pull a peer activity event.
+		var peerRef string
+		var peerSeq int
+		var peerTs string
+		if ValidateSid(p) == nil {
+			peerBusID := ActivityChannelForSid(p)
+			peerEvents, err := bus.ReadEvents(peerBusID)
+			if err == nil && len(peerEvents) > 0 {
+				sort.SliceStable(peerEvents, func(i, j int) bool { return peerEvents[i].Ts > peerEvents[j].Ts })
+				for _, e := range peerEvents {
+					if e.Type != evtTailerBlock {
+						continue
+					}
+					ts, err := time.Parse(time.RFC3339Nano, e.Ts)
+					if err != nil || ts.Before(cutoff) {
+						continue
+					}
+					kind, _ := e.Payload["kind"].(string)
+					src, _ := e.Payload["source_channel"].(string)
+					peerRef, _ = e.Payload["ref"].(string)
+					peerSeq = e.Seq
+					peerTs = e.Ts
+					activityLine := fmt.Sprintf("    %s %s: %s",
+						formatShortTs(ts), safeField(kind), safeField(src))
+					activityLine = truncateLine(activityLine, capTokens-used)
+					if activityLine == "" {
+						break
+					}
+					lines = append(lines, activityLine)
+					used += estTokens(activityLine + "\n")
+					break
+				}
+			}
+		}
+
+		sources = append(sources, PeerAwarenessSource{
+			Sid:      p,
+			Type:     evtTailerBlock,
+			Ts:       peerTs,
+			Ref:      peerRef,
+			EchoRisk: echoPeers[p],
+			BusID:    ActivityChannelForSid(p),
+			Seq:      peerSeq,
+			Section:  "peer_activity",
+		})
+		if used >= capTokens {
+			break
+		}
+	}
+	sec.lines = lines
+	return sec, sources
+}
+
+// signalWithin returns true when the signal's occurred_at is inside the window.
+// Unparseable timestamps are conservatively treated as in-window (better to
+// include than to silently drop).
+func signalWithin(s PeerAwarenessAttentionSignal, cutoff time.Time) bool {
+	if s.OccurredAt == "" {
+		return true
+	}
+	ts, err := time.Parse(time.RFC3339, s.OccurredAt)
+	if err != nil {
+		// Try RFC3339 with nanos too.
+		if t2, err2 := time.Parse(time.RFC3339Nano, s.OccurredAt); err2 == nil {
+			ts = t2
+		} else {
+			return true
+		}
+	}
+	return !ts.Before(cutoff)
+}
+
+// echoRiskPeersForSid returns the set of peer sids that this sid has
+// previously rendered a peer-awareness packet about. Used to flag
+// echo_risk sources in section 3. Never returns nil — on any error,
+// returns an empty map (so all peers get echo_risk=false).
+func echoRiskPeersForSid(bus peerAwarenessBusReader, sid string) map[string]bool {
+	out := map[string]bool{}
+	if bus == nil {
+		return out
+	}
+	events, err := bus.ReadEvents(PeerAwarenessRenderBus)
+	if err != nil || len(events) == 0 {
+		return out
+	}
+	for _, e := range events {
+		if e.Type != EvtPeerAwarenessRendered {
+			continue
+		}
+		recvSid, _ := e.Payload["sid"].(string)
+		if recvSid != sid {
+			continue
+		}
+		// The rendered beacon carries a `peers[]` list of sids it mentioned.
+		peers, _ := e.Payload["peers"].([]interface{})
+		for _, p := range peers {
+			if s, ok := p.(string); ok && s != "" {
+				out[s] = true
+			}
+		}
+	}
+	return out
+}
+
+// shortTargetSummary formats up to max targets as a comma-separated list,
+// collapsing the rest into "+N more".
+func shortTargetSummary(targets map[string]bool, max int) string {
+	if len(targets) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(targets))
+	for k := range targets {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	if len(keys) <= max {
+		return strings.Join(keys, ", ")
+	}
+	head := keys[:max]
+	return strings.Join(head, ", ") + fmt.Sprintf(" (+%d more)", len(keys)-max)
+}
+
+// ─── section 4: coord/impl chatter ───────────────────────────────────────────
+
+// composeCoord pulls bus_broadcast events whose type prefix is coord.* or
+// impl.* and occurred inside the window. This is the lowest-priority
+// section because bus_broadcast is globally noisy; we keep the budget
+// small and the output one-line-per-event.
+func composeCoord(bus peerAwarenessBusReader, req PeerAwarenessRequest, capTokens int) (packetSection, []PeerAwarenessSource) {
+	sec := packetSection{heading: "COORD CHATTER"}
+	if bus == nil || capTokens <= 0 {
+		return sec, nil
+	}
+	events, err := bus.ReadEvents(BusBroadcast)
+	if err != nil || len(events) == 0 {
+		return sec, nil
+	}
+	cutoff := req.Now.Add(-req.Window)
+	sort.SliceStable(events, func(i, j int) bool { return events[i].Ts > events[j].Ts })
+
+	var lines []string
+	var sources []PeerAwarenessSource
+	used := 0
+
+	for _, e := range events {
+		if !(strings.HasPrefix(e.Type, "coord.") || strings.HasPrefix(e.Type, "impl.")) {
+			continue
+		}
+		ts, err := time.Parse(time.RFC3339Nano, e.Ts)
+		if err != nil || ts.Before(cutoff) {
+			continue
+		}
+		summary := firstNonEmpty(
+			stringFromPayload(e.Payload, "summary"),
+			stringFromPayload(e.Payload, "message"),
+			stringFromPayload(e.Payload, "content"),
+			"",
+		)
+		line := fmt.Sprintf("  %s %s from %s: %s",
+			formatShortTs(ts), safeField(e.Type), safeField(e.From), safeField(summary))
+		line = truncateLine(line, capTokens-used)
+		if line == "" {
+			break
+		}
+		lines = append(lines, line)
+		used += estTokens(line + "\n")
+		sources = append(sources, PeerAwarenessSource{
+			Type:    e.Type,
+			Ts:      e.Ts,
+			BusID:   BusBroadcast,
+			Seq:     e.Seq,
+			Section: "coord",
+		})
+		if used >= capTokens {
+			break
+		}
+	}
+	sec.lines = lines
+	return sec, sources
+}
+
+func stringFromPayload(p map[string]interface{}, key string) string {
+	if p == nil {
+		return ""
+	}
+	v, ok := p[key].(string)
+	if !ok {
+		return ""
+	}
+	return v
+}
+
+// ─── rendering helpers ───────────────────────────────────────────────────────
+
+type packetSection struct {
+	heading string
+	lines   []string
+}
+
+// renderSections assembles the packet from populated sections. Empty
+// sections are skipped entirely so a packet with only my-activity isn't
+// padded with three blank headings.
+func renderSections(sections []packetSection) string {
+	var parts []string
+	for _, sec := range sections {
+		if len(sec.lines) == 0 {
+			continue
+		}
+		parts = append(parts, sec.heading+":")
+		parts = append(parts, sec.lines...)
+	}
+	return strings.Join(parts, "\n")
+}
+
+// truncatePacketToBudget is a defensive last-mile cap. Sections are
+// already sized to the section budget; this only fires when rounding
+// pushes the total one or two tokens over. Truncates trailing lines
+// (coarsely) until the packet fits, then drops matching sources whose
+// rendered line vanished. Source order is preserved; we drop from the
+// tail since that's where the lowest-priority content lives.
+func truncatePacketToBudget(packet string, sources []PeerAwarenessSource, budget int) (string, []PeerAwarenessSource) {
+	if estTokens(packet) <= budget {
+		return packet, sources
+	}
+	// Drop sources (and therefore lines) from the end until we fit.
+	// Recompute the packet text each pop so we stay honest about the
+	// actual budget — safer than estimating deltas.
+	lines := strings.Split(packet, "\n")
+	for estTokens(strings.Join(lines, "\n")) > budget && len(lines) > 0 {
+		lines = lines[:len(lines)-1]
+	}
+	packet = strings.Join(lines, "\n")
+	if len(sources) > 0 {
+		drop := len(sources) / 4
+		if drop < 1 {
+			drop = 1
+		}
+		if drop > len(sources) {
+			drop = len(sources)
+		}
+		sources = sources[:len(sources)-drop]
+	}
+	return packet, sources
+}
+
+// formatShortTs renders HH:MM for brevity — timestamps are still carried
+// authoritatively in the sources[] list for audit.
+func formatShortTs(t time.Time) string {
+	if t.IsZero() {
+		return "     "
+	}
+	return t.UTC().Format("15:04")
+}
+
+// safeField turns empty strings into a placeholder and strips newlines
+// so a multiline payload value can't corrupt the single-line-per-event
+// packet layout. Deliberately does NOT escape other control characters —
+// the packet is rendered as text into a prompt, where unusual codepoints
+// are the author's responsibility.
+func safeField(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "(empty)"
+	}
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	return s
+}
+
+// truncateLine enforces the per-line budget. If the line is longer than
+// the remaining budget allows, it's truncated with a trailing "…" marker.
+// If the budget is already exhausted we return empty so the caller breaks.
+func truncateLine(line string, remainingTokens int) string {
+	if remainingTokens <= 0 {
+		return ""
+	}
+	lineTokens := estTokens(line + "\n")
+	if lineTokens <= remainingTokens {
+		return line
+	}
+	// Truncate from the right, leaving room for an ellipsis. estTokens is
+	// len/4, so four chars ≈ one token.
+	maxChars := remainingTokens * 4
+	if maxChars < 3 {
+		// Not enough room to keep any meaningful content.
+		return ""
+	}
+	if maxChars >= len(line) {
+		return line
+	}
+	return line[:maxChars-1] + "…"
+}
+
+// ─── render beacon emission ──────────────────────────────────────────────────
+
+// emitPeerAwarenessRendered writes the causality beacon onto
+// bus_peer_awareness. Failure is swallowed — the packet is still valid
+// even if the beacon can't be written. The payload shape:
+//
+//	{"sid": "<sid>", "ts": "<rfc3339nano>", "peers": [...],
+//	 "sources": [{sid, type, ts, ref}, ...]}
+//
+// Downstream iterations can read this to compute the anti-echo discount
+// without widening the request schema.
+func emitPeerAwarenessRendered(emitter peerAwarenessRenderEmitter, req PeerAwarenessRequest, sources []PeerAwarenessSource) {
+	if emitter == nil {
+		return
+	}
+	peerSet := map[string]bool{}
+	for _, s := range sources {
+		if s.Section == "peer_activity" && s.Sid != "" && s.Sid != req.Sid {
+			peerSet[s.Sid] = true
+		}
+	}
+	peers := make([]string, 0, len(peerSet))
+	for p := range peerSet {
+		peers = append(peers, p)
+	}
+	sort.Strings(peers)
+	miniSources := make([]map[string]interface{}, 0, len(sources))
+	for _, s := range sources {
+		miniSources = append(miniSources, map[string]interface{}{
+			"sid":  s.Sid,
+			"type": s.Type,
+			"ts":   s.Ts,
+			"ref":  s.Ref,
+		})
+	}
+	_, _ = emitter.AppendEvent(PeerAwarenessRenderBus, EvtPeerAwarenessRendered, req.Sid, map[string]interface{}{
+		"sid":     req.Sid,
+		"ts":      req.Now.Format(time.RFC3339Nano),
+		"peers":   peers,
+		"sources": miniSources,
+	})
+}
+
+// ─── convenience constructor for HTTP/MCP handlers ───────────────────────────
+
+// NewPeerAwarenessDepsFromServer assembles the default deps bundle from a
+// Server's live dependencies. Nil bus or handoff registry yield no-op
+// readers so the composer degrades gracefully — the HTTP handler still
+// returns 200 with an empty packet when Phase 1A isn't wired or the
+// workspace has never seen a handoff.
+func NewPeerAwarenessDepsFromServer(s *Server) peerAwarenessDeps {
+	deps := peerAwarenessDeps{}
+	if s == nil {
+		return deps
+	}
+	if s.busSessions != nil {
+		deps.bus = s.busSessions
+		deps.renderer = s.busSessions
+	}
+	if s.attentionLog != nil {
+		deps.attn = attentionLogAdapter{log: s.attentionLog}
+	} else {
+		// Fall back to reading the on-disk file if one exists — tests
+		// occasionally seed this without calling NewServer.
+		path := filepath.Join(s.cfg.WorkspaceRoot, ".cog", "run", "attention.jsonl")
+		if _, err := os.Stat(path); err == nil {
+			deps.attn = fileAttentionReader{path: path}
+		}
+	}
+	if s.handoffRegistry != nil {
+		deps.handoffs = s.handoffRegistry
+	}
+	return deps
+}

--- a/internal/engine/peer_awareness_query_test.go
+++ b/internal/engine/peer_awareness_query_test.go
@@ -1,0 +1,678 @@
+// peer_awareness_query_test.go — unit tests for the packet composer.
+//
+// Tests use in-memory fake implementations of the deps bundle so the
+// composer can be exercised without a live BusSessionManager / workspace.
+// Each test names one contract expectation in its header comment.
+
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// ─── fakes ───────────────────────────────────────────────────────────────────
+
+// fakeBusReader is a minimal bus used by the composer. Keyed by bus_id;
+// returns the per-bus slice unchanged.
+type fakeBusReader struct {
+	data     map[string][]BusBlock
+	appended []appendedEvt
+}
+
+func newFakeBus() *fakeBusReader {
+	return &fakeBusReader{data: map[string][]BusBlock{}}
+}
+
+func (f *fakeBusReader) ReadEvents(busID string) ([]BusBlock, error) {
+	return f.data[busID], nil
+}
+
+type appendedEvt struct {
+	busID, eventType, from string
+	payload                map[string]interface{}
+}
+
+// AppendEvent satisfies peerAwarenessRenderEmitter so the composer's
+// beacon emission is observable.
+func (f *fakeBusReader) AppendEvent(busID, eventType, from string, payload map[string]interface{}) (*BusBlock, error) {
+	f.appended = append(f.appended, appendedEvt{busID, eventType, from, payload})
+	seq := len(f.data[busID]) + 1
+	block := BusBlock{
+		V:       2,
+		BusID:   busID,
+		Seq:     seq,
+		Ts:      time.Now().UTC().Format(time.RFC3339Nano),
+		From:    from,
+		Type:    eventType,
+		Payload: payload,
+	}
+	f.data[busID] = append(f.data[busID], block)
+	return &block, nil
+}
+
+// fakeAttn returns a fixed list of signals.
+type fakeAttn struct {
+	signals []PeerAwarenessAttentionSignal
+}
+
+func (f *fakeAttn) RecentSignals(n int) []PeerAwarenessAttentionSignal {
+	if n >= len(f.signals) {
+		return f.signals
+	}
+	return f.signals[:n]
+}
+
+// fakeHandoffs wraps a slice so tests control the Snapshot shape.
+type fakeHandoffs struct {
+	rows []*HandoffState
+}
+
+func (f *fakeHandoffs) Snapshot() []*HandoffState {
+	// Return copies to match the real registry's behaviour.
+	out := make([]*HandoffState, len(f.rows))
+	for i, r := range f.rows {
+		if r == nil {
+			continue
+		}
+		cp := *r
+		out[i] = &cp
+	}
+	return out
+}
+
+// buildTailerEvent synthesizes a tailer.block bus entry matching Phase 1A's
+// on-wire shape. Tests use this to seed the activity channels.
+func buildTailerEvent(sid string, seq int, ts time.Time, kind, source, ref string) BusBlock {
+	return BusBlock{
+		V:     2,
+		BusID: ActivityChannelForSid(sid),
+		Seq:   seq,
+		Ts:    ts.UTC().Format(time.RFC3339Nano),
+		From:  source,
+		Type:  evtTailerBlock,
+		Payload: map[string]interface{}{
+			"kind":           kind,
+			"source_channel": source,
+			"timestamp":      ts.UTC().Format(time.RFC3339Nano),
+			"ref":            ref,
+		},
+	}
+}
+
+// ─── ValidateSid ─────────────────────────────────────────────────────────────
+
+func TestValidateSid(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		sid     string
+		wantErr bool
+	}{
+		{"empty", "", true},
+		{"simple", "alpha-beta-gamma", false},
+		{"short", "a-b-c", false},
+		{"slash", "a/b/c", true},
+		{"backslash", "a\\b\\c", true},
+		{"space", "a b c", true},
+		{"newline", "a\nb", true},
+		{"double-hyphen", "a--b-c", true},
+		{"uppercase", "A-B-C", true},
+		{"trailing-hyphen", "a-b-", true},
+		{"leading-hyphen", "-a-b-c", true},
+		{"null-byte", "a\x00b", true},
+		{"too-long", strings.Repeat("a", 129), true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateSid(tc.sid)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ValidateSid(%q) err=%v, wantErr=%v", tc.sid, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// ─── core rendering ──────────────────────────────────────────────────────────
+
+// TestRenderEmptyWhenNoData asserts the graceful-empty contract: an sid
+// with no backing data yields a 200-compatible result (empty packet, no
+// sources, note "anti_echo_mvp"). Load-bearing — the HTTP handler reports
+// this as 200 not 503.
+func TestRenderEmptyWhenNoData(t *testing.T) {
+	t.Parallel()
+	bus := newFakeBus()
+	deps := peerAwarenessDeps{bus: bus, attn: &fakeAttn{}, handoffs: &fakeHandoffs{}, renderer: bus}
+	req := PeerAwarenessRequest{Sid: "alpha-beta-gamma", IncludePeers: true, Now: time.Now().UTC()}
+
+	res, err := RenderPeerAwarenessPacket(deps, req)
+	if err != nil {
+		t.Fatalf("render err=%v", err)
+	}
+	if res.Packet != "" {
+		t.Errorf("Packet = %q, want empty", res.Packet)
+	}
+	if len(res.Sources) != 0 {
+		t.Errorf("Sources len=%d, want 0", len(res.Sources))
+	}
+	if res.TokenCount != 0 {
+		t.Errorf("TokenCount = %d, want 0", res.TokenCount)
+	}
+	if len(res.Notes) == 0 || res.Notes[0] != "anti_echo_mvp" {
+		t.Errorf("Notes = %v, want [anti_echo_mvp]", res.Notes)
+	}
+	// Beacon is always emitted — even for empty packets so the causality
+	// chain has a clean "I looked at this sid at T" marker.
+	if len(bus.appended) != 1 {
+		t.Fatalf("beacon count = %d, want 1", len(bus.appended))
+	}
+	if bus.appended[0].busID != PeerAwarenessRenderBus || bus.appended[0].eventType != EvtPeerAwarenessRendered {
+		t.Errorf("beacon = %+v, want %s/%s", bus.appended[0], PeerAwarenessRenderBus, EvtPeerAwarenessRendered)
+	}
+}
+
+// TestRenderMyActivity populates the session's own activity channel and
+// expects the section to appear in the packet, with one line per event
+// and a source[] entry per event.
+func TestRenderMyActivity(t *testing.T) {
+	t.Parallel()
+	sid := "alpha-beta-gamma"
+	now := time.Date(2026, 4, 23, 15, 0, 0, 0, time.UTC)
+
+	bus := newFakeBus()
+	bus.data[ActivityChannelForSid(sid)] = []BusBlock{
+		buildTailerEvent(sid, 1, now.Add(-10*time.Minute), "assistant", "claude-code:conv-42", "h1"),
+		buildTailerEvent(sid, 2, now.Add(-3*time.Minute), "user", "claude-code:conv-42", "h2"),
+	}
+	deps := peerAwarenessDeps{bus: bus, attn: &fakeAttn{}, handoffs: &fakeHandoffs{}, renderer: bus}
+	req := PeerAwarenessRequest{Sid: sid, Budget: 500, Window: 15 * time.Minute, IncludePeers: true, Now: now}
+
+	res, err := RenderPeerAwarenessPacket(deps, req)
+	if err != nil {
+		t.Fatalf("render err=%v", err)
+	}
+	if !strings.Contains(res.Packet, "MY RECENT ACTIVITY") {
+		t.Errorf("missing heading\n%s", res.Packet)
+	}
+	if !strings.Contains(res.Packet, "assistant") || !strings.Contains(res.Packet, "user") {
+		t.Errorf("missing events\n%s", res.Packet)
+	}
+	if res.TokenCount <= 0 {
+		t.Errorf("TokenCount = %d, want >0", res.TokenCount)
+	}
+	// Count my_activity-tagged sources.
+	var myCount int
+	for _, s := range res.Sources {
+		if s.Section == "my_activity" {
+			myCount++
+		}
+	}
+	if myCount != 2 {
+		t.Errorf("my_activity sources = %d, want 2", myCount)
+	}
+}
+
+// TestRenderMyActivityWindowFilter confirms events older than the window
+// are dropped. 30-minute-old events must not contribute to a 15-minute query.
+func TestRenderMyActivityWindowFilter(t *testing.T) {
+	t.Parallel()
+	sid := "alpha-beta-gamma"
+	now := time.Date(2026, 4, 23, 15, 0, 0, 0, time.UTC)
+
+	bus := newFakeBus()
+	bus.data[ActivityChannelForSid(sid)] = []BusBlock{
+		buildTailerEvent(sid, 1, now.Add(-30*time.Minute), "assistant", "src", "old"), // OUT of window
+		buildTailerEvent(sid, 2, now.Add(-5*time.Minute), "user", "src", "fresh"),     // IN window
+	}
+	deps := peerAwarenessDeps{bus: bus, attn: &fakeAttn{}, handoffs: &fakeHandoffs{}, renderer: bus}
+	req := PeerAwarenessRequest{Sid: sid, Window: 15 * time.Minute, IncludePeers: true, Now: now}
+
+	res, _ := RenderPeerAwarenessPacket(deps, req)
+	if strings.Contains(res.Packet, "old") {
+		t.Errorf("old ref leaked into packet:\n%s", res.Packet)
+	}
+	if !strings.Contains(res.Packet, "MY RECENT ACTIVITY") {
+		t.Errorf("expected activity section\n%s", res.Packet)
+	}
+	my := 0
+	for _, s := range res.Sources {
+		if s.Section == "my_activity" {
+			my++
+		}
+	}
+	if my != 1 {
+		t.Errorf("my_activity sources = %d, want 1", my)
+	}
+}
+
+// TestRenderHandoffs verifies handoffs where the sid is the originating
+// session render, with state + counterparty in the line. Only handoffs
+// touched within the window appear.
+func TestRenderHandoffs(t *testing.T) {
+	t.Parallel()
+	sid := "alpha-beta-gamma"
+	now := time.Date(2026, 4, 23, 15, 0, 0, 0, time.UTC)
+
+	ho := &fakeHandoffs{rows: []*HandoffState{
+		{
+			HandoffID:   "ho-1",
+			FromSession: sid,
+			ToSession:   "peer-session-one",
+			Reason:      "rolling handoff",
+			CreatedAt:   now.Add(-10 * time.Minute),
+			State:       HandoffStateOpen,
+		},
+		{
+			HandoffID:       "ho-2",
+			FromSession:     "someone-else-entirely",
+			ClaimingSession: sid,
+			Reason:          "claimed by me",
+			CreatedAt:       now.Add(-20 * time.Minute),
+			ClaimedAt:       now.Add(-4 * time.Minute),
+			State:           HandoffStateClaimed,
+		},
+		{
+			HandoffID:   "ho-stale",
+			FromSession: sid,
+			CreatedAt:   now.Add(-2 * time.Hour), // outside window
+			State:       HandoffStateCompleted,
+		},
+	}}
+	bus := newFakeBus()
+	deps := peerAwarenessDeps{bus: bus, attn: &fakeAttn{}, handoffs: ho, renderer: bus}
+	req := PeerAwarenessRequest{Sid: sid, Window: 15 * time.Minute, IncludePeers: true, Now: now}
+
+	res, _ := RenderPeerAwarenessPacket(deps, req)
+	if !strings.Contains(res.Packet, "OPEN HANDOFFS") {
+		t.Fatalf("missing OPEN HANDOFFS heading:\n%s", res.Packet)
+	}
+	if !strings.Contains(res.Packet, "peer-session-one") {
+		t.Errorf("expected counterparty in line:\n%s", res.Packet)
+	}
+	if strings.Contains(res.Packet, "ho-stale") {
+		t.Errorf("stale handoff must not render:\n%s", res.Packet)
+	}
+
+	// Sources — filter to handoff section.
+	var hc int
+	for _, s := range res.Sources {
+		if s.Section == "handoffs" {
+			hc++
+			if s.BusID != BusHandoffs {
+				t.Errorf("handoff source bus_id = %q, want %q", s.BusID, BusHandoffs)
+			}
+		}
+	}
+	if hc != 2 {
+		t.Errorf("handoff sources = %d, want 2", hc)
+	}
+}
+
+// TestRenderPeerOverlap is the meat of the 4E loop: two peers sharing an
+// attention target plus the peer's own activity channel contributes to
+// the overlap section. Explicit assertion that the peer's activity line
+// is the one pulled into the packet.
+func TestRenderPeerOverlap(t *testing.T) {
+	t.Parallel()
+	me := "alpha-beta-gamma"
+	peer := "peer-session-one"
+	now := time.Date(2026, 4, 23, 15, 0, 0, 0, time.UTC)
+
+	bus := newFakeBus()
+	// Peer's activity channel — one recent event, one old (out of window).
+	bus.data[ActivityChannelForSid(peer)] = []BusBlock{
+		buildTailerEvent(peer, 1, now.Add(-30*time.Minute), "assistant", "peer:old", "peer-stale"),
+		buildTailerEvent(peer, 2, now.Add(-4*time.Minute), "user", "peer:fresh", "peer-fresh"),
+	}
+
+	attn := &fakeAttn{signals: []PeerAwarenessAttentionSignal{
+		{ParticipantID: me, TargetURI: "cog://mem/shared", SignalType: "visit", OccurredAt: now.Add(-5 * time.Minute).Format(time.RFC3339)},
+		{ParticipantID: peer, TargetURI: "cog://mem/shared", SignalType: "visit", OccurredAt: now.Add(-2 * time.Minute).Format(time.RFC3339)},
+		// Target only I look at — should not create overlap.
+		{ParticipantID: me, TargetURI: "cog://mem/solo", SignalType: "visit", OccurredAt: now.Add(-3 * time.Minute).Format(time.RFC3339)},
+	}}
+	deps := peerAwarenessDeps{bus: bus, attn: attn, handoffs: &fakeHandoffs{}, renderer: bus}
+	req := PeerAwarenessRequest{Sid: me, Window: 15 * time.Minute, IncludePeers: true, Now: now, Budget: 800}
+
+	res, _ := RenderPeerAwarenessPacket(deps, req)
+	if !strings.Contains(res.Packet, "PEER OVERLAP") {
+		t.Fatalf("missing PEER OVERLAP heading:\n%s", res.Packet)
+	}
+	if !strings.Contains(res.Packet, peer) {
+		t.Errorf("missing peer sid in packet:\n%s", res.Packet)
+	}
+	if !strings.Contains(res.Packet, "shared") {
+		t.Errorf("expected shared target in overlap line:\n%s", res.Packet)
+	}
+	if !strings.Contains(res.Packet, "peer:fresh") {
+		t.Errorf("expected peer's fresh activity line:\n%s", res.Packet)
+	}
+	if strings.Contains(res.Packet, "peer-stale") || strings.Contains(res.Packet, "peer:old") {
+		t.Errorf("stale peer event must not render:\n%s", res.Packet)
+	}
+
+	// Source entry for the peer, tagged as peer_activity.
+	var peerSrc *PeerAwarenessSource
+	for i := range res.Sources {
+		if res.Sources[i].Section == "peer_activity" && res.Sources[i].Sid == peer {
+			peerSrc = &res.Sources[i]
+			break
+		}
+	}
+	if peerSrc == nil {
+		t.Fatalf("no peer_activity source for peer %q; sources=%+v", peer, res.Sources)
+	}
+	if peerSrc.Ref != "peer-fresh" {
+		t.Errorf("peer source ref = %q, want peer-fresh", peerSrc.Ref)
+	}
+}
+
+// TestRenderIncludePeersFalse suppresses section 3 entirely when the flag
+// is off — confirms the contract knob works end-to-end.
+func TestRenderIncludePeersFalse(t *testing.T) {
+	t.Parallel()
+	me := "alpha-beta-gamma"
+	peer := "peer-session-one"
+	now := time.Date(2026, 4, 23, 15, 0, 0, 0, time.UTC)
+
+	bus := newFakeBus()
+	bus.data[ActivityChannelForSid(peer)] = []BusBlock{
+		buildTailerEvent(peer, 1, now.Add(-4*time.Minute), "assistant", "peer:fresh", "peer-fresh"),
+	}
+	attn := &fakeAttn{signals: []PeerAwarenessAttentionSignal{
+		{ParticipantID: me, TargetURI: "cog://mem/shared", SignalType: "visit", OccurredAt: now.Add(-5 * time.Minute).Format(time.RFC3339)},
+		{ParticipantID: peer, TargetURI: "cog://mem/shared", SignalType: "visit", OccurredAt: now.Add(-2 * time.Minute).Format(time.RFC3339)},
+	}}
+	deps := peerAwarenessDeps{bus: bus, attn: attn, handoffs: &fakeHandoffs{}, renderer: bus}
+	req := PeerAwarenessRequest{Sid: me, Window: 15 * time.Minute, IncludePeers: false, Now: now}
+
+	res, _ := RenderPeerAwarenessPacket(deps, req)
+	if strings.Contains(res.Packet, "PEER OVERLAP") {
+		t.Fatalf("peer overlap must be suppressed when include_peers=false:\n%s", res.Packet)
+	}
+	for _, s := range res.Sources {
+		if s.Section == "peer_activity" {
+			t.Errorf("peer_activity source leaked:\n%+v", s)
+		}
+	}
+}
+
+// TestRenderCoordEvents: coord.*/impl.* events on bus_broadcast render in
+// section 4; unrelated types on bus_broadcast are filtered out.
+func TestRenderCoordEvents(t *testing.T) {
+	t.Parallel()
+	sid := "alpha-beta-gamma"
+	now := time.Date(2026, 4, 23, 15, 0, 0, 0, time.UTC)
+
+	bus := newFakeBus()
+	bus.data[BusBroadcast] = []BusBlock{
+		{V: 2, BusID: BusBroadcast, Seq: 1, Ts: now.Add(-6 * time.Minute).Format(time.RFC3339Nano), From: "peer:p1", Type: "coord.standup", Payload: map[string]interface{}{"summary": "working on X"}},
+		{V: 2, BusID: BusBroadcast, Seq: 2, Ts: now.Add(-2 * time.Minute).Format(time.RFC3339Nano), From: "peer:p2", Type: "impl.merged", Payload: map[string]interface{}{"summary": "green on main"}},
+		{V: 2, BusID: BusBroadcast, Seq: 3, Ts: now.Add(-1 * time.Minute).Format(time.RFC3339Nano), From: "peer:p3", Type: "chat.chatter", Payload: map[string]interface{}{"summary": "ignored"}},
+	}
+	deps := peerAwarenessDeps{bus: bus, attn: &fakeAttn{}, handoffs: &fakeHandoffs{}, renderer: bus}
+	req := PeerAwarenessRequest{Sid: sid, Window: 15 * time.Minute, IncludePeers: true, Now: now, Budget: 800}
+
+	res, _ := RenderPeerAwarenessPacket(deps, req)
+	if !strings.Contains(res.Packet, "COORD CHATTER") {
+		t.Fatalf("missing COORD CHATTER heading:\n%s", res.Packet)
+	}
+	if !strings.Contains(res.Packet, "coord.standup") || !strings.Contains(res.Packet, "impl.merged") {
+		t.Errorf("expected coord+impl events:\n%s", res.Packet)
+	}
+	if strings.Contains(res.Packet, "chat.chatter") {
+		t.Errorf("unrelated bus_broadcast type leaked:\n%s", res.Packet)
+	}
+}
+
+// TestBudgetTruncation ensures the packet stays under the requested
+// token budget even when every section has data.
+func TestBudgetTruncation(t *testing.T) {
+	t.Parallel()
+	sid := "alpha-beta-gamma"
+	now := time.Date(2026, 4, 23, 15, 0, 0, 0, time.UTC)
+
+	bus := newFakeBus()
+	var events []BusBlock
+	for i := 0; i < 50; i++ {
+		events = append(events, buildTailerEvent(
+			sid, i+1, now.Add(-time.Duration(i)*time.Minute),
+			"assistant",
+			fmt.Sprintf("claude-code:conv-%d-with-a-very-long-identifier", i),
+			fmt.Sprintf("ref-%d", i),
+		))
+	}
+	bus.data[ActivityChannelForSid(sid)] = events
+
+	deps := peerAwarenessDeps{bus: bus, attn: &fakeAttn{}, handoffs: &fakeHandoffs{}, renderer: bus}
+	req := PeerAwarenessRequest{Sid: sid, Budget: 40, Window: 2 * time.Hour, IncludePeers: true, Now: now}
+
+	res, _ := RenderPeerAwarenessPacket(deps, req)
+	if res.TokenCount > 40 {
+		t.Errorf("TokenCount = %d, want <= 40; packet:\n%s", res.TokenCount, res.Packet)
+	}
+	if res.Packet == "" {
+		t.Errorf("expected a non-empty packet within budget")
+	}
+}
+
+// TestBeaconPayload: the peer_awareness.rendered event carries the sid
+// and the list of peers we mentioned. Used by the anti-echo follow-up.
+func TestBeaconPayload(t *testing.T) {
+	t.Parallel()
+	me := "alpha-beta-gamma"
+	peer := "peer-session-one"
+	now := time.Date(2026, 4, 23, 15, 0, 0, 0, time.UTC)
+
+	bus := newFakeBus()
+	bus.data[ActivityChannelForSid(peer)] = []BusBlock{
+		buildTailerEvent(peer, 1, now.Add(-4*time.Minute), "user", "peer:fresh", "ref-fresh"),
+	}
+	attn := &fakeAttn{signals: []PeerAwarenessAttentionSignal{
+		{ParticipantID: me, TargetURI: "cog://mem/shared", SignalType: "visit", OccurredAt: now.Add(-5 * time.Minute).Format(time.RFC3339)},
+		{ParticipantID: peer, TargetURI: "cog://mem/shared", SignalType: "visit", OccurredAt: now.Add(-2 * time.Minute).Format(time.RFC3339)},
+	}}
+	deps := peerAwarenessDeps{bus: bus, attn: attn, handoffs: &fakeHandoffs{}, renderer: bus}
+	req := PeerAwarenessRequest{Sid: me, Window: 15 * time.Minute, IncludePeers: true, Now: now, Budget: 500}
+
+	_, err := RenderPeerAwarenessPacket(deps, req)
+	if err != nil {
+		t.Fatalf("render err=%v", err)
+	}
+	var rendered *appendedEvt
+	for i := range bus.appended {
+		if bus.appended[i].eventType == EvtPeerAwarenessRendered {
+			rendered = &bus.appended[i]
+			break
+		}
+	}
+	if rendered == nil {
+		t.Fatalf("no beacon emitted; appended=%+v", bus.appended)
+	}
+	if got := rendered.payload["sid"]; got != me {
+		t.Errorf("beacon sid = %v, want %q", got, me)
+	}
+	peers, ok := rendered.payload["peers"].([]string)
+	if !ok {
+		t.Fatalf("beacon peers wrong type: %T", rendered.payload["peers"])
+	}
+	if len(peers) != 1 || peers[0] != peer {
+		t.Errorf("beacon peers = %v, want [%s]", peers, peer)
+	}
+}
+
+// TestEchoRiskTagging: after a prior peer_awareness.rendered event
+// mentioned a peer, a subsequent render flags that peer's source with
+// echo_risk=true. MVP tag — no subtractive filter.
+func TestEchoRiskTagging(t *testing.T) {
+	t.Parallel()
+	me := "alpha-beta-gamma"
+	peer := "peer-session-one"
+	now := time.Date(2026, 4, 23, 15, 0, 0, 0, time.UTC)
+
+	bus := newFakeBus()
+	// Prior render beacon: me already mentioned peer once.
+	bus.data[PeerAwarenessRenderBus] = []BusBlock{
+		{
+			V:     2,
+			BusID: PeerAwarenessRenderBus,
+			Seq:   1,
+			Ts:    now.Add(-2 * time.Minute).Format(time.RFC3339Nano),
+			From:  me,
+			Type:  EvtPeerAwarenessRendered,
+			Payload: map[string]interface{}{
+				"sid":   me,
+				"peers": []interface{}{peer},
+			},
+		},
+	}
+	bus.data[ActivityChannelForSid(peer)] = []BusBlock{
+		buildTailerEvent(peer, 1, now.Add(-1*time.Minute), "user", "peer:fresh", "ref-echo"),
+	}
+	attn := &fakeAttn{signals: []PeerAwarenessAttentionSignal{
+		{ParticipantID: me, TargetURI: "cog://mem/shared", OccurredAt: now.Add(-90 * time.Second).Format(time.RFC3339)},
+		{ParticipantID: peer, TargetURI: "cog://mem/shared", OccurredAt: now.Add(-30 * time.Second).Format(time.RFC3339)},
+	}}
+	deps := peerAwarenessDeps{bus: bus, attn: attn, handoffs: &fakeHandoffs{}, renderer: bus}
+	req := PeerAwarenessRequest{Sid: me, Window: 15 * time.Minute, IncludePeers: true, Now: now, Budget: 800}
+
+	res, _ := RenderPeerAwarenessPacket(deps, req)
+	var peerSrc *PeerAwarenessSource
+	for i := range res.Sources {
+		if res.Sources[i].Section == "peer_activity" && res.Sources[i].Sid == peer {
+			peerSrc = &res.Sources[i]
+			break
+		}
+	}
+	if peerSrc == nil {
+		t.Fatalf("no peer_activity source for %q; got %+v", peer, res.Sources)
+	}
+	if !peerSrc.EchoRisk {
+		t.Errorf("echo_risk = false; want true (prior beacon already mentioned %q)", peer)
+	}
+}
+
+// TestInvalidSidRejected: RenderPeerAwarenessPacket re-validates sid and
+// returns an error, not a half-rendered packet, when the sid is unsafe.
+func TestInvalidSidRejected(t *testing.T) {
+	t.Parallel()
+	bus := newFakeBus()
+	deps := peerAwarenessDeps{bus: bus, attn: &fakeAttn{}, handoffs: &fakeHandoffs{}, renderer: bus}
+
+	bad := []string{"", "../escape", "a/b/c", "A-B-C", "has space"}
+	for _, sid := range bad {
+		_, err := RenderPeerAwarenessPacket(deps, PeerAwarenessRequest{Sid: sid})
+		if err == nil {
+			t.Errorf("expected error for sid %q", sid)
+		}
+	}
+}
+
+// TestMCPToolContract runs the registered MCP tool end-to-end against a
+// live MCPServer. Confirms the input-schema → composer → JSON result
+// path that rfc003's UserPromptSubmit hook will exercise.
+func TestMCPToolContract(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	cfg := &Config{WorkspaceRoot: root, CogDir: root + "/.cog", Port: 0}
+	nucleus := &Nucleus{Name: "test"}
+	proc := NewProcess(cfg, nucleus)
+	m := NewMCPServer(cfg, nucleus, proc)
+
+	// Wire the session backend so the tool has a real bus + handoffs.
+	bus := NewBusSessionManager(root)
+	m.SetSessionsBackend(bus, NewSessionRegistry(), NewHandoffRegistry())
+
+	// Seed one activity event for sid "alpha-beta-gamma".
+	sid := "alpha-beta-gamma"
+	_, err := bus.AppendEvent(ActivityChannelForSid(sid), evtTailerBlock, "claude-code:conv-x", map[string]interface{}{
+		"kind":           "assistant",
+		"source_channel": "claude-code:conv-x",
+		"timestamp":      time.Now().UTC().Format(time.RFC3339Nano),
+		"ref":            "ref-mcp",
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	budget := 500
+	result, _, err := m.toolRenderPeerAwarenessPacket(context.Background(), nil, peerAwarenessInput{
+		Sid:    sid,
+		Budget: budget,
+	})
+	if err != nil {
+		t.Fatalf("tool err: %v", err)
+	}
+	if result == nil || len(result.Content) == 0 {
+		t.Fatalf("empty result")
+	}
+
+	// The MCP surface returns the JSON as TextContent.
+	var body PeerAwarenessResult
+	for _, c := range result.Content {
+		if tc, ok := c.(*mcp.TextContent); ok {
+			if err := json.Unmarshal([]byte(tc.Text), &body); err != nil {
+				t.Fatalf("unmarshal: %v; text=%s", err, tc.Text)
+			}
+			break
+		}
+	}
+	if !strings.Contains(body.Packet, "MY RECENT ACTIVITY") {
+		t.Errorf("missing activity section in MCP response:\n%s", body.Packet)
+	}
+	if body.TokenCount <= 0 {
+		t.Errorf("token_count = %d, want >0", body.TokenCount)
+	}
+	if len(body.Sources) == 0 {
+		t.Errorf("expected sources[]; got none")
+	}
+}
+
+// TestMCPToolContractBadSid: the tool returns an error result (not a
+// panic) when the sid is unsafe.
+func TestMCPToolContractBadSid(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	cfg := &Config{WorkspaceRoot: root, CogDir: root + "/.cog", Port: 0}
+	nucleus := &Nucleus{Name: "test"}
+	proc := NewProcess(cfg, nucleus)
+	m := NewMCPServer(cfg, nucleus, proc)
+
+	result, _, err := m.toolRenderPeerAwarenessPacket(context.Background(), nil, peerAwarenessInput{Sid: "../escape"})
+	if err != nil {
+		t.Fatalf("tool err (should be result.IsError): %v", err)
+	}
+	if result == nil || !result.IsError {
+		t.Errorf("expected IsError=true for bad sid; got %+v", result)
+	}
+}
+
+// TestNormalizeRequestDefaults checks the budget + window clamping logic.
+// Belt-and-braces: HTTP layer also validates, but the composer must
+// enforce its own bounds since MCP callers bypass the HTTP parser.
+func TestNormalizeRequestDefaults(t *testing.T) {
+	t.Parallel()
+	r := normalizePeerAwarenessRequest(PeerAwarenessRequest{Sid: "a-b-c"})
+	if r.Budget != DefaultPeerAwarenessBudget {
+		t.Errorf("Budget default = %d, want %d", r.Budget, DefaultPeerAwarenessBudget)
+	}
+	if r.Window != DefaultPeerAwarenessWindow {
+		t.Errorf("Window default = %v, want %v", r.Window, DefaultPeerAwarenessWindow)
+	}
+	if r.Now.IsZero() {
+		t.Errorf("Now should have been populated")
+	}
+
+	r = normalizePeerAwarenessRequest(PeerAwarenessRequest{Sid: "a-b-c", Budget: 99999})
+	if r.Budget != MaxPeerAwarenessBudget {
+		t.Errorf("Budget not clamped to max: got %d", r.Budget)
+	}
+}

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -171,6 +171,10 @@ func NewServer(cfg *Config, nucleus *Nucleus, process *Process) *Server {
 	// above (incompatible session_id formats — see serve_sessions_channel.go).
 	s.registerChannelSessionRoutes(mux)
 
+	// Phase 1B: peer-awareness packet endpoint (READ side of the 4E
+	// ambient-awareness loop; Phase 1A populates channel.<sid>.activity).
+	s.registerPeerAwarenessRoutes(mux)
+
 	// Replay bus_sessions + bus_handoffs into the in-memory registries so
 	// the kernel starts with an accurate derived view. Bus is authoritative
 	// either way; this just warms the read path.

--- a/internal/engine/serve_peer_awareness.go
+++ b/internal/engine/serve_peer_awareness.go
@@ -1,0 +1,141 @@
+// serve_peer_awareness.go — HTTP surface for the peer-awareness packet.
+//
+// Phase 1B of the 4E ambient-awareness loop. The single endpoint returns
+// a pre-rendered, token-budgeted string that a UserPromptSubmit hook can
+// prepend to its next prompt without running any of the composition logic
+// client-side. The hook's contract matches rfc003's pre-staged encoder.
+//
+// Route:
+//
+//	GET /v1/peer-awareness?sid=<sid>&budget=<N>&window=<duration>
+//	                     &include_peers=<bool>
+//
+// Response shape is locked by the contract — packet (string), token_count
+// (int), sources ([]{sid,type,ts,ref,echo_risk,...}). See
+// peer_awareness_query.go for the composition details; this file handles
+// only input parsing, status-code policy, and the final JSON marshal.
+//
+// Status codes:
+//   200 — packet rendered (possibly empty when no data fits).
+//   400 — sid missing or fails ValidateSid; malformed budget/window.
+//   500 — unexpected render error (shouldn't happen; composer returns a
+//         partial packet on section failures).
+//   503 — reserved for dependency outage. Today never triggered because
+//         the composer degrades each section independently; kept as a
+//         policy slot so a future dependency-monitor can promote the
+//         status from a best-effort 200-empty to an explicit 503.
+
+package engine
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// registerPeerAwarenessRoutes attaches the one route this file owns onto
+// mux. Called from NewServer alongside the other registerXxxRoutes helpers.
+func (s *Server) registerPeerAwarenessRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /v1/peer-awareness", s.handlePeerAwareness)
+}
+
+// handlePeerAwareness dispatches to RenderPeerAwarenessPacket and marshals
+// the PeerAwarenessResult as JSON. Defaults match the spec — budget=500,
+// window=15m, include_peers=true. Unknown query params are ignored (same
+// policy as the rest of /v1/bus/*).
+func (s *Server) handlePeerAwareness(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	req, err := parsePeerAwarenessQuery(r)
+	if err != nil {
+		writePeerAwarenessError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	deps := NewPeerAwarenessDepsFromServer(s)
+	result, err := RenderPeerAwarenessPacket(deps, req)
+	if err != nil {
+		// ValidateSid is the only documented error today; surface as 400
+		// because any other composer failure is internal.
+		if strings.Contains(err.Error(), "sid") {
+			writePeerAwarenessError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		slog.Warn("peer_awareness: render failed", "sid", req.Sid, "err", err)
+		writePeerAwarenessError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if result == nil {
+		// Defensive — the composer always returns a non-nil result today.
+		writePeerAwarenessError(w, http.StatusInternalServerError, "nil result")
+		return
+	}
+
+	_ = json.NewEncoder(w).Encode(result)
+}
+
+// parsePeerAwarenessQuery pulls sid/budget/window/include_peers out of r
+// and normalizes them into a PeerAwarenessRequest. Validation failures
+// yield a descriptive error so the caller gets a useful 400 body.
+func parsePeerAwarenessQuery(r *http.Request) (PeerAwarenessRequest, error) {
+	q := r.URL.Query()
+	sid := strings.TrimSpace(q.Get("sid"))
+	if sid == "" {
+		return PeerAwarenessRequest{}, fmt.Errorf("sid query parameter is required")
+	}
+	if err := ValidateSid(sid); err != nil {
+		return PeerAwarenessRequest{}, fmt.Errorf("invalid sid: %w", err)
+	}
+
+	req := PeerAwarenessRequest{
+		Sid:          sid,
+		IncludePeers: true, // default
+	}
+
+	if v := q.Get("budget"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return PeerAwarenessRequest{}, fmt.Errorf("budget must be an integer: %w", err)
+		}
+		if n < 0 {
+			return PeerAwarenessRequest{}, fmt.Errorf("budget must be >= 0 (got %d)", n)
+		}
+		req.Budget = n
+	}
+	if v := q.Get("window"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return PeerAwarenessRequest{}, fmt.Errorf("window must be a duration like '15m': %w", err)
+		}
+		if d <= 0 {
+			return PeerAwarenessRequest{}, fmt.Errorf("window must be > 0 (got %s)", d)
+		}
+		req.Window = d
+	}
+	if v := q.Get("include_peers"); v != "" {
+		switch strings.ToLower(v) {
+		case "true", "1", "yes", "y":
+			req.IncludePeers = true
+		case "false", "0", "no", "n":
+			req.IncludePeers = false
+		default:
+			return PeerAwarenessRequest{}, fmt.Errorf("include_peers must be true or false (got %q)", v)
+		}
+	}
+	return req, nil
+}
+
+// writePeerAwarenessError renders a simple {error, status} body. Matches
+// the convention used by serve_bus.go + serve_sessions_mgmt.go so client
+// decoders don't need a special-case path for this endpoint.
+func writePeerAwarenessError(w http.ResponseWriter, status int, msg string) {
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"error":  msg,
+		"status": status,
+	})
+}

--- a/internal/engine/serve_peer_awareness_test.go
+++ b/internal/engine/serve_peer_awareness_test.go
@@ -1,0 +1,329 @@
+// serve_peer_awareness_test.go — HTTP-level tests for /v1/peer-awareness.
+//
+// Uses a live Server wired with a temp workspace so the bus/attention log
+// paths are real, then seeds data directly through BusSessionManager and
+// the attention JSONL file. Exercises the happy path, default values,
+// 400 on bad input, and the end-to-end MCP contract shape.
+
+package engine
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newPeerAwarenessTestServer builds a minimal Server with a real bus and
+// handoff registry on a temp workspace. Exposed helpers seed the three
+// data sources the composer reads (activity channels, attention.jsonl,
+// bus_handoffs + bus_broadcast).
+func newPeerAwarenessTestServer(t *testing.T) (http.Handler, *Server, string) {
+	t.Helper()
+	root := t.TempDir()
+	cfg := &Config{WorkspaceRoot: root, CogDir: filepath.Join(root, ".cog"), Port: 0}
+	nucleus := &Nucleus{Name: "test"}
+	proc := NewProcess(cfg, nucleus)
+	srv := NewServer(cfg, nucleus, proc)
+	t.Cleanup(func() { _ = proc.Broker().Close() })
+	return srv.Handler(), srv, root
+}
+
+// seedActivity appends a tailer.block event onto channel.<sid>.activity.
+func seedActivity(t *testing.T, s *Server, sid string, ts time.Time, kind, source, ref string) {
+	t.Helper()
+	_, err := s.busSessions.AppendEvent(ActivityChannelForSid(sid), evtTailerBlock, source, map[string]interface{}{
+		"kind":           kind,
+		"source_channel": source,
+		"timestamp":      ts.UTC().Format(time.RFC3339Nano),
+		"ref":            ref,
+	})
+	if err != nil {
+		t.Fatalf("seed activity: %v", err)
+	}
+}
+
+// seedAttention writes one line into .cog/run/attention.jsonl.
+func seedAttention(t *testing.T, root, participantID, targetURI string, ts time.Time) {
+	t.Helper()
+	dir := filepath.Join(root, ".cog", "run")
+	_ = os.MkdirAll(dir, 0755)
+	f, err := os.OpenFile(filepath.Join(dir, "attention.jsonl"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatalf("open attention.jsonl: %v", err)
+	}
+	defer f.Close()
+	line := fmt.Sprintf(`{"participant_id":%q,"target_uri":%q,"signal_type":"visit","occurred_at":%q}`+"\n",
+		participantID, targetURI, ts.UTC().Format(time.RFC3339))
+	if _, err := f.WriteString(line); err != nil {
+		t.Fatalf("write attention: %v", err)
+	}
+}
+
+// ─── happy-path tests ────────────────────────────────────────────────────────
+
+// TestHTTPPeerAwarenessEmpty: a well-formed sid with no underlying data
+// returns 200 + packet="" + sources=[]. Load-bearing — the contract says
+// 503 is for dependency outage, not empty packets.
+func TestHTTPPeerAwarenessEmpty(t *testing.T) {
+	t.Parallel()
+	handler, _, _ := newPeerAwarenessTestServer(t)
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/v1/peer-awareness?sid=alpha-beta-gamma")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body=%s", resp.StatusCode, body)
+	}
+
+	var res PeerAwarenessResult
+	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if res.Packet != "" {
+		t.Errorf("packet = %q, want empty", res.Packet)
+	}
+	if len(res.Sources) != 0 {
+		t.Errorf("sources len = %d, want 0", len(res.Sources))
+	}
+	if res.TokenCount != 0 {
+		t.Errorf("token_count = %d, want 0", res.TokenCount)
+	}
+}
+
+// TestHTTPPeerAwarenessWithData: seeds all four sections and verifies
+// the packet contains representative text from each + sources match up.
+func TestHTTPPeerAwarenessWithData(t *testing.T) {
+	t.Parallel()
+	handler, s, root := newPeerAwarenessTestServer(t)
+	me := "alpha-beta-gamma"
+	peer := "peer-session-one"
+	now := time.Now().UTC()
+
+	seedActivity(t, s, me, now.Add(-3*time.Minute), "assistant", "claude-code:conv-1", "ref-mine")
+	seedActivity(t, s, peer, now.Add(-2*time.Minute), "user", "claude-code:conv-2", "ref-peer")
+
+	seedAttention(t, root, me, "cog://mem/shared", now.Add(-4*time.Minute))
+	seedAttention(t, root, peer, "cog://mem/shared", now.Add(-1*time.Minute))
+
+	// Handoff where `me` is the source.
+	_, _ = s.handoffRegistry.ApplyOffer(HandoffState{
+		HandoffID:   "ho-test-1",
+		FromSession: me,
+		ToSession:   peer,
+		Reason:      "rolling test",
+		CreatedAt:   now.Add(-5 * time.Minute),
+	}, now.Add(-5*time.Minute), nil)
+
+	// coord.* on bus_broadcast.
+	_, _ = s.busSessions.AppendEvent(BusBroadcast, "coord.standup", "peer:p1", map[string]interface{}{"summary": "tracking-progress"})
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/v1/peer-awareness?sid=" + me + "&budget=1000")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d body=%s", resp.StatusCode, body)
+	}
+	var res PeerAwarenessResult
+	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// Each section should show.
+	for _, want := range []string{"MY RECENT ACTIVITY", "OPEN HANDOFFS", "PEER OVERLAP", "COORD CHATTER"} {
+		if !strings.Contains(res.Packet, want) {
+			t.Errorf("missing section %q\nPacket:\n%s", want, res.Packet)
+		}
+	}
+
+	// And every source entry must have type+ts populated.
+	for i, s := range res.Sources {
+		if s.Type == "" || s.Ts == "" {
+			t.Errorf("sources[%d] missing type/ts: %+v", i, s)
+		}
+	}
+	// Notes carries the MVP flag.
+	if len(res.Notes) == 0 || res.Notes[0] != "anti_echo_mvp" {
+		t.Errorf("notes = %v, want [anti_echo_mvp]", res.Notes)
+	}
+}
+
+// TestHTTPPeerAwarenessDefaultBudget: no budget in query → 500 token default.
+// Spot check that a response fits within an order-of-magnitude of 500 tokens.
+func TestHTTPPeerAwarenessDefaultBudget(t *testing.T) {
+	t.Parallel()
+	handler, s, _ := newPeerAwarenessTestServer(t)
+	sid := "alpha-beta-gamma"
+	now := time.Now().UTC()
+	for i := 0; i < 20; i++ {
+		seedActivity(t, s, sid,
+			now.Add(-time.Duration(i+1)*time.Minute),
+			"assistant",
+			"claude-code:conv-"+fmt.Sprint(i),
+			fmt.Sprintf("ref-%d", i))
+	}
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/v1/peer-awareness?sid=" + sid)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	var res PeerAwarenessResult
+	_ = json.NewDecoder(resp.Body).Decode(&res)
+	if res.TokenCount > DefaultPeerAwarenessBudget {
+		t.Errorf("token_count = %d, want <= %d", res.TokenCount, DefaultPeerAwarenessBudget)
+	}
+}
+
+// TestHTTPPeerAwarenessIncludePeersFalse: flag suppresses peer section.
+func TestHTTPPeerAwarenessIncludePeersFalse(t *testing.T) {
+	t.Parallel()
+	handler, s, root := newPeerAwarenessTestServer(t)
+	me := "alpha-beta-gamma"
+	peer := "peer-session-one"
+	now := time.Now().UTC()
+
+	seedActivity(t, s, peer, now.Add(-2*time.Minute), "user", "src", "ref-peer")
+	seedAttention(t, root, me, "cog://mem/shared", now.Add(-3*time.Minute))
+	seedAttention(t, root, peer, "cog://mem/shared", now.Add(-1*time.Minute))
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/v1/peer-awareness?sid=" + me + "&include_peers=false")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	var res PeerAwarenessResult
+	_ = json.NewDecoder(resp.Body).Decode(&res)
+	if strings.Contains(res.Packet, "PEER OVERLAP") {
+		t.Errorf("peer overlap appeared despite include_peers=false:\n%s", res.Packet)
+	}
+}
+
+// ─── error paths ─────────────────────────────────────────────────────────────
+
+// TestHTTPPeerAwarenessBadSid exhausts the 400-mapping:
+//   - missing sid
+//   - path-char sid
+//   - malformed budget
+//   - malformed window
+//   - malformed include_peers
+func TestHTTPPeerAwarenessBadSid(t *testing.T) {
+	t.Parallel()
+	handler, _, _ := newPeerAwarenessTestServer(t)
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{"missing", srv.URL + "/v1/peer-awareness"},
+		{"empty", srv.URL + "/v1/peer-awareness?sid="},
+		{"path-chars", srv.URL + "/v1/peer-awareness?sid=" + strings.ReplaceAll("a/b/c", "/", "%2F")},
+		{"uppercase", srv.URL + "/v1/peer-awareness?sid=A-B-C"},
+		{"bad-budget", srv.URL + "/v1/peer-awareness?sid=alpha-beta-gamma&budget=notanint"},
+		{"bad-window", srv.URL + "/v1/peer-awareness?sid=alpha-beta-gamma&window=thirty-tacos"},
+		{"bad-include-peers", srv.URL + "/v1/peer-awareness?sid=alpha-beta-gamma&include_peers=maybe"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			resp, err := http.Get(tc.url)
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusBadRequest {
+				body, _ := io.ReadAll(resp.Body)
+				t.Errorf("status = %d, want 400; body=%s", resp.StatusCode, body)
+			}
+		})
+	}
+}
+
+// TestHTTPPeerAwarenessBeaconEmitted: after a successful render, the
+// causality bus bus_peer_awareness should have a fresh
+// peer_awareness.rendered event.
+func TestHTTPPeerAwarenessBeaconEmitted(t *testing.T) {
+	t.Parallel()
+	handler, s, _ := newPeerAwarenessTestServer(t)
+	sid := "alpha-beta-gamma"
+	now := time.Now().UTC()
+	seedActivity(t, s, sid, now.Add(-1*time.Minute), "assistant", "src", "ref")
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/v1/peer-awareness?sid=" + sid)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	resp.Body.Close()
+
+	events, err := s.busSessions.ReadEvents(PeerAwarenessRenderBus)
+	if err != nil {
+		t.Fatalf("read beacon bus: %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatalf("no beacon events on %s", PeerAwarenessRenderBus)
+	}
+	var matched bool
+	for _, e := range events {
+		if e.Type == EvtPeerAwarenessRendered {
+			matched = true
+			if e.Payload["sid"] != sid {
+				t.Errorf("beacon sid = %v, want %q", e.Payload["sid"], sid)
+			}
+		}
+	}
+	if !matched {
+		t.Errorf("no %s event on bus; got %+v", EvtPeerAwarenessRendered, events)
+	}
+}
+
+// TestHTTPPeerAwarenessResponseContentType: contract detail — response is
+// always application/json, even for 4xx.
+func TestHTTPPeerAwarenessResponseContentType(t *testing.T) {
+	t.Parallel()
+	handler, _, _ := newPeerAwarenessTestServer(t)
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	for _, url := range []string{
+		srv.URL + "/v1/peer-awareness?sid=alpha-beta-gamma",
+		srv.URL + "/v1/peer-awareness", // 400
+	} {
+		resp, err := http.Get(url)
+		if err != nil {
+			t.Errorf("GET %s: %v", url, err)
+			continue
+		}
+		if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+			t.Errorf("content-type for %s = %q", url, ct)
+		}
+		resp.Body.Close()
+	}
+}


### PR DESCRIPTION
## Summary

Phase 1B of the 4E ambient-awareness loop closure. Provides the kernel-side query surface that external-session hooks (e.g., rfc003's `05-peer-awareness.py` in cog-workspace) consume at `UserPromptSubmit` to inject session-aware context as `additionalContext`. Reads from the `channel.<sid>.activity` stream Phase 1A populates (PR #48).

**Both MCP + HTTP** per the B3 scope negotiated with rfc003 (bus_broadcast seq=36–37): MCP tool for structured callers, HTTP endpoint for shell-curlability and graceful hook fallback.

## Contract (locked with rfc003)

**MCP tool** `cog_render_peer_awareness_packet(sid, budget?, window?, include_peers?)` → `{packet, token_count, sources[]}`
**HTTP** `GET /v1/peer-awareness?sid=<sid>&budget=500&window=15m&include_peers=true` → same shape

Packet composition (FIFO until per-section cap, weights 0.35/0.20/0.30/0.15):
1. **My activity** — `channel.<sid>.activity` recent tailer blocks (Phase 1A feeds this)
2. **Handoffs** — rows where sid is offerer/claimant/completer
3. **Peer overlap** — attention-overlap-derived peer sessions + one representative activity line each
4. **Coord** — recent `coord.*` / `impl.*` on `bus_broadcast`

## Change summary (6 files, ~2,300 LoC, 42 new tests)

- `internal/engine/peer_awareness_query.go` (+1046 LoC) — pure-function composer with 4-interface dep bundle for test isolation
- `internal/engine/peer_awareness_query_test.go` (+678 LoC) — unit + MCP contract tests
- `internal/engine/serve_peer_awareness.go` (+141 LoC) — HTTP handler
- `internal/engine/serve_peer_awareness_test.go` (+329 LoC) — HTTP handler tests
- `internal/engine/mcp_server.go` (+87 LoC) — MCP tool registration via `withToolObserver`
- `internal/engine/serve.go` (+8) — route mount

## Anti-echo

MVP scope: event-emit + source tagging. Every render appends a `peer_awareness.rendered` beacon on `bus_peer_awareness` with `{sid, ts, peers[], sources[]}`. `source.echo_risk=true` is tagged on future renders where the peer has been previously surfaced to this sid. Response carries `notes: ["anti_echo_mvp"]` so callers know the subtractive filter isn't live yet. Follow-up can close the loop without schema change.

## Test plan

- [x] `go build -tags fts5 ./...` — clean
- [x] `go test -tags fts5 -count=1 ./...` — all green (42 new + no regressions)
- [x] `gofmt -l` on added/changed files — empty
- [ ] End-to-end after merge: fresh session with rfc003's hook installed, verify packet renders with real cross-session data

## Follow-ups (non-blocking)

- Anti-echo subtractive filter — needs real usage data to decide drop vs. mark vs. decay
- `503` slot reserved but unused — composer degrades per-section to empty-packet-200 today; future dependency monitor can promote to 503 without contract change
- Participant-id convention in the attention table — currently treats `ParticipantID == sid`; confirm with rfc003 the hook stamps this way