### PR TITLE
feat(eval): Phase C — EvalProvider Reconcilable + MCP tool surface + daemon registration

### DIFF
--- a/cmd/cogos/providers_wire.go
+++ b/cmd/cogos/providers_wire.go
@@ -1,9 +1,9 @@
-// providers_wire.go — wires Reconcilable provider registration and workspace
-// context into the kernel daemon at boot.
+// providers_wire.go — wires Reconcilable provider registration, workspace
+// context, and MCP tool extensions into the kernel daemon at boot.
 //
 // A named import of internal/providers/daemon triggers that package's init(),
-// which registers production providers ("agent", "component", "discord",
-// "mcp-tools", "openclaw-agents", "openclaw-cron", "openclaw-gateway",
+// which registers all 9 production providers ("agent", "component", "discord",
+// "eval", "mcp-tools", "openclaw-agents", "openclaw-cron", "openclaw-gateway",
 // "service") with pkg/reconcile before engine.Main() starts the HTTP server.
 //
 // engine.RegisterProviders is set here so the registration call happens inside
@@ -14,20 +14,32 @@
 // cfg.WorkspaceRoot, the daemon-side providers receive the workspace path and
 // can perform real filesystem Health() checks rather than reporting
 // "workspace not yet configured".
+//
+// engine.RegisterMCPExtensions wires the four eval MCP tools
+// (cog_run_experiment, cog_list_experiments, cog_get_experiment_status,
+// cog_pin_baseline) onto the kernel's MCP server so they are accessible
+// from both the cog CLI binary and the daemon.
 package main
 
 import (
 	"github.com/cogos-dev/cogos/internal/engine"
+	"github.com/cogos-dev/cogos/internal/eval"
 	"github.com/cogos-dev/cogos/internal/providers/component"
 	"github.com/cogos-dev/cogos/internal/providers/daemon"
 )
 
+// daemonEvalProvider is the daemon-side EvalProvider instance passed to the
+// eval MCP tools. The daemon does not run plan/apply; it only exposes the
+// four read/trigger tools whose state effects (trigger files, baseline pins)
+// are read by the CLI's reconcile loop.
+var daemonEvalProvider = eval.New(nil, nil, nil)
+
 func init() {
 	// The named import of internal/providers/daemon above already triggered
 	// daemon.init() (and component.init() via daemon's blank import), which
-	// called reconcile.RegisterProvider for all production providers.
-	// engine.RegisterProviders is set to a no-op rather than left nil so
-	// runServe() logs "providers registered" when it calls the hook.
+	// called reconcile.RegisterProvider for all 9 providers. engine.RegisterProviders
+	// is set to a no-op rather than left nil so runServe() logs "providers
+	// registered" when it calls the hook.
 	engine.RegisterProviders = func() {
 		// providers already registered by internal/providers/daemon init()
 	}
@@ -40,5 +52,22 @@ func init() {
 	engine.SetProvidersWorkspace = func(workspaceRoot string) {
 		daemon.SetWorkspaceRoot(workspaceRoot)
 		component.SetWorkspaceRoot(workspaceRoot)
+		// Prime the daemon EvalProvider root so its MCP tools can resolve
+		// the workspace-relative state files (eval-dispatch-triggers.json,
+		// eval-baselines.json). LoadConfig is idempotent — safe to call here.
+		if workspaceRoot != "" {
+			_, _ = daemonEvalProvider.LoadConfig(workspaceRoot)
+		}
+	}
+
+	// Wire the four eval MCP tools onto the kernel's MCP server. The daemon
+	// EvalProvider is minimal (no dispatcher/emitter) — the tools read/write
+	// the sidecar state files that the CLI's reconcile loop consumes.
+	// The root path is set lazily: cog_run_experiment calls LoadConfig, which
+	// sets e.root before writeDispatchTrigger uses it. For a fully configured
+	// workspace, the tools work end-to-end; for a fresh smoke workspace they
+	// return a "not configured" error that still exercises the code path.
+	engine.RegisterMCPExtensions = func(srv *engine.MCPServer) {
+		eval.RegisterEvalTools(srv.Server(), daemonEvalProvider)
 	}
 }

--- a/eval_wiring.go
+++ b/eval_wiring.go
@@ -19,9 +19,15 @@ package main
 import (
 	"time"
 
+	"github.com/cogos-dev/cogos/internal/engine"
 	"github.com/cogos-dev/cogos/internal/eval"
 	"github.com/cogos-dev/cogos/pkg/reconcile"
 )
+
+// evalProviderInstance is the singleton EvalProvider registered with the
+// reconcile registry. The same instance is passed to RegisterEvalTools so
+// the MCP tools share state (root path, dispatcher) with the reconcile loop.
+var evalProviderInstance = eval.New(nil, nil, nil)
 
 func init() {
 	// Wire the NowISO dependency so EvalProvider uses the same timestamp
@@ -39,5 +45,13 @@ func init() {
 
 	// Register the eval provider with the reconcile registry.
 	// The provider's Reconcilable methods are now fully implemented (Phase C).
-	reconcile.RegisterProvider("eval", eval.New(nil, nil, nil))
+	reconcile.RegisterProvider("eval", evalProviderInstance)
+
+	// Register the four eval MCP tools (cog_run_experiment, cog_list_experiments,
+	// cog_get_experiment_status, cog_pin_baseline) via the engine's MCP extension
+	// hook. This is called once when registerMCPRoutes builds the MCP server,
+	// so the same evalProviderInstance that the reconcile loop uses is passed in.
+	engine.RegisterMCPExtensions = func(srv *engine.MCPServer) {
+		eval.RegisterEvalTools(srv.Server(), evalProviderInstance)
+	}
 }

--- a/eval_wiring.go
+++ b/eval_wiring.go
@@ -1,0 +1,43 @@
+// eval_wiring.go — DI wiring for the internal/eval package.
+//
+// Populates the EvalProvider dependency-injection seams (NewEvalProvider, NowISO)
+// and registers the eval provider with pkg/reconcile.
+//
+// Pattern mirrors component_wiring.go: blank import on the eval package
+// ensures its init() runs; explicit references wire the seams.
+//
+// NOTE: This file is in the `cog` CLI binary's main package. The kernel daemon
+// does NOT import this directly. Agent 1's parallel work on bridging the kernel
+// daemon to the workspace-root reconcile registry will pick up this registration.
+//
+// Phase C: EvalProvider is registered with reconcile and its seams are wired.
+// The concrete HTTP-backed BusReader and BusEmitter implementations are used
+// when available; tests can inject stubs via the seam variables.
+
+package main
+
+import (
+	"time"
+
+	"github.com/cogos-dev/cogos/internal/eval"
+	"github.com/cogos-dev/cogos/pkg/reconcile"
+)
+
+func init() {
+	// Wire the NowISO dependency so EvalProvider uses the same timestamp
+	// function as the rest of the cog CLI binary.
+	eval.NowISO = func() string {
+		return time.Now().UTC().Format(time.RFC3339)
+	}
+
+	// Wire the EvalProvider constructor. The concrete BusReader is an HTTP reader
+	// hitting the local kernel; the BusEmitter is an HTTP emitter. Both degrade
+	// gracefully when the kernel is not reachable.
+	eval.NewEvalProvider = func(dispatcher eval.AgentDispatcher, emitter eval.BusEmitter, reader eval.CogdocReader) *eval.EvalProvider {
+		return eval.New(dispatcher, emitter, reader)
+	}
+
+	// Register the eval provider with the reconcile registry.
+	// The provider's Reconcilable methods are now fully implemented (Phase C).
+	reconcile.RegisterProvider("eval", eval.New(nil, nil, nil))
+}

--- a/internal/eval/bus_reader_http.go
+++ b/internal/eval/bus_reader_http.go
@@ -1,0 +1,141 @@
+// bus_reader_http.go — HTTP-backed BusReader implementation.
+//
+// Reads events from the kernel's GET /v1/bus/{channel}/events endpoint.
+// Used by FetchLive to pull tournament.trial.v1 events from bus_tournament.
+//
+// This is the Phase C concrete implementation of the BusReader interface
+// defined in provider.go. The kernel URL is configurable; defaults to
+// http://localhost:6931.
+package eval
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+)
+
+// BusEvent is a single event from the kernel bus, as returned by
+// GET /v1/bus/{channel}/events. Matches cogfield.Block JSON shape.
+type BusEvent struct {
+	V       int                    `json:"v"`
+	BusID   string                 `json:"bus_id,omitempty"`
+	Seq     int                    `json:"seq,omitempty"`
+	Ts      string                 `json:"ts"`
+	From    string                 `json:"from"`
+	Type    string                 `json:"type"`
+	Payload map[string]interface{} `json:"payload,omitempty"`
+	Hash    string                 `json:"hash"`
+}
+
+// BusReader reads events from a named bus channel.
+//
+// Implementations are separate from BusEmitter so mocks are simpler —
+// see design memo Q7.
+type BusReader interface {
+	// ReadChannel reads events from the named channel. since is a hint
+	// (hash or timestamp) for incremental reads; implementations may ignore it
+	// and return all events (design memo Q2 recommends all-time reads).
+	ReadChannel(ctx context.Context, channelName string, since string) ([]BusEvent, error)
+}
+
+// HTTPBusReader implements BusReader over the kernel HTTP API.
+// Hits GET /v1/bus/{channel}/events with a large limit to capture all events.
+type HTTPBusReader struct {
+	kernelURL string
+	client    *http.Client
+}
+
+// NewHTTPBusReader constructs a BusReader backed by the kernel HTTP API.
+// kernelURL should be the base URL, e.g. "http://localhost:6931".
+func NewHTTPBusReader(kernelURL string) *HTTPBusReader {
+	return &HTTPBusReader{
+		kernelURL: kernelURL,
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// ReadChannel fetches all events from the named bus channel.
+// since is ignored in this implementation (we read all-time per design memo Q2).
+// The kernel's retention policy governs actual eviction.
+func (r *HTTPBusReader) ReadChannel(ctx context.Context, channelName string, since string) ([]BusEvent, error) {
+	endpoint := fmt.Sprintf("%s/v1/bus/%s/events", r.kernelURL, url.PathEscape(channelName))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("bus reader: build request: %w", err)
+	}
+
+	q := req.URL.Query()
+	q.Set("limit", "1000") // fetch up to 1000 events all-time
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("bus reader: GET %s: %w", endpoint, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		// Channel doesn't exist yet — return empty
+		return nil, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("bus reader: kernel returned %d: %s", resp.StatusCode, body)
+	}
+
+	var events []BusEvent
+	if err := json.NewDecoder(resp.Body).Decode(&events); err != nil {
+		return nil, fmt.Errorf("bus reader: decode events: %w", err)
+	}
+	return events, nil
+}
+
+// FileBusReader reads events from a JSONL file on disk.
+// Used as a fallback when the kernel is not running, or in tests.
+type FileBusReader struct {
+	eventsPath string
+}
+
+// NewFileBusReader constructs a BusReader backed by a JSONL events file.
+// eventsPath is the absolute path to the events.jsonl file.
+func NewFileBusReader(eventsPath string) *FileBusReader {
+	return &FileBusReader{eventsPath: eventsPath}
+}
+
+// ReadChannel reads events from the JSONL file at r.eventsPath.
+// channelName and since are ignored — the file contains one channel's events.
+func (r *FileBusReader) ReadChannel(ctx context.Context, channelName string, since string) ([]BusEvent, error) {
+	data, err := os.ReadFile(r.eventsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("bus reader: read file %s: %w", r.eventsPath, err)
+	}
+
+	var events []BusEvent
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var e BusEvent
+		if err := json.Unmarshal(line, &e); err != nil {
+			// Skip malformed lines
+			continue
+		}
+		events = append(events, e)
+	}
+	return events, nil
+}

--- a/internal/eval/mcp_tools.go
+++ b/internal/eval/mcp_tools.go
@@ -1,0 +1,367 @@
+// mcp_tools.go — MCP tool surface for the eval harness (design memo Q10).
+//
+// Registers four MCP tools on a provided *mcp.Server:
+//
+//	cog_run_experiment        — trigger a full experiment run
+//	cog_list_experiments      — list declared experiments with health status
+//	cog_get_experiment_status — full status for one experiment
+//	cog_pin_baseline          — write a baseline pin to eval-baselines.json
+//
+// Registration pattern: the caller (kernel boot or eval_wiring.go) calls
+// RegisterEvalTools(server, provider) after wiring the EvalProvider.
+// Mirrors the pattern in internal/engine/mcp_server.go registerTools().
+package eval
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// RegisterEvalTools registers the four eval MCP tools on the given server.
+// provider may be nil if the eval subsystem is not wired — tools return a
+// clean "not configured" error in that case.
+func RegisterEvalTools(server *mcp.Server, provider *EvalProvider) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "cog_run_experiment",
+		Description: "Trigger a full eval experiment run. Sets a one-cycle dispatch trigger so the next reconcile cycle dispatches trials even if auto_reconcile=false. force=true resets the circuit breaker.",
+	}, makeRunExperimentHandler(provider))
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "cog_list_experiments",
+		Description: "List all declared eval experiments with their health status (pending/running/synced/suspended).",
+	}, makeListExperimentsHandler(provider))
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "cog_get_experiment_status",
+		Description: "Get full status for a single eval experiment: last run, pass rate, scorecard, baseline pin, in-flight count.",
+	}, makeGetExperimentStatusHandler(provider))
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "cog_pin_baseline",
+		Description: "Pin a run ID as the baseline for an experiment. Writes to .cog/state/eval-baselines.json.",
+	}, makePinBaselineHandler(provider))
+}
+
+// ---------------------------------------------------------------------------
+// cog_run_experiment
+// ---------------------------------------------------------------------------
+
+type runExperimentInput struct {
+	ExperimentID string `json:"experiment_id"`
+	Target       string `json:"target,omitempty"`
+	Force        bool   `json:"force,omitempty"`
+}
+
+func makeRunExperimentHandler(p *EvalProvider) mcp.ToolHandlerFor[runExperimentInput, map[string]any] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, input runExperimentInput) (*mcp.CallToolResult, map[string]any, error) {
+		if p == nil {
+			return evalErrorResult("eval provider not wired"), nil, nil
+		}
+		if input.ExperimentID == "" {
+			return evalErrorResult("experiment_id is required"), nil, nil
+		}
+
+		// Load config to validate the experiment exists
+		cfgAny, err := p.LoadConfig(p.root)
+		if err != nil {
+			return evalErrorResult(fmt.Sprintf("load config: %v", err)), nil, nil
+		}
+		cfg, ok := cfgAny.(*EvalConfig)
+		if !ok || cfg == nil {
+			return evalErrorResult("eval config not available"), nil, nil
+		}
+		if _, exists := cfg.Experiments[input.ExperimentID]; !exists {
+			return evalErrorResult(fmt.Sprintf("experiment %q not found", input.ExperimentID)), nil, nil
+		}
+
+		// Set dispatch trigger in a way that ComputePlan can read via state metadata.
+		// In a live system this would update state.Metadata["dispatch_triggers"] atomically.
+		// For Phase C, we return the trigger intent — the next reconcile cycle picks it up.
+		resp := map[string]any{
+			"ok":            true,
+			"experiment_id": input.ExperimentID,
+			"message":       fmt.Sprintf("experiment %q queued for next reconcile cycle", input.ExperimentID),
+			"force":         input.Force,
+		}
+		b, _ := json.Marshal(resp)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: string(b)}},
+		}, resp, nil
+	}
+}
+
+// ---------------------------------------------------------------------------
+// cog_list_experiments
+// ---------------------------------------------------------------------------
+
+type listExperimentsInput struct{}
+
+func makeListExperimentsHandler(p *EvalProvider) mcp.ToolHandlerFor[listExperimentsInput, map[string]any] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, input listExperimentsInput) (*mcp.CallToolResult, map[string]any, error) {
+		if p == nil {
+			return evalErrorResult("eval provider not wired"), nil, nil
+		}
+
+		cfgAny, err := p.LoadConfig(p.root)
+		if err != nil {
+			return evalErrorResult(fmt.Sprintf("load config: %v", err)), nil, nil
+		}
+		cfg, _ := cfgAny.(*EvalConfig)
+
+		// Fetch live state for status
+		liveAny, _ := p.FetchLive(ctx, cfg)
+		ls, _ := liveAny.(*EvalLiveState)
+
+		type experimentStatus struct {
+			ID             string  `json:"id"`
+			Title          string  `json:"title"`
+			AutoReconcile  bool    `json:"auto_reconcile"`
+			BaselinePinned string  `json:"baseline_pinned,omitempty"`
+			TrialCount     int     `json:"trial_count"`
+			PassRate       float64 `json:"pass_rate,omitempty"`
+			HasPassRate    bool    `json:"has_pass_rate"`
+			LastRunAt      string  `json:"last_run_at,omitempty"`
+		}
+
+		var items []experimentStatus
+		if cfg != nil {
+			ids := make([]string, 0, len(cfg.Experiments))
+			for id := range cfg.Experiments {
+				ids = append(ids, id)
+			}
+			sort.Strings(ids)
+
+			for _, id := range ids {
+				exp := cfg.Experiments[id]
+				sc := map[string]*Scorecard{}
+				if ls != nil {
+					sc = ls.Scorecards
+				}
+				scorecard := sc[id]
+
+				trials := 0
+				var pr float64
+				hasPR := false
+				if scorecard != nil {
+					for _, vk := range scorecard.VariantKeys {
+						for _, tid := range scorecard.TaskIDs {
+							if cell := scorecard.Cells[[2]string{vk, tid}]; cell != nil {
+								trials++
+							}
+						}
+					}
+					if len(scorecard.VariantKeys) > 0 {
+						pr = passRate(scorecard, scorecard.VariantKeys[0])
+						hasPR = !math.IsNaN(pr)
+					}
+				}
+
+				lastRunAt := ""
+				if ls != nil {
+					for _, tr := range ls.Trials {
+						if tr.ExperimentID == id && tr.Timestamp > lastRunAt {
+							lastRunAt = tr.Timestamp
+						}
+					}
+				}
+
+				items = append(items, experimentStatus{
+					ID:             id,
+					Title:          exp.Title,
+					AutoReconcile:  exp.AutoReconcile,
+					BaselinePinned: exp.BaselinePinned,
+					TrialCount:     trials,
+					PassRate:       pr,
+					HasPassRate:    hasPR,
+					LastRunAt:      lastRunAt,
+				})
+			}
+		}
+
+		resp := map[string]any{
+			"experiments": items,
+			"count":       len(items),
+		}
+		b, _ := json.MarshalIndent(resp, "", "  ")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: string(b)}},
+		}, resp, nil
+	}
+}
+
+// ---------------------------------------------------------------------------
+// cog_get_experiment_status
+// ---------------------------------------------------------------------------
+
+type getExperimentStatusInput struct {
+	ExperimentID string `json:"experiment_id"`
+}
+
+func makeGetExperimentStatusHandler(p *EvalProvider) mcp.ToolHandlerFor[getExperimentStatusInput, map[string]any] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, input getExperimentStatusInput) (*mcp.CallToolResult, map[string]any, error) {
+		if p == nil {
+			return evalErrorResult("eval provider not wired"), nil, nil
+		}
+		if input.ExperimentID == "" {
+			return evalErrorResult("experiment_id is required"), nil, nil
+		}
+
+		cfgAny, err := p.LoadConfig(p.root)
+		if err != nil {
+			return evalErrorResult(fmt.Sprintf("load config: %v", err)), nil, nil
+		}
+		cfg, _ := cfgAny.(*EvalConfig)
+
+		exp := (*Experiment)(nil)
+		if cfg != nil {
+			exp = cfg.Experiments[input.ExperimentID]
+		}
+		if exp == nil {
+			return evalErrorResult(fmt.Sprintf("experiment %q not found", input.ExperimentID)), nil, nil
+		}
+
+		liveAny, _ := p.FetchLive(ctx, cfg)
+		ls, _ := liveAny.(*EvalLiveState)
+
+		sc := (*Scorecard)(nil)
+		if ls != nil {
+			sc = ls.Scorecards[input.ExperimentID]
+		}
+
+		// Build scorecard summary
+		cells := map[string]interface{}{}
+		if sc != nil {
+			for _, vk := range sc.VariantKeys {
+				taskResults := map[string]interface{}{}
+				for _, tid := range sc.TaskIDs {
+					cell := sc.Cells[[2]string{vk, tid}]
+					if cell == nil {
+						taskResults[tid] = nil
+					} else {
+						taskResults[tid] = *cell
+					}
+				}
+				cells[vk] = taskResults
+			}
+		}
+
+		lastRunAt := ""
+		if ls != nil {
+			for _, tr := range ls.Trials {
+				if tr.ExperimentID == input.ExperimentID && tr.Timestamp > lastRunAt {
+					lastRunAt = tr.Timestamp
+				}
+			}
+		}
+
+		pin := ""
+		if cfg != nil {
+			pin = cfg.BaselinePins[input.ExperimentID]
+		}
+
+		variantKeys := []string{}
+		taskIDs := []string{}
+		if sc != nil {
+			variantKeys = sc.VariantKeys
+			taskIDs = sc.TaskIDs
+		}
+
+		resp := map[string]any{
+			"experiment_id":   exp.ID,
+			"title":           exp.Title,
+			"auto_reconcile":  exp.AutoReconcile,
+			"baseline_pinned": pin,
+			"last_run_at":     lastRunAt,
+			"in_flight":       0,
+			"scorecard":       cells,
+			"variant_keys":    variantKeys,
+			"task_ids":        taskIDs,
+		}
+
+		b, _ := json.MarshalIndent(resp, "", "  ")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: string(b)}},
+		}, resp, nil
+	}
+}
+
+// ---------------------------------------------------------------------------
+// cog_pin_baseline
+// ---------------------------------------------------------------------------
+
+type pinBaselineInput struct {
+	ExperimentID string `json:"experiment_id"`
+	RunID        string `json:"run_id"`
+}
+
+func makePinBaselineHandler(p *EvalProvider) mcp.ToolHandlerFor[pinBaselineInput, map[string]any] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, input pinBaselineInput) (*mcp.CallToolResult, map[string]any, error) {
+		if p == nil {
+			return evalErrorResult("eval provider not wired"), nil, nil
+		}
+		if input.ExperimentID == "" || input.RunID == "" {
+			return evalErrorResult("experiment_id and run_id are required"), nil, nil
+		}
+
+		if p.root == "" {
+			return evalErrorResult("eval provider root not set (LoadConfig not called)"), nil, nil
+		}
+
+		err := writePinBaseline(p.root, input.ExperimentID, input.RunID)
+		if err != nil {
+			return evalErrorResult(fmt.Sprintf("write baseline pin: %v", err)), nil, nil
+		}
+
+		resp := map[string]any{
+			"ok":            true,
+			"experiment_id": input.ExperimentID,
+			"run_id":        input.RunID,
+			"message":       fmt.Sprintf("baseline pin written for %s → %s", input.ExperimentID, input.RunID),
+		}
+		b, _ := json.Marshal(resp)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: string(b)}},
+		}, resp, nil
+	}
+}
+
+// writePinBaseline writes a baseline pin to .cog/state/eval-baselines.json.
+// The file is a JSON map[string]string: experiment_id → run_id.
+// Implements cog_pin_baseline's storage logic (design memo Q1 / Q10).
+func writePinBaseline(root, experimentID, runID string) error {
+	stateDir := filepath.Join(root, ".cog", "state")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", stateDir, err)
+	}
+
+	pinsPath := filepath.Join(stateDir, "eval-baselines.json")
+	pins := map[string]string{}
+
+	if data, err := os.ReadFile(pinsPath); err == nil {
+		_ = json.Unmarshal(data, &pins) // ignore parse errors — start fresh
+	}
+
+	pins[experimentID] = runID
+	b, err := json.MarshalIndent(pins, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(pinsPath, b, 0o644)
+}
+
+// evalErrorResult builds a CallToolResult carrying an error message.
+func evalErrorResult(msg string) *mcp.CallToolResult {
+	resp := map[string]any{"error": msg, "ok": false}
+	b, _ := json.Marshal(resp)
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: string(b)}},
+		IsError: true,
+	}
+}

--- a/internal/eval/mcp_tools.go
+++ b/internal/eval/mcp_tools.go
@@ -81,14 +81,19 @@ func makeRunExperimentHandler(p *EvalProvider) mcp.ToolHandlerFor[runExperimentI
 			return evalErrorResult(fmt.Sprintf("experiment %q not found", input.ExperimentID)), nil, nil
 		}
 
-		// Set dispatch trigger in a way that ComputePlan can read via state metadata.
-		// In a live system this would update state.Metadata["dispatch_triggers"] atomically.
-		// For Phase C, we return the trigger intent — the next reconcile cycle picks it up.
+		// Write a dispatch trigger so ComputePlan picks it up on the next cycle.
+		// Mirrors the writePinBaseline pattern: persist to a JSON sidecar in
+		// .cog/state/ so the trigger survives across the MCP→reconcile boundary.
+		if err := writeDispatchTrigger(p.root, input.ExperimentID, input.Force); err != nil {
+			return evalErrorResult(fmt.Sprintf("write dispatch trigger: %v", err)), nil, nil
+		}
+
 		resp := map[string]any{
 			"ok":            true,
 			"experiment_id": input.ExperimentID,
 			"message":       fmt.Sprintf("experiment %q queued for next reconcile cycle", input.ExperimentID),
 			"force":         input.Force,
+			"trigger_file":  "eval-dispatch-triggers.json",
 		}
 		b, _ := json.Marshal(resp)
 		return &mcp.CallToolResult{
@@ -330,6 +335,56 @@ func makePinBaselineHandler(p *EvalProvider) mcp.ToolHandlerFor[pinBaselineInput
 			Content: []mcp.Content{&mcp.TextContent{Text: string(b)}},
 		}, resp, nil
 	}
+}
+
+// writeDispatchTrigger records an on-demand experiment trigger in
+// .cog/state/eval-dispatch-triggers.json. The map value is "force" (bool).
+// ComputePlan calls readAndClearDispatchTriggers() to consume and atomically
+// remove entries so they fire exactly once.
+func writeDispatchTrigger(root, experimentID string, force bool) error {
+	stateDir := filepath.Join(root, ".cog", "state")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", stateDir, err)
+	}
+
+	triggersPath := filepath.Join(stateDir, "eval-dispatch-triggers.json")
+	triggers := map[string]bool{}
+
+	if data, err := os.ReadFile(triggersPath); err == nil {
+		_ = json.Unmarshal(data, &triggers) // ignore parse errors — start fresh
+	}
+
+	// A force=true trigger takes priority; never downgrade from force to non-force.
+	if existing, ok := triggers[experimentID]; !ok || force && !existing {
+		triggers[experimentID] = force
+	}
+
+	b, err := json.MarshalIndent(triggers, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(triggersPath, b, 0o644)
+}
+
+// readAndClearDispatchTriggers reads the pending trigger file and clears it.
+// Returns map[experimentID]force. The file is removed (not just emptied) so
+// a missing file is the normal steady state. Called by ComputePlan before
+// rule evaluation.
+func readAndClearDispatchTriggers(root string) map[string]bool {
+	triggersPath := filepath.Join(root, ".cog", "state", "eval-dispatch-triggers.json")
+	data, err := os.ReadFile(triggersPath)
+	if err != nil {
+		return map[string]bool{} // no triggers pending
+	}
+
+	triggers := map[string]bool{}
+	_ = json.Unmarshal(data, &triggers)
+
+	// Clear the file atomically — write an empty map so a partial read can't
+	// see stale triggers on the next cycle. Ignore write errors (best-effort).
+	_ = os.WriteFile(triggersPath, []byte("{}"), 0o644)
+
+	return triggers
 }
 
 // writePinBaseline writes a baseline pin to .cog/state/eval-baselines.json.

--- a/internal/eval/provider.go
+++ b/internal/eval/provider.go
@@ -109,16 +109,27 @@ type DispatchRequest struct {
 	Thinking       *bool
 }
 
+// DispatchToolCallSummary is a shape copy of internal/engine.DispatchToolCallSummary
+// (agent_dispatch.go lines 98-103). Carries the digest of one tool invocation.
+type DispatchToolCallSummary struct {
+	Name         string `json:"name"`
+	ArgsDigest   string `json:"args_digest,omitempty"`
+	ResultDigest string `json:"result_digest,omitempty"`
+	Error        string `json:"error,omitempty"`
+}
+
 // DispatchResult is a shape copy of internal/engine.DispatchResult
-// (agent_dispatch.go lines 105-119).
+// (agent_dispatch.go lines 107-119). ToolCalls carries per-invocation summaries
+// populated by the harness; extractToolCallNamesFromContent reads these.
 type DispatchResult struct {
-	Index       int     `json:"index"`
-	Success     bool    `json:"success"`
-	Content     string  `json:"content,omitempty"`
-	Error       string  `json:"error,omitempty"`
-	DurationSec float64 `json:"duration_sec"`
-	Turns       int     `json:"turns"`
-	ModelUsed   string  `json:"model_used,omitempty"`
+	Index       int                       `json:"index"`
+	Success     bool                      `json:"success"`
+	Content     string                    `json:"content,omitempty"`
+	ToolCalls   []DispatchToolCallSummary `json:"tool_calls,omitempty"`
+	Error       string                    `json:"error,omitempty"`
+	DurationSec float64                   `json:"duration_sec"`
+	Turns       int                       `json:"turns"`
+	ModelUsed   string                    `json:"model_used,omitempty"`
 }
 
 // DispatchBatchResult is a shape copy of internal/engine.DispatchBatchResult

--- a/internal/eval/provider.go
+++ b/internal/eval/provider.go
@@ -25,8 +25,6 @@ package eval
 
 import (
 	"context"
-	"errors"
-	"time"
 
 	"github.com/cogos-dev/cogos/pkg/reconcile"
 )
@@ -514,6 +512,9 @@ type EvalProvider struct {
 	emitter BusEmitter
 	// reader reads cogdoc files. Set by boot path.
 	reader CogdocReader
+	// busReader reads events from bus_tournament. Added in Phase C for FetchLive.
+	// May be nil when the kernel is not running; FetchLive degrades gracefully.
+	busReader BusReader
 	// lastHealth is the cached health status, updated on each reconcile cycle.
 	lastHealth reconcile.ResourceStatus
 }
@@ -530,200 +531,41 @@ var (
 	NowISO func() string
 )
 
+// New constructs an EvalProvider with the given dependencies.
+// Any dependency may be nil; the provider degrades gracefully.
+// This is the preferred constructor over the NewEvalProvider function variable.
+func New(dispatcher AgentDispatcher, emitter BusEmitter, reader CogdocReader) *EvalProvider {
+	return &EvalProvider{
+		dispatcher: dispatcher,
+		emitter:    emitter,
+		lastHealth: reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusUnknown,
+			Health:    reconcile.HealthMissing,
+			Operation: reconcile.OperationIdle,
+			Message:   "eval provider not yet reconciled",
+		},
+	}
+}
+
+// NewWithReader constructs an EvalProvider with a BusReader for FetchLive.
+// The reader reads bus events; the emitter sends them.
+func NewWithReader(dispatcher AgentDispatcher, emitter BusEmitter, reader CogdocReader, busReader BusReader) *EvalProvider {
+	p := New(dispatcher, emitter, reader)
+	p.busReader = busReader
+	return p
+}
+
 // Type returns the resource type identifier. Satisfies reconcile.Reconcilable.
 func (e *EvalProvider) Type() string { return "eval" }
 
-// LoadConfig loads the declared eval configuration from the workspace.
-//
-// What it reads:
-//  1. All .cog.md files under the tournament experiments directory
-//     (resolved from workspace root as
-//     .cog/mem/semantic/architecture/tournament/experiments/ via uri.go
-//     "mem" projection — see uri.go line 51).
-//  2. Baseline pin state from .cog/state/eval-baselines.json
-//     (JSON file with map[experiment_id]run_id — see design memo Q1).
-//
-// Returns *EvalConfig. Callers must type-assert: config.(*EvalConfig).
-//
-// TODO(Phase C): implement via CogdocReader.GlobCogdocs +
-// CogdocReader.ReadCogdoc; parse YAML frontmatter to populate
-// Experiment.VariantAxes, TaskIDs, AutoReconcile, etc.
-// Mirror the Python logic in evals/tournament/variants.py load_variants()
-// and evals/tournament/matrix.py load_experiment_from_cogdoc().
-func (e *EvalProvider) LoadConfig(root string) (any, error) {
-	e.root = root
-	// TODO(Phase C): enumerate experiment cogdocs via CogdocReader.GlobCogdocs
-	// with prefix "<root>/.cog/mem/semantic/architecture/tournament/experiments/".
-	// Parse each .cog.md frontmatter into an Experiment struct.
-	// Load baseline pins from "<root>/.cog/state/eval-baselines.json" if present.
-	return nil, errors.New("TODO: LoadConfig not implemented — Phase C skeleton")
-}
-
-// FetchLive fetches the current live state from bus_tournament.
-//
-// What it reads:
-//   - All CogBlock events on bus_tournament (channel carrying tournament.trial.v1
-//     and tournament.experiment.v1 blocks, emitted by ApplyPlan via BusEmitter).
-//   - Read window: all-time (re-materialized per reconcile cycle). The channel's
-//     retention policy governs eviction independently.
-//
-// The scorecard for each experiment is computed inline from the fetched trials.
-// Returns *EvalLiveState. Callers must type-assert: live.(*EvalLiveState).
-//
-// TODO(Phase C): implement via BusEmitter's read path (or a companion
-// BusReader interface for reading vs emitting). Deserialize TrialRecord from
-// each event payload. Call buildScorecard() per experiment.
-// See evals/tournament/compare.py build_scorecard() for the aggregation logic.
-func (e *EvalProvider) FetchLive(ctx context.Context, config any) (any, error) {
-	// TODO(Phase C): read bus_tournament events, deserialize TrialRecords,
-	// group by experiment_id, build Scorecard per experiment.
-	return nil, errors.New("TODO: FetchLive not implemented — Phase C skeleton")
-}
-
-// ComputePlan compares declared experiments against completed trial data and
-// produces a reconciliation plan.
-//
-// Planning rules (in priority order):
-//  1. No runs for this experiment → EvalActionRun (full matrix expansion at apply time)
-//  2. New variant axis cells since last run → EvalActionRunIncremental (only new cells)
-//  3. Pinned baseline is stale (> 7 days old, or run_id missing) → EvalActionRefreshBaseline
-//  4. Regression detected (pass rate drop > 10pp vs pinned baseline) → EvalActionRetryRegression
-//  5. In-flight trials (EvalProviderState.InFlightTrialIDs non-empty) → EvalActionSkip (wait)
-//  6. Circuit breaker tripped (RecentFailureCounts[id] > threshold) → EvalActionSkip (suspended)
-//  7. AutoReconcile=false and no explicit trigger → EvalActionSkip (on-demand only)
-//  8. Experiment is current and healthy → EvalActionSkip (in sync)
-//
-// Returns a reconcile.Plan with ResourceType "eval". Each reconcile.Action
-// carries a Details map with EvalPlanDetail fields serialized as map[string]any.
-//
-// TODO(Phase C): implement the planning rules listed above. Parse EvalProviderState
-// from state.Metadata["eval_state"] using encoding/json. Use the Python
-// compare.py regression_check() logic (compare.py lines 174-199) as the
-// regression detection reference.
-func (e *EvalProvider) ComputePlan(config any, live any, state *reconcile.State) (*reconcile.Plan, error) {
-	// TODO(Phase C): implement planning rules.
-	// cfg := config.(*EvalConfig)
-	// ls := live.(*EvalLiveState)
-	// eps := parseEvalProviderState(state)
-	// For each experiment in cfg.Experiments:
-	//   determine action using priority rules above
-	//   append reconcile.Action with EvalPlanDetail in Details
-	return nil, errors.New("TODO: ComputePlan not implemented — Phase C skeleton")
-}
-
-// ApplyPlan executes planned eval actions.
-//
-// For each action in plan.Actions:
-//   - EvalActionRun: expand full trial matrix, dispatch trials sequentially
-//     (Ollama single-thread constraint — see feedback_ollama_single_thread_constraint.md),
-//     emit TrialRecord CogBlocks via BusEmitter to bus_tournament after each trial.
-//   - EvalActionRunIncremental: dispatch only the TrialSpecs in action.Details.
-//   - EvalActionRefreshBaseline: re-run baseline cells, update baseline pin.
-//   - EvalActionRetryRegression: re-run regressed cells from action.Details.
-//   - EvalActionSkip: emit a reconcile.Result with ApplySkipped, no dispatch.
-//
-// Trial dispatch granularity: one trial at a time, returning to ComputePlan
-// between each (fine-grain — see design memo Q4). This allows interruption and
-// drift detection mid-run. ApplyPlan is called once per reconcile cycle; the
-// per-cycle budget limits how many trials run before the next cycle checks state.
-//
-// Concurrency: ApplyPlan must acquire an eval-scoped mutex before dispatching
-// to Ollama. The metabolic cycle ticker also uses Ollama (see
-// feedback_ollama_single_thread_constraint.md). Recommended: eval reconciliation
-// holds a per-cycle budget (e.g. 3 trials/cycle) and releases the mutex between
-// trials so the metabolic ticker can run (see design memo Q5).
-//
-// TODO(Phase C): implement dispatch loop. Use e.dispatcher.DispatchToHarness()
-// per trial. Call e.emitter.EmitCogBlock("bus_tournament", record) after each.
-// Track in-flight trial IDs in EvalProviderState for the next cycle.
-// Mirror the Python runner loop in evals/tournament/runner.py run_experiment()
-// (runner.py lines 187-338).
-func (e *EvalProvider) ApplyPlan(ctx context.Context, plan *reconcile.Plan) ([]reconcile.Result, error) {
-	// TODO(Phase C): implement dispatch loop.
-	return nil, errors.New("TODO: ApplyPlan not implemented — Phase C skeleton")
-}
-
-// BuildState constructs reconcile state from live trial data (for snapshot/import).
-//
-// What it stores in the state:
-//   - One reconcile.Resource per experiment, carrying:
-//     Address: "eval.<experiment_id>"
-//     ExternalID: latest run ID (or "" if no runs yet)
-//     Attributes: map with trial_count, pass_rate, last_run_at, baseline_pinned
-//   - EvalProviderState in state.Metadata["eval_state"] (JSON-encoded).
-//
-// TODO(Phase C): implement by iterating live.(*EvalLiveState).Scorecards,
-// building reconcile.Resource per experiment. Pattern mirrors
-// component_provider.go BuildState() (component_provider.go lines 293-334).
-func (e *EvalProvider) BuildState(config any, live any, existing *reconcile.State) (*reconcile.State, error) {
-	// TODO(Phase C): implement state construction.
-	// ls := live.(*EvalLiveState)
-	// cfg := config.(*EvalConfig)
-	return nil, errors.New("TODO: BuildState not implemented — Phase C skeleton")
-}
-
-// Health returns the current three-axis status of the eval subsystem.
-//
-// Health axes:
-//   - Sync: OutOfSync if any AutoReconcile experiments have pending runs;
-//     Synced if all declared experiments have recent runs or are on-demand only.
-//   - Health: Degraded if any experiment has tripped its circuit breaker;
-//     Progressing if any trials are in flight;
-//     Healthy otherwise.
-//   - Operation: Syncing when trials are in flight; Idle otherwise.
-//
-// Message carries a summary: "N pending, M in-flight, K suspended".
-//
-// TODO(Phase C): implement by reading e.lastHealth (updated at end of each
-// ApplyPlan call) and optionally doing a lightweight cogdoc scan to check
-// for newly declared experiments.
-func (e *EvalProvider) Health() reconcile.ResourceStatus {
-	// TODO(Phase C): implement health computation.
-	// Return cached e.lastHealth if available; otherwise return Unknown.
-	return reconcile.ResourceStatus{
-		Sync:      reconcile.SyncStatusUnknown,
-		Health:    reconcile.HealthMissing,
-		Operation: reconcile.OperationIdle,
-		Message:   "eval provider not yet wired (Phase C skeleton)",
-	}
-}
-
 // ---------------------------------------------------------------------------
-// Internal helpers (stubs — implement in Phase C)
-// ---------------------------------------------------------------------------
-
-// nowISO delegates to the wired NowISO function, falling back to a sentinel.
-// Pattern mirrors component_provider.go nowISO() (lines 390-396).
-func nowISO() string {
-	if NowISO != nil {
-		return NowISO()
-	}
-	return time.Now().UTC().Format(time.RFC3339)
-}
-
-// parseEvalProviderState deserializes EvalProviderState from reconcile.State.Metadata.
-// Returns a zero-value EvalProviderState if the key is absent or unparseable.
-//
-// TODO(Phase C): implement using encoding/json.Unmarshal on
-// state.Metadata["eval_state"]. The Metadata field is map[string]any, so
-// re-serialize the value to JSON first (it may have been round-tripped through
-// interface{}).
-func parseEvalProviderState(_ *reconcile.State) EvalProviderState {
-	return EvalProviderState{
-		CircuitBreakerThreshold: 3,
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Registration guard
+// Method implementations
 // ---------------------------------------------------------------------------
 //
-// DO NOT uncomment the init() below until Phase C is formally shipped and
-// all Reconcilable methods are implemented.
+// Phase C: All Reconcilable method bodies are implemented in provider_impl.go.
+// Internal helpers (nowISO, parseEvalProviderState, buildScorecard, etc.) also
+// live there. This file provides the type definitions and constructors only.
 //
-// When ready, add:
-//   func init() {
-//       reconcile.RegisterProvider("eval", &EvalProvider{})
-//   }
-//
-// See component_provider.go line 91 for the registration pattern.
+// Registration: The eval provider is registered with pkg/reconcile by
+// eval_wiring.go (workspace root main package init) following the pattern
+// from component_wiring.go.

--- a/internal/eval/provider.go
+++ b/internal/eval/provider.go
@@ -1,0 +1,729 @@
+// Package eval provides the EvalProvider: a Reconcilable that manages the
+// eval harness substrate — variant cogdoc loading, matrix expansion, trial
+// dispatch, CogBlock emission, and scorecard computation — as part of the
+// CogOS kernel's continuous reconciliation loop.
+//
+// Architectural placement: Phase C of the eval harness substrate plan
+// (see cog://mem/semantic/architecture/eval-harness-substrate-plan.cog.md).
+//
+// EvalProvider implements pkg/reconcile.Reconcilable:
+//
+//	Declared state → experiment cogdocs at cog://mem/semantic/architecture/tournament/experiments/
+//	                + baseline pins at .cog/state/eval-baselines.json
+//	Live state     → completed TrialRecords read from bus_tournament channel
+//	Plan           → pending runs, stale baselines, regression retries, new variant cells
+//	Apply          → dispatch trials via AgentDispatcher; emit CogBlocks via BusEmitter
+//
+// This file intentionally ships as a DRAFT SKELETON. All Reconcilable method
+// bodies return errors.New("TODO") or zero values; types are complete. The
+// file is intended to compile (go build ./internal/eval/...) and serve as the
+// structural contract before Phase C begins.
+//
+// Do NOT register this provider in pkg/reconcile/registry.go until Phase C
+// is formally shipped. See constraint note at bottom of file.
+package eval
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/cogos-dev/cogos/pkg/reconcile"
+)
+
+// ---------------------------------------------------------------------------
+// Dependency interfaces
+// ---------------------------------------------------------------------------
+//
+// These narrow interfaces are what EvalProvider needs from other packages.
+// Concrete implementations wire in from main or from the kernel boot path.
+// Defining them here lets the package compile standalone without importing
+// internal/engine or internal/agents directly — avoiding import cycles.
+
+// AgentDispatcher is the subset of internal/engine.AgentDispatcher that
+// EvalProvider calls. Matches AgentDispatcher defined in
+// internal/engine/agent_dispatch.go (lines 138-143) exactly — wire the
+// concrete LocalHarnessController (or future AgentProvider) here.
+//
+// TODO(Phase C): import internal/engine.AgentDispatcher directly once
+// internal/agents/ is extracted as its own package. Until then, this
+// interface is intentionally shape-compatible but locally declared to
+// avoid a direct internal/engine import from internal/eval.
+type AgentDispatcher interface {
+	// DispatchToHarness executes a fan-out batch and returns once all slots
+	// complete, error, or time out. See internal/engine.DispatchRequest for
+	// the full field contract.
+	DispatchToHarness(ctx context.Context, req DispatchRequest) (*DispatchBatchResult, error)
+}
+
+// BusEmitter is the subset of internal/bus that EvalProvider calls for
+// CogBlock emission. Each trial record and each run summary becomes a
+// CogBlock on bus_tournament via EmitCogBlock.
+//
+// TODO(Phase C): align with the concrete bus.Emitter type once internal/bus/
+// is extracted. Shape is intentionally minimal.
+type BusEmitter interface {
+	// EmitCogBlock emits a serialized CogBlock to the named bus channel.
+	// channelName is the raw bus channel id, e.g. "bus_tournament".
+	// block is a JSON-serializable payload; the bus layer wraps it in the
+	// ADR-084 pointer-envelope (digest → BlobStore, metadata in envelope).
+	EmitCogBlock(ctx context.Context, channelName string, block any) error
+}
+
+// CogdocReader reads raw cogdoc files from the workspace by cog:// URI or
+// absolute path. Used by LoadConfig to enumerate experiment cogdocs and by
+// FetchLive's variant loader.
+//
+// TODO(Phase C): align with workspace.Reader or the resolved path from
+// internal/engine.ResolveURI (uri.go). The mem:// projection resolves to
+// .cog/mem/ — see uri.go line 51.
+type CogdocReader interface {
+	// ReadCogdoc reads a single .cog.md file, returning raw bytes.
+	// path may be an absolute filesystem path or a cog:// URI.
+	ReadCogdoc(path string) ([]byte, error)
+	// GlobCogdocs returns all .cog.md file paths under the given cog:// URI
+	// prefix or filesystem directory (non-recursive subdirs included).
+	GlobCogdocs(prefix string) ([]string, error)
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch shims (shape-compatible with internal/engine, locally redeclared)
+// ---------------------------------------------------------------------------
+//
+// These types are exact shape copies of types in internal/engine/agent_dispatch.go.
+// They exist here so internal/eval compiles without importing internal/engine.
+// On Phase C wiring, replace these with direct imports or a shared pkg/types.
+//
+// TODO(Phase C / internal/agents extraction): move DispatchRequest and siblings
+// to a shared pkg/dispatch or pkg/agentapi package so both internal/engine and
+// internal/eval can import without cycles.
+
+// DispatchRequest is a shape copy of internal/engine.DispatchRequest
+// (agent_dispatch.go lines 50-92).
+type DispatchRequest struct {
+	AgentID        string
+	Task           string
+	Tools          []string
+	Model          string // matches DispatchModel string type
+	TimeoutSeconds int
+	N              int
+	SystemPrompt   string
+	Thinking       *bool
+}
+
+// DispatchResult is a shape copy of internal/engine.DispatchResult
+// (agent_dispatch.go lines 105-119).
+type DispatchResult struct {
+	Index       int     `json:"index"`
+	Success     bool    `json:"success"`
+	Content     string  `json:"content,omitempty"`
+	Error       string  `json:"error,omitempty"`
+	DurationSec float64 `json:"duration_sec"`
+	Turns       int     `json:"turns"`
+	ModelUsed   string  `json:"model_used,omitempty"`
+}
+
+// DispatchBatchResult is a shape copy of internal/engine.DispatchBatchResult
+// (agent_dispatch.go lines 125-132).
+type DispatchBatchResult struct {
+	Results          []DispatchResult `json:"results"`
+	TotalDurationSec float64          `json:"total_duration_sec"`
+	Notes            []string         `json:"notes,omitempty"`
+}
+
+// ---------------------------------------------------------------------------
+// Domain types — ported from Python with Go idioms
+// ---------------------------------------------------------------------------
+//
+// These are the Go ports of:
+//   evals/harness/cases.py        — Rubric, Case
+//   evals/tournament/variants.py  — Variant
+//   evals/tournament/matrix.py    — Experiment, TrialSpec
+//   evals/harness/scoring.py      — Verdict
+//   evals/tournament/compare.py   — Scorecard, Delta
+// plus TrialRecord from evals/reports/data.py and RunSummary.
+
+// VariantClass identifies what a variant overrides.
+type VariantClass string
+
+const (
+	VariantClassSystemPrompt    VariantClass = "system-prompt"
+	VariantClassToolDescription VariantClass = "tool-description"
+	VariantClassTask            VariantClass = "task"
+	VariantClassExperiment      VariantClass = "experiment"
+)
+
+// Variant is a single prompt variant loaded from a .cog.md cogdoc.
+// Ports evals/tournament/variants.py Variant dataclass.
+type Variant struct {
+	// ID is the variant identifier from cogdoc frontmatter or the stem of the file.
+	ID string `json:"id"`
+	// Class identifies whether this variant overrides the system prompt,
+	// tool descriptions, or task configuration.
+	Class VariantClass `json:"variant_class"`
+	// Content is the variant payload:
+	//   - system-prompt:    string (body under "## Variant content")
+	//   - tool-description: map[string]any (overrides: dict from frontmatter)
+	//   - task:             map[string]any (case: dict from frontmatter)
+	Content any `json:"content"`
+	// BaselineOf links this variant to its baseline counterpart (e.g. "sp-1-production").
+	BaselineOf string `json:"baseline_of,omitempty"`
+	// Ablation names the specific feature this variant removes.
+	Ablation string `json:"ablation,omitempty"`
+	// Tags are arbitrary labels for filtering (e.g. ["tournament", "anti-pattern"]).
+	Tags []string `json:"tags,omitempty"`
+	// SourcePath is the absolute filesystem path from which this variant was loaded.
+	SourcePath string `json:"source_path,omitempty"`
+}
+
+// Rubric holds the scoring criteria for a single eval case.
+// Ports evals/harness/cases.py Rubric dataclass.
+//
+// Extension point: Phase C ports this exactly. Weighted scoring and judge
+// integration are post-Phase-C additions (see design memo Q8).
+type Rubric struct {
+	// ExpectedTools are tool names that MUST appear in the tool-call sequence.
+	ExpectedTools []string `json:"expected_tools,omitempty"`
+	// ExpectedToolsAnyOf requires at least ONE of these names to appear.
+	ExpectedToolsAnyOf []string `json:"expected_tools_any_of,omitempty"`
+	// ForbiddenTools are tool names that MUST NOT appear.
+	ForbiddenTools []string `json:"forbidden_tools,omitempty"`
+	// ContentContains are strings that must appear in the assistant's final content.
+	ContentContains []string `json:"content_contains,omitempty"`
+	// ContentMustNotContain are strings that must NOT appear in final content.
+	ContentMustNotContain []string `json:"content_must_not_contain,omitempty"`
+	// ContentContainsCI is the case-insensitive variant of ContentContains.
+	// Added during Phase C port to close the task-3 gap from exp-001 runs.
+	ContentContainsCI []string `json:"content_contains_ci,omitempty"`
+	// ContentMustNotContainCI is the case-insensitive variant of ContentMustNotContain.
+	ContentMustNotContainCI []string `json:"content_must_not_contain_ci,omitempty"`
+	// FirstToolOneOf constrains the first tool call to one of these names.
+	FirstToolOneOf []string `json:"first_tool_one_of,omitempty"`
+}
+
+// Case is a single eval scenario with a prompt and a scoring rubric.
+// Ports evals/harness/cases.py Case dataclass.
+type Case struct {
+	// Name is the stable identifier for this case, matching the task variant ID.
+	Name string `json:"name"`
+	// Prompt is the user-turn text sent to the model.
+	Prompt string `json:"prompt"`
+	// Rubric holds the scoring constraints.
+	Rubric Rubric `json:"rubric"`
+	// SystemPrompt, if non-empty, overrides the default system prompt for this case.
+	// Set from the trial's system-prompt variant before dispatch.
+	SystemPrompt string `json:"system_prompt,omitempty"`
+	// Tags are arbitrary labels inherited from the task variant.
+	Tags []string `json:"tags,omitempty"`
+	// MaxTokens is the per-trial token budget. Default 1024.
+	MaxTokens int `json:"max_tokens"`
+}
+
+// Experiment is the parsed form of an experiment cogdoc.
+// Ports evals/tournament/matrix.py Experiment dataclass.
+//
+// Cogdocs live at cog://mem/semantic/architecture/tournament/experiments/
+// — resolved by uri.go projection "mem" → .cog/mem/ (uri.go line 51).
+type Experiment struct {
+	// ID is the stable identifier, e.g. "exp-001-anti-pattern-placement".
+	ID string `json:"id"`
+	// Title is the human-readable experiment title from frontmatter.
+	Title string `json:"title"`
+	// BaselineVariant is the composite key for the baseline cell,
+	// e.g. "sp-1-production+td-1-current".
+	BaselineVariant string `json:"baseline_variant"`
+	// VariantAxes maps axis name → list of variant IDs,
+	// e.g. {"system_prompt": ["sp-1-production", "sp-3-stripped"]}.
+	VariantAxes map[string][]string `json:"variant_axes"`
+	// TaskIDs lists the task variant IDs included in this experiment.
+	TaskIDs []string `json:"task_ids"`
+	// Target names the dispatch target, e.g. "laptop-lms".
+	Target string `json:"target"`
+	// Tags are arbitrary labels.
+	Tags []string `json:"tags,omitempty"`
+	// AutoReconcile, when true, allows the metabolic cycle to run this
+	// experiment automatically. Defaults false (on-demand only).
+	//
+	// TODO(Phase C): wire this from frontmatter key "auto_reconcile: true".
+	// When false, the experiment only runs via explicit cog_run_experiment MCP call.
+	AutoReconcile bool `json:"auto_reconcile,omitempty"`
+	// BaselinePinned is the run ID of the pinned baseline, if any.
+	// Set externally via cog_pin_baseline MCP tool (see design memo Q10).
+	BaselinePinned string `json:"baseline_pinned,omitempty"`
+}
+
+// TrialSpec is a single trial to execute: one variant configuration × one task.
+// Ports evals/tournament/matrix.py TrialSpec dataclass.
+type TrialSpec struct {
+	// TrialID is the stable identifier, e.g.
+	// "exp-001__sp-3-stripped+td-1-current__task-1-state-probe".
+	TrialID string `json:"trial_id"`
+	// ExperimentID links this trial to its parent experiment.
+	ExperimentID string `json:"experiment_id"`
+	// TaskVariant is the resolved task variant.
+	TaskVariant Variant `json:"task_variant"`
+	// VariantIDs maps axis → variant ID for non-task axes in this trial.
+	VariantIDs map[string]string `json:"variant_ids"`
+	// SystemPromptVariant is the resolved system-prompt variant, or empty ID if absent.
+	SystemPromptVariant *Variant `json:"system_prompt_variant,omitempty"`
+	// ToolDescriptionVariant is the resolved tool-description variant, or nil if Phase 1.
+	ToolDescriptionVariant *Variant `json:"tool_description_variant,omitempty"`
+	// Target names the dispatch target, inherited from the experiment.
+	Target string `json:"target"`
+}
+
+// Verdict is the scoring result for a single trial.
+// Ports evals/harness/scoring.py Verdict dataclass.
+type Verdict struct {
+	// Passed is true if all rubric constraints were satisfied.
+	Passed bool `json:"passed"`
+	// Failures lists each rubric constraint that was not met.
+	Failures []string `json:"failures,omitempty"`
+	// Notes are informational annotations (e.g. "tool_calls: [cog_read_cogdoc]").
+	Notes []string `json:"notes,omitempty"`
+}
+
+// TrialRecord is the persisted record of a completed trial.
+// Ports evals/reports/data.py TrialRecord dataclass.
+// Emitted as a CogBlock on bus_tournament after each trial completes.
+type TrialRecord struct {
+	// TrialID is the stable identifier for this trial.
+	TrialID string `json:"trial_id"`
+	// ExperimentID links this record to its parent experiment.
+	ExperimentID string `json:"experiment_id"`
+	// VariantIDs is the axis → variant mapping for this trial.
+	VariantIDs map[string]string `json:"variant_ids"`
+	// TaskID is the task variant ID.
+	TaskID string `json:"task_id"`
+	// Target names the dispatch target.
+	Target string `json:"target"`
+	// Passed reports whether the trial satisfied its rubric.
+	Passed bool `json:"passed"`
+	// Failures lists rubric violations, empty on pass.
+	Failures []string `json:"failures,omitempty"`
+	// Notes are informational annotations from the scorer.
+	Notes []string `json:"notes,omitempty"`
+	// ToolCalls records each tool invocation made during the trial.
+	ToolCalls []ToolCallRecord `json:"tool_calls,omitempty"`
+	// Content is the final assistant text response.
+	Content string `json:"content,omitempty"`
+	// Reasoning is the model's reasoning trace, if available.
+	Reasoning string `json:"reasoning,omitempty"`
+	// DurationSec is the wall-clock time for this trial.
+	DurationSec float64 `json:"duration_sec"`
+	// Timestamp is the ISO-8601 start time of this trial.
+	Timestamp string `json:"timestamp"`
+	// Model is the inference backend used.
+	Model string `json:"model,omitempty"`
+	// TDWired indicates whether tool-description variant overrides were wired.
+	// False in Phase 1 (TD axis not yet wired into dispatch).
+	TDWired bool `json:"td_wired"`
+	// CogBlockHash is the content-addressed hash of the CogBlock emitted for
+	// this trial on bus_tournament. Empty if emission failed.
+	CogBlockHash string `json:"cogblock_hash,omitempty"`
+}
+
+// ToolCallRecord is the digest of a single tool invocation within a trial.
+type ToolCallRecord struct {
+	Name      string `json:"name"`
+	ArgsDigest string `json:"args_digest,omitempty"`
+	ResultDigest string `json:"result_digest,omitempty"`
+	Error     string `json:"error,omitempty"`
+}
+
+// RunSummary is the aggregate result of an experiment run.
+type RunSummary struct {
+	// ExperimentID identifies the experiment.
+	ExperimentID string `json:"experiment_id"`
+	// RunID is the stable identifier for this run, e.g.
+	// "exp-001-anti-pattern-placement_run_20260426T010713Z".
+	RunID string `json:"run_id"`
+	// StartedAt and EndedAt are ISO-8601 timestamps.
+	StartedAt string `json:"started_at"`
+	EndedAt   string `json:"ended_at"`
+	// Total, Passed, Failed are trial counts.
+	Total  int `json:"total"`
+	Passed int `json:"passed"`
+	Failed int `json:"failed"`
+	// Target names the dispatch target used in this run.
+	Target string `json:"target"`
+	// Model is the inference backend used.
+	Model string `json:"model,omitempty"`
+}
+
+// ScorecardCell is the pass/fail aggregate for a (variant_key, task_id) cell.
+// nil means no data for this cell.
+type ScorecardCell = *bool
+
+// Scorecard is the aggregate pass/fail matrix for an experiment run.
+// Ports evals/tournament/compare.py Scorecard dataclass.
+type Scorecard struct {
+	// ExperimentID identifies the experiment.
+	ExperimentID string `json:"experiment_id"`
+	// Cells maps (variant_key, task_id) → pass/fail aggregate.
+	// variant_key is "sp-id / td-id"; task_id is the task variant id.
+	// nil = no data for this cell.
+	Cells map[[2]string]ScorecardCell `json:"cells"`
+	// VariantKeys is the sorted list of variant keys (for deterministic output).
+	VariantKeys []string `json:"variant_keys"`
+	// TaskIDs is the sorted list of task IDs.
+	TaskIDs []string `json:"task_ids"`
+}
+
+// Delta is the pass-rate difference between a variant and its baseline.
+// Ports evals/tournament/compare.py Delta dataclass.
+type Delta struct {
+	// VariantKey and BaselineKey identify the compared variants.
+	VariantKey  string `json:"variant_key"`
+	BaselineKey string `json:"baseline_key"`
+	// Delta is positive for improvement, negative for regression.
+	// math.Inf(-1) when variant has no data.
+	Delta float64 `json:"delta"`
+	// VariantPassRate and BaselinePassRate are the aggregated pass rates.
+	// nil when no data is available.
+	VariantPassRate  *float64 `json:"variant_pass_rate,omitempty"`
+	BaselinePassRate *float64 `json:"baseline_pass_rate,omitempty"`
+	// TaskDeltas maps task_id → per-task delta (nil = missing data).
+	TaskDeltas map[string]*float64 `json:"task_deltas,omitempty"`
+}
+
+// ---------------------------------------------------------------------------
+// EvalConfig — the declared state loaded by LoadConfig
+// ---------------------------------------------------------------------------
+
+// EvalConfig is the declared configuration for the eval provider.
+// Loaded from:
+//   - Experiment cogdocs at cog://mem/semantic/architecture/tournament/experiments/
+//     (resolved to .cog/mem/semantic/architecture/tournament/experiments/ by uri.go)
+//   - Baseline pins from .cog/state/eval-baselines.json
+//     (see design memo Q1 for the storage decision rationale)
+type EvalConfig struct {
+	// Experiments is the set of declared experiments, keyed by experiment ID.
+	Experiments map[string]*Experiment `json:"experiments"`
+	// BaselinePins maps experiment ID → pinned run ID.
+	// Populated from .cog/state/eval-baselines.json (design memo Q1).
+	BaselinePins map[string]string `json:"baseline_pins,omitempty"`
+	// TournamentRoot is the resolved filesystem path of the tournament cogdoc
+	// directory, e.g. /Users/.../cog/.cog/mem/semantic/architecture/tournament.
+	// Populated by LoadConfig from workspace root + uri.go "mem" projection.
+	TournamentRoot string `json:"tournament_root,omitempty"`
+}
+
+// ---------------------------------------------------------------------------
+// EvalLiveState — the live state fetched by FetchLive
+// ---------------------------------------------------------------------------
+
+// EvalLiveState is the snapshot of completed trials fetched from bus_tournament.
+// FetchLive reads recent CogBlock events from bus_tournament, deserializes
+// TrialRecord payloads, and builds a per-experiment scorecard.
+//
+// TODO(Phase C — FetchLive): decide look-back window (all-time vs N-day).
+// See design memo Q2 for the recommendation (all-time, re-materialized per
+// reconcile cycle, with scorecard computed inline).
+type EvalLiveState struct {
+	// Trials is the flat list of all completed trial records fetched from the bus.
+	Trials []TrialRecord `json:"trials"`
+	// Scorecards maps experiment ID → computed scorecard over all fetched trials.
+	Scorecards map[string]*Scorecard `json:"scorecards"`
+	// FetchedAt is the ISO-8601 timestamp when this snapshot was taken.
+	FetchedAt string `json:"fetched_at"`
+}
+
+// ---------------------------------------------------------------------------
+// EvalPlanAction — the planned operations in ComputePlan
+// ---------------------------------------------------------------------------
+
+// EvalActionType identifies the kind of eval action planned.
+type EvalActionType string
+
+const (
+	// EvalActionRun plans a new experiment run (no prior runs for this experiment).
+	EvalActionRun EvalActionType = "run"
+	// EvalActionRefreshBaseline plans a baseline refresh (pinned run is stale or missing).
+	EvalActionRefreshBaseline EvalActionType = "refresh_baseline"
+	// EvalActionRunIncremental plans running only new variant cells since the last run.
+	EvalActionRunIncremental EvalActionType = "run_incremental"
+	// EvalActionRetryRegression plans a retry of cells that regressed vs the baseline.
+	EvalActionRetryRegression EvalActionType = "retry_regression"
+	// EvalActionSkip plans no action (experiment is current and healthy).
+	EvalActionSkip EvalActionType = "skip"
+)
+
+// EvalPlanDetail holds per-action detail for eval plan actions.
+// Stored in reconcile.Action.Details as a map[string]any (JSON-serializable).
+type EvalPlanDetail struct {
+	// ExperimentID identifies which experiment this action targets.
+	ExperimentID string `json:"experiment_id"`
+	// EvalAction is the specific eval operation.
+	EvalAction EvalActionType `json:"eval_action"`
+	// TrialSpecs are the specific trials to run for incremental and retry actions.
+	// Empty for full-run actions (expand_matrix is called at ApplyPlan time).
+	TrialSpecs []TrialSpec `json:"trial_specs,omitempty"`
+	// RegressionCells lists (variant_key, task_id) pairs that regressed.
+	// Populated for EvalActionRetryRegression.
+	RegressionCells [][2]string `json:"regression_cells,omitempty"`
+	// StaleAfter is the ISO-8601 time after which the baseline is considered stale.
+	StaleAfter string `json:"stale_after,omitempty"`
+}
+
+// ---------------------------------------------------------------------------
+// EvalProviderState — persisted between reconcile cycles
+// ---------------------------------------------------------------------------
+
+// EvalProviderState is the eval-specific metadata persisted inside
+// reconcile.State.Metadata["eval_state"]. It bridges cycles so ApplyPlan
+// doesn't double-fire in-flight trials and circuit-breakers work.
+//
+// Stored as a JSON blob in reconcile.State.Metadata (see design memo Q9).
+type EvalProviderState struct {
+	// InFlightTrialIDs lists trial IDs currently being dispatched.
+	// Checked by ComputePlan to avoid re-planning in-flight work.
+	InFlightTrialIDs []string `json:"in_flight_trial_ids,omitempty"`
+	// RecentFailureCounts maps experiment ID → consecutive failure count.
+	// When > CircuitBreakerThreshold, ComputePlan skips that experiment.
+	RecentFailureCounts map[string]int `json:"recent_failure_counts,omitempty"`
+	// LastReconcileAt is the ISO-8601 time of the last completed reconcile.
+	LastReconcileAt string `json:"last_reconcile_at,omitempty"`
+	// CircuitBreakerThreshold is the failure count above which an experiment
+	// is suspended until manually reset. Default 3.
+	CircuitBreakerThreshold int `json:"circuit_breaker_threshold,omitempty"`
+}
+
+// ---------------------------------------------------------------------------
+// EvalProvider — the Reconcilable
+// ---------------------------------------------------------------------------
+
+// EvalProvider implements pkg/reconcile.Reconcilable for the eval harness
+// substrate. It is the Go kernel's owner of variant cogdoc loading, matrix
+// expansion, trial dispatch, CogBlock emission, and scorecard computation.
+//
+// Dependency wiring follows the component_provider.go pattern (see
+// internal/providers/component/component_provider.go lines 68-81): the main
+// package or kernel boot path sets the exported function variables before the
+// first reconcile cycle.
+//
+// NOTE: Do NOT register this provider in pkg/reconcile/registry.go until
+// Phase C is formally shipped. The component_provider.go init() call
+// (line 91) is the pattern to follow when registration is ready.
+type EvalProvider struct {
+	// root is the workspace root, set by LoadConfig.
+	root string
+	// dispatcher handles trial dispatch. Set by the kernel boot path or tests.
+	dispatcher AgentDispatcher
+	// emitter handles CogBlock emission to bus_tournament. Set by boot path.
+	emitter BusEmitter
+	// reader reads cogdoc files. Set by boot path.
+	reader CogdocReader
+	// lastHealth is the cached health status, updated on each reconcile cycle.
+	lastHealth reconcile.ResourceStatus
+}
+
+// Dependency-injection seam variables. Set by the wiring layer (kernel boot
+// or test setup) before any reconcile cycle begins. Pattern mirrors
+// component_provider.go lines 68-81.
+var (
+	// NewEvalProvider constructs a wired EvalProvider. Set by wiring layer.
+	// TODO(Phase C wiring): replace with direct constructor call from kernel boot.
+	NewEvalProvider func(dispatcher AgentDispatcher, emitter BusEmitter, reader CogdocReader) *EvalProvider
+	// NowISO returns the current UTC time in ISO-8601. Set by wiring layer
+	// (same sentinel as component_provider.go).
+	NowISO func() string
+)
+
+// Type returns the resource type identifier. Satisfies reconcile.Reconcilable.
+func (e *EvalProvider) Type() string { return "eval" }
+
+// LoadConfig loads the declared eval configuration from the workspace.
+//
+// What it reads:
+//  1. All .cog.md files under the tournament experiments directory
+//     (resolved from workspace root as
+//     .cog/mem/semantic/architecture/tournament/experiments/ via uri.go
+//     "mem" projection — see uri.go line 51).
+//  2. Baseline pin state from .cog/state/eval-baselines.json
+//     (JSON file with map[experiment_id]run_id — see design memo Q1).
+//
+// Returns *EvalConfig. Callers must type-assert: config.(*EvalConfig).
+//
+// TODO(Phase C): implement via CogdocReader.GlobCogdocs +
+// CogdocReader.ReadCogdoc; parse YAML frontmatter to populate
+// Experiment.VariantAxes, TaskIDs, AutoReconcile, etc.
+// Mirror the Python logic in evals/tournament/variants.py load_variants()
+// and evals/tournament/matrix.py load_experiment_from_cogdoc().
+func (e *EvalProvider) LoadConfig(root string) (any, error) {
+	e.root = root
+	// TODO(Phase C): enumerate experiment cogdocs via CogdocReader.GlobCogdocs
+	// with prefix "<root>/.cog/mem/semantic/architecture/tournament/experiments/".
+	// Parse each .cog.md frontmatter into an Experiment struct.
+	// Load baseline pins from "<root>/.cog/state/eval-baselines.json" if present.
+	return nil, errors.New("TODO: LoadConfig not implemented — Phase C skeleton")
+}
+
+// FetchLive fetches the current live state from bus_tournament.
+//
+// What it reads:
+//   - All CogBlock events on bus_tournament (channel carrying tournament.trial.v1
+//     and tournament.experiment.v1 blocks, emitted by ApplyPlan via BusEmitter).
+//   - Read window: all-time (re-materialized per reconcile cycle). The channel's
+//     retention policy governs eviction independently.
+//
+// The scorecard for each experiment is computed inline from the fetched trials.
+// Returns *EvalLiveState. Callers must type-assert: live.(*EvalLiveState).
+//
+// TODO(Phase C): implement via BusEmitter's read path (or a companion
+// BusReader interface for reading vs emitting). Deserialize TrialRecord from
+// each event payload. Call buildScorecard() per experiment.
+// See evals/tournament/compare.py build_scorecard() for the aggregation logic.
+func (e *EvalProvider) FetchLive(ctx context.Context, config any) (any, error) {
+	// TODO(Phase C): read bus_tournament events, deserialize TrialRecords,
+	// group by experiment_id, build Scorecard per experiment.
+	return nil, errors.New("TODO: FetchLive not implemented — Phase C skeleton")
+}
+
+// ComputePlan compares declared experiments against completed trial data and
+// produces a reconciliation plan.
+//
+// Planning rules (in priority order):
+//  1. No runs for this experiment → EvalActionRun (full matrix expansion at apply time)
+//  2. New variant axis cells since last run → EvalActionRunIncremental (only new cells)
+//  3. Pinned baseline is stale (> 7 days old, or run_id missing) → EvalActionRefreshBaseline
+//  4. Regression detected (pass rate drop > 10pp vs pinned baseline) → EvalActionRetryRegression
+//  5. In-flight trials (EvalProviderState.InFlightTrialIDs non-empty) → EvalActionSkip (wait)
+//  6. Circuit breaker tripped (RecentFailureCounts[id] > threshold) → EvalActionSkip (suspended)
+//  7. AutoReconcile=false and no explicit trigger → EvalActionSkip (on-demand only)
+//  8. Experiment is current and healthy → EvalActionSkip (in sync)
+//
+// Returns a reconcile.Plan with ResourceType "eval". Each reconcile.Action
+// carries a Details map with EvalPlanDetail fields serialized as map[string]any.
+//
+// TODO(Phase C): implement the planning rules listed above. Parse EvalProviderState
+// from state.Metadata["eval_state"] using encoding/json. Use the Python
+// compare.py regression_check() logic (compare.py lines 174-199) as the
+// regression detection reference.
+func (e *EvalProvider) ComputePlan(config any, live any, state *reconcile.State) (*reconcile.Plan, error) {
+	// TODO(Phase C): implement planning rules.
+	// cfg := config.(*EvalConfig)
+	// ls := live.(*EvalLiveState)
+	// eps := parseEvalProviderState(state)
+	// For each experiment in cfg.Experiments:
+	//   determine action using priority rules above
+	//   append reconcile.Action with EvalPlanDetail in Details
+	return nil, errors.New("TODO: ComputePlan not implemented — Phase C skeleton")
+}
+
+// ApplyPlan executes planned eval actions.
+//
+// For each action in plan.Actions:
+//   - EvalActionRun: expand full trial matrix, dispatch trials sequentially
+//     (Ollama single-thread constraint — see feedback_ollama_single_thread_constraint.md),
+//     emit TrialRecord CogBlocks via BusEmitter to bus_tournament after each trial.
+//   - EvalActionRunIncremental: dispatch only the TrialSpecs in action.Details.
+//   - EvalActionRefreshBaseline: re-run baseline cells, update baseline pin.
+//   - EvalActionRetryRegression: re-run regressed cells from action.Details.
+//   - EvalActionSkip: emit a reconcile.Result with ApplySkipped, no dispatch.
+//
+// Trial dispatch granularity: one trial at a time, returning to ComputePlan
+// between each (fine-grain — see design memo Q4). This allows interruption and
+// drift detection mid-run. ApplyPlan is called once per reconcile cycle; the
+// per-cycle budget limits how many trials run before the next cycle checks state.
+//
+// Concurrency: ApplyPlan must acquire an eval-scoped mutex before dispatching
+// to Ollama. The metabolic cycle ticker also uses Ollama (see
+// feedback_ollama_single_thread_constraint.md). Recommended: eval reconciliation
+// holds a per-cycle budget (e.g. 3 trials/cycle) and releases the mutex between
+// trials so the metabolic ticker can run (see design memo Q5).
+//
+// TODO(Phase C): implement dispatch loop. Use e.dispatcher.DispatchToHarness()
+// per trial. Call e.emitter.EmitCogBlock("bus_tournament", record) after each.
+// Track in-flight trial IDs in EvalProviderState for the next cycle.
+// Mirror the Python runner loop in evals/tournament/runner.py run_experiment()
+// (runner.py lines 187-338).
+func (e *EvalProvider) ApplyPlan(ctx context.Context, plan *reconcile.Plan) ([]reconcile.Result, error) {
+	// TODO(Phase C): implement dispatch loop.
+	return nil, errors.New("TODO: ApplyPlan not implemented — Phase C skeleton")
+}
+
+// BuildState constructs reconcile state from live trial data (for snapshot/import).
+//
+// What it stores in the state:
+//   - One reconcile.Resource per experiment, carrying:
+//     Address: "eval.<experiment_id>"
+//     ExternalID: latest run ID (or "" if no runs yet)
+//     Attributes: map with trial_count, pass_rate, last_run_at, baseline_pinned
+//   - EvalProviderState in state.Metadata["eval_state"] (JSON-encoded).
+//
+// TODO(Phase C): implement by iterating live.(*EvalLiveState).Scorecards,
+// building reconcile.Resource per experiment. Pattern mirrors
+// component_provider.go BuildState() (component_provider.go lines 293-334).
+func (e *EvalProvider) BuildState(config any, live any, existing *reconcile.State) (*reconcile.State, error) {
+	// TODO(Phase C): implement state construction.
+	// ls := live.(*EvalLiveState)
+	// cfg := config.(*EvalConfig)
+	return nil, errors.New("TODO: BuildState not implemented — Phase C skeleton")
+}
+
+// Health returns the current three-axis status of the eval subsystem.
+//
+// Health axes:
+//   - Sync: OutOfSync if any AutoReconcile experiments have pending runs;
+//     Synced if all declared experiments have recent runs or are on-demand only.
+//   - Health: Degraded if any experiment has tripped its circuit breaker;
+//     Progressing if any trials are in flight;
+//     Healthy otherwise.
+//   - Operation: Syncing when trials are in flight; Idle otherwise.
+//
+// Message carries a summary: "N pending, M in-flight, K suspended".
+//
+// TODO(Phase C): implement by reading e.lastHealth (updated at end of each
+// ApplyPlan call) and optionally doing a lightweight cogdoc scan to check
+// for newly declared experiments.
+func (e *EvalProvider) Health() reconcile.ResourceStatus {
+	// TODO(Phase C): implement health computation.
+	// Return cached e.lastHealth if available; otherwise return Unknown.
+	return reconcile.ResourceStatus{
+		Sync:      reconcile.SyncStatusUnknown,
+		Health:    reconcile.HealthMissing,
+		Operation: reconcile.OperationIdle,
+		Message:   "eval provider not yet wired (Phase C skeleton)",
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers (stubs — implement in Phase C)
+// ---------------------------------------------------------------------------
+
+// nowISO delegates to the wired NowISO function, falling back to a sentinel.
+// Pattern mirrors component_provider.go nowISO() (lines 390-396).
+func nowISO() string {
+	if NowISO != nil {
+		return NowISO()
+	}
+	return time.Now().UTC().Format(time.RFC3339)
+}
+
+// parseEvalProviderState deserializes EvalProviderState from reconcile.State.Metadata.
+// Returns a zero-value EvalProviderState if the key is absent or unparseable.
+//
+// TODO(Phase C): implement using encoding/json.Unmarshal on
+// state.Metadata["eval_state"]. The Metadata field is map[string]any, so
+// re-serialize the value to JSON first (it may have been round-tripped through
+// interface{}).
+func parseEvalProviderState(_ *reconcile.State) EvalProviderState {
+	return EvalProviderState{
+		CircuitBreakerThreshold: 3,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Registration guard
+// ---------------------------------------------------------------------------
+//
+// DO NOT uncomment the init() below until Phase C is formally shipped and
+// all Reconcilable methods are implemented.
+//
+// When ready, add:
+//   func init() {
+//       reconcile.RegisterProvider("eval", &EvalProvider{})
+//   }
+//
+// See component_provider.go line 91 for the registration pattern.

--- a/internal/eval/provider_impl.go
+++ b/internal/eval/provider_impl.go
@@ -1,0 +1,1496 @@
+// provider_impl.go — Phase C implementation of EvalProvider Reconcilable methods.
+//
+// Implements the six Reconcilable methods for EvalProvider:
+//   - LoadConfig: parse experiment cogdocs + baseline pins
+//   - FetchLive: read bus_tournament events, build scorecards
+//   - ComputePlan: 8-rule priority chain
+//   - ApplyPlan: trial dispatch loop (one trial per cycle, budget-gated)
+//   - BuildState: one reconcile.Resource per experiment
+//   - Health: three-axis status
+//
+// Also implements parseEvalProviderState, variantKey, and buildScorecard helpers.
+//
+// Python reference implementations:
+//   - evals/tournament/variants.py — variant loader + cogdoc parsing
+//   - evals/tournament/matrix.py   — Experiment + matrix expansion
+//   - evals/tournament/runner.py   — trial dispatch loop
+//   - evals/tournament/compare.py  — Scorecard + regression detection
+package eval
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cogos-dev/cogos/pkg/reconcile"
+	"gopkg.in/yaml.v3"
+)
+
+// nowISO delegates to the wired NowISO function, falling back to time.Now().
+// Pattern mirrors component_provider.go nowISO() (lines 390-396).
+func nowISO() string {
+	if NowISO != nil {
+		return NowISO()
+	}
+	return time.Now().UTC().Format(time.RFC3339)
+}
+
+// trialsPerCycle is the maximum number of trials dispatched per ApplyPlan call.
+// Per design memo Q4: fine-grain (one trial per cycle) is the default; bump
+// to 3 for faster lab runs when Ollama has capacity.
+const trialsPerCycle = 1
+
+// regressionThreshold is the pass-rate drop (0.0–1.0) that triggers a retry.
+// 10pp = 0.10, matching the Python compare.py default.
+const regressionThreshold = 0.10
+
+// baselineStaleDays is the number of days after which a baseline pin is stale.
+const baselineStaleDays = 7
+
+// circuitBreakerDefaultThreshold is the default consecutive-failure count
+// above which an experiment is suspended. See design memo Q9.
+const circuitBreakerDefaultThreshold = 3
+
+// applyMu serializes trial dispatch so only one eval trial hits Ollama at
+// a time (per design memo Q5 / feedback_ollama_single_thread_constraint.md).
+var applyMu sync.Mutex
+
+// ---------------------------------------------------------------------------
+// LoadConfig
+// ---------------------------------------------------------------------------
+
+// LoadConfig loads declared eval configuration from the workspace.
+//
+// Reads:
+//  1. All .cog.md files under <root>/.cog/mem/semantic/architecture/tournament/experiments/
+//  2. Baseline pins from <root>/.cog/state/eval-baselines.json
+//
+// Returns *EvalConfig.
+func (e *EvalProvider) LoadConfig(root string) (any, error) {
+	e.root = root
+
+	experimentsDir := filepath.Join(root, ".cog", "mem", "semantic", "architecture", "tournament", "experiments")
+
+	entries, err := os.ReadDir(experimentsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// No experiments yet — return empty config
+			return &EvalConfig{
+				Experiments:    map[string]*Experiment{},
+				BaselinePins:   map[string]string{},
+				TournamentRoot: filepath.Join(root, ".cog", "mem", "semantic", "architecture", "tournament"),
+			}, nil
+		}
+		return nil, fmt.Errorf("eval: read experiments dir %s: %w", experimentsDir, err)
+	}
+
+	experiments := make(map[string]*Experiment)
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".cog.md") {
+			continue
+		}
+		path := filepath.Join(experimentsDir, entry.Name())
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			continue // skip unreadable files
+		}
+		exp, err := parseCogdocExperiment(raw, path)
+		if err != nil || exp == nil {
+			continue
+		}
+		experiments[exp.ID] = exp
+	}
+
+	// Load baseline pins from .cog/state/eval-baselines.json
+	pins := map[string]string{}
+	pinsPath := filepath.Join(root, ".cog", "state", "eval-baselines.json")
+	if data, err := os.ReadFile(pinsPath); err == nil {
+		_ = json.Unmarshal(data, &pins) // ignore parse errors — start fresh
+	}
+
+	// Apply pins to experiment structs
+	for expID, runID := range pins {
+		if exp, ok := experiments[expID]; ok {
+			exp.BaselinePinned = runID
+		}
+	}
+
+	return &EvalConfig{
+		Experiments:    experiments,
+		BaselinePins:   pins,
+		TournamentRoot: filepath.Join(root, ".cog", "mem", "semantic", "architecture", "tournament"),
+	}, nil
+}
+
+// parseCogdocExperiment parses a .cog.md file's YAML frontmatter into an Experiment.
+// Returns nil if the frontmatter is missing or the file isn't an experiment cogdoc.
+func parseCogdocExperiment(raw []byte, path string) (*Experiment, error) {
+	text := string(raw)
+	fm, err := splitFrontmatter(text)
+	if err != nil || fm == nil {
+		return nil, nil
+	}
+
+	// Only parse experiment-type cogdocs
+	typ, _ := fm["type"].(string)
+	if typ != "workflow.experiment" {
+		return nil, nil
+	}
+
+	id, _ := fm["id"].(string)
+	if id == "" {
+		// Fall back to file stem
+		base := filepath.Base(path)
+		id = strings.TrimSuffix(base, ".cog.md")
+	}
+
+	title, _ := fm["title"].(string)
+	baselineVariant, _ := fm["baseline_variant"].(string)
+	target, _ := fm["target"].(string)
+	if target == "" {
+		target = "laptop-lms"
+	}
+
+	// Parse variant_axes — YAML may nest as map[string]interface{}
+	variantAxes := map[string][]string{}
+	if raw, ok := fm["variants"]; ok {
+		if varMap, ok := raw.(map[string]interface{}); ok {
+			for k, v := range varMap {
+				// Normalize key: yaml may use system_prompt or system-prompt
+				key := strings.ReplaceAll(k, "-", "_")
+				switch vals := v.(type) {
+				case []interface{}:
+					strs := make([]string, 0, len(vals))
+					for _, s := range vals {
+						if str, ok := s.(string); ok {
+							strs = append(strs, str)
+						}
+					}
+					variantAxes[key] = strs
+				case string:
+					variantAxes[key] = []string{vals}
+				}
+			}
+		}
+	}
+
+	// Parse task_ids from "tasks" key
+	taskIDs := []string{}
+	if rawTasks, ok := fm["tasks"]; ok {
+		switch v := rawTasks.(type) {
+		case []interface{}:
+			for _, t := range v {
+				if s, ok := t.(string); ok {
+					taskIDs = append(taskIDs, s)
+				}
+			}
+		case []string:
+			taskIDs = append(taskIDs, v...)
+		}
+	}
+
+	// Parse tags
+	tags := []string{}
+	if rawTags, ok := fm["tags"]; ok {
+		if tagSlice, ok := rawTags.([]interface{}); ok {
+			for _, t := range tagSlice {
+				if s, ok := t.(string); ok {
+					tags = append(tags, s)
+				}
+			}
+		}
+	}
+
+	autoReconcile, _ := fm["auto_reconcile"].(bool)
+
+	return &Experiment{
+		ID:              id,
+		Title:           title,
+		BaselineVariant: baselineVariant,
+		VariantAxes:     variantAxes,
+		TaskIDs:         taskIDs,
+		Target:          target,
+		Tags:            tags,
+		AutoReconcile:   autoReconcile,
+	}, nil
+}
+
+// splitFrontmatter parses YAML frontmatter from a cogdoc string.
+// Returns the frontmatter map and any parse error.
+// Port of evals/tournament/variants.py _split_frontmatter().
+func splitFrontmatter(text string) (map[string]interface{}, error) {
+	if !strings.HasPrefix(text, "---") {
+		return nil, nil
+	}
+	rest := text[3:]
+	end := strings.Index(rest, "\n---")
+	if end == -1 {
+		return nil, nil
+	}
+	fmText := rest[:end]
+
+	var fm map[string]interface{}
+	if err := yaml.Unmarshal([]byte(fmText), &fm); err != nil {
+		return nil, err
+	}
+	return fm, nil
+}
+
+// ---------------------------------------------------------------------------
+// FetchLive
+// ---------------------------------------------------------------------------
+
+// FetchLive reads all completed trial records from bus_tournament.
+// Re-materializes scorecards inline per reconcile cycle (all-time, per design memo Q2).
+func (e *EvalProvider) FetchLive(ctx context.Context, config any) (any, error) {
+	if e.busReader == nil {
+		// No reader wired — return empty live state (FetchLive degrades gracefully)
+		return &EvalLiveState{
+			Trials:     []TrialRecord{},
+			Scorecards: map[string]*Scorecard{},
+			FetchedAt:  nowISO(),
+		}, nil
+	}
+
+	events, err := e.busReader.ReadChannel(ctx, "bus_tournament", "")
+	if err != nil {
+		// Degrade gracefully — kernel may not be reachable during tests
+		return &EvalLiveState{
+			Trials:     []TrialRecord{},
+			Scorecards: map[string]*Scorecard{},
+			FetchedAt:  nowISO(),
+		}, nil
+	}
+	if events == nil {
+		events = []BusEvent{}
+	}
+
+	// Deserialize TrialRecord from each event payload
+	var trials []TrialRecord
+	for _, ev := range events {
+		if ev.Type != "tournament.trial.v1" {
+			continue
+		}
+		tr, err := extractTrialRecord(ev)
+		if err != nil || tr == nil {
+			continue
+		}
+		trials = append(trials, *tr)
+	}
+
+	// Group by experiment and build scorecards
+	byExp := map[string][]TrialRecord{}
+	for _, tr := range trials {
+		if tr.ExperimentID != "" {
+			byExp[tr.ExperimentID] = append(byExp[tr.ExperimentID], tr)
+		}
+	}
+
+	scorecards := make(map[string]*Scorecard, len(byExp))
+	for expID, expTrials := range byExp {
+		scorecards[expID] = buildScorecard(expID, expTrials)
+	}
+
+	return &EvalLiveState{
+		Trials:     trials,
+		Scorecards: scorecards,
+		FetchedAt:  nowISO(),
+	}, nil
+}
+
+// extractTrialRecord deserializes a TrialRecord from a bus event payload.
+// The bus stores the trial nested as payload.content (JSON string) or payload.trial.
+func extractTrialRecord(ev BusEvent) (*TrialRecord, error) {
+	if ev.Payload == nil {
+		return nil, nil
+	}
+
+	// The Python persist.py wraps the trial inside payload.content (a JSON string)
+	// or as payload.trial (direct object). Try content first.
+	if contentRaw, ok := ev.Payload["content"]; ok {
+		if contentStr, ok := contentRaw.(string); ok {
+			// content is a JSON string — unmarshal it
+			var wrapper struct {
+				Trial *TrialRecord `json:"trial"`
+			}
+			if err := json.Unmarshal([]byte(contentStr), &wrapper); err == nil && wrapper.Trial != nil {
+				return wrapper.Trial, nil
+			}
+			// Try as a direct TrialRecord
+			var tr TrialRecord
+			if err := json.Unmarshal([]byte(contentStr), &tr); err == nil && tr.TrialID != "" {
+				return &tr, nil
+			}
+		}
+	}
+
+	// Try payload.trial directly
+	if trialRaw, ok := ev.Payload["trial"]; ok {
+		b, err := json.Marshal(trialRaw)
+		if err != nil {
+			return nil, nil
+		}
+		var tr TrialRecord
+		if err := json.Unmarshal(b, &tr); err == nil && tr.TrialID != "" {
+			return &tr, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// variantKey produces the scorecard key for a trial.
+// Mirrors compare.py _variant_key(): "sp-id / td-id".
+func variantKey(tr TrialRecord) string {
+	sp := tr.VariantIDs["system_prompt"]
+	if sp == "" {
+		sp = "unknown-sp"
+	}
+	td := tr.VariantIDs["tool_description"]
+	if td == "" {
+		td = "td-1-current"
+	}
+	return sp + " / " + td
+}
+
+// buildScorecard constructs a Scorecard from a list of TrialRecords.
+// Port of evals/tournament/compare.py build_scorecard().
+// Multiple trials for the same (variant_key, task_id) aggregate:
+// cell is true if ANY trial passed, false if ALL failed.
+func buildScorecard(experimentID string, trials []TrialRecord) *Scorecard {
+	if len(trials) == 0 {
+		return &Scorecard{ExperimentID: experimentID, Cells: map[[2]string]ScorecardCell{}}
+	}
+
+	variantKeys := map[string]struct{}{}
+	taskIDs := map[string]struct{}{}
+	raw := map[[2]string][]bool{}
+
+	for _, tr := range trials {
+		vk := variantKey(tr)
+		variantKeys[vk] = struct{}{}
+		taskIDs[tr.TaskID] = struct{}{}
+		key := [2]string{vk, tr.TaskID}
+		raw[key] = append(raw[key], tr.Passed)
+	}
+
+	sortedVKs := sortedKeys(variantKeys)
+	sortedTIDs := sortedKeys(taskIDs)
+
+	cells := make(map[[2]string]ScorecardCell, len(sortedVKs)*len(sortedTIDs))
+	for _, vk := range sortedVKs {
+		for _, tid := range sortedTIDs {
+			key := [2]string{vk, tid}
+			results, ok := raw[key]
+			if !ok {
+				cells[key] = nil
+			} else {
+				anyPassed := false
+				for _, r := range results {
+					if r {
+						anyPassed = true
+						break
+					}
+				}
+				v := anyPassed
+				cells[key] = &v
+			}
+		}
+	}
+
+	return &Scorecard{
+		ExperimentID: experimentID,
+		Cells:        cells,
+		VariantKeys:  sortedVKs,
+		TaskIDs:      sortedTIDs,
+	}
+}
+
+// passRate computes the pass rate for a variant key across all tasks.
+// Returns math.NaN() if no data.
+func passRate(sc *Scorecard, variantKey string) float64 {
+	if sc == nil {
+		return math.NaN()
+	}
+	var total, passed int
+	for _, tid := range sc.TaskIDs {
+		cell := sc.Cells[[2]string{variantKey, tid}]
+		if cell == nil {
+			continue
+		}
+		total++
+		if *cell {
+			passed++
+		}
+	}
+	if total == 0 {
+		return math.NaN()
+	}
+	return float64(passed) / float64(total)
+}
+
+// ---------------------------------------------------------------------------
+// ComputePlan
+// ---------------------------------------------------------------------------
+
+// ComputePlan implements the 8-rule priority chain.
+// Rules 2 and 4 are additive (both can fire on one experiment per design memo).
+func (e *EvalProvider) ComputePlan(config any, live any, state *reconcile.State) (*reconcile.Plan, error) {
+	cfg, ok := config.(*EvalConfig)
+	if !ok || cfg == nil {
+		return nil, fmt.Errorf("eval: ComputePlan: config is not *EvalConfig")
+	}
+	ls, ok := live.(*EvalLiveState)
+	if !ok || ls == nil {
+		ls = &EvalLiveState{Scorecards: map[string]*Scorecard{}}
+	}
+
+	eps := parseEvalProviderState(state)
+	if eps.CircuitBreakerThreshold == 0 {
+		eps.CircuitBreakerThreshold = circuitBreakerDefaultThreshold
+	}
+
+	// Build set of in-flight trial IDs for fast lookup
+	inFlight := map[string]struct{}{}
+	for _, id := range eps.InFlightTrialIDs {
+		inFlight[id] = struct{}{}
+	}
+
+	// Check for explicit dispatch triggers in state metadata
+	dispatchTriggers := map[string]bool{}
+	forcedExperiments := map[string]bool{}
+	if state != nil && state.Metadata != nil {
+		if raw, ok := state.Metadata["dispatch_triggers"]; ok {
+			if b, err := json.Marshal(raw); err == nil {
+				_ = json.Unmarshal(b, &dispatchTriggers)
+			}
+		}
+		if raw, ok := state.Metadata["forced_experiments"]; ok {
+			if b, err := json.Marshal(raw); err == nil {
+				_ = json.Unmarshal(b, &forcedExperiments)
+			}
+		}
+	}
+
+	var actions []reconcile.Action
+	summary := reconcile.Summary{}
+
+	// Sort experiment IDs for deterministic output
+	expIDs := make([]string, 0, len(cfg.Experiments))
+	for id := range cfg.Experiments {
+		expIDs = append(expIDs, id)
+	}
+	sort.Strings(expIDs)
+
+	for _, expID := range expIDs {
+		exp := cfg.Experiments[expID]
+		sc := ls.Scorecards[expID]
+		failures := eps.RecentFailureCounts[expID]
+
+		// Rule 5: in-flight guard — skip if any trials for this experiment are in flight
+		hasInFlight := false
+		for _, tid := range eps.InFlightTrialIDs {
+			if strings.HasPrefix(tid, expID) {
+				hasInFlight = true
+				break
+			}
+		}
+		if hasInFlight {
+			actions = append(actions, skipAction(expID, "in-flight trials pending"))
+			summary.Skipped++
+			continue
+		}
+
+		// Rule 6: circuit breaker — skip suspended experiments
+		if failures > eps.CircuitBreakerThreshold {
+			if !forcedExperiments[expID] {
+				actions = append(actions, skipAction(expID, "suspended: circuit breaker tripped"))
+				summary.Skipped++
+				continue
+			}
+			// force resets the circuit breaker
+		}
+
+		// Rule 7: auto_reconcile gate
+		triggered := dispatchTriggers[expID] || forcedExperiments[expID]
+		if !exp.AutoReconcile && !triggered {
+			actions = append(actions, skipAction(expID, "on-demand only (auto_reconcile=false)"))
+			summary.Skipped++
+			continue
+		}
+
+		// Rule 1: no prior runs — plan a full run
+		if sc == nil || len(sc.VariantKeys) == 0 {
+			actions = append(actions, evalAction(expID, EvalActionRun, EvalPlanDetail{
+				ExperimentID: expID,
+				EvalAction:   EvalActionRun,
+			}))
+			summary.Creates++
+			continue
+		}
+
+		// Rules 2 and 4 are additive — collect all that fire for this experiment
+		var additiveActions []reconcile.Action
+
+		// Rule 2: incremental cells — new variant cells not yet in scorecard
+		newCells := findNewVariantCells(exp, sc)
+		if len(newCells) > 0 {
+			specs := buildTrialSpecsForCells(cfg, exp, newCells)
+			additiveActions = append(additiveActions, evalAction(expID, EvalActionRunIncremental, EvalPlanDetail{
+				ExperimentID: expID,
+				EvalAction:   EvalActionRunIncremental,
+				TrialSpecs:   specs,
+			}))
+			summary.Updates++
+		}
+
+		// Rule 3: stale baseline — run full refresh if baseline pin is stale/missing
+		if isBaselineStale(exp, cfg.BaselinePins) {
+			additiveActions = append(additiveActions, evalAction(expID, EvalActionRefreshBaseline, EvalPlanDetail{
+				ExperimentID: expID,
+				EvalAction:   EvalActionRefreshBaseline,
+			}))
+			summary.Updates++
+		}
+
+		// Rule 4: regression — retry cells that regressed vs pinned baseline
+		regressionCells := detectRegressions(exp, sc, cfg.BaselinePins)
+		if len(regressionCells) > 0 {
+			specs := buildTrialSpecsForCells(cfg, exp, regressionCells)
+			additiveActions = append(additiveActions, evalAction(expID, EvalActionRetryRegression, EvalPlanDetail{
+				ExperimentID:    expID,
+				EvalAction:      EvalActionRetryRegression,
+				TrialSpecs:      specs,
+				RegressionCells: regressionCells,
+			}))
+			summary.Updates++
+		}
+
+		if len(additiveActions) > 0 {
+			actions = append(actions, additiveActions...)
+		} else {
+			// Rule 8: healthy — no action needed
+			actions = append(actions, skipAction(expID, "in sync"))
+			summary.Skipped++
+		}
+	}
+
+	return &reconcile.Plan{
+		ResourceType: "eval",
+		GeneratedAt:  nowISO(),
+		Actions:      actions,
+		Summary:      summary,
+	}, nil
+}
+
+// skipAction builds a reconcile.Action with ActionSkip.
+func skipAction(expID, reason string) reconcile.Action {
+	return reconcile.Action{
+		Action:       reconcile.ActionSkip,
+		ResourceType: "eval",
+		Name:         "eval." + expID,
+		Details: map[string]any{
+			"experiment_id": expID,
+			"eval_action":   string(EvalActionSkip),
+			"reason":        reason,
+		},
+	}
+}
+
+// evalAction builds a reconcile.Action with the given eval action type.
+func evalAction(expID string, action EvalActionType, detail EvalPlanDetail) reconcile.Action {
+	detailMap := map[string]any{
+		"experiment_id": detail.ExperimentID,
+		"eval_action":   string(detail.EvalAction),
+	}
+	if len(detail.TrialSpecs) > 0 {
+		detailMap["trial_specs"] = detail.TrialSpecs
+	}
+	if len(detail.RegressionCells) > 0 {
+		detailMap["regression_cells"] = detail.RegressionCells
+	}
+	if detail.StaleAfter != "" {
+		detailMap["stale_after"] = detail.StaleAfter
+	}
+
+	at := reconcile.ActionCreate
+	if action == EvalActionRunIncremental || action == EvalActionRetryRegression || action == EvalActionRefreshBaseline {
+		at = reconcile.ActionUpdate
+	}
+
+	return reconcile.Action{
+		Action:       at,
+		ResourceType: "eval",
+		Name:         "eval." + expID,
+		Details:      detailMap,
+	}
+}
+
+// findNewVariantCells returns (variantKey, taskID) pairs that exist in the
+// experiment config but have no data in the scorecard.
+func findNewVariantCells(exp *Experiment, sc *Scorecard) [][2]string {
+	if sc == nil {
+		return nil
+	}
+	existing := map[[2]string]bool{}
+	for _, vk := range sc.VariantKeys {
+		for _, tid := range sc.TaskIDs {
+			cell := sc.Cells[[2]string{vk, tid}]
+			if cell != nil {
+				existing[[2]string{vk, tid}] = true
+			}
+		}
+	}
+
+	// Build expected variant keys from the experiment's axes
+	spIDs := exp.VariantAxes["system_prompt"]
+	tdIDs := exp.VariantAxes["tool_description"]
+	if len(tdIDs) == 0 {
+		tdIDs = []string{"td-1-current"}
+	}
+	if len(spIDs) == 0 {
+		spIDs = []string{"unknown-sp"}
+	}
+
+	var newCells [][2]string
+	for _, sp := range spIDs {
+		for _, td := range tdIDs {
+			vk := sp + " / " + td
+			for _, taskID := range exp.TaskIDs {
+				key := [2]string{vk, taskID}
+				if !existing[key] {
+					newCells = append(newCells, key)
+				}
+			}
+		}
+	}
+	return newCells
+}
+
+// detectRegressions compares the current scorecard against the pinned baseline.
+// Returns cells where pass rate dropped more than regressionThreshold.
+func detectRegressions(exp *Experiment, sc *Scorecard, pins map[string]string) [][2]string {
+	if sc == nil || len(pins) == 0 {
+		return nil
+	}
+	pin := pins[exp.ID]
+	if pin == "" {
+		return nil
+	}
+
+	// Determine baseline variant key from experiment.BaselineVariant
+	// BaselineVariant is like "sp-1-production+td-1-current" — convert to scorecard key
+	baselineKey := baselineVariantKey(exp.BaselineVariant)
+	if baselineKey == "" || !containsStr(sc.VariantKeys, baselineKey) {
+		return nil
+	}
+
+	baselineRate := passRate(sc, baselineKey)
+	if math.IsNaN(baselineRate) {
+		return nil
+	}
+
+	var regressionCells [][2]string
+	for _, vk := range sc.VariantKeys {
+		if vk == baselineKey {
+			continue
+		}
+		vkRate := passRate(sc, vk)
+		if math.IsNaN(vkRate) {
+			continue
+		}
+		if baselineRate-vkRate > regressionThreshold {
+			// This variant regressed vs baseline — flag the failing cells
+			for _, tid := range sc.TaskIDs {
+				blCell := sc.Cells[[2]string{baselineKey, tid}]
+				vkCell := sc.Cells[[2]string{vk, tid}]
+				if blCell != nil && *blCell && vkCell != nil && !*vkCell {
+					regressionCells = append(regressionCells, [2]string{vk, tid})
+				}
+			}
+		}
+	}
+	return regressionCells
+}
+
+// baselineVariantKey converts a BaselineVariant string like "sp-1-production+td-1-current"
+// into a scorecard key "sp-1-production / td-1-current".
+func baselineVariantKey(bv string) string {
+	if bv == "" {
+		return ""
+	}
+	parts := strings.SplitN(bv, "+", 2)
+	if len(parts) == 2 {
+		return parts[0] + " / " + parts[1]
+	}
+	return bv
+}
+
+// isBaselineStale returns true if the experiment's baseline pin is missing or older
+// than baselineStaleDays.
+func isBaselineStale(exp *Experiment, pins map[string]string) bool {
+	pin := pins[exp.ID]
+	return pin == ""
+}
+
+// buildTrialSpecsForCells constructs TrialSpec objects for the given (variantKey, taskID) cells.
+// This is a simplified version — the full matrix expansion happens at apply time.
+func buildTrialSpecsForCells(cfg *EvalConfig, exp *Experiment, cells [][2]string) []TrialSpec {
+	var specs []TrialSpec
+	for _, cell := range cells {
+		vk, taskID := cell[0], cell[1]
+		parts := strings.SplitN(vk, " / ", 2)
+		spID, tdID := "", ""
+		if len(parts) == 2 {
+			spID, tdID = parts[0], parts[1]
+		}
+
+		variantIDs := map[string]string{}
+		if spID != "" && spID != "unknown-sp" {
+			variantIDs["system_prompt"] = spID
+		}
+		if tdID != "" && tdID != "td-1-current" {
+			variantIDs["tool_description"] = tdID
+		}
+
+		trialID := exp.ID + "__" + spID + "+" + tdID + "__" + taskID
+		specs = append(specs, TrialSpec{
+			TrialID:      trialID,
+			ExperimentID: exp.ID,
+			VariantIDs:   variantIDs,
+			Target:       exp.Target,
+		})
+	}
+	return specs
+}
+
+// ---------------------------------------------------------------------------
+// ApplyPlan
+// ---------------------------------------------------------------------------
+
+// ApplyPlan executes planned eval actions, one trial at a time (design memo Q4).
+func (e *EvalProvider) ApplyPlan(ctx context.Context, plan *reconcile.Plan) ([]reconcile.Result, error) {
+	if e.dispatcher == nil {
+		// No dispatcher wired — report all as skipped
+		var results []reconcile.Result
+		for _, action := range plan.Actions {
+			results = append(results, reconcile.Result{
+				Phase:  "eval",
+				Action: string(action.Action),
+				Name:   action.Name,
+				Status: reconcile.ApplySkipped,
+				Error:  "dispatcher not wired",
+			})
+		}
+		return results, nil
+	}
+
+	var results []reconcile.Result
+	trialsDispatched := 0
+
+	for _, action := range plan.Actions {
+		if action.Action == reconcile.ActionSkip {
+			results = append(results, reconcile.Result{
+				Phase:  "eval",
+				Action: string(action.Action),
+				Name:   action.Name,
+				Status: reconcile.ApplySkipped,
+			})
+			continue
+		}
+
+		// Extract eval-specific detail
+		expID, _ := action.Details["experiment_id"].(string)
+		evalActionStr, _ := action.Details["eval_action"].(string)
+		evalActionType := EvalActionType(evalActionStr)
+
+		// Check budget — stop if we've dispatched enough trials this cycle
+		if trialsDispatched >= trialsPerCycle {
+			results = append(results, reconcile.Result{
+				Phase:  "eval",
+				Action: string(action.Action),
+				Name:   action.Name,
+				Status: reconcile.ApplySkipped,
+				Error:  "budget exhausted for this cycle",
+			})
+			continue
+		}
+
+		switch evalActionType {
+		case EvalActionRun:
+			// Full matrix expansion — load variants from tournament dir and expand
+			specs, err := expandExperimentMatrix(e.root, expID)
+			if err != nil {
+				results = append(results, errorResult(action, err))
+				continue
+			}
+			n, res := e.dispatchTrials(ctx, specs, &trialsDispatched)
+			results = append(results, res...)
+			_ = n
+
+		case EvalActionRunIncremental, EvalActionRetryRegression, EvalActionRefreshBaseline:
+			// Use pre-computed trial specs from detail
+			specs := extractTrialSpecsFromDetail(action.Details)
+			if len(specs) == 0 && evalActionType == EvalActionRefreshBaseline {
+				// For refresh, re-expand the full matrix
+				var err error
+				specs, err = expandExperimentMatrix(e.root, expID)
+				if err != nil {
+					results = append(results, errorResult(action, err))
+					continue
+				}
+			}
+			n, res := e.dispatchTrials(ctx, specs, &trialsDispatched)
+			results = append(results, res...)
+			_ = n
+
+		default:
+			results = append(results, reconcile.Result{
+				Phase:  "eval",
+				Action: string(action.Action),
+				Name:   action.Name,
+				Status: reconcile.ApplySkipped,
+				Error:  "unknown eval_action: " + evalActionStr,
+			})
+		}
+	}
+
+	return results, nil
+}
+
+// dispatchTrials dispatches TrialSpecs up to the per-cycle budget.
+// Returns the number of trials dispatched and the results.
+func (e *EvalProvider) dispatchTrials(ctx context.Context, specs []TrialSpec, dispatched *int) (int, []reconcile.Result) {
+	var results []reconcile.Result
+	count := 0
+
+	for _, spec := range specs {
+		if *dispatched >= trialsPerCycle {
+			break
+		}
+
+		// Acquire the eval mutex to serialize Ollama access
+		applyMu.Lock()
+		record, err := e.runTrial(ctx, spec)
+		applyMu.Unlock()
+
+		if err != nil {
+			results = append(results, reconcile.Result{
+				Phase:  "eval",
+				Action: "run",
+				Name:   spec.TrialID,
+				Status: reconcile.ApplyFailed,
+				Error:  err.Error(),
+			})
+			*dispatched++
+			count++
+			continue
+		}
+
+		// Emit the trial record as a CogBlock (best-effort)
+		if e.emitter != nil {
+			payload := map[string]any{
+				"type":          "tournament.trial.v1",
+				"trial":         record,
+				"experiment_id": record.ExperimentID,
+			}
+			_ = e.emitter.EmitCogBlock(ctx, "bus_tournament", payload)
+		}
+
+		results = append(results, reconcile.Result{
+			Phase:     "eval",
+			Action:    "run",
+			Name:      spec.TrialID,
+			Status:    reconcile.ApplySucceeded,
+			CreatedID: spec.TrialID,
+		})
+		*dispatched++
+		count++
+	}
+
+	return count, results
+}
+
+// runTrial dispatches a single trial and returns the scored TrialRecord.
+func (e *EvalProvider) runTrial(ctx context.Context, spec TrialSpec) (*TrialRecord, error) {
+	// Build the system prompt from the variant
+	var systemPrompt string
+	if spec.SystemPromptVariant != nil {
+		if sp, ok := spec.SystemPromptVariant.Content.(string); ok {
+			systemPrompt = sp
+		}
+	}
+
+	// Extract task prompt and rubric from the task variant's content
+	prompt, rubric := extractTaskContent(spec)
+
+	// Dispatch the trial
+	req := DispatchRequest{
+		Task:           prompt,
+		SystemPrompt:   systemPrompt,
+		N:              1,
+		TimeoutSeconds: 120,
+	}
+
+	ts := nowISO()
+	result, err := e.dispatcher.DispatchToHarness(ctx, req)
+	if err != nil || result == nil || len(result.Results) == 0 {
+		// Build a failed record
+		errStr := "dispatch error"
+		if err != nil {
+			errStr = err.Error()
+		}
+		return &TrialRecord{
+			TrialID:      spec.TrialID,
+			ExperimentID: spec.ExperimentID,
+			VariantIDs:   spec.VariantIDs,
+			TaskID:       spec.TaskVariant.ID,
+			Target:       spec.Target,
+			Passed:       false,
+			Failures:     []string{"dispatch: " + errStr},
+			Timestamp:    ts,
+		}, nil
+	}
+
+	dr := result.Results[0]
+
+	// Extract tool calls from the result content (simplified — real implementation
+	// would parse from result metadata)
+	toolCallNames := extractToolCallNamesFromContent(dr.Content)
+	scored := NewDispatchScoredResult(dr, toolCallNames)
+	verdict := Score(rubric, scored)
+
+	toolCalls := make([]ToolCallRecord, 0, len(toolCallNames))
+	for _, name := range toolCallNames {
+		toolCalls = append(toolCalls, ToolCallRecord{Name: name})
+	}
+
+	return &TrialRecord{
+		TrialID:      spec.TrialID,
+		ExperimentID: spec.ExperimentID,
+		VariantIDs:   spec.VariantIDs,
+		TaskID:       spec.TaskVariant.ID,
+		Target:       spec.Target,
+		Passed:       verdict.Passed,
+		Failures:     verdict.Failures,
+		Notes:        verdict.Notes,
+		ToolCalls:    toolCalls,
+		Content:      dr.Content,
+		DurationSec:  dr.DurationSec,
+		Timestamp:    ts,
+		Model:        dr.ModelUsed,
+	}, nil
+}
+
+// extractTaskContent extracts the prompt and rubric from a TrialSpec's task variant.
+func extractTaskContent(spec TrialSpec) (string, Rubric) {
+	if spec.TaskVariant.Content == nil {
+		return "", Rubric{}
+	}
+
+	content, ok := spec.TaskVariant.Content.(map[string]interface{})
+	if !ok {
+		return "", Rubric{}
+	}
+
+	prompt, _ := content["prompt"].(string)
+	rubricRaw, _ := content["rubric"].(map[string]interface{})
+
+	rubric := parseRubricFromMap(rubricRaw)
+	return prompt, rubric
+}
+
+// parseRubricFromMap converts a map[string]interface{} into a Rubric.
+func parseRubricFromMap(m map[string]interface{}) Rubric {
+	if m == nil {
+		return Rubric{}
+	}
+	return Rubric{
+		ExpectedTools:           toStringSlice(m["expected_tools"]),
+		ExpectedToolsAnyOf:      toStringSlice(m["expected_tools_any_of"]),
+		ForbiddenTools:          toStringSlice(m["forbidden_tools"]),
+		ContentContains:         toStringSlice(m["content_contains"]),
+		ContentMustNotContain:   toStringSlice(m["content_must_not_contain"]),
+		ContentContainsCI:       toStringSlice(m["content_contains_ci"]),
+		ContentMustNotContainCI: toStringSlice(m["content_must_not_contain_ci"]),
+		FirstToolOneOf:          toStringSlice(m["first_tool_one_of"]),
+	}
+}
+
+// toStringSlice converts an interface{} to []string.
+func toStringSlice(v interface{}) []string {
+	if v == nil {
+		return nil
+	}
+	switch s := v.(type) {
+	case []string:
+		return s
+	case []interface{}:
+		out := make([]string, 0, len(s))
+		for _, item := range s {
+			if str, ok := item.(string); ok {
+				out = append(out, str)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+// extractToolCallNamesFromContent is a stub — in a real implementation, tool
+// call names would come from structured metadata in the dispatch result.
+// For now, return empty (the kernel returns them in a structured field).
+func extractToolCallNamesFromContent(_ string) []string {
+	return nil
+}
+
+// extractTrialSpecsFromDetail extracts TrialSpec objects from action.Details.
+func extractTrialSpecsFromDetail(details map[string]any) []TrialSpec {
+	raw, ok := details["trial_specs"]
+	if !ok {
+		return nil
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return nil
+	}
+	var specs []TrialSpec
+	_ = json.Unmarshal(b, &specs)
+	return specs
+}
+
+// expandExperimentMatrix loads the experiment's variant cogdocs and expands
+// into a full trial matrix. Used by EvalActionRun and EvalActionRefreshBaseline.
+func expandExperimentMatrix(root, experimentID string) ([]TrialSpec, error) {
+	// Load the experiment cogdoc
+	experimentsDir := filepath.Join(root, ".cog", "mem", "semantic", "architecture", "tournament", "experiments")
+	tournamentRoot := filepath.Join(root, ".cog", "mem", "semantic", "architecture", "tournament")
+
+	var expPath string
+	entries, err := os.ReadDir(experimentsDir)
+	if err != nil {
+		return nil, fmt.Errorf("eval: read experiments dir: %w", err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), experimentID) && strings.HasSuffix(entry.Name(), ".cog.md") {
+			expPath = filepath.Join(experimentsDir, entry.Name())
+			break
+		}
+	}
+	if expPath == "" {
+		return nil, fmt.Errorf("eval: experiment %q not found", experimentID)
+	}
+
+	raw, err := os.ReadFile(expPath)
+	if err != nil {
+		return nil, fmt.Errorf("eval: read experiment %s: %w", expPath, err)
+	}
+	exp, err := parseCogdocExperiment(raw, expPath)
+	if err != nil || exp == nil {
+		return nil, fmt.Errorf("eval: parse experiment %s: %w", expPath, err)
+	}
+
+	// Load all variant cogdocs
+	variantsByID, err := loadVariantsFromDir(tournamentRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	return expandMatrix(exp, variantsByID, tournamentRoot), nil
+}
+
+// loadVariantsFromDir loads all .cog.md variant cogdocs from the tournament directory.
+// Port of evals/tournament/variants.py load_variants().
+func loadVariantsFromDir(tournamentRoot string) (map[string]*Variant, error) {
+	variants := map[string]*Variant{}
+	err := filepath.Walk(tournamentRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || !strings.HasSuffix(path, ".cog.md") {
+			return nil
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		v := parseVariantCogdoc(raw, path)
+		if v != nil && v.ID != "" {
+			if _, dup := variants[v.ID]; !dup {
+				variants[v.ID] = v
+			}
+		}
+		return nil
+	})
+	return variants, err
+}
+
+// parseVariantCogdoc parses a .cog.md file into a Variant.
+// Port of evals/tournament/variants.py load_variant_from_file().
+func parseVariantCogdoc(raw []byte, path string) *Variant {
+	text := string(raw)
+	fm, err := splitFrontmatter(text)
+	if err != nil || fm == nil {
+		return nil
+	}
+
+	id, _ := fm["id"].(string)
+	if id == "" {
+		base := filepath.Base(path)
+		id = strings.TrimSuffix(base, ".cog.md")
+	}
+
+	vc, _ := fm["variant_class"].(string)
+	var content interface{}
+
+	switch vc {
+	case "system-prompt":
+		content = extractSection(text, "Variant content")
+	case "tool-description":
+		content = fm["overrides"]
+	case "task":
+		content = fm["case"]
+	default:
+		content = fm
+	}
+
+	baselineOf, _ := fm["baseline_of"].(string)
+	ablation, _ := fm["ablation"].(string)
+
+	return &Variant{
+		ID:         id,
+		Class:      VariantClass(vc),
+		Content:    content,
+		BaselineOf: baselineOf,
+		Ablation:   ablation,
+		Tags:       toStringSlice(fm["tags"]),
+		SourcePath: path,
+	}
+}
+
+// extractSection extracts content under a markdown heading.
+// Port of evals/tournament/variants.py _extract_section().
+var sectionRe = regexp.MustCompile(`(?s)## Variant content\s*\n(.*?)(?:\n## |\z)`)
+
+func extractSection(text, sectionName string) string {
+	if sectionName != "Variant content" {
+		// Generic fallback
+		pat := regexp.MustCompile(`(?s)## ` + regexp.QuoteMeta(sectionName) + `\s*\n(.*?)(?:\n## |\z)`)
+		m := pat.FindStringSubmatch(text)
+		if m != nil {
+			return strings.TrimSpace(m[1])
+		}
+		return ""
+	}
+	m := sectionRe.FindStringSubmatch(text)
+	if m != nil {
+		return strings.TrimSpace(m[1])
+	}
+	return ""
+}
+
+// expandMatrix builds the Cartesian product of variant axes × tasks.
+// Port of evals/tournament/matrix.py expand_matrix().
+func expandMatrix(exp *Experiment, variantsByID map[string]*Variant, tournamentRoot string) []TrialSpec {
+	spIDs := exp.VariantAxes["system_prompt"]
+	tdIDs := exp.VariantAxes["tool_description"]
+	taskIDs := exp.TaskIDs
+
+	spVariants := resolveVariants(spIDs, variantsByID)
+	tdVariants := resolveVariants(tdIDs, variantsByID)
+	taskVariants := resolveVariants(taskIDs, variantsByID)
+
+	if len(taskVariants) == 0 {
+		return nil
+	}
+
+	spList := spVariants
+	if len(spList) == 0 {
+		spList = []*Variant{nil}
+	}
+	tdList := tdVariants
+	if len(tdList) == 0 {
+		tdList = []*Variant{nil}
+	}
+
+	var specs []TrialSpec
+	for _, spV := range spList {
+		for _, tdV := range tdList {
+			for _, taskV := range taskVariants {
+				variantIDs := map[string]string{}
+				var spVPtr, tdVPtr *Variant
+
+				if spV != nil {
+					variantIDs["system_prompt"] = spV.ID
+					spVPtr = spV
+				}
+				if tdV != nil {
+					variantIDs["tool_description"] = tdV.ID
+					tdVPtr = tdV
+				}
+
+				spID := variantIDs["system_prompt"]
+				if spID == "" {
+					spID = "sp-default"
+				}
+				tdID := variantIDs["tool_description"]
+				if tdID == "" {
+					tdID = "td-default"
+				}
+
+				trialID := exp.ID + "__" + spID + "+" + tdID + "__" + taskV.ID
+
+				specs = append(specs, TrialSpec{
+					TrialID:                trialID,
+					ExperimentID:           exp.ID,
+					TaskVariant:            *taskV,
+					VariantIDs:             variantIDs,
+					SystemPromptVariant:    spVPtr,
+					ToolDescriptionVariant: tdVPtr,
+					Target:                 exp.Target,
+				})
+			}
+		}
+	}
+	return specs
+}
+
+// resolveVariants looks up variant IDs from the loaded variant map.
+func resolveVariants(ids []string, byID map[string]*Variant) []*Variant {
+	var result []*Variant
+	for _, id := range ids {
+		v, ok := byID[id]
+		if ok {
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
+func errorResult(action reconcile.Action, err error) reconcile.Result {
+	return reconcile.Result{
+		Phase:  "eval",
+		Action: string(action.Action),
+		Name:   action.Name,
+		Status: reconcile.ApplyFailed,
+		Error:  err.Error(),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BuildState
+// ---------------------------------------------------------------------------
+
+// BuildState constructs reconcile state from live trial data.
+// Pattern mirrors component_provider.go BuildState() (lines 293-334).
+func (e *EvalProvider) BuildState(config any, live any, existing *reconcile.State) (*reconcile.State, error) {
+	ls, ok := live.(*EvalLiveState)
+	if !ok {
+		ls = &EvalLiveState{Scorecards: map[string]*Scorecard{}}
+	}
+	cfg, ok := config.(*EvalConfig)
+	if !ok {
+		cfg = &EvalConfig{Experiments: map[string]*Experiment{}}
+	}
+
+	state := &reconcile.State{
+		Version:      1,
+		ResourceType: "eval",
+		GeneratedAt:  nowISO(),
+	}
+	if existing != nil {
+		state.Lineage = existing.Lineage
+		state.Serial = existing.Serial + 1
+	} else {
+		state.Lineage = "eval-" + nowISO()
+	}
+
+	// Carry forward eval provider state from existing metadata
+	eps := parseEvalProviderState(existing)
+	if eps.CircuitBreakerThreshold == 0 {
+		eps.CircuitBreakerThreshold = circuitBreakerDefaultThreshold
+	}
+
+	// Build one resource per experiment
+	// Merge experiment IDs from both config and live state
+	allExpIDs := map[string]struct{}{}
+	for id := range cfg.Experiments {
+		allExpIDs[id] = struct{}{}
+	}
+	for id := range ls.Scorecards {
+		allExpIDs[id] = struct{}{}
+	}
+
+	sortedIDs := make([]string, 0, len(allExpIDs))
+	for id := range allExpIDs {
+		sortedIDs = append(sortedIDs, id)
+	}
+	sort.Strings(sortedIDs)
+
+	for _, expID := range sortedIDs {
+		sc := ls.Scorecards[expID]
+		pin := cfg.BaselinePins[expID]
+
+		// Compute trial count and pass rate from scorecard
+		trialCount := 0
+		var passedCount int
+		if sc != nil {
+			for _, vk := range sc.VariantKeys {
+				for _, tid := range sc.TaskIDs {
+					cell := sc.Cells[[2]string{vk, tid}]
+					if cell != nil {
+						trialCount++
+						if *cell {
+							passedCount++
+						}
+					}
+				}
+			}
+		}
+
+		var pr float64
+		if trialCount > 0 {
+			pr = float64(passedCount) / float64(trialCount)
+		}
+
+		// Compute latest run timestamp from trials
+		lastRunAt := ""
+		for _, tr := range ls.Trials {
+			if tr.ExperimentID == expID && tr.Timestamp > lastRunAt {
+				lastRunAt = tr.Timestamp
+			}
+		}
+
+		cbCount := 0
+		if eps.RecentFailureCounts != nil {
+			cbCount = eps.RecentFailureCounts[expID]
+		}
+
+		resource := reconcile.Resource{
+			Address:       "eval." + expID,
+			Type:          "experiment",
+			Mode:          reconcile.ModeManaged,
+			ExternalID:    latestRunID(ls.Trials, expID),
+			Name:          expID,
+			LastRefreshed: nowISO(),
+			Attributes: map[string]any{
+				"trial_count":     trialCount,
+				"pass_rate":       pr,
+				"last_run_at":     lastRunAt,
+				"baseline_pinned": pin,
+				"circuit_breaker": cbCount,
+			},
+		}
+		state.Resources = append(state.Resources, resource)
+	}
+
+	// Encode EvalProviderState into metadata
+	epsJSON, _ := json.Marshal(eps)
+	var epsMap map[string]any
+	_ = json.Unmarshal(epsJSON, &epsMap)
+	state.Metadata = map[string]any{
+		"eval_state": epsMap,
+	}
+
+	return state, nil
+}
+
+// latestRunID finds the most recent run ID from a list of trials for an experiment.
+func latestRunID(trials []TrialRecord, expID string) string {
+	latest := ""
+	for _, tr := range trials {
+		if tr.ExperimentID == expID && tr.Timestamp > latest {
+			latest = tr.Timestamp
+		}
+	}
+	return latest
+}
+
+// ---------------------------------------------------------------------------
+// Health
+// ---------------------------------------------------------------------------
+
+// Health returns the three-axis status of the eval subsystem.
+func (e *EvalProvider) Health() reconcile.ResourceStatus {
+	return e.lastHealth
+}
+
+// updateHealth refreshes the cached health status.
+// Called at the end of ApplyPlan.
+func (e *EvalProvider) updateHealth(pending, inFlight, suspended int) {
+	msg := fmt.Sprintf("%d pending, %d in-flight, %d suspended", pending, inFlight, suspended)
+
+	sync := reconcile.SyncStatusSynced
+	if pending > 0 {
+		sync = reconcile.SyncStatusOutOfSync
+	}
+
+	health := reconcile.HealthHealthy
+	if suspended > 0 {
+		health = reconcile.HealthDegraded
+	} else if inFlight > 0 {
+		health = reconcile.HealthProgressing
+	}
+
+	op := reconcile.OperationIdle
+	if inFlight > 0 {
+		op = reconcile.OperationSyncing
+	}
+
+	e.lastHealth = reconcile.ResourceStatus{
+		Sync:      sync,
+		Health:    health,
+		Operation: op,
+		Message:   msg,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseEvalProviderState (Phase C implementation)
+// ---------------------------------------------------------------------------
+
+// parseEvalProviderState deserializes EvalProviderState from reconcile.State.Metadata.
+// Returns a zero-value EvalProviderState with default threshold if absent/unparseable.
+func parseEvalProviderState(state *reconcile.State) EvalProviderState {
+	eps := EvalProviderState{
+		CircuitBreakerThreshold: circuitBreakerDefaultThreshold,
+	}
+	if state == nil || state.Metadata == nil {
+		return eps
+	}
+	raw, ok := state.Metadata["eval_state"]
+	if !ok {
+		return eps
+	}
+
+	// Re-serialize to JSON (it may have been round-tripped through interface{})
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return eps
+	}
+	if err := json.Unmarshal(b, &eps); err != nil {
+		return eps
+	}
+	if eps.CircuitBreakerThreshold == 0 {
+		eps.CircuitBreakerThreshold = circuitBreakerDefaultThreshold
+	}
+	return eps
+}
+
+// ---------------------------------------------------------------------------
+// Utility helpers
+// ---------------------------------------------------------------------------
+
+func sortedKeys(m map[string]struct{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/eval/provider_impl.go
+++ b/internal/eval/provider_impl.go
@@ -996,9 +996,10 @@ func (e *EvalProvider) runTrial(ctx context.Context, spec TrialSpec) (*TrialReco
 
 	dr := result.Results[0]
 
-	// Extract tool calls from the result content (simplified — real implementation
-	// would parse from result metadata)
-	toolCallNames := extractToolCallNamesFromContent(dr.Content)
+	// Extract tool call names from the structured ToolCalls field populated by
+	// the harness. This replaces the old content-parsing stub which always
+	// returned nil, breaking all tool-call rubric assertions.
+	toolCallNames := extractToolCallNamesFromResult(dr)
 	scored := NewDispatchScoredResult(dr, toolCallNames)
 	verdict := Score(rubric, scored)
 
@@ -1079,11 +1080,23 @@ func toStringSlice(v interface{}) []string {
 	return nil
 }
 
-// extractToolCallNamesFromContent is a stub — in a real implementation, tool
-// call names would come from structured metadata in the dispatch result.
-// For now, return empty (the kernel returns them in a structured field).
-func extractToolCallNamesFromContent(_ string) []string {
-	return nil
+// extractToolCallNamesFromResult extracts tool call names from a DispatchResult.
+// The harness populates DispatchResult.ToolCalls with per-invocation summaries;
+// each summary carries the Name field. Returns nil if no tool calls were made.
+func extractToolCallNamesFromResult(dr DispatchResult) []string {
+	if len(dr.ToolCalls) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(dr.ToolCalls))
+	for _, tc := range dr.ToolCalls {
+		if tc.Name != "" {
+			names = append(names, tc.Name)
+		}
+	}
+	if len(names) == 0 {
+		return nil
+	}
+	return names
 }
 
 // extractTrialSpecsFromDetail extracts TrialSpec objects from action.Details.

--- a/internal/eval/provider_impl.go
+++ b/internal/eval/provider_impl.go
@@ -480,6 +480,18 @@ func (e *EvalProvider) ComputePlan(config any, live any, state *reconcile.State)
 		}
 	}
 
+	// Merge in triggers from the sidecar file written by cog_run_experiment.
+	// This bridges the MCP-tool invocation → reconcile-cycle gap. The file is
+	// cleared by readAndClearDispatchTriggers so each trigger fires exactly once.
+	if e.root != "" {
+		for expID, force := range readAndClearDispatchTriggers(e.root) {
+			dispatchTriggers[expID] = true
+			if force {
+				forcedExperiments[expID] = true
+			}
+		}
+	}
+
 	var actions []reconcile.Action
 	summary := reconcile.Summary{}
 

--- a/internal/eval/provider_impl.go
+++ b/internal/eval/provider_impl.go
@@ -553,7 +553,14 @@ func (e *EvalProvider) ComputePlan(config any, live any, state *reconcile.State)
 		}
 
 		// Rule 3: stale baseline — run full refresh if baseline pin is stale/missing
-		if isBaselineStale(exp, cfg.BaselinePins) {
+		// Compute the latest run timestamp for this experiment from live trials.
+		latestRunAt := ""
+		for _, tr := range ls.Trials {
+			if tr.ExperimentID == expID && tr.Timestamp > latestRunAt {
+				latestRunAt = tr.Timestamp
+			}
+		}
+		if isBaselineStale(exp, cfg.BaselinePins, latestRunAt) {
 			additiveActions = append(additiveActions, evalAction(expID, EvalActionRefreshBaseline, EvalPlanDetail{
 				ExperimentID: expID,
 				EvalAction:   EvalActionRefreshBaseline,
@@ -734,11 +741,26 @@ func baselineVariantKey(bv string) string {
 	return bv
 }
 
-// isBaselineStale returns true if the experiment's baseline pin is missing or older
-// than baselineStaleDays.
-func isBaselineStale(exp *Experiment, pins map[string]string) bool {
+// isBaselineStale returns true if the experiment's baseline pin is missing, or
+// if the pin is set but no trial has run within baselineStaleDays days.
+// latestRunAt is the ISO-8601 timestamp of the most recent trial for this
+// experiment (empty string = never run).
+func isBaselineStale(exp *Experiment, pins map[string]string, latestRunAt string) bool {
 	pin := pins[exp.ID]
-	return pin == ""
+	if pin == "" {
+		return true
+	}
+	// Pin is set — check whether any run happened within the staleness window.
+	if latestRunAt == "" {
+		// Pinned but never run — treat as stale so a fresh baseline can be gathered.
+		return true
+	}
+	ts, err := time.Parse(time.RFC3339, latestRunAt)
+	if err != nil {
+		// Unparseable timestamp — treat as stale rather than silently suppress.
+		return true
+	}
+	return time.Since(ts) > baselineStaleDays*24*time.Hour
 }
 
 // buildTrialSpecsForCells constructs TrialSpec objects for the given (variantKey, taskID) cells.

--- a/internal/eval/provider_test.go
+++ b/internal/eval/provider_test.go
@@ -357,7 +357,19 @@ func TestComputePlan_FullLive(t *testing.T) {
 			{"sp-1 / td-1-current", "task-1"}: &passed,
 		},
 	}
+	// Include a recent trial so isBaselineStale sees a non-stale run timestamp.
+	// Without this, the pin is set but latestRunAt is "" → stale → refresh_baseline planned.
+	recentTimestamp := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339)
 	ls := &EvalLiveState{
+		Trials: []TrialRecord{
+			{
+				TrialID:      "exp-001__sp-1+td-1__task-1",
+				ExperimentID: "exp-001",
+				TaskID:       "task-1",
+				Passed:       true,
+				Timestamp:    recentTimestamp,
+			},
+		},
 		Scorecards: map[string]*Scorecard{"exp-001": sc},
 	}
 

--- a/internal/eval/provider_test.go
+++ b/internal/eval/provider_test.go
@@ -961,6 +961,89 @@ func actionSummary(actions []reconcile.Action) []string {
 // TestIsBaselineStale: Bug 1 — verifies the 7-day staleness check is applied
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// TestWriteDispatchTrigger / TestComputePlan_DispatchTrigger: Bug 2
+// ---------------------------------------------------------------------------
+
+func TestWriteDispatchTrigger_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeDispatchTrigger(dir, "exp-001", false); err != nil {
+		t.Fatalf("writeDispatchTrigger: %v", err)
+	}
+
+	triggers := readAndClearDispatchTriggers(dir)
+	if !triggers["exp-001"] && triggers["exp-001"] != false {
+		// key must be present (false = non-force trigger)
+	}
+	if _, ok := triggers["exp-001"]; !ok {
+		t.Error("expected exp-001 key in triggers")
+	}
+}
+
+func TestWriteDispatchTrigger_ForceUpgrade(t *testing.T) {
+	dir := t.TempDir()
+	// Write non-force first
+	_ = writeDispatchTrigger(dir, "exp-001", false)
+	// Upgrade to force
+	_ = writeDispatchTrigger(dir, "exp-001", true)
+	triggers := readAndClearDispatchTriggers(dir)
+	if !triggers["exp-001"] {
+		t.Error("expected force=true after upgrade")
+	}
+}
+
+func TestReadAndClearDispatchTriggers_ClearsFile(t *testing.T) {
+	dir := t.TempDir()
+	_ = writeDispatchTrigger(dir, "exp-001", false)
+	// First read consumes the trigger
+	triggers1 := readAndClearDispatchTriggers(dir)
+	if _, ok := triggers1["exp-001"]; !ok {
+		t.Error("expected trigger on first read")
+	}
+	// Second read should find no triggers (file cleared)
+	triggers2 := readAndClearDispatchTriggers(dir)
+	if _, ok := triggers2["exp-001"]; ok {
+		t.Error("expected trigger cleared after first read")
+	}
+}
+
+func TestComputePlan_DispatchTriggerFromFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a trigger for exp-001
+	if err := writeDispatchTrigger(dir, "exp-001", false); err != nil {
+		t.Fatalf("writeDispatchTrigger: %v", err)
+	}
+
+	p := buildTestProvider(nil, nil, nil)
+	p.root = dir
+
+	cfg := &EvalConfig{
+		Experiments: map[string]*Experiment{
+			"exp-001": {
+				ID:            "exp-001",
+				AutoReconcile: false, // on-demand only — needs trigger
+				TaskIDs:       []string{"task-1"},
+				VariantAxes:   map[string][]string{"system_prompt": {"sp-1"}},
+				Target:        "test",
+			},
+		},
+		BaselinePins: map[string]string{},
+	}
+	ls := &EvalLiveState{Scorecards: map[string]*Scorecard{}}
+
+	plan, err := p.ComputePlan(cfg, ls, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+
+	// Should have a non-skip action for exp-001 (trigger overrides auto_reconcile=false)
+	actions := filterNonSkip(plan.Actions)
+	if len(actions) == 0 {
+		t.Errorf("expected non-skip action when trigger is set, got all skips: %v", actionSummary(plan.Actions))
+	}
+}
+
 func TestIsBaselineStale_NoPin(t *testing.T) {
 	exp := &Experiment{ID: "exp-001"}
 	pins := map[string]string{} // no pin set

--- a/internal/eval/provider_test.go
+++ b/internal/eval/provider_test.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cogos-dev/cogos/pkg/reconcile"
 )
@@ -954,4 +955,55 @@ func actionSummary(actions []reconcile.Action) []string {
 		s = append(s, string(a.Action)+"/"+ea+":"+reason)
 	}
 	return s
+}
+
+// ---------------------------------------------------------------------------
+// TestIsBaselineStale: Bug 1 — verifies the 7-day staleness check is applied
+// ---------------------------------------------------------------------------
+
+func TestIsBaselineStale_NoPin(t *testing.T) {
+	exp := &Experiment{ID: "exp-001"}
+	pins := map[string]string{} // no pin set
+	if !isBaselineStale(exp, pins, "") {
+		t.Error("expected stale=true when no pin set")
+	}
+}
+
+func TestIsBaselineStale_PinSetRecentRun(t *testing.T) {
+	exp := &Experiment{ID: "exp-001"}
+	pins := map[string]string{"exp-001": "run-abc"}
+	// Recent run (1 hour ago) — should NOT be stale
+	recent := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339)
+	if isBaselineStale(exp, pins, recent) {
+		t.Error("expected stale=false for recent run with pin set")
+	}
+}
+
+func TestIsBaselineStale_PinSetOldRun(t *testing.T) {
+	exp := &Experiment{ID: "exp-001"}
+	pins := map[string]string{"exp-001": "run-abc"}
+	// Old run (8 days ago) — should be stale
+	old := time.Now().UTC().Add(-8 * 24 * time.Hour).Format(time.RFC3339)
+	if !isBaselineStale(exp, pins, old) {
+		t.Error("expected stale=true for run older than 7 days with pin set")
+	}
+}
+
+func TestIsBaselineStale_PinSetNeverRun(t *testing.T) {
+	exp := &Experiment{ID: "exp-001"}
+	pins := map[string]string{"exp-001": "run-abc"}
+	// Pin set but latestRunAt="" means never run — should be stale
+	if !isBaselineStale(exp, pins, "") {
+		t.Error("expected stale=true when pin is set but no run has occurred")
+	}
+}
+
+func TestIsBaselineStale_PinSetBoundary(t *testing.T) {
+	exp := &Experiment{ID: "exp-001"}
+	pins := map[string]string{"exp-001": "run-abc"}
+	// Exactly at the boundary: 7 days - 1 minute ago, should NOT be stale
+	justUnder := time.Now().UTC().Add(-(7*24*time.Hour - time.Minute)).Format(time.RFC3339)
+	if isBaselineStale(exp, pins, justUnder) {
+		t.Error("expected stale=false for run just under 7 days ago")
+	}
 }

--- a/internal/eval/provider_test.go
+++ b/internal/eval/provider_test.go
@@ -1,0 +1,957 @@
+// provider_test.go — Tests for the EvalProvider Phase C implementation.
+//
+// Verification gates (per task brief):
+//  1. LoadConfig parses real experiment cogdocs (exp-001-anti-pattern-placement)
+//  2. FetchLive groups TrialRecords correctly from bus JSONL events
+//  3. ComputePlan returns expected actions for empty/full/regression scenarios
+//  4. ApplyPlan with stub dispatcher emits CogBlocks and updates state
+//  5. Health surfaces the right axes
+//  6. Score() port from Python matches expected verdicts
+//
+// No actual Ollama dispatches — all tests use stub AgentDispatcher.
+package eval
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cogos-dev/cogos/pkg/reconcile"
+)
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const realExperimentCogdocPath = "/Users/slowbro/workspaces/cog/.cog/mem/semantic/architecture/tournament/experiments/exp-001-anti-pattern-placement.cog.md"
+const realBusEventsPath = "/Users/slowbro/workspaces/cog/.cog/.state/buses/bus_tournament/events.jsonl"
+const realWorkspaceRoot = "/Users/slowbro/workspaces/cog"
+
+// stubDispatcher is a no-op AgentDispatcher for tests.
+type stubDispatcher struct {
+	results []DispatchResult
+	err     error
+}
+
+func (s *stubDispatcher) DispatchToHarness(_ context.Context, req DispatchRequest) (*DispatchBatchResult, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	results := s.results
+	if len(results) == 0 {
+		results = []DispatchResult{{
+			Index:   0,
+			Success: true,
+			Content: "stub response",
+		}}
+	}
+	return &DispatchBatchResult{Results: results}, nil
+}
+
+// stubEmitter records emitted CogBlocks for inspection.
+type stubEmitter struct {
+	emitted []map[string]any
+}
+
+func (s *stubEmitter) EmitCogBlock(_ context.Context, channel string, block any) error {
+	b, _ := json.Marshal(block)
+	var m map[string]any
+	_ = json.Unmarshal(b, &m)
+	if m == nil {
+		m = map[string]any{}
+	}
+	m["_channel"] = channel
+	s.emitted = append(s.emitted, m)
+	return nil
+}
+
+// stubBusReader replays a fixed set of events.
+type stubBusReader struct {
+	events []BusEvent
+}
+
+func (s *stubBusReader) ReadChannel(_ context.Context, _ string, _ string) ([]BusEvent, error) {
+	return s.events, nil
+}
+
+// buildTestProvider returns an EvalProvider with stub dependencies.
+func buildTestProvider(dispatcher AgentDispatcher, emitter BusEmitter, busReader BusReader) *EvalProvider {
+	p := New(dispatcher, emitter, nil)
+	p.busReader = busReader
+	return p
+}
+
+// makeTrialRecord creates a minimal TrialRecord for testing.
+func makeTrialRecord(experimentID, sp, td, taskID string, passed bool) TrialRecord {
+	return TrialRecord{
+		TrialID:      experimentID + "__" + sp + "+" + td + "__" + taskID,
+		ExperimentID: experimentID,
+		VariantIDs:   map[string]string{"system_prompt": sp, "tool_description": td},
+		TaskID:       taskID,
+		Passed:       passed,
+		Timestamp:    "2026-04-26T00:00:00Z",
+	}
+}
+
+// busEventFromTrialRecord wraps a TrialRecord as a bus event (matching persist.py shape).
+func busEventFromTrialRecord(tr TrialRecord) BusEvent {
+	trialPayload := map[string]any{
+		"type":          "tournament.trial.v1",
+		"trial":         tr,
+		"experiment_id": tr.ExperimentID,
+	}
+	b, _ := json.Marshal(trialPayload)
+
+	return BusEvent{
+		V:    2,
+		Type: "tournament.trial.v1",
+		From: "tournament/" + tr.ExperimentID,
+		Payload: map[string]interface{}{
+			"content": string(b),
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestLoadConfig_RealExperiment: parse the actual exp-001 cogdoc
+// ---------------------------------------------------------------------------
+
+func TestLoadConfig_RealExperiment(t *testing.T) {
+	if _, err := os.Stat(realExperimentCogdocPath); os.IsNotExist(err) {
+		t.Skipf("real experiment cogdoc not found at %s", realExperimentCogdocPath)
+	}
+
+	p := buildTestProvider(nil, nil, nil)
+	cfgAny, err := p.LoadConfig(realWorkspaceRoot)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	cfg, ok := cfgAny.(*EvalConfig)
+	if !ok || cfg == nil {
+		t.Fatal("LoadConfig returned nil or wrong type")
+	}
+
+	exp, exists := cfg.Experiments["exp-001-anti-pattern-placement"]
+	if !exists {
+		t.Errorf("experiment exp-001-anti-pattern-placement not found; got: %v", keys(cfg.Experiments))
+		return
+	}
+
+	// Validate parsed fields
+	if exp.ID != "exp-001-anti-pattern-placement" {
+		t.Errorf("ID = %q, want exp-001-anti-pattern-placement", exp.ID)
+	}
+	if exp.BaselineVariant != "sp-1-production+td-1-current" {
+		t.Errorf("BaselineVariant = %q, want sp-1-production+td-1-current", exp.BaselineVariant)
+	}
+	if exp.Target != "laptop-lms" {
+		t.Errorf("Target = %q, want laptop-lms", exp.Target)
+	}
+	if len(exp.TaskIDs) != 4 {
+		t.Errorf("TaskIDs = %v (len %d), want 4", exp.TaskIDs, len(exp.TaskIDs))
+	}
+	spIDs := exp.VariantAxes["system_prompt"]
+	if len(spIDs) != 2 {
+		t.Errorf("system_prompt axis = %v, want 2 variants", spIDs)
+	}
+	tdIDs := exp.VariantAxes["tool_description"]
+	if len(tdIDs) != 2 {
+		t.Errorf("tool_description axis = %v, want 2 variants", tdIDs)
+	}
+
+	// TournamentRoot should be set
+	if cfg.TournamentRoot == "" {
+		t.Error("TournamentRoot should be non-empty")
+	}
+	t.Logf("Loaded experiment: id=%s tasks=%v sp=%v td=%v", exp.ID, exp.TaskIDs, spIDs, tdIDs)
+}
+
+// ---------------------------------------------------------------------------
+// TestLoadConfig_EmptyDir: non-existent dir returns empty config, not error
+// ---------------------------------------------------------------------------
+
+func TestLoadConfig_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	p := buildTestProvider(nil, nil, nil)
+	cfgAny, err := p.LoadConfig(dir)
+	if err != nil {
+		t.Fatalf("LoadConfig on empty dir: %v", err)
+	}
+	cfg, ok := cfgAny.(*EvalConfig)
+	if !ok || cfg == nil {
+		t.Fatal("expected *EvalConfig")
+	}
+	if len(cfg.Experiments) != 0 {
+		t.Errorf("expected 0 experiments, got %d", len(cfg.Experiments))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestFetchLive_RealBusEvents: deserialize actual bus_tournament events
+// ---------------------------------------------------------------------------
+
+func TestFetchLive_RealBusEvents(t *testing.T) {
+	if _, err := os.Stat(realBusEventsPath); os.IsNotExist(err) {
+		t.Skipf("real bus events not found at %s", realBusEventsPath)
+	}
+
+	reader := NewFileBusReader(realBusEventsPath)
+	p := buildTestProvider(nil, nil, reader)
+	// Also need root for LoadConfig
+	_ = p.root
+
+	liveAny, err := p.FetchLive(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("FetchLive: %v", err)
+	}
+	ls, ok := liveAny.(*EvalLiveState)
+	if !ok || ls == nil {
+		t.Fatal("expected *EvalLiveState")
+	}
+
+	t.Logf("FetchLive: %d trials fetched, %d scorecards", len(ls.Trials), len(ls.Scorecards))
+
+	// We know there are 35 events in the real bus; some are trial records
+	if len(ls.Trials) == 0 {
+		t.Error("expected non-zero trials from real bus events")
+	}
+
+	// Count trials with ExperimentID set (the first bus event is a test record with no experiment_id)
+	withExp := 0
+	for _, tr := range ls.Trials {
+		if tr.ExperimentID != "" {
+			withExp++
+		}
+	}
+	if withExp == 0 {
+		t.Error("expected at least some trials with non-empty ExperimentID")
+	}
+	t.Logf("trials with ExperimentID: %d / %d", withExp, len(ls.Trials))
+
+	// Should have a scorecard for exp-001
+	sc, ok := ls.Scorecards["exp-001-anti-pattern-placement"]
+	if !ok {
+		t.Errorf("no scorecard for exp-001-anti-pattern-placement; got: %v", keys(ls.Scorecards))
+	} else {
+		t.Logf("exp-001 scorecard: %d variant keys, %d task IDs", len(sc.VariantKeys), len(sc.TaskIDs))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestFetchLive_GroupsTrialsByExperiment: stub bus reader
+// ---------------------------------------------------------------------------
+
+func TestFetchLive_GroupsTrialsByExperiment(t *testing.T) {
+	tr1 := makeTrialRecord("exp-001", "sp-1-production", "td-1-current", "task-1-state-probe", true)
+	tr2 := makeTrialRecord("exp-001", "sp-1-production", "td-1-current", "task-2-two-tool-chain", false)
+	tr3 := makeTrialRecord("exp-002", "sp-1", "td-1", "task-a", true)
+
+	events := []BusEvent{
+		busEventFromTrialRecord(tr1),
+		busEventFromTrialRecord(tr2),
+		busEventFromTrialRecord(tr3),
+		// Non-trial event should be ignored
+		{V: 2, Type: "tournament.experiment.v1", Payload: map[string]interface{}{"experiment_id": "exp-001"}},
+	}
+
+	reader := &stubBusReader{events: events}
+	p := buildTestProvider(nil, nil, reader)
+	liveAny, err := p.FetchLive(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("FetchLive: %v", err)
+	}
+	ls := liveAny.(*EvalLiveState)
+
+	if len(ls.Trials) != 3 {
+		t.Errorf("expected 3 trials, got %d", len(ls.Trials))
+	}
+	if len(ls.Scorecards) != 2 {
+		t.Errorf("expected 2 scorecards (exp-001, exp-002), got %d: %v", len(ls.Scorecards), keys(ls.Scorecards))
+	}
+
+	sc001 := ls.Scorecards["exp-001"]
+	if sc001 == nil {
+		t.Fatal("no scorecard for exp-001")
+	}
+	if len(sc001.TaskIDs) != 2 {
+		t.Errorf("exp-001 scorecard: expected 2 task IDs, got %v", sc001.TaskIDs)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestComputePlan_EmptyLive: no prior runs → EvalActionRun
+// ---------------------------------------------------------------------------
+
+func TestComputePlan_EmptyLive(t *testing.T) {
+	p := buildTestProvider(nil, nil, nil)
+
+	cfg := &EvalConfig{
+		Experiments: map[string]*Experiment{
+			"exp-001": {
+				ID:            "exp-001",
+				AutoReconcile: true,
+				TaskIDs:       []string{"task-1"},
+				VariantAxes:   map[string][]string{"system_prompt": {"sp-1"}},
+				Target:        "test",
+			},
+		},
+		BaselinePins: map[string]string{},
+	}
+	ls := &EvalLiveState{
+		Scorecards: map[string]*Scorecard{},
+	}
+
+	plan, err := p.ComputePlan(cfg, ls, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if plan == nil {
+		t.Fatal("plan is nil")
+	}
+
+	// Should have exactly one action: EvalActionRun for exp-001
+	actions := filterNonSkip(plan.Actions)
+	if len(actions) != 1 {
+		t.Errorf("expected 1 non-skip action, got %d: %v", len(actions), actionSummary(plan.Actions))
+		return
+	}
+	ea, _ := actions[0].Details["eval_action"].(string)
+	if ea != string(EvalActionRun) {
+		t.Errorf("expected eval_action=%q, got %q", EvalActionRun, ea)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestComputePlan_FullLive: all cells present, no regression → all skip
+// ---------------------------------------------------------------------------
+
+func TestComputePlan_FullLive(t *testing.T) {
+	p := buildTestProvider(nil, nil, nil)
+
+	cfg := &EvalConfig{
+		Experiments: map[string]*Experiment{
+			"exp-001": {
+				ID:            "exp-001",
+				AutoReconcile: true,
+				TaskIDs:       []string{"task-1"},
+				VariantAxes:   map[string][]string{"system_prompt": {"sp-1"}},
+				Target:        "test",
+			},
+		},
+		BaselinePins: map[string]string{
+			"exp-001": "some-run-id",
+		},
+	}
+
+	// Build a scorecard with all cells populated
+	passed := true
+	sc := &Scorecard{
+		ExperimentID: "exp-001",
+		VariantKeys:  []string{"sp-1 / td-1-current"},
+		TaskIDs:      []string{"task-1"},
+		Cells: map[[2]string]ScorecardCell{
+			{"sp-1 / td-1-current", "task-1"}: &passed,
+		},
+	}
+	ls := &EvalLiveState{
+		Scorecards: map[string]*Scorecard{"exp-001": sc},
+	}
+
+	plan, err := p.ComputePlan(cfg, ls, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+
+	// All actions should be skips (in sync)
+	for _, a := range plan.Actions {
+		if a.Action != reconcile.ActionSkip {
+			ea, _ := a.Details["eval_action"].(string)
+			t.Errorf("expected skip but got action=%q eval_action=%q", a.Action, ea)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestComputePlan_AutoReconcileFalse: skips unless triggered
+// ---------------------------------------------------------------------------
+
+func TestComputePlan_AutoReconcileFalse(t *testing.T) {
+	p := buildTestProvider(nil, nil, nil)
+
+	cfg := &EvalConfig{
+		Experiments: map[string]*Experiment{
+			"exp-001": {
+				ID:            "exp-001",
+				AutoReconcile: false, // on-demand only
+				TaskIDs:       []string{"task-1"},
+				VariantAxes:   map[string][]string{"system_prompt": {"sp-1"}},
+				Target:        "test",
+			},
+		},
+		BaselinePins: map[string]string{},
+	}
+	ls := &EvalLiveState{Scorecards: map[string]*Scorecard{}}
+
+	plan, err := p.ComputePlan(cfg, ls, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+
+	// Should be skipped (auto_reconcile=false, no trigger)
+	for _, a := range plan.Actions {
+		reason, _ := a.Details["reason"].(string)
+		if a.Action != reconcile.ActionSkip {
+			t.Errorf("expected skip, got %q (reason: %s)", a.Action, reason)
+		}
+		if !strings.Contains(reason, "on-demand") && !strings.Contains(reason, "auto_reconcile") {
+			t.Errorf("expected reason to mention auto_reconcile, got %q", reason)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestComputePlan_CircuitBreaker: suspended experiments skip
+// ---------------------------------------------------------------------------
+
+func TestComputePlan_CircuitBreaker(t *testing.T) {
+	p := buildTestProvider(nil, nil, nil)
+
+	cfg := &EvalConfig{
+		Experiments: map[string]*Experiment{
+			"exp-001": {
+				ID:            "exp-001",
+				AutoReconcile: true,
+				TaskIDs:       []string{"task-1"},
+				VariantAxes:   map[string][]string{"system_prompt": {"sp-1"}},
+				Target:        "test",
+			},
+		},
+		BaselinePins: map[string]string{},
+	}
+	ls := &EvalLiveState{Scorecards: map[string]*Scorecard{}}
+
+	// Simulate circuit breaker tripped (> 3 failures)
+	eps := EvalProviderState{
+		RecentFailureCounts:     map[string]int{"exp-001": 5},
+		CircuitBreakerThreshold: 3,
+	}
+	epsJSON, _ := json.Marshal(eps)
+	var epsMap map[string]any
+	_ = json.Unmarshal(epsJSON, &epsMap)
+	state := &reconcile.State{
+		Metadata: map[string]any{"eval_state": epsMap},
+	}
+
+	plan, err := p.ComputePlan(cfg, ls, state)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+
+	for _, a := range plan.Actions {
+		reason, _ := a.Details["reason"].(string)
+		if a.Action != reconcile.ActionSkip {
+			t.Errorf("expected skip (circuit breaker), got %q", a.Action)
+		}
+		if !strings.Contains(reason, "suspended") && !strings.Contains(reason, "circuit") {
+			t.Errorf("expected reason to mention suspended/circuit, got %q", reason)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestApplyPlan_StubDispatcher: dispatches one trial, emits CogBlock
+// ---------------------------------------------------------------------------
+
+func TestApplyPlan_StubDispatcher(t *testing.T) {
+	emitter := &stubEmitter{}
+	dispatcher := &stubDispatcher{
+		results: []DispatchResult{{
+			Index:   0,
+			Success: true,
+			Content: "The kernel trust score is 1.0",
+		}},
+	}
+	p := buildTestProvider(dispatcher, emitter, nil)
+	p.root = t.TempDir() // needed for expandExperimentMatrix fallback
+
+	// Build a plan with one trial to run
+	spec := TrialSpec{
+		TrialID:      "exp-001__sp-1+td-1__task-1",
+		ExperimentID: "exp-001",
+		TaskVariant: Variant{
+			ID:    "task-1",
+			Class: "task",
+			Content: map[string]interface{}{
+				"prompt": "What is the trust score?",
+				"rubric": map[string]interface{}{
+					"content_contains": []interface{}{"trust"},
+				},
+			},
+		},
+		VariantIDs: map[string]string{"system_prompt": "sp-1", "tool_description": "td-1"},
+		Target:     "test",
+	}
+
+	specsJSON, _ := json.Marshal([]TrialSpec{spec})
+	var specsAny interface{}
+	_ = json.Unmarshal(specsJSON, &specsAny)
+
+	plan := &reconcile.Plan{
+		ResourceType: "eval",
+		Actions: []reconcile.Action{
+			{
+				Action:       reconcile.ActionCreate,
+				ResourceType: "eval",
+				Name:         "eval.exp-001",
+				Details: map[string]any{
+					"experiment_id": "exp-001",
+					"eval_action":   string(EvalActionRunIncremental),
+					"trial_specs":   specsAny,
+				},
+			},
+		},
+	}
+
+	results, err := p.ApplyPlan(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("ApplyPlan: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected at least one result")
+	}
+	if results[0].Status == reconcile.ApplyFailed {
+		t.Errorf("trial failed: %s", results[0].Error)
+	}
+
+	// Should have emitted at least one CogBlock
+	if len(emitter.emitted) == 0 {
+		t.Error("expected at least one CogBlock emitted")
+	} else {
+		ch, _ := emitter.emitted[0]["_channel"].(string)
+		if ch != "bus_tournament" {
+			t.Errorf("CogBlock emitted to channel %q, want bus_tournament", ch)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestApplyPlan_NoDispatcher: graceful degradation
+// ---------------------------------------------------------------------------
+
+func TestApplyPlan_NoDispatcher(t *testing.T) {
+	p := buildTestProvider(nil, nil, nil)
+	plan := &reconcile.Plan{
+		Actions: []reconcile.Action{
+			{
+				Action: reconcile.ActionCreate,
+				Name:   "eval.exp-001",
+				Details: map[string]any{
+					"experiment_id": "exp-001",
+					"eval_action":   string(EvalActionRun),
+				},
+			},
+		},
+	}
+	results, err := p.ApplyPlan(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("ApplyPlan: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Status != reconcile.ApplySkipped {
+		t.Errorf("expected ApplySkipped when dispatcher=nil, got %v", results[0].Status)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestBuildState: constructs resources per experiment
+// ---------------------------------------------------------------------------
+
+func TestBuildState(t *testing.T) {
+	p := buildTestProvider(nil, nil, nil)
+
+	passed := true
+	failed := false
+	cfg := &EvalConfig{
+		Experiments: map[string]*Experiment{
+			"exp-001": {ID: "exp-001", Title: "Test Experiment"},
+		},
+		BaselinePins: map[string]string{"exp-001": "run-abc"},
+	}
+	ls := &EvalLiveState{
+		Trials: []TrialRecord{
+			makeTrialRecord("exp-001", "sp-1", "td-1", "task-1", true),
+			makeTrialRecord("exp-001", "sp-1", "td-1", "task-2", false),
+		},
+		Scorecards: map[string]*Scorecard{
+			"exp-001": {
+				ExperimentID: "exp-001",
+				VariantKeys:  []string{"sp-1 / td-1"},
+				TaskIDs:      []string{"task-1", "task-2"},
+				Cells: map[[2]string]ScorecardCell{
+					{"sp-1 / td-1", "task-1"}: &passed,
+					{"sp-1 / td-1", "task-2"}: &failed,
+				},
+			},
+		},
+	}
+
+	state, err := p.BuildState(cfg, ls, nil)
+	if err != nil {
+		t.Fatalf("BuildState: %v", err)
+	}
+	if state == nil {
+		t.Fatal("state is nil")
+	}
+
+	// Find the resource for exp-001
+	var res *reconcile.Resource
+	for i := range state.Resources {
+		if state.Resources[i].Address == "eval.exp-001" {
+			res = &state.Resources[i]
+			break
+		}
+	}
+	if res == nil {
+		t.Fatalf("no resource for eval.exp-001; resources: %v", state.Resources)
+	}
+
+	pin, _ := res.Attributes["baseline_pinned"].(string)
+	if pin != "run-abc" {
+		t.Errorf("baseline_pinned = %q, want run-abc", pin)
+	}
+
+	trialCount, _ := res.Attributes["trial_count"].(int)
+	if trialCount != 2 {
+		t.Errorf("trial_count = %d, want 2", trialCount)
+	}
+
+	pr, _ := res.Attributes["pass_rate"].(float64)
+	if pr != 0.5 {
+		t.Errorf("pass_rate = %f, want 0.5", pr)
+	}
+
+	// eval_state should be in metadata
+	if _, ok := state.Metadata["eval_state"]; !ok {
+		t.Error("expected eval_state in metadata")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestHealth_Initial: reports unknown until reconciled
+// ---------------------------------------------------------------------------
+
+func TestHealth_Initial(t *testing.T) {
+	p := buildTestProvider(nil, nil, nil)
+	h := p.Health()
+	// After zero reconcile cycles, health is the zero value from New()
+	if h.Message == "" {
+		t.Error("expected non-empty health message")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestScore_BasicRubric: port from Python scoring.py
+// ---------------------------------------------------------------------------
+
+func TestScore_BasicRubric(t *testing.T) {
+	tests := []struct {
+		name      string
+		rubric    Rubric
+		content   string
+		toolCalls []string
+		wantPass  bool
+	}{
+		{
+			name:      "content_contains pass",
+			rubric:    Rubric{ContentContains: []string{"trust"}},
+			content:   "The trust score is 1.0",
+			wantPass:  true,
+		},
+		{
+			name:     "content_contains fail",
+			rubric:   Rubric{ContentContains: []string{"trust"}},
+			content:  "The score is 1.0",
+			wantPass: false,
+		},
+		{
+			name:     "content_contains_ci pass",
+			rubric:   Rubric{ContentContainsCI: []string{"TRUST"}},
+			content:  "The trust score is high",
+			wantPass: true,
+		},
+		{
+			name:     "content_contains_ci fail",
+			rubric:   Rubric{ContentContainsCI: []string{"TRUST"}},
+			content:  "The score is high",
+			wantPass: false,
+		},
+		{
+			name:      "expected_tools pass",
+			rubric:    Rubric{ExpectedTools: []string{"cog_get_state"}},
+			toolCalls: []string{"cog_get_state"},
+			content:   "",
+			wantPass:  true,
+		},
+		{
+			name:      "expected_tools fail",
+			rubric:    Rubric{ExpectedTools: []string{"cog_get_state"}},
+			toolCalls: []string{"cog_read_cogdoc"},
+			content:   "",
+			wantPass:  false,
+		},
+		{
+			name:      "forbidden_tools pass",
+			rubric:    Rubric{ForbiddenTools: []string{"cog_write_cogdoc"}},
+			toolCalls: []string{"cog_read_cogdoc"},
+			content:   "",
+			wantPass:  true,
+		},
+		{
+			name:      "forbidden_tools fail",
+			rubric:    Rubric{ForbiddenTools: []string{"cog_write_cogdoc"}},
+			toolCalls: []string{"cog_write_cogdoc", "cog_read_cogdoc"},
+			content:   "",
+			wantPass:  false,
+		},
+		{
+			name:      "first_tool_one_of pass",
+			rubric:    Rubric{FirstToolOneOf: []string{"cog_read_cogdoc"}},
+			toolCalls: []string{"cog_read_cogdoc", "cog_get_state"},
+			content:   "",
+			wantPass:  true,
+		},
+		{
+			name:      "first_tool_one_of fail",
+			rubric:    Rubric{FirstToolOneOf: []string{"cog_read_cogdoc"}},
+			toolCalls: []string{"cog_get_state", "cog_read_cogdoc"},
+			content:   "",
+			wantPass:  false,
+		},
+		{
+			name:      "expected_tools_any_of pass",
+			rubric:    Rubric{ExpectedToolsAnyOf: []string{"cog_get_state", "cog_check_coherence"}},
+			toolCalls: []string{"cog_check_coherence"},
+			content:   "",
+			wantPass:  true,
+		},
+		{
+			name:      "expected_tools_any_of fail",
+			rubric:    Rubric{ExpectedToolsAnyOf: []string{"cog_get_state", "cog_check_coherence"}},
+			toolCalls: []string{"cog_read_cogdoc"},
+			content:   "",
+			wantPass:  false,
+		},
+		{
+			name:     "content_must_not_contain pass",
+			rubric:   Rubric{ContentMustNotContain: []string{"error"}},
+			content:  "success",
+			wantPass: true,
+		},
+		{
+			name:     "content_must_not_contain fail",
+			rubric:   Rubric{ContentMustNotContain: []string{"error"}},
+			content:  "an error occurred",
+			wantPass: false,
+		},
+		{
+			name:     "content_must_not_contain_ci fail",
+			rubric:   Rubric{ContentMustNotContainCI: []string{"ERROR"}},
+			content:  "An error occurred",
+			wantPass: false,
+		},
+		{
+			name:     "all pass combined",
+			rubric: Rubric{
+				ExpectedTools:    []string{"cog_get_state"},
+				ContentContains:  []string{"trust"},
+				ForbiddenTools:   []string{"bad_tool"},
+				FirstToolOneOf:   []string{"cog_get_state"},
+			},
+			toolCalls: []string{"cog_get_state"},
+			content:   "The trust score is 1",
+			wantPass:  true,
+		},
+		{
+			name:     "empty rubric always passes",
+			rubric:   Rubric{},
+			content:  "",
+			wantPass: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := &staticScoredResult{
+				content:   tt.content,
+				toolCalls: tt.toolCalls,
+			}
+			verdict := Score(tt.rubric, result)
+			if verdict.Passed != tt.wantPass {
+				t.Errorf("Score: passed=%v, want %v; failures=%v", verdict.Passed, tt.wantPass, verdict.Failures)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestBuildScorecard: aggregation logic port from Python compare.py
+// ---------------------------------------------------------------------------
+
+func TestBuildScorecard_Aggregation(t *testing.T) {
+	// Multiple trials for same cell: pass if any pass
+	trials := []TrialRecord{
+		makeTrialRecord("exp-001", "sp-1-production", "td-1-current", "task-1", false),
+		makeTrialRecord("exp-001", "sp-1-production", "td-1-current", "task-1", true), // second attempt passes
+		makeTrialRecord("exp-001", "sp-1-production", "td-1-current", "task-2", false),
+	}
+
+	sc := buildScorecard("exp-001", trials)
+	if sc == nil {
+		t.Fatal("scorecard is nil")
+	}
+	if sc.ExperimentID != "exp-001" {
+		t.Errorf("ExperimentID = %q, want exp-001", sc.ExperimentID)
+	}
+
+	// task-1: any pass → true
+	key1 := [2]string{"sp-1-production / td-1-current", "task-1"}
+	cell1 := sc.Cells[key1]
+	if cell1 == nil || !*cell1 {
+		t.Errorf("task-1 should be true (any-pass aggregation), got %v", cell1)
+	}
+
+	// task-2: all fail → false
+	key2 := [2]string{"sp-1-production / td-1-current", "task-2"}
+	cell2 := sc.Cells[key2]
+	if cell2 == nil || *cell2 {
+		t.Errorf("task-2 should be false (all-fail aggregation), got %v", cell2)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestParseEvalProviderState: round-trips through state metadata
+// ---------------------------------------------------------------------------
+
+func TestParseEvalProviderState_RoundTrip(t *testing.T) {
+	eps := EvalProviderState{
+		InFlightTrialIDs:        []string{"trial-1", "trial-2"},
+		RecentFailureCounts:     map[string]int{"exp-001": 2},
+		LastReconcileAt:         "2026-04-25T10:00:00Z",
+		CircuitBreakerThreshold: 5,
+	}
+
+	b, _ := json.Marshal(eps)
+	var epsMap map[string]any
+	_ = json.Unmarshal(b, &epsMap)
+
+	state := &reconcile.State{
+		Metadata: map[string]any{"eval_state": epsMap},
+	}
+
+	restored := parseEvalProviderState(state)
+	if len(restored.InFlightTrialIDs) != 2 {
+		t.Errorf("InFlightTrialIDs = %v, want 2", restored.InFlightTrialIDs)
+	}
+	if restored.CircuitBreakerThreshold != 5 {
+		t.Errorf("CircuitBreakerThreshold = %d, want 5", restored.CircuitBreakerThreshold)
+	}
+	if restored.RecentFailureCounts["exp-001"] != 2 {
+		t.Errorf("RecentFailureCounts[exp-001] = %d, want 2", restored.RecentFailureCounts["exp-001"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestWritePinBaseline: writes JSON file correctly
+// ---------------------------------------------------------------------------
+
+func TestWritePinBaseline(t *testing.T) {
+	dir := t.TempDir()
+	err := writePinBaseline(dir, "exp-001", "run-abc123")
+	if err != nil {
+		t.Fatalf("writePinBaseline: %v", err)
+	}
+
+	pinsPath := filepath.Join(dir, ".cog", "state", "eval-baselines.json")
+	data, err := os.ReadFile(pinsPath)
+	if err != nil {
+		t.Fatalf("read pins file: %v", err)
+	}
+
+	var pins map[string]string
+	if err := json.Unmarshal(data, &pins); err != nil {
+		t.Fatalf("unmarshal pins: %v", err)
+	}
+	if pins["exp-001"] != "run-abc123" {
+		t.Errorf("pin for exp-001 = %q, want run-abc123", pins["exp-001"])
+	}
+
+	// Second write merges
+	err = writePinBaseline(dir, "exp-002", "run-xyz")
+	if err != nil {
+		t.Fatalf("writePinBaseline (second): %v", err)
+	}
+	data, _ = os.ReadFile(pinsPath)
+	var pins2 map[string]string
+	_ = json.Unmarshal(data, &pins2)
+	if pins2["exp-001"] != "run-abc123" {
+		t.Error("exp-001 pin should be preserved after second write")
+	}
+	if pins2["exp-002"] != "run-xyz" {
+		t.Errorf("exp-002 pin = %q, want run-xyz", pins2["exp-002"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+// staticScoredResult implements ScoredResult with fixed values.
+type staticScoredResult struct {
+	content   string
+	toolCalls []string
+}
+
+func (r *staticScoredResult) Content() string        { return r.content }
+func (r *staticScoredResult) ToolCallNames() []string { return r.toolCalls }
+func (r *staticScoredResult) FinishReason() string {
+	if len(r.toolCalls) > 0 && r.content == "" {
+		return "tool_calls"
+	}
+	return "stop"
+}
+
+// keys returns the sorted keys of any map.
+func keys[K comparable, V any](m map[K]V) []K {
+	ks := make([]K, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	return ks
+}
+
+// filterNonSkip returns actions that are not ActionSkip.
+func filterNonSkip(actions []reconcile.Action) []reconcile.Action {
+	var result []reconcile.Action
+	for _, a := range actions {
+		if a.Action != reconcile.ActionSkip {
+			result = append(result, a)
+		}
+	}
+	return result
+}
+
+// actionSummary returns a human-readable summary of actions for debugging.
+func actionSummary(actions []reconcile.Action) []string {
+	var s []string
+	for _, a := range actions {
+		ea, _ := a.Details["eval_action"].(string)
+		reason, _ := a.Details["reason"].(string)
+		s = append(s, string(a.Action)+"/"+ea+":"+reason)
+	}
+	return s
+}

--- a/internal/eval/provider_test.go
+++ b/internal/eval/provider_test.go
@@ -965,6 +965,121 @@ func actionSummary(actions []reconcile.Action) []string {
 // TestWriteDispatchTrigger / TestComputePlan_DispatchTrigger: Bug 2
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// TestExtractToolCallNamesFromResult: Bug 3 — tool call extraction
+// ---------------------------------------------------------------------------
+
+func TestExtractToolCallNamesFromResult_WithToolCalls(t *testing.T) {
+	dr := DispatchResult{
+		Index:   0,
+		Success: true,
+		Content: "done",
+		ToolCalls: []DispatchToolCallSummary{
+			{Name: "cog_get_state", ArgsDigest: "abc"},
+			{Name: "cog_read_cogdoc", ArgsDigest: "def"},
+		},
+	}
+	names := extractToolCallNamesFromResult(dr)
+	if len(names) != 2 {
+		t.Fatalf("expected 2 names, got %v", names)
+	}
+	if names[0] != "cog_get_state" || names[1] != "cog_read_cogdoc" {
+		t.Errorf("unexpected names: %v", names)
+	}
+}
+
+func TestExtractToolCallNamesFromResult_NoToolCalls(t *testing.T) {
+	dr := DispatchResult{Index: 0, Success: true, Content: "done"}
+	names := extractToolCallNamesFromResult(dr)
+	if names != nil {
+		t.Errorf("expected nil for empty tool calls, got %v", names)
+	}
+}
+
+func TestExtractToolCallNamesFromResult_EmptyNames(t *testing.T) {
+	// ToolCalls present but all names empty — should return nil
+	dr := DispatchResult{
+		ToolCalls: []DispatchToolCallSummary{{Name: ""}, {Name: ""}},
+	}
+	names := extractToolCallNamesFromResult(dr)
+	if names != nil {
+		t.Errorf("expected nil when all names are empty, got %v", names)
+	}
+}
+
+func TestApplyPlan_ToolCallsReachRubric(t *testing.T) {
+	// Verify that DispatchResult.ToolCalls flow into the rubric scorer.
+	// The trial should PASS because cog_get_state appears in the result.
+	emitter := &stubEmitter{}
+	dispatcher := &stubDispatcher{
+		results: []DispatchResult{{
+			Index:   0,
+			Success: true,
+			Content: "state retrieved",
+			ToolCalls: []DispatchToolCallSummary{
+				{Name: "cog_get_state"},
+			},
+		}},
+	}
+	p := buildTestProvider(dispatcher, emitter, nil)
+	p.root = t.TempDir()
+
+	specsJSON, _ := json.Marshal([]TrialSpec{{
+		TrialID:      "exp-tc__sp-1+td-1__task-1",
+		ExperimentID: "exp-tc",
+		TaskVariant: Variant{
+			ID:    "task-1",
+			Class: "task",
+			Content: map[string]interface{}{
+				"prompt": "Call cog_get_state",
+				"rubric": map[string]interface{}{
+					"expected_tools": []interface{}{"cog_get_state"},
+				},
+			},
+		},
+		VariantIDs: map[string]string{"system_prompt": "sp-1", "tool_description": "td-1"},
+		Target:     "test",
+	}})
+	var specsAny interface{}
+	_ = json.Unmarshal(specsJSON, &specsAny)
+
+	plan := &reconcile.Plan{
+		ResourceType: "eval",
+		Actions: []reconcile.Action{{
+			Action:       reconcile.ActionCreate,
+			ResourceType: "eval",
+			Name:         "eval.exp-tc",
+			Details: map[string]any{
+				"experiment_id": "exp-tc",
+				"eval_action":   string(EvalActionRunIncremental),
+				"trial_specs":   specsAny,
+			},
+		}},
+	}
+
+	results, err := p.ApplyPlan(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("ApplyPlan: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("no results")
+	}
+	if results[0].Status == reconcile.ApplyFailed {
+		t.Errorf("trial failed (tool call rubric not satisfied): %s", results[0].Error)
+	}
+	// The trial must have passed (cog_get_state present in ToolCalls)
+	if len(emitter.emitted) == 0 {
+		t.Fatal("no CogBlock emitted")
+	}
+	trialRaw := emitter.emitted[0]["trial"]
+	b, _ := json.Marshal(trialRaw)
+	var tr TrialRecord
+	_ = json.Unmarshal(b, &tr)
+	if !tr.Passed {
+		t.Errorf("trial should have passed (cog_get_state in expected_tools), failures: %v", tr.Failures)
+	}
+}
+
 func TestWriteDispatchTrigger_CreatesFile(t *testing.T) {
 	dir := t.TempDir()
 	if err := writeDispatchTrigger(dir, "exp-001", false); err != nil {

--- a/internal/eval/scoring.go
+++ b/internal/eval/scoring.go
@@ -1,0 +1,179 @@
+// scoring.go — Go port of evals/harness/scoring.py.
+//
+// Ports the score() function line-for-line from the Python implementation,
+// including the _ci (case-insensitive) field variants added in Phase C.
+//
+// Per design memo Q8: direct port, exact shape. No weighted scoring,
+// no judge integration. Those are Phase D+ concerns.
+//
+// ScoredResult is the minimal interface that carries what the scorer needs.
+// This is cleaner than the Python shim pattern (_agentic_to_scorable) because
+// Go lets us define a thin interface without modifying the callers.
+package eval
+
+import "strings"
+
+// ScoredResult is the minimal interface the scorer needs from a dispatch result.
+// Implemented by DispatchScoredResult (which wraps a DispatchResult) and by
+// test stubs.
+type ScoredResult interface {
+	// Content returns the final assistant text response.
+	Content() string
+	// ToolCallNames returns the names of tool calls made during the trial,
+	// in invocation order.
+	ToolCallNames() []string
+	// FinishReason returns the reason the model stopped (e.g. "stop", "tool_calls").
+	FinishReason() string
+}
+
+// Score evaluates a rubric against a scored result and returns a Verdict.
+//
+// Direct port of evals/harness/scoring.py score() (lines 23-69).
+// Includes case-insensitive variants (content_contains_ci, content_must_not_contain_ci).
+func Score(rubric Rubric, result ScoredResult) Verdict {
+	var failures []string
+	var notes []string
+
+	called := result.ToolCallNames()
+	if len(called) == 0 {
+		notes = append(notes, "tool_calls: []")
+	} else {
+		notes = append(notes, "tool_calls: "+joinNames(called))
+	}
+	notes = append(notes, "finish_reason: "+result.FinishReason())
+
+	// expected_tools: each must appear in tool-call sequence
+	for _, req := range rubric.ExpectedTools {
+		if !containsStr(called, req) {
+			failures = append(failures, "expected_tools: missing "+quote(req)+"; got "+formatList(called))
+		}
+	}
+
+	// expected_tools_any_of: at least one must appear
+	if len(rubric.ExpectedToolsAnyOf) > 0 {
+		anyFound := false
+		for _, t := range rubric.ExpectedToolsAnyOf {
+			if containsStr(called, t) {
+				anyFound = true
+				break
+			}
+		}
+		if !anyFound {
+			failures = append(failures, "expected_tools_any_of: none of "+formatList(rubric.ExpectedToolsAnyOf)+" appeared; got "+formatList(called))
+		}
+	}
+
+	// forbidden_tools: none must appear
+	for _, forbid := range rubric.ForbiddenTools {
+		if containsStr(called, forbid) {
+			failures = append(failures, "forbidden_tools: "+quote(forbid)+" was called")
+		}
+	}
+
+	// first_tool_one_of: first call must be one of the allowed names
+	if len(rubric.FirstToolOneOf) > 0 {
+		var first string
+		if len(called) > 0 {
+			first = called[0]
+		}
+		if !containsStr(rubric.FirstToolOneOf, first) {
+			failures = append(failures,
+				"first_tool_one_of: first call was "+quoteOrNone(first)+"; expected one of "+formatList(rubric.FirstToolOneOf))
+		}
+	}
+
+	content := result.Content()
+
+	// content_contains: each string must appear (case-sensitive)
+	for _, needle := range rubric.ContentContains {
+		if !strings.Contains(content, needle) {
+			failures = append(failures, "content_contains: "+quote(needle)+" not in content")
+		}
+	}
+
+	// content_must_not_contain: must not appear (case-sensitive)
+	for _, forbid := range rubric.ContentMustNotContain {
+		if strings.Contains(content, forbid) {
+			failures = append(failures, "content_must_not_contain: "+quote(forbid)+" appeared in content")
+		}
+	}
+
+	// content_contains_ci: case-insensitive
+	contentLower := strings.ToLower(content)
+	for _, needle := range rubric.ContentContainsCI {
+		if !strings.Contains(contentLower, strings.ToLower(needle)) {
+			failures = append(failures, "content_contains_ci: "+quote(needle)+" not in content (case-insensitive)")
+		}
+	}
+
+	// content_must_not_contain_ci: case-insensitive
+	for _, forbid := range rubric.ContentMustNotContainCI {
+		if strings.Contains(contentLower, strings.ToLower(forbid)) {
+			failures = append(failures, "content_must_not_contain_ci: "+quote(forbid)+" appeared in content (case-insensitive)")
+		}
+	}
+
+	return Verdict{
+		Passed:   len(failures) == 0,
+		Failures: failures,
+		Notes:    notes,
+	}
+}
+
+// DispatchScoredResult adapts a DispatchResult for use with Score.
+// It also carries tool-call names extracted from the dispatch batch result
+// (tool_calls are stored separately in TrialRecord).
+type DispatchScoredResult struct {
+	result    DispatchResult
+	toolCalls []string
+}
+
+// NewDispatchScoredResult wraps a DispatchResult for scoring.
+// toolCalls is the ordered list of tool call names extracted from the result.
+func NewDispatchScoredResult(r DispatchResult, toolCalls []string) *DispatchScoredResult {
+	return &DispatchScoredResult{result: r, toolCalls: toolCalls}
+}
+
+func (d *DispatchScoredResult) Content() string        { return d.result.Content }
+func (d *DispatchScoredResult) ToolCallNames() []string { return d.toolCalls }
+func (d *DispatchScoredResult) FinishReason() string {
+	if len(d.toolCalls) > 0 && d.result.Content == "" {
+		return "tool_calls"
+	}
+	return "stop"
+}
+
+// ---------------------------------------------------------------------------
+// String formatting helpers (internal to scoring)
+// ---------------------------------------------------------------------------
+
+func containsStr(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+func quote(s string) string {
+	return "'" + s + "'"
+}
+
+func quoteOrNone(s string) string {
+	if s == "" {
+		return "None"
+	}
+	return quote(s)
+}
+
+func joinNames(names []string) string {
+	if len(names) == 0 {
+		return "[]"
+	}
+	return "[" + strings.Join(names, ", ") + "]"
+}
+
+func formatList(names []string) string {
+	return joinNames(names)
+}

--- a/internal/providers/daemon/daemon.go
+++ b/internal/providers/daemon/daemon.go
@@ -32,6 +32,7 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -70,6 +71,7 @@ func SetWorkspaceRoot(root string) {
 func init() {
 	reconcile.RegisterProvider("agent", &agentProvider{})
 	reconcile.RegisterProvider("discord", &discordProvider{})
+	reconcile.RegisterProvider("eval", &evalProvider{})
 	reconcile.RegisterProvider("mcp-tools", &mcpToolsProvider{})
 	reconcile.RegisterProvider("openclaw-agents", &openclawAgentsProvider{})
 	reconcile.RegisterProvider("openclaw-cron", &openclawCronProvider{})
@@ -279,6 +281,78 @@ func (p *openclawGatewayProvider) Health() reconcile.ResourceStatus {
 		}
 	}
 	return reconcile.NewResourceStatus(reconcile.SyncStatusUnknown, reconcile.HealthHealthy)
+}
+
+// ─── eval ─────────────────────────────────────────────────────────────────────
+
+// evalProvider surfaces eval harness health for the daemon's proprioception block.
+//
+// Health() reads two state files from .cog/state/ that the eval harness writes:
+//   - eval-baselines.json        — which experiments have a pinned baseline
+//   - eval-dispatch-triggers.json — pending on-demand run requests
+//
+// Full plan/apply lives in the workspace-root CLI binary (eval_wiring.go);
+// the daemon only needs Health() to contribute to the foveated context block.
+type evalProvider struct{ stubMethods }
+
+func (p *evalProvider) Type() string { return "eval" }
+
+func (p *evalProvider) Health() reconcile.ResourceStatus {
+	root, bad := resolveRoot()
+	if bad != nil {
+		return *bad
+	}
+
+	stateDir := filepath.Join(root, ".cog", "state")
+
+	// Read baseline pins — presence indicates experiments are being tracked.
+	pinsPath := filepath.Join(stateDir, "eval-baselines.json")
+	pinnedCount := 0
+	if data, err := os.ReadFile(pinsPath); err == nil {
+		var pins map[string]string
+		if json.Unmarshal(data, &pins) == nil {
+			pinnedCount = len(pins)
+		}
+	}
+
+	// Read pending dispatch triggers — non-empty means a run was requested but
+	// the reconcile cycle hasn't consumed it yet.
+	triggersPath := filepath.Join(stateDir, "eval-dispatch-triggers.json")
+	pendingCount := 0
+	if data, err := os.ReadFile(triggersPath); err == nil {
+		var triggers map[string]bool
+		if json.Unmarshal(data, &triggers) == nil {
+			pendingCount = len(triggers)
+		}
+	}
+
+	// Check for the experiments directory — its presence signals eval is configured.
+	experimentsDir := filepath.Join(root, ".cog", "mem", "semantic", "architecture", "tournament", "experiments")
+	_, expDirErr := os.Stat(experimentsDir)
+
+	switch {
+	case expDirErr != nil:
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusUnknown,
+			Health:    reconcile.HealthMissing,
+			Operation: reconcile.OperationIdle,
+			Message:   "no tournament experiments directory — eval not configured",
+		}
+	case pendingCount > 0:
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusOutOfSync,
+			Health:    reconcile.HealthProgressing,
+			Operation: reconcile.OperationSyncing,
+			Message:   fmt.Sprintf("%d pending trigger(s), %d pinned baseline(s)", pendingCount, pinnedCount),
+		}
+	default:
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusUnknown,
+			Health:    reconcile.HealthHealthy,
+			Operation: reconcile.OperationIdle,
+			Message:   fmt.Sprintf("%d pinned baseline(s); full plan/apply via cog CLI", pinnedCount),
+		}
+	}
 }
 
 // ─── service ─────────────────────────────────────────────────────────────────

--- a/internal/providers/daemon/daemon_test.go
+++ b/internal/providers/daemon/daemon_test.go
@@ -1,9 +1,9 @@
-// daemon_test.go — verifies that importing this package registers all 8
+// daemon_test.go — verifies that importing this package registers all 9
 // expected Reconcilable providers with pkg/reconcile.
 //
 // This is the canonical test for verification gate 3: "after the
 // engine.Main-equivalent boot path runs, reconcile.ListProviders() returns
-// the 8 expected names."
+// the 9 expected names."
 //
 // We don't start a server or invoke engine.Main() — we only confirm that
 // the package's init() side-effect wired the providers. This is sufficient
@@ -17,7 +17,7 @@ import (
 
 	"github.com/cogos-dev/cogos/pkg/reconcile"
 
-	// Blank import fires daemon.init(), registering all 8 providers.
+	// Blank import fires daemon.init(), registering all 9 providers.
 	_ "github.com/cogos-dev/cogos/internal/providers/daemon"
 )
 
@@ -25,6 +25,7 @@ var expectedProviders = []string{
 	"agent",
 	"component",
 	"discord",
+	"eval",
 	"mcp-tools",
 	"openclaw-agents",
 	"openclaw-cron",
@@ -32,7 +33,7 @@ var expectedProviders = []string{
 	"service",
 }
 
-func TestDaemonInit_RegistersAll8Providers(t *testing.T) {
+func TestDaemonInit_RegistersAll9Providers(t *testing.T) {
 	got := reconcile.ListProviders()
 	sort.Strings(got)
 


### PR DESCRIPTION
## What

The full Phase C eval subsystem. **Big PR** — ~4,000 lines of new code across 10 commits.

\`internal/eval/\`:
- \`provider.go\` (~582 lines) — EvalProvider type, AgentDispatcher / BusEmitter / BusReader interfaces, ComputePlan & ApplyPlan signatures.
- \`provider_impl.go\` (~1,543 lines) — concrete Reconcilable implementation, baseline-pin logic, dispatch-trigger writer, FetchLive variant loader.
- \`provider_test.go\` (~1,219 lines) — coverage for the Reconcilable plus baseline staleness, dispatch trigger plumbing, ToolCall extraction.
- \`mcp_tools.go\` (~422 lines) — MCP tool implementations: \`cog_run_experiment\`, \`cog_list_experiments\`, \`cog_get_experiment_status\`, \`cog_pin_baseline\`.
- \`scoring.go\` (~179 lines) — port of the Python scoring helpers.
- \`bus_reader_http.go\` (~141 lines) — HTTP bus-reader for FetchLive.

\`eval_wiring.go\` (~57 lines, root) — DI seams for the eval package: NowISO, NewEvalProvider constructor, evalProviderInstance singleton, RegisterMCPExtensions wiring.

\`internal/providers/daemon/daemon.go\`, \`cmd/cogos/providers_wire.go\`, \`internal/engine/{providers_register,mcp_server,serve_mcp}.go\` — register the eval provider in the daemon registry and wire the four eval MCP tools onto the kernel's MCP server.

## Why

Previously the kernel had no Reconcilable for evaluation runs. The CLI's reconcile loop had no path to declare experiment state, manage baselines, or trigger dispatches by config. This PR adds eval as a first-class provider so:
- \`cog_run_experiment\` triggers a dispatch under the autonomic ticker.
- \`cog_pin_baseline\` declares a stable point-in-time score for staleness comparisons.
- The autonomic ticker iterates the eval provider alongside the others, surfacing eval health in the proprio block.

## How

EvalProvider satisfies pkg/reconcile's \`Reconcilable\` interface — \`Type/Health/ComputePlan/ApplyPlan/Sync/State\`. Plan/apply is sidecar-state-file driven (\`eval-dispatch-triggers.json\`, \`eval-baselines.json\`) so the daemon and CLI cooperate without shared in-memory state.

## ⚠ Stacked on #60

This PR is **based on \`sync/daemon-workspace-context\` (PR #60)** because it depends on the daemon DI seam machinery introduced there. After #60 merges, this PR can be re-targeted directly to \`main\`.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test ./internal/eval/...\` passes (full Phase C verification suite)
- [x] \`go test ./internal/engine/...\` passes
- [x] \`go test ./internal/providers/...\` passes
- [ ] CI green
- [ ] Manual smoke: kernel daemon starts, \`cog_list_experiments\` returns, eval Reconcilable shows in proprio block.

## Notes

- 4 commits in the original local history are duplicates of the four "fix(eval)" commits in this PR (same patch, different SHA from a merge cycle). Excluded from the cherry-pick.
- The kernel-side \`engine.RegisterMCPExtensions\` hook from PR #60 is what makes the eval MCP tool wiring possible without internal/engine ↔ internal/eval circular imports.