### PR TITLE
feat: ADR-084 Phase 1 — content-addressed bus payloads (G1-G10)

### DIFF
--- a/bus_session.go
+++ b/bus_session.go
@@ -13,6 +13,26 @@ import (
 	"time"
 )
 
+// ADR-084 dataref migration policy (Phase 1: schema-additive).
+//
+// This file implements the two CogBlock emit entry points that coexist on
+// every bus during the migration window:
+//
+//   - appendBusEvent(..., payload) — legacy inline path. Populates
+//     CogBlock.Payload directly; Digest/MediaType are empty.
+//   - appendBusEventRef(..., digest, mediaType, size) — ADR-084 by-reference
+//     path. Caller has already stored bytes in the shared BlobStore; the
+//     envelope carries only the content-addressed digest and Payload is nil.
+//
+// Both call sites share prev-chain, seq assignment, registry update, and
+// handler dispatch, so downstream consumers see a single unified stream with
+// mixed envelope shapes. Consumers MUST tolerate either form and should
+// resolve byref-first: check Digest, fetch via BlobStore / GET /v1/blobs/:digest,
+// and only fall back to inline Payload if Digest is empty.
+//
+// Phase 2 (ADR-084 revision pending) will retire the inline path once all
+// consumers have migrated. See: .cog/adr/084-bus-payloads-as-cogblocks.cog.md
+
 // computeBlockHash computes the V2 content-addressed hash for a CogBlock.
 // It hashes the full canonical form: all fields except hash and sig.
 // The canonical form is a JSON object with fields in a deterministic order.

--- a/bus_session.go
+++ b/bus_session.go
@@ -287,6 +287,77 @@ func (m *busSessionManager) appendBusEvent(busID, eventType, from string, payloa
 	return &evt, nil
 }
 
+// appendBusEventRef is the ADR-084 dataref variant of appendBusEvent. Callers
+// that have already stored their payload in the shared content-addressed blob
+// store pass the digest, media type, and size; this method writes an envelope
+// with those fields populated and Payload left nil. Consumers resolve the
+// bytes via GET /v1/blobs/:digest.
+//
+// All other envelope semantics (V2 block, prev-chain, registry update, handler
+// dispatch) match appendBusEvent so both shapes coexist on the same bus during
+// the Phase 1 migration (G3 pilot, ADR-084 Phase 2).
+//
+// `digest` is expected in the canonical "sha256:<hex>" form. `size` is the
+// original payload byte length.
+func (m *busSessionManager) appendBusEventRef(busID, eventType, from, digest, mediaType string, size int) (*CogBlock, error) {
+	m.mu.Lock()
+
+	lastSeq, lastHash := m.getLastEvent(busID)
+	newSeq := lastSeq + 1
+
+	var prev []string
+	if lastHash != "" {
+		prev = []string{lastHash}
+	}
+
+	evt := CogBlock{
+		V:         2,
+		BusID:     busID,
+		Seq:       newSeq,
+		Ts:        time.Now().UTC().Format(time.RFC3339Nano),
+		From:      from,
+		Type:      eventType,
+		Payload:   nil, // ADR-084: by-reference — bytes live in BlobStore
+		Digest:    digest,
+		MediaType: mediaType,
+		Size:      size,
+		Prev:      prev,
+		PrevHash:  lastHash,
+	}
+	evt.Hash = computeBlockHash(&evt)
+
+	line, err := json.Marshal(evt)
+	if err != nil {
+		m.mu.Unlock()
+		return nil, fmt.Errorf("marshal event: %w", err)
+	}
+
+	eventsFile := m.eventsPath(busID)
+	f, err := os.OpenFile(eventsFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		m.mu.Unlock()
+		return nil, fmt.Errorf("open events file: %w", err)
+	}
+	if _, err := f.WriteString(string(line) + "\n"); err != nil {
+		f.Close()
+		m.mu.Unlock()
+		return nil, fmt.Errorf("write event: %w", err)
+	}
+	f.Close()
+
+	m.updateRegistrySeq(busID, newSeq, evt.Ts)
+
+	handlers := make([]busEventHandler, len(m.eventHandlers))
+	copy(handlers, m.eventHandlers)
+	m.mu.Unlock()
+
+	for _, h := range handlers {
+		h.handler(busID, &evt)
+	}
+
+	return &evt, nil
+}
+
 // getLastEvent reads the last event from a bus to get seq and hash for chaining.
 func (m *busSessionManager) getLastEvent(busID string) (int, string) {
 	eventsFile := m.eventsPath(busID)

--- a/internal/engine/cogblock.go
+++ b/internal/engine/cogblock.go
@@ -43,6 +43,35 @@ type CogBlock struct {
 
 	// Artifacts produced from processing this block.
 	Artifacts []BlockArtifact `json:"artifacts,omitempty"`
+
+	// Sections carries the sub-block index for section-level content
+	// addressing (ADR-059 Phase 2). Each entry describes one addressable
+	// sub-unit of this block's payload by title, anchor, content hash,
+	// and byte size. Empty for blocks without sub-blocks.
+	Sections []Section `json:"sections,omitempty"`
+
+	// Prev carries the V2 DAG predecessor hashes (ADR-059).
+	//
+	// V1 chain semantics use a single string predecessor (historically
+	// PrevHash on sibling wire formats such as BusEvent/UCPMessage).
+	// V2 DAG semantics use Prev []string: one or more predecessors.
+	// Linear chain → len(Prev)==1; merge block → len(Prev)>1; genesis
+	// → empty. ADR-059 Phase 1: both shapes accepted on the wire; hash
+	// computation omits Prev (and any V1 PrevHash sibling field) from
+	// the canonical form to keep the hash stable across chain topology
+	// changes.
+	Prev []string `json:"prev,omitempty"`
+}
+
+// Section describes an addressable sub-block of a CogBlock's payload,
+// used for section-level content addressing and delta sync (ADR-059).
+// The Hash field contains "sha256:<hex>" of the canonicalized section
+// content; Size is the byte length of that content.
+type Section struct {
+	Title  string `json:"title,omitempty"`
+	Anchor string `json:"anchor,omitempty"` // fragment identifier (e.g. "#section-1")
+	Hash   string `json:"hash,omitempty"`   // sha256:<hex> of canonicalized section content
+	Size   int    `json:"size,omitempty"`   // byte length of section content
 }
 
 // Re-export shared types from pkg/cogblock.

--- a/internal/engine/cogblock_test.go
+++ b/internal/engine/cogblock_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -104,3 +105,124 @@ func mustTime(t *testing.T, ts string) time.Time {
 	}
 	return parsed
 }
+
+// TestCogBlockRoundtripEmptySectionsAndPrev verifies that a CogBlock with
+// no Sections and no Prev roundtrips cleanly and that both fields remain
+// nil/empty after unmarshal (omitempty semantics on the wire).
+func TestCogBlockRoundtripEmptySectionsAndPrev(t *testing.T) {
+	t.Parallel()
+
+	original := CogBlock{
+		ID:              "block-empty",
+		Timestamp:       mustTime(t, "2026-04-22T12:00:00Z"),
+		Kind:            BlockMessage,
+		SourceChannel:   "http",
+		SourceTransport: "openai-compat",
+	}
+
+	data, err := json.Marshal(&original)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	// Omitempty: neither "sections" nor "prev" should appear in the wire form.
+	s := string(data)
+	if strings.Contains(s, `"sections"`) {
+		t.Errorf("empty Sections should omit from JSON; got: %s", s)
+	}
+	if strings.Contains(s, `"prev"`) {
+		t.Errorf("empty Prev should omit from JSON; got: %s", s)
+	}
+
+	var decoded CogBlock
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if len(decoded.Sections) != 0 {
+		t.Errorf("decoded Sections = %v; want empty", decoded.Sections)
+	}
+	if len(decoded.Prev) != 0 {
+		t.Errorf("decoded Prev = %v; want empty", decoded.Prev)
+	}
+}
+
+// TestCogBlockRoundtripPopulatedSectionsAndPrev verifies that a CogBlock
+// with multiple Sections and a DAG-style Prev (len>1, i.e. a merge block)
+// roundtrips identically.
+func TestCogBlockRoundtripPopulatedSectionsAndPrev(t *testing.T) {
+	t.Parallel()
+
+	original := CogBlock{
+		ID:              "block-full",
+		Timestamp:       mustTime(t, "2026-04-22T12:00:00Z"),
+		Kind:            BlockMessage,
+		SourceChannel:   "bus",
+		SourceTransport: "bus",
+		Sections: []Section{
+			{Title: "Intro", Anchor: "#intro", Hash: "sha256:abc123", Size: 512},
+			{Title: "Body", Anchor: "#body", Hash: "sha256:def456", Size: 2048},
+		},
+		// DAG merge: two predecessors. Confirms len(Prev)>1 is supported.
+		Prev: []string{"sha256:aaa", "sha256:bbb"},
+	}
+
+	data, err := json.Marshal(&original)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var decoded CogBlock
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if len(decoded.Sections) != 2 {
+		t.Fatalf("Sections len = %d; want 2", len(decoded.Sections))
+	}
+	if decoded.Sections[0] != original.Sections[0] {
+		t.Errorf("Sections[0] = %+v; want %+v", decoded.Sections[0], original.Sections[0])
+	}
+	if decoded.Sections[1] != original.Sections[1] {
+		t.Errorf("Sections[1] = %+v; want %+v", decoded.Sections[1], original.Sections[1])
+	}
+
+	// DAG merge semantics: Prev has two entries, order preserved.
+	if len(decoded.Prev) != 2 {
+		t.Fatalf("Prev len = %d; want 2 (DAG merge)", len(decoded.Prev))
+	}
+	if decoded.Prev[0] != "sha256:aaa" || decoded.Prev[1] != "sha256:bbb" {
+		t.Errorf("Prev = %v; want [sha256:aaa sha256:bbb]", decoded.Prev)
+	}
+}
+
+// TestCogBlockLinearChainPrev verifies the V2 DAG linear-chain shape:
+// Prev with exactly one predecessor (len(Prev)==1 — linear chain).
+func TestCogBlockLinearChainPrev(t *testing.T) {
+	t.Parallel()
+
+	original := CogBlock{
+		ID:              "block-linear",
+		Timestamp:       mustTime(t, "2026-04-22T12:00:00Z"),
+		Kind:            BlockMessage,
+		SourceChannel:   "http",
+		SourceTransport: "openai-compat",
+		Prev:            []string{"sha256:predecessor"},
+	}
+
+	data, err := json.Marshal(&original)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var decoded CogBlock
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if len(decoded.Prev) != 1 {
+		t.Fatalf("Prev len = %d; want 1 (linear chain)", len(decoded.Prev))
+	}
+	if decoded.Prev[0] != "sha256:predecessor" {
+		t.Errorf("Prev[0] = %q; want sha256:predecessor", decoded.Prev[0])
+	}
+}
+

--- a/internal/engine/process.go
+++ b/internal/engine/process.go
@@ -169,6 +169,13 @@ type Process struct {
 	// by NewProcess, so call sites don't need to thread this pointer.
 	broker *EventBroker
 
+	// blobStore is the content-addressed blob store rooted at
+	// WorkspaceRoot/.cog/blobs/. Initialized at process startup so that
+	// ADR-084 digest-ref emit paths have a store ready to write into and
+	// serve_blocks handlers can reuse this shared handle instead of
+	// constructing new ones per request.
+	blobStore *BlobStore
+
 	// pendingToolCalls correlates client-ownership tool.call emissions with
 	// the role=tool response that arrives on a later HTTP turn. Lazily
 	// initialized on first registerPendingToolCall; swept by
@@ -187,6 +194,17 @@ func NewProcess(cfg *Config, nucleus *Nucleus) *Process {
 	// functionally identical to SetCurrentBroker; in tests it lets
 	// multiple parallel processes coexist without racing a single slot.
 	RegisterBroker(broker)
+
+	// Initialize the content-addressed blob store (ADR-084). Calling Init()
+	// here (not lazily) guarantees `.cog/blobs/` and the manifest are ready
+	// before any emit path starts writing digest-ref payloads. A failure to
+	// create the directory is logged but not fatal — individual Store calls
+	// will retry the mkdir and surface their own errors.
+	blobStore := NewBlobStore(workspaceRootFromCfg(cfg))
+	if err := blobStore.Init(); err != nil {
+		slog.Warn("process: blob store init failed", "err", err)
+	}
+
 	return &Process{
 		state:     StateReceptive,
 		nucleus:   nucleus,
@@ -210,6 +228,7 @@ func NewProcess(cfg *Config, nucleus *Nucleus) *Process {
 		nodeManifest:        loadManifestQuiet(cfg),
 		hookRegistry:        loadStateHookRegistry(workspaceRootFromCfg(cfg)),
 		broker:              broker,
+		blobStore:           blobStore,
 	}
 }
 
@@ -219,6 +238,17 @@ func (p *Process) Broker() *EventBroker {
 		return nil
 	}
 	return p.broker
+}
+
+// BlobStore returns the shared content-addressed blob store (nil if the
+// process was constructed without one). Emit paths and HTTP blob handlers
+// should prefer this shared handle over constructing new BlobStore values
+// per call so they pick up any future in-memory state (locks, caches).
+func (p *Process) BlobStore() *BlobStore {
+	if p == nil {
+		return nil
+	}
+	return p.blobStore
 }
 
 // workspaceRootFromCfg returns the workspace root from the config, or "" if nil.
@@ -357,6 +387,13 @@ func (p *Process) SubmitExternal(evt *GateEvent) bool {
 
 // Run starts the continuous process loop. It blocks until ctx is cancelled.
 func (p *Process) Run(ctx context.Context) error {
+	// Surface the blob store root in the boot log so operators can see
+	// where digest-ref payloads will land. Construction + Init happened in
+	// NewProcess; this is purely informational.
+	if p.blobStore != nil {
+		slog.Info("process: blob store ready", "root", p.blobStore.root)
+	}
+
 	// Build CogDoc index first (fast — just frontmatter parsing).
 	// This must happen before field.Update() which can be slow (git log per file).
 	slog.Info("process: building initial CogDoc index")

--- a/internal/engine/process_test.go
+++ b/internal/engine/process_test.go
@@ -51,6 +51,47 @@ func TestNewProcessInitialState(t *testing.T) {
 	}
 }
 
+// ── BlobStore wiring ──────────────────────────────────────────────────────
+
+// TestNewProcessInitializesBlobStore verifies that process construction
+// creates the content-addressed blob store, creates the `.cog/blobs/`
+// directory on disk, and exposes the store via the BlobStore() accessor so
+// emit paths (ADR-084) can write digest-ref payloads immediately.
+func TestNewProcessInitializesBlobStore(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	cfg := makeConfig(t, root)
+	p := NewProcess(cfg, makeNucleus("T", "r"))
+
+	bs := p.BlobStore()
+	if bs == nil {
+		t.Fatal("BlobStore() returned nil after NewProcess")
+	}
+
+	blobsDir := filepath.Join(root, ".cog", "blobs")
+	info, err := os.Stat(blobsDir)
+	if err != nil {
+		t.Fatalf("blobs dir not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("%s exists but is not a directory", blobsDir)
+	}
+
+	// A round-trip through the live store confirms Init() ran far enough
+	// that Store/Get succeed without any further bootstrap.
+	hash, err := bs.Store([]byte("g10 wiring probe"), "text/plain")
+	if err != nil {
+		t.Fatalf("Store on post-init BlobStore failed: %v", err)
+	}
+	got, err := bs.Get(hash)
+	if err != nil {
+		t.Fatalf("Get on post-init BlobStore failed: %v", err)
+	}
+	if string(got) != "g10 wiring probe" {
+		t.Fatalf("round-trip mismatch: got %q", got)
+	}
+}
+
 // ── Send ──────────────────────────────────────────────────────────────────
 
 func TestProcessSendAccepted(t *testing.T) {

--- a/internal/engine/section_hash.go
+++ b/internal/engine/section_hash.go
@@ -1,0 +1,166 @@
+package engine
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"unicode"
+)
+
+// ComputeSectionHash returns the canonical content hash for a Section's
+// content bytes in the form "sha256:<hex>". The caller is responsible for
+// passing the already-canonicalized content bytes; ComputeSectionHash does
+// not re-canonicalize (RFC 8785-style canonicalization applies at the
+// parse step in GenerateSectionIndex).
+func ComputeSectionHash(content []byte) string {
+	sum := sha256.Sum256(content)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// GenerateSectionIndex parses a Markdown document into h2-level sections
+// and returns a []Section with a stable content hash for each.
+//
+// A section spans from one `## Heading` line up to (but not including) the
+// next `## Heading` line. Any content preceding the first h2 heading is
+// discarded — only content addressable under an h2 title is indexed.
+//
+// The content used for hashing is the section's raw bytes (heading line
+// plus body) with trailing whitespace on each line trimmed and trailing
+// blank lines removed, so that cosmetic whitespace edits do not change
+// the hash. This is a lightweight canonicalization in the spirit of
+// ADR-059 Phase 2 / RFC 8785.
+//
+// Anchor is the slug form of the title: lowercase, ASCII alphanumerics
+// and hyphens only, spaces collapsed to single hyphens, leading/trailing
+// hyphens stripped. This matches common Markdown anchor conventions.
+//
+// Returns an empty []Section for empty or heading-free input.
+func GenerateSectionIndex(markdown string) []Section {
+	if markdown == "" {
+		return []Section{}
+	}
+
+	lines := strings.Split(markdown, "\n")
+	type rawSection struct {
+		title string
+		lines []string // includes the heading line
+	}
+	var raw []rawSection
+	var cur *rawSection
+
+	for _, line := range lines {
+		if isH2Heading(line) {
+			if cur != nil {
+				raw = append(raw, *cur)
+			}
+			title := extractH2Title(line)
+			cur = &rawSection{
+				title: title,
+				lines: []string{line},
+			}
+			continue
+		}
+		if cur != nil {
+			cur.lines = append(cur.lines, line)
+		}
+		// Lines before the first h2 are ignored.
+	}
+	if cur != nil {
+		raw = append(raw, *cur)
+	}
+
+	if len(raw) == 0 {
+		return []Section{}
+	}
+
+	out := make([]Section, 0, len(raw))
+	for _, r := range raw {
+		canon := canonicalizeSection(r.lines)
+		contentBytes := []byte(canon)
+		out = append(out, Section{
+			Title:  r.title,
+			Anchor: slugifyAnchor(r.title),
+			Hash:   ComputeSectionHash(contentBytes),
+			Size:   len(contentBytes),
+		})
+	}
+	return out
+}
+
+// isH2Heading reports whether a line is an ATX-style h2 heading
+// (exactly two leading '#' followed by a space). Leading whitespace is
+// allowed per CommonMark-ish tolerance but the heading marker itself
+// must be `## `.
+func isH2Heading(line string) bool {
+	trimmed := strings.TrimLeft(line, " \t")
+	if !strings.HasPrefix(trimmed, "## ") {
+		return false
+	}
+	// Reject h3+ (`### `, `#### `, etc.) which also pass the prefix check
+	// above only if the prefix is literally "## ". `strings.HasPrefix` on
+	// "## " already rejects "### " because "### "[0:3] == "###" != "## ".
+	// So no extra check needed. But we do want to reject lines like
+	// "##\t" or "##foo" — the HasPrefix on "## " handles that too.
+	return true
+}
+
+// extractH2Title returns the heading text from an h2 line, stripping
+// the `## ` prefix and any trailing whitespace or trailing `#` run
+// (CommonMark allows `## Foo ##` as an alternate heading form).
+func extractH2Title(line string) string {
+	trimmed := strings.TrimLeft(line, " \t")
+	trimmed = strings.TrimPrefix(trimmed, "## ")
+	trimmed = strings.TrimRight(trimmed, " \t")
+	// Strip optional trailing run of '#' and then more whitespace.
+	trimmed = strings.TrimRight(trimmed, "#")
+	trimmed = strings.TrimRight(trimmed, " \t")
+	return trimmed
+}
+
+// canonicalizeSection joins section lines with "\n" after trimming
+// trailing whitespace from each line and dropping trailing blank lines.
+// This is intentionally conservative: it removes cosmetic variance
+// (trailing spaces, extra blank lines at end) while preserving all
+// semantically meaningful content and ordering.
+func canonicalizeSection(lines []string) string {
+	cleaned := make([]string, len(lines))
+	for i, l := range lines {
+		cleaned[i] = strings.TrimRightFunc(l, unicode.IsSpace)
+	}
+	// Drop trailing blank lines.
+	end := len(cleaned)
+	for end > 0 && cleaned[end-1] == "" {
+		end--
+	}
+	return strings.Join(cleaned[:end], "\n")
+}
+
+// slugifyAnchor converts a heading title into a URL-safe anchor slug.
+// ASCII letters are lowercased; digits are preserved; everything else
+// becomes a hyphen separator. Runs of hyphens collapse to one, and
+// leading / trailing hyphens are trimmed. Distinct from the package
+// helper `slugify` (mcp_server.go) which additionally truncates to 50
+// chars — we avoid truncation here to keep section anchors injective
+// with respect to their full titles.
+func slugifyAnchor(title string) string {
+	var b strings.Builder
+	b.Grow(len(title))
+	prevHyphen := true // suppress leading hyphens
+	for _, r := range title {
+		switch {
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r + ('a' - 'A'))
+			prevHyphen = false
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			prevHyphen = false
+		default:
+			if !prevHyphen {
+				b.WriteByte('-')
+				prevHyphen = true
+			}
+		}
+	}
+	out := b.String()
+	return strings.TrimRight(out, "-")
+}

--- a/internal/engine/section_hash_test.go
+++ b/internal/engine/section_hash_test.go
@@ -1,0 +1,220 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateSectionIndex_EmptyInput(t *testing.T) {
+	got := GenerateSectionIndex("")
+	if got == nil {
+		t.Fatalf("GenerateSectionIndex(\"\") returned nil; want empty slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("GenerateSectionIndex(\"\") = %v; want empty slice", got)
+	}
+}
+
+func TestGenerateSectionIndex_NoHeadings(t *testing.T) {
+	md := "Just a paragraph.\nAnd another line.\n"
+	got := GenerateSectionIndex(md)
+	if len(got) != 0 {
+		t.Fatalf("GenerateSectionIndex with no h2 headings = %v; want empty slice", got)
+	}
+}
+
+func TestGenerateSectionIndex_SingleSection(t *testing.T) {
+	md := "## Introduction\n\nHello world.\n"
+	got := GenerateSectionIndex(md)
+	if len(got) != 1 {
+		t.Fatalf("GenerateSectionIndex single section: got %d sections, want 1", len(got))
+	}
+	s := got[0]
+	if s.Title != "Introduction" {
+		t.Errorf("Title = %q; want %q", s.Title, "Introduction")
+	}
+	if s.Anchor != "introduction" {
+		t.Errorf("Anchor = %q; want %q", s.Anchor, "introduction")
+	}
+	if !strings.HasPrefix(s.Hash, "sha256:") {
+		t.Errorf("Hash = %q; want sha256:<hex> prefix", s.Hash)
+	}
+	// sha256 hex is 64 chars; plus prefix "sha256:" = 71.
+	if len(s.Hash) != 71 {
+		t.Errorf("Hash length = %d; want 71 (sha256: + 64 hex)", len(s.Hash))
+	}
+	if s.Size <= 0 {
+		t.Errorf("Size = %d; want > 0", s.Size)
+	}
+}
+
+func TestGenerateSectionIndex_MultipleSections(t *testing.T) {
+	md := `## First
+body1
+
+## Second
+body2
+
+## Third
+body3
+`
+	got := GenerateSectionIndex(md)
+	if len(got) != 3 {
+		t.Fatalf("got %d sections, want 3", len(got))
+	}
+	wantTitles := []string{"First", "Second", "Third"}
+	wantAnchors := []string{"first", "second", "third"}
+	seen := map[string]bool{}
+	for i, s := range got {
+		if s.Title != wantTitles[i] {
+			t.Errorf("sections[%d].Title = %q; want %q", i, s.Title, wantTitles[i])
+		}
+		if s.Anchor != wantAnchors[i] {
+			t.Errorf("sections[%d].Anchor = %q; want %q", i, s.Anchor, wantAnchors[i])
+		}
+		if seen[s.Hash] {
+			t.Errorf("duplicate hash across distinct sections: %s", s.Hash)
+		}
+		seen[s.Hash] = true
+	}
+}
+
+func TestGenerateSectionIndex_Determinism(t *testing.T) {
+	md := "## Alpha\ncontent A\n\n## Beta\ncontent B\n"
+	a := GenerateSectionIndex(md)
+	b := GenerateSectionIndex(md)
+	if len(a) != len(b) {
+		t.Fatalf("non-deterministic length: %d vs %d", len(a), len(b))
+	}
+	for i := range a {
+		if a[i].Hash != b[i].Hash {
+			t.Errorf("non-deterministic hash at index %d: %s vs %s", i, a[i].Hash, b[i].Hash)
+		}
+	}
+
+	// Identical section content across two different parent documents
+	// should yield identical hashes for that section.
+	md2 := "## Alpha\ncontent A\n\n## Gamma\ndifferent tail\n"
+	c := GenerateSectionIndex(md2)
+	if len(c) < 1 {
+		t.Fatalf("expected at least one section in md2")
+	}
+	if a[0].Hash != c[0].Hash {
+		t.Errorf("identical 'Alpha' content across docs produced different hashes: %s vs %s", a[0].Hash, c[0].Hash)
+	}
+}
+
+func TestGenerateSectionIndex_ContentSensitivity(t *testing.T) {
+	mdA := "## Section\nhello\n"
+	mdB := "## Section\nhellx\n" // one-byte change
+	a := GenerateSectionIndex(mdA)
+	b := GenerateSectionIndex(mdB)
+	if len(a) != 1 || len(b) != 1 {
+		t.Fatalf("expected exactly one section each; got %d and %d", len(a), len(b))
+	}
+	if a[0].Hash == b[0].Hash {
+		t.Errorf("content change did not alter hash: both = %s", a[0].Hash)
+	}
+}
+
+func TestGenerateSectionIndex_TrailingWhitespaceStable(t *testing.T) {
+	base := "## Stable\nbody line\n"
+	withTrailingSpaces := "## Stable   \nbody line\t\t\n"
+	withTrailingBlankLines := "## Stable\nbody line\n\n\n\n"
+	withAllOfTheAbove := "## Stable  \nbody line \n\n  \n\t\n"
+
+	want := GenerateSectionIndex(base)
+	if len(want) != 1 {
+		t.Fatalf("base: got %d sections, want 1", len(want))
+	}
+	for _, variant := range []string{withTrailingSpaces, withTrailingBlankLines, withAllOfTheAbove} {
+		got := GenerateSectionIndex(variant)
+		if len(got) != 1 {
+			t.Fatalf("variant %q: got %d sections, want 1", variant, len(got))
+		}
+		if got[0].Hash != want[0].Hash {
+			t.Errorf("trailing-whitespace variant changed hash\n  base: %s\n  variant (%q): %s",
+				want[0].Hash, variant, got[0].Hash)
+		}
+		if got[0].Size != want[0].Size {
+			t.Errorf("trailing-whitespace variant changed Size\n  base: %d\n  variant (%q): %d",
+				want[0].Size, variant, got[0].Size)
+		}
+	}
+}
+
+func TestGenerateSectionIndex_SlugifyEdgeCases(t *testing.T) {
+	cases := []struct {
+		md     string
+		anchor string
+	}{
+		{"## Hello World\nx\n", "hello-world"},
+		{"## Foo: Bar!\nx\n", "foo-bar"},
+		{"## --Leading and trailing--\nx\n", "leading-and-trailing"},
+		{"## Mixed CASE 123\nx\n", "mixed-case-123"},
+		{"## Multiple   Spaces\nx\n", "multiple-spaces"},
+	}
+	for _, c := range cases {
+		got := GenerateSectionIndex(c.md)
+		if len(got) != 1 {
+			t.Fatalf("case %q: got %d sections, want 1", c.md, len(got))
+		}
+		if got[0].Anchor != c.anchor {
+			t.Errorf("case %q: Anchor = %q; want %q", c.md, got[0].Anchor, c.anchor)
+		}
+	}
+}
+
+func TestGenerateSectionIndex_PrefaceDiscarded(t *testing.T) {
+	md := `# Document Title
+
+Some preamble paragraph that is not under any h2.
+
+## Real First
+body
+`
+	got := GenerateSectionIndex(md)
+	if len(got) != 1 {
+		t.Fatalf("got %d sections, want 1", len(got))
+	}
+	if got[0].Title != "Real First" {
+		t.Errorf("Title = %q; want %q", got[0].Title, "Real First")
+	}
+}
+
+func TestGenerateSectionIndex_H3IsNotASection(t *testing.T) {
+	md := `## Parent
+intro
+
+### Child heading
+child body
+
+## Sibling
+sibling body
+`
+	got := GenerateSectionIndex(md)
+	if len(got) != 2 {
+		t.Fatalf("got %d sections, want 2 (h3 should not split)", len(got))
+	}
+	if got[0].Title != "Parent" || got[1].Title != "Sibling" {
+		t.Errorf("titles = [%q, %q]; want [Parent, Sibling]", got[0].Title, got[1].Title)
+	}
+	// Child heading text should be part of the Parent section's body,
+	// so Parent's hash should differ from a variant without the h3.
+	without := GenerateSectionIndex("## Parent\nintro\n\n## Sibling\nsibling body\n")
+	if len(without) != 2 {
+		t.Fatalf("without-h3 variant: got %d sections, want 2", len(without))
+	}
+	if got[0].Hash == without[0].Hash {
+		t.Errorf("Parent hash unchanged despite different body content: %s", got[0].Hash)
+	}
+}
+
+func TestComputeSectionHash_KnownValue(t *testing.T) {
+	// Stability anchor: sha256("") in the prefixed form.
+	got := ComputeSectionHash([]byte(""))
+	const want = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	if got != want {
+		t.Errorf("ComputeSectionHash(\"\") = %s; want %s", got, want)
+	}
+}

--- a/internal/engine/serve_blocks.go
+++ b/internal/engine/serve_blocks.go
@@ -14,16 +14,25 @@
 //   4. Stores them locally
 //
 // Content is verified by hash on both read and write — the hash IS the address.
+//
+// ADR-084 Phase 2 digest resolution:
+//
+//	GET /v1/blobs/{digest}     — resolve a `sha256:<hex>` content digest to
+//	                              raw blob bytes. Uses the BlobStore wired
+//	                              into Process by G10; preserves manifest
+//	                              Content-Type when available.
 package engine
 
 import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
+	"os"
 	"strings"
 )
 
@@ -33,6 +42,7 @@ func (s *Server) registerBlockRoutes(mux *http.ServeMux) {
 	s.route(mux, "POST /v1/blocks/verify", s.handleBlocksVerify)
 	s.route(mux, "GET /v1/blocks/{hash}", s.handleBlockGet)
 	s.route(mux, "PUT /v1/blocks/{hash}", s.handleBlockPut)
+	s.route(mux, "GET /v1/blobs/{digest}", s.handleBlobGet)
 }
 
 // handleBlockGet returns blob content by hash.
@@ -59,6 +69,86 @@ func (s *Server) handleBlockGet(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Blob-Hash", hash)
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(content)))
 	_, _ = w.Write(content)
+}
+
+// handleBlobGet resolves an ADR-084 content digest to raw blob bytes via
+// the BlobStore wired into Process at startup (G10).
+//
+//	GET /v1/blobs/{digest}
+//	   where digest = "sha256:<64-hex>"
+//	200 → raw blob bytes; Content-Type from manifest if known, else
+//	      application/octet-stream
+//	400 → malformed digest (wrong prefix, wrong hex length, non-hex chars)
+//	404 → digest is well-formed but no blob is stored for it
+//	500 → BlobStore unavailable or read failure unrelated to not-found
+//
+// BlobStore stores raw hex per G10, so the `sha256:` prefix is stripped
+// before delegating to Get(). The prefix is still required on the wire
+// because that is the canonical ADR-084 digest form and lets us extend to
+// other hash algorithms later without a route change.
+func (s *Server) handleBlobGet(w http.ResponseWriter, r *http.Request) {
+	digest := r.PathValue("digest")
+
+	hexPart, ok := parseSHA256Digest(digest)
+	if !ok {
+		http.Error(w, "malformed digest: want sha256:<64-hex>", http.StatusBadRequest)
+		return
+	}
+
+	bs := s.process.BlobStore()
+	if bs == nil {
+		http.Error(w, "blob store not initialized", http.StatusInternalServerError)
+		return
+	}
+
+	content, err := bs.Get(hexPart)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			http.Error(w, "blob not found", http.StatusNotFound)
+			return
+		}
+		slog.Warn("blobs: get failed", "digest", digest, "err", err)
+		http.Error(w, "blob read failed", http.StatusInternalServerError)
+		return
+	}
+
+	// Recover Content-Type from the manifest if available. List() is O(N)
+	// in the number of stored blobs; acceptable for the current deployment
+	// scale and matches the pattern used by handleBlocksManifest. A future
+	// optimization (G-series) could add a direct lookup helper.
+	contentType := "application/octet-stream"
+	if entries, listErr := bs.List(); listErr == nil {
+		for _, e := range entries {
+			if e.Hash == hexPart && e.ContentType != "" {
+				contentType = e.ContentType
+				break
+			}
+		}
+	}
+
+	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("X-Blob-Digest", digest)
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(content)))
+	_, _ = w.Write(content)
+}
+
+// parseSHA256Digest validates a `sha256:<64-hex>` digest string and returns
+// the hex portion. Returns (hex, true) on success; ("", false) otherwise.
+// The hex portion is normalized to lowercase because BlobStore stores hex in
+// lowercase (hex.EncodeToString output).
+func parseSHA256Digest(digest string) (string, bool) {
+	const prefix = "sha256:"
+	if !strings.HasPrefix(digest, prefix) {
+		return "", false
+	}
+	hexPart := strings.ToLower(digest[len(prefix):])
+	if len(hexPart) != 64 {
+		return "", false
+	}
+	if _, err := hex.DecodeString(hexPart); err != nil {
+		return "", false
+	}
+	return hexPart, true
 }
 
 // handleBlockPut stores a blob, verifying the hash matches the content.

--- a/internal/engine/serve_blocks_test.go
+++ b/internal/engine/serve_blocks_test.go
@@ -1,0 +1,175 @@
+// serve_blocks_test.go — HTTP handler tests for block + blob sync endpoints.
+//
+// Currently covers:
+//
+//	GET /v1/blobs/{digest}  — ADR-084 Phase 2 digest → bytes resolution
+//	                          (hit / miss / malformed paths)
+package engine
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newBlobsTestServer returns a real *Server rooted at a tmpdir plus the shared
+// Process so callers can pre-populate the BlobStore before firing requests.
+func newBlobsTestServer(t *testing.T) (http.Handler, *Process) {
+	t.Helper()
+	root := t.TempDir()
+	cfg := makeConfig(t, root)
+	nucleus := makeNucleus("Test", "tester")
+	proc := NewProcess(cfg, nucleus)
+	srv := NewServer(cfg, nucleus, proc)
+	t.Cleanup(func() {
+		if b := proc.Broker(); b != nil {
+			_ = b.Close()
+		}
+	})
+	return srv.Handler(), proc
+}
+
+// TestBlobGetHit exercises the happy path: a blob stored via BlobStore.Store
+// is retrievable by `sha256:<hex>` digest, with Content-Type recovered from
+// the manifest.
+func TestBlobGetHit(t *testing.T) {
+	t.Parallel()
+	handler, proc := newBlobsTestServer(t)
+
+	body := []byte("g2 blob fixture — ADR-084 by-reference payload")
+	const ct = "text/plain; charset=utf-8"
+	bs := proc.BlobStore()
+	if bs == nil {
+		t.Fatal("BlobStore() nil after NewProcess; G10 wiring regressed")
+	}
+	hashHex, err := bs.Store(body, ct)
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/blobs/sha256:"+hashHex, nil)
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200; body=%q", rec.Code, rec.Body.String())
+	}
+	got, _ := io.ReadAll(rec.Body)
+	if string(got) != string(body) {
+		t.Fatalf("body mismatch:\n got=%q\nwant=%q", got, body)
+	}
+	if gotCT := rec.Header().Get("Content-Type"); gotCT != ct {
+		t.Errorf("Content-Type = %q; want %q (from manifest)", gotCT, ct)
+	}
+	if gotDigest := rec.Header().Get("X-Blob-Digest"); gotDigest != "sha256:"+hashHex {
+		t.Errorf("X-Blob-Digest = %q; want sha256:%s", gotDigest, hashHex)
+	}
+}
+
+// TestBlobGetHitDefaultContentType confirms the handler falls back to
+// application/octet-stream when the manifest entry has no content_type
+// recorded (BlobStore.Store allows an empty ct string).
+func TestBlobGetHitDefaultContentType(t *testing.T) {
+	t.Parallel()
+	handler, proc := newBlobsTestServer(t)
+
+	body := []byte{0x00, 0x01, 0x02, 0x03}
+	hashHex, err := proc.BlobStore().Store(body, "")
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/blobs/sha256:"+hashHex, nil)
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200", rec.Code)
+	}
+	if gotCT := rec.Header().Get("Content-Type"); gotCT != "application/octet-stream" {
+		t.Errorf("Content-Type = %q; want application/octet-stream", gotCT)
+	}
+}
+
+// TestBlobGetNotFound confirms a well-formed digest with no stored blob
+// returns 404, not 500.
+func TestBlobGetNotFound(t *testing.T) {
+	t.Parallel()
+	handler, _ := newBlobsTestServer(t)
+
+	// Well-formed digest for content that was never stored.
+	h := sha256.Sum256([]byte("this was never stored"))
+	digest := "sha256:" + hex.EncodeToString(h[:])
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/blobs/"+digest, nil)
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d; want 404; body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+// TestBlobGetMalformedDigest exercises the 400 path for several malformed
+// inputs: missing prefix, wrong length, non-hex characters, and other
+// algorithms we don't support yet.
+func TestBlobGetMalformedDigest(t *testing.T) {
+	t.Parallel()
+	handler, _ := newBlobsTestServer(t)
+
+	cases := []struct {
+		name   string
+		digest string
+	}{
+		{"missing_prefix", strings.Repeat("a", 64)},
+		{"wrong_algo", "md5:" + strings.Repeat("a", 32)},
+		{"too_short", "sha256:" + strings.Repeat("a", 10)},
+		{"too_long", "sha256:" + strings.Repeat("a", 65)},
+		{"non_hex", "sha256:" + strings.Repeat("z", 64)},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/v1/blobs/"+tc.digest, nil)
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("digest=%q: status = %d; want 400; body=%q",
+					tc.digest, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestParseSHA256DigestRoundTrip is a small unit test on the parser so
+// regressions here surface independently of the HTTP layer.
+func TestParseSHA256DigestRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	want := strings.Repeat("a", 64)
+	got, ok := parseSHA256Digest("sha256:" + want)
+	if !ok || got != want {
+		t.Errorf("lowercase: got=(%q, %v); want=(%q, true)", got, ok, want)
+	}
+
+	// Mixed case hex is normalized to lowercase.
+	mixed := "sha256:AAAA" + strings.Repeat("b", 60)
+	got, ok = parseSHA256Digest(mixed)
+	if !ok || got != strings.ToLower(mixed[len("sha256:"):]) {
+		t.Errorf("mixed case: got=(%q, %v); want lowercase normalization", got, ok)
+	}
+
+	// Empty and nonsense reject.
+	if _, ok := parseSHA256Digest(""); ok {
+		t.Error("empty string: parser accepted")
+	}
+	if _, ok := parseSHA256Digest("sha256:"); ok {
+		t.Error("prefix only: parser accepted")
+	}
+}

--- a/pkg/cogblock/block.go
+++ b/pkg/cogblock/block.go
@@ -54,6 +54,21 @@ const (
 	BlockImport      CogBlockKind = "import"
 	BlockAttention   CogBlockKind = "attention"
 	BlockSystemEvent CogBlockKind = "system_event"
+
+	// ADR-059 block-type vocabulary.
+	//
+	// Document types (CogBlocks at rest).
+	BlockDocInsight   CogBlockKind = "doc.insight"
+	BlockDocEpisode   CogBlockKind = "doc.episode"
+	BlockDocProcedure CogBlockKind = "doc.procedure"
+
+	// Bus types (CogBlocks in flight).
+	BlockBusMessage    CogBlockKind = "bus.message"
+	BlockBusAck        CogBlockKind = "bus.ack"
+	BlockBusCheckpoint CogBlockKind = "bus.checkpoint"
+
+	// Session types.
+	BlockSessionTurn CogBlockKind = "session.turn"
 )
 
 // BlockProvenance records the origin and ingestion metadata of a CogBlock.

--- a/pkg/cogblock/block_test.go
+++ b/pkg/cogblock/block_test.go
@@ -17,11 +17,56 @@ func TestCogBlockKindConstants(t *testing.T) {
 		{BlockImport, "import"},
 		{BlockAttention, "attention"},
 		{BlockSystemEvent, "system_event"},
+		// ADR-059 block-type vocabulary.
+		{BlockDocInsight, "doc.insight"},
+		{BlockDocEpisode, "doc.episode"},
+		{BlockDocProcedure, "doc.procedure"},
+		{BlockBusMessage, "bus.message"},
+		{BlockBusAck, "bus.ack"},
+		{BlockBusCheckpoint, "bus.checkpoint"},
+		{BlockSessionTurn, "session.turn"},
 	}
 
 	for _, tt := range tests {
 		if string(tt.kind) != tt.want {
 			t.Errorf("CogBlockKind = %q; want %q", tt.kind, tt.want)
+		}
+	}
+}
+
+func TestCogBlockKind_ADR059_RoundTrip(t *testing.T) {
+	// Verify marshal/unmarshal roundtrip for every ADR-059 block type.
+	kinds := []CogBlockKind{
+		BlockDocInsight,
+		BlockDocEpisode,
+		BlockDocProcedure,
+		BlockBusMessage,
+		BlockBusAck,
+		BlockBusCheckpoint,
+		BlockSessionTurn,
+	}
+
+	for _, k := range kinds {
+		original := CogBlock{
+			ID:   "block-" + string(k),
+			Kind: k,
+		}
+
+		data, err := json.Marshal(original)
+		if err != nil {
+			t.Fatalf("Marshal(%q) failed: %v", k, err)
+		}
+
+		var decoded CogBlock
+		if err := json.Unmarshal(data, &decoded); err != nil {
+			t.Fatalf("Unmarshal(%q) failed: %v", k, err)
+		}
+
+		if decoded.Kind != k {
+			t.Errorf("Kind = %q; want %q", decoded.Kind, k)
+		}
+		if decoded.ID != original.ID {
+			t.Errorf("ID = %q; want %q", decoded.ID, original.ID)
 		}
 	}
 }

--- a/pkg/cogfield/block.go
+++ b/pkg/cogfield/block.go
@@ -1,5 +1,25 @@
 package cogfield
 
+// ADR-084 dataref migration policy (Phase 1: schema-additive).
+//
+// The Block envelope below is the single source of truth for the two
+// mutually-compatible payload forms that coexist during the migration:
+//
+//   - Inline (pre-ADR-084): Payload map[string]interface{}
+//   - By-reference (ADR-084): Digest + MediaType + Size pointing into BlobStore
+//
+// Phase 1 emit paths continue to populate Payload. Phase 2 pilot sites
+// (gated by COGOS_DATAREF_EMIT=<site-name>) store bytes via BlobStore and
+// leave Payload empty. Consumers MUST tolerate both shapes and should:
+//
+//   1. Prefer Digest + BlobStore.Get(digest) if Digest != ""
+//   2. Fall back to inline Payload otherwise
+//
+// Full cut-over happens in Phase 2 (ADR-084 revision pending) once all
+// consumers have been updated to the byref-first resolution path.
+//
+// See: .cog/adr/084-bus-payloads-as-cogblocks.cog.md
+
 // Block is the canonical content atom for the CogOS bus protocol (ADR-059).
 // V1 blocks use PrevHash (string); V2 blocks use Prev ([]string) for DAG-style linking.
 // Both fields are written during the transition period for backward compatibility.

--- a/pkg/cogfield/block.go
+++ b/pkg/cogfield/block.go
@@ -3,22 +3,32 @@ package cogfield
 // Block is the canonical content atom for the CogOS bus protocol (ADR-059).
 // V1 blocks use PrevHash (string); V2 blocks use Prev ([]string) for DAG-style linking.
 // Both fields are written during the transition period for backward compatibility.
+//
+// ADR-084 v1 — by-reference payload. When Digest and MediaType are set, the
+// envelope carries a content-addressed reference to the payload bytes stored
+// in BlobStore; Payload may be empty, and the actual bytes are fetched via
+// GET /v1/blobs/:digest. The inline Payload field is preserved for backward
+// compatibility during the Phase 1 schema-additive migration — producers may
+// emit either shape, and consumers MUST tolerate both. Size is shared by
+// both forms and indicates the payload size in bytes.
 type Block struct {
-	V        int                    `json:"v"`
-	ID       string                 `json:"id,omitempty"`
-	BusID    string                 `json:"bus_id,omitempty"`
-	Seq      int                    `json:"seq,omitempty"`
-	Ts       string                 `json:"ts"`
-	From     string                 `json:"from"`
-	To       string                 `json:"to,omitempty"`
-	Type     string                 `json:"type"`
-	Payload  map[string]interface{} `json:"payload"`
-	Prev     []string               `json:"prev,omitempty"`
-	PrevHash string                 `json:"prev_hash,omitempty"` // V1 compat
-	Hash     string                 `json:"hash"`
-	Merkle   string                 `json:"merkle,omitempty"`
-	Sig      string                 `json:"sig,omitempty"`
-	Size     int                    `json:"size,omitempty"`
+	V         int                    `json:"v"`
+	ID        string                 `json:"id,omitempty"`
+	BusID     string                 `json:"bus_id,omitempty"`
+	Seq       int                    `json:"seq,omitempty"`
+	Ts        string                 `json:"ts"`
+	From      string                 `json:"from"`
+	To        string                 `json:"to,omitempty"`
+	Type      string                 `json:"type"`
+	Payload   map[string]interface{} `json:"payload,omitempty"`
+	Digest    string                 `json:"digest,omitempty"`     // ADR-084: "sha256:<hex>" content hash of by-reference payload
+	MediaType string                 `json:"media_type,omitempty"` // ADR-084: OCI media type of the payload (e.g. application/vnd.cogos.trace.assessment.v1+json)
+	Prev      []string               `json:"prev,omitempty"`
+	PrevHash  string                 `json:"prev_hash,omitempty"` // V1 compat
+	Hash      string                 `json:"hash"`
+	Merkle    string                 `json:"merkle,omitempty"`
+	Sig       string                 `json:"sig,omitempty"`
+	Size      int                    `json:"size,omitempty"`
 }
 
 // GraphBlock is the intermediate representation for CogField graph rendering.

--- a/pkg/cogfield/block_test.go
+++ b/pkg/cogfield/block_test.go
@@ -73,3 +73,116 @@ func TestBlockOmitsEmptyFields(t *testing.T) {
 		}
 	}
 }
+
+// TestBlockInlinePayloadRoundTrip verifies the legacy Phase-1 envelope shape:
+// an inline Payload map with no ADR-084 digest reference.
+func TestBlockInlinePayloadRoundTrip(t *testing.T) {
+	block := Block{
+		V:     2,
+		ID:    "block-inline",
+		BusID: "bus-inline",
+		Seq:   7,
+		Ts:    "2026-04-22T10:00:00Z",
+		From:  "producer",
+		Type:  "bus.message",
+		Payload: map[string]interface{}{
+			"content": "hello from inline",
+			"count":   float64(3),
+		},
+		Hash: "hash-inline",
+		Size: 128,
+	}
+
+	data, err := json.Marshal(block)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal raw: %v", err)
+	}
+
+	// Inline form must serialize payload and omit the ADR-084 reference fields.
+	if _, ok := raw["payload"]; !ok {
+		t.Error("inline block should serialize payload field")
+	}
+	for _, field := range []string{"digest", "media_type"} {
+		if _, exists := raw[field]; exists {
+			t.Errorf("inline block should omit %q when empty", field)
+		}
+	}
+
+	var decoded Block
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.Payload["content"] != "hello from inline" {
+		t.Errorf("Payload.content = %v, want %q", decoded.Payload["content"], "hello from inline")
+	}
+	if decoded.Digest != "" {
+		t.Errorf("Digest = %q, want empty", decoded.Digest)
+	}
+	if decoded.MediaType != "" {
+		t.Errorf("MediaType = %q, want empty", decoded.MediaType)
+	}
+	if decoded.Size != 128 {
+		t.Errorf("Size = %d, want 128", decoded.Size)
+	}
+}
+
+// TestBlockByReferencePayloadRoundTrip verifies the ADR-084 Phase-2 envelope
+// shape: Digest + MediaType + Size carry a by-reference payload pointer, and
+// the inline Payload field is left empty so it does not serialize.
+func TestBlockByReferencePayloadRoundTrip(t *testing.T) {
+	block := Block{
+		V:         2,
+		ID:        "block-byref",
+		BusID:     "bus-byref",
+		Seq:       11,
+		Ts:        "2026-04-22T10:05:00Z",
+		From:      "producer",
+		Type:      "trace.assessment",
+		Digest:    "sha256:deadbeefcafebabe0000000000000000000000000000000000000000000000ff",
+		MediaType: "application/vnd.cogos.trace.assessment.v1+json",
+		Size:      512,
+		Hash:      "hash-byref",
+	}
+
+	data, err := json.Marshal(block)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal raw: %v", err)
+	}
+
+	// By-reference form must serialize the ADR-084 fields and omit empty payload.
+	for _, field := range []string{"digest", "media_type"} {
+		if _, ok := raw[field]; !ok {
+			t.Errorf("by-reference block should serialize %q", field)
+		}
+	}
+	if _, exists := raw["payload"]; exists {
+		t.Errorf("by-reference block should omit empty payload field, got %s", string(raw["payload"]))
+	}
+
+	var decoded Block
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.Digest != block.Digest {
+		t.Errorf("Digest = %q, want %q", decoded.Digest, block.Digest)
+	}
+	if decoded.MediaType != block.MediaType {
+		t.Errorf("MediaType = %q, want %q", decoded.MediaType, block.MediaType)
+	}
+	if decoded.Size != 512 {
+		t.Errorf("Size = %d, want 512", decoded.Size)
+	}
+	if len(decoded.Payload) != 0 {
+		t.Errorf("Payload should be empty, got %v", decoded.Payload)
+	}
+}

--- a/pkg/cogfield/block_test.go
+++ b/pkg/cogfield/block_test.go
@@ -186,3 +186,332 @@ func TestBlockByReferencePayloadRoundTrip(t *testing.T) {
 		t.Errorf("Payload should be empty, got %v", decoded.Payload)
 	}
 }
+
+// resolveBlockPayload is a test-only helper modeling the ADR-084 v1 consumer
+// resolution rule: prefer by-reference (Digest) when present, fall back to
+// inline Payload otherwise. Returns a label indicating which form was chosen.
+func resolveBlockPayload(b *Block) string {
+	if b.Digest != "" {
+		return "byref"
+	}
+	if len(b.Payload) > 0 {
+		return "inline"
+	}
+	return "none"
+}
+
+// TestBlockCoexistenceBothFormsPopulated verifies that during the ADR-084 v1
+// migration window, a Block may carry BOTH an inline Payload AND a Digest/
+// MediaType reference. Both forms must serialize and round-trip.
+func TestBlockCoexistenceBothFormsPopulated(t *testing.T) {
+	block := Block{
+		V:         2,
+		ID:        "block-both",
+		Ts:        "2026-04-22T11:00:00Z",
+		From:      "producer",
+		Type:      "bus.message",
+		Payload:   map[string]interface{}{"content": "inline copy"},
+		Digest:    "sha256:cafef00d000000000000000000000000000000000000000000000000000000aa",
+		MediaType: "application/vnd.cogos.test.v1+json",
+		Size:      256,
+		Hash:      "hash-both",
+	}
+
+	data, err := json.Marshal(block)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal raw: %v", err)
+	}
+	for _, field := range []string{"payload", "digest", "media_type"} {
+		if _, ok := raw[field]; !ok {
+			t.Errorf("coexistence block should serialize %q", field)
+		}
+	}
+
+	var decoded Block
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.Payload["content"] != "inline copy" {
+		t.Errorf("Payload.content = %v, want %q", decoded.Payload["content"], "inline copy")
+	}
+	if decoded.Digest != block.Digest {
+		t.Errorf("Digest = %q, want %q", decoded.Digest, block.Digest)
+	}
+}
+
+// TestBlockResolutionPrefersByReference verifies the consumer-side preference
+// order: when both forms are present, Digest wins over inline Payload.
+func TestBlockResolutionPrefersByReference(t *testing.T) {
+	cases := []struct {
+		name  string
+		block Block
+		want  string
+	}{
+		{
+			name:  "both-populated",
+			block: Block{Payload: map[string]interface{}{"x": 1}, Digest: "sha256:abc"},
+			want:  "byref",
+		},
+		{
+			name:  "only-inline",
+			block: Block{Payload: map[string]interface{}{"x": 1}},
+			want:  "inline",
+		},
+		{
+			name:  "only-byref",
+			block: Block{Digest: "sha256:abc"},
+			want:  "byref",
+		},
+		{
+			name:  "neither",
+			block: Block{},
+			want:  "none",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveBlockPayload(&tc.block); got != tc.want {
+				t.Errorf("resolveBlockPayload = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBlockSizeMatchesInlinePayloadBytes documents the invariant that Size
+// SHOULD equal len(json.Marshal(Payload)) for inline form. The producer is
+// responsible for setting Size; this test is skipped because Block itself
+// does not auto-compute Size — it's a producer contract, not a struct invariant.
+func TestBlockSizeMatchesInlinePayloadBytes(t *testing.T) {
+	t.Skip("Size is a producer-set contract, not a struct-computed invariant; " +
+		"Block{Payload: {...}} without an explicit Size leaves Size=0. " +
+		"See ADR-084 v1 — producers SHOULD set Size to the payload byte length, " +
+		"but Block itself does not enforce or compute this. Kept as documentation.")
+}
+
+// TestBlockSizeByRefMatchesStoredBytes documents the invariant for the by-ref
+// form: Size MUST equal the byte length of the blob stored under Digest.
+// We mock this since actual blob storage is in the engine package.
+func TestBlockSizeByRefMatchesStoredBytes(t *testing.T) {
+	storedBytes := []byte(`{"assessment":"ok","score":0.87}`)
+	digest := "sha256:abc123" // mocked — not a real hash of storedBytes
+	block := Block{
+		V:         2,
+		Ts:        "2026-04-22T11:00:00Z",
+		From:      "producer",
+		Type:      "trace.assessment",
+		Digest:    digest,
+		MediaType: "application/vnd.cogos.trace.assessment.v1+json",
+		Size:      len(storedBytes),
+		Hash:      "hash-byref",
+	}
+	if block.Size != len(storedBytes) {
+		t.Errorf("Size = %d, want %d (producer contract)", block.Size, len(storedBytes))
+	}
+
+	data, _ := json.Marshal(block)
+	var decoded Block
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.Size != len(storedBytes) {
+		t.Errorf("decoded Size = %d, want %d", decoded.Size, len(storedBytes))
+	}
+}
+
+// TestBlockEmptyMinimalJSON verifies that a Block with no optional fields
+// marshals to a minimal JSON object containing only the required fields
+// (v, ts, from, type, hash).
+func TestBlockEmptyMinimalJSON(t *testing.T) {
+	block := Block{}
+	data, err := json.Marshal(block)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal raw: %v", err)
+	}
+	// Required fields always present (no omitempty on block.go):
+	for _, field := range []string{"v", "ts", "from", "type", "hash"} {
+		if _, ok := raw[field]; !ok {
+			t.Errorf("required field %q missing from empty block", field)
+		}
+	}
+	// Optional fields omitted:
+	for _, field := range []string{"id", "bus_id", "seq", "to", "payload", "digest", "media_type", "prev", "prev_hash", "merkle", "sig", "size"} {
+		if _, exists := raw[field]; exists {
+			t.Errorf("optional field %q should be omitted from empty block", field)
+		}
+	}
+}
+
+// TestBlockUnmarshalHandAuthoredInlineJSON verifies the json: tags match
+// external-consumer expectations for the inline form. The JSON literal below
+// is what a non-Go producer (TypeScript, Python, etc.) would emit.
+func TestBlockUnmarshalHandAuthoredInlineJSON(t *testing.T) {
+	external := `{
+		"v": 2,
+		"id": "ext-inline-1",
+		"bus_id": "bus-ext",
+		"seq": 42,
+		"ts": "2026-04-22T12:00:00Z",
+		"from": "external-producer",
+		"type": "bus.message",
+		"payload": {"msg": "hello from ts"},
+		"hash": "hash-ext-1",
+		"size": 28
+	}`
+	var decoded Block
+	if err := json.Unmarshal([]byte(external), &decoded); err != nil {
+		t.Fatalf("unmarshal external JSON: %v", err)
+	}
+	if decoded.ID != "ext-inline-1" || decoded.BusID != "bus-ext" || decoded.Seq != 42 {
+		t.Errorf("snake_case tag mismatch: ID=%q BusID=%q Seq=%d", decoded.ID, decoded.BusID, decoded.Seq)
+	}
+	if decoded.Payload["msg"] != "hello from ts" {
+		t.Errorf("Payload.msg = %v, want %q", decoded.Payload["msg"], "hello from ts")
+	}
+	if decoded.Size != 28 {
+		t.Errorf("Size = %d, want 28", decoded.Size)
+	}
+}
+
+// TestBlockUnmarshalHandAuthoredByRefJSON verifies snake_case tags for the
+// ADR-084 by-reference fields (digest, media_type).
+func TestBlockUnmarshalHandAuthoredByRefJSON(t *testing.T) {
+	external := `{
+		"v": 2,
+		"ts": "2026-04-22T12:00:00Z",
+		"from": "external-producer",
+		"type": "trace.assessment",
+		"digest": "sha256:0011223344556677889900112233445566778899001122334455667788990011",
+		"media_type": "application/vnd.cogos.trace.assessment.v1+json",
+		"size": 1024,
+		"hash": "hash-ext-2"
+	}`
+	var decoded Block
+	if err := json.Unmarshal([]byte(external), &decoded); err != nil {
+		t.Fatalf("unmarshal external JSON: %v", err)
+	}
+	if decoded.Digest != "sha256:0011223344556677889900112233445566778899001122334455667788990011" {
+		t.Errorf("Digest mismatch: %q", decoded.Digest)
+	}
+	if decoded.MediaType != "application/vnd.cogos.trace.assessment.v1+json" {
+		t.Errorf("MediaType mismatch: %q", decoded.MediaType)
+	}
+	if decoded.Size != 1024 {
+		t.Errorf("Size = %d, want 1024", decoded.Size)
+	}
+}
+
+// TestBlockJSONKeysAreSnakeCase round-trips through map[string]interface{}
+// to confirm all emitted keys are lowercase-snake (no camelCase leaks).
+func TestBlockJSONKeysAreSnakeCase(t *testing.T) {
+	block := Block{
+		V:         2,
+		BusID:     "bus-snake",
+		Ts:        "2026-04-22T12:00:00Z",
+		From:      "producer",
+		Type:      "bus.message",
+		Payload:   map[string]interface{}{"k": "v"},
+		Digest:    "sha256:dead",
+		MediaType: "application/json",
+		PrevHash:  "ph",
+		Hash:      "h",
+		Size:      10,
+	}
+	data, _ := json.Marshal(block)
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	expected := []string{"v", "bus_id", "ts", "from", "type", "payload", "digest", "media_type", "prev_hash", "hash", "size"}
+	for _, k := range expected {
+		if _, ok := raw[k]; !ok {
+			t.Errorf("expected snake_case key %q not found; got keys %v", k, mapKeys(raw))
+		}
+	}
+	// Negative: no camelCase leak
+	for _, bad := range []string{"busId", "mediaType", "prevHash", "BusID", "MediaType"} {
+		if _, exists := raw[bad]; exists {
+			t.Errorf("unexpected camelCase/PascalCase key %q in JSON", bad)
+		}
+	}
+}
+
+func mapKeys(m map[string]interface{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// TestBlockMalformedDigestAccepted documents that the Block struct does NOT
+// validate the Digest format at the (de)serialization layer. A malformed
+// value round-trips as an opaque string. Validation is a higher-layer concern
+// (engine/blobstore on ingest), not a struct invariant.
+func TestBlockMalformedDigestAccepted(t *testing.T) {
+	block := Block{
+		V:      2,
+		Ts:     "2026-04-22T12:00:00Z",
+		From:   "producer",
+		Type:   "bus.message",
+		Digest: "not-a-hash",
+		Hash:   "hash-mal",
+	}
+	data, err := json.Marshal(block)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded Block
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.Digest != "not-a-hash" {
+		t.Errorf("malformed Digest did not round-trip; got %q", decoded.Digest)
+	}
+	// Documentation: schema accepts any string for Digest. Format validation
+	// (sha256:<64-hex>) lives in engine/blobstore ingest, not here.
+}
+
+// TestBlockLargePayloadRoundTrip verifies that a ~1MB inline payload
+// round-trips correctly through JSON.
+func TestBlockLargePayloadRoundTrip(t *testing.T) {
+	const target = 1 << 20 // 1 MB
+	big := make([]byte, target)
+	for i := range big {
+		big[i] = byte('a' + (i % 26))
+	}
+	block := Block{
+		V:       2,
+		Ts:      "2026-04-22T12:00:00Z",
+		From:    "producer",
+		Type:    "bus.message",
+		Payload: map[string]interface{}{"blob": string(big)},
+		Hash:    "hash-big",
+	}
+	data, err := json.Marshal(block)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if len(data) < target {
+		t.Errorf("serialized size %d is smaller than payload %d (encoding collapse?)", len(data), target)
+	}
+	var decoded Block
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got, ok := decoded.Payload["blob"].(string)
+	if !ok {
+		t.Fatalf("decoded Payload.blob not a string: %T", decoded.Payload["blob"])
+	}
+	if len(got) != target {
+		t.Errorf("decoded blob length = %d, want %d", len(got), target)
+	}
+}

--- a/trace_emit.go
+++ b/trace_emit.go
@@ -13,6 +13,25 @@
 //       * `engine.TraceIdentity` wired to the active identity name
 //     After that, engine/process.go and the agent harness can call
 //     `emitCycleEvent` (or the engine hook) without further setup.
+//
+// ADR-084 dataref migration policy (Phase 1: schema-additive) — this file
+// is the G3 pilot consumer of the by-reference emit path. Two paths coexist
+// inside emitCycleEvent:
+//
+//   - Inline (legacy / default): JSON-decoded payload map is stamped onto
+//     CogBlock.Payload via appendBusEvent.
+//   - By-reference (Phase 2 pilot): when COGOS_DATAREF_EMIT contains the
+//     "cycle_trace" token AND a BlobStore is wired, the raw bytes are stored
+//     content-addressed and the envelope carries only Digest + MediaType +
+//     Size via appendBusEventRef; Payload is nil. BlobStore errors fall
+//     through to the inline path so events are never dropped.
+//
+// Consumers of bus_cycle_trace MUST tolerate both shapes during Phase 1 and
+// resolve byref-first (Digest -> GET /v1/blobs/:digest, else inline Payload).
+// The media type is the single `traceMediaType` constant below, so decoders
+// can switch on it regardless of envelope shape.
+//
+// See: .cog/adr/084-bus-payloads-as-cogblocks.cog.md
 package main
 
 import (

--- a/trace_emit.go
+++ b/trace_emit.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 
 	"github.com/cogos-dev/cogos/internal/engine"
@@ -31,9 +32,26 @@ import (
 // existing /v1/events/stream SSE endpoint filtered on this bus.
 const traceBusID = "bus_cycle_trace"
 
+// traceMediaType is the OCI media type advertised on dataref emissions for
+// cycle-trace events (ADR-084). Consumers resolve the digest via
+// GET /v1/blobs/:digest and decode the bytes as trace.CycleEvent JSON.
+const traceMediaType = "application/vnd.cogos.trace.cycle.v1+json"
+
+// traceDatarefEnvVar is the comma-separated allowlist of emit sites that
+// should write payloads by reference (to BlobStore) instead of inline. The
+// G3 pilot recognises the token "cycle_trace"; other tokens are ignored.
+// When unset, emitCycleEvent falls back to the legacy inline-payload path so
+// existing consumers continue to work unchanged.
+const traceDatarefEnvVar = "COGOS_DATAREF_EMIT"
+
 // traceBusMgr holds the bus manager used by emitCycleEvent. Set once by
 // InstallTraceEmitter. Accessed without a lock — a single writer at startup.
 var traceBusMgr atomic.Pointer[busSessionManager]
+
+// traceBlobStore holds the shared content-addressed blob store used by the
+// dataref emit path (ADR-084 Phase 2). Set by InstallTraceEmitter when
+// provided; otherwise emitCycleEvent skips the dataref path and emits inline.
+var traceBlobStore atomic.Pointer[engine.BlobStore]
 
 // traceIdentityName is the cached active-identity name used as the `source`
 // field on emitted events. Falls back to "cog" until wired.
@@ -43,16 +61,39 @@ func init() {
 	traceIdentityName.Store("cog")
 }
 
+// datarefEmitEnabled reports whether the given emit-site token is present in
+// the COGOS_DATAREF_EMIT env var. The lookup is intentionally cheap (per
+// emit) so the flag can be toggled without restart in smoke tests.
+func datarefEmitEnabled(site string) bool {
+	raw := os.Getenv(traceDatarefEnvVar)
+	if raw == "" {
+		return false
+	}
+	for _, tok := range strings.Split(raw, ",") {
+		if strings.TrimSpace(tok) == site {
+			return true
+		}
+	}
+	return false
+}
+
 // InstallTraceEmitter wires the engine's TraceEmitter / TraceIdentity hooks
 // to the kernel bus and the active identity. Safe to call once at daemon
 // start; subsequent calls overwrite the bus manager.
 //
 // root is the workspace root (used to resolve the identity name).
-func InstallTraceEmitter(mgr *busSessionManager, root string) {
+//
+// bs is the shared BlobStore used by the ADR-084 dataref emit path. When nil,
+// emitCycleEvent always emits inline regardless of the COGOS_DATAREF_EMIT env
+// var — the dataref path degrades gracefully if blob storage is not wired.
+func InstallTraceEmitter(mgr *busSessionManager, root string, bs *engine.BlobStore) {
 	if mgr == nil {
 		return
 	}
 	traceBusMgr.Store(mgr)
+	if bs != nil {
+		traceBlobStore.Store(bs)
+	}
 	ensureTraceBus(mgr)
 
 	if name, err := GetIdentityName(root); err == nil && name != "" {
@@ -96,26 +137,55 @@ func ensureTraceBus(mgr *busSessionManager) {
 // marshal or append errors are logged, never returned. The publish runs on a
 // goroutine so the caller (state machine, harness loop) is never blocked by
 // bus I/O or handler dispatch.
+//
+// ADR-084 Phase 2 (G3 pilot): when COGOS_DATAREF_EMIT contains "cycle_trace"
+// and a BlobStore is wired, the payload bytes are written to the blob store
+// and the envelope carries only a digest reference (media type
+// `application/vnd.cogos.trace.cycle.v1+json`). Otherwise the legacy inline
+// payload path is used. Consumers MUST tolerate both shapes during Phase 1.
 func emitCycleEvent(ev trace.CycleEvent) {
 	mgr := traceBusMgr.Load()
 	if mgr == nil {
 		return
 	}
-	// Marshal via the trace package's canonical JSON shape, then re-decode
-	// into a map so appendBusEvent can carry it as a CogBlock payload.
 	raw, err := json.Marshal(ev)
 	if err != nil {
 		log.Printf("[trace] marshal: %v", err)
 		return
 	}
+	eventType := "cycle." + string(ev.Kind)
+	source := engine.TraceIdentity()
+
+	// ADR-084 dataref path: digest-by-reference via BlobStore. Only taken
+	// when both the emit-site flag is set and a BlobStore is wired, so the
+	// absence of either cleanly falls back to the legacy inline path.
+	if bs := traceBlobStore.Load(); bs != nil && datarefEmitEnabled("cycle_trace") {
+		hexHash, err := bs.Store(raw, traceMediaType)
+		if err != nil {
+			log.Printf("[trace] blob store: %v", err)
+			// Fall through to inline emit so the event is not lost.
+		} else {
+			digest := "sha256:" + hexHash
+			size := len(raw)
+			go func() {
+				if _, err := mgr.appendBusEventRef(traceBusID, eventType, source, digest, traceMediaType, size); err != nil {
+					log.Printf("[trace] append (dataref): %v", err)
+				}
+			}()
+			return
+		}
+	}
+
+	// Legacy inline path: decode the raw bytes into a map and stamp them on
+	// the envelope's Payload field. Consumers that pre-date ADR-084 see this
+	// shape unchanged.
 	var payload map[string]interface{}
 	if err := json.Unmarshal(raw, &payload); err != nil {
 		log.Printf("[trace] unmarshal: %v", err)
 		return
 	}
-	eventType := "cycle." + string(ev.Kind)
 	go func() {
-		if _, err := mgr.appendBusEvent(traceBusID, eventType, engine.TraceIdentity(), payload); err != nil {
+		if _, err := mgr.appendBusEvent(traceBusID, eventType, source, payload); err != nil {
 			log.Printf("[trace] append: %v", err)
 		}
 	}()

--- a/trace_emit_test.go
+++ b/trace_emit_test.go
@@ -1,0 +1,229 @@
+// trace_emit_test.go — Integration tests for the cycle-trace emit site
+// (G3 pilot of ADR-084 Phase 2: dataref emit via BlobStore).
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cogos-dev/cogos/internal/engine"
+	"github.com/cogos-dev/cogos/trace"
+)
+
+// resetTraceEmitterForTest clears the package-level atomics that
+// InstallTraceEmitter and the dataref branch consult. Tests that flip the
+// emit-site env var MUST call this on setup and cleanup so the global state
+// doesn't leak across subtests (or into unrelated tests that happen to also
+// exercise the trace path).
+func resetTraceEmitterForTest(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		traceBusMgr.Store(nil)
+		traceBlobStore.Store(nil)
+		_ = os.Unsetenv(traceDatarefEnvVar)
+	})
+	traceBusMgr.Store(nil)
+	traceBlobStore.Store(nil)
+	_ = os.Unsetenv(traceDatarefEnvVar)
+}
+
+// waitForBusEvents spins briefly until the bus's events.jsonl has at least n
+// lines or the deadline expires. emitCycleEvent dispatches the actual append
+// on a goroutine, so a direct read right after the emit races the writer.
+func waitForBusEvents(t *testing.T, root, busID string, n int, deadline time.Duration) []CogBlock {
+	t.Helper()
+	end := time.Now().Add(deadline)
+	path := filepath.Join(root, ".cog", ".state", "buses", busID, "events.jsonl")
+	for time.Now().Before(end) {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			var lines []string
+			for _, l := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
+				if l != "" {
+					lines = append(lines, l)
+				}
+			}
+			if len(lines) >= n {
+				out := make([]CogBlock, 0, len(lines))
+				for _, l := range lines {
+					var b CogBlock
+					if err := json.Unmarshal([]byte(l), &b); err == nil {
+						out = append(out, b)
+					}
+				}
+				return out
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d events on bus %s", n, busID)
+	return nil
+}
+
+// TestEmitCycleEvent_InlinePayload_Legacy verifies the pre-ADR-084 default:
+// with no env flag and no BlobStore, emitCycleEvent writes the trace payload
+// inline on the envelope (Payload populated, Digest/MediaType empty). This
+// pins backward compatibility for consumers that have not been updated.
+func TestEmitCycleEvent_InlinePayload_Legacy(t *testing.T) {
+	resetTraceEmitterForTest(t)
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".cog", ".state", "buses"), 0o755); err != nil {
+		t.Fatalf("mkdir state: %v", err)
+	}
+	mgr := newBusSessionManager(root)
+	// No BlobStore → the dataref branch is never taken.
+	InstallTraceEmitter(mgr, root, nil)
+
+	ev, err := trace.NewAssessment("cog", "cycle-legacy-1", "observe", 0.9, "legacy-inline")
+	if err != nil {
+		t.Fatalf("build assessment: %v", err)
+	}
+	emitCycleEvent(ev)
+
+	evts := waitForBusEvents(t, root, traceBusID, 1, 2*time.Second)
+	if len(evts) != 1 {
+		t.Fatalf("got %d events, want 1", len(evts))
+	}
+	got := evts[0]
+	if got.Type != "cycle.assessment" {
+		t.Errorf("type=%q want cycle.assessment", got.Type)
+	}
+	if got.Payload == nil {
+		t.Fatal("legacy emit: Payload is nil; expected inline map")
+	}
+	if got.Digest != "" || got.MediaType != "" {
+		t.Errorf("legacy emit: unexpected digest=%q media_type=%q", got.Digest, got.MediaType)
+	}
+	if got.Payload["kind"] != "assessment" {
+		t.Errorf("payload.kind=%v want assessment", got.Payload["kind"])
+	}
+}
+
+// TestEmitCycleEvent_DatarefViaBlobStore is the G3 pilot roundtrip: the
+// cycle_trace site is allow-listed via COGOS_DATAREF_EMIT, a BlobStore is
+// wired, and emitCycleEvent is expected to (a) write the payload bytes into
+// the blob store, (b) emit an envelope carrying only Digest + MediaType +
+// Size, and (c) produce bytes that a consumer can resolve through the
+// BlobStore back to the original trace.CycleEvent JSON.
+func TestEmitCycleEvent_DatarefViaBlobStore(t *testing.T) {
+	resetTraceEmitterForTest(t)
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".cog", ".state", "buses"), 0o755); err != nil {
+		t.Fatalf("mkdir state: %v", err)
+	}
+	bs := engine.NewBlobStore(root)
+	if err := bs.Init(); err != nil {
+		t.Fatalf("blob store init: %v", err)
+	}
+	mgr := newBusSessionManager(root)
+
+	// Gate the new emit behind the env var so only this test's emit site
+	// takes the dataref path; every other emit in the binary is unaffected.
+	t.Setenv(traceDatarefEnvVar, "cycle_trace")
+	InstallTraceEmitter(mgr, root, bs)
+
+	ev, err := trace.NewAssessment("cog", "cycle-dataref-1", "propose", 0.42, "g3-pilot")
+	if err != nil {
+		t.Fatalf("build assessment: %v", err)
+	}
+	// Re-marshal via the canonical trace JSON shape to know what bytes
+	// should land in the blob store. emitCycleEvent does the exact same
+	// json.Marshal(ev) internally, so the digests must match.
+	wantBytes, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal want-bytes: %v", err)
+	}
+
+	emitCycleEvent(ev)
+
+	evts := waitForBusEvents(t, root, traceBusID, 1, 2*time.Second)
+	if len(evts) != 1 {
+		t.Fatalf("got %d events, want 1", len(evts))
+	}
+	got := evts[0]
+
+	if got.Type != "cycle.assessment" {
+		t.Errorf("type=%q want cycle.assessment", got.Type)
+	}
+	if got.Payload != nil {
+		t.Errorf("dataref emit: Payload should be nil; got %v", got.Payload)
+	}
+	if got.MediaType != traceMediaType {
+		t.Errorf("media_type=%q want %q", got.MediaType, traceMediaType)
+	}
+	if got.Size != len(wantBytes) {
+		t.Errorf("size=%d want %d", got.Size, len(wantBytes))
+	}
+	if !strings.HasPrefix(got.Digest, "sha256:") || len(got.Digest) != len("sha256:")+64 {
+		t.Fatalf("digest=%q does not look like sha256:<hex64>", got.Digest)
+	}
+
+	// Consumer-side resolution: strip the "sha256:" prefix and round-trip
+	// through the shared blob store to recover the original payload bytes.
+	hexHash := strings.TrimPrefix(got.Digest, "sha256:")
+	raw, err := bs.Get(hexHash)
+	if err != nil {
+		t.Fatalf("blob store Get: %v", err)
+	}
+	if string(raw) != string(wantBytes) {
+		t.Fatalf("blob roundtrip mismatch:\n got %s\nwant %s", raw, wantBytes)
+	}
+
+	// A decoded CycleEvent from the resolved bytes should exactly equal
+	// what the caller emitted — this is what an updated consumer sees.
+	var decoded trace.CycleEvent
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("decode resolved bytes: %v", err)
+	}
+	if decoded.CycleID != "cycle-dataref-1" || decoded.Kind != trace.KindAssessment {
+		t.Errorf("decoded event cycle_id=%q kind=%q mismatch",
+			decoded.CycleID, decoded.Kind)
+	}
+}
+
+// TestEmitCycleEvent_DatarefOtherSiteNotMatched verifies that the env var
+// check is a substring-safe token match: setting COGOS_DATAREF_EMIT to an
+// unrelated site ("chat_response") leaves the cycle_trace emit on the legacy
+// inline path. This is the property that makes the flag safe to roll out one
+// site at a time without accidentally capturing neighbouring emit sites.
+func TestEmitCycleEvent_DatarefOtherSiteNotMatched(t *testing.T) {
+	resetTraceEmitterForTest(t)
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".cog", ".state", "buses"), 0o755); err != nil {
+		t.Fatalf("mkdir state: %v", err)
+	}
+	bs := engine.NewBlobStore(root)
+	if err := bs.Init(); err != nil {
+		t.Fatalf("blob store init: %v", err)
+	}
+	mgr := newBusSessionManager(root)
+
+	t.Setenv(traceDatarefEnvVar, "chat_response,some_other_site")
+	InstallTraceEmitter(mgr, root, bs)
+
+	ev, err := trace.NewAssessment("cog", "cycle-not-matched", "observe", 0.1, "other-site")
+	if err != nil {
+		t.Fatalf("build assessment: %v", err)
+	}
+	emitCycleEvent(ev)
+
+	evts := waitForBusEvents(t, root, traceBusID, 1, 2*time.Second)
+	if len(evts) != 1 {
+		t.Fatalf("got %d events, want 1", len(evts))
+	}
+	got := evts[0]
+	if got.Digest != "" {
+		t.Errorf("non-matching token should fall back to inline; got digest=%q", got.Digest)
+	}
+	if got.Payload == nil {
+		t.Errorf("non-matching token should populate inline Payload; got nil")
+	}
+}


### PR DESCRIPTION
## Summary

Lands the ADR-084 Phase 1 commit series (G1-G10 — 9 commits total, with G4+G6 squashed) onto upstream `main`. These commits have been carried on the fork's `main` for a while and block several feature PRs (#48, #49, #50) from rebasing cleanly onto upstream. Landing them as their own PR first makes those feature PRs trivially rebaseable (each then has only a single commit to replay).

Per the [Phase 9 PR rebase report](../../../../slowbro/cog-workspace/.cog/run/trackh/phase-9-pr-rebase-report.md) (local, not in repo): this was the recommended resolution path.

**ADR-084** establishes a content-addressed blob store for bus-event payloads — the envelope grows `Digest` + `MediaType` + `Size` fields pointing into `BlobStore`, coexisting with the legacy inline `Payload` during a phased migration. Phase 1 is schema-additive + infrastructure only; emit paths continue to populate `Payload`. Phase 2 starts piloting by-reference emits. See in-code docs in `pkg/cogfield/block.go` (near-top comment `// ADR-084 dataref migration policy (Phase 1: schema-additive).`) and `trace_emit.go`.

## Commit series (chronological)

| Commit | Tag | What |
|---|---|---|
| `4026fd7` | G7 | `cogblock`: expand `CogBlockKind` enum with ADR-059 types |
| `4e38c35` | G1 | `cogfield`: add ADR-084 `digest` + `media_type` fields on the envelope |
| `15c345f` | G4+G6 | `cogblock`: add `Sections[]` and `Prev []string` DAG chain fields |
| `876a864` | G10 | `engine`: wire `BlobStore` into process startup |
| `888e3a8` | G5 | `engine`: implement section-level hashing for `CogBlock` |
| `6a33a95` | G8 | `cogfield`: expand roundtrip test coverage for dataref envelope |
| `338a68f` | G2 | `engine`: add `GET /v1/blobs/:digest` endpoint (**see review item below**) |
| `3875057` | G3 | `engine`: pilot dataref emit via `BlobStore` at one site |
| `a3ccb16` | G9 | `docs`: ADR-084 Phase 1/2 migration policy comments |

All commits cherry-picked with `-x`, preserving original authorship and SHAs in the commit trailer (`cherry picked from commit <sha>`).

## Review item — conflict resolution in G2

**Please review `internal/engine/serve_blocks.go` in the G2 commit specifically.**

The original G2 commit was authored before upstream's Wave 3.5 routing refactor landed. Wave 3.5 introduced `s.route(mux, pattern, handler)` — a thin wrapper over `mux.HandleFunc` that also calls `s.recordRoute(pattern)` for manifest/introspection (see `serve_manifest.go:52`). All existing `/v1/blocks/*` endpoints were converted from `mux.HandleFunc` to `s.route` by that refactor.

G2's original form used `mux.HandleFunc("GET /v1/blobs/{digest}", s.handleBlobGet)` — the pre-refactor convention. During the cherry-pick, this conflicted with the upstream `s.route(...)` block.

**Resolution applied**: converted the new `/v1/blobs/{digest}` endpoint to `s.route(mux, ...)` to match upstream convention. This gives the endpoint the same manifest/introspection affordance as its siblings, which appears to be the intended behavior (the endpoint is semantically the same kind of handler as the other `/v1/blocks/*` routes it sits alongside). Verified:

- `go build ./...` — clean
- `go test ./...` — all green including the G2-specific `TestHandleBlob*` / `TestParseSHA256*` tests

Flagging it here because it's a semantic change from the original commit (not a byte-for-byte replay).

## Test status

- `go build ./...` — clean
- `go test ./... -count=1` — all packages green (`github.com/cogos-dev/cogos`, `internal/engine`)

## Unblocks

Once this merges:
- PR #48 (`feat/session-activity-channel`) rebases with 1 commit to replay
- PR #49 (`feat/peer-awareness-query-surface`) rebases with 1 commit to replay
- PR #50 (`feat/harness-dispatch-task-param`) rebases with 1 commit to replay

Each feature commit should land on a clean `main` with no conflicts (they touch disjoint files from Wave 3.5/4.5/5a/6a).

## Test plan

- [ ] CI green (build + test + lint)
- [ ] Reviewer confirms `s.route` conversion in G2 matches intent
- [ ] After merge: verify PRs #48/#49/#50 can rebase cleanly