### PR TITLE
Fix Codex app bundle resolution

### DIFF
--- a/internal/engine/provider_codex.go
+++ b/internal/engine/provider_codex.go
@@ -12,20 +12,32 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 )
 
+var (
+	codexLookPath = exec.LookPath
+	codexStat     = os.Stat
+	codexGOOS     = runtime.GOOS
+)
+
+const codexAppBundleBinary = "/Applications/Codex.app/Contents/Resources/codex"
+
 // CodexProvider implements Provider by spawning codex exec processes.
 type CodexProvider struct {
-	name    string
-	model   string // "gpt-5.4", "gpt-5.3-codex-spark", etc.
-	effort  string // "xhigh", "high", "medium", "low"
-	sandbox string // "read-only", "workspace-write", "danger-full-access"
-	timeout time.Duration
-	binary  string // path to codex binary (default: "codex")
-	workDir string // working directory for codex exec
+	name          string
+	model         string // "gpt-5.4", "gpt-5.3-codex-spark", etc.
+	effort        string // "xhigh", "high", "medium", "low"
+	sandbox       string // "read-only", "workspace-write", "danger-full-access"
+	timeout       time.Duration
+	binary        string // path to codex binary (default: "codex")
+	defaultBinary bool
+	workDir       string // working directory for codex exec
 }
 
 // NewCodexProvider creates a CodexProvider from a ProviderConfig.
@@ -39,8 +51,10 @@ func NewCodexProvider(name string, cfg ProviderConfig) *CodexProvider {
 		timeout = 120 * time.Second
 	}
 	binary := "codex"
+	defaultBinary := true
 	if cfg.Endpoint != "" {
 		binary = cfg.Endpoint
+		defaultBinary = false
 	}
 
 	var effort, sandbox, workDir string
@@ -63,20 +77,47 @@ func NewCodexProvider(name string, cfg ProviderConfig) *CodexProvider {
 	}
 
 	return &CodexProvider{
-		name:    name,
-		model:   model,
-		effort:  effort,
-		sandbox: sandbox,
-		timeout: timeout,
-		binary:  binary,
-		workDir: workDir,
+		name:          name,
+		model:         model,
+		effort:        effort,
+		sandbox:       sandbox,
+		timeout:       timeout,
+		binary:        binary,
+		defaultBinary: defaultBinary,
+		workDir:       workDir,
 	}
 }
 
 func (p *CodexProvider) Name() string { return p.name }
 
+func (p *CodexProvider) resolveBinary() (string, error) {
+	if path, err := codexLookPath(p.binary); err == nil && path != "" {
+		return path, nil
+	}
+
+	if !p.defaultBinary || p.binary != "codex" || codexGOOS != "darwin" {
+		return "", fmt.Errorf("codex binary %q not found", p.binary)
+	}
+
+	for _, path := range codexAppBundlePaths() {
+		if info, err := codexStat(path); err == nil && !info.IsDir() && info.Mode().Perm()&0o111 != 0 {
+			return path, nil
+		}
+	}
+
+	return "", fmt.Errorf("codex binary %q not found", p.binary)
+}
+
+func codexAppBundlePaths() []string {
+	paths := []string{codexAppBundleBinary}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		paths = append(paths, filepath.Join(home, "Applications/Codex.app/Contents/Resources/codex"))
+	}
+	return paths
+}
+
 func (p *CodexProvider) Available(ctx context.Context) bool {
-	path, err := exec.LookPath(p.binary)
+	path, err := p.resolveBinary()
 	return err == nil && path != ""
 }
 
@@ -98,7 +139,11 @@ func (p *CodexProvider) Capabilities() ProviderCapabilities {
 
 func (p *CodexProvider) Ping(ctx context.Context) (time.Duration, error) {
 	start := time.Now()
-	cmd := exec.CommandContext(ctx, p.binary, "--version")
+	binary, err := p.resolveBinary()
+	if err != nil {
+		return 0, fmt.Errorf("codex binary not available: %w", err)
+	}
+	cmd := exec.CommandContext(ctx, binary, "--version")
 	if err := cmd.Run(); err != nil {
 		return 0, fmt.Errorf("codex binary not available: %w", err)
 	}
@@ -167,7 +212,11 @@ func (p *CodexProvider) Complete(ctx context.Context, req *CompletionRequest) (*
 	args := p.buildArgs(req)
 	args = append(args, prompt)
 
-	cmd := exec.CommandContext(ctx, p.binary, args...)
+	binary, err := p.resolveBinary()
+	if err != nil {
+		return nil, fmt.Errorf("codex binary not available: %w", err)
+	}
+	cmd := exec.CommandContext(ctx, binary, args...)
 	if p.workDir != "" {
 		cmd.Dir = p.workDir
 	}
@@ -222,7 +271,11 @@ func (p *CodexProvider) Stream(ctx context.Context, req *CompletionRequest) (<-c
 	args := p.buildArgs(req)
 	args = append(args, prompt)
 
-	cmd := exec.CommandContext(ctx, p.binary, args...)
+	binary, err := p.resolveBinary()
+	if err != nil {
+		return nil, fmt.Errorf("codex binary not available: %w", err)
+	}
+	cmd := exec.CommandContext(ctx, binary, args...)
 	if p.workDir != "" {
 		cmd.Dir = p.workDir
 	}

--- a/internal/engine/provider_codex_test.go
+++ b/internal/engine/provider_codex_test.go
@@ -1,0 +1,155 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+)
+
+type fakeFileInfo struct {
+	name string
+	mode os.FileMode
+	dir  bool
+}
+
+func (f fakeFileInfo) Name() string       { return f.name }
+func (f fakeFileInfo) Size() int64        { return 1 }
+func (f fakeFileInfo) Mode() os.FileMode  { return f.mode }
+func (f fakeFileInfo) ModTime() time.Time { return time.Time{} }
+func (f fakeFileInfo) IsDir() bool        { return f.dir }
+func (f fakeFileInfo) Sys() any           { return nil }
+
+func resetCodexResolverForTest(t *testing.T) {
+	t.Helper()
+
+	oldLookPath := codexLookPath
+	oldStat := codexStat
+	oldGOOS := codexGOOS
+	t.Cleanup(func() {
+		codexLookPath = oldLookPath
+		codexStat = oldStat
+		codexGOOS = oldGOOS
+	})
+}
+
+func TestCodexResolveBinaryPrefersPath(t *testing.T) {
+	resetCodexResolverForTest(t)
+
+	codexGOOS = "darwin"
+	codexLookPath = func(file string) (string, error) {
+		if file != "codex" {
+			t.Fatalf("LookPath called with %q, want codex", file)
+		}
+		return "/usr/local/bin/codex", nil
+	}
+	codexStat = func(path string) (os.FileInfo, error) {
+		t.Fatalf("stat should not be called when PATH resolves, got %q", path)
+		return nil, errors.New("unreachable")
+	}
+
+	p := NewCodexProvider("codex", ProviderConfig{})
+	path, err := p.resolveBinary()
+	if err != nil {
+		t.Fatalf("resolveBinary returned error: %v", err)
+	}
+	if path != "/usr/local/bin/codex" {
+		t.Fatalf("resolveBinary returned %q, want PATH result", path)
+	}
+}
+
+func TestCodexResolveBinaryFallsBackToAppBundleOnDarwin(t *testing.T) {
+	resetCodexResolverForTest(t)
+
+	codexGOOS = "darwin"
+	codexLookPath = func(file string) (string, error) {
+		return "", errors.New("not found")
+	}
+	codexStat = func(path string) (os.FileInfo, error) {
+		if path == codexAppBundleBinary {
+			return fakeFileInfo{name: "codex", mode: 0o755}, nil
+		}
+		return nil, os.ErrNotExist
+	}
+
+	p := NewCodexProvider("codex", ProviderConfig{})
+	path, err := p.resolveBinary()
+	if err != nil {
+		t.Fatalf("resolveBinary returned error: %v", err)
+	}
+	if path != codexAppBundleBinary {
+		t.Fatalf("resolveBinary returned %q, want app bundle path", path)
+	}
+	if !p.Available(context.Background()) {
+		t.Fatal("Available should use the app bundle fallback resolver")
+	}
+}
+
+func TestCodexResolveBinarySkipsNonExecutableAppBundlePath(t *testing.T) {
+	resetCodexResolverForTest(t)
+
+	codexGOOS = "darwin"
+	codexLookPath = func(file string) (string, error) {
+		return "", errors.New("not found")
+	}
+	codexStat = func(path string) (os.FileInfo, error) {
+		if path == codexAppBundleBinary {
+			return fakeFileInfo{name: "codex", mode: 0o644}, nil
+		}
+		return nil, os.ErrNotExist
+	}
+
+	p := NewCodexProvider("codex", ProviderConfig{})
+	if _, err := p.resolveBinary(); err == nil {
+		t.Fatal("resolveBinary should fail when the app bundle path is not executable")
+	}
+	if p.Available(context.Background()) {
+		t.Fatal("Available should be false when the app bundle path is not executable")
+	}
+}
+
+func TestCodexResolveBinaryDoesNotFallbackForExplicitEndpoint(t *testing.T) {
+	resetCodexResolverForTest(t)
+
+	codexGOOS = "darwin"
+	codexLookPath = func(file string) (string, error) {
+		if file != "codex" {
+			t.Fatalf("LookPath called with %q, want explicit endpoint", file)
+		}
+		return "", errors.New("not found")
+	}
+	codexStat = func(path string) (os.FileInfo, error) {
+		t.Fatalf("stat should not be called for explicit endpoint, got %q", path)
+		return nil, errors.New("unreachable")
+	}
+
+	p := NewCodexProvider("codex", ProviderConfig{Endpoint: "codex"})
+	if _, err := p.resolveBinary(); err == nil {
+		t.Fatal("resolveBinary should fail for an explicit endpoint that is not on PATH")
+	}
+	if p.Available(context.Background()) {
+		t.Fatal("Available should be false for an unresolved explicit endpoint")
+	}
+}
+
+func TestCodexResolveBinaryDoesNotFallbackForExplicitPath(t *testing.T) {
+	resetCodexResolverForTest(t)
+
+	codexGOOS = "darwin"
+	codexLookPath = func(file string) (string, error) {
+		if file != "/opt/codex/bin/codex" {
+			t.Fatalf("LookPath called with %q, want explicit path", file)
+		}
+		return "", errors.New("not found")
+	}
+	codexStat = func(path string) (os.FileInfo, error) {
+		t.Fatalf("stat should not be called for explicit path, got %q", path)
+		return nil, errors.New("unreachable")
+	}
+
+	p := NewCodexProvider("codex", ProviderConfig{Endpoint: "/opt/codex/bin/codex"})
+	if _, err := p.resolveBinary(); err == nil {
+		t.Fatal("resolveBinary should fail for an explicit path that does not exist")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #57.

- Resolves the Codex CLI through PATH first for the default provider binary.
- Falls back to known macOS Codex.app bundle locations when launchd PATH cannot find `codex`.
- Preserves explicit `endpoint` overrides by avoiding app-bundle fallback for configured binary names or paths.
- Uses the same resolver for availability, ping, completion, and streaming.

## Validation

- `go test ./internal/engine -run 'TestCodex'`\n- `go test ./internal/engine`