### PR TITLE
chore: add issue/PR templates and contributor guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,179 @@
+name: Bug report
+description: Report a defect in the kernel or supporting tooling.
+title: "<one-line description of the defect, not the symptom on your machine>"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing. Before you start: the bug is in the **code**. Your
+        machine helped you find it, but it isn't the bug. The sections below
+        are structured to keep those two things separate — code-level
+        reproduction and acceptance criteria up top, your local environment
+        cordoned off at the bottom.
+
+        Worked examples that meet this standard: #75, #79, #80, #81.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: |
+        One paragraph describing what the bug is, in terms of code behavior —
+        not "X happened on my machine," but "the kernel does Y when it should
+        do Z." If you don't yet know the cause, that's fine; describe the
+        observable defect.
+      placeholder: |
+        The kernel's /v1/models endpoint advertises stale model IDs that no
+        longer match the canonical names declared in CLAUDE.md.
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: |
+        Concrete artifacts: log lines, HTTP responses, source-file:line
+        references, output of small commands. Quote them, don't paraphrase.
+        If a single command reproduces the evidence, paste the command and
+        its output.
+      placeholder: |
+        ```
+        $ curl -s http://localhost:6931/v1/models | jq '.data[].id'
+        "claude-sonnet-4-6"
+        "claude-opus-4-6"
+        "local"
+        ```
+
+        Source: `internal/engine/serve_compat.go:165-172` hardcodes these IDs.
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: |
+        Numbered steps that reproduce the bug on **any** system meeting the
+        project's supported config. Don't include paths or PIDs from your
+        machine here — those go in the Environment section below.
+      placeholder: |
+        1. Start the kernel: `cogos-v3 serve --port 6931`
+        2. Send: `curl -s http://localhost:6931/v1/models`
+        3. Observe: response includes `claude-opus-4-6` (stale).
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should the code do instead? If a spec, ADR, or RFC defines the correct behavior, link it.
+      placeholder: |
+        `/v1/models` should advertise the canonical model IDs. Per the
+        workspace CLAUDE.md, current canonical Opus is `claude-opus-4-7`.
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: |
+        Who or what is affected. Be specific about user-visible behavior
+        ("clients enumerating /v1/models see X") rather than abstract risk.
+    validations:
+      required: true
+
+  - type: textarea
+    id: hypotheses
+    attributes:
+      label: Hypotheses or proposed cause (optional)
+      description: |
+        If you have a guess at the root cause, share it — but mark it as a
+        hypothesis. If you're confident, cite file:line. If you don't know,
+        leave this blank or say "I don't know yet."
+      placeholder: |
+        Likely cause: the model list in `serve_compat.go:165-172` is a static
+        slice that was last updated when 4-6 shipped and was never made
+        config-driven.
+
+  - type: textarea
+    id: proposed_fix
+    attributes:
+      label: Proposed fix (optional)
+      description: |
+        What 1-3 changes would resolve this? File:line specifics if you have
+        them. Don't propose architecture rewrites unless the bug genuinely
+        warrants one.
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance checklist
+      description: |
+        What must be true for this issue to be considered fixed? Each item
+        should be testable. Reviewers will use this to scope the PR.
+      value: |
+        - [ ]
+        - [ ] Test added that would have caught this regression.
+        - [ ] Documentation updated if behavior changed.
+    validations:
+      required: true
+
+  - type: textarea
+    id: related
+    attributes:
+      label: Related
+      description: |
+        Linked issues, PRs, ADRs, RFCs. Use #N for this repo, full URLs for
+        cross-repo references.
+      placeholder: |
+        - Adjacent: #51 (same subsystem)
+        - Context: #75 (filed earlier, related routing logic)
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        ## Local Environment
+
+        **This section is informational only and is not load-bearing for the
+        fix.** Reproduction steps and acceptance criteria above must hold on
+        any system meeting the project's stated supported config. Anything
+        you put below should not appear in the sections above.
+
+        Don't put paths from your machine, your PIDs, your specific
+        dashboard process names, or your local config overrides in any
+        section other than this one.
+
+  - type: input
+    id: env_os
+    attributes:
+      label: OS / kernel
+      placeholder: macOS 15.4 (darwin/arm64) or Ubuntu 24.04 (linux/amd64)
+    validations:
+      required: true
+
+  - type: input
+    id: env_build
+    attributes:
+      label: cogos-v3 build / commit
+      description: Output of `cogos-v3 --version` or the build timestamp from `kernel.log.jsonl`.
+      placeholder: 2026-04-27T23:09:52Z (build timestamp) or commit 72f2161
+
+  - type: textarea
+    id: env_other
+    attributes:
+      label: Anything else specific to your environment
+      description: |
+        Workspace path (if relevant), active local services running on
+        ports the kernel touches, providers configured in
+        `providers.local.yaml`, anything else that's specific to your setup
+        rather than the project's defaults.
+      placeholder: |
+        - Workspace: ~/workspaces/cog
+        - Active local providers: claude-code, ollama (gemma4:e4b)
+        - Other services on adjacent ports: BrowserOS dashboard on :7000

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/cogos-dev/cogos/discussions
+    about: For open-ended questions, design discussions, or proposals not yet ready for an RFC.
+  - name: Constellation (multi-node) issue
+    url: https://github.com/cogos-dev/constellation/issues
+    about: For node-orchestration, sync, or multi-machine bugs unrelated to the kernel itself.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,70 @@
+name: Feature request / proposal
+description: Propose a new capability, behavior change, or design direction.
+title: "<one-line description of the proposal>"
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For substantial changes (new subsystems, protocol changes, breaking
+        behavior), prefer opening an RFC first via `./scripts/cog rfc new`
+        and link it here once it exists. Small, contained features can use
+        this template directly.
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: |
+        What problem does this solve? Who is blocked or inconvenienced today,
+        and how? If this is responding to user feedback or an observed gap,
+        cite it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: |
+        What should change. Be concrete: API surface, file paths, behavior
+        contract, defaults. If multiple subsystems are affected, list each
+        one with its own contract change.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: |
+        What else did you consider, and why was this proposal preferred?
+        "I didn't consider alternatives" is a valid answer for small
+        features but is a yellow flag for anything substantial.
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Out of scope
+      description: |
+        What is intentionally NOT being changed by this proposal? This
+        prevents scope creep during implementation review.
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance checklist
+      value: |
+        - [ ] Behavior contract documented (in code comments or `docs/`).
+        - [ ] Tests cover the new behavior and the boundary cases.
+        - [ ] Existing callers updated (if behavior changed for them).
+        - [ ] Migration / deprecation path documented (if applicable).
+    validations:
+      required: true
+
+  - type: textarea
+    id: related
+    attributes:
+      label: Related
+      description: |
+        Linked issues, RFCs, ADRs, or upstream proposals.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,52 @@
+<!--
+Thanks for the contribution. Fill out the sections below. Delete sections
+that don't apply to your PR.
+-->
+
+## What and why
+
+<!-- One paragraph: what this PR does and why. Link the issue it fixes. -->
+
+Fixes #
+
+## How
+
+<!-- Brief description of the approach. If the change is non-obvious, walk
+through the load-bearing decisions. File:line references are encouraged. -->
+
+## Acceptance
+
+<!-- Copy the acceptance checklist from the linked issue. Tick items as they
+become true. Don't open the PR for review until at least one item is ticked
+or you've explained why none yet are. -->
+
+- [ ]
+- [ ]
+
+## Test evidence
+
+<!-- How did you verify this works? Paste command output, screenshots of
+relevant UI, or links to CI runs. "Tests pass" alone is not evidence — quote
+the new tests by name. -->
+
+```
+$ go test ./internal/engine/...
+ok  ...
+```
+
+## Risk and rollback
+
+<!-- What's the blast radius if this regresses? How would an operator detect
+the regression and roll it back? "Low risk, revert the PR" is a valid answer
+for small changes. Required for anything touching the kernel hot path,
+persistence, or routing. -->
+
+## Out of scope
+
+<!-- What did you intentionally NOT change in this PR, even though it might
+seem related? Prevents scope-creep arguments in review. -->
+
+## Notes for reviewers
+
+<!-- Anything you want a reviewer to know that doesn't fit above. Areas you
+want extra eyes on. Decisions you want to defer. Optional. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,28 +33,58 @@ Key areas:
 - `docs/` -- Specifications and architecture documents
 - `scripts/` -- Build tooling, setup scripts, experiment harnesses
 
+## Reporting issues
+
+Use the templates in `.github/ISSUE_TEMPLATE/`. They aren't optional formality -- they encode the project's standard for what an actionable issue looks like.
+
+The single most important rule: **the bug is in the code, not on your machine.** Your environment helped you find the defect, but your paths, PIDs, dashboard processes, and local config overrides are not the bug. Keep them in the "Local Environment" section at the bottom of the bug template, and keep them out of the Summary, Evidence, Reproduction, Impact, and Acceptance sections.
+
+A reviewer in a different environment must be able to:
+
+- Read the Summary and understand what defect exists in the code.
+- Run the Reproduction steps on a fresh checkout (no machine-specific setup beyond the project's stated supported config).
+- Use the Acceptance checklist as a definition of done.
+
+If your reproduction depends on a specific local arrangement (a particular provider configured, a particular dashboard process running), describe the *class* of arrangement in Reproduction ("a kernel running with at least one chronically-degraded provider") and note your specific instantiation in the Local Environment section.
+
+### Examples that meet this standard
+
+- [#75](https://github.com/cogos-dev/cogos/issues/75) -- model advertisement staleness + routing semantics. Three sub-bugs in one issue with shared fix surface, each cited at file:line.
+- [#79](https://github.com/cogos-dev/cogos/issues/79) -- kernel hang RCA. Filed with hypotheses honestly marked as hypotheses, then updated with a follow-up RCA that named the actual root cause.
+- [#80](https://github.com/cogos-dev/cogos/issues/80), [#81](https://github.com/cogos-dev/cogos/issues/81) -- companion issues cross-linked so a reader entering through any one can find the others.
+
 ## Submitting changes
 
 1. Fork the repo and create a branch from `main`
 2. Make your changes
 3. Run `make test` and ensure all tests pass
-4. Write a clear commit message describing what changed and why
-5. Open a pull request
+4. Open a pull request using `.github/PULL_REQUEST_TEMPLATE.md`
+
+The bar for "ready for review":
+
+- The PR links the issue it fixes.
+- At least one acceptance checklist item from the linked issue is ticked, or you've said why none are yet.
+- Test evidence is concrete: new tests are named, command output is pasted, CI status is linked. "Tests pass" by itself doesn't count.
+- Out-of-scope is stated. Reviewers should never have to guess whether you intentionally left something for a follow-up or just forgot.
+
+## RFCs and ADRs
+
+For substantial design changes -- new subsystems, protocol changes, breaking behavior, or anything that touches the kernel's persistence or routing -- open an RFC before opening a PR:
+
+```sh
+./scripts/cog rfc new "<title>"
+```
+
+ADRs document decisions that have been made; RFCs gather input on decisions that are still open. RFC-004 covers the workflow.
 
 ## Code style
 
 - Follow standard Go conventions (`gofmt`, `go vet`)
 - Tests go in `*_test.go` files alongside the code they test
 - Error messages should be lowercase and not end with punctuation (Go convention)
-
-## Reporting issues
-
-Open an issue on GitHub. Include:
-
-- What you expected to happen
-- What actually happened
-- Steps to reproduce
-- Go version and OS
+- Default to no comments. Add one only when the *why* is non-obvious.
+- Don't add error-handling, fallbacks, or validation for scenarios that can't happen. Trust internal code and framework guarantees.
+- Don't add abstractions for hypothetical future requirements.
 
 ## License
 


### PR DESCRIPTION
## What and why

Adds structured forms for bug reports and feature requests, a PR template, and updates `CONTRIBUTING.md` with a worked-example index and explicit guidance on cordoning machine-local context away from code-level evidence.

Motivated by today's incident workflow (#79, #80, #81) where the bug reports drifted between "the code is broken" and "this happened on my machine." Future contributors entering the project should have a structural place to put their environment context that doesn't pollute the actionable parts of the issue.

Fixes nothing directly — meta-improvement to the contribution flow.

## How

Five files:

- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues, points at discussions and the constellation repo for off-target reports.
- `.github/ISSUE_TEMPLATE/bug_report.yml` — structured YAML form. Fields enforce: Summary / Evidence / Reproduction / Expected / Impact / (optional) Hypotheses / (optional) Proposed Fix / Acceptance / Related. Separately at the bottom, a **Local Environment** section marked as informational-only with explicit guidance not to put paths or PIDs in the other sections.
- `.github/ISSUE_TEMPLATE/feature_request.yml` — Motivation / Proposal / Alternatives / Out-of-scope / Acceptance / Related. Notes the RFC workflow for substantial changes.
- `.github/PULL_REQUEST_TEMPLATE.md` — links the issue, copies the issue's acceptance checklist, requires concrete test evidence, requires explicit out-of-scope.
- `CONTRIBUTING.md` — expanded the Reporting Issues and Submitting Changes sections, cited #75/#79/#80/#81 as worked examples, kept the existing build/test/structure guidance.

## Acceptance

- [x] Bug template separates code-level sections from machine-local context.
- [x] PR template ties acceptance back to the linked issue.
- [x] CONTRIBUTING.md cites concrete examples rather than abstract guidance.
- [ ] (Post-merge) Future bug reports use the form. Track adoption via a quick scan of the next 5 issues filed by non-core contributors.

## Test evidence

Templates are markdown/YAML, not code. Verified via:

- `gh issue list` shows existing issues unchanged.
- YAML linting: forms parse via `python3 -c "import yaml; yaml.safe_load(open('.github/ISSUE_TEMPLATE/bug_report.yml'))"` (no errors).
- Visual spot-check of rendered template structure on the branch.

## Risk and rollback

Low risk — pure documentation and form definitions, no code changes. Rollback is `git revert`. Existing issues unaffected.

## Out of scope

- Retroactively reformatting existing issues to match the templates.
- Changes to the workflow files in `.github/workflows/` (e.g., labeler bots, auto-triage).
- A code of conduct file (CONTRIBUTING.md has a brief CoC paragraph; a separate `CODE_OF_CONDUCT.md` is a follow-up if the project grows).
- Changes to the existing fork-based contribution model.

## Notes for reviewers

The cordoning philosophy in CONTRIBUTING.md is the load-bearing idea — if you disagree with how it's framed, that's the section worth iterating on. The templates themselves are mechanical implementations of that philosophy and are easy to revise.