### PR TITLE
fix(serve): bump advertised Opus to 4.7; pin model=local to a local provider (closes #75)

### DIFF
--- a/internal/engine/provider.go
+++ b/internal/engine/provider.go
@@ -330,6 +330,12 @@ type Router interface {
 	// ("", false) when no match. Name match takes precedence over model match.
 	ProviderForModel(model string) (string, bool)
 
+	// FirstLocalProvider returns the name of the first registered provider
+	// whose Capabilities().IsLocal is true. Used by the "local" model alias
+	// to pin requests to an on-device provider. Returns ("", false) when no
+	// local provider is registered.
+	FirstLocalProvider() (string, bool)
+
 	// Stats returns routing statistics.
 	Stats() RouterStats
 }

--- a/internal/engine/router.go
+++ b/internal/engine/router.go
@@ -116,6 +116,21 @@ func (r *SimpleRouter) ProviderForModel(model string) (string, bool) {
 	return "", false
 }
 
+// FirstLocalProvider returns the name of the first registered provider whose
+// Capabilities().IsLocal is true. Providers are iterated in registration
+// order (alphabetically sorted by Name). Returns ("", false) when none is
+// registered.
+func (r *SimpleRouter) FirstLocalProvider() (string, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, p := range r.providers {
+		if p.Capabilities().IsLocal {
+			return p.Name(), true
+		}
+	}
+	return "", false
+}
+
 // Route selects the best available provider for the request.
 func (r *SimpleRouter) Route(ctx context.Context, req *CompletionRequest) (Provider, *RoutingDecision, error) {
 	start := time.Now()

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -722,13 +722,32 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 	// Map OpenClaw model names to provider routing.
 	// "claude", "codex", "ollama" are provider aliases, not model names.
 	switch req.Model {
-	case "", "local":
-		// use default routing
+	case "":
+		// empty model: use default routing
+	case "local":
+		// Pin to a local provider explicitly. Prefer ollama (always-resident
+		// baseline), then any other provider with IsLocal=true. If no local
+		// provider is registered, fall through to default routing and warn so
+		// operators notice (silent cloud routing under a "local" alias is the
+		// bug this fixes; see cogos-dev/cogos#75).
+		if name, ok := s.router.ProviderForName("ollama"); ok {
+			creq.Metadata.PreferProvider = name
+		} else if name, ok := s.router.FirstLocalProvider(); ok {
+			creq.Metadata.PreferProvider = name
+		} else {
+			slog.Warn("chat: model=local requested but no local provider registered; falling back to default routing",
+				"request_id", creq.Metadata.RequestID,
+			)
+		}
 	case "claude":
 		creq.Metadata.PreferProvider = "claude-code"
 	case "codex":
 		creq.Metadata.PreferProvider = "codex"
-	case "ollama":
+	case "ollama", "kernel-agent":
+		// "kernel-agent" is the canonical alias for "the same harness the
+		// dispatch tool uses" — currently Ollama with the default kernel-core
+		// model. Eventually this aliases the kernel-managed in-host harness;
+		// see .cog/scratch/audit-inference-paths/REPORT.md.
 		creq.Metadata.PreferProvider = "ollama"
 	default:
 		// First check: is req.Model a provider alias (exact name match)? If so,

--- a/internal/engine/serve_compat.go
+++ b/internal/engine/serve_compat.go
@@ -85,8 +85,8 @@ func (s *Server) handleCard(w http.ResponseWriter, r *http.Request) {
 				},
 			},
 			{
-				"id":   "claude-opus-4-6",
-				"name": "Claude Opus 4.6",
+				"id":   "claude-opus-4-7",
+				"name": "Claude Opus 4.7",
 				"limits": map[string]int{
 					"context": 1000000,
 					"output":  32000,
@@ -139,7 +139,7 @@ func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
 		ID         string            `json:"id"`
 		Object     string            `json:"object"`
 		Created    int64             `json:"created"`
-		OwnedBy   string            `json:"owned_by"`
+		OwnedBy    string            `json:"owned_by"`
 		Permission []modelPermission `json:"permission"`
 	}
 	type response struct {
@@ -166,7 +166,7 @@ func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
 		Object: "list",
 		Data: []model{
 			mkModel("claude-sonnet-4-6", "anthropic"),
-			mkModel("claude-opus-4-6", "anthropic"),
+			mkModel("claude-opus-4-7", "anthropic"),
 			mkModel("local", "cogos"),
 		},
 	})

--- a/internal/engine/serve_local_routing_test.go
+++ b/internal/engine/serve_local_routing_test.go
@@ -1,0 +1,207 @@
+// serve_local_routing_test.go — tests for model="local" routing semantics
+// and /v1/models advertisement.
+//
+// Covers cogos-dev/cogos#75:
+//   - model="local" pins to the "ollama" provider when one is registered.
+//   - model="local" with no local provider falls through to default routing
+//     and emits a structured warning.
+//   - /v1/models advertises claude-opus-4-7, not the stale claude-opus-4-6.
+package engine
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// capturingHandler is a minimal slog.Handler that records logged messages so
+// tests can assert on structured warnings without touching stderr.
+type capturingHandler struct {
+	mu   sync.Mutex
+	recs []slog.Record
+}
+
+func (h *capturingHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (h *capturingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.recs = append(h.recs, r)
+	return nil
+}
+func (h *capturingHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return h // attrs ignored for test purposes
+}
+func (h *capturingHandler) WithGroup(name string) slog.Handler {
+	return h
+}
+
+// messages returns all logged message strings (snapshot).
+func (h *capturingHandler) messages() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]string, len(h.recs))
+	for i, r := range h.recs {
+		out[i] = r.Message
+	}
+	return out
+}
+
+// hasWarnContaining returns true if any captured Warn-level record's message
+// contains the given substring.
+func (h *capturingHandler) hasWarnContaining(sub string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, r := range h.recs {
+		if r.Level == slog.LevelWarn && strings.Contains(r.Message, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// newTestServerWithRouter creates a Server wired with the provided router.
+func newTestServerWithRouter(t *testing.T, router Router) *Server {
+	t.Helper()
+	srv := newTestServer(t)
+	srv.SetRouter(router)
+	return srv
+}
+
+// newCloudStub creates a StubProvider that is NOT local (IsLocal=false) so it
+// won't satisfy a FirstLocalProvider() walk.
+func newCloudStub(name, response string) *StubProvider {
+	s := NewStubProvider(name, response)
+	s.capabilities.IsLocal = false
+	return s
+}
+
+// TestModelLocal_PinsToOllamaWhenAvailable verifies that a chat request with
+// model="local" routes to the "ollama" provider when one is registered,
+// regardless of any other providers in the pool.
+func TestModelLocal_PinsToOllamaWhenAvailable(t *testing.T) {
+	t.Parallel()
+
+	ollamaStub := NewStubProvider("ollama", "ollama response")
+	cloudStub := newCloudStub("claude-code", "cloud response")
+
+	router := NewSimpleRouter(RoutingConfig{Default: "claude-code"})
+	router.RegisterProvider(cloudStub)
+	router.RegisterProvider(ollamaStub)
+
+	srv := newTestServerWithRouter(t, router)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"local","messages":[{"role":"user","content":"hello"}],"stream":false}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleChat(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d; want 200", w.Code)
+	}
+
+	// The ollama stub should have received the request — its lastRequest is set
+	// only when it is actually invoked by the provider.
+	if ollamaStub.lastRequest == nil {
+		t.Error("ollama stub was not called; model=local did not route to ollama")
+	}
+	if cloudStub.lastRequest != nil {
+		t.Error("cloud stub was unexpectedly called; model=local should prefer ollama")
+	}
+
+	// Confirm the response content came from ollama.
+	var body oaiChatResponse
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if len(body.Choices) == 0 {
+		t.Fatal("no choices in response")
+	}
+	got := ""
+	if body.Choices[0].Message != nil {
+		got = extractContent(body.Choices[0].Message.Content)
+	}
+	if got != "ollama response" {
+		t.Errorf("response content = %q; want %q", got, "ollama response")
+	}
+}
+
+// TestModelLocal_FallsThroughWhenNoLocalProvider verifies that when no local
+// provider is registered, model="local" falls through to default routing and
+// emits a structured warning so operators can observe the mismatch.
+func TestModelLocal_FallsThroughWhenNoLocalProvider(t *testing.T) {
+	t.Parallel()
+
+	// Install a capturing logger so we can assert on the warning without
+	// touching the global default permanently.
+	handler := &capturingHandler{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	cloudStub := newCloudStub("claude-code", "cloud fallback")
+
+	router := NewSimpleRouter(RoutingConfig{Default: "claude-code"})
+	router.RegisterProvider(cloudStub)
+
+	srv := newTestServerWithRouter(t, router)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"local","messages":[{"role":"user","content":"ping"}],"stream":false}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleChat(w, req)
+
+	// Should not fail — fall-through to default routing returns a valid response.
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d; want 200 (fall-through to default routing)", w.Code)
+	}
+
+	// The cloud stub should have been called as the default.
+	if cloudStub.lastRequest == nil {
+		t.Error("cloud stub was not called on fallthrough; default routing broken")
+	}
+
+	// A structured warning must have been emitted mentioning "local".
+	if !handler.hasWarnContaining("model=local") {
+		t.Errorf("expected a Warn-level log containing %q; got messages: %v",
+			"model=local", handler.messages())
+	}
+}
+
+// TestModelsEndpoint_AdvertisesOpus47 verifies that /v1/models includes
+// claude-opus-4-7 and does NOT include the stale claude-opus-4-6.
+func TestModelsEndpoint_AdvertisesOpus47(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	w := httptest.NewRecorder()
+	srv.handleModels(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d; want 200", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type = %q; want application/json", ct)
+	}
+
+	body := w.Body.Bytes()
+
+	// Must advertise the canonical Opus 4.7 ID.
+	if !bytes.Contains(body, []byte("claude-opus-4-7")) {
+		t.Errorf("/v1/models response does not contain claude-opus-4-7; body: %s", body)
+	}
+
+	// Must NOT advertise the stale Opus 4.6 ID.
+	if bytes.Contains(body, []byte("claude-opus-4-6")) {
+		t.Errorf("/v1/models response still contains stale claude-opus-4-6; body: %s", body)
+	}
+}


### PR DESCRIPTION
## What and why

Closes #75. Two coupled fixes in the kernel's OpenAI-compatible surface:

1. **Stale advertisement**: `/v1/models` and `/v1/card` advertised `claude-opus-4-6`. Per `CLAUDE.md` the canonical Opus is now `claude-opus-4-7`. Bumped both. Sonnet stays at `4-6`.
2. **`model: "local"` was a no-op alias for empty model**: previously fell through to process-state-default routing, which on an interactive node lands at `claude-code` — i.e. the advertised "local" model was actually cloud. Now it explicitly pins to a local provider (Ollama by name first, then any provider with `IsLocal: true` capability, then a structured warning + fall-through if no local provider is registered).

The `local` semantics also reconcile with the `cog/.cog/inference.go` UCP layer's intent (which already aliased `"local"` to a local-inference model). Documented at the issue.

## How

| File | Change |
|---|---|
| `internal/engine/serve_compat.go` | `claude-opus-4-6` → `claude-opus-4-7` in card `defaultModel`, card models list, and `/v1/models` data list. Minor `gofmt` alignment fix on `OwnedBy`. |
| `internal/engine/provider.go` | New method on `Router` interface: `FirstLocalProvider() (string, bool)`. |
| `internal/engine/router.go` | `*SimpleRouter.FirstLocalProvider()` implementation. Walks the alphabetically-sorted provider slice, returns the first whose `Capabilities().IsLocal == true`. Takes the read lock. |
| `internal/engine/serve.go` | Split `case "", "local":` into two branches. Empty model keeps default routing. `model=local` pins to `ollama` by name, falls back to `FirstLocalProvider()`, falls through to default routing with a `slog.Warn` ("model=local requested but no local provider registered") if nothing local exists. Added `kernel-agent` alias to the existing `ollama` case for the dispatch tool harness. |
| `internal/engine/serve_local_routing_test.go` (new) | Three tests: pin-to-ollama, fall-through-when-no-local, advertise-opus-47. |

## Acceptance

From #75:
- [x] `/v1/models` advertises `claude-opus-4-7` (not `4-6`).
- [x] `model: "local"` lands at an `is_local=true` provider on every node where one exists.
- [x] `model: "local"` with no local provider produces documented behavior (structured warning, fall-through to default — preserves backward-compat for cloud-only nodes).
- [x] Tests added.
- [ ] **Workspace companion** (`.cog/bin/agents/definitions/*.yaml`, `agents.hcl` default) — out of scope for this kernel PR; tracked separately.
- [ ] ADR/RFC documenting `local` semantics — follow-up; PR comment + commit message capture intent for now.

## Test evidence

```
$ go test ./internal/engine/... -run "TestModelLocal|TestModelsEndpoint_AdvertisesOpus47" -count=1 -v
--- PASS: TestModelLocal_PinsToOllamaWhenAvailable (...)
--- PASS: TestModelLocal_FallsThroughWhenNoLocalProvider (...)
--- PASS: TestModelsEndpoint_AdvertisesOpus47 (...)
PASS

$ go vet ./...                  # clean
$ gofmt -l <changed files>      # clean
$ go test ./internal/engine/... -count=1 -race    # full suite passes
```

## Risk and rollback

Low-medium. The advertisement bump is cosmetic. The `model=local` routing change is a *behavior change* for any caller that was sending `model: "local"` and relying on the silent-cloud-routing — but per #75 that was the bug. New behavior matches the keyword's intent. Structured warning ensures any node missing a local provider still surfaces the situation in logs.

Rollback: `git revert` of the single commit. Tests in `serve_local_routing_test.go` will start failing, which is the intended rollback signal.

## Out of scope

- Workspace agent YAMLs and `agents.hcl` default (different repo / file set).
- ADR documenting `local` semantics formally (follow-up; this PR's commit message + #75 capture intent).
- Dynamic `/v1/models` reflecting actually-loaded providers (a larger change suggested in #75).

## Related

- Closes #75
- Adjacent: #51 (BusEventBroker no HTTP route — same subsystem area, separate fix)
- Sibling: PR for #44 (also opening today)