### PR TITLE
RFC-017 Phase B: port MemoryIndex + MemoryTOC to v3 kernel

### DIFF
--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -280,6 +280,24 @@ func (m *MCPServer) registerTools() {
 		Description: "Search kernel trace JSONL streams in .cog/run/ (attention, proprioceptive, internal_requests). Filter by source, session_id, level, case-insensitive substring, and time range (since/until accept RFC3339 or duration like 5m/1h). Returns unified chronological results with per-source scan diagnostics. Fallback: ls .cog/run/*.jsonl && jq -c . .cog/run/<name>.jsonl | head",
 	}), m.toolSearchTraces)
 
+	// Memory section-index ops (RFC-017 Phase B). Port of the legacy
+	// `cog memory toc` / `cog memory index` verbs from the 2.5.0 monolith
+	// (cog-workspace/.cog/memory.go:670,718). Before these tools existed,
+	// the v3 kernel could only surface section-aware reads by shelling
+	// out to scripts/cog — so agents reaching the kernel via MCP had no
+	// path to generate or inspect the `sections:` frontmatter block.
+	// Without that block, every cog_read_cogdoc degrades to a full-doc
+	// read. See Phase 24 MCP API Coverage Audit for the gap analysis.
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name:        "cog_memory_toc",
+		Description: "List a CogDoc's sections with line ranges and byte sizes. Default output is a pretty-printed text table showing total lines/bytes plus per-section nesting, line range, and size; pass as_yaml=true to get the `sections:` frontmatter YAML block that cog_memory_index injects. Useful for orienting to a long document before extracting a specific section via cog_read_cogdoc with #fragment. Fallback: ./scripts/cog memory toc <path> [--yaml]",
+	}, withToolObserver(m, "cog_memory_toc", m.toolMemoryTOC))
+
+	mcp.AddTool(m.server, &mcp.Tool{
+		Name:        "cog_memory_index",
+		Description: "Generate the `sections:` frontmatter block for a CogDoc and inject it into the file's frontmatter (replacing any prior sections field). Required for cheap section-addressed reads: without `sections:` every cog_read_cogdoc call with a section selector falls back to whole-document reads. Pass dry_run=true to preview the block without writing. Requires existing frontmatter; indexing a plain markdown file is a no-op by design (run cog_write_cogdoc first). Writes are atomic. Fallback: ./scripts/cog memory index <path> [--dry-run]",
+	}, withToolObserver(m, "cog_memory_index", m.toolMemoryIndex))
+
 	// Kernel-native session/handoff tools (mcp_sessions.go). The 8 tools
 	// complement the 8 cogos_* bridge tools living in cog-sandbox-mcp:
 	// both surfaces coexist by design — same kernel truth, two MCP
@@ -541,6 +559,50 @@ type readCogdocResult struct {
 	SchemaIssues     []string          `json:"schema_issues,omitempty"`
 	PatchFrontmatter map[string]any    `json:"patch_frontmatter,omitempty"`
 	SchemaHint       string            `json:"schema_hint,omitempty"`
+}
+
+// memoryTOCInput matches the legacy `cog memory toc <path> [--yaml]` CLI.
+// Path resolution accepts absolute paths, workspace-relative paths, and
+// memory-relative paths (semantic/insights/foo.cog.md) — handled by the
+// underlying MemoryTOC function.
+type memoryTOCInput struct {
+	Path   string `json:"path" jsonschema:"Path to the CogDoc: absolute, workspace-relative, or memory-relative (e.g. semantic/insights/topic.cog.md)"`
+	AsYAML bool   `json:"as_yaml,omitempty" jsonschema:"Return the raw sections: YAML block (matches cog memory toc --yaml) instead of the text table"`
+}
+
+// memoryIndexInput matches the legacy `cog memory index <path>
+// [--dry-run]` CLI. Unlike the legacy --all mode (which walked every
+// cogdoc under .cog/mem/), this tool indexes a single document per
+// invocation. Bulk indexing is deferred to a follow-up tool so the MCP
+// surface stays clearly scoped per call.
+type memoryIndexInput struct {
+	Path   string `json:"path" jsonschema:"Path to the CogDoc: absolute, workspace-relative, or memory-relative (e.g. semantic/insights/topic.cog.md)"`
+	DryRun bool   `json:"dry_run,omitempty" jsonschema:"Preview the generated sections: block without writing it to the file"`
+}
+
+// memoryTOCResult is the structured response returned by cog_memory_toc.
+// The text/yaml field carries the rendered output exactly matching the
+// legacy CLI; path echoes the resolved input for clients that want to
+// confirm what was read.
+type memoryTOCResult struct {
+	Path     string `json:"path"`
+	AsYAML   bool   `json:"as_yaml"`
+	Rendered string `json:"rendered"`
+	NumLines int    `json:"num_lines,omitempty"`
+	NumBytes int    `json:"num_bytes,omitempty"`
+	NumSecs  int    `json:"num_sections,omitempty"`
+}
+
+// memoryIndexResult is the structured response returned by cog_memory_index.
+// When DryRun is true SectionsBlock carries the preview payload; when
+// DryRun is false Message carries the "Indexed <path> (N sections)"
+// confirmation string and SectionsBlock is empty.
+type memoryIndexResult struct {
+	Path          string `json:"path"`
+	DryRun        bool   `json:"dry_run"`
+	NumSections   int    `json:"num_sections"`
+	SectionsBlock string `json:"sections_block,omitempty"`
+	Message       string `json:"message,omitempty"`
 }
 
 type emitEventInput struct {
@@ -993,6 +1055,120 @@ func (m *MCPServer) toolWriteCogdoc(ctx context.Context, req *mcp.CallToolReques
 		"path":    result.Path,
 		"uri":     result.URI,
 	})
+}
+
+// toolMemoryTOC exposes the MemoryTOC port as cog_memory_toc. The handler
+// forwards to MemoryTOC in memory_sections.go and wraps the rendered
+// output in a structured result so clients that want metadata (section
+// count, total bytes) can read it without re-parsing the text table.
+func (m *MCPServer) toolMemoryTOC(ctx context.Context, req *mcp.CallToolRequest, input memoryTOCInput) (*mcp.CallToolResult, any, error) {
+	if input.Path == "" {
+		return textResult("path is required")
+	}
+
+	rendered, err := MemoryTOC(m.cfg.WorkspaceRoot, input.Path, input.AsYAML)
+	if err != nil {
+		return fallbackResult(fmt.Sprintf("toc failed: %v", err),
+			fmt.Sprintf("./scripts/cog memory toc %q", input.Path))
+	}
+
+	// Best-effort metadata. We re-parse to surface counts in the JSON
+	// response; this is a millisecond-scale double-read that matches the
+	// legacy CLI behaviour (legacy renders its own summary line too).
+	result := memoryTOCResult{
+		Path:     input.Path,
+		AsYAML:   input.AsYAML,
+		Rendered: rendered,
+	}
+	if raw, readErr := readCogDocContentV3(m.cfg.WorkspaceRoot, input.Path); readErr == nil {
+		body := raw
+		if _, b, ok := splitFrontmatter(raw); ok {
+			body = b
+		}
+		result.NumLines = len(strings.Split(raw, "\n"))
+		result.NumBytes = len(raw)
+		result.NumSecs = len(ParseMemorySections(body))
+	}
+	return marshalResult(result)
+}
+
+// toolMemoryIndex exposes the MemoryIndex port as cog_memory_index. On
+// dry-run the generated sections: block is returned but the file is
+// untouched. On live run the frontmatter is rewritten atomically and a
+// confirmation message is returned; the caller receives the final section
+// count so observability of the write is first-class.
+func (m *MCPServer) toolMemoryIndex(ctx context.Context, req *mcp.CallToolRequest, input memoryIndexInput) (*mcp.CallToolResult, any, error) {
+	if input.Path == "" {
+		return textResult("path is required")
+	}
+
+	out, err := MemoryIndex(m.cfg.WorkspaceRoot, input.Path, input.DryRun)
+	if err != nil {
+		suffix := ""
+		if input.DryRun {
+			suffix = " --dry-run"
+		}
+		return fallbackResult(fmt.Sprintf("index failed: %v", err),
+			fmt.Sprintf("./scripts/cog memory index %q%s", input.Path, suffix))
+	}
+
+	result := memoryIndexResult{
+		Path:   input.Path,
+		DryRun: input.DryRun,
+	}
+
+	// Count sections for the JSON response. On both dry-run and live
+	// paths the body we just parsed produced the sections we care about;
+	// re-reading is cheaper than threading a return value through the
+	// pure-Go core.
+	if raw, readErr := readCogDocContentV3(m.cfg.WorkspaceRoot, input.Path); readErr == nil {
+		body := raw
+		if _, b, ok := splitFrontmatter(raw); ok {
+			body = b
+		}
+		// Only count level ≥ 2 — matches what made it into the sections:
+		// block. The full ParseMemorySections return includes the doc
+		// title (level 1) which we filter out of the frontmatter.
+		count := 0
+		for _, s := range ParseMemorySections(body) {
+			if s.Level >= 2 {
+				count++
+			}
+		}
+		result.NumSections = count
+	}
+
+	if input.DryRun {
+		result.SectionsBlock = out
+	} else {
+		result.Message = out
+		// Refresh the CogDoc index so the freshly-indexed document
+		// reflects in the kernel's in-memory view on the next query.
+		// Parity with CogDocService.refreshIndex but local: MemoryIndex
+		// is not a go through CogDocService because it operates on raw
+		// frontmatter bytes rather than the structured opts shape.
+		m.refreshIndexAfterWrite()
+	}
+
+	return marshalResult(result)
+}
+
+// refreshIndexAfterWrite rebuilds the CogDoc index after a non-WriteAndSync
+// write path mutates disk. Kept small to avoid pulling the whole
+// CogDocService into the MemoryIndex path (which does not need field
+// boosts or ledger events — it's a metadata-only injection).
+func (m *MCPServer) refreshIndexAfterWrite() {
+	if m.process == nil {
+		return
+	}
+	idx, err := BuildIndex(m.cfg.WorkspaceRoot)
+	if err != nil {
+		slog.Warn("cog_memory_index: index refresh failed", "err", err)
+		return
+	}
+	m.process.indexMu.Lock()
+	m.process.index = idx
+	m.process.indexMu.Unlock()
 }
 
 // CogDocWriteOpts holds options for writing a CogDoc via the internal API.

--- a/internal/engine/memory_sections.go
+++ b/internal/engine/memory_sections.go
@@ -1,0 +1,470 @@
+// memory_sections.go — Port of legacy MemoryTOC + MemoryIndex from
+// cog-workspace/.cog/memory.go:670-765 (+ supporting helpers from
+// cog-workspace/.cog/lib/go/frontmatter/sections.go).
+//
+// RFC-017 Cogdoc Substrate Unity, Phase B: eliminates the v3→shell→legacy
+// dependency inversion for section-aware memory operations. Before this file
+// existed the kernel had no way to surface `cog memory toc` / `cog memory
+// index` except by shelling out to scripts/cog, which invoked the 2.5.0
+// monolith binary. Agents reaching the v3 kernel via MCP therefore could
+// not generate or inspect the `sections:` frontmatter block that makes
+// cheap section-addressed reads possible — and without that block, every
+// cog_read_cogdoc call degrades to reading the full document.
+//
+// The port is behavior-exact with the legacy implementation. Specifically:
+//
+//   - ParseMemorySections matches .cog/lib/go/frontmatter/sections.go:ParseSections.
+//     Identical fenced-code-block skipping, anchor extraction, 1-indexed
+//     line numbering, EndLine-exclusive ranges, and per-section byte size
+//     accounting (one extra byte per line for the newline).
+//
+//   - GenerateMemorySectionsYAML matches sections.go:GenerateSectionsYAML:
+//     only level ≥ 2 headings flow into the frontmatter block, the YAML
+//     shape is `- title/anchor/line/size` (anchor omitted when empty), and
+//     serialization is gopkg.in/yaml.v3 default output.
+//
+//   - MemoryTOC matches memory.go:670. Same stripped-frontmatter body,
+//     same --yaml path emitting `sections:\n` + 2-space-indented YAML, same
+//     textual table (header, lines/bytes totals, per-section indentation by
+//     (level-2)*2 spaces, fixed-width columns).
+//
+//   - MemoryIndex matches memory.go:718. Dry-run returns the `sections:`
+//     block only; live-run requires existing frontmatter, removes any prior
+//     `sections:` field with its continuation lines, appends the new block,
+//     and writes via atomicWriteFile (temp file + fsync + rename). Refuses
+//     to clobber a file that has no frontmatter to inject into.
+//
+// The v3 kernel already has a type `Section` (cogblock.go:70) with a
+// different shape — Title/Anchor/Hash/Size — used for CogBlock content
+// addressing. To avoid colliding with it, the ported type is named
+// `MemorySection` here. The two types serve different purposes: Section
+// is content-hash-addressed for ADR-059 delta sync; MemorySection is
+// line-addressed for the legacy-compatible frontmatter TOC block.
+package engine
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// MemorySection describes a markdown heading and its content range within
+// a CogDoc body. Matches the legacy Section type in lib/go/frontmatter/
+// sections.go field-for-field (the fields consumed by the legacy
+// frontmatter/TOC code paths).
+type MemorySection struct {
+	Title   string `yaml:"title" json:"title"`
+	Anchor  string `yaml:"anchor,omitempty" json:"anchor,omitempty"`
+	Level   int    `yaml:"level" json:"level"`
+	Line    int    `yaml:"line" json:"line"`         // 1-indexed start line
+	EndLine int    `yaml:"end_line" json:"end_line"` // 1-indexed end line (exclusive)
+	Size    int    `yaml:"size" json:"size"`         // bytes, incl. newlines
+}
+
+// memSectionAnchorRe matches {#anchor-id} at the end of a heading title.
+var memSectionAnchorRe = regexp.MustCompile(`\{#([a-zA-Z0-9_-]+)\}\s*$`)
+
+// memSectionHeadingRe matches markdown ATX headings (# through ######).
+var memSectionHeadingRe = regexp.MustCompile(`^(#{1,6})\s+(.+)$`)
+
+// ParseMemorySections scans markdown body for ATX headings and returns a
+// flat list of sections with computed line ranges and byte sizes. Headings
+// inside fenced code blocks (``` or ~~~) are ignored. The result includes
+// level-1 headings so MemoryTOC can display document titles; the
+// frontmatter serializer (GenerateMemorySectionsYAML) filters those out.
+func ParseMemorySections(body string) []MemorySection {
+	lines := strings.Split(body, "\n")
+	var sections []MemorySection
+	inCodeBlock := false
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
+			inCodeBlock = !inCodeBlock
+			continue
+		}
+		if inCodeBlock {
+			continue
+		}
+
+		m := memSectionHeadingRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+
+		level := len(m[1])
+		title := strings.TrimSpace(m[2])
+		anchor := ""
+
+		// Extract {#anchor} if present.
+		if am := memSectionAnchorRe.FindStringSubmatch(title); am != nil {
+			anchor = am[1]
+			title = strings.TrimSpace(memSectionAnchorRe.ReplaceAllString(title, ""))
+		}
+
+		sections = append(sections, MemorySection{
+			Title:  title,
+			Anchor: anchor,
+			Level:  level,
+			Line:   i + 1, // 1-indexed
+		})
+	}
+
+	// Compute EndLine and Size for each section.
+	for i := range sections {
+		if i+1 < len(sections) {
+			sections[i].EndLine = sections[i+1].Line
+		} else {
+			sections[i].EndLine = len(lines) + 1
+		}
+
+		// Byte size of the section, counting a newline per line (matching
+		// the legacy implementation; a document that ends without a final
+		// newline therefore over-counts by one byte on its last section —
+		// intentional for parity).
+		start := sections[i].Line - 1 // 0-indexed
+		end := sections[i].EndLine - 1
+		if end > len(lines) {
+			end = len(lines)
+		}
+		size := 0
+		for j := start; j < end; j++ {
+			size += len(lines[j]) + 1
+		}
+		sections[i].Size = size
+	}
+
+	return sections
+}
+
+// GenerateMemorySectionsYAML produces the YAML payload for a `sections:`
+// frontmatter field. The return value is the YAML list body only — the
+// caller prepends `sections:\n` and indents each line by two spaces, in
+// both the live-write path (MemoryIndex) and the read-only YAML path
+// (MemoryTOC with asYAML=true).
+//
+// Only level ≥ 2 headings are emitted. The level-1 heading of a document
+// is the document title; the section index is for navigation within the
+// body, so including it would be redundant.
+func GenerateMemorySectionsYAML(body string) string {
+	sections := ParseMemorySections(body)
+	if len(sections) == 0 {
+		return ""
+	}
+
+	// Entry shape matches the legacy projection exactly. yaml.v3 omits
+	// empty Anchor (omitempty) and stable-orders the struct fields in
+	// declaration order.
+	type sectionEntry struct {
+		Title  string `yaml:"title"`
+		Anchor string `yaml:"anchor,omitempty"`
+		Line   int    `yaml:"line"`
+		Size   int    `yaml:"size"`
+	}
+
+	var entries []sectionEntry
+	for _, s := range sections {
+		if s.Level < 2 {
+			continue
+		}
+		entries = append(entries, sectionEntry{
+			Title:  s.Title,
+			Anchor: s.Anchor,
+			Line:   s.Line,
+			Size:   s.Size,
+		})
+	}
+
+	if len(entries) == 0 {
+		return ""
+	}
+
+	data, err := yaml.Marshal(entries)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+// splitFrontmatter extracts frontmatter and body from a CogDoc exactly
+// matching the legacy frontmatter.Extract semantics (lib/go/frontmatter/
+// frontmatter.go:Extract). hasFM is true iff the content opens with
+// "---\n" AND a closing "\n---" is found before EOF. When hasFM is false
+// the returned fmText is empty and body equals the full input content —
+// mirroring how MemoryTOC and MemoryIndex treat pre-frontmatter or
+// frontmatter-less documents.
+func splitFrontmatter(content string) (fmText, body string, hasFM bool) {
+	if !strings.HasPrefix(content, "---\n") {
+		return "", content, false
+	}
+	end := strings.Index(content[4:], "\n---")
+	if end == -1 {
+		return "", content, false
+	}
+	fmText = content[4 : 4+end]
+	fmText = strings.TrimSuffix(fmText, "\n")
+	body = strings.TrimPrefix(content[4+end+4:], "\n")
+	return fmText, body, true
+}
+
+// resolveMemoryDocPath resolves an input path to an absolute filesystem
+// path. Handles memory-relative paths (`.cog/mem/...`), workspace-relative
+// paths, absolute paths, and memory-bare paths (e.g. `semantic/foo.md`).
+// Mirrors legacy memory.go:resolveDocPath:769.
+func resolveMemoryDocPath(path, cogRoot string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	memoryDir := filepath.Join(cogRoot, ".cog", "mem")
+	if strings.Contains(path, "/.cog/mem/") {
+		parts := strings.SplitN(path, "/.cog/mem/", 2)
+		if len(parts) == 2 {
+			return filepath.Join(memoryDir, parts[1])
+		}
+	}
+	if after, ok := strings.CutPrefix(path, ".cog/mem/"); ok {
+		return filepath.Join(memoryDir, after)
+	}
+	// Try as workspace-relative first (mirrors legacy: some paths like
+	// `.cog/ontology/crystal.cog.md` live outside `.cog/mem/`).
+	wsPath := filepath.Join(cogRoot, path)
+	if _, err := os.Stat(wsPath); err == nil {
+		return wsPath
+	}
+	// Fall back to memory-relative.
+	return filepath.Join(memoryDir, path)
+}
+
+// readCogDocContentV3 is the side-effect-free read used by MemoryTOC and
+// MemoryIndex. It does NOT update last_accessed (the legacy counterpart
+// at memory.go:620 is named readCogDocContent and has the same contract).
+// The v3-specific suffix avoids clashing with any future kernel-wide
+// read helper.
+func readCogDocContentV3(cogRoot, path string) (string, error) {
+	fullPath := resolveMemoryDocPath(path, cogRoot)
+	data, err := os.ReadFile(fullPath)
+	if err != nil {
+		return "", fmt.Errorf("file not found: %s", path)
+	}
+	return string(data), nil
+}
+
+// indentLines prefixes each non-empty line of s with prefix and appends a
+// trailing newline. Matches legacy memory.go:indent.
+func indentLines(s, prefix string) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	for i, line := range lines {
+		if line != "" {
+			lines[i] = prefix + line
+		}
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+// formatMemorySectionSize formats a byte count as a human-readable size
+// string for section display in the textual TOC. Matches legacy
+// memory.go:formatSectionSize.
+func formatMemorySectionSize(b int) string {
+	if b < 1024 {
+		return fmt.Sprintf("%dB", b)
+	}
+	return fmt.Sprintf("%.1fKB", float64(b)/1024.0)
+}
+
+// removeMemoryFrontmatterField removes a YAML field (including any array
+// or mapping continuation lines) from a frontmatter body. Used by
+// MemoryIndex to strip any stale `sections:` block before appending a
+// freshly generated one. Mirrors legacy memory.go:removeFrontmatterField.
+//
+// The legacy heuristic: lines that start with the field prefix are
+// elided; subsequent lines that are indented (space or tab) or that start
+// with `- ` (array item) are considered continuation and also elided; the
+// first top-level line terminates the removal.
+func removeMemoryFrontmatterField(fm, field string) string {
+	lines := strings.Split(fm, "\n")
+	var result []string
+	inField := false
+	fieldPrefix := field + ":"
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if strings.HasPrefix(trimmed, fieldPrefix) {
+			inField = true
+			continue
+		}
+
+		if inField {
+			if strings.HasPrefix(line, "  ") || strings.HasPrefix(line, "\t") || strings.HasPrefix(trimmed, "- ") {
+				continue
+			}
+			inField = false
+		}
+
+		result = append(result, line)
+	}
+	return strings.Join(result, "\n")
+}
+
+// atomicWriteMemoryFile writes data to path via temp-file + fsync +
+// rename, refusing to clobber a non-empty file with zero-byte content.
+// Mirrors legacy memory.go:atomicWriteFile. Distinct name from
+// engine/config_write.go:atomicWriteConfigFile because the config helper
+// pre-creates parent directories — for memory writes the caller should
+// already have a path to an existing file (MemoryIndex only modifies
+// cogdocs that were read moments earlier).
+//
+// See cog-workspace/.cog/mem/reflective/incidents/
+// 2026-04-16-cogdoc-truncation.md for the truncation incident that made
+// the empty-content guard load-bearing.
+func atomicWriteMemoryFile(path string, data []byte, perm os.FileMode) error {
+	// Guard: refuse to truncate a non-empty file to zero bytes.
+	if len(data) == 0 {
+		if info, err := os.Stat(path); err == nil && info.Size() > 0 {
+			return fmt.Errorf("refusing to truncate non-empty file %s to zero bytes", path)
+		}
+	}
+
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".cogdoc-*.tmp")
+	if err != nil {
+		return fmt.Errorf("atomicWriteMemoryFile: create temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	// Clean up temp on any failure before rename.
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("atomicWriteMemoryFile: write: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("atomicWriteMemoryFile: sync: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("atomicWriteMemoryFile: close: %w", err)
+	}
+	if err := os.Chmod(tmpPath, perm); err != nil {
+		return fmt.Errorf("atomicWriteMemoryFile: chmod: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("atomicWriteMemoryFile: rename: %w", err)
+	}
+	return nil
+}
+
+// MemoryTOC returns a formatted table of contents for a cogdoc. When
+// asYAML is true the output is the raw `sections:` YAML block (the same
+// shape MemoryIndex would inject into the frontmatter). When asYAML is
+// false the output is a pretty-printed text table with total line count,
+// total byte size, per-section line ranges, and sizes.
+//
+// Port of legacy cog-workspace/.cog/memory.go:670.
+func MemoryTOC(cogRoot, path string, asYAML bool) (string, error) {
+	content, err := readCogDocContentV3(cogRoot, path)
+	if err != nil {
+		return "", err
+	}
+
+	// Strip frontmatter to get body.
+	body := content
+	if _, b, ok := splitFrontmatter(content); ok {
+		body = b
+	}
+
+	if asYAML {
+		yamlStr := GenerateMemorySectionsYAML(body)
+		if yamlStr == "" {
+			return "", fmt.Errorf("no sections found in: %s", path)
+		}
+		return "sections:\n" + indentLines(yamlStr, "  "), nil
+	}
+
+	sections := ParseMemorySections(body)
+	if len(sections) == 0 {
+		return "", fmt.Errorf("no sections found in: %s", path)
+	}
+
+	totalLines := len(strings.Split(content, "\n"))
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Sections in %s (%d lines, %d bytes):\n\n", path, totalLines, len(content))
+
+	for _, s := range sections {
+		prefix := strings.Repeat("#", s.Level)
+		sizeStr := formatMemorySectionSize(s.Size)
+		indent := ""
+		if s.Level > 2 {
+			indent = strings.Repeat("  ", s.Level-2)
+		}
+		fmt.Fprintf(&b, "  %s%-4s %-40s lines %4d-%-4d %s\n",
+			indent, prefix, s.Title, s.Line, s.EndLine-1, sizeStr)
+	}
+	return b.String(), nil
+}
+
+// MemoryIndex generates the `sections:` YAML block for a cogdoc and
+// injects it into the document's frontmatter, replacing any prior
+// sections field. When dryRun is true the injection is skipped and the
+// generated block is returned for preview; the on-disk file is unchanged.
+//
+// Port of legacy cog-workspace/.cog/memory.go:718.
+//
+// Failure modes preserved exactly:
+//   - `no sections found in: <path>` — the body has no headings level 2+.
+//   - `no frontmatter to inject into: <path>` — live write requires an
+//     existing frontmatter block; indexing a plain markdown file is a
+//     no-op by design (the operator is expected to cog memory write
+//     first, then index).
+//
+// Writes are atomic: a sibling `.cogdoc-*.tmp` file is written + fsynced
+// + renamed over the destination, so a mid-write crash leaves either the
+// old content or the new content, never a zero-byte file.
+func MemoryIndex(cogRoot, path string, dryRun bool) (string, error) {
+	content, err := readCogDocContentV3(cogRoot, path)
+	if err != nil {
+		return "", err
+	}
+
+	// Strip frontmatter to get body.
+	body := content
+	fmContent := ""
+	if fm, b, ok := splitFrontmatter(content); ok {
+		body = b
+		fmContent = fm
+	}
+
+	yamlStr := GenerateMemorySectionsYAML(body)
+	if yamlStr == "" {
+		return "", fmt.Errorf("no sections found in: %s", path)
+	}
+
+	sectionsBlock := "sections:\n" + indentLines(yamlStr, "  ")
+
+	if dryRun {
+		return sectionsBlock, nil
+	}
+
+	// Inject into frontmatter.
+	if fmContent == "" {
+		return "", fmt.Errorf("no frontmatter to inject into: %s", path)
+	}
+
+	// Remove existing sections: block if present.
+	newFM := removeMemoryFrontmatterField(fmContent, "sections")
+	newFM = strings.TrimRight(newFM, "\n") + "\n" + sectionsBlock
+
+	newContent := "---\n" + newFM + "---\n" + body
+
+	fullPath := resolveMemoryDocPath(path, cogRoot)
+	if err := atomicWriteMemoryFile(fullPath, []byte(newContent), 0644); err != nil {
+		return "", fmt.Errorf("failed to write: %w", err)
+	}
+
+	return fmt.Sprintf("Indexed %s (%d sections)", path, len(ParseMemorySections(body))), nil
+}

--- a/internal/engine/memory_sections_test.go
+++ b/internal/engine/memory_sections_test.go
@@ -1,0 +1,627 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ── ParseMemorySections ───────────────────────────────────────────────────────
+
+func TestParseMemorySections_EmptyBody(t *testing.T) {
+	t.Parallel()
+	got := ParseMemorySections("")
+	// strings.Split("", "\n") returns [""] — a single empty line with
+	// no headings produces no sections.
+	if len(got) != 0 {
+		t.Errorf("len = %d; want 0", len(got))
+	}
+}
+
+func TestParseMemorySections_HeadingsOnly(t *testing.T) {
+	t.Parallel()
+	body := "# Title\n\n## Section A\n\nbody a\n\n## Section B\n\nbody b\n"
+	got := ParseMemorySections(body)
+	if len(got) != 3 {
+		t.Fatalf("len = %d; want 3; got %+v", len(got), got)
+	}
+	if got[0].Title != "Title" || got[0].Level != 1 || got[0].Line != 1 {
+		t.Errorf("section[0] = %+v", got[0])
+	}
+	if got[1].Title != "Section A" || got[1].Level != 2 || got[1].Line != 3 {
+		t.Errorf("section[1] = %+v", got[1])
+	}
+	if got[2].Title != "Section B" || got[2].Level != 2 || got[2].Line != 7 {
+		t.Errorf("section[2] = %+v", got[2])
+	}
+	// The body ends with a trailing newline, so strings.Split yields
+	// 10 elements (the last "" after the final \n). EndLine of the last
+	// section spans to len(lines)+1 = 11.
+	if got[2].EndLine != 11 {
+		t.Errorf("section[2].EndLine = %d; want 11", got[2].EndLine)
+	}
+	// EndLine of section A should equal section B's start (line 7).
+	if got[1].EndLine != 7 {
+		t.Errorf("section[1].EndLine = %d; want 7", got[1].EndLine)
+	}
+}
+
+func TestParseMemorySections_WithAnchors(t *testing.T) {
+	t.Parallel()
+	body := "## The Constants {#constants}\n\nfoo\n"
+	got := ParseMemorySections(body)
+	if len(got) != 1 {
+		t.Fatalf("len = %d; want 1", len(got))
+	}
+	if got[0].Title != "The Constants" {
+		t.Errorf("Title = %q; want %q", got[0].Title, "The Constants")
+	}
+	if got[0].Anchor != "constants" {
+		t.Errorf("Anchor = %q; want %q", got[0].Anchor, "constants")
+	}
+}
+
+func TestParseMemorySections_SkipsHeadingsInCodeBlocks(t *testing.T) {
+	t.Parallel()
+	body := "## Real\n\n```\n# fake heading\n## also fake\n```\n\n## After\n"
+	got := ParseMemorySections(body)
+	if len(got) != 2 {
+		t.Fatalf("len = %d; want 2; got %+v", len(got), got)
+	}
+	if got[0].Title != "Real" || got[1].Title != "After" {
+		t.Errorf("titles = [%q %q]; want [Real After]", got[0].Title, got[1].Title)
+	}
+}
+
+func TestParseMemorySections_TildeFenceAlsoSkipped(t *testing.T) {
+	t.Parallel()
+	body := "## Real\n\n~~~\n## buried\n~~~\n\n## After\n"
+	got := ParseMemorySections(body)
+	if len(got) != 2 {
+		t.Fatalf("len = %d; want 2; got %+v", len(got), got)
+	}
+	if got[0].Title != "Real" || got[1].Title != "After" {
+		t.Errorf("titles = [%q %q]; want [Real After]", got[0].Title, got[1].Title)
+	}
+}
+
+func TestParseMemorySections_SizeAccountingIncludesNewlines(t *testing.T) {
+	t.Parallel()
+	// "## H\n" (5) + "a\n" (2) + "b\n" (2) = 9 bytes for section 1;
+	// "## H2\n" (6) for section 2 on its own line.
+	body := "## H\na\nb\n## H2\n"
+	got := ParseMemorySections(body)
+	if len(got) != 2 {
+		t.Fatalf("len = %d; want 2", len(got))
+	}
+	if got[0].Size != 9 {
+		t.Errorf("section[0].Size = %d; want 9", got[0].Size)
+	}
+}
+
+// ── GenerateMemorySectionsYAML ────────────────────────────────────────────────
+
+func TestGenerateMemorySectionsYAML_FiltersLevel1(t *testing.T) {
+	t.Parallel()
+	body := "# Title\n\n## A\n\n## B\n"
+	yaml := GenerateMemorySectionsYAML(body)
+	if strings.Contains(yaml, "Title") {
+		t.Errorf("YAML should NOT include level-1 Title; got:\n%s", yaml)
+	}
+	if !strings.Contains(yaml, "title: A") {
+		t.Errorf("YAML should include A; got:\n%s", yaml)
+	}
+	if !strings.Contains(yaml, "title: B") {
+		t.Errorf("YAML should include B; got:\n%s", yaml)
+	}
+}
+
+func TestGenerateMemorySectionsYAML_EmptyWhenNoLevel2(t *testing.T) {
+	t.Parallel()
+	if yaml := GenerateMemorySectionsYAML("# Only Title\n"); yaml != "" {
+		t.Errorf("YAML should be empty when only level-1 heading; got %q", yaml)
+	}
+	if yaml := GenerateMemorySectionsYAML("no headings at all\n"); yaml != "" {
+		t.Errorf("YAML should be empty when no headings; got %q", yaml)
+	}
+}
+
+func TestGenerateMemorySectionsYAML_OmitsEmptyAnchor(t *testing.T) {
+	t.Parallel()
+	body := "## Plain\n\ntext\n## With Anchor {#a}\n\nmore\n"
+	yaml := GenerateMemorySectionsYAML(body)
+	// Plain section should not have an anchor key (YAML `anchor:` should
+	// be absent). The second should carry anchor: a.
+	if strings.Contains(yaml, "anchor: \"\"") {
+		t.Errorf("YAML should omit empty anchor; got:\n%s", yaml)
+	}
+	if !strings.Contains(yaml, "anchor: a") {
+		t.Errorf("YAML should include anchor: a; got:\n%s", yaml)
+	}
+}
+
+// ── splitFrontmatter ──────────────────────────────────────────────────────────
+
+func TestSplitFrontmatter_WithFrontmatter(t *testing.T) {
+	t.Parallel()
+	content := "---\ntitle: Foo\n---\n# Body\n"
+	fm, body, ok := splitFrontmatter(content)
+	if !ok {
+		t.Fatal("expected hasFM = true")
+	}
+	if fm != "title: Foo" {
+		t.Errorf("fm = %q; want %q", fm, "title: Foo")
+	}
+	if body != "# Body\n" {
+		t.Errorf("body = %q; want %q", body, "# Body\n")
+	}
+}
+
+func TestSplitFrontmatter_NoFrontmatter(t *testing.T) {
+	t.Parallel()
+	content := "# Just body\n\ntext\n"
+	fm, body, ok := splitFrontmatter(content)
+	if ok {
+		t.Errorf("expected hasFM = false")
+	}
+	if fm != "" {
+		t.Errorf("fm = %q; want empty", fm)
+	}
+	if body != content {
+		t.Errorf("body should equal content when no frontmatter; got %q", body)
+	}
+}
+
+func TestSplitFrontmatter_UnclosedFrontmatter(t *testing.T) {
+	t.Parallel()
+	// Legacy behaviour: if the closing --- is missing, return hasFM=false
+	// and treat the whole thing as body — avoid losing any content.
+	content := "---\ntitle: Foo\n# Body"
+	_, body, ok := splitFrontmatter(content)
+	if ok {
+		t.Error("expected hasFM = false for unclosed frontmatter")
+	}
+	if body != content {
+		t.Errorf("body should equal content; got %q", body)
+	}
+}
+
+// ── removeMemoryFrontmatterField ──────────────────────────────────────────────
+
+func TestRemoveMemoryFrontmatterField_RemovesSectionsBlockWithArrayItems(t *testing.T) {
+	t.Parallel()
+	fm := `title: Foo
+sections:
+  - title: A
+    line: 3
+    size: 100
+  - title: B
+    line: 10
+    size: 200
+tags:
+  - test`
+	got := removeMemoryFrontmatterField(fm, "sections")
+	if strings.Contains(got, "sections:") {
+		t.Errorf("sections: should be removed; got:\n%s", got)
+	}
+	if strings.Contains(got, "title: A") {
+		t.Errorf("sections array items should be removed; got:\n%s", got)
+	}
+	// tags: should survive.
+	if !strings.Contains(got, "tags:") {
+		t.Errorf("tags: field should survive; got:\n%s", got)
+	}
+	if !strings.Contains(got, "- test") {
+		t.Errorf("tags item should survive; got:\n%s", got)
+	}
+}
+
+func TestRemoveMemoryFrontmatterField_NoOpWhenFieldAbsent(t *testing.T) {
+	t.Parallel()
+	fm := "title: Foo\ntags:\n  - a\n"
+	got := removeMemoryFrontmatterField(fm, "sections")
+	if got != fm {
+		t.Errorf("should be unchanged; got %q want %q", got, fm)
+	}
+}
+
+// ── resolveMemoryDocPath ──────────────────────────────────────────────────────
+
+func TestResolveMemoryDocPath_Variants(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	memDir := filepath.Join(root, ".cog", "mem")
+	if err := os.MkdirAll(memDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"absolute", "/some/absolute/path.md", "/some/absolute/path.md"},
+		{"dotcog-mem-prefix", ".cog/mem/semantic/foo.md", filepath.Join(memDir, "semantic/foo.md")},
+		{"bare-memory-relative", "semantic/insights/foo.cog.md", filepath.Join(memDir, "semantic/insights/foo.cog.md")},
+	}
+	for _, tc := range cases {
+		got := resolveMemoryDocPath(tc.in, root)
+		if got != tc.want {
+			t.Errorf("%s: got %q; want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestResolveMemoryDocPath_WorkspaceRelativePreferred(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	// Create an ontology file OUTSIDE .cog/mem/ — resolution should
+	// find it as workspace-relative rather than forcing it into .cog/mem/.
+	if err := os.MkdirAll(filepath.Join(root, ".cog", "ontology"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".cog", "ontology", "crystal.cog.md"), []byte("# Crystal\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	got := resolveMemoryDocPath(".cog/ontology/crystal.cog.md", root)
+	want := filepath.Join(root, ".cog", "ontology", "crystal.cog.md")
+	if got != want {
+		t.Errorf("got %q; want %q", got, want)
+	}
+}
+
+// ── MemoryTOC ─────────────────────────────────────────────────────────────────
+
+func writeMemDoc(t *testing.T, root, relPath, content string) string {
+	t.Helper()
+	full := filepath.Join(root, ".cog", "mem", relPath)
+	if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return full
+}
+
+func TestMemoryTOC_TextOutput(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	doc := `---
+title: Testing TOC
+---
+# Testing TOC
+
+## Introduction
+
+Some intro text.
+
+## Details
+
+More content here.
+
+### Sub-detail
+
+A child heading.
+`
+	writeMemDoc(t, root, "semantic/insights/toc-test.cog.md", doc)
+
+	out, err := MemoryTOC(root, "semantic/insights/toc-test.cog.md", false)
+	if err != nil {
+		t.Fatalf("MemoryTOC: %v", err)
+	}
+	// Header line includes total byte count.
+	if !strings.Contains(out, "Sections in semantic/insights/toc-test.cog.md") {
+		t.Errorf("output missing header; got:\n%s", out)
+	}
+	if !strings.Contains(out, "Introduction") {
+		t.Errorf("output missing Introduction section; got:\n%s", out)
+	}
+	if !strings.Contains(out, "Details") {
+		t.Errorf("output missing Details section; got:\n%s", out)
+	}
+	// Sub-detail (level 3) should be indented more than level-2 headings.
+	if !strings.Contains(out, "Sub-detail") {
+		t.Errorf("output missing Sub-detail; got:\n%s", out)
+	}
+}
+
+func TestMemoryTOC_YAMLOutput(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	doc := `---
+title: Y
+---
+# Y
+
+## A
+
+body a
+
+## B
+
+body b
+`
+	writeMemDoc(t, root, "semantic/y.cog.md", doc)
+
+	out, err := MemoryTOC(root, "semantic/y.cog.md", true)
+	if err != nil {
+		t.Fatalf("MemoryTOC yaml: %v", err)
+	}
+	if !strings.HasPrefix(out, "sections:\n") {
+		t.Errorf("YAML output should start with sections:; got:\n%s", out)
+	}
+	if !strings.Contains(out, "title: A") {
+		t.Errorf("YAML should include title: A; got:\n%s", out)
+	}
+	if !strings.Contains(out, "title: B") {
+		t.Errorf("YAML should include title: B; got:\n%s", out)
+	}
+	// The level-1 title should NOT appear.
+	if strings.Contains(out, "title: Y\n") {
+		t.Errorf("YAML should NOT include level-1 title Y; got:\n%s", out)
+	}
+}
+
+func TestMemoryTOC_ErrorWhenNoSections(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	doc := `---
+title: empty
+---
+Just prose, no headings at all.
+`
+	writeMemDoc(t, root, "semantic/empty.cog.md", doc)
+
+	if _, err := MemoryTOC(root, "semantic/empty.cog.md", false); err == nil {
+		t.Error("expected error for doc with no sections")
+	}
+	if _, err := MemoryTOC(root, "semantic/empty.cog.md", true); err == nil {
+		t.Error("expected error for doc with no sections (yaml mode)")
+	}
+}
+
+func TestMemoryTOC_ErrorWhenFileMissing(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".cog", "mem"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := MemoryTOC(root, "nonexistent.md", false); err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+// ── MemoryIndex ───────────────────────────────────────────────────────────────
+
+func TestMemoryIndex_DryRunDoesNotWrite(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	doc := `---
+title: dry
+---
+## One
+
+body
+
+## Two
+
+body
+`
+	path := "semantic/dry.cog.md"
+	full := writeMemDoc(t, root, path, doc)
+
+	out, err := MemoryIndex(root, path, true)
+	if err != nil {
+		t.Fatalf("MemoryIndex dry-run: %v", err)
+	}
+	if !strings.HasPrefix(out, "sections:\n") {
+		t.Errorf("dry-run output should start with sections:; got:\n%s", out)
+	}
+	// File on disk should be unchanged.
+	after, err := os.ReadFile(full)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != doc {
+		t.Errorf("dry-run mutated file; before:\n%s\nafter:\n%s", doc, string(after))
+	}
+}
+
+func TestMemoryIndex_LiveInjectsSections(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	doc := `---
+title: live
+tags:
+  - test
+---
+## Alpha
+
+first
+
+## Beta
+
+second
+
+### Beta child
+
+nested
+`
+	path := "semantic/live.cog.md"
+	full := writeMemDoc(t, root, path, doc)
+
+	out, err := MemoryIndex(root, path, false)
+	if err != nil {
+		t.Fatalf("MemoryIndex live: %v", err)
+	}
+	// Message should report the count (level ≥ 2 is 3: Alpha, Beta, Beta child).
+	if !strings.Contains(out, "Indexed") {
+		t.Errorf("live output should mention Indexed; got %q", out)
+	}
+	if !strings.Contains(out, "3 sections") {
+		t.Errorf("live output should count 3 sections; got %q", out)
+	}
+
+	// Verify the file now has a sections: block.
+	after, err := os.ReadFile(full)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ac := string(after)
+	if !strings.Contains(ac, "sections:") {
+		t.Errorf("file should have sections: block; got:\n%s", ac)
+	}
+	if !strings.Contains(ac, "title: Alpha") {
+		t.Errorf("sections should list Alpha; got:\n%s", ac)
+	}
+	// tags: should survive (not cannibalized by removeFrontmatterField).
+	if !strings.Contains(ac, "tags:") {
+		t.Errorf("tags: should survive; got:\n%s", ac)
+	}
+	// Body should survive intact.
+	if !strings.Contains(ac, "## Alpha") {
+		t.Errorf("body should survive; got:\n%s", ac)
+	}
+	if !strings.Contains(ac, "### Beta child") {
+		t.Errorf("nested heading body should survive; got:\n%s", ac)
+	}
+}
+
+func TestMemoryIndex_LiveReplacesExistingSectionsBlock(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	// Doc already has a stale sections: block — index should overwrite it
+	// with a fresh one that reflects the current body.
+	doc := `---
+title: stale
+sections:
+  - title: old-stale-name
+    line: 999
+    size: 1
+---
+## New A
+
+body
+
+## New B
+
+body
+`
+	path := "semantic/stale.cog.md"
+	full := writeMemDoc(t, root, path, doc)
+
+	if _, err := MemoryIndex(root, path, false); err != nil {
+		t.Fatalf("MemoryIndex: %v", err)
+	}
+
+	after, err := os.ReadFile(full)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ac := string(after)
+	if strings.Contains(ac, "old-stale-name") {
+		t.Errorf("stale sections entry should be gone; got:\n%s", ac)
+	}
+	if !strings.Contains(ac, "title: New A") {
+		t.Errorf("new section should be indexed; got:\n%s", ac)
+	}
+	if !strings.Contains(ac, "title: New B") {
+		t.Errorf("new section should be indexed; got:\n%s", ac)
+	}
+}
+
+func TestMemoryIndex_ErrorWhenNoFrontmatter(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	doc := "## A\nbody\n"
+	path := "semantic/no-fm.md"
+	writeMemDoc(t, root, path, doc)
+
+	_, err := MemoryIndex(root, path, false)
+	if err == nil {
+		t.Fatal("expected error: no frontmatter to inject into")
+	}
+	if !strings.Contains(err.Error(), "no frontmatter") {
+		t.Errorf("error should mention missing frontmatter; got %v", err)
+	}
+}
+
+func TestMemoryIndex_DryRunWorksWithoutFrontmatter(t *testing.T) {
+	t.Parallel()
+	// Dry-run does NOT require frontmatter — it only asks for sections
+	// to generate. This lets agents preview the block for a plain .md
+	// file before deciding whether to add a frontmatter.
+	root := t.TempDir()
+	doc := "## A\n\nbody\n"
+	path := "semantic/plain.md"
+	writeMemDoc(t, root, path, doc)
+
+	out, err := MemoryIndex(root, path, true)
+	if err != nil {
+		t.Fatalf("MemoryIndex dry-run without fm: %v", err)
+	}
+	if !strings.HasPrefix(out, "sections:\n") {
+		t.Errorf("dry-run output should still produce sections: block; got:\n%s", out)
+	}
+}
+
+func TestMemoryIndex_ErrorWhenNoSectionsFound(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	doc := `---
+title: empty
+---
+Just prose.
+`
+	path := "semantic/no-secs.cog.md"
+	writeMemDoc(t, root, path, doc)
+
+	if _, err := MemoryIndex(root, path, false); err == nil {
+		t.Error("expected error for doc with no sections")
+	}
+}
+
+// ── atomicWriteMemoryFile ─────────────────────────────────────────────────────
+
+func TestAtomicWriteMemoryFile_RefusesZeroByteOverwrite(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "doc.md")
+	if err := os.WriteFile(path, []byte("# Keep\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	err := atomicWriteMemoryFile(path, []byte{}, 0644)
+	if err == nil {
+		t.Fatal("expected error: refuse to truncate non-empty file")
+	}
+	if !strings.Contains(err.Error(), "refusing") {
+		t.Errorf("error should mention refusing; got %v", err)
+	}
+	// File must still contain the original content.
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "# Keep\n" {
+		t.Errorf("file mutated despite guard; got %q", string(got))
+	}
+}
+
+func TestAtomicWriteMemoryFile_RoundTrip(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "doc.md")
+	payload := []byte("# Hello\n\nbody.\n")
+	if err := atomicWriteMemoryFile(path, payload, 0644); err != nil {
+		t.Fatalf("atomicWriteMemoryFile: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(payload) {
+		t.Errorf("round-trip mismatch; got %q want %q", string(got), string(payload))
+	}
+}


### PR DESCRIPTION
## Summary

Port `MemoryIndex` and `MemoryTOC` from the legacy 2.5.0 monolith
(`cog-workspace/.cog/memory.go:670,718`) into the v3 kernel and expose
them as MCP tools `cog_memory_toc` / `cog_memory_index`. Closes the
section-aware-memory gap called out in the Phase 24 MCP API Coverage
Audit — before this PR, the only path to generate or inspect the
`sections:` frontmatter block was shelling out to `scripts/cog`, which
invoked the 2.5.0 monolith (v3 → shell → legacy dependency inversion).

Without the `sections:` block, every `cog_read_cogdoc` with a section
selector degrades to a full-document read. Fixing this is called out
in the audit as the second-highest-leverage item (after registering
v3 `/mcp` in `~/.claude.json`, which Phase A already landed).

### Commits

1. **engine: port MemoryIndex + MemoryTOC from legacy monolith** —
   pure Go port + supporting helpers (`ParseMemorySections`,
   `GenerateMemorySectionsYAML`, `splitFrontmatter`,
   `resolveMemoryDocPath`, `removeMemoryFrontmatterField`,
   `atomicWriteMemoryFile`). Behavior-exact with the legacy
   implementation; 28 unit tests cover parsing, YAML generation,
   frontmatter splitting, field removal, path resolution, TOC
   rendering (text + YAML), index dry-run and live-write, stale
   sections replacement, atomic-write zero-byte guard.

2. **engine: register cog_memory_toc + cog_memory_index MCP tools** —
   wires the handlers into `mcp_server.go:registerTools`, adds input
   types (`memoryTOCInput`, `memoryIndexInput`), result types with
   metadata fields (`num_lines`, `num_bytes`, `num_sections`),
   structured JSON responses, fallback-command error messages
   (`./scripts/cog memory toc/index`), and runs through
   `withToolObserver` so tool.call/tool.result events hit the
   hash-chained ledger consistently with the other `cog_*` tools.
   Live-write triggers an index refresh so freshly-indexed documents
   are visible to the next query immediately.

### Design notes

- **No collision with existing `Section` type** — the v3 kernel already
  has `cogblock.go:70:Section` which is hash-addressed for ADR-059
  delta sync. The ported type is named `MemorySection` and carries
  `Title/Anchor/Level/Line/EndLine/Size` matching the legacy shape.
  The two types serve different purposes.

- **Backwards-compatible** — no change to the existing
  `memory.go:18-43` shell-out path. Phase C removes that; Phase B
  only ADDS the native route. Existing agents keep working.

- **No `--all` bulk-index mode yet** — a single document per call for
  now so the MCP surface stays clearly scoped. If bulk is needed it
  can become a separate `cog_memory_index_all` tool (deferred, noted
  here rather than stubbed in; no-stubs discipline per
  `feedback_no_stubs_finish_or_defer.md`).

- **Atomic writes** — live-write goes through
  `atomicWriteMemoryFile` which does temp-file + fsync + rename,
  including the "refuse to truncate non-empty to zero bytes" guard
  that the legacy incident write-up
  (`cog-workspace/.cog/mem/reflective/incidents/2026-04-16-cogdoc-truncation.md`)
  documents.

### Deferrals (explicit)

- `--all` bulk index — the legacy `cog memory index --all` walks every
  cogdoc under `.cog/mem/` and reindexes. Not ported in this PR to
  keep the MCP surface scoped; easy follow-up if needed.
- `cog memory append`, `cog memory stats`, `cog memory list` — per the
  Phase 24 audit these are also missing on v3 but they are outside
  this PR's scope (which is specifically TOC + Index).
- Waypoint-activation search (`--deep` mode of `cog memory search`) —
  out of scope for Phase B (Phase C item).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l internal/engine/memory_sections.go internal/engine/memory_sections_test.go internal/engine/mcp_server.go` clean
- [x] `go test -tags fts5 -count=1 ./internal/engine/` — 630 pass, 0 fail (28 new)
- [x] `go test -tags fts5 -count=1 github.com/cogos-dev/cogos/internal/engine` — OK
- [ ] Pre-existing failure on main: `TestQueryConstellationWithIris_FallbackToStandard` in the root `github.com/cogos-dev/cogos` package fails with `-tags fts5`. Verified on a clean `git stash` of `main` — unrelated to this PR.
- [ ] Manual smoke (post-merge): call `cog_memory_toc` + `cog_memory_index` through `/mcp` against a real workspace cogdoc.

## Refs

- RFC-017 Cogdoc Substrate Unity (ratified, wave 2)
- `cog-workspace/.cog/run/trackh/phase-24-mcp-api-coverage-audit.md` — gap analysis, §4.3 (toc) and §4.4 (index) specifically
- Legacy source: `cog-workspace/.cog/memory.go:670-765`
- Legacy helpers: `cog-workspace/.cog/lib/go/frontmatter/sections.go`