### PR TITLE
chore: gitignore .cog/ledger/ + untrack /cog binary build artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ run/
 
 # CogOS state (runtime-generated, may contain personal data)
 .cog/.state/
+.cog/ledger/
 
 # Moved to standalone autoresearch repo (2026-04-20)
 autoresearch-foveated/

--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,8 @@ run/
 .cog/.state/
 .cog/ledger/
 
+# Built binary (root cmd output) — should never be committed
+/cog
+
 # Moved to standalone autoresearch repo (2026-04-20)
 autoresearch-foveated/


### PR DESCRIPTION
## What

Two small repo-hygiene changes:

1. **Add `.cog/ledger/` to `.gitignore`.** The ledger directory is runtime-generated bus-event/handoff state, equivalent in nature to the existing `.cog/.state/` rule.
2. **Untrack the `/cog` binary build artifact.** The repo had been carrying a 38 MB stripped Mach-O binary at `/cog` as a tracked file. It's the output of `go build ./cmd/cogos` — every rebuild was dirtying the working tree and PRs could accidentally include binary churn.
   - `git rm --cached cog` removes from the index (kept on disk).
   - `.gitignore` adds `/cog` rule so rebuilds stop showing in `git status`.

## Why

Triage of the working tree on cogos-dev/cogos surfaced both as ongoing nuisance — ledger files appearing as untracked in every PR, and the `cog` binary showing as `M` after every rebuild.

## How

- `.gitignore` extended with `.cog/ledger/` and `/cog` entries.
- Binary unindexed via `git rm --cached cog`. Build still regenerates it: `go build -o cog ./cmd/cogos` (verified locally).

## Test plan

- [x] `go build ./cmd/cogos` regenerates the binary (verified locally).
- [ ] CI green.