### PR TITLE
feat(router): provider-alias resolution + providers.local.yaml deep-merge + dispatch timeout headroom

### DIFF
--- a/internal/engine/agent_dispatch_query.go
+++ b/internal/engine/agent_dispatch_query.go
@@ -15,10 +15,13 @@ import (
 // h.httpClient.Timeout (180s) so the inner HTTP call is the actual cap.
 const dispatchTimeoutDefault = 30
 
-// dispatchTimeoutMax caps the per-slot budget. 120s lines up with the
-// existing AgentController.TriggerAgent wait limit (90s) plus a buffer for
-// degraded-network / 26B routing.
-const dispatchTimeoutMax = 120
+// dispatchTimeoutMax caps the per-slot budget. 300s accommodates cold-start
+// load of larger local models (gemma4:e4b at ~110s on M4 Pro) plus the
+// localHarnessCycleTimeout (300s) for tool-loop dispatches that run multiple
+// Ollama round-trips. The previous 120s cap was lifted from the legacy
+// TriggerAgent wait limit, but eval sweeps and Reconcilable-driven
+// dispatches need headroom for cold cycles.
+const dispatchTimeoutMax = 300
 
 // dispatchNDefault is the parallel fan-out when 0 is passed. Mirrors the
 // "single dispatch" baseline so a minimal call shape behaves like a normal

--- a/internal/engine/agent_dispatch_query_test.go
+++ b/internal/engine/agent_dispatch_query_test.go
@@ -61,8 +61,8 @@ func TestQueryDispatchToHarness_ClampsRanges(t *testing.T) {
 	if disp.lastReq.N != 4 {
 		t.Errorf("N not clamped to 4, got %d", disp.lastReq.N)
 	}
-	if disp.lastReq.TimeoutSeconds != 120 {
-		t.Errorf("TimeoutSeconds not clamped to 120, got %d", disp.lastReq.TimeoutSeconds)
+	if disp.lastReq.TimeoutSeconds != 300 {
+		t.Errorf("TimeoutSeconds not clamped to 300, got %d", disp.lastReq.TimeoutSeconds)
 	}
 }
 

--- a/internal/engine/local_agent_harness.go
+++ b/internal/engine/local_agent_harness.go
@@ -29,7 +29,7 @@ var defaultLocalHarnessToolScope = []string{
 
 const (
 	localHarnessHistoryLimit   = 24
-	localHarnessCycleTimeout   = 90 * time.Second
+	localHarnessCycleTimeout   = 5 * time.Minute
 	localHarnessAssessMaxToks  = 256
 	localHarnessExecuteMaxToks = 1024
 )

--- a/internal/engine/provider.go
+++ b/internal/engine/provider.go
@@ -32,6 +32,12 @@ type Provider interface {
 	// Name returns the provider identifier (e.g. "ollama", "anthropic").
 	Name() string
 
+	// Model returns the configured model identifier for this provider
+	// (e.g. "gemma4:e4b", "sonnet", "gemma-4-e4b-agentic-opus-reasoning-geminicli-mlx").
+	// Used by the router to resolve OpenAI-compat `model: X` requests to the
+	// provider serving X. Empty string means "no specific model" (stubs/tests).
+	Model() string
+
 	// Available reports whether the provider is ready to serve requests.
 	// For local providers: checks the model server is running and model loaded.
 	Available(ctx context.Context) bool
@@ -310,6 +316,12 @@ type Router interface {
 
 	// DeregisterProvider removes a provider.
 	DeregisterProvider(name string)
+
+	// ProviderForModel returns the registered provider name whose Name() or
+	// Model() matches the requested model string. Used by the OpenAI-compat
+	// chat handler to resolve `model: X` to the provider serving X. Returns
+	// ("", false) when no match. Name match takes precedence over model match.
+	ProviderForModel(model string) (string, bool)
 
 	// Stats returns routing statistics.
 	Stats() RouterStats

--- a/internal/engine/provider.go
+++ b/internal/engine/provider.go
@@ -317,6 +317,13 @@ type Router interface {
 	// DeregisterProvider removes a provider.
 	DeregisterProvider(name string)
 
+	// ProviderForName returns the registered provider name when `name` is an
+	// exact match for a provider's Name(). Used to detect provider aliases
+	// in OpenAI-compat `model: X` requests so callers can target a specific
+	// provider without forwarding the alias as a ModelOverride. Returns
+	// ("", false) when no provider matches.
+	ProviderForName(name string) (string, bool)
+
 	// ProviderForModel returns the registered provider name whose Name() or
 	// Model() matches the requested model string. Used by the OpenAI-compat
 	// chat handler to resolve `model: X` to the provider serving X. Returns

--- a/internal/engine/provider_anthropic.go
+++ b/internal/engine/provider_anthropic.go
@@ -76,6 +76,9 @@ func NewAnthropicProvider(name string, cfg ProviderConfig) *AnthropicProvider {
 // Name returns the provider identifier.
 func (p *AnthropicProvider) Name() string { return p.name }
 
+// Model returns the configured model identifier.
+func (p *AnthropicProvider) Model() string { return p.model }
+
 // Available reports whether an API key is configured.
 // For cloud providers we avoid a network round-trip on every health check —
 // the presence of a non-empty API key is the availability signal.

--- a/internal/engine/provider_claudecode.go
+++ b/internal/engine/provider_claudecode.go
@@ -95,6 +95,9 @@ func NewClaudeCodeProvider(name string, cfg ProviderConfig, procMgr *ProcessMana
 // Name returns the provider identifier.
 func (p *ClaudeCodeProvider) Name() string { return p.name }
 
+// Model returns the configured model identifier (e.g. "sonnet", "haiku").
+func (p *ClaudeCodeProvider) Model() string { return p.model }
+
 // Available checks that the claude binary exists and is authenticated.
 func (p *ClaudeCodeProvider) Available(ctx context.Context) bool {
 	path, err := exec.LookPath(p.cliBinary)

--- a/internal/engine/provider_codex.go
+++ b/internal/engine/provider_codex.go
@@ -88,7 +88,8 @@ func NewCodexProvider(name string, cfg ProviderConfig) *CodexProvider {
 	}
 }
 
-func (p *CodexProvider) Name() string { return p.name }
+func (p *CodexProvider) Name() string  { return p.name }
+func (p *CodexProvider) Model() string { return p.model }
 
 func (p *CodexProvider) resolveBinary() (string, error) {
 	if path, err := codexLookPath(p.binary); err == nil && path != "" {

--- a/internal/engine/provider_ollama.go
+++ b/internal/engine/provider_ollama.go
@@ -84,7 +84,8 @@ func NewOllamaProvider(name string, cfg ProviderConfig) *OllamaProvider {
 }
 
 // Name returns the provider identifier.
-func (p *OllamaProvider) Name() string { return p.name }
+func (p *OllamaProvider) Name() string  { return p.name }
+func (p *OllamaProvider) Model() string { return p.model }
 
 // Available checks if Ollama is running and the configured model is loaded.
 func (p *OllamaProvider) Available(ctx context.Context) bool {

--- a/internal/engine/provider_openai.go
+++ b/internal/engine/provider_openai.go
@@ -75,6 +75,9 @@ func NewOpenAICompatProvider(name string, cfg ProviderConfig) *OpenAICompatProvi
 // Name returns the provider identifier.
 func (p *OpenAICompatProvider) Name() string { return p.name }
 
+// Model returns the configured model identifier.
+func (p *OpenAICompatProvider) Model() string { return p.model }
+
 // Available checks if the server is reachable and has at least one model.
 func (p *OpenAICompatProvider) Available(ctx context.Context) bool {
 	models, err := p.listModels(ctx)

--- a/internal/engine/provider_pi.go
+++ b/internal/engine/provider_pi.go
@@ -80,7 +80,8 @@ func NewPiProvider(name string, cfg ProviderConfig, procMgr *ProcessManager) *Pi
 	}
 }
 
-func (p *PiProvider) Name() string { return p.name }
+func (p *PiProvider) Name() string  { return p.name }
+func (p *PiProvider) Model() string { return p.model }
 
 func (p *PiProvider) Available(ctx context.Context) bool {
 	path, err := exec.LookPath(p.piBinary)

--- a/internal/engine/provider_stub.go
+++ b/internal/engine/provider_stub.go
@@ -44,9 +44,10 @@ func NewStubProvider(name, response string) *StubProvider {
 	}
 }
 
-func (s *StubProvider) Name() string                              { return s.name }
-func (s *StubProvider) Available(_ context.Context) bool          { return s.available }
-func (s *StubProvider) Capabilities() ProviderCapabilities        { return s.capabilities }
+func (s *StubProvider) Name() string                       { return s.name }
+func (s *StubProvider) Model() string                      { return "" }
+func (s *StubProvider) Available(_ context.Context) bool   { return s.available }
+func (s *StubProvider) Capabilities() ProviderCapabilities { return s.capabilities }
 
 func (s *StubProvider) Ping(_ context.Context) (time.Duration, error) {
 	if s.err != nil {

--- a/internal/engine/router.go
+++ b/internal/engine/router.go
@@ -17,6 +17,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -51,11 +52,16 @@ func NewSimpleRouter(cfg RoutingConfig) *SimpleRouter {
 }
 
 // RegisterProvider adds a provider to the pool.
+// Providers are kept sorted by Name() so that ProviderForModel iteration
+// is deterministic when multiple providers share the same Model() string.
 func (r *SimpleRouter) RegisterProvider(p Provider) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.byName[p.Name()] = p
 	r.providers = append(r.providers, p)
+	sort.Slice(r.providers, func(i, j int) bool {
+		return r.providers[i].Name() < r.providers[j].Name()
+	})
 }
 
 // DeregisterProvider removes a provider by name.
@@ -449,6 +455,8 @@ func mergeRoutingConfig(base, overlay RoutingConfig) RoutingConfig {
 	if overlay.LocalThreshold != 0 {
 		base.LocalThreshold = overlay.LocalThreshold
 	}
+	// FallbackChain is intentionally replaced wholesale (not element-merged) so the overlay
+	// can reorder or shrink the chain; element-wise merge would make removal impossible.
 	if len(overlay.FallbackChain) > 0 {
 		base.FallbackChain = overlay.FallbackChain
 	}

--- a/internal/engine/router.go
+++ b/internal/engine/router.go
@@ -72,6 +72,22 @@ func (r *SimpleRouter) DeregisterProvider(name string) {
 	r.providers = updated
 }
 
+// ProviderForName returns the registered provider name when `name` is an
+// exact match for a provider's Name(). Used to detect provider aliases so
+// callers can target a specific provider without forwarding the alias as a
+// ModelOverride. Returns ("", false) when no provider matches.
+func (r *SimpleRouter) ProviderForName(name string) (string, bool) {
+	if name == "" {
+		return "", false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if p, ok := r.byName[name]; ok {
+		return p.Name(), true
+	}
+	return "", false
+}
+
 // ProviderForModel returns the registered provider name whose Name() or
 // Model() matches `model`. Name match takes precedence over model match so
 // callers can target a specific provider instance even when multiple

--- a/internal/engine/router.go
+++ b/internal/engine/router.go
@@ -72,6 +72,28 @@ func (r *SimpleRouter) DeregisterProvider(name string) {
 	r.providers = updated
 }
 
+// ProviderForModel returns the registered provider name whose Name() or
+// Model() matches `model`. Name match takes precedence over model match so
+// callers can target a specific provider instance even when multiple
+// providers serve the same underlying model. Returns ("", false) when no
+// provider matches.
+func (r *SimpleRouter) ProviderForModel(model string) (string, bool) {
+	if model == "" {
+		return "", false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if p, ok := r.byName[model]; ok {
+		return p.Name(), true
+	}
+	for _, p := range r.providers {
+		if p.Model() == model {
+			return p.Name(), true
+		}
+	}
+	return "", false
+}
+
 // Route selects the best available provider for the request.
 func (r *SimpleRouter) Route(ctx context.Context, req *CompletionRequest) (Provider, *RoutingDecision, error) {
 	start := time.Now()
@@ -305,8 +327,8 @@ func WithProcessManager(pm *ProcessManager) BuildRouterOption {
 }
 
 func loadProvidersConfig(cfg *Config) (ProvidersConfig, error) {
-	path := filepath.Join(cfg.CogDir, "config", "providers.yaml")
-	data, err := os.ReadFile(path)
+	basePath := filepath.Join(cfg.CogDir, "config", "providers.yaml")
+	data, err := os.ReadFile(basePath)
 	if err != nil {
 		return ProvidersConfig{}, err
 	}
@@ -314,8 +336,118 @@ func loadProvidersConfig(cfg *Config) (ProvidersConfig, error) {
 	if err := yaml.Unmarshal(data, &pcfg); err != nil {
 		return ProvidersConfig{}, fmt.Errorf("parse providers.yaml: %w", err)
 	}
+
+	// Deep-merge providers.local.yaml on top if present. The local file is
+	// gitignored and holds node-specific endpoints, API key env-var names, and
+	// fallback overrides. Documented since the file shipped; this is the
+	// implementation that backs the documentation.
+	localPath := filepath.Join(cfg.CogDir, "config", "providers.local.yaml")
+	if localData, lerr := os.ReadFile(localPath); lerr == nil {
+		var local ProvidersConfig
+		if perr := yaml.Unmarshal(localData, &local); perr != nil {
+			slog.Warn("router: providers.local.yaml parse error, ignoring overlay", "err", perr)
+		} else {
+			pcfg = mergeProvidersConfig(pcfg, local)
+			slog.Info("router: providers.local.yaml merged",
+				"providers_added", len(local.Providers),
+				"path", localPath,
+			)
+		}
+	} else if !os.IsNotExist(lerr) {
+		slog.Warn("router: providers.local.yaml read error, ignoring overlay", "err", lerr)
+	}
+
 	applyLocalModelConfig(cfg, &pcfg)
 	return pcfg, nil
+}
+
+// mergeProvidersConfig deep-merges overlay onto base and returns the result.
+// Per-provider entries are field-level merged (overlay non-zero values win,
+// zero values keep base). Routing uses the same shape. New providers in the
+// overlay are added; the base map is preserved for keys not in overlay.
+func mergeProvidersConfig(base, overlay ProvidersConfig) ProvidersConfig {
+	if overlay.Providers != nil {
+		if base.Providers == nil {
+			base.Providers = make(map[string]ProviderConfig, len(overlay.Providers))
+		}
+		for name, oc := range overlay.Providers {
+			if existing, ok := base.Providers[name]; ok {
+				base.Providers[name] = mergeProviderConfig(existing, oc)
+			} else {
+				base.Providers[name] = oc
+			}
+		}
+	}
+	base.Routing = mergeRoutingConfig(base.Routing, overlay.Routing)
+	return base
+}
+
+func mergeProviderConfig(base, overlay ProviderConfig) ProviderConfig {
+	if overlay.Type != "" {
+		base.Type = overlay.Type
+	}
+	if overlay.APIKeyEnv != "" {
+		base.APIKeyEnv = overlay.APIKeyEnv
+	}
+	if overlay.Endpoint != "" {
+		base.Endpoint = overlay.Endpoint
+	}
+	if overlay.Model != "" {
+		base.Model = overlay.Model
+	}
+	if overlay.ContextWindow != 0 {
+		base.ContextWindow = overlay.ContextWindow
+	}
+	if overlay.MaxTokens != 0 {
+		base.MaxTokens = overlay.MaxTokens
+	}
+	if overlay.Timeout != 0 {
+		base.Timeout = overlay.Timeout
+	}
+	if overlay.Enabled != nil {
+		base.Enabled = overlay.Enabled
+	}
+	if len(overlay.Headers) > 0 {
+		if base.Headers == nil {
+			base.Headers = make(map[string]string, len(overlay.Headers))
+		}
+		for k, v := range overlay.Headers {
+			base.Headers[k] = v
+		}
+	}
+	if len(overlay.Options) > 0 {
+		if base.Options == nil {
+			base.Options = make(map[string]interface{}, len(overlay.Options))
+		}
+		for k, v := range overlay.Options {
+			base.Options[k] = v
+		}
+	}
+	return base
+}
+
+func mergeRoutingConfig(base, overlay RoutingConfig) RoutingConfig {
+	if overlay.Default != "" {
+		base.Default = overlay.Default
+	}
+	if overlay.LocalThreshold != 0 {
+		base.LocalThreshold = overlay.LocalThreshold
+	}
+	if len(overlay.FallbackChain) > 0 {
+		base.FallbackChain = overlay.FallbackChain
+	}
+	if overlay.MaxCostPerDayUSD != 0 {
+		base.MaxCostPerDayUSD = overlay.MaxCostPerDayUSD
+	}
+	if len(overlay.ProcessStateRouting) > 0 {
+		if base.ProcessStateRouting == nil {
+			base.ProcessStateRouting = make(map[string]string, len(overlay.ProcessStateRouting))
+		}
+		for k, v := range overlay.ProcessStateRouting {
+			base.ProcessStateRouting[k] = v
+		}
+	}
+	return base
 }
 
 func applyLocalModelConfig(cfg *Config, pcfg *ProvidersConfig) {

--- a/internal/engine/router_test.go
+++ b/internal/engine/router_test.go
@@ -416,3 +416,109 @@ func keysOf(m map[string]ProviderConfig) []string {
 	}
 	return out
 }
+
+// ── ProviderForName / ProviderForModel ───────────────────────────────────────
+
+// modelStub wraps a StubProvider but overrides Model() to return a fixed string.
+// Used to test ProviderForModel resolution without modifying StubProvider.
+type modelStub struct {
+	*StubProvider
+	model string
+}
+
+func (m *modelStub) Model() string { return m.model }
+
+// TestProviderForName_AliasHit verifies that when req.Model matches a registered
+// provider's Name(), ProviderForName returns (name, true) so the caller knows
+// NOT to set a ModelOverride — the provider already knows its configured model.
+func TestProviderForName_AliasHit(t *testing.T) {
+	t.Parallel()
+	r := NewSimpleRouter(RoutingConfig{Default: "mlx-gemma"})
+	r.RegisterProvider(NewStubProvider("mlx-gemma", ""))
+
+	name, ok := r.ProviderForName("mlx-gemma")
+	if !ok {
+		t.Fatal("ProviderForName: expected hit, got miss")
+	}
+	if name != "mlx-gemma" {
+		t.Errorf("ProviderForName: got %q; want mlx-gemma", name)
+	}
+}
+
+// TestProviderForName_Miss verifies that a string that is not a registered
+// provider name returns ("", false), so the caller falls through to ModelOverride.
+func TestProviderForName_Miss(t *testing.T) {
+	t.Parallel()
+	r := NewSimpleRouter(RoutingConfig{})
+	r.RegisterProvider(NewStubProvider("mlx-gemma", ""))
+
+	_, ok := r.ProviderForName("gemma-3-4b-it")
+	if ok {
+		t.Error("ProviderForName: expected miss for non-name model string, got hit")
+	}
+}
+
+// TestProviderForModel_HitSetsPreferProvider verifies that when req.Model is not
+// a provider alias (ProviderForName miss) but matches a provider's Model() string,
+// ProviderForModel returns (name, true) — the caller should set PreferProvider AND
+// ModelOverride so the targeted provider gets the explicit model id.
+func TestProviderForModel_HitSetsPreferProvider(t *testing.T) {
+	t.Parallel()
+	r := NewSimpleRouter(RoutingConfig{Default: "cloud"})
+	cloud := &modelStub{StubProvider: NewStubProvider("cloud", ""), model: "claude-opus-4"}
+	r.RegisterProvider(cloud)
+
+	name, ok := r.ProviderForModel("claude-opus-4")
+	if !ok {
+		t.Fatal("ProviderForModel: expected hit, got miss")
+	}
+	if name != "cloud" {
+		t.Errorf("ProviderForModel: got %q; want cloud", name)
+	}
+}
+
+// TestProviderForModel_Miss verifies ("", false) when no provider's Name or Model
+// matches — the caller should route via defaults with ModelOverride only.
+func TestProviderForModel_Miss(t *testing.T) {
+	t.Parallel()
+	r := NewSimpleRouter(RoutingConfig{})
+	r.RegisterProvider(NewStubProvider("ollama", ""))
+
+	_, ok := r.ProviderForModel("gpt-5")
+	if ok {
+		t.Error("ProviderForModel: expected miss for unknown model, got hit")
+	}
+}
+
+// TestProviderForModel_DeterministicTiebreak verifies that when two providers
+// declare the same Model() string, ProviderForModel always resolves to the same
+// one. Providers are sorted by Name() on registration, so the alphabetically first
+// name wins consistently regardless of registration order.
+func TestProviderForModel_DeterministicTiebreak(t *testing.T) {
+	t.Parallel()
+
+	const sharedModel = "gemma-3-4b-it"
+
+	// Register in reverse-alpha order to confirm sort, not insertion, governs.
+	r := NewSimpleRouter(RoutingConfig{Default: "zebra"})
+	r.RegisterProvider(&modelStub{StubProvider: NewStubProvider("zebra", ""), model: sharedModel})
+	r.RegisterProvider(&modelStub{StubProvider: NewStubProvider("alpha", ""), model: sharedModel})
+	r.RegisterProvider(&modelStub{StubProvider: NewStubProvider("mango", ""), model: sharedModel})
+
+	name, ok := r.ProviderForModel(sharedModel)
+	if !ok {
+		t.Fatal("ProviderForModel: expected hit, got miss")
+	}
+	// "alpha" sorts first — that should always win.
+	if name != "alpha" {
+		t.Errorf("ProviderForModel: got %q; want alpha (alphabetically first)", name)
+	}
+
+	// Call multiple times to confirm stability.
+	for range 10 {
+		got, _ := r.ProviderForModel(sharedModel)
+		if got != name {
+			t.Errorf("ProviderForModel: non-deterministic — got %q on repeat, want %q", got, name)
+		}
+	}
+}

--- a/internal/engine/router_test.go
+++ b/internal/engine/router_test.go
@@ -282,3 +282,137 @@ routing:
 		t.Errorf("ollama model = %q; want gemma4:e2b", pcfg.Providers["ollama"].Model)
 	}
 }
+
+// TestLoadProvidersConfigDeepMergesLocalYAML verifies that providers.local.yaml
+// is deep-merged over providers.yaml — node-specific endpoints, env-var-backed
+// API keys, and additional providers all land in the merged config without
+// requiring the user to copy the entire defaults file.
+func TestLoadProvidersConfigDeepMergesLocalYAML(t *testing.T) {
+	t.Parallel()
+
+	root := makeWorkspace(t)
+	writeTestFile(t, filepath.Join(root, ".cog", "config", "providers.yaml"), `providers:
+  ollama:
+    type: ollama
+    enabled: true
+    endpoint: "http://localhost:11434"
+    model: "gemma4:e4b"
+    timeout: 60
+  claude-code:
+    type: claude-code
+    model: sonnet
+    timeout: 300
+routing:
+  default: claude-code
+  fallback_chain: [claude-code, ollama]
+  process_state_routing:
+    active: claude-code
+    receptive: ollama
+`)
+
+	writeTestFile(t, filepath.Join(root, ".cog", "config", "providers.local.yaml"), `providers:
+  ollama:
+    context_window: 32768
+  lmstudio-mlx:
+    type: openai
+    endpoint: http://localhost:1234
+    model: gemma-mlx-id
+    api_key_env: LMS_API_KEY
+    options:
+      is_local: true
+routing:
+  fallback_chain: [claude-code, lmstudio-mlx, ollama]
+  process_state_routing:
+    consolidating: lmstudio-mlx
+`)
+
+	cfg, err := LoadConfig(root, 0)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	pcfg, err := loadProvidersConfig(cfg)
+	if err != nil {
+		t.Fatalf("loadProvidersConfig: %v", err)
+	}
+
+	// Existing provider field-level merge: ollama keeps base type/endpoint,
+	// gains context_window from overlay.
+	ollama := pcfg.Providers["ollama"]
+	if ollama.Type != "ollama" {
+		t.Errorf("ollama type = %q; want preserved 'ollama'", ollama.Type)
+	}
+	if ollama.Endpoint != "http://localhost:11434" {
+		t.Errorf("ollama endpoint changed unexpectedly: %q", ollama.Endpoint)
+	}
+	if ollama.ContextWindow != 32768 {
+		t.Errorf("ollama context_window = %d; want 32768 from overlay", ollama.ContextWindow)
+	}
+
+	// New provider added wholesale.
+	lms, ok := pcfg.Providers["lmstudio-mlx"]
+	if !ok {
+		t.Fatalf("lmstudio-mlx not added by overlay; providers=%v", keysOf(pcfg.Providers))
+	}
+	if lms.Type != "openai" || lms.Endpoint != "http://localhost:1234" || lms.APIKeyEnv != "LMS_API_KEY" {
+		t.Errorf("lmstudio-mlx fields wrong: %+v", lms)
+	}
+	if v, ok := lms.Options["is_local"].(bool); !ok || !v {
+		t.Errorf("lmstudio-mlx options.is_local not preserved: %v", lms.Options)
+	}
+
+	// Routing merged: fallback_chain replaced, process_state_routing extended
+	// (active/receptive preserved from base, consolidating added by overlay).
+	if got := pcfg.Routing.FallbackChain; len(got) != 3 || got[1] != "lmstudio-mlx" {
+		t.Errorf("fallback_chain = %v; want overlay value", got)
+	}
+	if pcfg.Routing.ProcessStateRouting["active"] != "claude-code" {
+		t.Error("process_state_routing.active lost during merge")
+	}
+	if pcfg.Routing.ProcessStateRouting["consolidating"] != "lmstudio-mlx" {
+		t.Errorf("process_state_routing.consolidating = %q; want overlay value",
+			pcfg.Routing.ProcessStateRouting["consolidating"])
+	}
+
+	// Untouched provider preserved.
+	if pcfg.Providers["claude-code"].Type != "claude-code" {
+		t.Error("claude-code provider lost during merge")
+	}
+}
+
+// TestLoadProvidersConfigSkipsMissingLocalYAML verifies that a missing
+// providers.local.yaml is not an error — the base config is returned as-is.
+func TestLoadProvidersConfigSkipsMissingLocalYAML(t *testing.T) {
+	t.Parallel()
+
+	root := makeWorkspace(t)
+	writeTestFile(t, filepath.Join(root, ".cog", "config", "providers.yaml"), `providers:
+  ollama:
+    type: ollama
+    model: gemma4:e4b
+routing:
+  default: ollama
+`)
+	// Deliberately do NOT write providers.local.yaml.
+
+	cfg, err := LoadConfig(root, 0)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	pcfg, err := loadProvidersConfig(cfg)
+	if err != nil {
+		t.Fatalf("loadProvidersConfig: %v", err)
+	}
+	if pcfg.Providers["ollama"].Model != "gemma4:e4b" {
+		t.Errorf("base config not returned cleanly: %+v", pcfg.Providers["ollama"])
+	}
+}
+
+func keysOf(m map[string]ProviderConfig) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -725,16 +725,25 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 	case "ollama":
 		creq.Metadata.PreferProvider = "ollama"
 	default:
-		// Pass through as model override (e.g. "opus", "haiku", "gpt-5.4").
-		creq.ModelOverride = req.Model
-		// If a registered provider's name or configured model matches, prefer
-		// it explicitly so the request lands at the provider serving that
-		// model rather than falling through to the process-state default.
-		// This is what makes `model: lmstudio-mlx` or
-		// `model: gemma-4-e4b-agentic-opus-reasoning-geminicli-mlx` route
-		// to the LMS-MLX provider instead of claude-code (the active default).
-		if name, ok := s.router.ProviderForModel(req.Model); ok {
+		// First check: is req.Model a provider alias (exact name match)? If so,
+		// route to that provider with NO ModelOverride — the provider knows its
+		// own configured model and we shouldn't second-guess it. This is what
+		// makes `model: mlx-gemma` resolve to the mlx-gemma provider's
+		// preloaded path instead of forwarding "mlx-gemma" upstream as a model
+		// id (which mlx_lm.server would try to fetch from HuggingFace).
+		if name, byName := s.router.ProviderForName(req.Model); byName {
 			creq.Metadata.PreferProvider = name
+			// No ModelOverride; provider uses its configured model.
+		} else {
+			// Pass through as model override (e.g. "opus", "haiku", "gpt-5.4",
+			// or a full HF model id). If a provider's configured Model()
+			// matches, prefer it so the request lands at the provider serving
+			// that model rather than falling through to the process-state
+			// default.
+			creq.ModelOverride = req.Model
+			if name, ok := s.router.ProviderForModel(req.Model); ok {
+				creq.Metadata.PreferProvider = name
+			}
 		}
 	}
 

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -725,8 +725,17 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 	case "ollama":
 		creq.Metadata.PreferProvider = "ollama"
 	default:
-		// Pass through as model override (e.g. "opus", "haiku", "gpt-5.4")
+		// Pass through as model override (e.g. "opus", "haiku", "gpt-5.4").
 		creq.ModelOverride = req.Model
+		// If a registered provider's name or configured model matches, prefer
+		// it explicitly so the request lands at the provider serving that
+		// model rather than falling through to the process-state default.
+		// This is what makes `model: lmstudio-mlx` or
+		// `model: gemma-4-e4b-agentic-opus-reasoning-geminicli-mlx` route
+		// to the LMS-MLX provider instead of claude-code (the active default).
+		if name, ok := s.router.ProviderForModel(req.Model); ok {
+			creq.Metadata.PreferProvider = name
+		}
 	}
 
 	var pkg *ContextPackage

--- a/internal/engine/tool_loop_test.go
+++ b/internal/engine/tool_loop_test.go
@@ -327,7 +327,8 @@ func (p *scriptedToolLoopProvider) Stream(context.Context, *CompletionRequest) (
 	return ch, nil
 }
 
-func (p *scriptedToolLoopProvider) Name() string { return p.name }
+func (p *scriptedToolLoopProvider) Name() string  { return p.name }
+func (p *scriptedToolLoopProvider) Model() string { return "test" }
 
 func (p *scriptedToolLoopProvider) Available(context.Context) bool { return true }
 


### PR DESCRIPTION
## What

Three router/dispatch improvements landed together:

1. **`feat(dispatch): expand timeout headroom for slow-loading local models`** — local model startup (e.g. Ollama / mlx) can take longer than the previous default; expands the timeout window so cold-start dispatches don't false-fail.
2. **`feat(router): providers.local.yaml deep-merge + model-based routing`** — provider config from \`providers.local.yaml\` is deep-merged onto base config (rather than full-replace); router now picks providers based on declared model alias rather than just provider name.
3. **`feat(router): provider-alias resolution suppresses ModelOverride`** — when a request resolves through a provider alias, the alias's model is honored over the request's \`ModelOverride\` field, fixing the LMS-as-kernel-provider gap where the override clobbered the alias's intent.

## Why

Before these changes, two operational gaps:
- Slow local-model cold-starts produced timeout false-negatives.
- Provider configuration was append-only / replace-only; users couldn't override single fields.
- ModelOverride suppressed the alias's model selection, leading to wrong-provider routing for LM Studio (LMS).

## How

- \`router.go\`: alias resolution path; new ModelOverride suppression logic when an alias is in use.
- \`router_test.go\`: new test coverage for alias + override interaction and deep-merge behavior.
- Provider files (\`provider_anthropic\`, \`provider_codex\`, \`provider_openai\`, etc.): minor adjustments — most are passthrough touches.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test ./internal/engine/...\` passes (router tests included)
- [ ] CI green