### PR TITLE
feat(harness): expand URI cheat sheet in local agent prompts

### DIFF
--- a/internal/engine/local_agent_harness.go
+++ b/internal/engine/local_agent_harness.go
@@ -43,10 +43,28 @@ Prefer "sleep" unless the observation names a concrete task worth doing now.`
 
 const localHarnessExecutePrompt = `You are the resident local CogOS maintenance agent.
 Stay local-only. Use the provided kernel tools when they materially improve the answer.
-Prefer inspection and diagnosis over mutation. Finish with a concise plain-text result.`
+Prefer inspection and diagnosis over mutation. Finish with a concise plain-text result.
+
+CogDoc URIs use the form cog://<type>/<path>. Valid types:
+  mem, adr, role, skill, agent, spec, status, ledger, crystal,
+  kernel, canonical, config, ontology, work, handoff, artifact, docs, hooks
+Examples:
+  cog://adr/077                    (ADRs resolve by numeric prefix)
+  cog://mem/semantic/foo/bar       (memory under .cog/mem/<sector>/...)
+  cog://spec/rfc-022-foo           (specs under .cog/specs/)
+Invalid: cog://adrs/..., cog://workspace/..., cog://docs/... with raw fs paths.
+If cog_search_memory returns a bus event path (".cog/.state/buses/.../events.jsonl#N"),
+that is a chat log entry, not a readable CogDoc — do not try to read it.`
 
 const localHarnessDispatchPrompt = `You are the resident local CogOS harness.
-Stay local-only. Use only the provided kernel tools. Be concise and finish with a direct answer.`
+Stay local-only. Use only the provided kernel tools. Be concise and finish with a direct answer.
+
+CogDoc URIs use the form cog://<type>/<path>. Valid types:
+  mem, adr, role, skill, agent, spec, status, ledger, crystal,
+  kernel, canonical, config, ontology, work, handoff, artifact, docs, hooks
+Example: cog://adr/077 (ADRs resolve by numeric prefix).
+If cog_search_memory returns ".cog/.state/buses/.../events.jsonl#N", that's a chat log entry,
+not a readable CogDoc — do not try to read it.`
 
 type localHarnessAssessment struct {
 	Action  string  `json:"action"`


### PR DESCRIPTION
## What

Single-commit micro-PR. Expands the cog:// URI cheat sheet that the local agent harness includes in its system prompt — adds a few more URI-shape examples (sector projections, identity refs) so harness-driven agents see the full surface up front.

## Why

The original cheat sheet covered the common cogdoc / ledger / mem cases but was missing the projections that landed in subsequent waves. Agents would occasionally hallucinate URI shapes on those sectors because they weren't enumerated.

## How

\`internal/engine/local_agent_harness.go\` — extends the prompt-side template string. No code change beyond the constant.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test ./internal/engine/...\` passes
- [ ] CI green