### PR TITLE
feat(agent): cog_dispatch_to_harness task-parameterized dispatch + pool (Phase 2)

### DIFF
--- a/agent_dispatch.go
+++ b/agent_dispatch.go
@@ -1,0 +1,301 @@
+// agent_dispatch.go — Concrete dispatcher behind the cog_dispatch_to_harness
+// MCP tool. Lives in the root package so it can call AgentHarness.ExecuteScoped
+// directly; engine-side types (DispatchRequest, AgentDispatcher) are defined
+// in internal/engine/agent_dispatch.go to keep the import direction one-way.
+//
+// Pool mechanism: option (c) hybrid from the Phase 2 plan.
+// A single AgentHarness *struct* is shared across dispatches; each dispatch
+// is a goroutine that calls ExecuteScoped with its own per-call options
+// (system prompt, tool subset, backend URL/kind/model, think flag, deadline).
+// Concurrency is bounded by N (1..4); KV-cache isolation is provided by
+// Ollama's per-request cache keying — each call rebuilds the messages slice
+// fresh and posts to /api/chat with a distinct context. No shared mutable
+// state between slots beyond the harness's tool-func map (read-only after
+// RegisterCoreTools).
+//
+// Identity propagation: claims travel via DispatchRequest.Identity. The
+// dispatcher logs them on the cycle-trace metadata and stores a tagged
+// context value so the respond tool's session_id behavior is preserved
+// (a dispatch from Claude carries Sub as a synthetic session for fan-out).
+// Full CRD-based identity binding waits for Wave 6b.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cogos-dev/cogos/internal/engine"
+)
+
+// HarnessDispatcher is the AgentDispatcher implementation backed by the
+// kernel's resident *AgentHarness. The MCP layer reaches it via the
+// AgentController interface (it is composed into the same controller
+// adapter that surfaces ListAgents / GetAgent / TriggerAgent).
+type HarnessDispatcher struct {
+	// AgentID is the handle this dispatcher serves. Today always
+	// engine.DefaultAgentID. The plural-ready API surface preserves room
+	// for future multi-agent deployments without a wire break.
+	AgentID string
+
+	// Harness is the resident harness instance. The dispatcher does not
+	// take ownership; the kernel owns the lifecycle. The ExecuteScoped
+	// method on *AgentHarness is goroutine-safe by construction (read-only
+	// access to h.tools and h.toolFuncs after RegisterCoreTools).
+	Harness *AgentHarness
+
+	// LMStudioBaseURL is the OpenAI-compatible endpoint the "26b" model
+	// route targets. Empty disables the route — all 26b requests then
+	// degrade to e4b with a per-slot warning.
+	LMStudioBaseURL string
+
+	// LMStudioModel is the model name to send in the OpenAI request when
+	// routing to LM Studio. Defaults to "gemma-3-27b-it" if empty (the
+	// canonical 27B-class identifier; LM Studio is tolerant of either
+	// identifier prefix).
+	LMStudioModel string
+
+	// reachable cache for LM Studio. mu protects the two fields together.
+	// reachableUntil is the wall-clock instant after which we re-probe;
+	// reachableOK records the last probe result.
+	mu             sync.Mutex
+	reachableUntil time.Time
+	reachableOK    bool
+}
+
+// reachabilityCacheTTL is how long a successful or failed LM Studio probe
+// is trusted before re-checking. 60s lines up with the Phase 2 plan and
+// keeps probe overhead negligible.
+const reachabilityCacheTTL = 60 * time.Second
+
+// reachabilityProbeTimeout is the per-probe HTTP timeout. 2s is enough for a
+// localhost-LAN /v1/models response and keeps a misconfigured remote from
+// pinning the dispatcher.
+const reachabilityProbeTimeout = 2 * time.Second
+
+// defaultLMStudioModel is the model identifier sent to LM Studio when the
+// dispatcher's LMStudioModel field is empty.
+const defaultLMStudioModel = "gemma-3-27b-it"
+
+// DispatchToHarness implements engine.AgentDispatcher. See the engine-side
+// contract for semantics. This method blocks until every slot has finished
+// (success, error, or timeout); the returned batch is always non-nil when
+// err is nil.
+func (d *HarnessDispatcher) DispatchToHarness(ctx context.Context, req engine.DispatchRequest) (*engine.DispatchBatchResult, error) {
+	if d == nil || d.Harness == nil {
+		return nil, engine.ErrAgentUnavailable
+	}
+	if req.AgentID != "" && d.AgentID != "" && req.AgentID != d.AgentID {
+		return nil, engine.ErrAgentNotFound
+	}
+
+	// Validate the requested tool allowlist against the live registry
+	// once, batch-wide. The same allowlist applies to every slot, so a
+	// per-slot recheck would be wasted work.
+	if len(req.Tools) > 0 {
+		registered := stringSet(d.Harness.ToolNames())
+		for _, name := range req.Tools {
+			if _, ok := registered[name]; !ok {
+				return nil, &engine.AgentControllerError{
+					Code:    "invalid_input",
+					Message: fmt.Sprintf("tool %q not registered (available: %s)", name, strings.Join(d.Harness.ToolNames(), ", ")),
+				}
+			}
+		}
+	}
+
+	// Decide model routing once per batch. If the caller asked for 26B and
+	// LM Studio is unreachable, every slot degrades to e4b with the same
+	// warning attached.
+	resolvedModel := req.Model
+	var degradeNote string
+	if resolvedModel == engine.DispatchModel26B {
+		if d.lmStudioReachable(ctx) {
+			// stay on 26b
+		} else {
+			resolvedModel = engine.DispatchModelE4B
+			degradeNote = "26b backend unreachable, all slots degraded to e4b"
+		}
+	}
+
+	batch := &engine.DispatchBatchResult{
+		Results: make([]engine.DispatchResult, req.N),
+	}
+	if degradeNote != "" {
+		batch.Notes = append(batch.Notes, degradeNote)
+	}
+
+	// Stamp identity onto the parent context for trace correlation.
+	parentCtx := withDispatchIdentity(ctx, req.Identity)
+
+	// Fan out N goroutines; each writes its slot in batch.Results by
+	// index. No mutex needed because slot indices are disjoint.
+	batchStart := time.Now()
+	var wg sync.WaitGroup
+	wg.Add(req.N)
+	for i := 0; i < req.N; i++ {
+		idx := i
+		go func() {
+			defer wg.Done()
+			batch.Results[idx] = d.runSlot(parentCtx, idx, req, resolvedModel)
+		}()
+	}
+	wg.Wait()
+	batch.TotalDurationSec = time.Since(batchStart).Seconds()
+
+	if degradeNote != "" {
+		// Replicate the batch-level note in each slot's Error so callers
+		// inspecting individual slots see the degradation context.
+		for i := range batch.Results {
+			if batch.Results[i].Error == "" {
+				batch.Results[i].Error = degradeNote
+			}
+		}
+	}
+	return batch, nil
+}
+
+// runSlot runs one dispatch index to completion. Returns a populated
+// DispatchResult with Success, Content, Error, etc filled in.
+func (d *HarnessDispatcher) runSlot(parentCtx context.Context, idx int, req engine.DispatchRequest, resolvedModel engine.DispatchModel) engine.DispatchResult {
+	res := engine.DispatchResult{
+		Index:     idx,
+		ModelUsed: resolvedModel,
+	}
+	timeout := time.Duration(req.TimeoutSeconds) * time.Second
+	slotCtx, cancel := context.WithTimeout(parentCtx, timeout)
+	defer cancel()
+
+	opts := ExecuteScopedOptions{
+		SystemPrompt: req.SystemPrompt,
+		AllowedTools: req.Tools,
+		Thinking:     req.Thinking,
+	}
+	if resolvedModel == engine.DispatchModel26B {
+		opts.BackendURL = d.LMStudioBaseURL
+		opts.BackendKind = backendKindOpenAI
+		opts.Model = d.LMStudioModel
+		if opts.Model == "" {
+			opts.Model = defaultLMStudioModel
+		}
+	}
+
+	slotStart := time.Now()
+	r, err := d.Harness.ExecuteScoped(slotCtx, req.Task, opts)
+	res.DurationSec = time.Since(slotStart).Seconds()
+
+	if r != nil {
+		res.Turns = r.Turns
+		res.Content = r.Content
+		for _, tc := range r.ToolCalls {
+			res.ToolCalls = append(res.ToolCalls, engine.DispatchToolCallSummary{
+				Name:         tc.Name,
+				ArgsDigest:   tc.ArgsDigest,
+				ResultDigest: tc.ResultDigest,
+				Error:        tc.Error,
+			})
+		}
+	}
+
+	if err != nil {
+		// Distinguish timeout from generic failure. context.DeadlineExceeded
+		// is canonical; the harness wraps it via fmt.Errorf so check the
+		// slot context directly.
+		if slotCtx.Err() == context.DeadlineExceeded {
+			res.Error = "timeout"
+		} else {
+			res.Error = err.Error()
+		}
+		res.Success = false
+		return res
+	}
+	res.Success = true
+	return res
+}
+
+// lmStudioReachable returns true when the LM Studio /v1/models endpoint
+// responded OK within reachabilityProbeTimeout in the last
+// reachabilityCacheTTL. Empty LMStudioBaseURL always returns false (the
+// route is disabled).
+func (d *HarnessDispatcher) lmStudioReachable(ctx context.Context) bool {
+	if d.LMStudioBaseURL == "" {
+		return false
+	}
+	d.mu.Lock()
+	if time.Now().Before(d.reachableUntil) {
+		ok := d.reachableOK
+		d.mu.Unlock()
+		return ok
+	}
+	d.mu.Unlock()
+
+	probeCtx, cancel := context.WithTimeout(ctx, reachabilityProbeTimeout)
+	defer cancel()
+	httpReq, err := http.NewRequestWithContext(probeCtx, http.MethodGet, d.LMStudioBaseURL+"/v1/models", nil)
+	if err != nil {
+		d.cacheReachability(false)
+		return false
+	}
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		log.Printf("[dispatch] lm-studio probe failed: %v", err)
+		d.cacheReachability(false)
+		return false
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	ok := resp.StatusCode == http.StatusOK
+	d.cacheReachability(ok)
+	return ok
+}
+
+// cacheReachability stores the probe result with a TTL.
+func (d *HarnessDispatcher) cacheReachability(ok bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.reachableOK = ok
+	d.reachableUntil = time.Now().Add(reachabilityCacheTTL)
+}
+
+// dispatchIdentityKey is the context key used to thread DispatchIdentity
+// into the harness's tool dispatchers. Tools that care about caller
+// provenance (respond's session_id fan-out, propose's authorship metadata)
+// can read it via DispatchIdentityFromContext.
+type dispatchIdentityKey struct{}
+
+// withDispatchIdentity stamps the identity onto ctx. Empty identity is a
+// no-op so existing tests don't see a synthetic identity stamp.
+func withDispatchIdentity(ctx context.Context, id engine.DispatchIdentity) context.Context {
+	if id.Iss == "" && id.Sub == "" && id.Aud == "" && len(id.Claims) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, dispatchIdentityKey{}, id)
+}
+
+// DispatchIdentityFromContext returns the identity claims attached by the
+// dispatcher, or the zero value when the call did not originate from a
+// dispatch.
+func DispatchIdentityFromContext(ctx context.Context) engine.DispatchIdentity {
+	if ctx == nil {
+		return engine.DispatchIdentity{}
+	}
+	v, _ := ctx.Value(dispatchIdentityKey{}).(engine.DispatchIdentity)
+	return v
+}
+
+// stringSet builds a presence map from a slice. Used to validate the
+// requested tool allowlist against the harness registry without a nested
+// loop scan per name.
+func stringSet(ss []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(ss))
+	for _, s := range ss {
+		out[s] = struct{}{}
+	}
+	return out
+}

--- a/agent_dispatch_live_test.go
+++ b/agent_dispatch_live_test.go
@@ -1,0 +1,109 @@
+// agent_dispatch_live_test.go — opt-in smoke test against the live Ollama
+// instance at localhost:11434. Skipped by default to keep `go test ./...`
+// hermetic; enable with:
+//
+//	go test -tags fts5,dispatchlive -run TestDispatchLive_ -v ./...
+//
+// The smoke is a sanity probe, not a correctness test: it confirms (a) the
+// dispatcher can reach Ollama, (b) the structured return is populated when a
+// real model responds, (c) failure modes (no model loaded) are surfaced as
+// Error rather than panicking.
+
+//go:build dispatchlive
+
+package main
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cogos-dev/cogos/internal/engine"
+)
+
+func TestDispatchLive_HelloFromGemma(t *testing.T) {
+	ollamaURL := os.Getenv("DISPATCH_LIVE_OLLAMA_URL")
+	if ollamaURL == "" {
+		ollamaURL = "http://localhost:11434"
+	}
+	model := os.Getenv("DISPATCH_LIVE_MODEL")
+	if model == "" {
+		model = "gemma3:e4b"
+	}
+
+	h := NewAgentHarness(AgentHarnessConfig{OllamaURL: ollamaURL, Model: model})
+	RegisterRespondTool(h)
+	d := &HarnessDispatcher{AgentID: engine.DefaultAgentID, Harness: h}
+
+	req := engine.DispatchRequest{
+		Task:           "Reply with exactly: hello from gemma",
+		N:              1,
+		TimeoutSeconds: 15,
+	}
+	if err := req.Normalize(); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	res, err := d.DispatchToHarness(ctx, req)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if len(res.Results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(res.Results))
+	}
+	r := res.Results[0]
+	t.Logf("[live] success=%v error=%q content=%q tool_calls=%d turns=%d duration=%.2fs",
+		r.Success, r.Error, r.Content, len(r.ToolCalls), r.Turns, r.DurationSec)
+	if !r.Success {
+		// Don't fail the test on no-model — this smoke is informational.
+		// We just want the dispatcher to surface a clean error string.
+		t.Logf("[live] dispatcher surfaced error gracefully: %s", r.Error)
+	} else if r.Content == "" {
+		t.Errorf("[live] expected non-empty content from gemma, got empty")
+	}
+}
+
+func TestDispatchLive_ConcurrentN3(t *testing.T) {
+	ollamaURL := os.Getenv("DISPATCH_LIVE_OLLAMA_URL")
+	if ollamaURL == "" {
+		ollamaURL = "http://localhost:11434"
+	}
+	model := os.Getenv("DISPATCH_LIVE_MODEL")
+	if model == "" {
+		model = "gemma3:e4b"
+	}
+
+	h := NewAgentHarness(AgentHarnessConfig{OllamaURL: ollamaURL, Model: model})
+	d := &HarnessDispatcher{AgentID: engine.DefaultAgentID, Harness: h}
+
+	req := engine.DispatchRequest{
+		Task:           "Pick a fruit and reply with just its name (one word).",
+		N:              3,
+		TimeoutSeconds: 30,
+	}
+	if err := req.Normalize(); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	start := time.Now()
+	res, err := d.DispatchToHarness(ctx, req)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	t.Logf("[live] batch elapsed=%.2fs total_results=%d", time.Since(start).Seconds(), len(res.Results))
+	for i, r := range res.Results {
+		t.Logf("[live] slot[%d] success=%v error=%q content=%q duration=%.2fs",
+			i, r.Success, r.Error, r.Content, r.DurationSec)
+	}
+	// Sanity: every slot should have a non-negative DurationSec, even on
+	// error. Sub-microsecond errors can round to 0.0 on some platforms,
+	// so we only flag actively-negative values.
+	for _, r := range res.Results {
+		if r.DurationSec < 0 {
+			t.Errorf("slot %d had negative duration %.2fs", r.Index, r.DurationSec)
+		}
+	}
+}

--- a/agent_dispatch_test.go
+++ b/agent_dispatch_test.go
@@ -1,0 +1,508 @@
+// agent_dispatch_test.go — Unit coverage for the Phase 2 dispatch transport.
+//
+// Tests use httptest.Server stand-ins for both the Ollama native /api/chat
+// endpoint and the LM Studio /v1/chat/completions endpoint. No live Gemma is
+// required; the harness's chatCompletionTo is exercised against the stand-in.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cogos-dev/cogos/internal/engine"
+)
+
+// ollamaServer returns a stand-in /api/chat endpoint that responds with the
+// canned agentChatResponse on every call. The handler increments callCount
+// so tests can assert per-slot fan-out behaviour.
+func ollamaServer(t *testing.T, callCount *atomic.Int32, responder func(callIdx int) agentChatResponse) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/chat" {
+			t.Errorf("expected /api/chat, got %s", r.URL.Path)
+		}
+		idx := int(callCount.Add(1)) - 1
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(responder(idx))
+	}))
+}
+
+// openaiServer returns a stand-in /v1/chat/completions endpoint that translates
+// the canned agentChatResponse into the OpenAI choices[].message envelope.
+func openaiServer(t *testing.T, callCount *atomic.Int32, responder func(callIdx int) agentChatResponse) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/models":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":[{"id":"gemma-3-27b-it"}]}`))
+			return
+		case "/v1/chat/completions":
+			idx := int(callCount.Add(1)) - 1
+			canned := responder(idx)
+			out := map[string]interface{}{
+				"choices": []map[string]interface{}{
+					{
+						"message": map[string]interface{}{
+							"role":       canned.Message.Role,
+							"content":    canned.Message.Content,
+							"tool_calls": canned.Message.ToolCalls,
+						},
+					},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(out)
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+}
+
+// TestDispatch_SinglePath_ContentReturned verifies the simplest happy path:
+// n=1, no tool calls, the agent emits content, the dispatcher surfaces it
+// as DispatchResult.Content with Success=true.
+func TestDispatch_SinglePath_ContentReturned(t *testing.T) {
+	var calls atomic.Int32
+	server := ollamaServer(t, &calls, func(i int) agentChatResponse {
+		return makeContentResponse(fmt.Sprintf("hello slot %d", i))
+	})
+	defer server.Close()
+
+	h := NewAgentHarness(AgentHarnessConfig{OllamaURL: server.URL, Model: "gemma-test"})
+	d := &HarnessDispatcher{AgentID: engine.DefaultAgentID, Harness: h}
+
+	req := engine.DispatchRequest{Task: "say hello", N: 1}
+	if err := req.Normalize(); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	res, err := d.DispatchToHarness(context.Background(), req)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if got := len(res.Results); got != 1 {
+		t.Fatalf("expected 1 result, got %d", got)
+	}
+	r0 := res.Results[0]
+	if !r0.Success {
+		t.Fatalf("expected success, got error=%q", r0.Error)
+	}
+	if r0.Content != "hello slot 0" {
+		t.Fatalf("expected content 'hello slot 0', got %q", r0.Content)
+	}
+	if r0.ModelUsed != engine.DispatchModelE4B {
+		t.Fatalf("expected ModelUsed=e4b, got %q", r0.ModelUsed)
+	}
+	if r0.Turns != 1 {
+		t.Fatalf("expected 1 turn, got %d", r0.Turns)
+	}
+}
+
+// TestDispatch_RespondToolContent verifies that when the agent invokes the
+// respond tool (rather than emitting plain text), Content is populated with
+// the respond tool's "text" argument — the contract for Phase 2'.
+func TestDispatch_RespondToolContent(t *testing.T) {
+	var calls atomic.Int32
+	server := ollamaServer(t, &calls, func(i int) agentChatResponse {
+		// Turn 0: respond tool. Turn 1: empty content (loop terminates).
+		if i == 0 {
+			return makeToolCallResponse("call_resp", "respond", `{"text":"local-model says hi"}`)
+		}
+		return makeContentResponse("")
+	})
+	defer server.Close()
+
+	h := NewAgentHarness(AgentHarnessConfig{OllamaURL: server.URL, Model: "gemma-test"})
+	RegisterRespondTool(h)
+	d := &HarnessDispatcher{AgentID: engine.DefaultAgentID, Harness: h}
+
+	req := engine.DispatchRequest{Task: "greet the user", N: 1}
+	_ = req.Normalize()
+	res, err := d.DispatchToHarness(context.Background(), req)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	r0 := res.Results[0]
+	if !r0.Success {
+		t.Fatalf("expected success, got error=%q", r0.Error)
+	}
+	if r0.Content != "local-model says hi" {
+		t.Fatalf("expected respond text, got %q", r0.Content)
+	}
+	// Tool-call summary should record the respond invocation.
+	if len(r0.ToolCalls) != 1 || r0.ToolCalls[0].Name != "respond" {
+		t.Fatalf("expected one respond tool-call summary, got %+v", r0.ToolCalls)
+	}
+}
+
+// TestDispatch_ConcurrentN3 dispatches 3 slots in one batch and asserts that
+// (a) all three return distinct results, (b) no slot's failure is visible in
+// the others, (c) total elapsed time is closer to one slot's latency than
+// three (concurrency, not serialization).
+func TestDispatch_ConcurrentN3(t *testing.T) {
+	var calls atomic.Int32
+	const slotDelay = 80 * time.Millisecond
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		idx := int(calls.Add(1)) - 1
+		// Inject a deterministic per-call latency so the wall-clock
+		// concurrency win is observable regardless of host load.
+		time.Sleep(slotDelay)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(makeContentResponse(fmt.Sprintf("reply-%d", idx)))
+	}))
+	defer server.Close()
+
+	h := NewAgentHarness(AgentHarnessConfig{OllamaURL: server.URL, Model: "gemma-test"})
+	d := &HarnessDispatcher{AgentID: engine.DefaultAgentID, Harness: h}
+
+	req := engine.DispatchRequest{Task: "echo", N: 3}
+	_ = req.Normalize()
+	start := time.Now()
+	res, err := d.DispatchToHarness(context.Background(), req)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if got := len(res.Results); got != 3 {
+		t.Fatalf("expected 3 results, got %d", got)
+	}
+
+	// Distinct results: index 0..2 each visible.
+	seen := make(map[string]bool)
+	for _, r := range res.Results {
+		if !r.Success {
+			t.Errorf("slot %d not successful: %q", r.Index, r.Error)
+		}
+		if r.Content == "" {
+			t.Errorf("slot %d had empty content", r.Index)
+		}
+		seen[r.Content] = true
+	}
+	if len(seen) != 3 {
+		t.Errorf("expected 3 distinct contents, got %d (%v)", len(seen), seen)
+	}
+
+	// Concurrency check: serialized would be ~3*slotDelay (240ms) plus
+	// margin; concurrent should be closer to 1*slotDelay. Allow 2.5x as
+	// a generous threshold for CI noise.
+	if elapsed > slotDelay*5/2 {
+		t.Errorf("expected concurrent dispatch (elapsed ~%v), got %v", slotDelay, elapsed)
+	}
+}
+
+// TestDispatch_ToolScopeNarrowing verifies AllowedTools restricts the
+// dispatch to the named subset and that an unknown name surfaces as an
+// invalid-input error before any HTTP call is made.
+func TestDispatch_ToolScopeNarrowing(t *testing.T) {
+	var calls atomic.Int32
+	var seenTools []ToolDefinition
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body agentChatRequest
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if seenTools == nil {
+			seenTools = body.Tools
+		}
+		_ = calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(makeContentResponse("ok"))
+	}))
+	defer server.Close()
+
+	h := NewAgentHarness(AgentHarnessConfig{OllamaURL: server.URL, Model: "gemma-test"})
+	// Register two tools so we can scope to one.
+	RegisterRespondTool(h)
+	RegisterWaitTool(h, "/tmp/unused")
+	d := &HarnessDispatcher{AgentID: engine.DefaultAgentID, Harness: h}
+
+	// Happy path: scope to just `wait`, expect only wait sent to the model.
+	req := engine.DispatchRequest{Task: "scoped run", Tools: []string{"wait"}}
+	_ = req.Normalize()
+	if _, err := d.DispatchToHarness(context.Background(), req); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if len(seenTools) != 1 || seenTools[0].Function.Name != "wait" {
+		t.Errorf("expected only 'wait' in tools, got %+v", seenTools)
+	}
+
+	// Error path: unknown tool name surfaces before the HTTP call.
+	calls.Store(0)
+	seenTools = nil
+	req2 := engine.DispatchRequest{Task: "bogus", Tools: []string{"not_a_tool"}}
+	_ = req2.Normalize()
+	_, err := d.DispatchToHarness(context.Background(), req2)
+	if err == nil {
+		t.Fatal("expected error for unknown tool, got nil")
+	}
+	if !strings.Contains(err.Error(), "not_a_tool") {
+		t.Errorf("error should name the missing tool, got %q", err.Error())
+	}
+	if calls.Load() != 0 {
+		t.Errorf("expected zero HTTP calls before validation failed, got %d", calls.Load())
+	}
+}
+
+// TestDispatch_TimeoutSlot verifies a slot whose context exceeds the per-slot
+// budget returns Success=false Error="timeout" while sibling slots continue.
+//
+// The slow handler picks up cancellation via its request context (so the
+// httptest.Server can drain on Close) but it sleeps long enough that the
+// dispatcher's per-slot deadline fires first.
+func TestDispatch_TimeoutSlot(t *testing.T) {
+	var calls atomic.Int32
+	stopHandler := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		idx := int(calls.Add(1)) - 1
+		// Slot 0 sleeps until the dispatcher cancels (via r.Context()) or
+		// the test signals shutdown via stopHandler, whichever comes first.
+		// Slot 1 returns instantly.
+		if idx == 0 {
+			select {
+			case <-r.Context().Done():
+			case <-stopHandler:
+			case <-time.After(5 * time.Second):
+			}
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(makeContentResponse("fast"))
+	}))
+	// Order matters: signal handlers to bail BEFORE the server tries to
+	// drain in-flight connections, otherwise Close() blocks waiting for
+	// the still-sleeping handler.
+	defer server.Close()
+	defer close(stopHandler)
+
+	h := NewAgentHarness(AgentHarnessConfig{OllamaURL: server.URL, Model: "gemma-test"})
+	d := &HarnessDispatcher{AgentID: engine.DefaultAgentID, Harness: h}
+
+	req := engine.DispatchRequest{Task: "race", N: 2, TimeoutSeconds: 1}
+	_ = req.Normalize()
+	res, err := d.DispatchToHarness(context.Background(), req)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if len(res.Results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(res.Results))
+	}
+
+	// Find the slot that timed out and the one that succeeded by content.
+	var timedOut, succeeded *engine.DispatchResult
+	for i := range res.Results {
+		if res.Results[i].Success {
+			succeeded = &res.Results[i]
+		} else if res.Results[i].Error == "timeout" {
+			timedOut = &res.Results[i]
+		}
+	}
+	if timedOut == nil {
+		t.Fatalf("expected one timeout, got %+v", res.Results)
+	}
+	if succeeded == nil {
+		t.Fatalf("expected one success, got %+v", res.Results)
+	}
+	if succeeded.Content != "fast" {
+		t.Errorf("succeeded slot content = %q, want 'fast'", succeeded.Content)
+	}
+}
+
+// TestDispatch_LMStudioReachableRoutes26B exercises the 26B path with a
+// stand-in OpenAI-compatible server. Verifies the dispatcher (a) probes
+// /v1/models, (b) routes /v1/chat/completions when reachable, (c) records
+// ModelUsed=26b on the result.
+func TestDispatch_LMStudioReachableRoutes26B(t *testing.T) {
+	var calls atomic.Int32
+	server := openaiServer(t, &calls, func(i int) agentChatResponse {
+		return makeContentResponse("from twentysix-b")
+	})
+	defer server.Close()
+
+	h := NewAgentHarness(AgentHarnessConfig{OllamaURL: "http://localhost:0/unused", Model: "gemma-e4b"})
+	d := &HarnessDispatcher{
+		AgentID:         engine.DefaultAgentID,
+		Harness:         h,
+		LMStudioBaseURL: server.URL,
+		LMStudioModel:   "gemma-3-27b-it",
+	}
+
+	req := engine.DispatchRequest{Task: "ask the big one", Model: engine.DispatchModel26B, N: 1}
+	_ = req.Normalize()
+	res, err := d.DispatchToHarness(context.Background(), req)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if !res.Results[0].Success {
+		t.Fatalf("expected success, got error=%q", res.Results[0].Error)
+	}
+	if res.Results[0].Content != "from twentysix-b" {
+		t.Errorf("unexpected content: %q", res.Results[0].Content)
+	}
+	if res.Results[0].ModelUsed != engine.DispatchModel26B {
+		t.Errorf("expected ModelUsed=26b, got %q", res.Results[0].ModelUsed)
+	}
+	if len(res.Notes) != 0 {
+		t.Errorf("expected no batch notes when 26B reachable, got %v", res.Notes)
+	}
+}
+
+// TestDispatch_LMStudioUnreachableDegradesToE4B verifies the degrade-to-e4b
+// fallback fires when the 26B endpoint isn't reachable. The result should
+// carry ModelUsed=e4b and a warning note.
+func TestDispatch_LMStudioUnreachableDegradesToE4B(t *testing.T) {
+	var calls atomic.Int32
+	ollama := ollamaServer(t, &calls, func(i int) agentChatResponse {
+		return makeContentResponse("e4b fallback")
+	})
+	defer ollama.Close()
+
+	h := NewAgentHarness(AgentHarnessConfig{OllamaURL: ollama.URL, Model: "gemma-e4b"})
+	d := &HarnessDispatcher{
+		AgentID:         engine.DefaultAgentID,
+		Harness:         h,
+		LMStudioBaseURL: "http://127.0.0.1:1/unreachable", // port 1 closed by convention
+	}
+
+	req := engine.DispatchRequest{Task: "26b please", Model: engine.DispatchModel26B, N: 1}
+	_ = req.Normalize()
+	res, err := d.DispatchToHarness(context.Background(), req)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if !res.Results[0].Success {
+		t.Fatalf("expected success after degrade, got error=%q", res.Results[0].Error)
+	}
+	if res.Results[0].ModelUsed != engine.DispatchModelE4B {
+		t.Errorf("expected ModelUsed=e4b after degrade, got %q", res.Results[0].ModelUsed)
+	}
+	if len(res.Notes) == 0 || !strings.Contains(res.Notes[0], "degraded") {
+		t.Errorf("expected degrade note, got %v", res.Notes)
+	}
+	// Per-slot Error should mirror the batch note so callers inspecting
+	// individual slots see the degradation context.
+	if !strings.Contains(res.Results[0].Error, "degraded") {
+		t.Errorf("expected per-slot Error to carry degrade note, got %q", res.Results[0].Error)
+	}
+}
+
+// TestDispatch_SystemPromptOverride confirms the per-call SystemPrompt
+// reaches the model in the system message slot.
+func TestDispatch_SystemPromptOverride(t *testing.T) {
+	var seenSystem string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body agentChatRequest
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if len(body.Messages) > 0 && body.Messages[0].Role == "system" {
+			seenSystem = body.Messages[0].Content
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(makeContentResponse("k"))
+	}))
+	defer server.Close()
+
+	h := NewAgentHarness(AgentHarnessConfig{OllamaURL: server.URL, Model: "gemma-test"})
+	d := &HarnessDispatcher{AgentID: engine.DefaultAgentID, Harness: h}
+
+	req := engine.DispatchRequest{Task: "go", SystemPrompt: "you are a validator"}
+	_ = req.Normalize()
+	if _, err := d.DispatchToHarness(context.Background(), req); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if seenSystem != "you are a validator" {
+		t.Errorf("system prompt not threaded through; got %q", seenSystem)
+	}
+}
+
+// TestDispatch_QueryUnavailable confirms the QueryDispatchToHarness helper
+// surfaces ErrAgentUnavailable when the controller is nil and a clean
+// invalid-input error when normalization fails (empty task).
+func TestDispatch_QueryUnavailable(t *testing.T) {
+	if _, err := engine.QueryDispatchToHarness(context.Background(), nil, engine.DispatchRequest{Task: "x"}); err == nil {
+		t.Fatal("expected error when controller is nil")
+	}
+}
+
+// TestDispatch_QueryEmptyTask verifies the empty-task branch of normalize.
+func TestDispatch_QueryEmptyTask(t *testing.T) {
+	h := NewAgentHarness(AgentHarnessConfig{OllamaURL: "http://unused", Model: "x"})
+	d := &HarnessDispatcher{AgentID: engine.DefaultAgentID, Harness: h}
+	_, err := engine.QueryDispatchToHarness(context.Background(), &dispatchControllerStub{disp: d}, engine.DispatchRequest{Task: "  "})
+	if err == nil {
+		t.Fatal("expected error for empty task")
+	}
+	if !strings.Contains(err.Error(), "task is required") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestDispatch_IdentityPropagation confirms identity claims pass through to
+// the harness's tool context via DispatchIdentityFromContext.
+func TestDispatch_IdentityPropagation(t *testing.T) {
+	var capturedIdentity engine.DispatchIdentity
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(makeToolCallResponse("c1", "ident_probe", `{}`))
+	}))
+	defer server.Close()
+
+	h := NewAgentHarness(AgentHarnessConfig{OllamaURL: server.URL, Model: "gemma-test"})
+	// Register a probe tool that captures the dispatch identity from ctx.
+	h.RegisterTool(ToolDefinition{
+		Type: "function",
+		Function: ToolFunction{
+			Name:        "ident_probe",
+			Description: "probe",
+			Parameters:  json.RawMessage(`{"type":"object","properties":{}}`),
+		},
+	}, func(ctx context.Context, _ json.RawMessage) (json.RawMessage, error) {
+		capturedIdentity = DispatchIdentityFromContext(ctx)
+		return json.Marshal(map[string]string{"ok": "1"})
+	})
+	d := &HarnessDispatcher{AgentID: engine.DefaultAgentID, Harness: h}
+
+	req := engine.DispatchRequest{
+		Task: "probe",
+		Identity: engine.DispatchIdentity{
+			Iss: "anthropic.claude-code",
+			Sub: "session-xyz",
+			Aud: "cogos.kernel",
+		},
+		// Bound the loop — once the probe tool returns, the model would
+		// be asked for another turn; the canned server keeps returning
+		// the same tool call, so cap turns to 1 by triggering wait next
+		// turn. Easier path: timeout tight so we only do one turn.
+		TimeoutSeconds: 1,
+	}
+	_ = req.Normalize()
+	_, _ = d.DispatchToHarness(context.Background(), req)
+
+	if capturedIdentity.Iss != "anthropic.claude-code" {
+		t.Errorf("identity Iss not propagated, got %+v", capturedIdentity)
+	}
+	if capturedIdentity.Sub != "session-xyz" {
+		t.Errorf("identity Sub not propagated, got %+v", capturedIdentity)
+	}
+}
+
+// dispatchControllerStub is a minimal AgentController + AgentDispatcher
+// composition used by the QueryDispatchToHarness tests to bypass the rest
+// of the controller surface.
+type dispatchControllerStub struct{ disp *HarnessDispatcher }
+
+func (s *dispatchControllerStub) ListAgents(_ context.Context, _ bool) ([]engine.AgentSummary, error) {
+	return nil, nil
+}
+func (s *dispatchControllerStub) GetAgent(_ context.Context, _ string, _ bool, _ int) (*engine.AgentSnapshot, error) {
+	return nil, nil
+}
+func (s *dispatchControllerStub) TriggerAgent(_ context.Context, _ string, _ string, _ bool) (*engine.AgentTriggerResult, error) {
+	return nil, nil
+}
+func (s *dispatchControllerStub) DispatchToHarness(ctx context.Context, req engine.DispatchRequest) (*engine.DispatchBatchResult, error) {
+	return s.disp.DispatchToHarness(ctx, req)
+}

--- a/agent_harness.go
+++ b/agent_harness.go
@@ -3,7 +3,7 @@
 // Runs as a goroutine inside the kernel process. Calls a local model (Gemma E4B
 // via Ollama) through the OpenAI chat completions wire protocol. The loop is:
 //
-//   Observation → Assess (JSON mode) → Execute (tool loop) → Callback
+//	Observation → Assess (JSON mode) → Execute (tool loop) → Callback
 //
 // No framework dependencies. Uses net/http directly against Ollama's
 // OpenAI-compatible /v1/chat/completions endpoint.
@@ -121,20 +121,20 @@ func WithSessionIDs(ctx context.Context, ids []string) context.Context {
 
 // agentChatRequest is the Ollama native /api/chat request body.
 type agentChatRequest struct {
-	Model    string             `json:"model"`
-	Messages []agentChatMessage `json:"messages"`
-	Tools    []ToolDefinition   `json:"tools,omitempty"`
-	Stream   bool               `json:"stream"`
-	Think    bool               `json:"think"`              // explicit thinking control
-	Format   string             `json:"format,omitempty"`   // "json" for structured output
+	Model    string                 `json:"model"`
+	Messages []agentChatMessage     `json:"messages"`
+	Tools    []ToolDefinition       `json:"tools,omitempty"`
+	Stream   bool                   `json:"stream"`
+	Think    bool                   `json:"think"`             // explicit thinking control
+	Format   string                 `json:"format,omitempty"`  // "json" for structured output
 	Options  map[string]interface{} `json:"options,omitempty"` // Ollama model options (num_ctx, temperature, etc.)
 }
 
 // agentChatMessage is a single message in the conversation.
 type agentChatMessage struct {
-	Role       string          `json:"role"`                  // system, user, assistant, tool
-	Content    string          `json:"content,omitempty"`     // text content
-	ToolCalls  []agentToolCall `json:"tool_calls,omitempty"`  // assistant tool invocations
+	Role       string          `json:"role"`                   // system, user, assistant, tool
+	Content    string          `json:"content,omitempty"`      // text content
+	ToolCalls  []agentToolCall `json:"tool_calls,omitempty"`   // assistant tool invocations
 	ToolCallID string          `json:"tool_call_id,omitempty"` // for role=tool responses (OpenAI compat in Ollama)
 }
 
@@ -160,12 +160,12 @@ type agentChatResponse struct {
 	DoneReason string `json:"done_reason,omitempty"`
 
 	// Ollama performance metrics (nanoseconds)
-	TotalDuration    int64 `json:"total_duration,omitempty"`
-	LoadDuration     int64 `json:"load_duration,omitempty"`
-	PromptEvalCount  int   `json:"prompt_eval_count,omitempty"`
+	TotalDuration      int64 `json:"total_duration,omitempty"`
+	LoadDuration       int64 `json:"load_duration,omitempty"`
+	PromptEvalCount    int   `json:"prompt_eval_count,omitempty"`
 	PromptEvalDuration int64 `json:"prompt_eval_duration,omitempty"`
-	EvalCount        int   `json:"eval_count,omitempty"`
-	EvalDuration     int64 `json:"eval_duration,omitempty"`
+	EvalCount          int   `json:"eval_count,omitempty"`
+	EvalDuration       int64 `json:"eval_duration,omitempty"`
 }
 
 // --- Tool definition types ---
@@ -296,7 +296,7 @@ func (h *AgentHarness) Execute(ctx context.Context, systemPrompt, task string) (
 			Messages: messages,
 			Tools:    h.tools,
 			Stream:   false,
-			Think:    false, // disable thinking for tool loop
+			Think:    false,                                   // disable thinking for tool loop
 			Options:  map[string]interface{}{"num_ctx": 8192}, // 8K context for tool loop
 		}
 
@@ -446,4 +446,466 @@ func (h *AgentHarness) dispatchTool(ctx context.Context, tc agentToolCall) (json
 		return nil, fmt.Errorf("unknown tool: %s", tc.Function.Name)
 	}
 	return fn(ctx, json.RawMessage(tc.Function.Arguments))
+}
+
+// --- Phase 2: task-parameterized dispatch (cog_dispatch_to_harness) ---
+//
+// ExecuteScoped is the per-call variant of Execute that supports:
+//   - per-call tool subset (scope narrowing) without mutating h.tools
+//   - per-call backend override (LM Studio routing, custom model name)
+//   - per-call think-flag override (peer reasoning vs JSON discipline)
+//   - structured return: surfaces tool-call summaries + the respond-tool's
+//     content (when the agent invoked respond instead of emitting plain text)
+//
+// Background: a dispatch from the foveal Claude into the peripheral Gemma
+// swarm needs (a) deterministic tool envelope per role, (b) the actual user-
+// visible text the agent produced, and (c) enough trace metadata to debug
+// without touching the ledger. Execute returns "" when respond is the only
+// thing the agent did; ExecuteScoped fixes that by remembering the respond
+// argument's text and using it as the canonical Content.
+//
+// KV-cache discipline: each call rebuilds the messages slice fresh and posts
+// to Ollama with its own context — Ollama's KV cache is request-keyed by the
+// full prompt, so distinct dispatches don't collide. Concurrent calls are
+// safe; correctness comes from the freshness of the messages slice rather
+// than goroutine isolation.
+
+// ExecuteScopedOptions controls a single ExecuteScoped invocation. The zero
+// value behaves identically to Execute: harness defaults for system prompt,
+// tools, backend, and think flag.
+type ExecuteScopedOptions struct {
+	// SystemPrompt overrides the default system prompt for this call only.
+	// Empty string keeps the caller-supplied default.
+	SystemPrompt string
+
+	// AllowedTools, when non-empty, restricts the tool registry to names in
+	// the slice. Names not present in h.toolFuncs surface as
+	// ErrUnknownScopedTool. nil/empty uses the full default set.
+	AllowedTools []string
+
+	// BackendURL overrides h.ollamaURL for this call. Empty keeps the
+	// default. Must point at an OpenAI-compatible-or-Ollama-native chat
+	// endpoint; the dispatcher decides which family.
+	BackendURL string
+
+	// BackendKind selects how to talk to BackendURL: "ollama" (default,
+	// /api/chat) or "openai" (LM Studio, /v1/chat/completions).
+	BackendKind string
+
+	// Model overrides h.model for this call. Empty keeps the default.
+	Model string
+
+	// Thinking, when non-nil, overrides the think flag for this call.
+	Thinking *bool
+
+	// MaxTurns overrides h.maxTurns. Zero keeps the default.
+	MaxTurns int
+}
+
+// ErrUnknownScopedTool is returned by ExecuteScoped when AllowedTools
+// references a tool name that is not in the harness registry. Surfaces
+// as the per-slot Error in the dispatcher rather than a transport panic.
+var ErrUnknownScopedTool = fmt.Errorf("scoped tool not registered")
+
+// ExecuteScopedResult is the structured return from ExecuteScoped. Content
+// is the canonical user-visible string (the respond tool's text, or the
+// final assistant content if respond never ran), ToolCalls is the per-turn
+// summary, and Turns counts how many tool-loop iterations actually ran.
+type ExecuteScopedResult struct {
+	Content   string                       `json:"content"`
+	ToolCalls []ScopedExecuteToolCallEntry `json:"tool_calls"`
+	Turns     int                          `json:"turns"`
+}
+
+// ScopedExecuteToolCallEntry is one tool invocation observed in the loop,
+// truncated to keep result envelopes small.
+type ScopedExecuteToolCallEntry struct {
+	Name         string `json:"name"`
+	ArgsDigest   string `json:"args_digest,omitempty"`
+	ResultDigest string `json:"result_digest,omitempty"`
+	Error        string `json:"error,omitempty"`
+}
+
+// ExecuteScoped runs the tool loop with per-call overrides. See
+// ExecuteScopedOptions for what each field does. Returns the structured
+// result regardless of whether the model called respond or not.
+func (h *AgentHarness) ExecuteScoped(ctx context.Context, task string, opts ExecuteScopedOptions) (*ExecuteScopedResult, error) {
+	systemPrompt := opts.SystemPrompt
+	maxTurns := opts.MaxTurns
+	if maxTurns <= 0 {
+		maxTurns = h.maxTurns
+	}
+	think := false
+	if opts.Thinking != nil {
+		think = *opts.Thinking
+	}
+
+	// Build the per-call tool view. We keep two parallel structures: the
+	// allowed []ToolDefinition (sent to the model) and an allowed
+	// map[string]ToolFunc (used to dispatch by name). Both default to the
+	// harness's full registry when AllowedTools is empty.
+	allowedDefs, allowedFuncs, err := h.scopeTools(opts.AllowedTools)
+	if err != nil {
+		return nil, err
+	}
+
+	model := opts.Model
+	if model == "" {
+		model = h.model
+	}
+	backendURL := opts.BackendURL
+	if backendURL == "" {
+		backendURL = h.ollamaURL
+	}
+	backendKind := opts.BackendKind
+	if backendKind == "" {
+		backendKind = backendKindOllama
+	}
+
+	messages := []agentChatMessage{
+		{Role: "system", Content: systemPrompt},
+		{Role: "user", Content: task},
+	}
+
+	result := &ExecuteScopedResult{}
+	respondContent := ""
+
+	for turn := 0; turn < maxTurns; turn++ {
+		req := agentChatRequest{
+			Model:    model,
+			Messages: messages,
+			Tools:    allowedDefs,
+			Stream:   false,
+			Think:    think,
+			Options:  map[string]interface{}{"num_ctx": 8192},
+		}
+
+		resp, err := h.chatCompletionTo(ctx, backendURL, backendKind, req)
+		if err != nil {
+			return result, fmt.Errorf("execute-scoped turn %d: %w", turn, err)
+		}
+		result.Turns = turn + 1
+
+		msg := resp.Message
+
+		// No tool calls — model is done. Use respondContent if we captured
+		// one earlier; otherwise the assistant's final content.
+		if len(msg.ToolCalls) == 0 {
+			if respondContent != "" {
+				result.Content = respondContent
+			} else {
+				result.Content = msg.Content
+			}
+			return result, nil
+		}
+
+		messages = append(messages, agentChatMessage{
+			Role:      "assistant",
+			ToolCalls: msg.ToolCalls,
+		})
+
+		var waitInvoked bool
+		var waitReason string
+		for _, tc := range msg.ToolCalls {
+			entry := ScopedExecuteToolCallEntry{
+				Name:       tc.Function.Name,
+				ArgsDigest: digestJSON(tc.Function.Arguments),
+			}
+
+			fn, ok := allowedFuncs[tc.Function.Name]
+			if !ok {
+				// Out-of-scope tool: tell the model it's not available
+				// without aborting the loop, and record the violation.
+				errMsg := fmt.Sprintf("tool %q is not in this dispatch's scope", tc.Function.Name)
+				entry.Error = errMsg
+				result.ToolCalls = append(result.ToolCalls, entry)
+				blocked := json.RawMessage(fmt.Sprintf(`{"error": %q}`, errMsg))
+				messages = append(messages, agentChatMessage{
+					Role:       "tool",
+					ToolCallID: tc.ID,
+					Content:    string(blocked),
+				})
+				continue
+			}
+
+			toolStart := time.Now()
+			toolResult, toolErr := fn(ctx, json.RawMessage(tc.Function.Arguments))
+			toolDuration := time.Since(toolStart)
+			if cycleID := cycleIDFromContext(ctx); cycleID != "" {
+				ev, bErr := trace.NewToolDispatch(
+					engine.TraceIdentity(),
+					cycleID,
+					tc.Function.Name,
+					tc.Function.Arguments,
+					toolDuration,
+					toolErr,
+				)
+				if bErr == nil {
+					emitCycleEvent(ev)
+				}
+			}
+			if toolErr != nil {
+				entry.Error = toolErr.Error()
+				toolResult = []byte(fmt.Sprintf(`{"error": %q}`, toolErr.Error()))
+			}
+			entry.ResultDigest = digestJSON(toolResult)
+
+			if tc.Function.Name == waitToolName {
+				waitInvoked = true
+				if r := extractWaitReason(toolResult); r != "" {
+					waitReason = r
+				}
+			}
+			if tc.Function.Name == respondToolName {
+				if t := extractRespondText(json.RawMessage(tc.Function.Arguments)); t != "" {
+					respondContent = t
+				}
+			}
+
+			result.ToolCalls = append(result.ToolCalls, entry)
+			messages = append(messages, agentChatMessage{
+				Role:       "tool",
+				ToolCallID: tc.ID,
+				Content:    string(toolResult),
+			})
+		}
+
+		if waitInvoked {
+			if respondContent != "" {
+				result.Content = respondContent
+			} else if waitReason != "" {
+				result.Content = fmt.Sprintf("waited: %s", waitReason)
+			} else {
+				result.Content = "waited"
+			}
+			return result, nil
+		}
+	}
+
+	if respondContent != "" {
+		result.Content = respondContent
+		return result, nil
+	}
+	return result, fmt.Errorf("execute-scoped: hit max turns (%d) without completion", maxTurns)
+}
+
+// scopeTools returns the per-call tool view. Empty AllowedTools yields the
+// full default registry. Unknown names cause an error.
+func (h *AgentHarness) scopeTools(allowed []string) ([]ToolDefinition, map[string]ToolFunc, error) {
+	if len(allowed) == 0 {
+		return h.tools, h.toolFuncs, nil
+	}
+	defs := make([]ToolDefinition, 0, len(allowed))
+	funcs := make(map[string]ToolFunc, len(allowed))
+	for _, name := range allowed {
+		fn, ok := h.toolFuncs[name]
+		if !ok {
+			return nil, nil, fmt.Errorf("%w: %s", ErrUnknownScopedTool, name)
+		}
+		funcs[name] = fn
+		// Find the matching definition by name; toolFuncs and tools are
+		// kept in sync by RegisterTool, so the definition is guaranteed
+		// to exist when fn does.
+		for _, def := range h.tools {
+			if def.Function.Name == name {
+				defs = append(defs, def)
+				break
+			}
+		}
+	}
+	return defs, funcs, nil
+}
+
+// ToolNames returns the names of all currently-registered tools. Useful for
+// tests and for the dispatcher to validate AllowedTools without poking at
+// internals.
+func (h *AgentHarness) ToolNames() []string {
+	out := make([]string, 0, len(h.toolFuncs))
+	for name := range h.toolFuncs {
+		out = append(out, name)
+	}
+	return out
+}
+
+// extractRespondText pulls the "text" field from the respond tool's JSON
+// arguments. Returns "" on parse failure or empty text.
+func extractRespondText(args json.RawMessage) string {
+	if len(args) == 0 {
+		return ""
+	}
+	var p struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return ""
+	}
+	return p.Text
+}
+
+// digestJSON returns a short, log-safe view of a JSON value: trimmed of
+// surrounding whitespace and clipped to digestMaxBytes characters with an
+// ellipsis suffix when truncated. Returns "" for empty input.
+func digestJSON(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	s := string(raw)
+	if len(s) > digestMaxBytes {
+		return s[:digestMaxBytes] + "..."
+	}
+	return s
+}
+
+// digestMaxBytes caps the per-field size in tool-call summaries so a single
+// dispatch result envelope stays well under any reasonable HTTP body limit
+// even with N=4 and 10 tool calls per slot.
+const digestMaxBytes = 200
+
+// backendKindOllama and backendKindOpenAI select which wire protocol
+// chatCompletionTo speaks. Ollama uses /api/chat with the native shape;
+// OpenAI uses /v1/chat/completions and a slightly different request/response.
+const (
+	backendKindOllama = "ollama"
+	backendKindOpenAI = "openai"
+)
+
+// chatCompletionTo is the per-call variant of chatCompletion: takes an
+// explicit backend URL and kind so a dispatch can route to LM Studio without
+// mutating h.ollamaURL. Ollama path is the existing /api/chat shape; OpenAI
+// path translates to /v1/chat/completions and back.
+func (h *AgentHarness) chatCompletionTo(ctx context.Context, backendURL, kind string, req agentChatRequest) (*agentChatResponse, error) {
+	if backendURL == "" {
+		backendURL = h.ollamaURL
+	}
+	if kind == "" {
+		kind = backendKindOllama
+	}
+	if kind == backendKindOpenAI {
+		return h.chatCompletionOpenAI(ctx, backendURL, req)
+	}
+	// Ollama native — same as chatCompletion but parameterized URL.
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, backendURL+"/api/chat", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpResp, err := h.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("http request: %w", err)
+	}
+	defer httpResp.Body.Close()
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if httpResp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("http %d: %s", httpResp.StatusCode, string(respBody))
+	}
+	var resp agentChatResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	return &resp, nil
+}
+
+// chatCompletionOpenAI talks to a /v1/chat/completions endpoint (LM Studio,
+// vLLM, OpenAI proper). Translates the Ollama-shaped request into the
+// OpenAI shape and translates the response back. Tool-call ID and arguments
+// shape match the Ollama native format already, so the rest of the loop
+// doesn't need to know which backend served a turn.
+func (h *AgentHarness) chatCompletionOpenAI(ctx context.Context, backendURL string, req agentChatRequest) (*agentChatResponse, error) {
+	type openaiToolCallFn struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	}
+	type openaiToolCall struct {
+		ID       string           `json:"id"`
+		Type     string           `json:"type"`
+		Function openaiToolCallFn `json:"function"`
+	}
+	type openaiMessage struct {
+		Role       string           `json:"role"`
+		Content    string           `json:"content,omitempty"`
+		ToolCalls  []openaiToolCall `json:"tool_calls,omitempty"`
+		ToolCallID string           `json:"tool_call_id,omitempty"`
+	}
+	type openaiRequest struct {
+		Model    string           `json:"model"`
+		Messages []openaiMessage  `json:"messages"`
+		Tools    []ToolDefinition `json:"tools,omitempty"`
+		Stream   bool             `json:"stream"`
+	}
+
+	// Translate request — flatten our agentChatMessage into openaiMessage.
+	// OpenAI's tool_calls.function.arguments is a JSON-encoded *string*,
+	// not a JSON object — re-encode as needed.
+	outMsgs := make([]openaiMessage, 0, len(req.Messages))
+	for _, m := range req.Messages {
+		om := openaiMessage{Role: m.Role, Content: m.Content, ToolCallID: m.ToolCallID}
+		for _, tc := range m.ToolCalls {
+			om.ToolCalls = append(om.ToolCalls, openaiToolCall{
+				ID:   tc.ID,
+				Type: "function",
+				Function: openaiToolCallFn{
+					Name:      tc.Function.Name,
+					Arguments: string(tc.Function.Arguments),
+				},
+			})
+		}
+		outMsgs = append(outMsgs, om)
+	}
+	body, err := json.Marshal(openaiRequest{
+		Model:    req.Model,
+		Messages: outMsgs,
+		Tools:    req.Tools,
+		Stream:   false,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal openai request: %w", err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, backendURL+"/v1/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create openai request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpResp, err := h.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("http openai request: %w", err)
+	}
+	defer httpResp.Body.Close()
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read openai response: %w", err)
+	}
+	if httpResp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("openai http %d: %s", httpResp.StatusCode, string(respBody))
+	}
+
+	// Translate response — OpenAI returns choices[0].message; flatten.
+	var rawResp struct {
+		Choices []struct {
+			Message openaiMessage `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(respBody, &rawResp); err != nil {
+		return nil, fmt.Errorf("parse openai response: %w", err)
+	}
+	out := &agentChatResponse{Done: true}
+	if len(rawResp.Choices) == 0 {
+		return out, nil
+	}
+	m := rawResp.Choices[0].Message
+	out.Message.Role = m.Role
+	out.Message.Content = m.Content
+	for _, tc := range m.ToolCalls {
+		ac := agentToolCall{ID: tc.ID, Type: "function"}
+		ac.Function.Name = tc.Function.Name
+		ac.Function.Arguments = json.RawMessage(tc.Function.Arguments)
+		out.Message.ToolCalls = append(out.Message.ToolCalls, ac)
+	}
+	return out, nil
 }

--- a/internal/engine/agent_dispatch.go
+++ b/internal/engine/agent_dispatch.go
@@ -1,0 +1,143 @@
+// agent_dispatch.go — Phase 2 transport: task-parameterized dispatch into the
+// kernel-interior agent harness, with concurrency, structured return, per-call
+// scope narrowing, and pluggable model routing.
+//
+// The cog_dispatch_to_harness MCP tool surfaces this transport. It is the
+// foveal -> peripheral handoff: a big external Claude session can offload a
+// piece of cognitive work (validation, rewriting, modality matching) onto the
+// always-resident Gemma E4B (or LM Studio 26B) without burning Anthropic
+// tokens.
+//
+// This file owns the *contract* — the request and result types and the
+// AgentController extension. The concrete dispatcher lives in the root
+// package (agent_dispatch.go in main) so it can reach the *AgentHarness
+// instance the kernel runs.
+//
+// Identity propagation note: per the Phase 2 plan, identity claims travel
+// through DispatchRequest.Identity as opaque OIDC-shaped fields (iss/sub/aud
+// + claims map). Today the controller adapter copies these through to the
+// harness as cycle-trace metadata; full CRD-based identity binding waits for
+// the Wave 6b migration. The field is wired now so that integration is
+// additive — no schema break later.
+package engine
+
+import "context"
+
+// DispatchModel selects the inference backend. "e4b" routes to the always-
+// resident Ollama (localhost:11434), "26b" routes to the configured remote
+// OpenAI-compatible endpoint (see COGOS_LLM_ENDPOINT or providers.yaml).
+// Empty string is normalized to "e4b" by the dispatcher.
+type DispatchModel string
+
+const (
+	DispatchModelE4B DispatchModel = "e4b"
+	DispatchModel26B DispatchModel = "26b"
+)
+
+// DispatchIdentity carries OIDC-shaped identity claims propagated from the
+// caller. All fields are optional — when absent, the dispatcher records
+// "anonymous" in the trace and lets the harness operate under its default
+// envelope. Once Wave 6b lands, these claims will be checked against the
+// Identity CRD reconciler before tool selection; today they are observability
+// metadata only.
+type DispatchIdentity struct {
+	Iss    string                 `json:"iss,omitempty"`    // issuer (e.g. "anthropic.claude-code")
+	Sub    string                 `json:"sub,omitempty"`    // subject (e.g. session id, user handle)
+	Aud    string                 `json:"aud,omitempty"`    // audience (e.g. "cogos.kernel")
+	Claims map[string]interface{} `json:"claims,omitempty"` // free-form claim bag
+}
+
+// DispatchRequest is the normalized input one DispatchToHarness call accepts.
+// Validation and clamping happen in the controller adapter; engine callers
+// can pass through unchecked since the controller re-normalizes.
+type DispatchRequest struct {
+	// AgentID names the harness instance. Defaults to "primary" when empty.
+	AgentID string
+
+	// Task is the user-role prompt sent into the harness's Execute loop.
+	// Required and non-empty.
+	Task string
+
+	// Tools is the optional allowlist for this dispatch. nil or empty means
+	// "use the harness's default tool registry". Names that don't match any
+	// registered tool surface as an error in the result, not silent drop.
+	Tools []string
+
+	// Model selects the inference backend. Unknown values default to e4b.
+	Model DispatchModel
+
+	// TimeoutSeconds is the per-dispatch wall-clock budget. Clamped to
+	// [1,120] by the controller. Default 30s.
+	TimeoutSeconds int
+
+	// N controls the parallel fan-out. Clamped to [1,4]. Default 1. Each
+	// dispatch in the batch gets its own Index, its own context, its own
+	// deadline; failures in one do not abort siblings.
+	N int
+
+	// SystemPrompt overrides the harness's default system prompt for this
+	// dispatch. Empty string keeps the harness default. Used by the output-
+	// alignment layer to swap in role-specific prompts (validator, rewriter,
+	// modality-matcher) without persistent config changes.
+	SystemPrompt string
+
+	// Thinking optionally overrides the harness's "think" flag. nil keeps
+	// the harness default (false today, JSON-mode-friendly). Pass &true to
+	// let the model emit a reasoning trace before answering.
+	Thinking *bool
+
+	// Identity propagates OIDC-shaped caller claims for trace metadata.
+	// Optional; see DispatchIdentity for forward-compat notes.
+	Identity DispatchIdentity
+}
+
+// DispatchToolCallSummary is the digest of one tool invocation made during a
+// dispatch's Execute loop. Args and result are summarized to keep the result
+// shape small (full transcripts are still recoverable via the kernel's
+// ledger using the dispatch's cycle id).
+type DispatchToolCallSummary struct {
+	Name         string `json:"name"`
+	ArgsDigest   string `json:"args_digest,omitempty"`   // first 200 chars of the JSON args
+	ResultDigest string `json:"result_digest,omitempty"` // first 200 chars of the JSON result
+	Error        string `json:"error,omitempty"`
+}
+
+// DispatchResult is one slot in the batch — the outcome of a single dispatch
+// invocation. Index is its position in the batch (0..N-1).
+type DispatchResult struct {
+	Index       int                       `json:"index"`
+	Success     bool                      `json:"success"`
+	Content     string                    `json:"content,omitempty"`
+	ToolCalls   []DispatchToolCallSummary `json:"tool_calls,omitempty"`
+	Error       string                    `json:"error,omitempty"`
+	DurationSec float64                   `json:"duration_sec"`
+	Turns       int                       `json:"turns"`
+	// ModelUsed reports the backend that actually served this slot. May
+	// differ from DispatchRequest.Model when "26b" degraded to e4b due to
+	// LM Studio being unreachable — Error then carries the warning.
+	ModelUsed DispatchModel `json:"model_used,omitempty"`
+}
+
+// DispatchBatchResult is the envelope returned to the caller. Results is
+// always len(N), filled in dispatch index order, even when some slots
+// failed. TotalDurationSec is wall-clock from dispatch start to last slot
+// finishing.
+type DispatchBatchResult struct {
+	Results          []DispatchResult `json:"results"`
+	TotalDurationSec float64          `json:"total_duration_sec"`
+	// Notes carries batch-level diagnostic strings (e.g. "26b unreachable,
+	// degraded to e4b for slots 0,2"). Per-slot warnings live in the
+	// individual Error fields.
+	Notes []string `json:"notes,omitempty"`
+}
+
+// AgentDispatcher is the AgentController extension that surfaces the Phase 2
+// transport. The interface lives separate from AgentController so older
+// implementations can satisfy the latter without growing the dispatch
+// surface. The MCP layer type-asserts to detect availability.
+type AgentDispatcher interface {
+	// DispatchToHarness runs the request as a fan-out batch and returns
+	// once every slot has either completed, errored, or timed out. The
+	// returned batch is always non-nil when the error is nil.
+	DispatchToHarness(ctx context.Context, req DispatchRequest) (*DispatchBatchResult, error)
+}

--- a/internal/engine/agent_dispatch_query.go
+++ b/internal/engine/agent_dispatch_query.go
@@ -1,0 +1,116 @@
+// agent_dispatch_query.go — validation, clamping, and orchestration glue for
+// DispatchRequest. Pure functions over the AgentDispatcher contract; the
+// concrete dispatcher lives in the root package because it needs *AgentHarness.
+package engine
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// dispatchTimeoutDefault is the per-slot wall-clock budget when the caller
+// passed 0 or omitted the field. 30s comfortably covers the resident E4B's
+// 10-turn worst case at ~3s/turn while staying well under the
+// h.httpClient.Timeout (180s) so the inner HTTP call is the actual cap.
+const dispatchTimeoutDefault = 30
+
+// dispatchTimeoutMax caps the per-slot budget. 120s lines up with the
+// existing AgentController.TriggerAgent wait limit (90s) plus a buffer for
+// degraded-network / 26B routing.
+const dispatchTimeoutMax = 120
+
+// dispatchNDefault is the parallel fan-out when 0 is passed. Mirrors the
+// "single dispatch" baseline so a minimal call shape behaves like a normal
+// trigger.
+const dispatchNDefault = 1
+
+// dispatchNMax caps fan-out. The 48 GB VRAM box comfortably runs 4 concurrent
+// E4B requests against the resident weights; tighter caps belong upstream.
+const dispatchNMax = 4
+
+// Normalize fills defaults, clamps ranges, and returns the first invalid-input
+// error it finds (or nil). Mutates the receiver — callers pass by pointer.
+func (r *DispatchRequest) Normalize() error {
+	if r.AgentID == "" {
+		r.AgentID = DefaultAgentID
+	}
+	if err := ValidateAgentID(r.AgentID); err != nil {
+		return err
+	}
+	r.Task = strings.TrimSpace(r.Task)
+	if r.Task == "" {
+		return &AgentControllerError{Code: "invalid_input", Message: "task is required"}
+	}
+	switch r.Model {
+	case "", DispatchModelE4B:
+		r.Model = DispatchModelE4B
+	case DispatchModel26B:
+		// keep
+	default:
+		// Unknown values silently fall back to e4b per the spec — the
+		// dispatcher logs the substitution at its own layer if it cares.
+		r.Model = DispatchModelE4B
+	}
+	if r.TimeoutSeconds <= 0 {
+		r.TimeoutSeconds = dispatchTimeoutDefault
+	}
+	if r.TimeoutSeconds > dispatchTimeoutMax {
+		r.TimeoutSeconds = dispatchTimeoutMax
+	}
+	if r.N <= 0 {
+		r.N = dispatchNDefault
+	}
+	if r.N > dispatchNMax {
+		r.N = dispatchNMax
+	}
+	// Tools are validated against the live registry by the dispatcher
+	// (only it knows what's registered). Trim/dedupe here to keep the
+	// downstream adapter simple.
+	if len(r.Tools) > 0 {
+		r.Tools = dedupeStrings(r.Tools)
+	}
+	return nil
+}
+
+// QueryDispatchToHarness wraps an AgentDispatcher with normalization and the
+// "controller installed?" check. Returns ErrAgentUnavailable when the
+// controller is nil or doesn't implement AgentDispatcher.
+func QueryDispatchToHarness(ctx context.Context, ctrl AgentController, req DispatchRequest) (*DispatchBatchResult, error) {
+	if ctrl == nil {
+		return nil, ErrAgentUnavailable
+	}
+	disp, ok := ctrl.(AgentDispatcher)
+	if !ok {
+		return nil, &AgentControllerError{
+			Code:    "unavailable",
+			Message: fmt.Sprintf("agent %q does not support dispatch (controller missing AgentDispatcher)", req.AgentID),
+		}
+	}
+	if err := req.Normalize(); err != nil {
+		return nil, err
+	}
+	return disp.DispatchToHarness(ctx, req)
+}
+
+// dedupeStrings returns ss with empty strings removed and order-preserving
+// dedupe. Allocates only when the input has duplicates or empties.
+func dedupeStrings(ss []string) []string {
+	if len(ss) == 0 {
+		return ss
+	}
+	seen := make(map[string]struct{}, len(ss))
+	out := ss[:0]
+	for _, s := range ss {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}

--- a/internal/engine/agent_dispatch_query_test.go
+++ b/internal/engine/agent_dispatch_query_test.go
@@ -1,0 +1,134 @@
+// agent_dispatch_query_test.go — coverage for the engine-side validation,
+// normalization, and controller-availability checks. The concrete dispatcher
+// lives in the root package; here we exercise only the contract that engine
+// callers can rely on.
+package engine
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// fakeAgentDispatcher is a fakeAgentController extension that satisfies
+// AgentDispatcher. It records the last DispatchRequest it observed and
+// returns a canned batch.
+type fakeAgentDispatcher struct {
+	fakeAgentController
+	lastReq  DispatchRequest
+	canned   *DispatchBatchResult
+	cannedOk bool
+}
+
+func (f *fakeAgentDispatcher) DispatchToHarness(_ context.Context, req DispatchRequest) (*DispatchBatchResult, error) {
+	f.lastReq = req
+	if f.canned != nil {
+		return f.canned, nil
+	}
+	if !f.cannedOk {
+		return nil, &AgentControllerError{Code: "internal", Message: "no canned response set"}
+	}
+	return &DispatchBatchResult{Results: []DispatchResult{{Index: 0, Success: true}}}, nil
+}
+
+func TestQueryDispatchToHarness_NormalizationDefaults(t *testing.T) {
+	disp := &fakeAgentDispatcher{cannedOk: true}
+	req := DispatchRequest{Task: "do thing"}
+	if _, err := QueryDispatchToHarness(context.Background(), disp, req); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	got := disp.lastReq
+	if got.AgentID != DefaultAgentID {
+		t.Errorf("AgentID default not applied, got %q", got.AgentID)
+	}
+	if got.Model != DispatchModelE4B {
+		t.Errorf("Model default not applied, got %q", got.Model)
+	}
+	if got.TimeoutSeconds != 30 {
+		t.Errorf("TimeoutSeconds default not applied, got %d", got.TimeoutSeconds)
+	}
+	if got.N != 1 {
+		t.Errorf("N default not applied, got %d", got.N)
+	}
+}
+
+func TestQueryDispatchToHarness_ClampsRanges(t *testing.T) {
+	disp := &fakeAgentDispatcher{cannedOk: true}
+	req := DispatchRequest{Task: "x", N: 99, TimeoutSeconds: 99999}
+	if _, err := QueryDispatchToHarness(context.Background(), disp, req); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if disp.lastReq.N != 4 {
+		t.Errorf("N not clamped to 4, got %d", disp.lastReq.N)
+	}
+	if disp.lastReq.TimeoutSeconds != 120 {
+		t.Errorf("TimeoutSeconds not clamped to 120, got %d", disp.lastReq.TimeoutSeconds)
+	}
+}
+
+func TestQueryDispatchToHarness_UnknownModelDefaultsToE4B(t *testing.T) {
+	disp := &fakeAgentDispatcher{cannedOk: true}
+	req := DispatchRequest{Task: "x", Model: DispatchModel("frobnicate")}
+	if _, err := QueryDispatchToHarness(context.Background(), disp, req); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if disp.lastReq.Model != DispatchModelE4B {
+		t.Errorf("unknown model not normalized to e4b, got %q", disp.lastReq.Model)
+	}
+}
+
+func TestQueryDispatchToHarness_EmptyTaskRejected(t *testing.T) {
+	disp := &fakeAgentDispatcher{cannedOk: true}
+	if _, err := QueryDispatchToHarness(context.Background(), disp, DispatchRequest{Task: ""}); err == nil {
+		t.Fatal("expected error for empty task")
+	}
+	if _, err := QueryDispatchToHarness(context.Background(), disp, DispatchRequest{Task: "   "}); err == nil {
+		t.Fatal("expected error for whitespace-only task")
+	}
+}
+
+func TestQueryDispatchToHarness_NilControllerUnavailable(t *testing.T) {
+	_, err := QueryDispatchToHarness(context.Background(), nil, DispatchRequest{Task: "x"})
+	if err == nil {
+		t.Fatal("expected ErrAgentUnavailable")
+	}
+	ace, ok := err.(*AgentControllerError)
+	if !ok || ace.Code != "unavailable" {
+		t.Errorf("expected unavailable error, got %v", err)
+	}
+}
+
+func TestQueryDispatchToHarness_ControllerWithoutDispatcher(t *testing.T) {
+	// Plain fakeAgentController doesn't satisfy AgentDispatcher; the
+	// query helper should report unavailable rather than panic.
+	plain := &fakeAgentController{}
+	_, err := QueryDispatchToHarness(context.Background(), plain, DispatchRequest{Task: "x"})
+	if err == nil {
+		t.Fatal("expected error for non-dispatch controller")
+	}
+	if !strings.Contains(err.Error(), "does not support dispatch") {
+		t.Errorf("expected does-not-support message, got %v", err)
+	}
+}
+
+func TestDispatchRequest_NormalizeDedupesTools(t *testing.T) {
+	req := DispatchRequest{Task: "x", Tools: []string{"a", " ", "a", "b", "", "b"}}
+	if err := req.Normalize(); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if got, want := req.Tools, []string{"a", "b"}; !equalStrings(got, want) {
+		t.Errorf("expected %v, got %v", want, got)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -240,6 +240,11 @@ func (m *MCPServer) registerTools() {
 		Description: "Manually invoke one homeostatic cycle of the specified agent, outside the regular ticker. Equivalent to POST /v1/agents/{id}/tick. Returns immediately with a trigger receipt; cycle runs async unless wait=true. Refuses if a cycle is already in flight (overlap guard). Fallback: curl -X POST http://localhost:6931/v1/agents/primary/tick",
 	}), m.toolTriggerAgentLoop)
 
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name:        "cog_dispatch_to_harness",
+		Description: "Phase 2 transport: dispatch a task into the kernel-interior agent harness with structured return, optional concurrency (n=1..4), per-call tool scope narrowing, optional system-prompt override, and pluggable model routing (e4b local Ollama, default; 26b LM Studio with degrade-to-e4b fallback). Synchronous: blocks until every slot completes, errors, or hits its per-slot timeout (default 30s, max 120s). Returns one DispatchResult per slot with content (the agent's final respond text), tool-call digests, duration, and turn count. Use this for the foveal->peripheral handoff — offload validation, rewriting, modality matching to the resident swarm instead of paying with Anthropic tokens. Backward-compat note: cog_trigger_agent_loop still wakes the singleton with no payload; this tool is the new payload-bearing path.",
+	}, m.toolDispatchToHarness)
+
 	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name:        "cog_tail_kernel_log",
 		Description: "Read recent entries from the kernel's own diagnostic log (slog JSON at .cog/run/kernel.log.jsonl). Returns newest-first, optionally filtered by level, substring, and time range. This is the OPERATOR/DEBUG surface — for hash-chained event history use cog_read_ledger (when available); for client metabolites (turn metrics, attention, proprioceptive) use cog_search_traces. Fallback: tail -n 100 .cog/run/kernel.log.jsonl | jq -c .",
@@ -605,6 +610,25 @@ type triggerAgentLoopInput struct {
 	AgentID string `json:"agent_id,omitempty" jsonschema:"Which agent to trigger. Default \"primary\"."`
 	Reason  string `json:"reason,omitempty" jsonschema:"Free-text tag stored on a synthetic agent.wake event for audit (optional)."`
 	Wait    bool   `json:"wait,omitempty" jsonschema:"If true, block until the cycle completes (up to 90s) and return the outcome. Default false (fire-and-forget)."`
+}
+
+// dispatchToHarnessInput is the wire shape for cog_dispatch_to_harness — the
+// Phase 2 task-parameterized transport from the foveal Claude session into
+// the resident peripheral swarm. See engine/agent_dispatch.go for the
+// underlying DispatchRequest contract.
+type dispatchToHarnessInput struct {
+	AgentID      string                 `json:"agent_id,omitempty" jsonschema:"Which harness instance to dispatch into. Default \"primary\"."`
+	Task         string                 `json:"task" jsonschema:"Required. The user-role prompt the harness's Execute loop will receive."`
+	Tools        []string               `json:"tools,omitempty" jsonschema:"Optional tool allowlist (subset of registered core tools). nil/empty uses the full default set. Unknown names error in the per-slot result rather than silently dropping."`
+	Model        string                 `json:"model,omitempty" jsonschema:"Inference backend. \"e4b\" (default, local Ollama) or \"26b\" (configured remote OpenAI-compatible endpoint). Unknown values fall back to e4b."`
+	Timeout      int                    `json:"timeout_seconds,omitempty" jsonschema:"Per-slot wall-clock budget in seconds. Default 30, max 120. On exceed, that slot returns success=false error=\"timeout\"; sibling slots continue."`
+	N            int                    `json:"n,omitempty" jsonschema:"Parallel fan-out, [1,4]. Default 1. Each slot gets its own context, its own deadline, and its own result entry; failures don't abort siblings."`
+	SystemPrompt string                 `json:"system_prompt,omitempty" jsonschema:"Optional system-prompt override for this dispatch only. Empty keeps the harness default. Used by output-alignment roles (validator/rewriter/modality-matcher)."`
+	Thinking     *bool                  `json:"thinking,omitempty" jsonschema:"Optional override of the model's think flag. nil keeps the harness default."`
+	Iss          string                 `json:"iss,omitempty" jsonschema:"OIDC-shaped identity claim: issuer (e.g. \"anthropic.claude-code\"). Forwarded as trace metadata; full CRD binding waits for Wave 6b."`
+	Sub          string                 `json:"sub,omitempty" jsonschema:"OIDC-shaped identity claim: subject (e.g. session id, user handle)."`
+	Aud          string                 `json:"aud,omitempty" jsonschema:"OIDC-shaped identity claim: audience (e.g. \"cogos.kernel\")."`
+	Claims       map[string]interface{} `json:"claims,omitempty" jsonschema:"Free-form OIDC claim bag forwarded to the dispatch's trace metadata."`
 }
 
 // readToolCallsInput mirrors ToolCallQuery for the MCP surface. Time bounds
@@ -1497,6 +1521,34 @@ func (m *MCPServer) toolTriggerAgentLoop(ctx context.Context, req *mcp.CallToolR
 	})
 	if err != nil {
 		return agentErrorResult(err, "curl -X POST http://localhost:6931/v1/agents/primary/tick")
+	}
+	return marshalResult(result)
+}
+
+// toolDispatchToHarness implements cog_dispatch_to_harness — Phase 2
+// task-parameterized transport. See engine/agent_dispatch.go for the
+// underlying contract and the project_cogos_foveal_and_peripheral.md memory
+// note for the architectural framing.
+func (m *MCPServer) toolDispatchToHarness(ctx context.Context, req *mcp.CallToolRequest, input dispatchToHarnessInput) (*mcp.CallToolResult, any, error) {
+	dr := DispatchRequest{
+		AgentID:        input.AgentID,
+		Task:           input.Task,
+		Tools:          input.Tools,
+		Model:          DispatchModel(input.Model),
+		TimeoutSeconds: input.Timeout,
+		N:              input.N,
+		SystemPrompt:   input.SystemPrompt,
+		Thinking:       input.Thinking,
+		Identity: DispatchIdentity{
+			Iss:    input.Iss,
+			Sub:    input.Sub,
+			Aud:    input.Aud,
+			Claims: input.Claims,
+		},
+	}
+	result, err := QueryDispatchToHarness(ctx, m.agentController, dr)
+	if err != nil {
+		return agentErrorResult(err, "curl -X POST http://localhost:6931/v1/agents/primary/dispatch -d @body.json")
 	}
 	return marshalResult(result)
 }


### PR DESCRIPTION
## Summary

Phase 2 transport for the foveal→peripheral architecture. External Claude sessions can offload cognitive work (validation, rewriting, modality matching) to the kernel-resident Gemma E4B (or any other internal model provider) through a new MCP tool `cog_dispatch_to_harness`, rather than paying Anthropic tokens for it. `cog_trigger_agent_loop` schema unchanged — fully backward-compat.

## Contract

```
cog_dispatch_to_harness({
  task:           string,           // required — the prompt
  tools?:         []string,         // optional — per-call tool allowlist (scope narrowing)
  model?:         "e4b" | "26b",    // default "e4b" (local Ollama); "26b" routes to LM Studio
  timeout_seconds?: int,            // default 30, max 120
  n?:             int,              // default 1, max 4 — concurrent dispatches
  system_prompt?: string,           // per-call system prompt override (enables role-specific roles)
  thinking?:      bool              // override Ollama's think flag
})
→ {
  results: [{ index, success, content, tool_calls[], error, duration_sec, turns }],
  total_duration_sec: float
}
```

## Change summary (~1840 LoC, 11 hermetic tests + 2 opt-in live smoke tests)

- `agent_dispatch.go` (+301) — `HarnessDispatcher` struct, dispatch orchestration, LM Studio reachability probe + 60s cache
- `agent_dispatch_test.go` (+508) — hermetic unit tests (stand-in HTTP servers): single path, N=3 concurrency, scope narrowing happy + error, slot timeout with sibling continuation, LM Studio reachable + unreachable degrade, system prompt override, identity propagation
- `agent_dispatch_live_test.go` (+110) — 2 opt-in smoke tests behind `//go:build dispatchlive`
- `agent_harness.go` (+478) — `ExecuteScoped`, `scopeTools`, `chatCompletionTo`, OpenAI-compatible path for LM Studio
- `internal/engine/agent_dispatch.go` (+143) — `DispatchRequest`, `DispatchResult`, `DispatchBatchResult`, `DispatchIdentity`, `AgentDispatcher` interface
- `internal/engine/agent_dispatch_query.go` (+116) — normalize + validate + QueryDispatchToHarness entry
- `internal/engine/agent_dispatch_query_test.go` (+134) — engine validation tests
- `internal/engine/mcp_server.go` (+52) — tool registration + handler

## Pool mechanism: option (c) hybrid

Single `*AgentHarness` shared across slots; each slot is a goroutine calling `ExecuteScoped` with its own per-call options (system prompt, tool subset, backend URL/model, think flag, deadline). Ollama keys its KV cache per-request on full message history, so concurrent calls with distinct contexts don't collide. Harness tool registry is read-only after `RegisterCoreTools` — no mutex.

## Gates

- [x] `go build -tags fts5 ./...` — clean
- [x] `go test -tags fts5 -count=1 ./...` — all green (existing 6 `TestQueryTriggerAgent_*` + 18 new dispatch tests)
- [x] `gofmt -l` on touched files — empty
- [x] Hermetic concurrency: N=3 with 80ms latency completes under 2.5x serialized budget; all three slots return distinct content
- [x] Hermetic LM Studio paths: reachable + unreachable-degrade both covered via httptest stand-ins
- [~] **Live smoke against local Ollama on :11434**: dispatcher issued requests correctly, surfaced HTTP 404 as structured `Error` rather than panicking. Happy-path content assertion couldn't run because `gemma3:e4b` model not pulled in the test env — graceful-fail path exercised instead. Needs `ollama pull gemma3:e4b` for end-to-end content validation.

## Known wiring gap (post-merge follow-up)

`HarnessDispatcher` satisfies `engine.AgentDispatcher`, and the MCP tool's handler type-asserts `m.agentController.(engine.AgentDispatcher)`. The root-package `AgentController` adapter on `main` does NOT currently embed `*HarnessDispatcher` — that adapter lives on sibling branch `feat/agent-state-api`. So on `main` today, this tool returns a clean "does not support dispatch" error rather than panicking.

Resolution options (pick one during review):
1. Rebase this PR on top of `feat/agent-state-api` (and merge them together or in sequence)
2. Add the adapter wiring in this PR as a follow-up commit on `main`
3. Land `feat/agent-state-api` first, then a one-line adapter-embed commit here

## Runtime ops notes

- Ollama's `OLLAMA_NUM_PARALLEL` should be set (e.g., `=4`) on the kernel host to actually parallelize N>1 dispatches at the inference layer. Without it, Ollama queues serially and the concurrency speedup evaporates.
- LM Studio 26B routing was hermetically tested; not live-verified because `192.168.10.191:1234` wasn't reachable from the agent's environment. When user's desktop is on and LM Studio serving, the path should just work (OpenAI-compatible shape, bearer auth optional).

## Follow-ups (non-blocking)

- `RegisterRespondTool` should read `DispatchIdentityFromContext` for session_id-scoped respond routing (addtitive — doesn't change existing behavior)
- Full identity binding via IdentityProvider CRD lookup awaits Wave 6b migration; today's dispatcher forwards opaque OIDC-shaped metadata through context