### PR TITLE
chore: post-sync cleanup — accurate probeAllProviders comment + drop ghost TODO

### DIFF
--- a/internal/engine/context_blocks_health.go
+++ b/internal/engine/context_blocks_health.go
@@ -89,9 +89,14 @@ func buildHealthBlock(ctx context.Context) *ContextBlock {
 	return &block
 }
 
-// probeAllProviders probes every named provider in parallel-friendly fashion
-// (each in its own goroutine with an independent timeout). The kernel's
-// registry mutex is only held briefly to fetch the provider reference.
+// probeAllProviders probes every named provider sequentially. Each probeOne
+// call runs Health() in its own goroutine (so a misbehaving provider can't
+// block the foveated handler past healthProbeTimeout), but the outer loop
+// is sequential — worst-case wall-clock latency is N × healthProbeTimeout.
+// The kernel's registry mutex is only held briefly to fetch the provider
+// reference. If provider count grows large enough that N × timeout becomes
+// noticeable, this loop can be fanned out with a WaitGroup; today's N keeps
+// it simple.
 func probeAllProviders(ctx context.Context, names []string) []healthSample {
 	sort.Strings(names)
 	samples := make([]healthSample, len(names))

--- a/internal/eval/provider.go
+++ b/internal/eval/provider.go
@@ -252,9 +252,8 @@ type Experiment struct {
 	Tags []string `json:"tags,omitempty"`
 	// AutoReconcile, when true, allows the metabolic cycle to run this
 	// experiment automatically. Defaults false (on-demand only).
-	//
-	// TODO(Phase C): wire this from frontmatter key "auto_reconcile: true".
-	// When false, the experiment only runs via explicit cog_run_experiment MCP call.
+	// Wired from the cogdoc frontmatter key "auto_reconcile: true";
+	// when false the experiment only runs via explicit cog_run_experiment.
 	AutoReconcile bool `json:"auto_reconcile,omitempty"`
 	// BaselinePinned is the run ID of the pinned baseline, if any.
 	// Set externally via cog_pin_baseline MCP tool (see design memo Q10).


### PR DESCRIPTION
## What

Two minor comment-hygiene fixes surfaced during code review of the sync wave (#60–#66). Pure doc changes — no code.

1. **\`internal/engine/context_blocks_health.go\`**: \`probeAllProviders\`' comment said "parallel-friendly fashion (each in its own goroutine)" but the outer loop is sequential. Each \`probeOne\` call still has its own goroutine + per-provider timeout (so a misbehaving provider can't block past \`healthProbeTimeout\`), but the worst-case wall-clock latency is N × healthProbeTimeout, not max(). Comment now matches the implementation and flags the fan-out path if N grows.

2. **\`internal/eval/provider.go\`**: \`AutoReconcile\` carried a \`TODO(Phase C): wire this from frontmatter\` comment, but it was already wired — \`provider_impl.go:212\` reads \`fm["auto_reconcile"].(bool)\` and \`provider_impl.go:537\` gates on it in ComputePlan rule 7. Replaced with a doc comment describing the actual behavior.

## Why

Reviewers flagged both as nits during PR #62/#64/#65 review. Bundled into one cleanup PR rather than amending the merged branches.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test ./internal/engine/... ./internal/eval/...\` passes
- [ ] CI green