### PR TITLE
feat(daemon): expose 8 production providers + workspace DI seam

### DIFF
--- a/cmd/cogos/providers_wire.go
+++ b/cmd/cogos/providers_wire.go
@@ -1,0 +1,37 @@
+// providers_wire.go — wires Reconcilable provider registration into the
+// kernel daemon at boot.
+//
+// A blank import of internal/providers/daemon triggers that package's init(),
+// which registers all 8 production providers ("agent", "component", "discord",
+// "mcp-tools", "openclaw-agents", "openclaw-cron", "openclaw-gateway",
+// "service") with pkg/reconcile before engine.Main() starts the HTTP server.
+//
+// engine.RegisterProviders is set here so the registration call happens inside
+// runServe() (after the logger is up) rather than in a file-level init() that
+// might fire before tracing/logging infrastructure is ready.
+package main
+
+import (
+	"github.com/cogos-dev/cogos/internal/engine"
+
+	// Blank import registers all daemon-safe Reconcilable providers.
+	_ "github.com/cogos-dev/cogos/internal/providers/daemon"
+)
+
+func init() {
+	// The blank import above already triggered daemon.init(), which called
+	// reconcile.RegisterProvider for all 8 providers. We point
+	// engine.RegisterProviders at a no-op so that runServe() can confirm
+	// registration was requested (non-nil hook) while the actual
+	// registration has already occurred via init() ordering.
+	//
+	// Note: Go guarantees that all init() functions in imported packages
+	// run before the importing package's init(). So by the time this
+	// function body executes, internal/providers/daemon.init() has already
+	// registered the providers. engine.RegisterProviders is set to a no-op
+	// rather than left nil so runServe() logs "providers registered" when
+	// it calls the hook.
+	engine.RegisterProviders = func() {
+		// providers already registered by internal/providers/daemon init()
+	}
+}

--- a/cmd/cogos/providers_wire.go
+++ b/cmd/cogos/providers_wire.go
@@ -1,37 +1,44 @@
-// providers_wire.go — wires Reconcilable provider registration into the
-// kernel daemon at boot.
+// providers_wire.go — wires Reconcilable provider registration and workspace
+// context into the kernel daemon at boot.
 //
-// A blank import of internal/providers/daemon triggers that package's init(),
-// which registers all 8 production providers ("agent", "component", "discord",
+// A named import of internal/providers/daemon triggers that package's init(),
+// which registers production providers ("agent", "component", "discord",
 // "mcp-tools", "openclaw-agents", "openclaw-cron", "openclaw-gateway",
 // "service") with pkg/reconcile before engine.Main() starts the HTTP server.
 //
 // engine.RegisterProviders is set here so the registration call happens inside
 // runServe() (after the logger is up) rather than in a file-level init() that
 // might fire before tracing/logging infrastructure is ready.
+//
+// engine.SetProvidersWorkspace is set here so that after LoadConfig resolves
+// cfg.WorkspaceRoot, the daemon-side providers receive the workspace path and
+// can perform real filesystem Health() checks rather than reporting
+// "workspace not yet configured".
 package main
 
 import (
 	"github.com/cogos-dev/cogos/internal/engine"
-
-	// Blank import registers all daemon-safe Reconcilable providers.
-	_ "github.com/cogos-dev/cogos/internal/providers/daemon"
+	"github.com/cogos-dev/cogos/internal/providers/component"
+	"github.com/cogos-dev/cogos/internal/providers/daemon"
 )
 
 func init() {
-	// The blank import above already triggered daemon.init(), which called
-	// reconcile.RegisterProvider for all 8 providers. We point
-	// engine.RegisterProviders at a no-op so that runServe() can confirm
-	// registration was requested (non-nil hook) while the actual
-	// registration has already occurred via init() ordering.
-	//
-	// Note: Go guarantees that all init() functions in imported packages
-	// run before the importing package's init(). So by the time this
-	// function body executes, internal/providers/daemon.init() has already
-	// registered the providers. engine.RegisterProviders is set to a no-op
-	// rather than left nil so runServe() logs "providers registered" when
-	// it calls the hook.
+	// The named import of internal/providers/daemon above already triggered
+	// daemon.init() (and component.init() via daemon's blank import), which
+	// called reconcile.RegisterProvider for all production providers.
+	// engine.RegisterProviders is set to a no-op rather than left nil so
+	// runServe() logs "providers registered" when it calls the hook.
 	engine.RegisterProviders = func() {
 		// providers already registered by internal/providers/daemon init()
+	}
+
+	// Wire workspace context into daemon-side providers. runServe() calls this
+	// after LoadConfig resolves cfg.WorkspaceRoot. Until then, workspaceRoot
+	// is "" and Health() returns "workspace not yet configured" — acceptable
+	// because no Health() is called until the autonomic ticker or foveated
+	// handler fires.
+	engine.SetProvidersWorkspace = func(workspaceRoot string) {
+		daemon.SetWorkspaceRoot(workspaceRoot)
+		component.SetWorkspaceRoot(workspaceRoot)
 	}
 }

--- a/internal/engine/cli.go
+++ b/internal/engine/cli.go
@@ -172,6 +172,14 @@ func runServe(workspace string, port int, bindAddr string) {
 	upgradeLoggerWithFileSink(cfg)
 	slog.Info("config loaded", "workspace", cfg.WorkspaceRoot, "port", cfg.Port, "bind", cfg.BindAddr)
 
+	// Inject the resolved workspace root into daemon-side providers so their
+	// Health() implementations can perform real filesystem checks.
+	// SetProvidersWorkspace is set by cmd/cogos/providers_wire.go; nil in tests.
+	if SetProvidersWorkspace != nil {
+		SetProvidersWorkspace(cfg.WorkspaceRoot)
+		slog.Info("providers workspace wired", "workspace", cfg.WorkspaceRoot)
+	}
+
 	if reuse, msg, err := planServeState(cfg, checkDaemonHealth); err != nil {
 		slog.Error("daemon lifecycle failed", "err", err)
 		os.Exit(1)

--- a/internal/engine/cli.go
+++ b/internal/engine/cli.go
@@ -137,6 +137,12 @@ func runServeCmd(args []string, defaultWorkspace string, defaultPort int, defaul
 }
 
 func runServe(workspace string, port int, bindAddr string) {
+	// Register production Reconcilable providers before anything else.
+	// RegisterProviders is set by cmd/cogos/providers_wire.go; nil in tests.
+	if RegisterProviders != nil {
+		RegisterProviders()
+	}
+
 	setupLogger()
 	slog.Info("cogos-v3: starting", "build", BuildTime)
 

--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -137,6 +137,15 @@ func (m *MCPServer) Handler() http.Handler {
 	return m.handler
 }
 
+// Server returns the underlying *mcp.Server for use by extension hooks
+// (e.g. eval.RegisterEvalTools) that call mcp.AddTool directly.
+// Extensions must be registered before Handler() is first called — the
+// intended call site is RegisterMCPExtensions, which fires inside
+// registerMCPRoutes before h := mcpSrv.Handler().
+func (m *MCPServer) Server() *mcp.Server {
+	return m.server
+}
+
 // registerTools registers MCP tools.
 // Design: tools are actions with side effects or non-trivial computation.
 // Read-only state queries will migrate to MCP Resources in Phase 2.

--- a/internal/engine/providers_register.go
+++ b/internal/engine/providers_register.go
@@ -1,12 +1,24 @@
-// providers_register.go — registration hook for Reconcilable providers.
+// providers_register.go — registration hooks for Reconcilable providers
+// and MCP tool extensions.
 //
 // RegisterProviders is a function variable that, when non-nil, is called once
 // at daemon boot (inside runServe) before the HTTP server starts. The daemon
-// binary (cmd/cogos) sets this variable from its own init() via a blank import
+// binary (cmd/cogos) sets this variable from its own init() via an import
 // of internal/providers/daemon, which triggers that package's init() and
-// registers all 8 production providers with pkg/reconcile.
+// registers all 9 production providers with pkg/reconcile.
 //
-// This hook is intentionally nil in the engine package itself so that test
+// SetProvidersWorkspace is called after LoadConfig resolves the workspace root
+// so daemon-side providers can resolve their filesystem checks without
+// depending on workspace.ResolveWorkspace()'s DI seams (which are not wired
+// in the cmd/cogos binary).
+//
+// RegisterMCPExtensions is a function variable that, when non-nil, is called
+// once when the MCP server is built inside registerMCPRoutes. It receives the
+// live *MCPServer so that extension packages (e.g. internal/eval) can register
+// additional MCP tools without importing internal/engine directly. Set by
+// workspace-root wiring (e.g. eval_wiring.go).
+//
+// All hooks are intentionally nil in the engine package itself so that test
 // binaries (which register stub providers directly) are not affected.
 package engine
 
@@ -14,3 +26,15 @@ package engine
 // pkg/reconcile provider registry. Set by cmd/cogos/providers_wire.go.
 // Nil means "no additional providers to register" (e.g. in tests).
 var RegisterProviders func()
+
+// SetProvidersWorkspace is called once after LoadConfig resolves
+// cfg.WorkspaceRoot so daemon-side provider Health() implementations can
+// perform real filesystem checks. Set by cmd/cogos/providers_wire.go.
+// Nil means "workspace injection not requested" (e.g. in tests).
+var SetProvidersWorkspace func(workspaceRoot string)
+
+// RegisterMCPExtensions is called once when the MCP server is created during
+// registerMCPRoutes. Extensions receive the live *MCPServer so they can call
+// mcp.AddTool on its internal server. Set by workspace-root wiring.
+// Nil means no extensions are registered.
+var RegisterMCPExtensions func(srv *MCPServer)

--- a/internal/engine/providers_register.go
+++ b/internal/engine/providers_register.go
@@ -1,0 +1,16 @@
+// providers_register.go — registration hook for Reconcilable providers.
+//
+// RegisterProviders is a function variable that, when non-nil, is called once
+// at daemon boot (inside runServe) before the HTTP server starts. The daemon
+// binary (cmd/cogos) sets this variable from its own init() via a blank import
+// of internal/providers/daemon, which triggers that package's init() and
+// registers all 8 production providers with pkg/reconcile.
+//
+// This hook is intentionally nil in the engine package itself so that test
+// binaries (which register stub providers directly) are not affected.
+package engine
+
+// RegisterProviders is called once at daemon boot to populate the
+// pkg/reconcile provider registry. Set by cmd/cogos/providers_wire.go.
+// Nil means "no additional providers to register" (e.g. in tests).
+var RegisterProviders func()

--- a/internal/engine/serve_mcp.go
+++ b/internal/engine/serve_mcp.go
@@ -22,6 +22,11 @@ func (s *Server) registerMCPRoutes(mux *http.ServeMux) {
 	// happens in exactly one place (this Server). Handlers dispatching
 	// to mod3 directly was the Wave 3 divergence this removes.
 	mcpSrv.SetChannelSessionBackend(s)
+	// Call any extension hook registered by workspace-root wiring (e.g.
+	// eval_wiring.go calling eval.RegisterEvalTools). Nil when not set.
+	if RegisterMCPExtensions != nil {
+		RegisterMCPExtensions(mcpSrv)
+	}
 	s.mcpServer = mcpSrv
 	h := mcpSrv.Handler()
 	s.routeH(mux, "GET /mcp", h)

--- a/internal/providers/component/component_provider.go
+++ b/internal/providers/component/component_provider.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"sync"
 
 	"github.com/cogos-dev/cogos/internal/workspace"
 	"github.com/cogos-dev/cogos/pkg/reconcile"
@@ -79,6 +80,24 @@ var (
 	// NowISO returns the current timestamp in ISO-8601 form.
 	NowISO func() string
 )
+
+// daemonWorkspaceRoot is injected by SetWorkspaceRoot at daemon boot so
+// Health() does not fall back to workspace.ResolveWorkspace() (whose DI seams
+// are not wired in cmd/cogos).
+var (
+	daemonWorkspaceRootMu sync.RWMutex
+	daemonWorkspaceRoot   string
+)
+
+// SetWorkspaceRoot injects the resolved workspace path into this package so
+// that Health() can resolve the component config path without depending on
+// workspace.ResolveWorkspace(). Called by engine.SetProvidersWorkspace
+// immediately after LoadConfig resolves cfg.WorkspaceRoot.
+func SetWorkspaceRoot(root string) {
+	daemonWorkspaceRootMu.Lock()
+	defer daemonWorkspaceRootMu.Unlock()
+	daemonWorkspaceRoot = root
+}
 
 // ComponentProvider implements reconcile.Reconcilable for workspace
 // component management.
@@ -336,6 +355,13 @@ func (c *ComponentProvider) BuildState(config any, live any, existing *reconcile
 // Health returns the current three-axis status of the component subsystem.
 func (c *ComponentProvider) Health() reconcile.ResourceStatus {
 	root := c.root
+	if root == "" {
+		// Prefer the daemon-injected root (set at boot by SetWorkspaceRoot) so
+		// the daemon binary does not need workspace.ResolveWorkspace's DI seams.
+		daemonWorkspaceRootMu.RLock()
+		root = daemonWorkspaceRoot
+		daemonWorkspaceRootMu.RUnlock()
+	}
 	if root == "" {
 		var err error
 		root, _, err = workspace.ResolveWorkspace()

--- a/internal/providers/daemon/daemon.go
+++ b/internal/providers/daemon/daemon.go
@@ -1,0 +1,286 @@
+// Package daemon registers all Reconcilable providers that the kernel daemon
+// (cmd/cogos) needs to surface in proprioception health blocks.
+//
+// Background: The 8 production providers (agent, component, discord,
+// mcp-tools, openclaw-agents, openclaw-cron, openclaw-gateway, service) were
+// originally defined in the workspace-root package main of the cog CLI.
+// Because package main cannot be imported, the daemon binary (built from
+// cmd/cogos) could not reach those registrations and pkg/reconcile.ListProviders()
+// always returned empty.
+//
+// This package provides daemon-safe provider structs whose Health()
+// implementations replicate the workspace-root logic using only importable
+// packages (os, filepath, pkg/reconcile, internal/workspace).
+// The non-health methods (LoadConfig, FetchLive, ComputePlan, ApplyPlan,
+// BuildState) return errors — the daemon only exercises Health() through the
+// proprioception block.
+//
+// The component provider is already fully extracted to
+// internal/providers/component and is wired here via blank import.
+// The other seven are implemented as minimal structs below.
+//
+// cmd/cogos/providers_wire.go blank-imports this package so its init()
+// runs at daemon boot, completing the registration before the HTTP server
+// starts.
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/cogos-dev/cogos/internal/workspace"
+	"github.com/cogos-dev/cogos/pkg/reconcile"
+
+	// Trigger internal/providers/component's init() which registers "component".
+	_ "github.com/cogos-dev/cogos/internal/providers/component"
+)
+
+func init() {
+	reconcile.RegisterProvider("agent", &agentProvider{})
+	reconcile.RegisterProvider("discord", &discordProvider{})
+	reconcile.RegisterProvider("mcp-tools", &mcpToolsProvider{})
+	reconcile.RegisterProvider("openclaw-agents", &openclawAgentsProvider{})
+	reconcile.RegisterProvider("openclaw-cron", &openclawCronProvider{})
+	reconcile.RegisterProvider("openclaw-gateway", &openclawGatewayProvider{})
+	reconcile.RegisterProvider("service", &serviceProvider{})
+}
+
+// resolveRoot returns workspace root or an error status.
+func resolveRoot() (string, *reconcile.ResourceStatus) {
+	root, _, err := workspace.ResolveWorkspace()
+	if err != nil {
+		s := reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusUnknown,
+			Health:    reconcile.HealthMissing,
+			Operation: reconcile.OperationIdle,
+			Message:   "workspace not found",
+		}
+		return "", &s
+	}
+	return root, nil
+}
+
+// stubMethods satisfies the non-Health parts of reconcile.Reconcilable.
+// All operations return "daemon: operation not available" — the daemon only
+// calls Health() through the proprioception block.
+type stubMethods struct{ name string }
+
+func (s *stubMethods) LoadConfig(_ string) (any, error) {
+	return nil, fmt.Errorf("daemon: LoadConfig not available for %s provider", s.name)
+}
+func (s *stubMethods) FetchLive(_ context.Context, _ any) (any, error) {
+	return nil, fmt.Errorf("daemon: FetchLive not available for %s provider", s.name)
+}
+func (s *stubMethods) ComputePlan(_ any, _ any, _ *reconcile.State) (*reconcile.Plan, error) {
+	return nil, fmt.Errorf("daemon: ComputePlan not available for %s provider", s.name)
+}
+func (s *stubMethods) ApplyPlan(_ context.Context, _ *reconcile.Plan) ([]reconcile.Result, error) {
+	return nil, fmt.Errorf("daemon: ApplyPlan not available for %s provider", s.name)
+}
+func (s *stubMethods) BuildState(_ any, _ any, _ *reconcile.State) (*reconcile.State, error) {
+	return nil, fmt.Errorf("daemon: BuildState not available for %s provider", s.name)
+}
+
+// ─── agent ────────────────────────────────────────────────────────────────────
+
+type agentProvider struct{ stubMethods }
+
+func (p *agentProvider) Type() string { return "agent" }
+
+func (p *agentProvider) Health() reconcile.ResourceStatus {
+	root, bad := resolveRoot()
+	if bad != nil {
+		return *bad
+	}
+	agentsDir := filepath.Join(root, ".cog", "bin", "agents")
+	info, err := os.Stat(agentsDir)
+	if err != nil {
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusUnknown,
+			Health:    reconcile.HealthMissing,
+			Operation: reconcile.OperationIdle,
+			Message:   fmt.Sprintf("agents directory missing: %v", err),
+		}
+	}
+	if !info.IsDir() {
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusUnknown,
+			Health:    reconcile.HealthDegraded,
+			Operation: reconcile.OperationIdle,
+			Message:   "agents path exists but is not a directory",
+		}
+	}
+	registryPath := filepath.Join(agentsDir, "registry.yaml")
+	if _, err := os.Stat(registryPath); err != nil {
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusUnknown,
+			Health:    reconcile.HealthDegraded,
+			Operation: reconcile.OperationIdle,
+			Message:   "registry.yaml missing",
+		}
+	}
+	return reconcile.ResourceStatus{
+		Sync:      reconcile.SyncStatusUnknown,
+		Health:    reconcile.HealthHealthy,
+		Operation: reconcile.OperationIdle,
+		Message:   fmt.Sprintf("agents directory readable (%s)", agentsDir),
+	}
+}
+
+// ─── discord ──────────────────────────────────────────────────────────────────
+
+type discordProvider struct{ stubMethods }
+
+func (p *discordProvider) Type() string { return "discord" }
+
+func (p *discordProvider) Health() reconcile.ResourceStatus {
+	// Token presence mirrors the workspace-root DiscordProvider.Health() check.
+	if os.Getenv("DISCORD_BOT_TOKEN") == "" {
+		// Check .cog/config/discord/config.hcl for token field.
+		root, bad := resolveRoot()
+		if bad != nil {
+			return *bad
+		}
+		hclPath := filepath.Join(root, ".cog", "config", "discord", "config.hcl")
+		if _, err := os.Stat(hclPath); err != nil {
+			return reconcile.ResourceStatus{
+				Sync:      reconcile.SyncStatusUnknown,
+				Health:    reconcile.HealthMissing,
+				Operation: reconcile.OperationIdle,
+				Message:   "no bot token configured",
+			}
+		}
+	}
+	return reconcile.NewResourceStatus(reconcile.SyncStatusUnknown, reconcile.HealthHealthy)
+}
+
+// ─── mcp-tools ────────────────────────────────────────────────────────────────
+
+type mcpToolsProvider struct{ stubMethods }
+
+func (p *mcpToolsProvider) Type() string { return "mcp-tools" }
+
+func (p *mcpToolsProvider) Health() reconcile.ResourceStatus {
+	if os.Getenv("OPENCLAW_URL") == "" {
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusUnknown,
+			Health:    reconcile.HealthSuspended,
+			Operation: reconcile.OperationIdle,
+			Message:   "OPENCLAW_URL not set — bridge not available",
+		}
+	}
+	root, bad := resolveRoot()
+	if bad != nil {
+		return *bad
+	}
+	statePath := filepath.Join(root, ".cog", "config", "mcp-tools", ".state.json")
+	if _, err := os.Stat(statePath); err != nil {
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusUnknown,
+			Health:    reconcile.HealthProgressing,
+			Operation: reconcile.OperationIdle,
+			Message:   "no state file — tools not yet discovered",
+		}
+	}
+	return reconcile.NewResourceStatus(reconcile.SyncStatusSynced, reconcile.HealthHealthy)
+}
+
+// ─── openclaw-agents ─────────────────────────────────────────────────────────
+
+type openclawAgentsProvider struct{ stubMethods }
+
+func (p *openclawAgentsProvider) Type() string { return "openclaw-agents" }
+
+func (p *openclawAgentsProvider) Health() reconcile.ResourceStatus {
+	home, _ := os.UserHomeDir()
+	configPath := filepath.Join(home, ".openclaw", "openclaw.json")
+	if _, err := os.Stat(configPath); err != nil {
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusUnknown,
+			Health:    reconcile.HealthMissing,
+			Operation: reconcile.OperationIdle,
+			Message:   "openclaw.json not found",
+		}
+	}
+	return reconcile.NewResourceStatus(reconcile.SyncStatusUnknown, reconcile.HealthHealthy)
+}
+
+// ─── openclaw-cron ───────────────────────────────────────────────────────────
+
+type openclawCronProvider struct{ stubMethods }
+
+func (p *openclawCronProvider) Type() string { return "openclaw-cron" }
+
+func (p *openclawCronProvider) Health() reconcile.ResourceStatus {
+	home, _ := os.UserHomeDir()
+	cronPath := filepath.Join(home, ".openclaw", "cron", "jobs.json")
+	if _, err := os.Stat(cronPath); err != nil {
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusUnknown,
+			Health:    reconcile.HealthMissing,
+			Operation: reconcile.OperationIdle,
+			Message:   "jobs.json not found (will be created on first apply)",
+		}
+	}
+	return reconcile.NewResourceStatus(reconcile.SyncStatusUnknown, reconcile.HealthHealthy)
+}
+
+// ─── openclaw-gateway ────────────────────────────────────────────────────────
+
+type openclawGatewayProvider struct{ stubMethods }
+
+func (p *openclawGatewayProvider) Type() string { return "openclaw-gateway" }
+
+func (p *openclawGatewayProvider) Health() reconcile.ResourceStatus {
+	home, _ := os.UserHomeDir()
+	configPath := filepath.Join(home, ".openclaw", "openclaw.json")
+	if _, err := os.Stat(configPath); err != nil {
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusUnknown,
+			Health:    reconcile.HealthMissing,
+			Operation: reconcile.OperationIdle,
+			Message:   "openclaw.json not found",
+		}
+	}
+	return reconcile.NewResourceStatus(reconcile.SyncStatusUnknown, reconcile.HealthHealthy)
+}
+
+// ─── service ─────────────────────────────────────────────────────────────────
+
+// serviceProvider checks for service CRD yaml files under
+// .cog/config/services/. Full Docker container-status checks require the
+// workspace-root CLI (cog plan service) — the daemon reports structural
+// presence only.
+type serviceProvider struct{ stubMethods }
+
+func (p *serviceProvider) Type() string { return "service" }
+
+func (p *serviceProvider) Health() reconcile.ResourceStatus {
+	root, bad := resolveRoot()
+	if bad != nil {
+		return *bad
+	}
+	servicesDir := filepath.Join(root, ".cog", "config", "services")
+	entries, err := os.ReadDir(servicesDir)
+	if err != nil {
+		// No services directory — treat as healthy (no services declared).
+		return reconcile.NewResourceStatus(reconcile.SyncStatusSynced, reconcile.HealthHealthy)
+	}
+	count := 0
+	for _, e := range entries {
+		if !e.IsDir() && filepath.Ext(e.Name()) == ".yaml" {
+			count++
+		}
+	}
+	if count == 0 {
+		return reconcile.NewResourceStatus(reconcile.SyncStatusSynced, reconcile.HealthHealthy)
+	}
+	return reconcile.ResourceStatus{
+		Sync:      reconcile.SyncStatusUnknown,
+		Health:    reconcile.HealthHealthy,
+		Operation: reconcile.OperationIdle,
+		Message:   fmt.Sprintf("%d service CRD(s) declared; runtime status requires CLI", count),
+	}
+}

--- a/internal/providers/daemon/daemon.go
+++ b/internal/providers/daemon/daemon.go
@@ -10,18 +10,24 @@
 //
 // This package provides daemon-safe provider structs whose Health()
 // implementations replicate the workspace-root logic using only importable
-// packages (os, filepath, pkg/reconcile, internal/workspace).
+// packages (os, filepath, pkg/reconcile).
 // The non-health methods (LoadConfig, FetchLive, ComputePlan, ApplyPlan,
 // BuildState) return errors — the daemon only exercises Health() through the
 // proprioception block.
+//
+// Workspace context is injected at boot via SetWorkspaceRoot(), called by
+// engine.SetProvidersWorkspace after LoadConfig resolves cfg.WorkspaceRoot.
+// This avoids the workspace.ResolveWorkspace() dependency-injection seams
+// (LoadConfig/GitRoot func vars) that are only wired in the cog CLI's main
+// package, not in cmd/cogos.
 //
 // The component provider is already fully extracted to
 // internal/providers/component and is wired here via blank import.
 // The other seven are implemented as minimal structs below.
 //
-// cmd/cogos/providers_wire.go blank-imports this package so its init()
-// runs at daemon boot, completing the registration before the HTTP server
-// starts.
+// cmd/cogos/providers_wire.go imports this package (triggering init()) and
+// wires both engine.RegisterProviders and engine.SetProvidersWorkspace so
+// the full seam is operational before the HTTP server starts serving requests.
 package daemon
 
 import (
@@ -29,13 +35,37 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
-	"github.com/cogos-dev/cogos/internal/workspace"
 	"github.com/cogos-dev/cogos/pkg/reconcile"
 
 	// Trigger internal/providers/component's init() which registers "component".
 	_ "github.com/cogos-dev/cogos/internal/providers/component"
 )
+
+// workspaceRoot is set at daemon boot by SetWorkspaceRoot (called from
+// engine.SetProvidersWorkspace after LoadConfig resolves the workspace path).
+// It is read by resolveRoot() on every Health() probe. Zero value means
+// "not yet wired" — callers get a clear error rather than a silent bad result.
+var (
+	workspaceRootMu sync.RWMutex
+	workspaceRoot   string
+)
+
+// SetWorkspaceRoot injects the resolved workspace path into this package so
+// that all daemon-side provider Health() implementations can resolve their
+// filesystem checks without depending on workspace.ResolveWorkspace(), whose
+// dependency-injection seams (LoadConfig/GitRoot) are not wired in the
+// cmd/cogos binary.
+//
+// Must be called before any provider Health() invocation — engine.runServe()
+// calls it via engine.SetProvidersWorkspace immediately after LoadConfig
+// resolves cfg.WorkspaceRoot.
+func SetWorkspaceRoot(root string) {
+	workspaceRootMu.Lock()
+	defer workspaceRootMu.Unlock()
+	workspaceRoot = root
+}
 
 func init() {
 	reconcile.RegisterProvider("agent", &agentProvider{})
@@ -47,15 +77,19 @@ func init() {
 	reconcile.RegisterProvider("service", &serviceProvider{})
 }
 
-// resolveRoot returns workspace root or an error status.
+// resolveRoot returns the workspace root or an error status.
+// It reads the package-level workspaceRoot set by SetWorkspaceRoot, bypassing
+// workspace.ResolveWorkspace() whose DI seams are not wired in cmd/cogos.
 func resolveRoot() (string, *reconcile.ResourceStatus) {
-	root, _, err := workspace.ResolveWorkspace()
-	if err != nil {
+	workspaceRootMu.RLock()
+	root := workspaceRoot
+	workspaceRootMu.RUnlock()
+	if root == "" {
 		s := reconcile.ResourceStatus{
 			Sync:      reconcile.SyncStatusUnknown,
 			Health:    reconcile.HealthMissing,
 			Operation: reconcile.OperationIdle,
-			Message:   "workspace not found",
+			Message:   "workspace not yet configured",
 		}
 		return "", &s
 	}

--- a/internal/providers/daemon/daemon_test.go
+++ b/internal/providers/daemon/daemon_test.go
@@ -1,0 +1,90 @@
+// daemon_test.go — verifies that importing this package registers all 8
+// expected Reconcilable providers with pkg/reconcile.
+//
+// This is the canonical test for verification gate 3: "after the
+// engine.Main-equivalent boot path runs, reconcile.ListProviders() returns
+// the 8 expected names."
+//
+// We don't start a server or invoke engine.Main() — we only confirm that
+// the package's init() side-effect wired the providers. This is sufficient
+// because cmd/cogos/providers_wire.go blank-imports this package, so the
+// same init() fires at daemon boot.
+package daemon_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/cogos-dev/cogos/pkg/reconcile"
+
+	// Blank import fires daemon.init(), registering all 8 providers.
+	_ "github.com/cogos-dev/cogos/internal/providers/daemon"
+)
+
+var expectedProviders = []string{
+	"agent",
+	"component",
+	"discord",
+	"mcp-tools",
+	"openclaw-agents",
+	"openclaw-cron",
+	"openclaw-gateway",
+	"service",
+}
+
+func TestDaemonInit_RegistersAll8Providers(t *testing.T) {
+	got := reconcile.ListProviders()
+	sort.Strings(got)
+
+	want := make([]string, len(expectedProviders))
+	copy(want, expectedProviders)
+	sort.Strings(want)
+
+	if len(got) != len(want) {
+		t.Fatalf("provider count: got %d want %d\ngot:  %v\nwant: %v", len(got), len(want), got, want)
+	}
+
+	missing := []string{}
+	for _, name := range want {
+		if !reconcile.HasProvider(name) {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		t.Errorf("missing providers after daemon init: %v\nregistered: %v", missing, got)
+	}
+}
+
+func TestDaemonProviders_TypeMethodsMatchNames(t *testing.T) {
+	for _, name := range expectedProviders {
+		p, err := reconcile.GetProvider(name)
+		if err != nil {
+			t.Errorf("GetProvider(%q): %v", name, err)
+			continue
+		}
+		if got := p.Type(); got != name {
+			t.Errorf("provider %q: Type()=%q, want %q", name, got, name)
+		}
+	}
+}
+
+func TestDaemonProviders_HealthDoesNotPanic(t *testing.T) {
+	for _, name := range expectedProviders {
+		p, err := reconcile.GetProvider(name)
+		if err != nil {
+			t.Errorf("GetProvider(%q): %v", name, err)
+			continue
+		}
+		// Health() must not panic. We don't assert on the return value
+		// because it depends on filesystem state (workspace presence,
+		// ~/.openclaw/openclaw.json, etc.) which varies by environment.
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("provider %q Health() panicked: %v", name, r)
+				}
+			}()
+			_ = p.Health()
+		}()
+	}
+}


### PR DESCRIPTION
## What

Two commits that together let \`cmd/cogos\` daemon-side Reconcilable providers report real Health() against an injected workspace path:

1. **`feat(engine): bridge reconcile registry seam so daemon exposes all 8 providers`** — adds `engine.RegisterProviders` hook variable and the `internal/providers/daemon` + `component` packages that wire the 8 production providers (agent, component, discord, mcp-tools, openclaw-{agents,cron,gateway}, service) into pkg/reconcile via init() side-effect.
2. **`fix(providers/daemon): wire SetWorkspaceRoot DI seam for daemon-side providers`** — daemon providers can't use \`workspace.ResolveWorkspace()\` because that helper depends on \`LoadConfig/GitRoot\` DI seams only wired in the \`cog\` CLI binary. Adds a package-level \`workspaceRoot\` var + \`SetWorkspaceRoot()\` setter on both daemon and component packages, plumbed via a new \`engine.SetProvidersWorkspace\` function variable that \`cli.runServe()\` calls right after \`LoadConfig\`.

Also adds \`engine.RegisterMCPExtensions\` hook (nil-guarded) so future packages (eval, etc.) can register additional MCP tools without importing internal/engine directly.

## Why

The kernel daemon at \`cmd/cogos\` boots with no Reconcilable providers because no init() side-effect imports daemon registrations there. This PR wires that bridge and adds the workspace context machinery the daemon providers need to perform real filesystem health checks.

## How

Pattern follows existing `cog` CLI binary's wiring shape — `engine.X = func() { ... }` seam variables set in `cmd/cogos/providers_wire.go`. All seam variables are nil-guarded so test binaries that register stub providers directly are unaffected.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/providers/...` passes (daemon test verifies all 8 providers register)
- [x] `go test ./internal/engine/...` passes
- [ ] CI green

## Notes

- Foundational PR — others in the sync wave (autonomic ticker, Phase C eval, dashboard autonomic history) build on this.
- The \`evalProvider\` registration and \`eval\` MCP tool wiring are intentionally **not** in this PR — they will land in the Phase C eval subsystem PR which adds the \`internal/eval/*\` package that those references require.