### PR TITLE
refactor(eval): drop CogdocReader from EvalProvider constructor

### DIFF
--- a/cmd/cogos/providers_wire.go
+++ b/cmd/cogos/providers_wire.go
@@ -32,7 +32,7 @@ import (
 // eval MCP tools. The daemon does not run plan/apply; it only exposes the
 // four read/trigger tools whose state effects (trigger files, baseline pins)
 // are read by the CLI's reconcile loop.
-var daemonEvalProvider = eval.New(nil, nil, nil)
+var daemonEvalProvider = eval.New(nil, nil)
 
 func init() {
 	// The named import of internal/providers/daemon above already triggered

--- a/eval_wiring.go
+++ b/eval_wiring.go
@@ -27,7 +27,7 @@ import (
 // evalProviderInstance is the singleton EvalProvider registered with the
 // reconcile registry. The same instance is passed to RegisterEvalTools so
 // the MCP tools share state (root path, dispatcher) with the reconcile loop.
-var evalProviderInstance = eval.New(nil, nil, nil)
+var evalProviderInstance = eval.New(nil, nil)
 
 func init() {
 	// Wire the NowISO dependency so EvalProvider uses the same timestamp
@@ -39,8 +39,8 @@ func init() {
 	// Wire the EvalProvider constructor. The concrete BusReader is an HTTP reader
 	// hitting the local kernel; the BusEmitter is an HTTP emitter. Both degrade
 	// gracefully when the kernel is not reachable.
-	eval.NewEvalProvider = func(dispatcher eval.AgentDispatcher, emitter eval.BusEmitter, reader eval.CogdocReader) *eval.EvalProvider {
-		return eval.New(dispatcher, emitter, reader)
+	eval.NewEvalProvider = func(dispatcher eval.AgentDispatcher, emitter eval.BusEmitter) *eval.EvalProvider {
+		return eval.New(dispatcher, emitter)
 	}
 
 	// Register the eval provider with the reconcile registry.

--- a/internal/eval/provider.go
+++ b/internal/eval/provider.go
@@ -68,22 +68,6 @@ type BusEmitter interface {
 	EmitCogBlock(ctx context.Context, channelName string, block any) error
 }
 
-// CogdocReader reads raw cogdoc files from the workspace by cog:// URI or
-// absolute path. Used by LoadConfig to enumerate experiment cogdocs and by
-// FetchLive's variant loader.
-//
-// TODO(Phase C): align with workspace.Reader or the resolved path from
-// internal/engine.ResolveURI (uri.go). The mem:// projection resolves to
-// .cog/mem/ — see uri.go line 51.
-type CogdocReader interface {
-	// ReadCogdoc reads a single .cog.md file, returning raw bytes.
-	// path may be an absolute filesystem path or a cog:// URI.
-	ReadCogdoc(path string) ([]byte, error)
-	// GlobCogdocs returns all .cog.md file paths under the given cog:// URI
-	// prefix or filesystem directory (non-recursive subdirs included).
-	GlobCogdocs(prefix string) ([]string, error)
-}
-
 // ---------------------------------------------------------------------------
 // Dispatch shims (shape-compatible with internal/engine, locally redeclared)
 // ---------------------------------------------------------------------------
@@ -520,8 +504,6 @@ type EvalProvider struct {
 	dispatcher AgentDispatcher
 	// emitter handles CogBlock emission to bus_tournament. Set by boot path.
 	emitter BusEmitter
-	// reader reads cogdoc files. Set by boot path.
-	reader CogdocReader
 	// busReader reads events from bus_tournament. Added in Phase C for FetchLive.
 	// May be nil when the kernel is not running; FetchLive degrades gracefully.
 	busReader BusReader
@@ -535,7 +517,7 @@ type EvalProvider struct {
 var (
 	// NewEvalProvider constructs a wired EvalProvider. Set by wiring layer.
 	// TODO(Phase C wiring): replace with direct constructor call from kernel boot.
-	NewEvalProvider func(dispatcher AgentDispatcher, emitter BusEmitter, reader CogdocReader) *EvalProvider
+	NewEvalProvider func(dispatcher AgentDispatcher, emitter BusEmitter) *EvalProvider
 	// NowISO returns the current UTC time in ISO-8601. Set by wiring layer
 	// (same sentinel as component_provider.go).
 	NowISO func() string
@@ -544,7 +526,7 @@ var (
 // New constructs an EvalProvider with the given dependencies.
 // Any dependency may be nil; the provider degrades gracefully.
 // This is the preferred constructor over the NewEvalProvider function variable.
-func New(dispatcher AgentDispatcher, emitter BusEmitter, reader CogdocReader) *EvalProvider {
+func New(dispatcher AgentDispatcher, emitter BusEmitter) *EvalProvider {
 	return &EvalProvider{
 		dispatcher: dispatcher,
 		emitter:    emitter,
@@ -558,9 +540,9 @@ func New(dispatcher AgentDispatcher, emitter BusEmitter, reader CogdocReader) *E
 }
 
 // NewWithReader constructs an EvalProvider with a BusReader for FetchLive.
-// The reader reads bus events; the emitter sends them.
-func NewWithReader(dispatcher AgentDispatcher, emitter BusEmitter, reader CogdocReader, busReader BusReader) *EvalProvider {
-	p := New(dispatcher, emitter, reader)
+// The busReader reads bus events; the emitter sends them.
+func NewWithReader(dispatcher AgentDispatcher, emitter BusEmitter, busReader BusReader) *EvalProvider {
+	p := New(dispatcher, emitter)
 	p.busReader = busReader
 	return p
 }

--- a/internal/eval/provider_test.go
+++ b/internal/eval/provider_test.go
@@ -80,7 +80,7 @@ func (s *stubBusReader) ReadChannel(_ context.Context, _ string, _ string) ([]Bu
 
 // buildTestProvider returns an EvalProvider with stub dependencies.
 func buildTestProvider(dispatcher AgentDispatcher, emitter BusEmitter, busReader BusReader) *EvalProvider {
-	p := New(dispatcher, emitter, nil)
+	p := New(dispatcher, emitter)
 	p.busReader = busReader
 	return p
 }


### PR DESCRIPTION
## What

Lifts a Phase C stash (`add Phase C verification gate tests` WIP) that was sitting parked on `feat/autonomic-iterates-reconcilables`. The stash's actual content is a constructor-signature cleanup, not test additions — the title was misleading.

Removes the `CogdocReader` interface from `EvalProvider` and drops the now-unnecessary `nil` reader argument from every call site.

## Why

`CogdocReader` was a Phase C placeholder that ended up unused — `LoadConfig` and `FetchLive`'s variant loader took different paths, and the reader seam was never wired in. Carrying it forward forces every construction site to pass a `nil` it never reads.

## How

- `internal/eval/provider.go`: drop the interface definition; drop the unused `reader` field on `EvalProvider`; collapse `New(...)` and `NewWithReader(...)` signatures to drop the parameter; update the `NewEvalProvider` seam variable.
- `eval_wiring.go`: update the singleton `evalProviderInstance` construction and the `NewEvalProvider` seam to the new 2-arg form. (One conflict resolved: post-stash main introduced an `evalProviderInstance` variable + `engine.RegisterMCPExtensions` wiring; kept those, just retargeted the constructor call.)
- `cmd/cogos/providers_wire.go`: update `daemonEvalProvider` call site (this site didn't exist when the stash was created — added separately).
- `internal/eval/provider_test.go`: update `buildTestProvider` helper.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/eval/...` passes
- [x] `go test ./internal/engine/...` passes
- [ ] CI green on the kernel + plugin checks

Net diff: 4 files, +10 / -28.