### PR TITLE
feat(claudecode) + test(daemon): tool_use stream extraction + SetWorkspaceRoot regression test

### DIFF
--- a/internal/engine/provider_claudecode.go
+++ b/internal/engine/provider_claudecode.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"os/exec"
 	"strings"
@@ -134,15 +135,26 @@ func (p *ClaudeCodeProvider) Ping(ctx context.Context) (time.Duration, error) {
 }
 
 // Complete sends a prompt and waits for the full response.
+// It uses stream-json internally so that tool_use events emitted by the
+// subprocess are captured and returned in CompletionResponse.ToolCalls.
 func (p *ClaudeCodeProvider) Complete(ctx context.Context, req *CompletionRequest) (*CompletionResponse, error) {
 	start := time.Now()
 
 	prompt := p.buildPrompt(req)
 	args := p.buildArgs(req)
-	args = append(args, "--output-format", "json")
+	args = append(args,
+		"--output-format", "stream-json",
+		"--verbose",
+		"--include-partial-messages",
+	)
 
 	cmd := exec.CommandContext(ctx, p.cliBinary, args...)
 	cmd.Stdin = strings.NewReader(prompt)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stdout pipe: %w", err)
+	}
 
 	proc := p.procMgr.Track(cmd, ManagedProcessOpts{
 		Kind:   ProcessForeground,
@@ -150,34 +162,74 @@ func (p *ClaudeCodeProvider) Complete(ctx context.Context, req *CompletionReques
 	})
 	defer p.procMgr.Remove(proc.ID)
 
-	out, err := cmd.Output()
-	if err != nil {
-		if ctx.Err() != nil {
-			return nil, fmt.Errorf("cancelled: %w", ctx.Err())
-		}
-		return nil, fmt.Errorf("claude exited with error: %w", err)
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start claude: %w", err)
 	}
 
-	var result ccResult
-	if err := json.Unmarshal(out, &result); err != nil {
-		return nil, fmt.Errorf("parse claude output: %w", err)
+	content, toolCalls, usage, stopReason, parseErr := p.drainStreamJSON(stdout)
+
+	if waitErr := cmd.Wait(); waitErr != nil && ctx.Err() != nil {
+		return nil, fmt.Errorf("cancelled: %w", ctx.Err())
 	}
 
-	if result.IsError {
-		return nil, fmt.Errorf("claude error: %s", result.Result)
+	if parseErr != nil {
+		return nil, parseErr
 	}
 
-	usage := p.extractUsage(&result)
-	return &CompletionResponse{
-		Content:    result.Result,
-		StopReason: result.StopReason,
+	resp := &CompletionResponse{
+		Content:    content,
+		ToolCalls:  toolCalls,
+		StopReason: stopReason,
 		Usage:      usage,
 		ProviderMeta: ProviderMeta{
 			Provider: p.name,
-			Model:    p.resolveModel(&result),
+			Model:    p.model,
 			Latency:  time.Since(start),
 		},
-	}, nil
+	}
+	return resp, nil
+}
+
+// drainStreamJSON reads NDJSON lines from r and aggregates them into a
+// complete response. It returns the accumulated text content, any tool calls
+// that were emitted (finalized at content_block_stop), the token usage from
+// the result message, the stop reason, and any parse error.
+func (p *ClaudeCodeProvider) drainStreamJSON(r io.Reader) (content string, toolCalls []ToolCall, usage TokenUsage, stopReason string, err error) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 256*1024), 256*1024)
+
+	state := newCCStreamState()
+	var sb strings.Builder
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		chunk, done := p.parseStreamLine(line, state)
+		if chunk != nil {
+			if chunk.Error != nil {
+				return "", nil, TokenUsage{}, "", chunk.Error
+			}
+			if chunk.Delta != "" {
+				sb.WriteString(chunk.Delta)
+			}
+			if chunk.Done && chunk.Usage != nil {
+				usage = *chunk.Usage
+			}
+		}
+		if done {
+			if chunk != nil {
+				stopReason = chunk.StopReason
+			}
+			break
+		}
+	}
+	if scanErr := scanner.Err(); scanErr != nil {
+		return "", nil, TokenUsage{}, "", fmt.Errorf("scan stream: %w", scanErr)
+	}
+
+	return sb.String(), state.done, usage, state.stopReason, nil
 }
 
 // Stream spawns a claude process and returns incremental chunks.
@@ -219,13 +271,15 @@ func (p *ClaudeCodeProvider) Stream(ctx context.Context, req *CompletionRequest)
 		scanner := bufio.NewScanner(stdout)
 		scanner.Buffer(make([]byte, 256*1024), 256*1024) // 256KB line buffer
 
+		state := newCCStreamState()
+
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			if len(line) == 0 {
 				continue
 			}
 
-			chunk, done := p.parseStreamLine(line)
+			chunk, done := p.parseStreamLine(line, state)
 			if chunk != nil {
 				select {
 				case ch <- *chunk:
@@ -411,17 +465,48 @@ type ccResult struct {
 
 // ccStreamEvent wraps an Anthropic SSE event inside stream-json output.
 type ccStreamEvent struct {
-	Type  string `json:"type"` // content_block_delta, message_delta, message_stop, etc.
+	Type  string `json:"type"` // content_block_start, content_block_delta, content_block_stop, message_delta, etc.
 	Index int    `json:"index"`
+	// ContentBlock is populated for content_block_start events.
+	ContentBlock struct {
+		Type string `json:"type"` // "text" or "tool_use"
+		ID   string `json:"id"`   // tool call id (tool_use only)
+		Name string `json:"name"` // tool name (tool_use only)
+	} `json:"content_block"`
+	// Delta is populated for content_block_delta events.
 	Delta struct {
-		Type string `json:"type"` // text_delta, input_json_delta
-		Text string `json:"text"`
+		Type      string `json:"type"`       // "text_delta" or "input_json_delta"
+		Text      string `json:"text"`       // populated for text_delta
+		PartialJSON string `json:"partial_json"` // populated for input_json_delta
 	} `json:"delta"`
 }
 
+// partialToolCall accumulates streamed tool_use content block data.
+type partialToolCall struct {
+	id   string
+	name string
+	args strings.Builder
+}
+
+// ccStreamState holds mutable state across a sequence of parseStreamLine calls.
+type ccStreamState struct {
+	// pending maps content_block index → in-progress tool call.
+	pending map[int]*partialToolCall
+	// done is the list of finalized tool calls.
+	done []ToolCall
+	// stopReason from the result message.
+	stopReason string
+}
+
+func newCCStreamState() *ccStreamState {
+	return &ccStreamState{pending: make(map[int]*partialToolCall)}
+}
+
 // parseStreamLine parses a single NDJSON line from claude's stream output.
-// Returns a StreamChunk (or nil if the line should be skipped) and whether this is the final line.
-func (p *ClaudeCodeProvider) parseStreamLine(line []byte) (*StreamChunk, bool) {
+// State carries mutable tool-call aggregation across calls; pass the same
+// pointer for every line in a stream. Returns a StreamChunk (or nil if the
+// line should be skipped) and whether this is the final line.
+func (p *ClaudeCodeProvider) parseStreamLine(line []byte, state *ccStreamState) (*StreamChunk, bool) {
 	var msg ccStreamMessage
 	if err := json.Unmarshal(line, &msg); err != nil {
 		slog.Debug("claudecode: unparseable stream line", "err", err)
@@ -434,16 +519,68 @@ func (p *ClaudeCodeProvider) parseStreamLine(line []byte) (*StreamChunk, bool) {
 		if err := json.Unmarshal(msg.Event, &evt); err != nil {
 			return nil, false
 		}
-		if evt.Delta.Type == "text_delta" && evt.Delta.Text != "" {
-			return &StreamChunk{Delta: evt.Delta.Text}, false
+
+		switch evt.Type {
+		case "content_block_start":
+			if evt.ContentBlock.Type == "tool_use" {
+				state.pending[evt.Index] = &partialToolCall{
+					id:   evt.ContentBlock.ID,
+					name: evt.ContentBlock.Name,
+				}
+				return &StreamChunk{
+					ToolCallDelta: &ToolCallDelta{
+						Index: evt.Index,
+						ID:    evt.ContentBlock.ID,
+						Name:  evt.ContentBlock.Name,
+					},
+				}, false
+			}
+			return nil, false
+
+		case "content_block_delta":
+			switch evt.Delta.Type {
+			case "text_delta":
+				if evt.Delta.Text != "" {
+					return &StreamChunk{Delta: evt.Delta.Text}, false
+				}
+			case "input_json_delta":
+				if ptc, ok := state.pending[evt.Index]; ok && evt.Delta.PartialJSON != "" {
+					ptc.args.WriteString(evt.Delta.PartialJSON)
+					return &StreamChunk{
+						ToolCallDelta: &ToolCallDelta{
+							Index:     evt.Index,
+							ArgsDelta: evt.Delta.PartialJSON,
+						},
+					}, false
+				}
+			}
+			return nil, false
+
+		case "content_block_stop":
+			// Finalize any pending tool call at this index.
+			if ptc, ok := state.pending[evt.Index]; ok {
+				state.done = append(state.done, ToolCall{
+					ID:        ptc.id,
+					Name:      ptc.name,
+					Arguments: ptc.args.String(),
+				})
+				delete(state.pending, evt.Index)
+			}
+			return nil, false
+
+		default:
+			return nil, false
 		}
-		return nil, false
 
 	case "result":
+		if state != nil {
+			state.stopReason = msg.StopReason
+		}
 		usage := p.extractUsageFromRaw(msg.Usage)
 		chunk := &StreamChunk{
-			Done:  true,
-			Usage: &usage,
+			Done:       true,
+			StopReason: msg.StopReason,
+			Usage:      &usage,
 			ProviderMeta: &ProviderMeta{
 				Provider: p.name,
 				Model:    p.model,

--- a/internal/engine/provider_claudecode.go
+++ b/internal/engine/provider_claudecode.go
@@ -219,9 +219,6 @@ func (p *ClaudeCodeProvider) drainStreamJSON(r io.Reader) (content string, toolC
 			}
 		}
 		if done {
-			if chunk != nil {
-				stopReason = chunk.StopReason
-			}
 			break
 		}
 	}

--- a/internal/engine/provider_claudecode_test.go
+++ b/internal/engine/provider_claudecode_test.go
@@ -1,0 +1,332 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+)
+
+// fixture lines are captured Anthropic stream-json NDJSON events.
+// Each string is one NDJSON line as emitted by `claude --output-format stream-json`.
+
+// toolUseFixture exercises the full tool_use event sequence:
+//   content_block_start (tool_use) → content_block_delta (input_json_delta) × N → content_block_stop → result
+var toolUseFixture = []string{
+	// system init
+	`{"type":"system","subtype":"init","session_id":"test-session","tools":[],"mcp_servers":[]}`,
+	// content_block_start for a tool_use block at index 0
+	`{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01","name":"calculator"}}}`,
+	// first input_json_delta chunk
+	`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"op\""}}}`,
+	// second input_json_delta chunk
+	`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":\"+\",\"a\":2,\"b\":2}"}}}`,
+	// content_block_stop finalises the tool call
+	`{"type":"stream_event","event":{"type":"content_block_stop","index":0}}`,
+	// result message
+	`{"type":"result","subtype":"success","result":"4","is_error":false,"stop_reason":"tool_use","usage":{"input_tokens":10,"output_tokens":5}}`,
+}
+
+// textOnlyFixture exercises normal text streaming with no tool calls.
+var textOnlyFixture = []string{
+	`{"type":"system","subtype":"init","session_id":"test-session","tools":[],"mcp_servers":[]}`,
+	`{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"text","id":"","name":""}}}`,
+	`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}}`,
+	`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":", world!"}}}`,
+	`{"type":"stream_event","event":{"type":"content_block_stop","index":0}}`,
+	`{"type":"result","subtype":"success","result":"Hello, world!","is_error":false,"stop_reason":"end_turn","usage":{"input_tokens":8,"output_tokens":3}}`,
+}
+
+// multiToolFixture exercises two tool calls at different content block indices.
+var multiToolFixture = []string{
+	`{"type":"system","subtype":"init","session_id":"test-session","tools":[],"mcp_servers":[]}`,
+	// first tool call at index 0
+	`{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01","name":"read_file"}}}`,
+	`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"path\":\"/tmp/foo\"}"}}}`,
+	`{"type":"stream_event","event":{"type":"content_block_stop","index":0}}`,
+	// second tool call at index 1
+	`{"type":"stream_event","event":{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_02","name":"write_file"}}}`,
+	`{"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"path\":\"/tmp/bar\"}"}}}`,
+	`{"type":"stream_event","event":{"type":"content_block_stop","index":1}}`,
+	`{"type":"result","subtype":"success","result":"done","is_error":false,"stop_reason":"tool_use","usage":{"input_tokens":20,"output_tokens":10}}`,
+}
+
+func fixtureReader(lines []string) *strings.Reader {
+	return strings.NewReader(strings.Join(lines, "\n"))
+}
+
+// ── drainStreamJSON tests ─────────────────────────────────────────────────────
+
+func TestDrainStreamJSON_TextOnly(t *testing.T) {
+	t.Parallel()
+
+	p := &ClaudeCodeProvider{name: "test", model: "sonnet"}
+	content, toolCalls, usage, stopReason, err := p.drainStreamJSON(fixtureReader(textOnlyFixture))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if content != "Hello, world!" {
+		t.Errorf("expected content %q, got %q", "Hello, world!", content)
+	}
+	if len(toolCalls) != 0 {
+		t.Errorf("expected no tool calls, got %d", len(toolCalls))
+	}
+	if usage.InputTokens != 8 {
+		t.Errorf("expected 8 input tokens, got %d", usage.InputTokens)
+	}
+	if stopReason != "end_turn" {
+		t.Errorf("expected stop_reason end_turn, got %q", stopReason)
+	}
+}
+
+func TestDrainStreamJSON_SingleToolCall(t *testing.T) {
+	t.Parallel()
+
+	p := &ClaudeCodeProvider{name: "test", model: "sonnet"}
+	content, toolCalls, usage, stopReason, err := p.drainStreamJSON(fixtureReader(toolUseFixture))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// No text content in this fixture.
+	if content != "" {
+		t.Errorf("expected empty content, got %q", content)
+	}
+	if len(toolCalls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(toolCalls))
+	}
+	tc := toolCalls[0]
+	if tc.ID != "toolu_01" {
+		t.Errorf("expected tool ID %q, got %q", "toolu_01", tc.ID)
+	}
+	if tc.Name != "calculator" {
+		t.Errorf("expected tool name %q, got %q", "calculator", tc.Name)
+	}
+	want := `{"op":"+","a":2,"b":2}`
+	if tc.Arguments != want {
+		t.Errorf("expected arguments %q, got %q", want, tc.Arguments)
+	}
+	if usage.InputTokens != 10 {
+		t.Errorf("expected 10 input tokens, got %d", usage.InputTokens)
+	}
+	if stopReason != "tool_use" {
+		t.Errorf("expected stop_reason tool_use, got %q", stopReason)
+	}
+}
+
+func TestDrainStreamJSON_MultipleToolCalls(t *testing.T) {
+	t.Parallel()
+
+	p := &ClaudeCodeProvider{name: "test", model: "sonnet"}
+	_, toolCalls, _, _, err := p.drainStreamJSON(fixtureReader(multiToolFixture))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(toolCalls) != 2 {
+		t.Fatalf("expected 2 tool calls, got %d", len(toolCalls))
+	}
+
+	names := map[string]bool{}
+	for _, tc := range toolCalls {
+		names[tc.Name] = true
+	}
+	if !names["read_file"] {
+		t.Error("expected read_file tool call")
+	}
+	if !names["write_file"] {
+		t.Error("expected write_file tool call")
+	}
+
+	ids := map[string]bool{}
+	for _, tc := range toolCalls {
+		ids[tc.ID] = true
+	}
+	if !ids["toolu_01"] {
+		t.Error("expected toolu_01 ID")
+	}
+	if !ids["toolu_02"] {
+		t.Error("expected toolu_02 ID")
+	}
+}
+
+// ── parseStreamLine unit tests ────────────────────────────────────────────────
+
+func TestParseStreamLine_TextDelta(t *testing.T) {
+	t.Parallel()
+
+	p := &ClaudeCodeProvider{name: "test", model: "sonnet"}
+	state := newCCStreamState()
+	line := []byte(`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}}`)
+	chunk, done := p.parseStreamLine(line, state)
+	if done {
+		t.Fatal("text_delta should not be a done signal")
+	}
+	if chunk == nil {
+		t.Fatal("expected a chunk")
+	}
+	if chunk.Delta != "hi" {
+		t.Errorf("expected delta %q, got %q", "hi", chunk.Delta)
+	}
+	if chunk.ToolCallDelta != nil {
+		t.Error("text_delta should not produce a ToolCallDelta")
+	}
+}
+
+func TestParseStreamLine_ContentBlockStart_ToolUse(t *testing.T) {
+	t.Parallel()
+
+	p := &ClaudeCodeProvider{name: "test", model: "sonnet"}
+	state := newCCStreamState()
+	line := []byte(`{"type":"stream_event","event":{"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"toolu_99","name":"bash"}}}`)
+	chunk, done := p.parseStreamLine(line, state)
+	if done {
+		t.Fatal("content_block_start should not be a done signal")
+	}
+	if chunk == nil {
+		t.Fatal("expected a chunk for tool_use start")
+	}
+	if chunk.ToolCallDelta == nil {
+		t.Fatal("expected ToolCallDelta")
+	}
+	if chunk.ToolCallDelta.ID != "toolu_99" {
+		t.Errorf("expected ID %q, got %q", "toolu_99", chunk.ToolCallDelta.ID)
+	}
+	if chunk.ToolCallDelta.Name != "bash" {
+		t.Errorf("expected Name %q, got %q", "bash", chunk.ToolCallDelta.Name)
+	}
+	if chunk.ToolCallDelta.Index != 2 {
+		t.Errorf("expected Index 2, got %d", chunk.ToolCallDelta.Index)
+	}
+	// Pending entry should be registered.
+	if _, ok := state.pending[2]; !ok {
+		t.Error("state.pending should have entry at index 2")
+	}
+}
+
+func TestParseStreamLine_ContentBlockStart_Text_NoChunk(t *testing.T) {
+	t.Parallel()
+
+	p := &ClaudeCodeProvider{name: "test", model: "sonnet"}
+	state := newCCStreamState()
+	line := []byte(`{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"text","id":"","name":""}}}`)
+	chunk, done := p.parseStreamLine(line, state)
+	if done {
+		t.Fatal("content_block_start for text should not be a done signal")
+	}
+	// text content_block_start produces no chunk — delta events carry the text.
+	if chunk != nil {
+		t.Errorf("expected nil chunk for text content_block_start, got %+v", chunk)
+	}
+}
+
+func TestParseStreamLine_InputJSONDelta_AppendsToState(t *testing.T) {
+	t.Parallel()
+
+	p := &ClaudeCodeProvider{name: "test", model: "sonnet"}
+	state := newCCStreamState()
+	// Seed a pending tool call so delta has somewhere to write.
+	state.pending[0] = &partialToolCall{id: "toolu_01", name: "calc"}
+
+	line := []byte(`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"n\":1}"}}}`)
+	chunk, done := p.parseStreamLine(line, state)
+	if done {
+		t.Fatal("input_json_delta should not be done")
+	}
+	if chunk == nil || chunk.ToolCallDelta == nil {
+		t.Fatal("expected ToolCallDelta chunk")
+	}
+	if chunk.ToolCallDelta.ArgsDelta != `{"n":1}` {
+		t.Errorf("expected ArgsDelta %q, got %q", `{"n":1}`, chunk.ToolCallDelta.ArgsDelta)
+	}
+	if state.pending[0].args.String() != `{"n":1}` {
+		t.Errorf("state args buffer wrong: %q", state.pending[0].args.String())
+	}
+}
+
+func TestParseStreamLine_ContentBlockStop_FinalizesToolCall(t *testing.T) {
+	t.Parallel()
+
+	p := &ClaudeCodeProvider{name: "test", model: "sonnet"}
+	state := newCCStreamState()
+	ptc := &partialToolCall{id: "toolu_01", name: "calc"}
+	ptc.args.WriteString(`{"n":42}`)
+	state.pending[0] = ptc
+
+	line := []byte(`{"type":"stream_event","event":{"type":"content_block_stop","index":0}}`)
+	chunk, done := p.parseStreamLine(line, state)
+	if done {
+		t.Fatal("content_block_stop should not be a done signal")
+	}
+	if chunk != nil {
+		t.Errorf("content_block_stop should produce nil chunk, got %+v", chunk)
+	}
+	// pending entry should be removed and added to done.
+	if _, ok := state.pending[0]; ok {
+		t.Error("pending entry should be removed after stop")
+	}
+	if len(state.done) != 1 {
+		t.Fatalf("expected 1 finalized tool call, got %d", len(state.done))
+	}
+	tc := state.done[0]
+	if tc.ID != "toolu_01" || tc.Name != "calc" || tc.Arguments != `{"n":42}` {
+		t.Errorf("finalized tool call wrong: %+v", tc)
+	}
+}
+
+func TestParseStreamLine_ContentBlockStop_TextBlock_NoOp(t *testing.T) {
+	t.Parallel()
+
+	p := &ClaudeCodeProvider{name: "test", model: "sonnet"}
+	state := newCCStreamState()
+	// No pending entry at index 0 — should be a no-op.
+	line := []byte(`{"type":"stream_event","event":{"type":"content_block_stop","index":0}}`)
+	chunk, done := p.parseStreamLine(line, state)
+	if done {
+		t.Fatal("content_block_stop should not be done")
+	}
+	if chunk != nil {
+		t.Errorf("no-op stop should produce nil chunk")
+	}
+	if len(state.done) != 0 {
+		t.Error("no finalized calls expected")
+	}
+}
+
+func TestParseStreamLine_Result_IsDone(t *testing.T) {
+	t.Parallel()
+
+	p := &ClaudeCodeProvider{name: "test", model: "sonnet"}
+	state := newCCStreamState()
+	line := []byte(`{"type":"result","subtype":"success","result":"4","is_error":false,"stop_reason":"tool_use","usage":{"input_tokens":10,"output_tokens":5}}`)
+	chunk, done := p.parseStreamLine(line, state)
+	if !done {
+		t.Fatal("result message should signal done")
+	}
+	if chunk == nil {
+		t.Fatal("result message should produce a chunk")
+	}
+	if !chunk.Done {
+		t.Error("chunk.Done should be true")
+	}
+	if chunk.StopReason != "tool_use" {
+		t.Errorf("expected stop_reason %q, got %q", "tool_use", chunk.StopReason)
+	}
+	if chunk.Usage == nil || chunk.Usage.InputTokens != 10 {
+		t.Errorf("expected 10 input tokens in usage, got %+v", chunk.Usage)
+	}
+}
+
+func TestParseStreamLine_ErrorResult(t *testing.T) {
+	t.Parallel()
+
+	p := &ClaudeCodeProvider{name: "test", model: "sonnet"}
+	state := newCCStreamState()
+	line := []byte(`{"type":"result","is_error":true,"result":"something went wrong","stop_reason":""}`)
+	chunk, done := p.parseStreamLine(line, state)
+	if !done {
+		t.Fatal("error result should signal done")
+	}
+	if chunk.Error == nil {
+		t.Fatal("expected an error in chunk")
+	}
+	if !strings.Contains(chunk.Error.Error(), "something went wrong") {
+		t.Errorf("error message wrong: %v", chunk.Error)
+	}
+}

--- a/internal/providers/daemon/daemon_test.go
+++ b/internal/providers/daemon/daemon_test.go
@@ -7,17 +7,21 @@
 //
 // We don't start a server or invoke engine.Main() — we only confirm that
 // the package's init() side-effect wired the providers. This is sufficient
-// because cmd/cogos/providers_wire.go blank-imports this package, so the
-// same init() fires at daemon boot.
+// because cmd/cogos/providers_wire.go imports this package, so the same
+// init() fires at daemon boot.
 package daemon_test
 
 import (
+	"os"
+	"path/filepath"
 	"sort"
 	"testing"
 
+	"github.com/cogos-dev/cogos/internal/providers/daemon"
 	"github.com/cogos-dev/cogos/pkg/reconcile"
 
-	// Blank import fires daemon.init(), registering all 9 providers.
+	// Blank import fires daemon.init(), registering all 9 providers; the named
+	// import above is for the new SetWorkspaceRoot regression test.
 	_ "github.com/cogos-dev/cogos/internal/providers/daemon"
 )
 
@@ -88,4 +92,56 @@ func TestDaemonProviders_HealthDoesNotPanic(t *testing.T) {
 			_ = p.Health()
 		}()
 	}
+}
+
+// TestSetWorkspaceRoot_HealthReflectsWorkspaceState verifies that after
+// SetWorkspaceRoot is called with a real workspace path, providers that depend
+// only on filesystem presence (agent, service) return a non-"workspace-not-found"
+// status. This is the core regression test for the daemon workspace seam fix.
+func TestSetWorkspaceRoot_HealthReflectsWorkspaceState(t *testing.T) {
+	// Build a minimal fake workspace: <tmp>/.cog/bin/agents/registry.yaml
+	// so the agent provider can return Healthy.
+	tmp := t.TempDir()
+	agentsDir := filepath.Join(tmp, ".cog", "bin", "agents")
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		t.Fatalf("mkdir agents: %v", err)
+	}
+	registryPath := filepath.Join(agentsDir, "registry.yaml")
+	if err := os.WriteFile(registryPath, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write registry.yaml: %v", err)
+	}
+
+	// Before SetWorkspaceRoot: agent Health() should say workspace-not-found
+	// (or at least not be Healthy).
+	daemon.SetWorkspaceRoot("")
+	p, err := reconcile.GetProvider("agent")
+	if err != nil {
+		t.Fatalf("GetProvider(agent): %v", err)
+	}
+	before := p.Health()
+	if before.Health == reconcile.HealthHealthy {
+		t.Error("agent provider unexpectedly Healthy before SetWorkspaceRoot — test environment has a real workspace wired")
+	}
+
+	// After SetWorkspaceRoot with our fake workspace: agent should be Healthy.
+	daemon.SetWorkspaceRoot(tmp)
+	after := p.Health()
+	if after.Health != reconcile.HealthHealthy {
+		t.Errorf("agent provider Health()=%s after SetWorkspaceRoot(%s); want Healthy; message=%q",
+			after.Health, tmp, after.Message)
+	}
+
+	// service provider should also be Healthy (no services dir = no services = fine).
+	svc, err := reconcile.GetProvider("service")
+	if err != nil {
+		t.Fatalf("GetProvider(service): %v", err)
+	}
+	svcStatus := svc.Health()
+	if svcStatus.Health != reconcile.HealthHealthy {
+		t.Errorf("service provider Health()=%s; want Healthy; message=%q",
+			svcStatus.Health, svcStatus.Message)
+	}
+
+	// Reset for other tests.
+	daemon.SetWorkspaceRoot("")
 }


### PR DESCRIPTION
## What

Two commits cherry-picked from the older `feat/daemon-workspace-context` branch, which had drifted ~25 commits behind main:

1. **`feat(provider_claudecode)`** — Extract `tool_use` events from `claude --output-format stream-json` into `CompletionResponse.ToolCalls`. Switches `Complete()` from `--output-format json` to `stream-json` so tool calls are observable on the non-streaming path too. New `provider_claudecode_test.go` covers the stream parser. Net: +498/-29 across 2 files.

2. **`test(daemon)`** — Adds `TestSetWorkspaceRoot_HealthReflectsWorkspaceState`. The original commit also tried to add the `SetWorkspaceRoot` implementation, but main has since landed that wiring via a different path (separate workspace-root commits). The test was the one piece of unique value; cherry-picked alone, with an amended message reflecting the reduced scope.

## Why

The 5b6c9cb claudecode tool extraction is foundational for any Claude-Code-via-substrate work that needs to observe tool calls. The regression test for `SetWorkspaceRoot` covers the wired-vs-unwired Health() flip — useful as the workspace-root machinery evolves.

## How

- Cherry-picked `5b6c9cb` clean (auto-merged on `provider_claudecode.go`).
- Cherry-picked `1bcb4fb` with 3 conflicts: `providers_wire.go` and `providers_register.go` both already had main's version of the workspace-context wiring (via independent commits), so HEAD was kept for those. `daemon_test.go` had a 1-line conflict on the import comment (8-vs-9 providers); resolved to keep main's "9 providers" structure plus the new test that auto-merge correctly stitched in.
- Amended the second commit's message to reflect that only the test remains (the implementation is already in main).

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/engine/...` passes (claudecode test included)
- [x] `go test ./internal/providers/daemon/...` passes (new SetWorkspaceRoot test included)
- [ ] CI green

Net diff: 3 files, +557 / -32.

## Notes

- The original branch `feat/daemon-workspace-context` is now stale debris; can be deleted after this lands.