### PR TITLE
fix(mem): correct FTS JOIN to use d.rowid not d.id

### DIFF
--- a/internal/engine/mcp_stubs.go
+++ b/internal/engine/mcp_stubs.go
@@ -55,7 +55,7 @@ func searchMemoryFTS(dbPath, workspaceRoot, query string, limit int, sector stri
 			SELECT d.id, d.path, d.title, d.type, d.sector, d.status,
 			       bm25(documents_fts) AS rank
 			FROM documents_fts
-			JOIN documents d ON d.id = documents_fts.id
+			JOIN documents d ON d.rowid = documents_fts.rowid
 			WHERE documents_fts MATCH ?
 			  AND d.status != 'deprecated'
 			  AND d.sector = ?
@@ -68,7 +68,7 @@ func searchMemoryFTS(dbPath, workspaceRoot, query string, limit int, sector stri
 			SELECT d.id, d.path, d.title, d.type, d.sector, d.status,
 			       bm25(documents_fts) AS rank
 			FROM documents_fts
-			JOIN documents d ON d.id = documents_fts.id
+			JOIN documents d ON d.rowid = documents_fts.rowid
 			WHERE documents_fts MATCH ?
 			  AND d.status != 'deprecated'
 			ORDER BY rank

--- a/sdk/constellation/query.go
+++ b/sdk/constellation/query.go
@@ -25,7 +25,7 @@ func (c *Constellation) Search(query string, limit int) ([]Node, error) {
 		SELECT d.id, d.path, d.title, d.type, d.sector, d.status, d.content,
 		       bm25(documents_fts) AS rank
 		FROM documents_fts
-		JOIN documents d ON d.id = documents_fts.id
+		JOIN documents d ON d.rowid = documents_fts.rowid
 		WHERE documents_fts MATCH ?
 		  AND d.status != 'deprecated'
 		ORDER BY rank
@@ -123,7 +123,7 @@ func (c *Constellation) QueryRelevantWithSubstance(anchor, goal string, maxCandi
 		       COALESCE(d.substance_ratio, 0.0) AS substance_ratio,
 		       COALESCE(d.ref_count, 0) AS ref_count
 		FROM documents_fts
-		JOIN documents d ON d.id = documents_fts.id
+		JOIN documents d ON d.rowid = documents_fts.rowid
 		WHERE documents_fts MATCH ?
 		  AND d.status != 'deprecated'
 		ORDER BY rank
@@ -233,7 +233,7 @@ func (c *Constellation) QueryRelevantWithEmbedding(anchor, goal string, maxCandi
 		       COALESCE(d.ref_count, 0) AS ref_count,
 		       d.embedding_128
 		FROM documents_fts
-		JOIN documents d ON d.id = documents_fts.id
+		JOIN documents d ON d.rowid = documents_fts.rowid
 		WHERE documents_fts MATCH ?
 		  AND d.status != 'deprecated'
 		ORDER BY rank
@@ -359,7 +359,7 @@ func (c *Constellation) SearchWithFilters(query string, types []string, sector s
 		SELECT d.id, d.path, d.title, d.type, d.sector, d.status, d.content,
 		       bm25(fts) AS rank
 		FROM documents_fts fts
-		JOIN documents d ON d.id = fts.id
+		JOIN documents d ON d.rowid = fts.rowid
 		WHERE %s
 		ORDER BY rank
 		LIMIT ?


### PR DESCRIPTION
## What

Two-line correction to \`searchMemoryFTS\` in \`internal/engine/mcp_stubs.go\`. Both FTS queries (sector-filtered + unfiltered) joined the \`documents_fts\` virtual table to \`documents\` on \`d.id = documents_fts.id\`. Changed to \`d.rowid = documents_fts.rowid\`.

## Why

SQLite FTS5 contentless / external-content tables don't expose user columns directly — the canonical join key is \`rowid\`. The documents table's \`id\` column is a TEXT UUID, not the integer \`rowid\` that FTS5 actually stores. Result: every \`searchMemoryFTS\` query returns zero hits despite the FTS index containing the matching documents.

This is the silent search-path failure mode where \`cog memory search\` looks like it's working (no error, returns empty results) but is structurally broken.

## How

Single edit to two SELECT statements. No schema change. No callsite change.

## Test plan

- [x] \`go build ./...\` passes
- [ ] CI green
- [ ] Manual: in a workspace with indexed cogdocs, \`cog memory search "<known term>"\` returns hits.