### PR TITLE
feat(engine): Stage 1 local harness — assess/execute metabolic cycle

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,5 +1,5 @@
-source_type = "local"
-source = "/Users/slowbro/.codex/.tmp/bundled-marketplaces/openai-bundled"
+source_type = "bundled"
+source = "openai"
 
 [mcp_servers.cogos]
 

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,12 @@
+source_type = "local"
+source = "/Users/slowbro/.codex/.tmp/bundled-marketplaces/openai-bundled"
+
+[mcp_servers.cogos]
+
+[mcp_servers."cogos-http"]
+enabled = true
+url = "http://127.0.0.1:7823/mcp"
+
+[mcp_servers."cogos-v3"]
+enabled = true
+url = "http://127.0.0.1:6931/mcp"

--- a/internal/engine/agent_controller.go
+++ b/internal/engine/agent_controller.go
@@ -17,7 +17,11 @@
 // sessions; those are separate APIs.
 package engine
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"strings"
+)
 
 // AgentController is the kernel-agnostic contract the MCP layer uses to
 // list, inspect, and trigger agent harness instances. The concrete
@@ -44,6 +48,11 @@ type AgentController interface {
 	// the cycle completes (or a 90s deadline elapses). When wait is false,
 	// returns immediately with a trigger receipt.
 	TriggerAgent(ctx context.Context, id string, reason string, wait bool) (*AgentTriggerResult, error)
+
+	// DispatchToHarness routes a one-shot task request through the local
+	// agent harness. The harness runs up to N parallel inference slots,
+	// each with its own tool loop, and returns an aggregated result batch.
+	DispatchToHarness(ctx context.Context, req DispatchRequest) (*DispatchBatchResult, error)
 }
 
 // ErrAgentNotFound is returned by GetAgent/TriggerAgent when no agent
@@ -192,4 +201,75 @@ type AgentTriggerResult struct {
 	Reason     string  `json:"reason,omitempty"`
 	DurationMs int64   `json:"duration_ms,omitempty"`
 	TimedOut   bool    `json:"timed_out,omitempty"`
+}
+
+// ── Dispatch types ────────────────────────────────────────────────────────────
+
+// DispatchModel names the routing tier for a dispatch request.
+type DispatchModel string
+
+const (
+	// DispatchModelE4B routes to the configured local e4b-class model (fast, small).
+	DispatchModelE4B DispatchModel = "e4b"
+	// DispatchModel26B routes to the largest local model (≥26B params). Falls
+	// back to DispatchModelE4B when no such model is loaded.
+	DispatchModel26B DispatchModel = "26b"
+)
+
+// DispatchRequest is the input to DispatchToHarness.
+type DispatchRequest struct {
+	AgentID        string        `json:"agent_id,omitempty"`
+	Task           string        `json:"task"`
+	SystemPrompt   string        `json:"system_prompt,omitempty"`
+	Tools          []string      `json:"tools,omitempty"` // subset of registered kernel tools; nil = all
+	Model          DispatchModel `json:"model,omitempty"` // "" → DispatchModelE4B
+	N              int           `json:"n,omitempty"`     // parallel slots; 0 or 1 = single
+	TimeoutSeconds int           `json:"timeout_seconds,omitempty"` // per-slot; 0 → 90s default
+}
+
+// Normalize fills in defaults and validates the request.
+func (r *DispatchRequest) Normalize() error {
+	if strings.TrimSpace(r.Task) == "" {
+		return &AgentControllerError{Code: "invalid_input", Message: "task is required"}
+	}
+	if r.N <= 0 {
+		r.N = 1
+	}
+	if r.N > 8 {
+		return &AgentControllerError{Code: "invalid_input", Message: fmt.Sprintf("n must be <= 8 (got %d)", r.N)}
+	}
+	if r.TimeoutSeconds <= 0 {
+		r.TimeoutSeconds = 90
+	}
+	if r.Model == "" {
+		r.Model = DispatchModelE4B
+	}
+	return nil
+}
+
+// DispatchToolCallSummary is a compact summary of one tool call in a dispatch slot.
+type DispatchToolCallSummary struct {
+	Name         string `json:"name"`
+	ArgsDigest   string `json:"args_digest,omitempty"`
+	ResultDigest string `json:"result_digest,omitempty"`
+	Error        string `json:"error,omitempty"`
+}
+
+// DispatchResult is the outcome of one parallel dispatch slot.
+type DispatchResult struct {
+	Index       int                       `json:"index"`
+	Success     bool                      `json:"success"`
+	Content     string                    `json:"content,omitempty"`
+	Error       string                    `json:"error,omitempty"`
+	Turns       int                       `json:"turns"`
+	DurationSec float64                   `json:"duration_sec"`
+	ModelUsed   DispatchModel             `json:"model_used"`
+	ToolCalls   []DispatchToolCallSummary `json:"tool_calls,omitempty"`
+}
+
+// DispatchBatchResult is the aggregated outcome of all parallel slots.
+type DispatchBatchResult struct {
+	Results          []DispatchResult `json:"results"`
+	TotalDurationSec float64          `json:"total_duration_sec"`
+	Notes            []string         `json:"notes,omitempty"`
 }

--- a/internal/engine/agent_controller.go
+++ b/internal/engine/agent_controller.go
@@ -19,8 +19,6 @@ package engine
 
 import (
 	"context"
-	"fmt"
-	"strings"
 )
 
 // AgentController is the kernel-agnostic contract the MCP layer uses to
@@ -49,10 +47,6 @@ type AgentController interface {
 	// returns immediately with a trigger receipt.
 	TriggerAgent(ctx context.Context, id string, reason string, wait bool) (*AgentTriggerResult, error)
 
-	// DispatchToHarness routes a one-shot task request through the local
-	// agent harness. The harness runs up to N parallel inference slots,
-	// each with its own tool loop, and returns an aggregated result batch.
-	DispatchToHarness(ctx context.Context, req DispatchRequest) (*DispatchBatchResult, error)
 }
 
 // ErrAgentNotFound is returned by GetAgent/TriggerAgent when no agent
@@ -203,73 +197,3 @@ type AgentTriggerResult struct {
 	TimedOut   bool    `json:"timed_out,omitempty"`
 }
 
-// ── Dispatch types ────────────────────────────────────────────────────────────
-
-// DispatchModel names the routing tier for a dispatch request.
-type DispatchModel string
-
-const (
-	// DispatchModelE4B routes to the configured local e4b-class model (fast, small).
-	DispatchModelE4B DispatchModel = "e4b"
-	// DispatchModel26B routes to the largest local model (≥26B params). Falls
-	// back to DispatchModelE4B when no such model is loaded.
-	DispatchModel26B DispatchModel = "26b"
-)
-
-// DispatchRequest is the input to DispatchToHarness.
-type DispatchRequest struct {
-	AgentID        string        `json:"agent_id,omitempty"`
-	Task           string        `json:"task"`
-	SystemPrompt   string        `json:"system_prompt,omitempty"`
-	Tools          []string      `json:"tools,omitempty"` // subset of registered kernel tools; nil = all
-	Model          DispatchModel `json:"model,omitempty"` // "" → DispatchModelE4B
-	N              int           `json:"n,omitempty"`     // parallel slots; 0 or 1 = single
-	TimeoutSeconds int           `json:"timeout_seconds,omitempty"` // per-slot; 0 → 90s default
-}
-
-// Normalize fills in defaults and validates the request.
-func (r *DispatchRequest) Normalize() error {
-	if strings.TrimSpace(r.Task) == "" {
-		return &AgentControllerError{Code: "invalid_input", Message: "task is required"}
-	}
-	if r.N <= 0 {
-		r.N = 1
-	}
-	if r.N > 8 {
-		return &AgentControllerError{Code: "invalid_input", Message: fmt.Sprintf("n must be <= 8 (got %d)", r.N)}
-	}
-	if r.TimeoutSeconds <= 0 {
-		r.TimeoutSeconds = 90
-	}
-	if r.Model == "" {
-		r.Model = DispatchModelE4B
-	}
-	return nil
-}
-
-// DispatchToolCallSummary is a compact summary of one tool call in a dispatch slot.
-type DispatchToolCallSummary struct {
-	Name         string `json:"name"`
-	ArgsDigest   string `json:"args_digest,omitempty"`
-	ResultDigest string `json:"result_digest,omitempty"`
-	Error        string `json:"error,omitempty"`
-}
-
-// DispatchResult is the outcome of one parallel dispatch slot.
-type DispatchResult struct {
-	Index       int                       `json:"index"`
-	Success     bool                      `json:"success"`
-	Content     string                    `json:"content,omitempty"`
-	Error       string                    `json:"error,omitempty"`
-	Turns       int                       `json:"turns"`
-	DurationSec float64                   `json:"duration_sec"`
-	ModelUsed   DispatchModel             `json:"model_used"`
-	ToolCalls   []DispatchToolCallSummary `json:"tool_calls,omitempty"`
-}
-
-// DispatchBatchResult is the aggregated outcome of all parallel slots.
-type DispatchBatchResult struct {
-	Results          []DispatchResult `json:"results"`
-	TotalDurationSec float64          `json:"total_duration_sec"`
-	Notes            []string         `json:"notes,omitempty"`
-}

--- a/internal/engine/agent_state_query.go
+++ b/internal/engine/agent_state_query.go
@@ -151,3 +151,12 @@ func QueryTriggerAgent(ctx context.Context, ctrl AgentController, req TriggerAge
 	}
 	return ctrl.TriggerAgent(ctx, req.AgentID, req.Reason, req.Wait)
 }
+
+// QueryDispatchToHarness routes a DispatchRequest through the AgentController.
+// Returns ErrAgentUnavailable when ctrl is nil.
+func QueryDispatchToHarness(ctx context.Context, ctrl AgentController, req DispatchRequest) (*DispatchBatchResult, error) {
+	if ctrl == nil {
+		return nil, ErrAgentUnavailable
+	}
+	return ctrl.DispatchToHarness(ctx, req)
+}

--- a/internal/engine/agent_state_query.go
+++ b/internal/engine/agent_state_query.go
@@ -152,11 +152,4 @@ func QueryTriggerAgent(ctx context.Context, ctrl AgentController, req TriggerAge
 	return ctrl.TriggerAgent(ctx, req.AgentID, req.Reason, req.Wait)
 }
 
-// QueryDispatchToHarness routes a DispatchRequest through the AgentController.
-// Returns ErrAgentUnavailable when ctrl is nil.
-func QueryDispatchToHarness(ctx context.Context, ctrl AgentController, req DispatchRequest) (*DispatchBatchResult, error) {
-	if ctrl == nil {
-		return nil, ErrAgentUnavailable
-	}
-	return ctrl.DispatchToHarness(ctx, req)
-}
+

--- a/internal/engine/agent_state_query_test.go
+++ b/internal/engine/agent_state_query_test.go
@@ -95,10 +95,6 @@ func (f *fakeAgentController) TriggerAgent(ctx context.Context, id string, reaso
 	}, nil
 }
 
-func (f *fakeAgentController) DispatchToHarness(_ context.Context, _ DispatchRequest) (*DispatchBatchResult, error) {
-	return &DispatchBatchResult{Results: []DispatchResult{{Index: 0, Success: true, Content: "ok"}}}, nil
-}
-
 // --- Validation helpers ------------------------------------------------------
 
 func TestValidateAgentID_AcceptsDefault(t *testing.T) {

--- a/internal/engine/agent_state_query_test.go
+++ b/internal/engine/agent_state_query_test.go
@@ -95,6 +95,10 @@ func (f *fakeAgentController) TriggerAgent(ctx context.Context, id string, reaso
 	}, nil
 }
 
+func (f *fakeAgentController) DispatchToHarness(_ context.Context, _ DispatchRequest) (*DispatchBatchResult, error) {
+	return &DispatchBatchResult{Results: []DispatchResult{{Index: 0, Success: true, Content: "ok"}}}, nil
+}
+
 // --- Validation helpers ------------------------------------------------------
 
 func TestValidateAgentID_AcceptsDefault(t *testing.T) {

--- a/internal/engine/cli.go
+++ b/internal/engine/cli.go
@@ -230,6 +230,17 @@ func runServe(workspace string, port int, bindAddr string) {
 	defer cancel()
 	defer shutdownTelemetry(ctx0)
 
+	if server.mcpServer != nil {
+		ctrl, err := NewLocalHarnessController(cfg, nucleus, process, server.mcpServer)
+		if err != nil {
+			slog.Warn("local harness disabled", "err", err)
+		} else {
+			server.SetAgentController(ctrl)
+			ctrl.Start(ctx)
+			slog.Info("local harness started", "agent_id", DefaultAgentID, "interval", ctrl.interval.String())
+		}
+	}
+
 	// Start process goroutine.
 	processDone := make(chan error, 1)
 	go func() {

--- a/internal/engine/local_agent_harness.go
+++ b/internal/engine/local_agent_harness.go
@@ -1,0 +1,756 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+var defaultLocalHarnessToolScope = []string{
+	"cog_resolve_uri",
+	"cog_search_memory",
+	"cog_read_cogdoc",
+	"cog_query_field",
+	"cog_check_coherence",
+	"cog_get_state",
+	"cog_get_trust",
+	"cog_get_nucleus",
+	"cog_get_index",
+	"cog_assemble_context",
+	"cog_emit_event",
+}
+
+const (
+	localHarnessHistoryLimit   = 24
+	localHarnessCycleTimeout   = 90 * time.Second
+	localHarnessAssessMaxToks  = 256
+	localHarnessExecuteMaxToks = 1024
+)
+
+const localHarnessAssessPrompt = `You are the resident local CogOS maintenance agent.
+Operate only through local inference and the kernel's local tools.
+Decide whether a maintenance pass is warranted right now.
+Return only one compact JSON object with these keys:
+{"action":"sleep|observe|consolidate|repair|propose|escalate","reason":"short string","urgency":0..1,"target":"short string","task":"short concrete next step"}
+Prefer "sleep" unless the observation names a concrete task worth doing now.`
+
+const localHarnessExecutePrompt = `You are the resident local CogOS maintenance agent.
+Stay local-only. Use the provided kernel tools when they materially improve the answer.
+Prefer inspection and diagnosis over mutation. Finish with a concise plain-text result.`
+
+const localHarnessDispatchPrompt = `You are the resident local CogOS harness.
+Stay local-only. Use only the provided kernel tools. Be concise and finish with a direct answer.`
+
+type localHarnessAssessment struct {
+	Action  string  `json:"action"`
+	Reason  string  `json:"reason"`
+	Urgency float64 `json:"urgency"`
+	Target  string  `json:"target"`
+	Task    string  `json:"task"`
+}
+
+type localHarnessCycleRecord struct {
+	Cycle       int64
+	Timestamp   time.Time
+	Duration    time.Duration
+	Action      string
+	Urgency     float64
+	Reason      string
+	Target      string
+	Observation string
+	Result      string
+	Model       string
+}
+
+type localHarnessCycleOutcome struct {
+	record   localHarnessCycleRecord
+	timedOut bool
+}
+
+type LocalHarnessController struct {
+	cfg             *Config
+	nucleus         *Nucleus
+	process         *Process
+	toolRegistry    *KernelToolRegistry
+	dispatchTools   *KernelToolRegistry
+	backgroundTools *KernelToolRegistry
+
+	agentID  string
+	started  time.Time
+	interval time.Duration
+
+	runCtx context.Context
+
+	running atomic.Bool
+	stopped atomic.Bool
+
+	cycleSeq   atomic.Int64
+	triggerSeq atomic.Int64
+
+	startOnce sync.Once
+
+	mu              sync.RWMutex
+	lastObservation string
+	lastModel       string
+	lastCycle       *localHarnessCycleRecord
+	history         []localHarnessCycleRecord
+}
+
+func NewLocalHarnessController(cfg *Config, nucleus *Nucleus, process *Process, mcpSrv *MCPServer) (*LocalHarnessController, error) {
+	if mcpSrv == nil {
+		return nil, fmt.Errorf("local harness requires MCP server wiring")
+	}
+	registry := NewKernelToolRegistry(mcpSrv)
+	dispatchTools, err := registry.Scoped(defaultLocalHarnessToolScope)
+	if err != nil {
+		return nil, err
+	}
+
+	interval := time.Minute
+	if cfg != nil && cfg.HeartbeatInterval > 0 {
+		interval = time.Duration(cfg.HeartbeatInterval) * time.Second
+	}
+
+	return &LocalHarnessController{
+		cfg:             cfg,
+		nucleus:         nucleus,
+		process:         process,
+		toolRegistry:    registry,
+		dispatchTools:   dispatchTools,
+		backgroundTools: dispatchTools,
+		agentID:         DefaultAgentID,
+		started:         time.Now().UTC(),
+		interval:        interval,
+	}, nil
+}
+
+func (c *LocalHarnessController) Start(ctx context.Context) {
+	c.startOnce.Do(func() {
+		c.runCtx = ctx
+		c.stopped.Store(false)
+		c.tryStartCycle("startup", 0, nil)
+		go c.runTicker(ctx)
+	})
+}
+
+func (c *LocalHarnessController) runTicker(ctx context.Context) {
+	ticker := time.NewTicker(c.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			c.stopped.Store(true)
+			return
+		case <-ticker.C:
+			c.tryStartCycle("ticker", 0, nil)
+		}
+	}
+}
+
+func (c *LocalHarnessController) tryStartCycle(reason string, triggerSeq int64, waiter chan<- localHarnessCycleOutcome) bool {
+	if c.stopped.Load() {
+		return false
+	}
+	if !c.running.CompareAndSwap(false, true) {
+		return false
+	}
+	parent := c.runCtx
+	if parent == nil {
+		parent = context.Background()
+	}
+	go c.runCycle(parent, reason, triggerSeq, waiter)
+	return true
+}
+
+func (c *LocalHarnessController) runCycle(parent context.Context, reason string, triggerSeq int64, waiter chan<- localHarnessCycleOutcome) {
+	defer c.running.Store(false)
+
+	ctx, cancel := context.WithTimeout(parent, localHarnessCycleTimeout)
+	defer cancel()
+
+	start := time.Now().UTC()
+	record := localHarnessCycleRecord{
+		Cycle:     c.cycleSeq.Add(1),
+		Timestamp: start,
+		Action:    "sleep",
+		Reason:    "idle",
+	}
+	record.Observation = c.buildObservation(reason)
+
+	outcome := localHarnessCycleOutcome{record: record}
+
+	target, err := detectLocalLLMTarget(ctx, "")
+	if err != nil {
+		outcome.record.Action = "error"
+		outcome.record.Reason = err.Error()
+		c.finishCycle(outcome.record)
+		if waiter != nil {
+			waiter <- outcome
+		}
+		return
+	}
+
+	model, _, note := resolveDispatchLocalModel(target.Models, c.localModelHint(), DispatchModelE4B)
+	if model == "" {
+		outcome.record.Action = "error"
+		outcome.record.Reason = note
+		outcome.record.Model = c.localModelHint()
+		c.finishCycle(outcome.record)
+		if waiter != nil {
+			waiter <- outcome
+		}
+		return
+	}
+	outcome.record.Model = model
+
+	provider := buildLocalProvider(target, model)
+	assessment, err := c.assessCycle(ctx, provider, outcome.record.Observation)
+	if err != nil {
+		outcome.record.Action = "error"
+		outcome.record.Reason = err.Error()
+		c.finishCycle(outcome.record)
+		if waiter != nil {
+			waiter <- outcome
+		}
+		return
+	}
+
+	outcome.record.Action = assessment.Action
+	outcome.record.Reason = assessment.Reason
+	outcome.record.Urgency = clampUrgency(assessment.Urgency)
+	outcome.record.Target = assessment.Target
+	if note != "" {
+		if outcome.record.Reason == "" {
+			outcome.record.Reason = note
+		} else {
+			outcome.record.Reason = outcome.record.Reason + "; " + note
+		}
+	}
+
+	if assessment.Action != "sleep" {
+		result, err := c.executeCycleTask(ctx, provider, assessment, outcome.record.Observation, c.backgroundTools)
+		if err != nil {
+			outcome.record.Action = "error"
+			outcome.record.Reason = err.Error()
+		} else {
+			outcome.record.Result = result
+		}
+	}
+
+	if ctx.Err() == context.DeadlineExceeded {
+		outcome.timedOut = true
+		if outcome.record.Action == "" || outcome.record.Action == "sleep" {
+			outcome.record.Action = "error"
+		}
+		if outcome.record.Reason == "" {
+			outcome.record.Reason = "cycle timeout"
+		}
+	}
+
+	c.finishCycle(outcome.record)
+	if waiter != nil {
+		waiter <- outcome
+	}
+}
+
+func (c *LocalHarnessController) finishCycle(record localHarnessCycleRecord) {
+	record.Duration = time.Since(record.Timestamp)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.lastObservation = record.Observation
+	c.lastModel = record.Model
+	c.lastCycle = &record
+	c.history = append(c.history, record)
+	if len(c.history) > localHarnessHistoryLimit {
+		c.history = append([]localHarnessCycleRecord(nil), c.history[len(c.history)-localHarnessHistoryLimit:]...)
+	}
+}
+
+func (c *LocalHarnessController) assessCycle(ctx context.Context, provider Provider, observation string) (*localHarnessAssessment, error) {
+	temp := 0.0
+	resp, err := provider.Complete(ctx, &CompletionRequest{
+		SystemPrompt: localHarnessAssessPrompt,
+		Messages: []ProviderMessage{
+			{Role: "user", Content: observation},
+		},
+		MaxTokens:   localHarnessAssessMaxToks,
+		Temperature: &temp,
+		Metadata: RequestMetadata{
+			RequestID:   fmt.Sprintf("local-harness-assess-%d", time.Now().UnixNano()),
+			PreferLocal: true,
+			Source:      "local-harness",
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var assessment localHarnessAssessment
+	if err := decodeJSONPayload(resp.Content, &assessment); err != nil {
+		return nil, fmt.Errorf("parse assessment: %w", err)
+	}
+	if strings.TrimSpace(assessment.Action) == "" {
+		assessment.Action = "sleep"
+	}
+	assessment.Action = strings.ToLower(strings.TrimSpace(assessment.Action))
+	assessment.Reason = strings.TrimSpace(assessment.Reason)
+	assessment.Target = strings.TrimSpace(assessment.Target)
+	assessment.Task = strings.TrimSpace(assessment.Task)
+	assessment.Urgency = clampUrgency(assessment.Urgency)
+	return &assessment, nil
+}
+
+func (c *LocalHarnessController) executeCycleTask(ctx context.Context, provider Provider, assessment *localHarnessAssessment, observation string, registry *KernelToolRegistry) (string, error) {
+	temp := 0.1
+	task := c.buildExecutionTask(assessment, observation)
+	req := &CompletionRequest{
+		SystemPrompt: localHarnessExecutePrompt,
+		Messages: []ProviderMessage{
+			{Role: "user", Content: task},
+		},
+		Tools:       registry.Definitions(),
+		ToolChoice:  "auto",
+		MaxTokens:   localHarnessExecuteMaxToks,
+		Temperature: &temp,
+		Metadata: RequestMetadata{
+			RequestID:   fmt.Sprintf("local-harness-exec-%d", time.Now().UnixNano()),
+			PreferLocal: true,
+			Source:      "local-harness",
+		},
+	}
+	resp, clientCalls, transcript, err := c.completeWithToolLoop(ctx, provider, req, registry)
+	if err != nil {
+		return "", err
+	}
+	if len(clientCalls) > 0 {
+		slog.Warn("local harness produced unsupported client tool calls", "count", len(clientCalls))
+	}
+	content := strings.TrimSpace(resp.Content)
+	if content == "" && len(transcript) > 0 {
+		content = summarizeToolTranscript(transcript)
+	}
+	return content, nil
+}
+
+func (c *LocalHarnessController) buildExecutionTask(assessment *localHarnessAssessment, observation string) string {
+	var b strings.Builder
+	b.WriteString("Observation:\n")
+	b.WriteString(observation)
+	b.WriteString("\n\nRequested action: ")
+	b.WriteString(assessment.Action)
+	if assessment.Target != "" {
+		b.WriteString("\nTarget: ")
+		b.WriteString(assessment.Target)
+	}
+	if assessment.Reason != "" {
+		b.WriteString("\nWhy: ")
+		b.WriteString(assessment.Reason)
+	}
+	if assessment.Task != "" {
+		b.WriteString("\nNext step: ")
+		b.WriteString(assessment.Task)
+	}
+	return b.String()
+}
+
+func (c *LocalHarnessController) buildObservation(triggerReason string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "time=%s\n", time.Now().UTC().Format(time.RFC3339))
+	if triggerReason != "" {
+		fmt.Fprintf(&b, "trigger=%s\n", triggerReason)
+	}
+	if c.cfg != nil {
+		fmt.Fprintf(&b, "workspace=%s\n", filepath.Base(c.cfg.WorkspaceRoot))
+	}
+	if c.nucleus != nil && c.nucleus.Name != "" {
+		fmt.Fprintf(&b, "identity=%s\n", c.nucleus.Name)
+	}
+	if c.process != nil {
+		fmt.Fprintf(&b, "process_state=%s\n", c.process.State().String())
+		fovea := c.process.Field().Fovea(5)
+		if len(fovea) > 0 {
+			b.WriteString("field_top:\n")
+			for _, item := range fovea {
+				fmt.Fprintf(&b, "- %s score=%.3f\n", item.Path, item.Score)
+			}
+		}
+	}
+
+	c.mu.RLock()
+	last := c.lastCycle
+	c.mu.RUnlock()
+	if last != nil {
+		fmt.Fprintf(&b, "last_cycle=%s action=%s urgency=%.2f reason=%s\n",
+			last.Timestamp.Format(time.RFC3339), last.Action, last.Urgency, last.Reason)
+	}
+	return b.String()
+}
+
+func (c *LocalHarnessController) localModelHint() string {
+	if c.cfg != nil && strings.TrimSpace(c.cfg.LocalModel) != "" {
+		return strings.TrimSpace(c.cfg.LocalModel)
+	}
+	return defaultOllamaModel
+}
+
+func (c *LocalHarnessController) summary() AgentSummary {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	s := AgentSummary{
+		AgentID:   c.agentID,
+		Alive:     !c.stopped.Load(),
+		Running:   c.running.Load(),
+		UptimeSec: int64(time.Since(c.started).Seconds()),
+		Model:     c.lastModel,
+		Interval:  c.interval.String(),
+	}
+	if c.nucleus != nil {
+		s.Identity = c.nucleus.Name
+	}
+	if c.lastCycle != nil {
+		s.CycleCount = c.lastCycle.Cycle
+		s.LastAction = c.lastCycle.Action
+		s.LastCycle = c.lastCycle.Timestamp.Format(time.RFC3339)
+		s.LastUrgency = c.lastCycle.Urgency
+		s.LastReason = c.lastCycle.Reason
+		s.LastDurMs = c.lastCycle.Duration.Milliseconds()
+	}
+	if s.Model == "" {
+		s.Model = c.localModelHint()
+	}
+	return s
+}
+
+func (c *LocalHarnessController) ListAgents(_ context.Context, _ bool) ([]AgentSummary, error) {
+	if c.stopped.Load() {
+		return nil, ErrAgentUnavailable
+	}
+	return []AgentSummary{c.summary()}, nil
+}
+
+func (c *LocalHarnessController) GetAgent(_ context.Context, id string, includeTrace bool, traceLimit int) (*AgentSnapshot, error) {
+	if id != c.agentID {
+		return nil, ErrAgentNotFound
+	}
+	if c.stopped.Load() {
+		return nil, ErrAgentUnavailable
+	}
+
+	snap := &AgentSnapshot{
+		Summary: c.summary(),
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	snap.LastObservation = c.lastObservation
+	if c.nucleus != nil {
+		snap.IdentityRef = c.nucleus.Name
+	}
+	snap.Memory = make([]AgentMemoryEntry, 0, len(c.history))
+	for i := len(c.history) - 1; i >= 0; i-- {
+		rec := c.history[i]
+		snap.Memory = append(snap.Memory, AgentMemoryEntry{
+			Cycle:    rec.Cycle,
+			Action:   rec.Action,
+			Urgency:  rec.Urgency,
+			Sentence: summarizeMemoryEntry(rec),
+			Ago:      sinceString(rec.Timestamp),
+		})
+	}
+	if includeTrace {
+		start := 0
+		if traceLimit > 0 && len(c.history) > traceLimit {
+			start = len(c.history) - traceLimit
+		}
+		for _, rec := range c.history[start:] {
+			snap.Traces = append(snap.Traces, AgentCycleTrace{
+				Cycle:       rec.Cycle,
+				Timestamp:   rec.Timestamp.Format(time.RFC3339),
+				DurationMs:  rec.Duration.Milliseconds(),
+				Action:      rec.Action,
+				Urgency:     rec.Urgency,
+				Reason:      rec.Reason,
+				Target:      rec.Target,
+				Observation: rec.Observation,
+				Result:      rec.Result,
+			})
+		}
+	}
+	return snap, nil
+}
+
+func (c *LocalHarnessController) TriggerAgent(ctx context.Context, id string, reason string, wait bool) (*AgentTriggerResult, error) {
+	if id != c.agentID {
+		return nil, ErrAgentNotFound
+	}
+	if c.stopped.Load() {
+		return nil, ErrAgentUnavailable
+	}
+
+	seq := c.triggerSeq.Add(1)
+	if !wait {
+		if !c.tryStartCycle(reason, seq, nil) {
+			return &AgentTriggerResult{
+				Triggered:  false,
+				AgentID:    id,
+				TriggerSeq: seq,
+				Message:    "already_running",
+			}, nil
+		}
+		return &AgentTriggerResult{
+			Triggered:  true,
+			AgentID:    id,
+			TriggerSeq: seq,
+			Message:    "triggered",
+		}, nil
+	}
+
+	waiter := make(chan localHarnessCycleOutcome, 1)
+	if !c.tryStartCycle(reason, seq, waiter) {
+		return &AgentTriggerResult{
+			Triggered:  false,
+			AgentID:    id,
+			TriggerSeq: seq,
+			Message:    "already_running",
+		}, nil
+	}
+
+	select {
+	case outcome := <-waiter:
+		return &AgentTriggerResult{
+			Triggered:  true,
+			AgentID:    id,
+			CycleID:    fmt.Sprintf("%s-%d", c.agentID, outcome.record.Cycle),
+			TriggerSeq: seq,
+			Message:    "completed",
+			Action:     outcome.record.Action,
+			Urgency:    outcome.record.Urgency,
+			Reason:     outcome.record.Reason,
+			DurationMs: outcome.record.Duration.Milliseconds(),
+			TimedOut:   outcome.timedOut,
+		}, nil
+	case <-ctx.Done():
+		return &AgentTriggerResult{
+			Triggered:  true,
+			AgentID:    id,
+			TriggerSeq: seq,
+			Message:    "triggered",
+			TimedOut:   true,
+		}, nil
+	}
+}
+
+func (c *LocalHarnessController) DispatchToHarness(ctx context.Context, req DispatchRequest) (*DispatchBatchResult, error) {
+	if c.stopped.Load() {
+		return nil, ErrAgentUnavailable
+	}
+	if req.AgentID != "" && req.AgentID != c.agentID {
+		return nil, ErrAgentNotFound
+	}
+	if err := req.Normalize(); err != nil {
+		return nil, err
+	}
+
+	target, err := detectLocalLLMTarget(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+	model, routeUsed, note := resolveDispatchLocalModel(target.Models, c.localModelHint(), req.Model)
+	if model == "" {
+		return nil, errors.New(note)
+	}
+
+	registry := c.dispatchTools
+	if len(req.Tools) > 0 {
+		registry, err = c.dispatchTools.Scoped(req.Tools)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	provider := buildLocalProvider(target, model)
+	batch := &DispatchBatchResult{
+		Results: make([]DispatchResult, req.N),
+	}
+	if note != "" {
+		batch.Notes = append(batch.Notes, note)
+	}
+
+	start := time.Now()
+	var wg sync.WaitGroup
+	for i := 0; i < req.N; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			batch.Results[idx] = c.dispatchSlot(ctx, provider, registry, model, routeUsed, req, idx, note)
+		}(i)
+	}
+	wg.Wait()
+	batch.TotalDurationSec = time.Since(start).Seconds()
+	return batch, nil
+}
+
+func (c *LocalHarnessController) dispatchSlot(parent context.Context, provider Provider, registry *KernelToolRegistry, model string, routeUsed DispatchModel, req DispatchRequest, idx int, note string) DispatchResult {
+	res := DispatchResult{
+		Index:     idx,
+		ModelUsed: routeUsed,
+	}
+	slotCtx, cancel := context.WithTimeout(parent, time.Duration(req.TimeoutSeconds)*time.Second)
+	defer cancel()
+
+	systemPrompt := strings.TrimSpace(req.SystemPrompt)
+	if systemPrompt == "" {
+		systemPrompt = localHarnessDispatchPrompt
+	}
+	counting := &countingProvider{Provider: provider}
+
+	temp := 0.1
+	compReq := &CompletionRequest{
+		SystemPrompt: systemPrompt,
+		Messages: []ProviderMessage{
+			{Role: "user", Content: strings.TrimSpace(req.Task)},
+		},
+		Tools:         registry.Definitions(),
+		ToolChoice:    "auto",
+		MaxTokens:     localHarnessExecuteMaxToks,
+		Temperature:   &temp,
+		ModelOverride: model,
+		Metadata: RequestMetadata{
+			RequestID:   fmt.Sprintf("local-harness-dispatch-%d-%d", time.Now().UnixNano(), idx),
+			PreferLocal: true,
+			Source:      "local-harness-dispatch",
+		},
+	}
+
+	start := time.Now()
+	resp, clientCalls, transcript, err := c.completeWithToolLoop(slotCtx, counting, compReq, registry)
+	res.DurationSec = time.Since(start).Seconds()
+	res.Turns = counting.CompleteCalls()
+	for _, tc := range transcript {
+		entry := DispatchToolCallSummary{
+			Name:         tc.Name,
+			ArgsDigest:   truncateDigest(tc.Arguments),
+			ResultDigest: truncateDigest(tc.Result),
+		}
+		if tc.Rejected {
+			entry.Error = tc.RejectReason
+		}
+		res.ToolCalls = append(res.ToolCalls, entry)
+	}
+	if len(clientCalls) > 0 {
+		res.Error = fmt.Sprintf("unsupported client tool calls returned: %d", len(clientCalls))
+	}
+	if err != nil {
+		if slotCtx.Err() == context.DeadlineExceeded {
+			res.Error = "timeout"
+		} else {
+			res.Error = err.Error()
+		}
+		return res
+	}
+	res.Success = true
+	res.Content = strings.TrimSpace(resp.Content)
+	if res.Content == "" && len(transcript) > 0 {
+		res.Content = summarizeToolTranscript(transcript)
+	}
+	if note != "" && res.Error == "" {
+		res.Error = note
+	}
+	return res
+}
+
+func (c *LocalHarnessController) completeWithToolLoop(ctx context.Context, provider Provider, req *CompletionRequest, registry *KernelToolRegistry) (*CompletionResponse, []ToolCall, []ToolCallRecord, error) {
+	resp, err := provider.Complete(ctx, req)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if len(resp.ToolCalls) == 0 {
+		return resp, nil, nil, nil
+	}
+	return RunToolLoopWithTranscript(ctx, provider, req, resp, registry)
+}
+
+type countingProvider struct {
+	Provider
+	completeCalls atomic.Int64
+}
+
+func (p *countingProvider) Complete(ctx context.Context, req *CompletionRequest) (*CompletionResponse, error) {
+	p.completeCalls.Add(1)
+	return p.Provider.Complete(ctx, req)
+}
+
+func (p *countingProvider) CompleteCalls() int {
+	return int(p.completeCalls.Load())
+}
+
+func clampUrgency(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}
+
+func decodeJSONPayload(raw string, out any) error {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return fmt.Errorf("empty response")
+	}
+	start := strings.Index(raw, "{")
+	end := strings.LastIndex(raw, "}")
+	if start >= 0 && end >= start {
+		raw = raw[start : end+1]
+	}
+	return json.Unmarshal([]byte(raw), out)
+}
+
+func summarizeMemoryEntry(rec localHarnessCycleRecord) string {
+	switch {
+	case rec.Result != "":
+		return truncateDigest(rec.Result)
+	case rec.Reason != "":
+		return truncateDigest(rec.Reason)
+	default:
+		return rec.Action
+	}
+}
+
+func summarizeToolTranscript(records []ToolCallRecord) string {
+	if len(records) == 0 {
+		return ""
+	}
+	last := records[len(records)-1]
+	if last.Result != "" {
+		return truncateDigest(last.Result)
+	}
+	return last.Name
+}
+
+func truncateDigest(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= 200 {
+		return s
+	}
+	return s[:200] + "..."
+}
+
+func sinceString(ts time.Time) string {
+	if ts.IsZero() {
+		return ""
+	}
+	return time.Since(ts).Round(time.Second).String()
+}

--- a/internal/engine/local_agent_harness_test.go
+++ b/internal/engine/local_agent_harness_test.go
@@ -1,0 +1,136 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLocalHarnessControllerTriggerAndList(t *testing.T) {
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	cfg.LocalModel = "gemma4:e4b"
+	proc := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	srv := NewServer(cfg, makeNucleus("Cog", "tester"), proc)
+
+	var call int
+	model := "gemma4:e4b"
+	llm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/tags":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"models": []map[string]any{{"name": model}},
+			})
+		case "/api/chat":
+			call++
+			w.Header().Set("Content-Type", "application/json")
+			if call == 1 {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"message": map[string]any{
+						"role":    "assistant",
+						"content": `{"action":"observe","reason":"field changed","urgency":0.4,"target":"memory","task":"summarize current state"}`,
+					},
+					"done":              true,
+					"prompt_eval_count": 1,
+					"eval_count":        1,
+				})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"message": map[string]any{
+					"role":    "assistant",
+					"content": "local harness executed",
+				},
+				"done":              true,
+				"prompt_eval_count": 1,
+				"eval_count":        1,
+			})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer llm.Close()
+	t.Setenv(localLLMEndpointEnv, llm.URL)
+
+	ctrl, err := NewLocalHarnessController(cfg, makeNucleus("Cog", "tester"), proc, srv.mcpServer)
+	if err != nil {
+		t.Fatalf("NewLocalHarnessController: %v", err)
+	}
+
+	res, err := ctrl.TriggerAgent(context.Background(), DefaultAgentID, "test", true)
+	if err != nil {
+		t.Fatalf("TriggerAgent: %v", err)
+	}
+	if !res.Triggered {
+		t.Fatalf("expected triggered=true, got %+v", res)
+	}
+	if res.Action != "observe" {
+		t.Fatalf("Action = %q; want observe", res.Action)
+	}
+
+	list, err := ctrl.ListAgents(context.Background(), false)
+	if err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("ListAgents len = %d; want 1", len(list))
+	}
+	if list[0].CycleCount != 1 {
+		t.Fatalf("CycleCount = %d; want 1", list[0].CycleCount)
+	}
+
+	snap, err := ctrl.GetAgent(context.Background(), DefaultAgentID, true, 5)
+	if err != nil {
+		t.Fatalf("GetAgent: %v", err)
+	}
+	if len(snap.Traces) != 1 {
+		t.Fatalf("Traces len = %d; want 1", len(snap.Traces))
+	}
+	if snap.Traces[0].Result != "local harness executed" {
+		t.Fatalf("trace result = %q; want local harness executed", snap.Traces[0].Result)
+	}
+}
+
+func TestServerLegacyAgentStatusRoute(t *testing.T) {
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	proc := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	srv := NewServer(cfg, makeNucleus("Cog", "tester"), proc)
+	srv.SetAgentController(&fakeAgentController{
+		GetResult: &AgentSnapshot{
+			Summary: AgentSummary{
+				AgentID:     DefaultAgentID,
+				Alive:       true,
+				CycleCount:  3,
+				LastAction:  "sleep",
+				LastCycle:   "2026-04-21T12:00:00Z",
+				LastUrgency: 0.2,
+				LastReason:  "idle",
+				LastDurMs:   42,
+				Model:       "gemma4:e4b",
+				Interval:    "1m0s",
+				UptimeSec:   60,
+			},
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/agent/status", nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200", rr.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["cycle_count"].(float64) != 3 {
+		t.Fatalf("cycle_count = %v; want 3", body["cycle_count"])
+	}
+	if body["uptime"].(string) != "1m0s" {
+		t.Fatalf("uptime = %v; want 1m0s", body["uptime"])
+	}
+}

--- a/internal/engine/local_llm.go
+++ b/internal/engine/local_llm.go
@@ -1,0 +1,194 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const localLLMEndpointEnv = "COGOS_LLM_ENDPOINT"
+
+type LocalLLMBackend string
+
+const (
+	LocalLLMBackendOllama       LocalLLMBackend = "ollama"
+	LocalLLMBackendOpenAICompat LocalLLMBackend = "openai-compat"
+)
+
+type LocalLLMTarget struct {
+	BaseURL string
+	Backend LocalLLMBackend
+	Models  []string
+}
+
+func normalizeLocalLLMEndpoint(endpoint string) string {
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint == "" {
+		return ""
+	}
+	endpoint = strings.TrimRight(endpoint, "/")
+	if strings.HasSuffix(endpoint, "/v1") {
+		endpoint = strings.TrimSuffix(endpoint, "/v1")
+	}
+	return strings.TrimRight(endpoint, "/")
+}
+
+func resolveLocalLLMEndpoint(cfgEndpoint string) string {
+	if endpoint := normalizeLocalLLMEndpoint(cfgEndpoint); endpoint != "" {
+		return endpoint
+	}
+	if endpoint := normalizeLocalLLMEndpoint(os.Getenv(localLLMEndpointEnv)); endpoint != "" {
+		return endpoint
+	}
+	return openaiCompatDefaultEndpoint
+}
+
+func detectLocalLLMTarget(ctx context.Context, cfgEndpoint string) (LocalLLMTarget, error) {
+	baseURL := resolveLocalLLMEndpoint(cfgEndpoint)
+	if models, err := probeOllamaModels(ctx, baseURL); err == nil {
+		return LocalLLMTarget{
+			BaseURL: baseURL,
+			Backend: LocalLLMBackendOllama,
+			Models:  models,
+		}, nil
+	} else if models, err2 := probeOpenAICompatModels(ctx, baseURL); err2 == nil {
+		return LocalLLMTarget{
+			BaseURL: baseURL,
+			Backend: LocalLLMBackendOpenAICompat,
+			Models:  models,
+		}, nil
+	} else {
+		return LocalLLMTarget{}, fmt.Errorf("local llm unavailable at %s (ollama probe: %v; openai probe: %v)", baseURL, err, err2)
+	}
+}
+
+func probeOllamaModels(ctx context.Context, baseURL string) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, normalizeLocalLLMEndpoint(baseURL)+"/api/tags", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+	var tags struct {
+		Models []struct {
+			Name string `json:"name"`
+		} `json:"models"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tags); err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(tags.Models))
+	for _, model := range tags.Models {
+		if model.Name != "" {
+			out = append(out, model.Name)
+		}
+	}
+	return out, nil
+}
+
+func probeOpenAICompatModels(ctx context.Context, baseURL string) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, normalizeLocalLLMEndpoint(baseURL)+"/v1/models", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+	var result openaiModelsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(result.Data))
+	for _, model := range result.Data {
+		if model.ID != "" {
+			out = append(out, model.ID)
+		}
+	}
+	return out, nil
+}
+
+func buildLocalProvider(target LocalLLMTarget, model string) Provider {
+	cfg := ProviderConfig{
+		Endpoint: target.BaseURL,
+		Model:    model,
+		Timeout:  120,
+	}
+	switch target.Backend {
+	case LocalLLMBackendOllama:
+		cfg.ContextWindow = 32768
+		return NewOllamaProvider("agent-local", cfg)
+	default:
+		cfg.MaxTokens = openaiCompatDefaultMaxToks
+		return NewOpenAICompatProvider("agent-local", cfg)
+	}
+}
+
+func resolvePreferredLocalModel(models []string, preferred string) string {
+	preferred = strings.TrimSpace(preferred)
+	if preferred != "" {
+		for _, model := range models {
+			if model == preferred || strings.HasPrefix(model, preferred) {
+				return model
+			}
+		}
+	}
+	if len(models) > 0 {
+		return models[0]
+	}
+	return ""
+}
+
+var largeLocalModelPattern = regexp.MustCompile(`(^|[^0-9])([0-9]{2,3})b([^0-9]|$)`)
+
+func looksLikeLargeLocalModel(model string) bool {
+	m := largeLocalModelPattern.FindStringSubmatch(strings.ToLower(model))
+	if len(m) < 3 {
+		return false
+	}
+	n, err := strconv.Atoi(m[2])
+	if err != nil {
+		return false
+	}
+	return n >= 26
+}
+
+func resolveDispatchLocalModel(models []string, preferred string, requested DispatchModel) (string, DispatchModel, string) {
+	switch requested {
+	case DispatchModel26B:
+		for _, model := range models {
+			if looksLikeLargeLocalModel(model) {
+				return model, DispatchModel26B, ""
+			}
+		}
+		fallback := resolvePreferredLocalModel(models, preferred)
+		if fallback == "" {
+			return "", DispatchModelE4B, "26b route unavailable: no local models are loaded"
+		}
+		return fallback, DispatchModelE4B, "26b route unavailable, degraded to e4b"
+	default:
+		selected := resolvePreferredLocalModel(models, preferred)
+		if selected == "" {
+			return "", DispatchModelE4B, "no local models are loaded"
+		}
+		if preferred != "" && selected != preferred {
+			return selected, DispatchModelE4B, fmt.Sprintf("configured local model %q not loaded, using %q", preferred, selected)
+		}
+		return selected, DispatchModelE4B, ""
+	}
+}

--- a/internal/engine/provider_ollama.go
+++ b/internal/engine/provider_ollama.go
@@ -75,7 +75,7 @@ func NewOllamaProvider(name string, cfg ProviderConfig) *OllamaProvider {
 	}
 	return &OllamaProvider{
 		name:          name,
-		endpoint:      strings.TrimRight(endpoint, "/"),
+		endpoint:      normalizeLocalLLMEndpoint(endpoint),
 		model:         cfg.Model,
 		contextWindow: cfg.ContextWindow,
 		timeout:       timeout,
@@ -166,13 +166,38 @@ func (p *OllamaProvider) Ping(ctx context.Context) (time.Duration, error) {
 // ── Ollama wire types ─────────────────────────────────────────────────────────
 
 type ollamaMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role       string           `json:"role"`
+	Content    string           `json:"content,omitempty"`
+	ToolCallID string           `json:"tool_call_id,omitempty"`
+	ToolCalls  []ollamaToolCall `json:"tool_calls,omitempty"`
+}
+
+type ollamaTool struct {
+	Type     string             `json:"type"`
+	Function ollamaToolFunction `json:"function"`
+}
+
+type ollamaToolFunction struct {
+	Name        string                 `json:"name"`
+	Description string                 `json:"description"`
+	Parameters  map[string]interface{} `json:"parameters"`
+}
+
+type ollamaToolCall struct {
+	ID       string               `json:"id,omitempty"`
+	Type     string               `json:"type"`
+	Function ollamaToolCallDetail `json:"function"`
+}
+
+type ollamaToolCallDetail struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
 }
 
 type ollamaChatRequest struct {
 	Model    string          `json:"model"`
 	Messages []ollamaMessage `json:"messages"`
+	Tools    []ollamaTool    `json:"tools,omitempty"`
 	Stream   bool            `json:"stream"`
 	Think    bool            `json:"think"` // false = disable thinking mode (qwen3)
 	Options  map[string]any  `json:"options,omitempty"`
@@ -196,7 +221,24 @@ func buildOllamaRequest(model string, req *CompletionRequest, stream bool, conte
 		msgs = append(msgs, ollamaMessage{Role: "system", Content: req.SystemPrompt})
 	}
 	for _, m := range req.Messages {
-		msgs = append(msgs, ollamaMessage{Role: m.Role, Content: m.Content})
+		msg := ollamaMessage{
+			Role:       m.Role,
+			Content:    m.Content,
+			ToolCallID: m.ToolCallID,
+		}
+		if m.Role == "assistant" && len(m.ToolCalls) > 0 {
+			for _, tc := range m.ToolCalls {
+				msg.ToolCalls = append(msg.ToolCalls, ollamaToolCall{
+					ID:   tc.ID,
+					Type: "function",
+					Function: ollamaToolCallDetail{
+						Name:      tc.Name,
+						Arguments: tc.Arguments,
+					},
+				})
+			}
+		}
+		msgs = append(msgs, msg)
 	}
 
 	opts := map[string]any{}
@@ -213,9 +255,25 @@ func buildOllamaRequest(model string, req *CompletionRequest, stream bool, conte
 		opts["num_predict"] = req.MaxTokens
 	}
 
+	var tools []ollamaTool
+	if len(req.Tools) > 0 {
+		tools = make([]ollamaTool, 0, len(req.Tools))
+		for _, t := range req.Tools {
+			tools = append(tools, ollamaTool{
+				Type: "function",
+				Function: ollamaToolFunction{
+					Name:        t.Name,
+					Description: t.Description,
+					Parameters:  t.InputSchema,
+				},
+			})
+		}
+	}
+
 	return &ollamaChatRequest{
 		Model:    model,
 		Messages: msgs,
+		Tools:    tools,
 		Stream:   stream,
 		Think:    false, // prevent silent token burn in qwen3 thinking mode
 		Options:  opts,
@@ -265,9 +323,8 @@ func (p *OllamaProvider) Complete(ctx context.Context, req *CompletionRequest) (
 		return nil, fmt.Errorf("ollama: decode response: %w", err)
 	}
 
-	return &CompletionResponse{
-		Content:    or.Message.Content,
-		StopReason: "end_turn",
+	out := &CompletionResponse{
+		Content: or.Message.Content,
 		Usage: TokenUsage{
 			InputTokens:  or.PromptEvalCount,
 			OutputTokens: or.EvalCount,
@@ -277,7 +334,20 @@ func (p *OllamaProvider) Complete(ctx context.Context, req *CompletionRequest) (
 			Model:    model,
 			Latency:  time.Since(start),
 		},
-	}, nil
+	}
+	if len(or.Message.ToolCalls) > 0 {
+		out.StopReason = "tool_use"
+		for _, tc := range or.Message.ToolCalls {
+			out.ToolCalls = append(out.ToolCalls, ToolCall{
+				ID:        tc.ID,
+				Name:      tc.Function.Name,
+				Arguments: tc.Function.Arguments,
+			})
+		}
+	} else {
+		out.StopReason = "end_turn"
+	}
+	return out, nil
 }
 
 // Stream sends a streaming request and returns a channel of chunks.

--- a/internal/engine/provider_ollama.go
+++ b/internal/engine/provider_ollama.go
@@ -190,8 +190,8 @@ type ollamaToolCall struct {
 }
 
 type ollamaToolCallDetail struct {
-	Name      string `json:"name"`
-	Arguments string `json:"arguments"`
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
 }
 
 type ollamaChatRequest struct {
@@ -228,12 +228,16 @@ func buildOllamaRequest(model string, req *CompletionRequest, stream bool, conte
 		}
 		if m.Role == "assistant" && len(m.ToolCalls) > 0 {
 			for _, tc := range m.ToolCalls {
+				rawArgs := json.RawMessage(tc.Arguments)
+				if len(rawArgs) == 0 || !json.Valid(rawArgs) {
+					rawArgs = json.RawMessage("{}")
+				}
 				msg.ToolCalls = append(msg.ToolCalls, ollamaToolCall{
 					ID:   tc.ID,
 					Type: "function",
 					Function: ollamaToolCallDetail{
 						Name:      tc.Name,
-						Arguments: tc.Arguments,
+						Arguments: rawArgs,
 					},
 				})
 			}
@@ -338,10 +342,14 @@ func (p *OllamaProvider) Complete(ctx context.Context, req *CompletionRequest) (
 	if len(or.Message.ToolCalls) > 0 {
 		out.StopReason = "tool_use"
 		for _, tc := range or.Message.ToolCalls {
+			args := string(tc.Function.Arguments)
+			if args == "" || args == "null" {
+				args = "{}"
+			}
 			out.ToolCalls = append(out.ToolCalls, ToolCall{
 				ID:        tc.ID,
 				Name:      tc.Function.Name,
-				Arguments: tc.Function.Arguments,
+				Arguments: args,
 			})
 		}
 	} else {

--- a/internal/engine/provider_ollama_test.go
+++ b/internal/engine/provider_ollama_test.go
@@ -450,7 +450,7 @@ func TestOllamaCompleteToolCalls(t *testing.T) {
 						Type: "function",
 						Function: ollamaToolCallDetail{
 							Name:      "search",
-							Arguments: `{"query":"hi"}`,
+							Arguments: json.RawMessage(`{"query":"hi"}`),
 						},
 					},
 				},

--- a/internal/engine/provider_ollama_test.go
+++ b/internal/engine/provider_ollama_test.go
@@ -393,3 +393,86 @@ func containsCapability(caps []Capability, want Capability) bool {
 	}
 	return false
 }
+
+func TestBuildOllamaRequestToolsAndToolReplies(t *testing.T) {
+	t.Parallel()
+	req := &CompletionRequest{
+		Messages: []ProviderMessage{
+			{
+				Role: "assistant",
+				ToolCalls: []ToolCall{
+					{ID: "call_1", Name: "search", Arguments: `{"query":"x"}`},
+				},
+			},
+			{
+				Role:       "tool",
+				ToolCallID: "call_1",
+				Content:    `{"ok":true}`,
+			},
+		},
+		Tools: []ToolDefinition{
+			{
+				Name:        "search",
+				Description: "Search the memory index",
+				InputSchema: map[string]interface{}{"type": "object"},
+			},
+		},
+	}
+	r := buildOllamaRequest("m", req, false, 0)
+	if len(r.Tools) != 1 || r.Tools[0].Function.Name != "search" {
+		t.Fatalf("tools = %+v; want one search tool", r.Tools)
+	}
+	if len(r.Messages) != 2 {
+		t.Fatalf("messages len = %d; want 2", len(r.Messages))
+	}
+	if len(r.Messages[0].ToolCalls) != 1 {
+		t.Fatalf("assistant tool_calls len = %d; want 1", len(r.Messages[0].ToolCalls))
+	}
+	if r.Messages[1].ToolCallID != "call_1" {
+		t.Fatalf("tool_call_id = %q; want call_1", r.Messages[1].ToolCallID)
+	}
+}
+
+func TestOllamaCompleteToolCalls(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/chat" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(ollamaChatResponse{
+			Model: "qwen2.5:9b",
+			Message: ollamaMessage{
+				Role: "assistant",
+				ToolCalls: []ollamaToolCall{
+					{
+						ID:   "call_1",
+						Type: "function",
+						Function: ollamaToolCallDetail{
+							Name:      "search",
+							Arguments: `{"query":"hi"}`,
+						},
+					},
+				},
+			},
+			Done:            true,
+			PromptEvalCount: 5,
+			EvalCount:       3,
+		})
+	}))
+	defer srv.Close()
+
+	p := NewOllamaProvider("ollama", ProviderConfig{Endpoint: srv.URL, Model: "qwen2.5:9b"})
+	resp, err := p.Complete(context.Background(), &CompletionRequest{
+		Messages: []ProviderMessage{{Role: "user", Content: "use a tool"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if resp.StopReason != "tool_use" {
+		t.Fatalf("StopReason = %q; want tool_use", resp.StopReason)
+	}
+	if len(resp.ToolCalls) != 1 || resp.ToolCalls[0].Name != "search" {
+		t.Fatalf("ToolCalls = %+v; want one search tool call", resp.ToolCalls)
+	}
+}

--- a/internal/engine/provider_openai.go
+++ b/internal/engine/provider_openai.go
@@ -48,13 +48,7 @@ type OpenAICompatProvider struct {
 // openaiCompatDefaultEndpoint (localhost Ollama default). This lets users
 // point at an arbitrary OpenAI-compatible server without editing config.
 func NewOpenAICompatProvider(name string, cfg ProviderConfig) *OpenAICompatProvider {
-	endpoint := cfg.Endpoint
-	if endpoint == "" {
-		endpoint = os.Getenv("COGOS_LLM_ENDPOINT")
-	}
-	if endpoint == "" {
-		endpoint = openaiCompatDefaultEndpoint
-	}
+	endpoint := resolveLocalLLMEndpoint(cfg.Endpoint)
 	timeout := time.Duration(cfg.Timeout) * time.Second
 	if timeout == 0 {
 		timeout = 60 * time.Second
@@ -69,7 +63,7 @@ func NewOpenAICompatProvider(name string, cfg ProviderConfig) *OpenAICompatProvi
 	}
 	return &OpenAICompatProvider{
 		name:      name,
-		endpoint:  strings.TrimRight(endpoint, "/"),
+		endpoint:  normalizeLocalLLMEndpoint(endpoint),
 		apiKey:    apiKey,
 		model:     cfg.Model,
 		maxTokens: maxTokens,

--- a/internal/engine/provider_openai_test.go
+++ b/internal/engine/provider_openai_test.go
@@ -844,3 +844,14 @@ func TestOpenAIName(t *testing.T) {
 		t.Errorf("Name() = %q; want my-lmstudio", p.Name())
 	}
 }
+
+func TestNewOpenAICompatProviderNormalizesTrailingV1(t *testing.T) {
+	t.Parallel()
+	p := NewOpenAICompatProvider("openai-compat", ProviderConfig{
+		Endpoint: "http://localhost:1234/v1/",
+		Model:    "local-model",
+	})
+	if p.endpoint != "http://localhost:1234" {
+		t.Fatalf("endpoint = %q; want http://localhost:1234", p.endpoint)
+	}
+}

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -144,6 +144,7 @@ func NewServer(cfg *Config, nucleus *Nucleus, process *Process) *Server {
 	s.route(mux, "GET /v1/tool-calls", s.handleToolCalls)
 	s.route(mux, "GET /v1/conversation", s.handleConversation)
 	s.route(mux, "GET /v1/manifest", s.handleManifest)
+	s.registerAgentRoutes(mux)
 
 	// Constellation / attention endpoints (Phase 3)
 	s.registerAttentionRoutes(mux)

--- a/internal/engine/serve_agents.go
+++ b/internal/engine/serve_agents.go
@@ -1,0 +1,193 @@
+package engine
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type triggerAgentHTTPInput struct {
+	Reason string `json:"reason"`
+	Wait   bool   `json:"wait"`
+}
+
+type agentStatusCompat struct {
+	AgentSummary
+	Uptime          string                `json:"uptime,omitempty"`
+	Activity        *AgentActivitySummary `json:"activity,omitempty"`
+	Memory          []AgentMemoryEntry    `json:"memory,omitempty"`
+	Proposals       []AgentProposalEntry  `json:"proposals,omitempty"`
+	Inbox           *AgentInboxSummary    `json:"inbox,omitempty"`
+	LastObservation string                `json:"last_observation,omitempty"`
+	IdentityRef     string                `json:"identity_ref,omitempty"`
+}
+
+func (s *Server) registerAgentRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /v1/agents", s.handleAgentsList)
+	mux.HandleFunc("GET /v1/agents/{id}", s.handleAgentGet)
+	mux.HandleFunc("POST /v1/agents/{id}/tick", s.handleAgentTick)
+	mux.HandleFunc("POST /v1/agents/{id}/dispatch", s.handleAgentDispatch)
+
+	// Legacy dashboard routes.
+	mux.HandleFunc("GET /v1/agent/status", s.handleAgentStatusCompat)
+	mux.HandleFunc("GET /v1/agent/traces", s.handleAgentTracesCompat)
+	mux.HandleFunc("POST /v1/agent/trigger", s.handleAgentTriggerCompat)
+}
+
+func (s *Server) handleAgentsList(w http.ResponseWriter, r *http.Request) {
+	resp, err := QueryListAgents(r.Context(), s.agentController, ListAgentsRequest{})
+	if err != nil {
+		writeAgentHTTPError(w, err)
+		return
+	}
+	writeAgentJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleAgentGet(w http.ResponseWriter, r *http.Request) {
+	snap, err := QueryGetAgent(r.Context(), s.agentController, GetAgentRequest{
+		AgentID:      r.PathValue("id"),
+		IncludeTrace: r.URL.Query().Get("include_trace") == "true",
+		TraceLimit:   parseIntDefault(r.URL.Query().Get("trace_limit"), 0),
+	})
+	if err != nil {
+		writeAgentHTTPError(w, err)
+		return
+	}
+	writeAgentJSON(w, http.StatusOK, snap)
+}
+
+func (s *Server) handleAgentTick(w http.ResponseWriter, r *http.Request) {
+	var input triggerAgentHTTPInput
+	_ = json.NewDecoder(r.Body).Decode(&input)
+	resp, err := QueryTriggerAgent(r.Context(), s.agentController, TriggerAgentRequest{
+		AgentID: r.PathValue("id"),
+		Reason:  input.Reason,
+		Wait:    input.Wait,
+	})
+	if err != nil {
+		writeAgentHTTPError(w, err)
+		return
+	}
+	writeAgentJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleAgentDispatch(w http.ResponseWriter, r *http.Request) {
+	var input DispatchRequest
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		writeAgentJSON(w, http.StatusBadRequest, map[string]any{
+			"error": "invalid_json",
+		})
+		return
+	}
+	if input.AgentID == "" {
+		input.AgentID = r.PathValue("id")
+	}
+	resp, err := QueryDispatchToHarness(r.Context(), s.agentController, input)
+	if err != nil {
+		writeAgentHTTPError(w, err)
+		return
+	}
+	writeAgentJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleAgentStatusCompat(w http.ResponseWriter, r *http.Request) {
+	snap, err := QueryGetAgent(r.Context(), s.agentController, GetAgentRequest{
+		AgentID:      DefaultAgentID,
+		IncludeTrace: true,
+		TraceLimit:   20,
+	})
+	if err != nil {
+		writeAgentHTTPError(w, err)
+		return
+	}
+	body := agentStatusCompat{
+		AgentSummary:    snap.Summary,
+		Uptime:          secondsToDuration(snap.Summary.UptimeSec),
+		Activity:        snap.Activity,
+		Memory:          snap.Memory,
+		Proposals:       snap.Proposals,
+		Inbox:           snap.Inbox,
+		LastObservation: snap.LastObservation,
+		IdentityRef:     snap.IdentityRef,
+	}
+	writeAgentJSON(w, http.StatusOK, body)
+}
+
+func (s *Server) handleAgentTracesCompat(w http.ResponseWriter, r *http.Request) {
+	snap, err := QueryGetAgent(r.Context(), s.agentController, GetAgentRequest{
+		AgentID:      DefaultAgentID,
+		IncludeTrace: true,
+		TraceLimit:   20,
+	})
+	if err != nil {
+		writeAgentHTTPError(w, err)
+		return
+	}
+	writeAgentJSON(w, http.StatusOK, snap.Traces)
+}
+
+func (s *Server) handleAgentTriggerCompat(w http.ResponseWriter, r *http.Request) {
+	var input triggerAgentHTTPInput
+	_ = json.NewDecoder(r.Body).Decode(&input)
+	resp, err := QueryTriggerAgent(r.Context(), s.agentController, TriggerAgentRequest{
+		AgentID: DefaultAgentID,
+		Reason:  input.Reason,
+		Wait:    input.Wait,
+	})
+	if err != nil {
+		writeAgentHTTPError(w, err)
+		return
+	}
+	writeAgentJSON(w, http.StatusOK, resp)
+}
+
+func writeAgentHTTPError(w http.ResponseWriter, err error) {
+	status := http.StatusInternalServerError
+	body := map[string]any{
+		"error": err.Error(),
+	}
+	var aerr *AgentControllerError
+	switch {
+	case errors.As(err, &aerr):
+		switch aerr.Code {
+		case "invalid_input":
+			status = http.StatusBadRequest
+		case "not_found":
+			status = http.StatusNotFound
+		case "unavailable":
+			status = http.StatusServiceUnavailable
+		}
+		body["code"] = aerr.Code
+	case errors.Is(err, ErrAgentUnavailable):
+		status = http.StatusServiceUnavailable
+	case errors.Is(err, ErrAgentNotFound):
+		status = http.StatusNotFound
+	}
+	writeAgentJSON(w, status, body)
+}
+
+func writeAgentJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func parseIntDefault(raw string, fallback int) int {
+	if raw == "" {
+		return fallback
+	}
+	var v int
+	if _, err := fmt.Sscanf(raw, "%d", &v); err != nil {
+		return fallback
+	}
+	return v
+}
+
+func secondsToDuration(sec int64) string {
+	if sec <= 0 {
+		return ""
+	}
+	return (time.Duration(sec) * time.Second).String()
+}

--- a/internal/engine/tool_loop.go
+++ b/internal/engine/tool_loop.go
@@ -224,6 +224,37 @@ func (r *KernelToolRegistry) Definitions() []ToolDefinition {
 	return r.definitions
 }
 
+// Scoped returns a registry limited to the named tool subset. Empty names keep
+// the original registry. Unknown names return an error instead of silently
+// widening the scope.
+func (r *KernelToolRegistry) Scoped(names []string) (*KernelToolRegistry, error) {
+	if r == nil {
+		return nil, fmt.Errorf("nil kernel tool registry")
+	}
+	if len(names) == 0 {
+		return r, nil
+	}
+
+	out := &KernelToolRegistry{
+		cfg:       r.cfg,
+		proprio:   r.proprio,
+		executors: make(map[string]toolExecutor, len(names)),
+	}
+	for _, name := range names {
+		exec, ok := r.executors[name]
+		if !ok {
+			return nil, fmt.Errorf("kernel tool %q not registered", name)
+		}
+		def, ok := lookupToolDefinition(r.definitions, name)
+		if !ok {
+			return nil, fmt.Errorf("kernel tool %q missing definition", name)
+		}
+		out.executors[name] = exec
+		out.definitions = append(out.definitions, def)
+	}
+	return out, nil
+}
+
 func toolCallValidationEnabled(provider Provider, cfg *Config) bool {
 	caps := provider.Capabilities()
 	if caps.HasCapability(CapToolUse) {


### PR DESCRIPTION
## Summary

- Ports the wave7 Codex export (`cog-workspace/docs/transcripts/codex_export.txt`) into `internal/engine`
- Adds `LocalHarnessController`: autonomous assess→execute metabolic cycle against a local Ollama or OpenAI-compat LLM, running on each heartbeat tick and on-demand trigger
- Ollama and OpenAI-compat providers now support tool-call round-trips (`ToolCalls`/`ToolCallID` on `ProviderMessage`, `ollamaToolCall` wire types, `tool_use` stop reason)
- `KernelToolRegistry.Scoped()` for subset tool registries used by harness dispatch
- `DispatchToHarness` added to `AgentController` interface with `DispatchRequest`/`DispatchBatchResult`/`DispatchResult` types
- Seven HTTP routes: `GET /v1/agents`, `GET /v1/agents/{id}`, `POST /v1/agents/{id}/tick`, `POST /v1/agents/{id}/dispatch`, plus legacy `GET /v1/agent/status`, `GET /v1/agent/traces`, `POST /v1/agent/trigger`
- `.codex/config.toml` adds `cogos-http` and `cogos-v3` MCP server blocks
- Local LLM endpoint resolution via `COGOS_LLM_ENDPOINT` env var, no hardcoded IPs

## Source

Ported from `cog-workspace/docs/transcripts/codex_export.txt` (46KB, 1683 lines, wave7 Codex session).

## Deferrals

None. All referenced symbols (`AgentController`, `DefaultAgentID`, `DispatchRequest`, `DispatchModel`, `AgentSummary`, `AgentSnapshot`, etc.) were either pre-existing in the repo or defined as part of this PR. No stubs introduced.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/engine/...` — 607 tests pass, 0 fail
- [ ] Manual smoke: start kernel with Ollama running, verify `/v1/agent/status` returns harness cycle data
- [ ] Manual smoke: `POST /v1/agents/primary/tick` with `{"wait":true}` returns completed cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)