### PR TITLE
feat(engine): named harness tool scopes + audit FS tools + HTTP span tracing

### DIFF
--- a/internal/engine/agent_dispatch.go
+++ b/internal/engine/agent_dispatch.go
@@ -58,9 +58,15 @@ type DispatchRequest struct {
 	// Required and non-empty.
 	Task string
 
+	// Scope selects the named tool scope for this dispatch. Empty string
+	// means "use the harness's default scope" (consolidation). Unknown scope
+	// names are rejected before the dispatch runs. The Tools field, if set,
+	// further narrows within the resolved scope.
+	Scope string
+
 	// Tools is the optional allowlist for this dispatch. nil or empty means
-	// "use the harness's default tool registry". Names that don't match any
-	// registered tool surface as an error in the result, not silent drop.
+	// "use the full scope set". Names that don't match any tool in the
+	// chosen scope surface as an error rather than silently dropping.
 	Tools []string
 
 	// Model selects the inference backend. Unknown values default to e4b.

--- a/internal/engine/handler_span.go
+++ b/internal/engine/handler_span.go
@@ -1,0 +1,226 @@
+// handler_span.go — per-handler span instrumentation for the kernel HTTP surface.
+//
+// Every handler registered via Server.route (or Server.routeH) is automatically
+// wrapped by withSpan, which:
+//
+//   - Captures start time, HTTP method, path, session-id header, and origin.
+//   - Intercepts the response via a capturing ResponseWriter so it can record
+//     the status code and response byte count without buffering the body.
+//   - Emits a KernelHandlerSpan to the bus_traces bus when the handler returns.
+//
+// Wire contract (bus channel: bus_traces, block type: kernel.handler.span.v1):
+//
+//	The KernelHandlerSpan struct is the stable payload shape. The bus_traces
+//	channel bridge (RFC-003, deferred) will surface these as <channel> tags.
+//	Fields are chosen for observability without leaking sensitive content:
+//	no request body, no response body, no full header dump.
+//
+// SSE and streaming handlers will still emit a span — the span fires on
+// handler return, which for streaming responses is when the stream is fully
+// drained. Duration therefore reflects the full streaming wall-clock time,
+// which is the correct metric for throughput observability.
+package engine
+
+import (
+	"bufio"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// BusTraces is the well-known bus channel ID for handler span events.
+// Mirrors the naming convention in sessions.go (BusSessions, BusHandoffs).
+const BusTraces = "bus_traces"
+
+// KernelHandlerSpan is the wire contract for a single handler invocation.
+// It is serialised as the payload of a bus_traces event with
+// BlockType = "kernel.handler.span.v1".
+//
+// Sensitive content is explicitly excluded: no request body, no response body,
+// no full header dump. SpanID is a UUID v4 (not ULID — ulid is not in go.mod;
+// UUID is already imported and provides equivalent uniqueness for this use).
+type KernelHandlerSpan struct {
+	SpanID       string            `json:"span_id"`
+	Handler      string            `json:"handler"`
+	Method       string            `json:"method"`
+	Path         string            `json:"path"`
+	StartedAt    time.Time         `json:"started_at"`
+	DurationMS   int64             `json:"duration_ms"`
+	Status       int               `json:"status"`
+	RequestSize  int               `json:"request_size"`
+	ResponseSize int               `json:"response_size"`
+	SessionID    string            `json:"session_id,omitempty"`
+	Origin       string            `json:"origin"`
+	Error        string            `json:"error,omitempty"`
+	Metadata     map[string]string `json:"metadata,omitempty"`
+}
+
+// spanEmitter is the interface used by withSpan to persist spans so tests can
+// inject a no-op or a recording emitter without needing a live BusSessionManager.
+type spanEmitter interface {
+	emitSpan(span KernelHandlerSpan)
+}
+
+// serverSpanEmitter forwards spans to the server's busSessions manager.
+// It is wired once in NewServer so that withSpan closures stay small.
+type serverSpanEmitter struct {
+	bus *BusSessionManager
+}
+
+func (e *serverSpanEmitter) emitSpan(span KernelHandlerSpan) {
+	if e.bus == nil {
+		return
+	}
+	payload := map[string]interface{}{
+		"span_id":       span.SpanID,
+		"handler":       span.Handler,
+		"method":        span.Method,
+		"path":          span.Path,
+		"started_at":    span.StartedAt.UTC().Format(time.RFC3339Nano),
+		"duration_ms":   span.DurationMS,
+		"status":        span.Status,
+		"request_size":  span.RequestSize,
+		"response_size": span.ResponseSize,
+		"origin":        span.Origin,
+	}
+	if span.SessionID != "" {
+		payload["session_id"] = span.SessionID
+	}
+	if span.Error != "" {
+		payload["error"] = span.Error
+	}
+	if len(span.Metadata) > 0 {
+		payload["metadata"] = span.Metadata
+	}
+
+	// Ensure bus_traces exists before appending. EnsureBus is idempotent and
+	// cheap (stat + mkdir) so calling it per-span is safe; it only allocates on
+	// the first call for this bus ID.
+	if err := e.bus.EnsureBus(BusTraces); err != nil {
+		slog.Warn("handler_span: ensure bus_traces failed", "err", err)
+		return
+	}
+	// Register the bus the first time it is touched. RegisterBus is also
+	// idempotent — subsequent calls update state to "active".
+	if err := e.bus.RegisterBus(BusTraces, "kernel", "kernel"); err != nil {
+		slog.Warn("handler_span: register bus_traces failed", "err", err)
+	}
+	if _, err := e.bus.AppendEvent(BusTraces, "kernel.handler.span.v1", "kernel", payload); err != nil {
+		slog.Warn("handler_span: AppendEvent failed", "err", err, "handler", span.Handler)
+	}
+}
+
+// capturingResponseWriter wraps http.ResponseWriter to intercept the status
+// code and count the bytes written to the response body. It implements
+// http.Flusher so SSE handlers keep working: if the underlying writer is a
+// Flusher, Flush() is forwarded; otherwise it's a no-op.
+//
+// It also implements http.Hijacker if the underlying writer supports it, so
+// WebSocket upgrade paths are not broken.
+type capturingResponseWriter struct {
+	http.ResponseWriter
+	statusCode int
+	written    atomic.Int64
+}
+
+func newCapturingResponseWriter(w http.ResponseWriter) *capturingResponseWriter {
+	return &capturingResponseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+}
+
+func (c *capturingResponseWriter) WriteHeader(code int) {
+	c.statusCode = code
+	c.ResponseWriter.WriteHeader(code)
+}
+
+func (c *capturingResponseWriter) Write(b []byte) (int, error) {
+	n, err := c.ResponseWriter.Write(b)
+	c.written.Add(int64(n))
+	return n, err
+}
+
+// Flush forwards to the underlying Flusher if available.
+func (c *capturingResponseWriter) Flush() {
+	if f, ok := c.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Hijack forwards to the underlying Hijacker if available (WebSocket support).
+func (c *capturingResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if h, ok := c.ResponseWriter.(http.Hijacker); ok {
+		return h.Hijack()
+	}
+	return nil, nil, fmt.Errorf("handler_span: underlying ResponseWriter does not implement http.Hijacker")
+}
+
+// inferOrigin classifies the caller origin from the request. Priority:
+//   - X-CogOS-Origin header if set (e.g. "mcp", "kernel-loop").
+//   - Presence of a known MCP path prefix.
+//   - Falls back to "http".
+func inferOrigin(r *http.Request) string {
+	if o := r.Header.Get("X-CogOS-Origin"); o != "" {
+		return o
+	}
+	if strings.HasPrefix(r.URL.Path, "/mcp") {
+		return "mcp"
+	}
+	return "http"
+}
+
+// withSpan returns an http.HandlerFunc that wraps h with span instrumentation.
+// The emitter receives the completed span after h returns. Span emission is
+// synchronous but cheap: it only allocates a payload map and calls
+// AppendEvent (file append). The handler's hot path is not affected because
+// the span write happens after the response is already on the wire.
+func withSpan(handlerName string, h http.HandlerFunc, emit spanEmitter) http.HandlerFunc {
+	if emit == nil {
+		// Safety: if the emitter is nil (e.g. in tests that don't need spans),
+		// return the original handler unmodified.
+		return h
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		cw := newCapturingResponseWriter(w)
+
+		// Best-effort request size: Content-Length if available, 0 otherwise.
+		// We do NOT buffer the body — just read the header field.
+		reqSize := 0
+		if r.ContentLength > 0 {
+			reqSize = int(r.ContentLength)
+		}
+
+		sessionID := r.Header.Get("X-Session-ID")
+		origin := inferOrigin(r)
+
+		h(cw, r)
+
+		span := KernelHandlerSpan{
+			SpanID:       uuid.New().String(),
+			Handler:      handlerName,
+			Method:       r.Method,
+			Path:         r.URL.Path,
+			StartedAt:    start,
+			DurationMS:   time.Since(start).Milliseconds(),
+			Status:       cw.statusCode,
+			RequestSize:  reqSize,
+			ResponseSize: int(cw.written.Load()),
+			SessionID:    sessionID,
+			Origin:       origin,
+		}
+
+		// Emit synchronously. For non-streaming handlers the response is
+		// already on the wire (bufio/http.ResponseWriter has flushed) before
+		// this line runs, so the bus-append adds no user-visible latency.
+		// For streaming handlers (SSE) the handler blocks until the stream
+		// is fully drained, so the span is always emitted after the session
+		// completes regardless. A goroutine would race with test TempDir
+		// cleanup and cause spurious test failures.
+		emit.emitSpan(span)
+	}
+}

--- a/internal/engine/local_agent_harness.go
+++ b/internal/engine/local_agent_harness.go
@@ -13,18 +13,55 @@ import (
 	"time"
 )
 
-var defaultLocalHarnessToolScope = []string{
-	"cog_resolve_uri",
-	"cog_search_memory",
-	"cog_read_cogdoc",
-	"cog_query_field",
-	"cog_check_coherence",
-	"cog_get_state",
-	"cog_get_trust",
-	"cog_get_nucleus",
-	"cog_get_index",
-	"cog_assemble_context",
-	"cog_emit_event",
+// defaultHarnessScopeName is the scope used when no scope is requested.
+// Callers that don't specify a scope get exactly the tool set they always have.
+const defaultHarnessScopeName = "consolidation"
+
+// harnessToolScopes is the named-scope catalog for harness dispatches.
+// Each scope is a named set of tool names the harness may use.
+//
+// "consolidation" — substrate-only tools: memory, observability, identity.
+//   This is the default scope (unchanged from the original tool set).
+//   The harness operates on cogdocs, the field, and coherence only.
+//
+// "audit" — consolidation tools PLUS read-only filesystem access.
+//   Use this scope when the harness needs to inspect source, configs,
+//   or workspace files without mutating anything.
+//
+// Future scopes (add entries here when the underlying mechanisms land):
+//   "maintenance" — read+write filesystem tools gated behind per-dispatch
+//                   worktree isolation (see ADR-081 §8 worktree work).
+//   "introspection" — audit tools plus kernel state-dump tools for deep
+//                     diagnostic cycles.
+var harnessToolScopes = map[string][]string{
+	"consolidation": {
+		"cog_resolve_uri",
+		"cog_search_memory",
+		"cog_read_cogdoc",
+		"cog_query_field",
+		"cog_check_coherence",
+		"cog_get_state",
+		"cog_get_trust",
+		"cog_get_nucleus",
+		"cog_get_index",
+		"cog_assemble_context",
+		"cog_emit_event",
+	},
+	"audit": {
+		"cog_resolve_uri",
+		"cog_search_memory",
+		"cog_read_cogdoc",
+		"cog_query_field",
+		"cog_check_coherence",
+		"cog_get_state",
+		"cog_get_trust",
+		"cog_get_nucleus",
+		"cog_get_index",
+		"cog_assemble_context",
+		"cog_emit_event",
+		"cog_read_file",
+		"cog_grep_files",
+	},
 }
 
 const (
@@ -143,11 +180,25 @@ type LocalHarnessController struct {
 }
 
 func NewLocalHarnessController(cfg *Config, nucleus *Nucleus, process *Process, mcpSrv *MCPServer) (*LocalHarnessController, error) {
+	return NewLocalHarnessControllerWithScope(cfg, nucleus, process, mcpSrv, "")
+}
+
+// NewLocalHarnessControllerWithScope creates a LocalHarnessController using
+// the named harness scope. An empty scopeName selects defaultHarnessScopeName.
+// Unknown scope names return an error immediately.
+func NewLocalHarnessControllerWithScope(cfg *Config, nucleus *Nucleus, process *Process, mcpSrv *MCPServer, scopeName string) (*LocalHarnessController, error) {
 	if mcpSrv == nil {
 		return nil, fmt.Errorf("local harness requires MCP server wiring")
 	}
+	if scopeName == "" {
+		scopeName = defaultHarnessScopeName
+	}
+	toolNames, ok := harnessToolScopes[scopeName]
+	if !ok {
+		return nil, fmt.Errorf("unknown harness scope %q (known: consolidation, audit)", scopeName)
+	}
 	registry := NewKernelToolRegistry(mcpSrv)
-	dispatchTools, err := registry.Scoped(defaultLocalHarnessToolScope)
+	dispatchTools, err := registry.Scoped(toolNames)
 	if err != nil {
 		return nil, err
 	}
@@ -735,9 +786,31 @@ func (c *LocalHarnessController) DispatchToHarness(ctx context.Context, req Disp
 		return nil, errors.New(note)
 	}
 
-	registry := c.dispatchTools
+	// Resolve the named scope. Empty scope means the harness's own default
+	// scope (c.dispatchTools, already scoped at construction time). A
+	// non-empty scope is resolved from the catalog; unknown names are
+	// rejected here so the error is immediate and clear.
+	baseRegistry := c.dispatchTools
+	if req.Scope != "" {
+		scopeTools, ok := harnessToolScopes[req.Scope]
+		if !ok {
+			known := make([]string, 0, len(harnessToolScopes))
+			for k := range harnessToolScopes {
+				known = append(known, k)
+			}
+			return nil, &AgentControllerError{
+				Code:    "invalid_input",
+				Message: fmt.Sprintf("unknown harness scope %q (known: %v)", req.Scope, known),
+			}
+		}
+		baseRegistry, err = c.toolRegistry.Scoped(scopeTools)
+		if err != nil {
+			return nil, err
+		}
+	}
+	registry := baseRegistry
 	if len(req.Tools) > 0 {
-		registry, err = c.dispatchTools.Scoped(req.Tools)
+		registry, err = baseRegistry.Scoped(req.Tools)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -16,14 +16,19 @@
 package engine
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -251,7 +256,7 @@ func (m *MCPServer) registerTools() {
 
 	mcp.AddTool(m.server, &mcp.Tool{
 		Name:        "cog_dispatch_to_harness",
-		Description: "Phase 2 transport: dispatch a task into the kernel-interior agent harness with structured return, optional concurrency (n=1..4), per-call tool scope narrowing, optional system-prompt override, and pluggable model routing (e4b local Ollama, default; 26b LM Studio with degrade-to-e4b fallback). Synchronous: blocks until every slot completes, errors, or hits its per-slot timeout (default 30s, max 120s). Returns one DispatchResult per slot with content (the agent's final respond text), tool-call digests, duration, and turn count. Use this for the foveal->peripheral handoff — offload validation, rewriting, modality matching to the resident swarm instead of paying with Anthropic tokens. Backward-compat note: cog_trigger_agent_loop still wakes the singleton with no payload; this tool is the new payload-bearing path.",
+		Description: "Phase 2 transport: dispatch a task into the kernel-interior agent harness with structured return, optional concurrency (n=1..4), named tool scope, per-call tool narrowing, optional system-prompt override, and pluggable model routing (e4b local Ollama, default; 26b LM Studio with degrade-to-e4b fallback). Synchronous: blocks until every slot completes, errors, or hits its per-slot timeout (default 30s, max 120s). Returns one DispatchResult per slot with content (the agent's final respond text), tool-call digests, duration, and turn count. Use this for the foveal->peripheral handoff — offload validation, rewriting, modality matching to the resident swarm instead of paying with Anthropic tokens. Named scopes: \"consolidation\" (default, 11 substrate tools: memory/field/coherence/identity), \"audit\" (consolidation + cog_read_file + cog_grep_files for read-only filesystem inspection). The tools parameter narrows within the chosen scope; unknown scope names error immediately. Backward-compat note: cog_trigger_agent_loop still wakes the singleton with no payload; this tool is the new payload-bearing path.",
 	}, m.toolDispatchToHarness)
 
 	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
@@ -318,6 +323,19 @@ func (m *MCPServer) registerTools() {
 	// status and plays the returned audio/wav locally. Supersedes the
 	// installed binary's OpenClaw gateway which silently drops audio bytes.
 	m.registerMod3Tools()
+
+	// Audit-scope read-only filesystem tools. Also registered as first-class
+	// MCP tools so they're callable directly from Claude Code sessions.
+	// In harness dispatches these are available only when scope="audit".
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+		Name:        "cog_read_file",
+		Description: "Read an arbitrary file within the workspace root. Returns line-numbered content with optional offset/limit (default 500 lines). Rejects paths outside the workspace root. Use for source inspection and substrate-introspection tasks. Fallback: cat -n <path>",
+	}), withToolObserver(m, "cog_read_file", m.toolReadFile))
+
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+		Name:        "cog_grep_files",
+		Description: "Regex search over files within the workspace root (uses ripgrep when available, falls back to pure-Go walk). Returns matching lines with relative path and line number. Rejects search paths outside the workspace root. Fallback: rg --no-heading -n <pattern> <path>",
+	}), withToolObserver(m, "cog_grep_files", m.toolGrepFiles))
 
 	// Phase 1B: peer-awareness packet (READ side of the 4E ambient-
 	// awareness loop; Phase 1A publishes channel.<sid>.activity).
@@ -690,7 +708,8 @@ type triggerAgentLoopInput struct {
 type dispatchToHarnessInput struct {
 	AgentID      string                 `json:"agent_id,omitempty" jsonschema:"Which harness instance to dispatch into. Default \"primary\"."`
 	Task         string                 `json:"task" jsonschema:"Required. The user-role prompt the harness's Execute loop will receive."`
-	Tools        []string               `json:"tools,omitempty" jsonschema:"Optional tool allowlist (subset of registered core tools). nil/empty uses the full default set. Unknown names error in the per-slot result rather than silently dropping."`
+	Scope        string                 `json:"scope,omitempty" jsonschema:"Named tool scope for this dispatch. \"consolidation\" (default, 11 substrate tools: memory/field/coherence/identity) or \"audit\" (consolidation + cog_read_file + cog_grep_files for read-only filesystem inspection). Unknown scope names error immediately. The tools parameter, if set, narrows further within the chosen scope."`
+	Tools        []string               `json:"tools,omitempty" jsonschema:"Optional tool allowlist (subset of the chosen scope's tools). nil/empty uses the full scope set. Unknown names error in the per-slot result rather than silently dropping."`
 	Model        string                 `json:"model,omitempty" jsonschema:"Inference backend. \"e4b\" (default, local Ollama) or \"26b\" (configured remote OpenAI-compatible endpoint). Unknown values fall back to e4b."`
 	Timeout      int                    `json:"timeout_seconds,omitempty" jsonschema:"Per-slot wall-clock budget in seconds. Default 30, max 120. On exceed, that slot returns success=false error=\"timeout\"; sibling slots continue."`
 	N            int                    `json:"n,omitempty" jsonschema:"Parallel fan-out, [1,4]. Default 1. Each slot gets its own context, its own deadline, and its own result entry; failures don't abort siblings."`
@@ -756,6 +775,20 @@ type searchTracesInput struct {
 	Until     string `json:"until,omitempty" jsonschema:"Upper time bound. RFC3339 timestamp or Go duration."`
 	Limit     int    `json:"limit,omitempty" jsonschema:"Maximum results (default 100, max 1000)."`
 	Order     string `json:"order,omitempty" jsonschema:"'desc' (default, newest first) or 'asc'."`
+}
+
+// readFileInput is the input type for cog_read_file (audit scope).
+type readFileInput struct {
+	Path   string `json:"path" jsonschema:"Absolute path within workspace root"`
+	Offset int    `json:"offset,omitempty" jsonschema:"Line offset (0-based). Default 0."`
+	Limit  int    `json:"limit,omitempty" jsonschema:"Maximum lines to return. Default 500."`
+}
+
+// grepFilesInput is the input type for cog_grep_files (audit scope).
+type grepFilesInput struct {
+	Pattern    string `json:"pattern" jsonschema:"Regular expression pattern to search for"`
+	Path       string `json:"path,omitempty" jsonschema:"Directory or file to search (defaults to workspace root)"`
+	MaxResults int    `json:"max_results,omitempty" jsonschema:"Maximum matches to return. Default 50."`
 }
 
 // ── Tool Implementations ─────────────────────────────────────────────────────
@@ -1718,6 +1751,7 @@ func (m *MCPServer) toolDispatchToHarness(ctx context.Context, req *mcp.CallTool
 	dr := DispatchRequest{
 		AgentID:        input.AgentID,
 		Task:           input.Task,
+		Scope:          input.Scope,
 		Tools:          input.Tools,
 		Model:          DispatchModel(input.Model),
 		TimeoutSeconds: input.Timeout,
@@ -2247,6 +2281,257 @@ func fallbackResult(errMsg, fallbackCmd string) (*mcp.CallToolResult, any, error
 		},
 		IsError: true,
 	}, nil, nil
+}
+
+// ── Audit-scope tool implementations ─────────────────────────────────────────
+
+// toolReadFile implements cog_read_file. Reads an arbitrary file path that
+// must be within cfg.WorkspaceRoot. Returns line-numbered content with
+// optional offset and limit for large files.
+//
+// Example output:
+//
+//	{"content":"   1\tpackage engine\n   2\t\n", "lines":2, "truncated":false}
+func (m *MCPServer) toolReadFile(ctx context.Context, req *mcp.CallToolRequest, input readFileInput) (*mcp.CallToolResult, any, error) {
+	if input.Path == "" {
+		return textResult("path is required")
+	}
+
+	workspaceRoot := ""
+	if m.cfg != nil {
+		workspaceRoot = m.cfg.WorkspaceRoot
+	}
+
+	// Workspace jail: reject paths that are not under the workspace root.
+	// We resolve both to absolute paths so symlink traversal can't escape.
+	abs, err := filepath.Abs(input.Path)
+	if err != nil {
+		return textResult(fmt.Sprintf("invalid path: %v", err))
+	}
+	if workspaceRoot != "" {
+		rootAbs, err2 := filepath.Abs(workspaceRoot)
+		if err2 != nil {
+			return textResult(fmt.Sprintf("workspace root resolution failed: %v", err2))
+		}
+		// EvalSymlinks to catch symlink escapes.
+		absReal, err3 := filepath.EvalSymlinks(abs)
+		if err3 != nil {
+			// If the file doesn't exist EvalSymlinks fails; use abs for the check.
+			absReal = abs
+		}
+		rootReal, _ := filepath.EvalSymlinks(rootAbs)
+		if rootReal == "" {
+			rootReal = rootAbs
+		}
+		if !strings.HasPrefix(absReal, rootReal+string(filepath.Separator)) && absReal != rootReal {
+			return textResult(fmt.Sprintf("path %q is outside workspace root %q", input.Path, workspaceRoot))
+		}
+	}
+
+	f, err := os.Open(abs)
+	if err != nil {
+		return textResult(fmt.Sprintf("open failed: %v", err))
+	}
+	defer f.Close()
+
+	const defaultLimit = 500
+	limit := input.Limit
+	if limit <= 0 {
+		limit = defaultLimit
+	}
+	offset := input.Offset
+	if offset < 0 {
+		offset = 0
+	}
+
+	scanner := bufio.NewScanner(f)
+	var buf bytes.Buffer
+	lineNo := 0
+	linesWritten := 0
+	truncated := false
+
+	for scanner.Scan() {
+		lineNo++
+		if lineNo <= offset {
+			continue
+		}
+		if linesWritten >= limit {
+			// Peek to see if there's more.
+			if scanner.Scan() {
+				truncated = true
+			}
+			break
+		}
+		fmt.Fprintf(&buf, "%4d\t%s\n", lineNo, scanner.Text())
+		linesWritten++
+	}
+	if err := scanner.Err(); err != nil {
+		return textResult(fmt.Sprintf("read error: %v", err))
+	}
+
+	return marshalResult(map[string]any{
+		"content":   buf.String(),
+		"lines":     linesWritten,
+		"truncated": truncated,
+	})
+}
+
+// toolGrepFiles implements cog_grep_files. Runs ripgrep (rg) when available,
+// otherwise falls back to a pure-Go regexp walk. The search path must be
+// within cfg.WorkspaceRoot.
+//
+// Example match entry: {"path":"engine/foo.go","line":42,"text":"func Foo() {"}
+func (m *MCPServer) toolGrepFiles(ctx context.Context, req *mcp.CallToolRequest, input grepFilesInput) (*mcp.CallToolResult, any, error) {
+	if input.Pattern == "" {
+		return textResult("pattern is required")
+	}
+
+	workspaceRoot := ""
+	if m.cfg != nil {
+		workspaceRoot = m.cfg.WorkspaceRoot
+	}
+
+	// Resolve search path.
+	searchPath := input.Path
+	if searchPath == "" {
+		searchPath = workspaceRoot
+	}
+	if searchPath == "" {
+		searchPath = "."
+	}
+
+	absSearch, err := filepath.Abs(searchPath)
+	if err != nil {
+		return textResult(fmt.Sprintf("invalid search path: %v", err))
+	}
+
+	// Workspace jail check.
+	if workspaceRoot != "" {
+		rootAbs, err2 := filepath.Abs(workspaceRoot)
+		if err2 != nil {
+			return textResult(fmt.Sprintf("workspace root resolution failed: %v", err2))
+		}
+		rootReal, _ := filepath.EvalSymlinks(rootAbs)
+		if rootReal == "" {
+			rootReal = rootAbs
+		}
+		absReal, err3 := filepath.EvalSymlinks(absSearch)
+		if err3 != nil {
+			absReal = absSearch
+		}
+		if !strings.HasPrefix(absReal, rootReal+string(filepath.Separator)) && absReal != rootReal {
+			return textResult(fmt.Sprintf("search path %q is outside workspace root %q", searchPath, workspaceRoot))
+		}
+	}
+
+	maxResults := input.MaxResults
+	if maxResults <= 0 {
+		maxResults = 50
+	}
+
+	type matchEntry struct {
+		Path string `json:"path"`
+		Line int    `json:"line"`
+		Text string `json:"text"`
+	}
+
+	var matches []matchEntry
+	truncated := false
+
+	// Try ripgrep first (much faster on large trees).
+	if rgPath, rgErr := exec.LookPath("rg"); rgErr == nil {
+		// rg --no-heading --line-number --max-count N pattern path
+		args := []string{
+			"--no-heading",
+			"--line-number",
+			"--color=never",
+			"--max-count", strconv.Itoa(maxResults + 1), // +1 to detect truncation
+			input.Pattern,
+			absSearch,
+		}
+		cmd := exec.CommandContext(ctx, rgPath, args...)
+		out, _ := cmd.Output() // exit 1 means no match, not an error we care about
+		scanner := bufio.NewScanner(bytes.NewReader(out))
+		for scanner.Scan() {
+			line := scanner.Text()
+			// rg --no-heading format: path:linenum:text
+			parts := strings.SplitN(line, ":", 3)
+			if len(parts) < 3 {
+				continue
+			}
+			lineNum, err2 := strconv.Atoi(parts[1])
+			if err2 != nil {
+				continue
+			}
+			if len(matches) >= maxResults {
+				truncated = true
+				break
+			}
+			relPath := parts[0]
+			if workspaceRoot != "" {
+				if rel, err3 := filepath.Rel(workspaceRoot, relPath); err3 == nil {
+					relPath = rel
+				}
+			}
+			matches = append(matches, matchEntry{
+				Path: relPath,
+				Line: lineNum,
+				Text: parts[2],
+			})
+		}
+	} else {
+		// Pure-Go fallback: walk the tree and grep with regexp.
+		slog.Debug("cog_grep_files: rg not found, using Go fallback", "path", absSearch)
+		re, err2 := regexp.Compile(input.Pattern)
+		if err2 != nil {
+			return textResult(fmt.Sprintf("invalid pattern: %v", err2))
+		}
+		err = filepath.Walk(absSearch, func(p string, info os.FileInfo, walkErr error) error {
+			if walkErr != nil || info.IsDir() {
+				return nil
+			}
+			if len(matches) >= maxResults {
+				truncated = true
+				return io.EOF // stop walk
+			}
+			f, ferr := os.Open(p)
+			if ferr != nil {
+				return nil
+			}
+			defer f.Close()
+			scanner := bufio.NewScanner(f)
+			lineNo := 0
+			for scanner.Scan() {
+				lineNo++
+				if re.MatchString(scanner.Text()) {
+					if len(matches) >= maxResults {
+						truncated = true
+						return io.EOF
+					}
+					relPath := p
+					if workspaceRoot != "" {
+						if rel, err3 := filepath.Rel(workspaceRoot, p); err3 == nil {
+							relPath = rel
+						}
+					}
+					matches = append(matches, matchEntry{
+						Path: relPath,
+						Line: lineNo,
+						Text: scanner.Text(),
+					})
+				}
+			}
+			return nil
+		})
+		if err != nil && err != io.EOF {
+			return textResult(fmt.Sprintf("walk error: %v", err))
+		}
+	}
+
+	return marshalResult(map[string]any{
+		"matches":   matches,
+		"truncated": truncated,
+	})
 }
 
 // extractSection pulls a section from markdown by heading anchor.

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -98,6 +98,11 @@ type Server struct {
 	// slice. Populated at startup only — reads are lock-free because the
 	// slice is frozen by the time Start returns.
 	httpRoutes []routeMeta
+
+	// spanEmitter is wired to busSessions at startup so that withSpan
+	// closures can emit KernelHandlerSpan events to bus_traces. Nil-safe:
+	// withSpan is a no-op wrapper when spanEmitter is nil.
+	spanEmitter spanEmitter
 }
 
 // NewServer constructs a Server bound to the configured port.
@@ -108,6 +113,7 @@ func NewServer(cfg *Config, nucleus *Nucleus, process *Process) *Server {
 	// handlers don't need nil-safety for the common case; tests can
 	// override via the exported fields if they want an isolated fixture.
 	s.busSessions = NewBusSessionManager(cfg.WorkspaceRoot)
+	s.spanEmitter = &serverSpanEmitter{bus: s.busSessions}
 	s.busBroker = NewBusEventBroker()
 	s.busConsumers = NewConsumerRegistry(
 		// Match root's persistence path: .cog/run/bus/{bus_id}.cursors.jsonl

--- a/internal/engine/serve_agents.go
+++ b/internal/engine/serve_agents.go
@@ -25,15 +25,15 @@ type agentStatusCompat struct {
 }
 
 func (s *Server) registerAgentRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("GET /v1/agents", s.handleAgentsList)
-	mux.HandleFunc("GET /v1/agents/{id}", s.handleAgentGet)
-	mux.HandleFunc("POST /v1/agents/{id}/tick", s.handleAgentTick)
-	mux.HandleFunc("POST /v1/agents/{id}/dispatch", s.handleAgentDispatch)
+	s.route(mux, "GET /v1/agents", s.handleAgentsList)
+	s.route(mux, "GET /v1/agents/{id}", s.handleAgentGet)
+	s.route(mux, "POST /v1/agents/{id}/tick", s.handleAgentTick)
+	s.route(mux, "POST /v1/agents/{id}/dispatch", s.handleAgentDispatch)
 
 	// Legacy dashboard routes.
-	mux.HandleFunc("GET /v1/agent/status", s.handleAgentStatusCompat)
-	mux.HandleFunc("GET /v1/agent/traces", s.handleAgentTracesCompat)
-	mux.HandleFunc("POST /v1/agent/trigger", s.handleAgentTriggerCompat)
+	s.route(mux, "GET /v1/agent/status", s.handleAgentStatusCompat)
+	s.route(mux, "GET /v1/agent/traces", s.handleAgentTracesCompat)
+	s.route(mux, "POST /v1/agent/trigger", s.handleAgentTriggerCompat)
 }
 
 func (s *Server) handleAgentsList(w http.ResponseWriter, r *http.Request) {

--- a/internal/engine/serve_manifest.go
+++ b/internal/engine/serve_manifest.go
@@ -49,8 +49,15 @@ type mcpToolMeta struct {
 // route registers a handler on mux and records the (method, path) tuple onto
 // s.httpRoutes. The pattern follows http.ServeMux's method-prefixed form,
 // e.g. "GET /v1/health" or "POST /v1/sessions/{id}/heartbeat".
+//
+// Every handler is automatically wrapped by withSpan so that each invocation
+// emits a KernelHandlerSpan to the bus_traces bus. The handler name is derived
+// from the pattern (method + path) rather than reflection; it is stable and
+// readable in log output.
 func (s *Server) route(mux *http.ServeMux, pattern string, handler http.HandlerFunc) {
-	mux.HandleFunc(pattern, handler)
+	method, path := splitRoutePattern(pattern)
+	handlerName := method + " " + path
+	mux.HandleFunc(pattern, withSpan(handlerName, handler, s.spanEmitter))
 	s.recordRoute(pattern)
 }
 

--- a/internal/engine/serve_peer_awareness.go
+++ b/internal/engine/serve_peer_awareness.go
@@ -40,7 +40,7 @@ import (
 // registerPeerAwarenessRoutes attaches the one route this file owns onto
 // mux. Called from NewServer alongside the other registerXxxRoutes helpers.
 func (s *Server) registerPeerAwarenessRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("GET /v1/peer-awareness", s.handlePeerAwareness)
+	s.route(mux, "GET /v1/peer-awareness", s.handlePeerAwareness)
 }
 
 // handlePeerAwareness dispatches to RenderPeerAwarenessPacket and marshals

--- a/internal/engine/tool_loop.go
+++ b/internal/engine/tool_loop.go
@@ -190,6 +190,29 @@ func NewKernelToolRegistry(mcpSrv *MCPServer) *KernelToolRegistry {
 			),
 			executor: makeExecutor(mcpSrv, mcpSrv.toolIngest, ingestInput{}),
 		},
+		// Audit-scope tools — read-only filesystem access within the workspace root.
+		// Listed here so they are in the full kernel registry; they are only
+		// visible to harness dispatches when scope="audit" (or a superset).
+		{
+			name:        "cog_read_file",
+			description: "Read an arbitrary file within the workspace root. Returns line-numbered content with optional offset/limit. Rejects paths outside the workspace root.",
+			schema: mergeSchemas(
+				requiredSchema("path", "string", "Absolute path within workspace root"),
+				optionalSchema("offset", "integer", "Line offset (0-based, default 0)"),
+				optionalSchema("limit", "integer", "Maximum lines to return (default 500)"),
+			),
+			executor: makeExecutor(mcpSrv, mcpSrv.toolReadFile, readFileInput{}),
+		},
+		{
+			name:        "cog_grep_files",
+			description: "Regex search over files within the workspace root (ripgrep-style). Returns matching lines with path and line number. Rejects search paths outside the workspace root.",
+			schema: mergeSchemas(
+				requiredSchema("pattern", "string", "Regular expression pattern to search for"),
+				optionalSchema("path", "string", "Directory or file to search (defaults to workspace root)"),
+				optionalSchema("max_results", "integer", "Maximum matches to return (default 50)"),
+			),
+			executor: makeExecutor(mcpSrv, mcpSrv.toolGrepFiles, grepFilesInput{}),
+		},
 	}
 
 	for _, t := range tools {


### PR DESCRIPTION
## What

Three coupled engine changes that were sitting uncommitted in the working tree:

1. **Named harness tool scopes** — `DispatchRequest` gains a `Scope` field (with `consolidation` and `audit` named scopes). Bare tool lists still work for ad-hoc dispatches.
2. **Audit-scope filesystem tools** — `cog_read_file` and `cog_grep_files` registered as kernel-side MCP tools, surfaced under the audit scope. For audit-shaped harness sessions that need to inspect repo content read-only.
3. **HTTP span tracing on engine routes** — new `handler_span.go` introduces a `spanEmitter` interface and `withSpan` wrapper. Block / agent / manifest / peer-awareness routes migrate from bare `mux.HandleFunc` to `s.route()`, which now wraps every handler with span emission. `Server` gains a `spanEmitter` field wired at startup.

## Why

These three changes were developed together because they share the same plumbing — the harness scope machinery and the audit FS tools both rely on the kernel's MCP tool registry, and the span tracing covers the new audit endpoints uniformly with the existing ones. Splitting them post-hoc would just rebuild the dependencies in commit boundaries.

## How

`s.route()` already exists in upstream as a route-recording wrapper; this PR extends it to also emit spans via the new `spanEmitter`. The interface is intentionally small (one method) so backends can be swapped or no-op'd in tests.

## Notes

- Branch is based on fork `main` which currently sits 33 commits ahead of `cogos-dev/cogos:main`. The 9-file/654-line diff above is clean against fork main; against upstream the branch carries the 33 unrelated catch-up commits. Re-targeting upstream after a fork sync is a separate decision.
- Excludes the rebuilt `cog` binary and `.cog/ledger/` runtime artifacts from the working tree.

## Test plan

- [ ] `go build ./...` passes (verified locally)
- [ ] `go test ./internal/engine/...`
- [ ] Smoke: dispatch a harness call with `Scope: "audit"` and confirm the FS tools resolve.
- [ ] Smoke: `curl /v1/blocks/manifest` and confirm a span event lands.