### PR TITLE
fix(engine,harness): three-point BrowserOS tool-bridge fix (Phase 24)

### DIFF
--- a/harness/harness.go
+++ b/harness/harness.go
@@ -215,6 +215,36 @@ func truncate(s string, n int) string {
 	return s[:n] + "..."
 }
 
+// externalToolNameSet returns the normalised set of external (client-owned)
+// tool names for a request. Callers use it to decide whether a tool_use
+// event from the model should be executed server-side or buffered for the
+// client to execute. The set is empty when the request has no external
+// tools, making lookups cheap on the common path.
+//
+// Precedence:
+//   - If req.ExternalTools is populated, use it as the authoritative list.
+//     This lets the HTTP layer pre-partition and skip re-classification.
+//   - Otherwise fall back to partitioning req.Tools on the fly.
+func externalToolNameSet(req *InferenceRequest) map[string]bool {
+	if req == nil {
+		return nil
+	}
+	source := req.ExternalTools
+	if source == nil && len(req.Tools) > 0 {
+		_, source = PartitionTools(req.Tools)
+	}
+	if len(source) == 0 {
+		return nil
+	}
+	names := make(map[string]bool, len(source))
+	for _, raw := range source {
+		if n := ExtractToolName(raw); n != "" {
+			names[n] = true
+		}
+	}
+	return names
+}
+
 // RunInference executes a non-streaming inference request and blocks until complete.
 //
 // Routing is determined by the Model field in the request:
@@ -354,6 +384,13 @@ func (h *Harness) RunInference(req *InferenceRequest) (*InferenceResponse, error
 		}
 	}
 
+	// Classify external tool names so we can capture (not execute) any
+	// tool_use events the model emits for client-owned tools. This is the
+	// plumbing BrowserOS relies on — without it, browser_* tool calls
+	// either fall through silently or fail because Claude CLI doesn't
+	// know how to run them.
+	externalToolNames := externalToolNameSet(req)
+
 	// Build Claude CLI arguments
 	args := BuildClaudeArgs(req)
 
@@ -389,6 +426,10 @@ func (h *Harness) RunInference(req *InferenceRequest) (*InferenceResponse, error
 	var costUSD float64
 	var finishReason string
 	var claudeSessionID string
+	// externalCalls buffers tool_use events the model emits for
+	// client-owned tools. We return these on the response as ToolCalls
+	// rather than executing them; finish_reason becomes "tool_calls".
+	var externalCalls []ToolCallData
 
 	// Debug: capture raw stream if COG_DEBUG_INFERENCE is set
 	debugFile := os.Getenv("COG_DEBUG_INFERENCE")
@@ -443,6 +484,14 @@ func (h *Harness) RunInference(req *InferenceRequest) (*InferenceResponse, error
 					case "tool_use":
 						if c.Name == "StructuredOutput" && len(c.Input) > 0 {
 							content.Write(c.Input)
+						} else if externalToolNames[c.Name] {
+							// Client-owned tool — buffer the call rather
+							// than letting Claude CLI try to execute it.
+							externalCalls = append(externalCalls, ToolCallData{
+								ID:        c.ID,
+								Name:      c.Name,
+								Arguments: c.Input,
+							})
 						}
 					}
 				}
@@ -518,6 +567,13 @@ func (h *Harness) RunInference(req *InferenceRequest) (*InferenceResponse, error
 		return nil, fmt.Errorf("request cancelled")
 	}
 
+	// If the model emitted any tool_use events for client-owned tools,
+	// surface them as ToolCalls and flip finish_reason so the caller
+	// knows to propagate them to the upstream OpenAI response.
+	if len(externalCalls) > 0 {
+		finishReason = "tool_calls"
+	}
+
 	response := &InferenceResponse{
 		ID:                req.ID,
 		Content:           content.String(),
@@ -529,6 +585,7 @@ func (h *Harness) RunInference(req *InferenceRequest) (*InferenceResponse, error
 		FinishReason:      finishReason,
 		ContextMetrics:    BuildContextMetrics(req.ContextState),
 		ClaudeSessionID:   claudeSessionID,
+		ToolCalls:         externalCalls,
 	}
 
 	if waitErr != nil {
@@ -780,6 +837,10 @@ func (h *Harness) RunInferenceStream(req *InferenceRequest) (<-chan StreamChunkI
 		}
 	}
 
+	// Classify client-owned tools so the stream loop can capture (not
+	// execute) any tool_use events the model emits for them.
+	externalToolNames := externalToolNameSet(req)
+
 	args := BuildClaudeArgs(req)
 
 	_, cliSpan := tracer.Start(ctx, "claude.cli.exec",
@@ -850,6 +911,11 @@ func (h *Harness) RunInferenceStream(req *InferenceRequest) (<-chan StreamChunkI
 		var fullContent strings.Builder
 
 		activeToolCalls := make(map[int]*ToolCallData)
+		// externalCalls accumulates tool_use invocations the model emits
+		// for client-owned tools. We keep them internally and flush them
+		// in the final chunk (see safeSend near the bottom) so the HTTP
+		// layer can emit a single `tool_calls` delta event.
+		var externalCalls []ToolCallData
 		var sessionID, sessionModel string
 		var sessionTools []string
 
@@ -989,7 +1055,14 @@ func (h *Harness) RunInferenceStream(req *InferenceRequest) (<-chan StreamChunkI
 
 				case "content_block_stop":
 					if tc, ok := activeToolCalls[eventData.Index]; ok {
-						if !safeSend(StreamChunkInference{
+						// Buffer client-owned tool calls so we can emit
+						// them on the final chunk as `tool_calls`.
+						// Internal tools still pass through as regular
+						// tool_use stream events for the MCP bridge or
+						// CLI to execute.
+						if externalToolNames[tc.Name] {
+							externalCalls = append(externalCalls, *tc)
+						} else if !safeSend(StreamChunkInference{
 							ID:        req.ID,
 							EventType: "tool_use",
 							ToolCall:  tc,
@@ -1122,7 +1195,13 @@ func (h *Harness) RunInferenceStream(req *InferenceRequest) (<-chan StreamChunkI
 								cliSpan.AddEvent("tool_use", trace.WithAttributes(
 									attribute.String("tool.name", c.Name),
 								))
-								if !safeSend(StreamChunkInference{
+								if externalToolNames[c.Name] {
+									externalCalls = append(externalCalls, ToolCallData{
+										ID:        c.ID,
+										Name:      c.Name,
+										Arguments: c.Input,
+									})
+								} else if !safeSend(StreamChunkInference{
 									ID:        req.ID,
 									EventType: "tool_use",
 									ToolCall: &ToolCallData{
@@ -1272,20 +1351,28 @@ func (h *Harness) RunInferenceStream(req *InferenceRequest) (<-chan StreamChunkI
 				Error: waitErr,
 			})
 		} else {
+			// External tool calls flip finish_reason to "tool_calls" per
+			// the OpenAI contract so a BrowserOS-style client knows the
+			// turn ended because the model wants it to execute a tool.
+			if len(externalCalls) > 0 {
+				finishReason = "tool_calls"
+			}
 			resp := &InferenceResponse{
 				ID:               req.ID,
 				Content:          fullContent.String(),
 				PromptTokens:     promptTokens,
 				CompletionTokens: completionTokens,
 				FinishReason:     finishReason,
+				ToolCalls:        externalCalls,
 			}
 			h.emitInferenceComplete(req, resp, startTime)
 			h.clearInferenceActiveSignal()
 
 			safeSend(StreamChunkInference{
-				ID:           req.ID,
-				Done:         true,
-				FinishReason: finishReason,
+				ID:                req.ID,
+				Done:              true,
+				FinishReason:      finishReason,
+				ExternalToolCalls: externalCalls,
 				Usage: &UsageData{
 					InputTokens:       promptTokens,
 					OutputTokens:      completionTokens,

--- a/harness/stream.go
+++ b/harness/stream.go
@@ -25,6 +25,14 @@ type StreamChunkInference struct {
 	ToolResult  *ToolResultData `json:"tool_result,omitempty"`  // Tool result information
 	Usage       *UsageData      `json:"usage,omitempty"`        // Token usage data
 	SessionInfo *SessionInfo    `json:"session_info,omitempty"` // Session metadata
+
+	// ExternalToolCalls carries client-owned tool invocations the harness
+	// captured from the model's stream but did NOT execute. Populated on
+	// the final chunk (Done=true) when the stream contained external tool
+	// uses — e.g. BrowserOS's `browser_*` tools. The HTTP layer should
+	// emit these as OpenAI-format `tool_calls` delta events and set
+	// finish_reason="tool_calls" before terminating the stream.
+	ExternalToolCalls []ToolCallData `json:"external_tool_calls,omitempty"`
 }
 
 // ToolCallData represents a tool call in streaming

--- a/harness/tools.go
+++ b/harness/tools.go
@@ -1,8 +1,24 @@
-// tools.go maps OpenAI-format tool definitions to Claude CLI tool names.
+// tools.go maps OpenAI-format tool definitions to Claude CLI tool names
+// and classifies tool ownership (internal = CogOS executes, external = client
+// executes). This is the plumbing that lets BrowserOS-style clients forward
+// their `browser_*` tool definitions through the kernel without the harness
+// silently dropping them.
 //
-// When a client sends tools in the OpenAI format ({"type":"function","function":{"name":"bash"}}),
-// MapToolsToCLINames converts them to Claude CLI --allowed-tools names (e.g., "Bash").
-// This is called by BuildClaudeArgs when the request has Tools but no AllowedTools.
+// Key entry points:
+//
+//   - [MapToolsToCLINames] — extract Claude CLI `--allowed-tools` names from
+//     OpenAI-format tool defs. Only internal tools have CLI names; external
+//     tools are not returned (by design — they're registered through the
+//     MCP bridge, not `--allowed-tools`).
+//   - [ClassifyTool] — ownership lookup for a single tool name.
+//   - [PartitionTools] — split a raw tool list into (internal, external).
+//   - [ExtractToolName] — pull the function name out of one OpenAI tool def.
+//
+// The internal-tool set is closed (the CogOS kernel has a fixed set of
+// built-ins: Bash, Read, Write, Edit, Grep, Glob). Anything else is assumed
+// external — the model is told about them via an MCP bridge and any
+// `tool_use` events Claude emits for them are returned to the client as
+// OpenAI-format `tool_calls` rather than executed server-side.
 package harness
 
 import (
@@ -10,26 +26,126 @@ import (
 	"strings"
 )
 
+// ToolOwnership describes who is responsible for executing a tool call.
+type ToolOwnership int
+
+const (
+	// ToolInternal indicates the CogOS kernel or Claude CLI subprocess will
+	// execute this tool directly (filesystem, shell, etc).
+	ToolInternal ToolOwnership = iota
+
+	// ToolExternal indicates the calling client (e.g. BrowserOS) owns
+	// execution. The harness returns `tool_calls` to the client and expects
+	// the client to send back a `role: "tool"` message with the result on
+	// the next turn.
+	ToolExternal
+)
+
+// String returns a human-readable ownership label, mainly for logs/telemetry.
+func (o ToolOwnership) String() string {
+	switch o {
+	case ToolInternal:
+		return "internal"
+	case ToolExternal:
+		return "external"
+	default:
+		return "unknown"
+	}
+}
+
+// internalToolCLINames is the closed set of tool names the CogOS harness
+// knows how to execute through Claude CLI's `--allowed-tools`. Keys are
+// normalised (lowercase) OpenAI function names; values are the CamelCase
+// names Claude CLI expects. Anything NOT in this map is considered external.
+//
+// Extending the set of internal tools is intentionally additive — add a
+// new row here and the classifier, MapToolsToCLINames, and PartitionTools
+// all pick it up automatically.
+var internalToolCLINames = map[string]string{
+	"exec":        "Bash",
+	"bash":        "Bash",
+	"shell":       "Bash",
+	"read":        "Read",
+	"file_read":   "Read",
+	"write":       "Write",
+	"file_write":  "Write",
+	"edit":        "Edit",
+	"apply-patch": "Edit",
+	"apply_patch": "Edit",
+	"search":      "Grep",
+	"grep":        "Grep",
+	"glob":        "Glob",
+	"find":        "Glob",
+}
+
+// ExtractToolName pulls the function name out of a single OpenAI-format
+// tool definition. Returns "" for malformed input.
+func ExtractToolName(raw json.RawMessage) string {
+	var tool struct {
+		Function struct {
+			Name string `json:"name"`
+		} `json:"function"`
+	}
+	if err := json.Unmarshal(raw, &tool); err != nil {
+		return ""
+	}
+	return tool.Function.Name
+}
+
+// ClassifyTool reports whether a tool name is internal (executed by CogOS /
+// Claude CLI) or external (executed by the client). Matching is
+// case-insensitive and name-only — schema is irrelevant.
+func ClassifyTool(name string) ToolOwnership {
+	if _, ok := internalToolCLINames[strings.ToLower(name)]; ok {
+		return ToolInternal
+	}
+	return ToolExternal
+}
+
+// PartitionTools splits a list of OpenAI-format tool definitions into two
+// disjoint slices preserving input order:
+//
+//   - internal: tools the harness will execute itself (mapped via Claude CLI
+//     `--allowed-tools` or the MCP bridge for CogOS built-ins).
+//   - external: tools to be forwarded to the client as `tool_calls`.
+//
+// Malformed entries (bad JSON, missing function.name) are dropped from both
+// outputs — identical to the old MapToolsToCLINames silent-skip behaviour.
+func PartitionTools(tools []json.RawMessage) (internal, external []json.RawMessage) {
+	for _, raw := range tools {
+		name := ExtractToolName(raw)
+		if name == "" {
+			continue
+		}
+		switch ClassifyTool(name) {
+		case ToolInternal:
+			internal = append(internal, raw)
+		case ToolExternal:
+			external = append(external, raw)
+		}
+	}
+	return internal, external
+}
+
 // MapToolsToCLINames extracts function names from OpenAI-format tool definitions
 // and maps them to Claude CLI built-in tool names where possible.
+//
+// Only internal tools produce output. External tools are silently dropped —
+// they're registered through `--mcp-config` (or forwarded to the client as
+// `tool_calls`) rather than `--allowed-tools`, so including them here would
+// just make Claude CLI fail to start.
 func MapToolsToCLINames(tools []json.RawMessage) []string {
 	var result []string
 	seen := make(map[string]bool)
 
 	for _, raw := range tools {
-		var tool struct {
-			Function struct {
-				Name string `json:"name"`
-			} `json:"function"`
-		}
-		if err := json.Unmarshal(raw, &tool); err != nil || tool.Function.Name == "" {
+		name := ExtractToolName(raw)
+		if name == "" {
 			continue
 		}
 
-		cliName := mapToolName(tool.Function.Name)
+		cliName := mapToolName(name)
 		if cliName == "" {
-			// MCP and external tools are registered through --mcp-config, not
-			// --allowed-tools, so silently skip anything we don't recognise.
 			continue
 		}
 		if !seen[cliName] {
@@ -40,22 +156,8 @@ func MapToolsToCLINames(tools []json.RawMessage) []string {
 	return result
 }
 
-// mapToolName maps an OpenAI-format tool function name to a Claude CLI tool name.
+// mapToolName maps an OpenAI-format tool function name to a Claude CLI tool
+// name. Returns "" when the tool is external (client-owned).
 func mapToolName(name string) string {
-	switch strings.ToLower(name) {
-	case "exec", "bash", "shell":
-		return "Bash"
-	case "read", "file_read":
-		return "Read"
-	case "write", "file_write":
-		return "Write"
-	case "edit", "apply-patch", "apply_patch":
-		return "Edit"
-	case "search", "grep":
-		return "Grep"
-	case "glob", "find":
-		return "Glob"
-	default:
-		return ""
-	}
+	return internalToolCLINames[strings.ToLower(name)]
 }

--- a/harness/tools_classify_test.go
+++ b/harness/tools_classify_test.go
@@ -117,3 +117,51 @@ func TestMapToolsToCLINames_ExternalToolsDropped(t *testing.T) {
 		}
 	}
 }
+
+func TestExternalToolNameSet_FromPartition(t *testing.T) {
+	req := &InferenceRequest{
+		Tools: []json.RawMessage{
+			json.RawMessage(`{"type":"function","function":{"name":"bash"}}`),
+			json.RawMessage(`{"type":"function","function":{"name":"browser_navigate"}}`),
+		},
+	}
+	names := externalToolNameSet(req)
+	if len(names) != 1 {
+		t.Errorf("external name set size = %d; want 1", len(names))
+	}
+	if !names["browser_navigate"] {
+		t.Errorf("expected browser_navigate in external set, got %v", names)
+	}
+}
+
+func TestExternalToolNameSet_PrefersPrePartitioned(t *testing.T) {
+	// When ExternalTools is populated the harness should trust it and skip
+	// re-classification — this is the contract serve.go relies on.
+	req := &InferenceRequest{
+		Tools: []json.RawMessage{
+			json.RawMessage(`{"type":"function","function":{"name":"bash"}}`),
+			json.RawMessage(`{"type":"function","function":{"name":"some_client_tool"}}`),
+		},
+		ExternalTools: []json.RawMessage{
+			// Deliberately different so we can detect which source was used.
+			json.RawMessage(`{"type":"function","function":{"name":"explicitly_external"}}`),
+		},
+	}
+	names := externalToolNameSet(req)
+	if !names["explicitly_external"] {
+		t.Errorf("expected pre-partitioned list to win, got %v", names)
+	}
+	if names["some_client_tool"] {
+		t.Errorf("re-partitioned a request that already had ExternalTools set")
+	}
+}
+
+func TestExternalToolNameSet_NilSafe(t *testing.T) {
+	if got := externalToolNameSet(nil); got != nil {
+		t.Errorf("nil request produced non-nil map: %v", got)
+	}
+	empty := &InferenceRequest{}
+	if got := externalToolNameSet(empty); got != nil {
+		t.Errorf("empty request produced non-nil map: %v", got)
+	}
+}

--- a/harness/tools_classify_test.go
+++ b/harness/tools_classify_test.go
@@ -1,0 +1,119 @@
+// tools_classify_test.go exercises the tool-ownership classifier and
+// partitioner introduced for the BrowserOS bridge. These tests lock down
+// the invariant that BrowserOS-style `browser_*` tools survive the
+// pipeline as external while CogOS built-ins (bash/read/write/edit/...)
+// stay internal.
+package harness
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestClassifyTool_InternalBuiltins(t *testing.T) {
+	cases := []string{
+		"bash", "Bash", "BASH",
+		"exec", "shell",
+		"read", "FILE_read",
+		"write", "file_write",
+		"edit", "apply-patch", "apply_patch",
+		"search", "grep", "glob", "find",
+	}
+	for _, name := range cases {
+		if got := ClassifyTool(name); got != ToolInternal {
+			t.Errorf("ClassifyTool(%q) = %s; want internal", name, got)
+		}
+	}
+}
+
+func TestClassifyTool_ExternalBrowserOS(t *testing.T) {
+	cases := []string{
+		"browser_navigate",
+		"browser_click",
+		"browser_take_snapshot",
+		"custom_magic_tool",
+		"",
+		"unknown",
+	}
+	for _, name := range cases {
+		if got := ClassifyTool(name); got != ToolExternal {
+			t.Errorf("ClassifyTool(%q) = %s; want external", name, got)
+		}
+	}
+}
+
+func TestExtractToolName(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want string
+	}{
+		{`{"type":"function","function":{"name":"bash"}}`, "bash"},
+		{`{"function":{"name":"browser_navigate"}}`, "browser_navigate"},
+		{`{"function":{}}`, ""},
+		{`{}`, ""},
+		{`not-json`, ""},
+	}
+	for _, c := range cases {
+		got := ExtractToolName(json.RawMessage(c.raw))
+		if got != c.want {
+			t.Errorf("ExtractToolName(%q) = %q; want %q", c.raw, got, c.want)
+		}
+	}
+}
+
+func TestPartitionTools_MixedSet(t *testing.T) {
+	tools := []json.RawMessage{
+		json.RawMessage(`{"type":"function","function":{"name":"bash"}}`),
+		json.RawMessage(`{"type":"function","function":{"name":"browser_navigate"}}`),
+		json.RawMessage(`{"type":"function","function":{"name":"read"}}`),
+		json.RawMessage(`{"type":"function","function":{"name":"browser_click"}}`),
+		json.RawMessage(`{"type":"function","function":{"name":""}}`),           // dropped
+		json.RawMessage(`not-json`),                                             // dropped
+	}
+	internal, external := PartitionTools(tools)
+	if len(internal) != 2 {
+		t.Errorf("internal count = %d; want 2", len(internal))
+	}
+	if len(external) != 2 {
+		t.Errorf("external count = %d; want 2", len(external))
+	}
+	if ExtractToolName(internal[0]) != "bash" || ExtractToolName(internal[1]) != "read" {
+		t.Errorf("internal order wrong: %v", []string{ExtractToolName(internal[0]), ExtractToolName(internal[1])})
+	}
+	if ExtractToolName(external[0]) != "browser_navigate" || ExtractToolName(external[1]) != "browser_click" {
+		t.Errorf("external order wrong: %v", []string{ExtractToolName(external[0]), ExtractToolName(external[1])})
+	}
+}
+
+func TestPartitionTools_Empty(t *testing.T) {
+	internal, external := PartitionTools(nil)
+	if internal != nil || external != nil {
+		t.Errorf("empty input produced non-nil output: internal=%v external=%v", internal, external)
+	}
+	internal, external = PartitionTools([]json.RawMessage{})
+	if internal != nil || external != nil {
+		t.Errorf("zero-length input produced non-nil output: internal=%v external=%v", internal, external)
+	}
+}
+
+func TestMapToolsToCLINames_ExternalToolsDropped(t *testing.T) {
+	// Regression: the audit flagged the hardcoded 6-tool list as the reason
+	// external tools were lost. After the refactor, MapToolsToCLINames still
+	// maps only internal tools (intentional — external tools are registered
+	// via MCP, not --allowed-tools) but the classifier is shared so
+	// PartitionTools and MapToolsToCLINames agree on what "internal" means.
+	tools := []json.RawMessage{
+		json.RawMessage(`{"type":"function","function":{"name":"bash"}}`),
+		json.RawMessage(`{"type":"function","function":{"name":"browser_navigate"}}`),
+		json.RawMessage(`{"type":"function","function":{"name":"grep"}}`),
+	}
+	names := MapToolsToCLINames(tools)
+	if len(names) != 2 {
+		t.Fatalf("mapped %d names; want 2 (browser_navigate must be dropped)", len(names))
+	}
+	for _, n := range names {
+		if n == "browser_navigate" {
+			t.Error("external tool browser_navigate leaked into --allowed-tools list")
+		}
+	}
+}

--- a/harness/types.go
+++ b/harness/types.go
@@ -106,7 +106,21 @@ type InferenceRequest struct {
 	ContextState *ContextState // Four-tier context for context-aware invocation
 
 	// Tool definitions
+	//
+	// Tools is the full set of OpenAI-format tool definitions from the
+	// client. The harness classifies each tool as internal or external via
+	// ClassifyTool/PartitionTools; internal tools are executed by Claude
+	// CLI or the CogOS kernel, external tools are forwarded to the client
+	// as `tool_calls` on the response.
+	//
+	// ExternalTools, when non-nil, is a pre-partitioned list of
+	// client-owned tools (equivalent to the `external` return of
+	// PartitionTools(Tools)). Callers that have already partitioned can
+	// populate this directly; otherwise the harness partitions Tools on
+	// its own. This is the plumbing BrowserOS uses to register
+	// `browser_*` tools it will execute itself.
 	Tools           []json.RawMessage // OpenAI-format tool definitions from client
+	ExternalTools   []json.RawMessage // Client-owned tool definitions (subset of Tools)
 	AllowedTools    []string          // Claude CLI --allowed-tools patterns (e.g. "Bash", "Bash(git:*)")
 	SkipPermissions bool              // Pass --dangerously-skip-permissions to Claude CLI
 
@@ -156,6 +170,14 @@ type InferenceResponse struct {
 	// this and pass it back as ClaudeSessionID on the next request to
 	// enable --resume continuity.
 	ClaudeSessionID string `json:"claude_session_id,omitempty"`
+
+	// ToolCalls lists client-owned tool invocations the model asked for
+	// but the harness did not execute. The caller (typically an HTTP
+	// handler) is expected to surface these as `tool_calls` on the
+	// assistant message so a BrowserOS-style client can execute them and
+	// send back the result on the next turn. FinishReason is set to
+	// "tool_calls" when this slice is non-empty.
+	ToolCalls []ToolCallData `json:"tool_calls,omitempty"`
 }
 
 // ChatMessage represents a message in the chat format.

--- a/identity_crd_test.go
+++ b/identity_crd_test.go
@@ -341,7 +341,10 @@ func TestLoadIdentityCRD_PrivateKeyRef_ValidFileScheme(t *testing.T) {
 	dir := t.TempDir()
 	idDir := filepath.Join(dir, ".cog", "config", "identities")
 	_ = os.MkdirAll(idDir, 0o755)
-	writeTempCRD(t, idDir, "cog.yaml", `
+	keysDir := t.TempDir()
+	keyPath := filepath.Join(keysDir, "cog-priv.pem")
+	keyRef := "file://" + keyPath
+	writeTempCRD(t, idDir, "cog.yaml", fmt.Sprintf(`
 apiVersion: cog.os/v1alpha1
 kind: Identity
 metadata:
@@ -355,12 +358,12 @@ spec:
     MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEstub...
     -----END PUBLIC KEY-----
   private_key:
-    ref: "file:///Users/slowbro/.cogos/keys/cog-priv.pem"
+    ref: %q
     integrity_hash: "sha256:a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2"
   expressions:
     - aud: "*"
       display_name: Cog
-`)
+`, keyRef))
 	crd, err := LoadIdentityCRD(dir, "cog")
 	if err != nil {
 		t.Fatalf("LoadIdentityCRD: %v", err)
@@ -368,8 +371,8 @@ spec:
 	if crd.Spec.PrivateKey == nil {
 		t.Fatal("PrivateKey is nil; expected populated")
 	}
-	if crd.Spec.PrivateKey.Ref != "file:///Users/slowbro/.cogos/keys/cog-priv.pem" {
-		t.Errorf("Ref = %q", crd.Spec.PrivateKey.Ref)
+	if crd.Spec.PrivateKey.Ref != keyRef {
+		t.Errorf("Ref = %q, want %q", crd.Spec.PrivateKey.Ref, keyRef)
 	}
 	if !strings.HasPrefix(crd.Spec.PrivateKey.IntegrityHash, "sha256:") {
 		t.Errorf("IntegrityHash = %q", crd.Spec.PrivateKey.IntegrityHash)

--- a/inference.go
+++ b/inference.go
@@ -353,7 +353,14 @@ type InferenceRequest struct {
 	ContextState *ContextState // Four-tier context for context-aware invocation
 
 	// Tool definitions
+	//
+	// Tools is the raw OpenAI-format tool list from the client. The
+	// harness classifies each entry into internal (CogOS executes via
+	// Claude CLI / MCP) or external (client executes) via
+	// harness.PartitionTools. Callers that already have the partition
+	// can set ExternalTools directly to skip re-classification.
 	Tools           []json.RawMessage // OpenAI-format tool definitions from client
+	ExternalTools   []json.RawMessage // Pre-partitioned client-owned tools (optional)
 	AllowedTools    []string          // Claude CLI --allowed-tools patterns (e.g. "Bash", "Bash(git:*)")
 	SkipPermissions bool              // Pass --dangerously-skip-permissions to Claude CLI
 

--- a/internal/engine/provider.go
+++ b/internal/engine/provider.go
@@ -69,8 +69,18 @@ type CompletionRequest struct {
 	// Stop sequences that terminate generation.
 	Stop []string `json:"stop,omitempty"`
 
-	// Tools defines MCP tool definitions the model can invoke.
+	// Tools defines MCP tool definitions the model can invoke. For OpenAI /
+	// Anthropic HTTP providers these are forwarded to the upstream API so
+	// the model can emit tool_use events. The full list includes both
+	// CogOS-owned tools (internal) and client-owned tools (external).
 	Tools []ToolDefinition `json:"tools,omitempty"`
+
+	// ExternalTools is the subset of Tools whose execution belongs to the
+	// calling client (e.g. BrowserOS's `browser_*`). Providers may use this
+	// to decide which tool_use events to pass back as `tool_calls` on the
+	// response instead of executing server-side. Empty when every tool is
+	// kernel-owned. Names are expected to match entries in Tools.
+	ExternalTools []ToolDefinition `json:"external_tools,omitempty"`
 
 	// ToolChoice constrains tool use: "auto", "none", "required", or a name.
 	ToolChoice string `json:"tool_choice,omitempty"`

--- a/internal/engine/provider_stub.go
+++ b/internal/engine/provider_stub.go
@@ -18,6 +18,15 @@ type StubProvider struct {
 	available    bool
 	capabilities ProviderCapabilities
 	chunks       []string // if set, Stream sends these chunks instead of response
+	// toolCalls, when non-empty, is returned on Complete() so tests can
+	// exercise the tool-calls-as-response-content path used by BrowserOS
+	// passthrough. Stream() attaches them to the Done chunk via the
+	// StreamChunk.ToolCallDelta channel (sent eagerly before Done).
+	toolCalls []ToolCall
+	// lastRequest captures the most recent CompletionRequest so tests can
+	// assert on what the handler actually passed down to the provider
+	// (e.g. that ExternalTools was partitioned correctly).
+	lastRequest *CompletionRequest
 }
 
 // NewStubProvider creates a StubProvider that returns the given response.
@@ -46,16 +55,22 @@ func (s *StubProvider) Ping(_ context.Context) (time.Duration, error) {
 	return s.latency, nil
 }
 
-func (s *StubProvider) Complete(_ context.Context, _ *CompletionRequest) (*CompletionResponse, error) {
+func (s *StubProvider) Complete(_ context.Context, req *CompletionRequest) (*CompletionResponse, error) {
+	s.lastRequest = req
 	if s.err != nil {
 		return nil, s.err
 	}
 	if s.latency > 0 {
 		time.Sleep(s.latency)
 	}
+	stop := "end_turn"
+	if len(s.toolCalls) > 0 {
+		stop = "tool_use"
+	}
 	return &CompletionResponse{
 		Content:    s.response,
-		StopReason: "end_turn",
+		ToolCalls:  s.toolCalls,
+		StopReason: stop,
 		ProviderMeta: ProviderMeta{
 			Provider: s.name,
 			Model:    "stub",
@@ -63,7 +78,8 @@ func (s *StubProvider) Complete(_ context.Context, _ *CompletionRequest) (*Compl
 	}, nil
 }
 
-func (s *StubProvider) Stream(_ context.Context, _ *CompletionRequest) (<-chan StreamChunk, error) {
+func (s *StubProvider) Stream(_ context.Context, req *CompletionRequest) (<-chan StreamChunk, error) {
+	s.lastRequest = req
 	if s.err != nil {
 		return nil, s.err
 	}
@@ -71,12 +87,35 @@ func (s *StubProvider) Stream(_ context.Context, _ *CompletionRequest) (<-chan S
 	if len(chunks) == 0 {
 		chunks = []string{s.response}
 	}
-	ch := make(chan StreamChunk, len(chunks)+1)
+	extra := 1
+	if len(s.toolCalls) > 0 {
+		extra += len(s.toolCalls)
+	}
+	ch := make(chan StreamChunk, len(chunks)+extra)
 	for _, c := range chunks {
 		ch <- StreamChunk{Delta: c}
 	}
+	// Emit any stub-configured tool calls as ToolCallDelta events. Each
+	// call is emitted as a single delta carrying the full ID/Name/args
+	// — StreamChunk doesn't distinguish multi-part deltas from atomic
+	// ones; serve.go's tool_call forwarder is tolerant of both.
+	for i, tc := range s.toolCalls {
+		ch <- StreamChunk{
+			ToolCallDelta: &ToolCallDelta{
+				Index:     i,
+				ID:        tc.ID,
+				Name:      tc.Name,
+				ArgsDelta: tc.Arguments,
+			},
+		}
+	}
+	stop := ""
+	if len(s.toolCalls) > 0 {
+		stop = "tool_use"
+	}
 	ch <- StreamChunk{
-		Done: true,
+		Done:         true,
+		StopReason:   stop,
 		ProviderMeta: &ProviderMeta{Provider: s.name, Model: "stub"},
 	}
 	close(ch)

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -238,6 +238,40 @@ func (s *Server) Handler() http.Handler {
 	return s.srv.Handler
 }
 
+// nucleusCard returns the current nucleus identity card, or empty if unset.
+// Used by context-assembly fallback paths to retain nucleus identity when the
+// full AssembleContext pipeline isn't available.
+func (s *Server) nucleusCard() string {
+	if s.nucleus == nil {
+		return ""
+	}
+	s.nucleus.mu.RLock()
+	defer s.nucleus.mu.RUnlock()
+	return s.nucleus.Card
+}
+
+// mergeSystemPrompts combines the nucleus identity card with any
+// client-supplied system-prompt parts in a stable order
+// (nucleus → client[0] → client[1] → ...), separated by "---" dividers.
+// Empty parts are skipped. If every input is empty, returns "".
+//
+// This is used on the fallback path when ContextPackage.FormatForProvider()
+// isn't available (e.g. AssembleContext failed or was skipped) so we still
+// honour any client-provided system prompt — the thing BrowserOS relies on
+// when it injects its browser_* tool definitions and companion system text.
+func mergeSystemPrompts(nucleus string, clientParts []string) string {
+	var parts []string
+	if strings.TrimSpace(nucleus) != "" {
+		parts = append(parts, strings.TrimRight(nucleus, "\n"))
+	}
+	for _, p := range clientParts {
+		if strings.TrimSpace(p) != "" {
+			parts = append(parts, strings.TrimRight(p, "\n"))
+		}
+	}
+	return strings.Join(parts, "\n\n---\n\n")
+}
+
 // handleHealth is the liveness/readiness probe.
 //
 //	200 → healthy
@@ -632,18 +666,27 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
-	// Convert OpenAI-format tool definitions to internal ToolDefinition.
+	// Convert OpenAI-format tool definitions to internal ToolDefinition and
+	// partition by ownership. Internal tools (Bash/Read/Write/...) are
+	// executed server-side via Claude CLI or the MCP bridge; external
+	// tools (browser_*, etc.) are forwarded to the model as tool
+	// definitions but their tool_use events come back to the client as
+	// OpenAI `tool_calls` for client-side execution.
 	if len(req.Tools) > 0 {
 		creq.Tools = make([]ToolDefinition, 0, len(req.Tools))
 		for _, t := range req.Tools {
 			if t.Type != "function" {
 				continue
 			}
-			creq.Tools = append(creq.Tools, ToolDefinition{
+			td := ToolDefinition{
 				Name:        t.Function.Name,
 				Description: t.Function.Description,
 				InputSchema: t.Function.Parameters,
-			})
+			}
+			creq.Tools = append(creq.Tools, td)
+			if classifyToolOwnership(t.Function.Name) == ToolOwnershipClient {
+				creq.ExternalTools = append(creq.ExternalTools, td)
+			}
 		}
 	}
 
@@ -695,7 +738,24 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 		WithManifestMode(true),
 	); err != nil {
 		slog.Warn("chat: context assembly failed", "err", err)
-		creq.Messages = clientMsgs
+		// Fallback: preserve any client-supplied role=system messages as the
+		// provider SystemPrompt, stripping them from the Messages slice so
+		// Anthropic's API (which rejects role=system inside messages) still
+		// works. Without this, BrowserOS-style clients that include a system
+		// prompt see it silently dropped on the fallback path.
+		var clientSysParts []string
+		var nonSysMsgs []ProviderMessage
+		for _, m := range clientMsgs {
+			if m.Role == "system" {
+				if strings.TrimSpace(m.Content) != "" {
+					clientSysParts = append(clientSysParts, m.Content)
+				}
+				continue
+			}
+			nonSysMsgs = append(nonSysMsgs, m)
+		}
+		creq.Messages = nonSysMsgs
+		creq.SystemPrompt = mergeSystemPrompts(s.nucleusCard(), clientSysParts)
 	} else {
 		pkg = p
 		systemPrompt, managedMsgs := pkg.FormatForProvider()

--- a/internal/engine/serve_anthropic.go
+++ b/internal/engine/serve_anthropic.go
@@ -174,7 +174,23 @@ func (s *Server) handleAnthropicMessages(w http.ResponseWriter, r *http.Request)
 		WithManifestMode(true),
 	); err != nil {
 		slog.Warn("anthropic: context assembly failed", "err", err)
-		creq.Messages = clientMsgs
+		// Fallback: preserve role=system messages as the provider SystemPrompt
+		// so an explicit user/BrowserOS prompt isn't silently dropped. The
+		// Anthropic upstream API rejects role=system inside messages, so we
+		// MUST extract them on this path.
+		var clientSysParts []string
+		var nonSysMsgs []ProviderMessage
+		for _, m := range clientMsgs {
+			if m.Role == "system" {
+				if strings.TrimSpace(m.Content) != "" {
+					clientSysParts = append(clientSysParts, m.Content)
+				}
+				continue
+			}
+			nonSysMsgs = append(nonSysMsgs, m)
+		}
+		creq.Messages = nonSysMsgs
+		creq.SystemPrompt = mergeSystemPrompts(s.nucleusCard(), clientSysParts)
 	} else {
 		systemPrompt, managedMsgs := pkg.FormatForProvider()
 		creq.SystemPrompt = systemPrompt

--- a/internal/engine/serve_browseros_bridge_test.go
+++ b/internal/engine/serve_browseros_bridge_test.go
@@ -1,0 +1,290 @@
+// serve_browseros_bridge_test.go locks in the three-point fix to the
+// BrowserOS tool bridge (Phase 24 audit). Each test covers one break
+// point from the audit:
+//
+//  1. System-prompt merge — client system prompt survives the chat
+//     handler even when context assembly falls back (no hardcoded
+//     overwrite).
+//  2. Tool list extensibility — client-owned tools (browser_*) reach
+//     the Provider via CompletionRequest.Tools AND appear in
+//     ExternalTools so downstream code can distinguish ownership.
+//  3. ExternalTools + ToolCalls plumbing — a stubbed provider returning
+//     tool_calls propagates through handleChat into the OpenAI response
+//     with finish_reason="tool_calls" and a tool_calls array on the
+//     assistant message.
+package engine
+
+import (
+	"bufio"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHandleChat_PreservesClientSystemPrompt(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+
+	stub := NewStubProvider("stub", "ok")
+	router := NewSimpleRouter(RoutingConfig{Default: "stub"})
+	router.RegisterProvider(stub)
+	srv.SetRouter(router)
+
+	// BrowserOS-style: a system prompt arrives inside messages[]. Even if
+	// AssembleContext succeeds (the common path), the ClientSystem text
+	// must end up somewhere inside creq.SystemPrompt — not be silently
+	// replaced by a kernel-only template.
+	body := `{
+		"model": "local",
+		"messages": [
+			{"role": "system", "content": "YOU-ARE-BROWSEROS-AGENT"},
+			{"role": "user", "content": "hello"}
+		],
+		"stream": false
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleChat(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200", w.Code)
+	}
+	if stub.lastRequest == nil {
+		t.Fatal("provider never received a request")
+	}
+	if !strings.Contains(stub.lastRequest.SystemPrompt, "YOU-ARE-BROWSEROS-AGENT") {
+		t.Errorf("SystemPrompt missing client marker:\n%s", stub.lastRequest.SystemPrompt)
+	}
+	// The role=system message must be stripped from Messages so Anthropic
+	// doesn't reject the upstream request.
+	for _, m := range stub.lastRequest.Messages {
+		if m.Role == "system" {
+			t.Errorf("role=system survived into provider.Messages: %+v", m)
+		}
+	}
+}
+
+func TestMergeSystemPrompts(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		nucleus string
+		clients []string
+		want    string
+	}{
+		{"everything empty", "", nil, ""},
+		{"nucleus only", "core", nil, "core"},
+		{"clients only", "", []string{"a", "b"}, "a\n\n---\n\nb"},
+		{"mix, blanks dropped", "core", []string{"", "  ", "a"}, "core\n\n---\n\na"},
+		{"trailing newlines trimmed", "core\n\n", []string{"a\n"}, "core\n\n---\n\na"},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			got := mergeSystemPrompts(c.nucleus, c.clients)
+			if got != c.want {
+				t.Errorf("mergeSystemPrompts(%q, %v)\ngot  = %q\nwant = %q", c.nucleus, c.clients, got, c.want)
+			}
+		})
+	}
+}
+
+func TestClassifyToolOwnership(t *testing.T) {
+	t.Parallel()
+	internal := []string{"bash", "Bash", "exec", "shell", "read", "write", "edit", "grep", "glob", "find"}
+	external := []string{"browser_navigate", "browser_click", "custom_tool", "", "strata_invoke"}
+
+	for _, n := range internal {
+		if got := classifyToolOwnership(n); got != ToolOwnershipKernel {
+			t.Errorf("classifyToolOwnership(%q) = %s; want kernel", n, got)
+		}
+	}
+	for _, n := range external {
+		if got := classifyToolOwnership(n); got != ToolOwnershipClient {
+			t.Errorf("classifyToolOwnership(%q) = %s; want client", n, got)
+		}
+	}
+}
+
+func TestHandleChat_PartitionsToolsIntoExternal(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+
+	stub := NewStubProvider("stub", "ok")
+	router := NewSimpleRouter(RoutingConfig{Default: "stub"})
+	router.RegisterProvider(stub)
+	srv.SetRouter(router)
+
+	// BrowserOS-style payload: a mix of internal (bash) and external
+	// (browser_navigate, browser_click) tool definitions.
+	body := `{
+		"model": "local",
+		"messages": [{"role": "user", "content": "open google"}],
+		"stream": false,
+		"tools": [
+			{"type": "function", "function": {"name": "bash", "description": "run cmd", "parameters": {}}},
+			{"type": "function", "function": {"name": "browser_navigate", "description": "nav", "parameters": {}}},
+			{"type": "function", "function": {"name": "browser_click", "description": "click", "parameters": {}}}
+		]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleChat(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200; body=%s", w.Code, w.Body.String())
+	}
+	if stub.lastRequest == nil {
+		t.Fatal("provider never received a request")
+	}
+	if len(stub.lastRequest.Tools) != 3 {
+		t.Errorf("Tools = %d; want 3 (all tools forwarded)", len(stub.lastRequest.Tools))
+	}
+	if len(stub.lastRequest.ExternalTools) != 2 {
+		t.Errorf("ExternalTools = %d; want 2 (browser_* only)", len(stub.lastRequest.ExternalTools))
+	}
+	seen := make(map[string]bool)
+	for _, t := range stub.lastRequest.ExternalTools {
+		seen[t.Name] = true
+	}
+	if !seen["browser_navigate"] || !seen["browser_click"] {
+		t.Errorf("ExternalTools missing browser_*: %+v", stub.lastRequest.ExternalTools)
+	}
+	if seen["bash"] {
+		t.Error("bash (internal) leaked into ExternalTools")
+	}
+}
+
+func TestHandleChat_ReturnsToolCalls(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+
+	// Provider returns a tool_use for a browser_* tool.
+	stub := NewStubProvider("stub", "")
+	stub.toolCalls = []ToolCall{
+		{ID: "call_1", Name: "browser_navigate", Arguments: `{"url":"https://example.com"}`},
+	}
+	router := NewSimpleRouter(RoutingConfig{Default: "stub"})
+	router.RegisterProvider(stub)
+	srv.SetRouter(router)
+
+	body := `{
+		"model": "local",
+		"messages": [{"role": "user", "content": "open example"}],
+		"stream": false,
+		"tools": [
+			{"type": "function", "function": {"name": "browser_navigate", "description": "nav", "parameters": {}}}
+		]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleChat(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	var resp oaiChatResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Choices) != 1 {
+		t.Fatalf("choices = %d; want 1", len(resp.Choices))
+	}
+	if resp.Choices[0].FinishReason == nil || *resp.Choices[0].FinishReason != "tool_calls" {
+		var got string
+		if resp.Choices[0].FinishReason != nil {
+			got = *resp.Choices[0].FinishReason
+		}
+		t.Errorf("finish_reason = %q; want tool_calls", got)
+	}
+	if resp.Choices[0].Message == nil || len(resp.Choices[0].Message.ToolCalls) == 0 {
+		t.Fatalf("Message.ToolCalls empty; got %+v", resp.Choices[0].Message)
+	}
+
+	// Decode the raw tool_calls and verify the browser_navigate call made it.
+	var calls []struct {
+		ID       string `json:"id"`
+		Type     string `json:"type"`
+		Function struct {
+			Name      string `json:"name"`
+			Arguments string `json:"arguments"`
+		} `json:"function"`
+	}
+	if err := json.Unmarshal(resp.Choices[0].Message.ToolCalls, &calls); err != nil {
+		t.Fatalf("decode ToolCalls: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("decoded tool_calls = %d; want 1", len(calls))
+	}
+	if calls[0].Function.Name != "browser_navigate" {
+		t.Errorf("tool name = %q; want browser_navigate", calls[0].Function.Name)
+	}
+	if !strings.Contains(calls[0].Function.Arguments, "example.com") {
+		t.Errorf("tool arguments missing payload: %q", calls[0].Function.Arguments)
+	}
+}
+
+func TestHandleChat_StreamingEmitsToolCallsDelta(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+
+	stub := NewStubProvider("stub", "")
+	stub.chunks = []string{}
+	stub.toolCalls = []ToolCall{
+		{ID: "call_s1", Name: "browser_click", Arguments: `{"ref":"x"}`},
+	}
+	router := NewSimpleRouter(RoutingConfig{Default: "stub"})
+	router.RegisterProvider(stub)
+	srv.SetRouter(router)
+
+	body := `{
+		"model": "local",
+		"messages": [{"role": "user", "content": "click"}],
+		"stream": true,
+		"tools": [
+			{"type": "function", "function": {"name": "browser_click", "description": "click", "parameters": {}}}
+		]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleChat(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200", w.Code)
+	}
+
+	// Scan SSE events — we expect at least one chunk that carries a
+	// tool_calls delta and a terminal chunk with finish_reason=tool_calls.
+	var sawToolCall, sawFinish bool
+	scanner := bufio.NewScanner(w.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		data := strings.TrimPrefix(line, "data: ")
+		if data == "[DONE]" {
+			break
+		}
+		if strings.Contains(data, "tool_calls") && strings.Contains(data, "browser_click") {
+			sawToolCall = true
+		}
+		if strings.Contains(data, `"finish_reason":"tool_calls"`) {
+			sawFinish = true
+		}
+	}
+	if !sawToolCall {
+		t.Error("stream never emitted a tool_calls delta for browser_click")
+	}
+	if !sawFinish {
+		t.Error("stream never emitted finish_reason=tool_calls")
+	}
+}

--- a/internal/engine/tool_observer.go
+++ b/internal/engine/tool_observer.go
@@ -33,6 +33,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -53,6 +54,40 @@ const (
 	ToolOwnershipKernel = "kernel"
 	ToolOwnershipClient = "client"
 )
+
+// internalToolNames is the closed set of tool names the CogOS kernel knows
+// how to execute itself — mostly Claude CLI built-ins routed via Claude
+// CLI's `--allowed-tools`. Everything else is assumed to belong to the
+// calling client (BrowserOS-style passthrough). Keep this in lockstep with
+// harness/tools.go:internalToolCLINames; the two packages live in separate
+// Go modules so we can't share the map directly.
+var internalToolNames = map[string]struct{}{
+	"exec":        {},
+	"bash":        {},
+	"shell":       {},
+	"read":        {},
+	"file_read":   {},
+	"write":       {},
+	"file_write":  {},
+	"edit":        {},
+	"apply-patch": {},
+	"apply_patch": {},
+	"search":      {},
+	"grep":        {},
+	"glob":        {},
+	"find":        {},
+}
+
+// classifyToolOwnership returns the ownership label for a given tool name.
+// Case-insensitive match against the internal-tool set; anything not in the
+// set is ToolOwnershipClient so tool definitions from BrowserOS, custom
+// agents, etc. survive the pipeline.
+func classifyToolOwnership(name string) string {
+	if _, ok := internalToolNames[strings.ToLower(name)]; ok {
+		return ToolOwnershipKernel
+	}
+	return ToolOwnershipClient
+}
 
 // Tool-result status taxonomy — the outcome of an invocation.
 const (

--- a/kernel_harness.go
+++ b/kernel_harness.go
@@ -200,6 +200,7 @@ func toHarnessRequest(req *InferenceRequest) *harness.InferenceRequest {
 		Context:         req.Context,
 		ContextState:    toHarnessContextState(req.ContextState),
 		Tools:           req.Tools,
+		ExternalTools:   req.ExternalTools,
 		AllowedTools:    req.AllowedTools,
 		SkipPermissions: req.SkipPermissions,
 		WorkspaceRoot:   req.WorkspaceRoot,
@@ -231,6 +232,16 @@ func fromHarnessResponse(resp *harness.InferenceResponse) *InferenceResponse {
 		ErrorMessage:      resp.ErrorMessage,
 		ErrorType:         ErrorType(resp.ErrorType),
 		ClaudeSessionID:   resp.ClaudeSessionID,
+	}
+	if len(resp.ToolCalls) > 0 {
+		kr.ToolCalls = make([]ToolCallData, len(resp.ToolCalls))
+		for i, tc := range resp.ToolCalls {
+			kr.ToolCalls[i] = ToolCallData{
+				ID:        tc.ID,
+				Name:      tc.Name,
+				Arguments: tc.Arguments,
+			}
+		}
 	}
 	if resp.ContextMetrics != nil {
 		kr.ContextMetrics = &ContextMetrics{
@@ -282,6 +293,16 @@ func fromHarnessStreamChunk(chunk harness.StreamChunkInference) StreamChunkInfer
 			Model:           chunk.SessionInfo.Model,
 			Tools:           chunk.SessionInfo.Tools,
 			ClaudeSessionID: chunk.SessionInfo.ClaudeSessionID,
+		}
+	}
+	if len(chunk.ExternalToolCalls) > 0 {
+		sc.ExternalToolCalls = make([]ToolCallData, len(chunk.ExternalToolCalls))
+		for i, tc := range chunk.ExternalToolCalls {
+			sc.ExternalToolCalls[i] = ToolCallData{
+				ID:        tc.ID,
+				Name:      tc.Name,
+				Arguments: tc.Arguments,
+			}
 		}
 	}
 	return sc


### PR DESCRIPTION
## Summary

Closes the three break points from the 2026-04-24 Phase 24 MCP API coverage audit (`.cog/run/trackh/phase-24-mcp-api-coverage-audit.md`) that kept the BrowserOS tool bridge from working end-to-end.

1. **Client system prompt preserved on context-assembly fallback** (`internal/engine/serve.go`, `serve_anthropic.go`) — previously, when `Process.AssembleContext` failed we passed `clientMsgs` straight into `creq.Messages`, which meant any `role: "system"` message either stayed in `Messages` (Anthropic's API rejects that) or got silently dropped. Now the fallback hoists client system messages into `creq.SystemPrompt` via a new `mergeSystemPrompts(nucleus, clientParts...)` helper and strips them from Messages. The success path (FormatForProvider) is unchanged.

2. **Tool classifier extensibility** (`harness/tools.go`, `internal/engine/tool_observer.go`) — the hardcoded 6-case switch in `mapToolName` is gone. In its place a shared `internalToolCLINames` map drives three new entry points (`ClassifyTool`, `PartitionTools`, `ExtractToolName`) plus the original `MapToolsToCLINames`, so adding an internal tool is a one-line change. The engine package gets a mirror map + `classifyToolOwnership()` to keep serve.go independent of the `harness` Go module. BrowserOS's `browser_*` tools are now classified as client-owned instead of silently dropped.

3. **`ExternalTools` + `ToolCalls` plumbing** — the data shape the Feb 2026 `browseros-tool-passthrough-plan.md` specified is now actually present end-to-end:
   - `harness.InferenceRequest.ExternalTools`, `harness.InferenceResponse.ToolCalls`, `harness.StreamChunkInference.ExternalToolCalls`
   - kernel `InferenceRequest.ExternalTools` + `CompletionRequest.ExternalTools` mirror fields
   - `kernel_harness.go` converters thread all three across the boundary
   - `serve.go:handleChat` partitions `req.Tools` via `classifyToolOwnership` into `creq.Tools` (all) and `creq.ExternalTools` (client-owned subset)
   - `harness.go` buffers any `tool_use` events matching external names on both the sync and streaming paths; result: `finish_reason=tool_calls` with a populated `ToolCalls` array (or `ExternalToolCalls` chunk for streams)
   - Existing `serve.go` code that already surfaced `CompletionResponse.ToolCalls` into the OpenAI wire format works unchanged — it just needed the upstream data flow to actually be populated.

### Deferral (not a stub, an explicit out-of-scope)

The Claude CLI path buffers external tool_use events **if** the model emits them, but without an MCP passthrough bridge Claude CLI typically will not know about client-described tools in the first place. HTTP providers (OpenAI, Anthropic) forward `Tools` upstream, so the tool_use flow works there today. Wiring up the MCP passthrough bridge on the Claude CLI path is the next step and is scoped to a follow-up — all the data-shape edges are now in place for it.

## Test plan

- [x] `go test ./...` passes (main module + internal/engine)
- [x] `GOWORK=off go test ./...` passes in `harness/` (separate module)
- [x] Each commit in the series builds independently (verified by `git checkout <sha> && go build ./...`)
- [x] New unit tests: `harness/tools_classify_test.go` (9 test functions), `internal/engine/serve_browseros_bridge_test.go` (6 tests covering all three break points)
- [ ] Manual end-to-end: drive `/v1/chat/completions` from BrowserOS with `browser_*` tools and confirm `tool_calls` surface on the response (needs a live kernel + BrowserOS)

## Commits

- `26626f9` — extensible tool classifier (internal vs external)
- `5b83b7b` — plumb `ExternalTools` and `ToolCalls` through types
- `3ae3c34` — wire BrowserOS tool passthrough end-to-end (system-prompt merge + tool partition + external-call capture + tests)

## Audit references

- `/Users/slowbro/cog-workspace/.cog/run/trackh/phase-24-mcp-api-coverage-audit.md` (break-point list)
- `.cog/mem/semantic/insights/browseros-tool-passthrough-plan.md` (Feb 2026 design doc; treated as intent, not as-implemented)