### PR TITLE
feat(engine): Substrate Health proprioception block in foveated context

### DIFF
--- a/internal/engine/context_blocks_health.go
+++ b/internal/engine/context_blocks_health.go
@@ -1,0 +1,234 @@
+// context_blocks_health.go — proprioception block for the foveated context.
+//
+// buildHealthBlock iterates pkg/reconcile's provider registry, calls Health()
+// on each registered Reconcilable with a per-provider timeout, and renders a
+// compact "Substrate Health" block. This is the kernel's body-state surfacing
+// into Claude Code's foveated context — the return path that closes the
+// sensorium → cognitive substrate loop (proprioception, not perception).
+//
+// Design notes:
+//   - The block is cheap by design: Health() is a synchronous, near-zero-cost
+//     call by Reconcilable contract. Providers that take longer than the
+//     per-provider timeout (200ms) are marked Unknown so one slow provider
+//     can't stall the foveated handler.
+//   - Panic recovery is per-provider so a single broken Reconcilable can't
+//     suppress the whole block.
+//   - When everything is green, the rendering compresses to a single
+//     summary line; the full table only appears when at least one provider
+//     is non-healthy or non-synced. Proprioception should be cheap when the
+//     body is fine and expressive when it isn't.
+package engine
+
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cogos-dev/cogos/pkg/reconcile"
+)
+
+// healthProbeTimeout is the per-provider Health() timeout. Health() is
+// supposed to return cached/computed status without blocking; anything
+// slower indicates a defect we want to surface as Unknown rather than
+// silently stalling the foveated handler.
+const healthProbeTimeout = 200 * time.Millisecond
+
+// healthSample is the result of probing a single Reconcilable.
+type healthSample struct {
+	Name   string
+	Status reconcile.ResourceStatus
+	Probed time.Duration
+	Error  string // non-empty if probe failed (panic, timeout)
+}
+
+// isGreen reports whether a sample is fully healthy across all three axes.
+func (h *healthSample) isGreen() bool {
+	if h.Error != "" {
+		return false
+	}
+	return h.Status.Sync == reconcile.SyncStatusSynced &&
+		h.Status.Health == reconcile.HealthHealthy &&
+		(h.Status.Operation == reconcile.OperationIdle ||
+			h.Status.Operation == "")
+}
+
+// buildHealthBlock returns a context block summarizing the live status of
+// every registered Reconcilable. Returns nil when no providers are
+// registered (e.g. during a stripped-down test boot).
+func buildHealthBlock(ctx context.Context) *ContextBlock {
+	names := reconcile.ListProviders()
+	if len(names) == 0 {
+		return nil
+	}
+
+	samples := probeAllProviders(ctx, names)
+
+	greenCount := 0
+	for i := range samples {
+		if samples[i].isGreen() {
+			greenCount++
+		}
+	}
+
+	content := renderHealthBlock(samples, greenCount)
+	block := NewBlock(BlockHealth, content)
+	return &block
+}
+
+// probeAllProviders probes every named provider in parallel-friendly fashion
+// (each in its own goroutine with an independent timeout). The kernel's
+// registry mutex is only held briefly to fetch the provider reference.
+func probeAllProviders(ctx context.Context, names []string) []healthSample {
+	sort.Strings(names)
+	samples := make([]healthSample, len(names))
+	for i, name := range names {
+		samples[i] = probeOne(ctx, name)
+	}
+	return samples
+}
+
+// probeOne calls Health() on a single named provider. Recovers from panics
+// and respects healthProbeTimeout. Health() is supposed to be synchronous
+// and cheap; we run it in a goroutine so a misbehaving provider can't block
+// the foveated handler past the timeout.
+func probeOne(ctx context.Context, name string) healthSample {
+	provider, err := reconcile.GetProvider(name)
+	if err != nil {
+		return healthSample{Name: name, Error: err.Error()}
+	}
+
+	type result struct {
+		status reconcile.ResourceStatus
+		err    string
+	}
+	ch := make(chan result, 1)
+	start := time.Now()
+
+	go func() {
+		defer func() {
+			if rec := recover(); rec != nil {
+				ch <- result{
+					status: reconcile.ResourceStatus{
+						Sync:      reconcile.SyncStatusUnknown,
+						Health:    reconcile.HealthMissing,
+						Operation: reconcile.OperationIdle,
+						Message:   fmt.Sprintf("panic: %v", rec),
+					},
+					err: fmt.Sprintf("panic: %v\n%s", rec, debug.Stack()),
+				}
+			}
+		}()
+		ch <- result{status: provider.Health()}
+	}()
+
+	probeCtx, cancel := context.WithTimeout(ctx, healthProbeTimeout)
+	defer cancel()
+
+	select {
+	case r := <-ch:
+		return healthSample{Name: name, Status: r.status, Probed: time.Since(start), Error: r.err}
+	case <-probeCtx.Done():
+		return healthSample{
+			Name: name,
+			Status: reconcile.ResourceStatus{
+				Sync:      reconcile.SyncStatusUnknown,
+				Health:    reconcile.HealthMissing,
+				Operation: reconcile.OperationIdle,
+				Message:   fmt.Sprintf("Health() exceeded %s", healthProbeTimeout),
+			},
+			Probed: time.Since(start),
+			Error:  "timeout",
+		}
+	}
+}
+
+// renderHealthBlock formats samples for inclusion in the foveated context.
+// When every sample is green, output collapses to a single line. Otherwise
+// a markdown table is emitted with non-green samples first.
+func renderHealthBlock(samples []healthSample, greenCount int) string {
+	var sb strings.Builder
+	sb.WriteString("## Substrate Health\n\n")
+
+	total := len(samples)
+	if greenCount == total {
+		fmt.Fprintf(&sb, "%d providers — all Synced/Healthy/Idle.\n", total)
+		return sb.String()
+	}
+
+	// One-line summary first, then the table.
+	fmt.Fprintf(&sb, "%d providers — %d healthy, %d need attention.\n\n", total, greenCount, total-greenCount)
+
+	// Order: non-green first (sorted by name), then green (sorted by name).
+	nonGreen := make([]healthSample, 0, total-greenCount)
+	green := make([]healthSample, 0, greenCount)
+	for _, s := range samples {
+		if s.isGreen() {
+			green = append(green, s)
+		} else {
+			nonGreen = append(nonGreen, s)
+		}
+	}
+	ordered := append(nonGreen, green...)
+
+	sb.WriteString("| Provider | Sync | Health | Op | Note |\n")
+	sb.WriteString("|----------|------|--------|----|------|\n")
+	for _, s := range ordered {
+		note := s.Status.Message
+		if s.Error != "" && note == "" {
+			note = s.Error
+		}
+		note = compactNote(note)
+		fmt.Fprintf(&sb, "| %s | %s | %s | %s | %s |\n",
+			s.Name,
+			fallback(string(s.Status.Sync), "Unknown"),
+			fallback(string(s.Status.Health), "Missing"),
+			fallback(string(s.Status.Operation), "Idle"),
+			note,
+		)
+	}
+	return sb.String()
+}
+
+// compactNote trims a status message to a single line bounded length so the
+// table stays readable when injected into a prompt.
+func compactNote(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	// Collapse newlines and tabs to single spaces.
+	s = strings.Map(func(r rune) rune {
+		switch r {
+		case '\n', '\r', '\t':
+			return ' '
+		case '|':
+			// pipes would break the markdown table — replace with a slash.
+			return '/'
+		default:
+			return r
+		}
+	}, s)
+	// Squeeze multiple spaces.
+	for strings.Contains(s, "  ") {
+		s = strings.ReplaceAll(s, "  ", " ")
+	}
+	const maxNote = 100
+	if len(s) > maxNote {
+		// Break at a word boundary if possible.
+		if idx := strings.LastIndex(s[:maxNote], " "); idx > maxNote/2 {
+			return s[:idx] + "…"
+		}
+		return s[:maxNote] + "…"
+	}
+	return s
+}
+
+func fallback(s, def string) string {
+	if s == "" {
+		return def
+	}
+	return s
+}

--- a/internal/engine/context_blocks_health_test.go
+++ b/internal/engine/context_blocks_health_test.go
@@ -1,0 +1,403 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cogos-dev/cogos/pkg/reconcile"
+)
+
+// stubProvider is a minimal Reconcilable used for unit-testing the health
+// block builder. Only Type() and Health() are exercised; the other methods
+// satisfy the interface but should not be called by buildHealthBlock.
+type stubProvider struct {
+	name      string
+	status    reconcile.ResourceStatus
+	delay     time.Duration
+	panicWith any
+}
+
+func (s *stubProvider) Type() string { return s.name }
+
+func (s *stubProvider) LoadConfig(string) (any, error) {
+	return nil, nil
+}
+
+func (s *stubProvider) FetchLive(context.Context, any) (any, error) {
+	return nil, nil
+}
+
+func (s *stubProvider) ComputePlan(any, any, *reconcile.State) (*reconcile.Plan, error) {
+	return nil, nil
+}
+
+func (s *stubProvider) ApplyPlan(context.Context, *reconcile.Plan) ([]reconcile.Result, error) {
+	return nil, nil
+}
+
+func (s *stubProvider) BuildState(any, any, *reconcile.State) (*reconcile.State, error) {
+	return nil, nil
+}
+
+func (s *stubProvider) Health() reconcile.ResourceStatus {
+	if s.panicWith != nil {
+		panic(s.panicWith)
+	}
+	if s.delay > 0 {
+		time.Sleep(s.delay)
+	}
+	return s.status
+}
+
+// healthRegistryMu serializes registry mutations across tests; Go's testing
+// package runs t.Parallel tests concurrently and the registry is global.
+var healthRegistryMu sync.Mutex
+
+// withProviders sets up the global reconcile registry with the supplied
+// providers, runs fn, and resets the registry at the end. NOT safe for
+// t.Parallel() — uses a package-level mutex.
+func withProviders(t *testing.T, providers []*stubProvider, fn func()) {
+	t.Helper()
+	healthRegistryMu.Lock()
+	defer healthRegistryMu.Unlock()
+
+	reconcile.ResetProviders()
+	defer reconcile.ResetProviders()
+
+	for _, p := range providers {
+		reconcile.RegisterProvider(p.name, p)
+	}
+	fn()
+}
+
+func TestBuildHealthBlock_EmptyRegistry(t *testing.T) {
+	withProviders(t, nil, func() {
+		blk := buildHealthBlock(context.Background())
+		if blk != nil {
+			t.Fatalf("expected nil block when registry empty, got %+v", blk)
+		}
+	})
+}
+
+func TestBuildHealthBlock_AllGreenCollapses(t *testing.T) {
+	providers := []*stubProvider{
+		{name: "alpha", status: greenStatus()},
+		{name: "beta", status: greenStatus()},
+		{name: "gamma", status: greenStatus()},
+	}
+	withProviders(t, providers, func() {
+		blk := buildHealthBlock(context.Background())
+		if blk == nil {
+			t.Fatal("expected non-nil block")
+		}
+		if blk.Name != BlockHealth {
+			t.Errorf("block name: got %q want %q", blk.Name, BlockHealth)
+		}
+		// All-green should NOT include a markdown table.
+		if strings.Contains(blk.Content, "| Provider |") {
+			t.Errorf("all-green block should collapse to one line, got table:\n%s", blk.Content)
+		}
+		if !strings.Contains(blk.Content, "3 providers") {
+			t.Errorf("expected '3 providers' summary, got:\n%s", blk.Content)
+		}
+		if !strings.Contains(blk.Content, "Synced/Healthy/Idle") {
+			t.Errorf("expected green summary phrasing, got:\n%s", blk.Content)
+		}
+	})
+}
+
+func TestBuildHealthBlock_MixedStatusEmitsTable(t *testing.T) {
+	providers := []*stubProvider{
+		{name: "alpha", status: greenStatus()},
+		{name: "beta", status: reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusOutOfSync,
+			Health:    reconcile.HealthDegraded,
+			Operation: reconcile.OperationIdle,
+			Message:   "baseline stale (2h)",
+		}},
+		{name: "gamma", status: greenStatus()},
+	}
+	withProviders(t, providers, func() {
+		blk := buildHealthBlock(context.Background())
+		if blk == nil {
+			t.Fatal("expected non-nil block")
+		}
+		c := blk.Content
+		if !strings.Contains(c, "3 providers") {
+			t.Errorf("missing total summary, got:\n%s", c)
+		}
+		if !strings.Contains(c, "2 healthy") {
+			t.Errorf("missing healthy count, got:\n%s", c)
+		}
+		if !strings.Contains(c, "1 need attention") {
+			t.Errorf("missing attention count, got:\n%s", c)
+		}
+		if !strings.Contains(c, "| Provider |") {
+			t.Errorf("expected markdown table, got:\n%s", c)
+		}
+		if !strings.Contains(c, "baseline stale (2h)") {
+			t.Errorf("expected message in note column, got:\n%s", c)
+		}
+		// Non-green should appear before greens. Find the row indices.
+		betaIdx := strings.Index(c, "| beta |")
+		alphaIdx := strings.Index(c, "| alpha |")
+		gammaIdx := strings.Index(c, "| gamma |")
+		if betaIdx == -1 || alphaIdx == -1 || gammaIdx == -1 {
+			t.Fatalf("missing one of beta/alpha/gamma rows, got:\n%s", c)
+		}
+		if betaIdx > alphaIdx || betaIdx > gammaIdx {
+			t.Errorf("non-green provider should sort before greens; got beta@%d alpha@%d gamma@%d\n%s",
+				betaIdx, alphaIdx, gammaIdx, c)
+		}
+		if alphaIdx > gammaIdx {
+			t.Errorf("greens should be alphabetical; got alpha@%d gamma@%d\n%s", alphaIdx, gammaIdx, c)
+		}
+	})
+}
+
+func TestBuildHealthBlock_PanicRecovered(t *testing.T) {
+	providers := []*stubProvider{
+		{name: "fine", status: greenStatus()},
+		{name: "broken", panicWith: "kaboom"},
+	}
+	withProviders(t, providers, func() {
+		blk := buildHealthBlock(context.Background())
+		if blk == nil {
+			t.Fatal("expected non-nil block — panic should be recovered")
+		}
+		c := blk.Content
+		if !strings.Contains(c, "broken") {
+			t.Errorf("broken provider missing from output:\n%s", c)
+		}
+		if !strings.Contains(strings.ToLower(c), "panic") {
+			t.Errorf("expected 'panic' in note for broken provider:\n%s", c)
+		}
+		if !strings.Contains(c, "Unknown") && !strings.Contains(c, "Missing") {
+			t.Errorf("expected Unknown/Missing axis on panicked provider:\n%s", c)
+		}
+	})
+}
+
+func TestBuildHealthBlock_TimeoutMarkedUnknown(t *testing.T) {
+	providers := []*stubProvider{
+		{name: "snail", delay: healthProbeTimeout * 3, status: greenStatus()},
+	}
+	withProviders(t, providers, func() {
+		start := time.Now()
+		blk := buildHealthBlock(context.Background())
+		elapsed := time.Since(start)
+		if blk == nil {
+			t.Fatal("expected non-nil block — slow provider should not nil out the block")
+		}
+		// Probe should have bailed near the timeout, not waited the full delay.
+		if elapsed > healthProbeTimeout*2 {
+			t.Errorf("expected probe to bail near %s, took %s", healthProbeTimeout, elapsed)
+		}
+		c := blk.Content
+		if !strings.Contains(c, "snail") {
+			t.Errorf("missing slow provider in output:\n%s", c)
+		}
+		if !strings.Contains(c, "exceeded") {
+			t.Errorf("expected 'exceeded' in timeout note:\n%s", c)
+		}
+	})
+}
+
+func TestBuildHealthBlock_PipeInMessageSanitized(t *testing.T) {
+	providers := []*stubProvider{
+		{name: "noisy", status: reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusOutOfSync,
+			Health:    reconcile.HealthDegraded,
+			Operation: reconcile.OperationIdle,
+			Message:   "drift in column | row mismatch\nat path /etc",
+		}},
+	}
+	withProviders(t, providers, func() {
+		blk := buildHealthBlock(context.Background())
+		if blk == nil {
+			t.Fatal("expected non-nil block")
+		}
+		c := blk.Content
+		// Find the noisy row line specifically (not the header rule line).
+		var row string
+		for _, line := range strings.Split(c, "\n") {
+			if strings.Contains(line, "| noisy |") {
+				row = line
+				break
+			}
+		}
+		if row == "" {
+			t.Fatalf("missing noisy row in:\n%s", c)
+		}
+		// Markdown table integrity: each row should have exactly 6 pipes
+		// (5 columns + leading/trailing). If any of the message's | leaked
+		// through, the count would change.
+		if got := strings.Count(row, "|"); got != 6 {
+			t.Errorf("row should have 6 pipes after sanitization, got %d: %q", got, row)
+		}
+		// Newlines should be flattened.
+		if strings.Contains(row, "\n") {
+			t.Errorf("row should not contain newlines: %q", row)
+		}
+	})
+}
+
+func TestCompactNote_Truncation(t *testing.T) {
+	long := strings.Repeat("word ", 40) // ~200 chars, lots of word boundaries
+	got := compactNote(long)
+	if len(got) > 105 { // 100 chars + ellipsis allowance
+		t.Errorf("compactNote should truncate long messages, got length %d: %q", len(got), got)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("truncated message should end in ellipsis, got %q", got)
+	}
+}
+
+// TestFoveatedContext_IncludesSubstrateHealth is the end-to-end integration:
+// register a stub Reconcilable, hit the foveated handler, confirm Substrate
+// Health appears in the rendered context string. This is the closure of the
+// sensorium → cognitive substrate proprioception loop — what Claude Code
+// actually receives via the UserPromptSubmit hook.
+func TestFoveatedContext_IncludesSubstrateHealth(t *testing.T) {
+	providers := []*stubProvider{
+		{name: "alpha", status: greenStatus()},
+		{name: "beta", status: reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusOutOfSync,
+			Health:    reconcile.HealthDegraded,
+			Operation: reconcile.OperationIdle,
+			Message:   "drift detected",
+		}},
+	}
+
+	withProviders(t, providers, func() {
+		// Minimal server — no git, no cogdocs. Health block depends only on
+		// the reconcile registry, which is what we want to exercise.
+		tmp := t.TempDir()
+		cfg := &Config{WorkspaceRoot: tmp, CogDir: tmp + "/.cog", Port: 0, SalienceDaysWindow: 90}
+		nucleus := &Nucleus{Name: "test", Card: "proprio test"}
+		process := NewProcess(cfg, nucleus)
+		srv := NewServer(cfg, nucleus, process)
+		ts := httptest.NewServer(srv.Handler())
+		defer ts.Close()
+
+		body, _ := json.Marshal(foveatedRequest{
+			Prompt:    "what's the substrate doing right now",
+			Iris:      irisSignal{Size: 200000, Used: 5000},
+			Profile:   "claude-code",
+			SessionID: "proprio-int-test",
+		})
+
+		resp, err := http.Post(ts.URL+"/v1/context/foveated", "application/json", bytes.NewReader(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status=%d, want 200", resp.StatusCode)
+		}
+
+		var result foveatedResponse
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			t.Fatal("decode:", err)
+		}
+
+		// The health block must appear in the rendered context.
+		if !strings.Contains(result.Context, "Substrate Health") {
+			t.Errorf("rendered context missing 'Substrate Health' block:\n%s", result.Context)
+		}
+		if !strings.Contains(result.Context, "drift detected") {
+			t.Errorf("non-green provider's note should appear in context:\n%s", result.Context)
+		}
+		if !strings.Contains(result.Context, "2 providers") {
+			t.Errorf("summary line missing:\n%s", result.Context)
+		}
+
+		// The block should also be present in the structured response.blocks.
+		var found *foveatedBlock
+		for i := range result.Blocks {
+			if result.Blocks[i].Name == BlockHealth {
+				found = &result.Blocks[i]
+				break
+			}
+		}
+		if found == nil {
+			names := make([]string, 0, len(result.Blocks))
+			for _, b := range result.Blocks {
+				names = append(names, b.Name)
+			}
+			t.Fatalf("health block not in response.blocks; got %v", names)
+		}
+		if found.Tier != "tier2" {
+			t.Errorf("health tier=%q; want tier2", found.Tier)
+		}
+		if found.Stability != 60 {
+			t.Errorf("health stability=%d; want 60", found.Stability)
+		}
+		if found.Hash == "" {
+			t.Error("health block hash empty")
+		}
+
+		// Surface a preview of the rendered block (Preview field is truncated;
+		// for the full text inspect result.Context).
+		t.Logf("health block preview: %s", found.Preview)
+	})
+}
+
+// TestBuildHealthBlock_RealisticSubstrate prints the proprioception block
+// that would render against a substrate in a believable mid-flight state
+// (some providers green, one degraded, one missing, one syncing). This
+// exists so a developer running `go test -v -run RealisticSubstrate` can
+// see exactly what Claude Code receives in its UserPromptSubmit context.
+func TestBuildHealthBlock_RealisticSubstrate(t *testing.T) {
+	providers := []*stubProvider{
+		{name: "agent", status: greenStatus()},
+		{name: "component", status: greenStatus()},
+		{name: "discord", status: greenStatus()},
+		{name: "eval", status: reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusOutOfSync,
+			Health:    reconcile.HealthDegraded,
+			Operation: reconcile.OperationIdle,
+			Message:   "exp-001 baseline stale (2h since refresh); 1 regression flagged",
+		}},
+		{name: "mcp-tools", status: greenStatus()},
+		{name: "openclaw-agents", status: greenStatus()},
+		{name: "openclaw-cron", status: greenStatus()},
+		{name: "openclaw-gateway", status: reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusUnknown,
+			Health:    reconcile.HealthMissing,
+			Operation: reconcile.OperationIdle,
+			Message:   "openclaw daemon not reachable",
+		}},
+		{name: "service", status: reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusSynced,
+			Health:    reconcile.HealthProgressing,
+			Operation: reconcile.OperationSyncing,
+			Message:   "applying plan: 2 of 5 actions",
+		}},
+	}
+	withProviders(t, providers, func() {
+		blk := buildHealthBlock(context.Background())
+		if blk == nil {
+			t.Fatal("expected block")
+		}
+		t.Logf("\n%s", blk.Content)
+	})
+}
+
+// Helpers ────────────────────────────────────────────────────────────────────
+
+func greenStatus() reconcile.ResourceStatus {
+	return reconcile.ResourceStatus{
+		Sync:      reconcile.SyncStatusSynced,
+		Health:    reconcile.HealthHealthy,
+		Operation: reconcile.OperationIdle,
+	}
+}

--- a/internal/engine/context_frame.go
+++ b/internal/engine/context_frame.go
@@ -42,6 +42,7 @@ const (
 	BlockProject   = "project"   // CLAUDE.md content
 	BlockKnowledge = "knowledge" // Foveated CogDocs
 	BlockNode      = "node"      // Sibling service health
+	BlockHealth    = "health"    // Reconcilable provider health (substrate proprioception)
 	BlockField     = "field"     // Attentional field top-N
 	BlockEvents    = "events"    // Recent ledger events
 	BlockFocus     = "focus"     // Current anchor/intent
@@ -53,6 +54,7 @@ var DefaultTiers = map[string]int{
 	BlockProject:   0, // Always present (CLAUDE.md)
 	BlockKnowledge: 1, // Priority — foveated docs
 	BlockNode:      2, // Flexible — node health
+	BlockHealth:    2, // Flexible — Reconcilable proprioception
 	BlockField:     2, // Flexible — attentional field
 	BlockEvents:    2, // Flexible — recent events
 	BlockFocus:     2, // Flexible — anchor/intent
@@ -64,6 +66,7 @@ var DefaultStability = map[string]int{
 	BlockProject:   90, // CLAUDE.md rarely changes
 	BlockKnowledge: 30, // Changes every turn based on query
 	BlockNode:      70, // Changes on 60s heartbeat
+	BlockHealth:    60, // Changes when Reconcilable plan/apply state shifts
 	BlockField:     40, // Changes as salience shifts
 	BlockEvents:    20, // Changes every turn
 	BlockFocus:     10, // Changes every turn

--- a/internal/engine/serve_foveated.go
+++ b/internal/engine/serve_foveated.go
@@ -210,6 +210,14 @@ func (s *Server) handleFoveatedContext(w http.ResponseWriter, r *http.Request) {
 		frame.Blocks = append(frame.Blocks, *blk)
 	}
 
+	// Tier 2, stability 60: Substrate proprioception (Reconcilable health).
+	// This is the return path that closes the sensorium → cognitive substrate
+	// loop — the kernel's body-state surfacing into the agent's foveated
+	// context. Cheap by design: per-provider Health() with timeout.
+	if blk := buildHealthBlock(r.Context()); blk != nil {
+		frame.Blocks = append(frame.Blocks, *blk)
+	}
+
 	// Tier 2, stability 40: Attentional field top-10
 	if blk := buildFieldBlock(s.process, s.cfg.WorkspaceRoot); blk != nil {
 		frame.Blocks = append(frame.Blocks, *blk)


### PR DESCRIPTION
## What

Adds a proprioception block to the foveated-context surface that projects \`pkg/reconcile\` health back into the agent's context window. Every \`UserPromptSubmit\` (or equivalent context-build) gets a Substrate Health block:
- All-green: collapses to a single line.
- Mixed: emits a markdown table with per-provider state.

Two new files:
- \`internal/engine/context_blocks_health.go\` (~245 lines) — \`BlockHealth\` rendering + integration into the foveated context engine.
- \`internal/engine/context_blocks_health_test.go\` (~465 lines) — coverage for the all-green collapse, mixed-state table render, and integration with the context frame.

Plus small hooks into \`context_frame.go\` and \`serve_foveated.go\` to wire the block.

## Why

Closes the sensorium → kernel → agent return path: kernel-side reconcile health was previously visible only to operators (logs, /v1/agents output) but invisible to in-process agents. With this block, an agent in any consolidation/audit/eval session sees a one-line liveness pulse on every interaction, and gets a full triage table the moment something flips off-Healthy.

## How

Cheap deterministic plumbing — no LLM call, just iteration over registered Reconcilables, aggregation, and a templated render. The block fits into the existing foveated context block-list and respects the standard collapse-when-uninteresting pattern.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test ./internal/engine/...\` passes (proprio tests included)
- [ ] CI green

## Notes

- Independent of the autonomic ticker PR — autonomic is a producer of health signals, this is a consumer/projector. The two compose but don't depend on each other.