### PR TITLE
docs: update constellation row in ecosystem table

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ CogOS is one piece of a larger system. Each component is its own repo with indep
 | Repo | Purpose | Status |
 |------|---------|--------|
 | **[cogos](https://github.com/cogos-dev/cogos)** | The daemon -- this repo | Active |
-| [constellation](https://github.com/cogos-dev/constellation) | Distributed identity and workspace sync (BEP-based) | Active |
+| [constellation](https://github.com/cogos-dev/constellation) | L1 trust-node protocol for the Constellation substrate. Git-backed hash-chained ledger, ECDSA P-256 identity, EMA-weighted peer trust. Consumed via the kernel's `ConstellationBridge` seam. | Active |
 | [mod3](https://github.com/cogos-dev/mod3) | Modality bus -- voice I/O, TTS, channel multiplexing | Active |
 | [skills](https://github.com/cogos-dev/skills) | Agent skill library (Claude Code compatible) | Active |
 | [charts](https://github.com/cogos-dev/charts) | Helm charts and Docker Compose for deployment | Active |


### PR DESCRIPTION
## Summary

Aligns the constellation row in the cogos ecosystem table with the new framing that landed in [cogos-dev/constellation#7](https://github.com/cogos-dev/constellation/pull/7). The old row described constellation as \"Distributed identity and workspace sync (BEP-based)\" — the new framing positions it as the L1 trust-node protocol of a broader Constellation substrate, with the kernel consuming it via a ConstellationBridge seam.

## Why

The constellation repo's README and PAPER were just rewritten to reflect three updates:
1. Constellation is a unified substrate (multiple node populations on shared primitives), not just an identity protocol.
2. Three-layer model: Node (L1, in that repo) / Identity (L2, kernel CRD) / Presence (L3, emergent).
3. Reference implementation, not Proof of Concept.

This PR updates the cogos repo's reference to constellation so visitors don't get a contradictory description across the two repos.

## Scope

One row in the ecosystem table. No code changes. No other ecosystem rows touched.

## Test plan

- [ ] Read the diff and confirm the wording is accurate
- [ ] Confirm the link still resolves to cogos-dev/constellation