### PR TITLE
fix(session): preserve registered_at across re-register so bus event matches SessionState (closes #44)

### DIFF
--- a/internal/engine/mcp_sessions.go
+++ b/internal/engine/mcp_sessions.go
@@ -189,12 +189,14 @@ func (m *MCPServer) toolRegisterSession(ctx context.Context, req *mcp.CallToolRe
 		ContextUsage: in.ContextUsage, Status: in.Status, CurrentTask: in.CurrentTask,
 		Extras: in.Extras, RegisteredAt: now, LastSeen: now,
 	}
+	// registered_at is written in the appendFn using the canonical value
+	// supplied by ApplyRegister — for a re-register of an active session
+	// this is the original time (T1), not `now`. Fixes #44.
 	payload := map[string]interface{}{
 		"session_id": in.SessionID, "workspace": in.Workspace, "role": in.Role,
 		"task": in.Task, "model": in.Model, "hostname": in.Hostname,
 		"status": in.Status, "current_task": in.CurrentTask,
 		"context_usage": in.ContextUsage,
-		"registered_at": now.Format(time.RFC3339Nano),
 	}
 	for k, v := range in.Extras {
 		if _, exists := payload[k]; !exists {
@@ -202,7 +204,8 @@ func (m *MCPServer) toolRegisterSession(ctx context.Context, req *mcp.CallToolRe
 		}
 	}
 	var evt *BusBlock
-	appendFn := func() error {
+	appendFn := func(canonicalRegisteredAt time.Time) error {
+		payload["registered_at"] = canonicalRegisteredAt.Format(time.RFC3339Nano)
 		var err error
 		evt, err = m.busSessions.AppendEvent(BusSessions, EvtSessionRegister, in.SessionID, payload)
 		return err

--- a/internal/engine/serve_sessions_mgmt.go
+++ b/internal/engine/serve_sessions_mgmt.go
@@ -136,13 +136,11 @@ func (s *Server) handleSessionRegister(w http.ResponseWriter, r *http.Request) {
 		RegisteredAt: now,
 		LastSeen:     now,
 	}
-	// Build the bus payload up front so the appendFn closure can reference
-	// it. The registered_at field is derived from the final stored state's
-	// RegisteredAt (which may have been preserved from a prior re-register
-	// by ApplyRegister); since we don't yet know if this is a new row vs
-	// an update, we use `now` here and let ApplyRegister correct lineage
-	// internally. The bus event's ts field is authoritative for ordering
-	// anyway.
+	// Build the base payload. registered_at is intentionally omitted here;
+	// it is written inside the appendFn once ApplyRegister has determined
+	// the canonical value (which for a re-register of an active session is
+	// the original T1, not `now`). Fixes #44: bus event payload must agree
+	// with the in-memory SessionState.RegisteredAt.
 	payload := map[string]interface{}{
 		"session_id":    req.SessionID,
 		"workspace":     req.Workspace,
@@ -153,7 +151,6 @@ func (s *Server) handleSessionRegister(w http.ResponseWriter, r *http.Request) {
 		"status":        req.Status,
 		"current_task":  req.CurrentTask,
 		"context_usage": req.ContextUsage,
-		"registered_at": now.Format(time.RFC3339Nano),
 	}
 	if req.Extras != nil {
 		for k, v := range req.Extras {
@@ -166,7 +163,8 @@ func (s *Server) handleSessionRegister(w http.ResponseWriter, r *http.Request) {
 	// fields), so the only error ApplyRegister can return now is from
 	// appendFn — i.e. bus-append failure, which is always a 500.
 	var evt *BusBlock
-	appendFn := func() error {
+	appendFn := func(canonicalRegisteredAt time.Time) error {
+		payload["registered_at"] = canonicalRegisteredAt.Format(time.RFC3339Nano)
 		var err error
 		evt, err = s.busSessions.AppendEvent(BusSessions, EvtSessionRegister, req.SessionID, payload)
 		return err

--- a/internal/engine/sessions.go
+++ b/internal/engine/sessions.go
@@ -7,18 +7,18 @@
 // enforce the state-machine invariants the bridge-only implementation was
 // doing by convention:
 //
-//   • session_id format validation (regex) on register
-//   • idempotent re-register = update-semantics (re-register a live session
+//   - session_id format validation (regex) on register
+//   - idempotent re-register = update-semantics (re-register a live session
 //     updates the in-memory row; re-register after end is allowed only if the
 //     prior session is ended or its heartbeat is outside the active window)
-//   • heartbeat/end refused against unknown sessions
-//   • end refused against already-ended sessions
-//   • handoff.offer → claim → complete state machine with:
-//       - first-wins claim (atomic check under handoff mutex)
-//       - TTL enforcement (offer rejected if now - created_at > ttl_seconds)
-//       - claim-before-offer rejection (phantom offers) as 404
-//       - complete-before-claim rejected as 409
-//   • on every rejected claim, emit a handoff.claim_rejected event on
+//   - heartbeat/end refused against unknown sessions
+//   - end refused against already-ended sessions
+//   - handoff.offer → claim → complete state machine with:
+//   - first-wins claim (atomic check under handoff mutex)
+//   - TTL enforcement (offer rejected if now - created_at > ttl_seconds)
+//   - claim-before-offer rejection (phantom offers) as 404
+//   - complete-before-claim rejected as 409
+//   - on every rejected claim, emit a handoff.claim_rejected event on
 //     bus_handoffs so operators have an audit trail (amendment #4 of the
 //     user-approved plan).
 //
@@ -71,8 +71,9 @@ const (
 // "exactly three tokens."
 //
 // Example: slowbro-laptop-cogos-gap-closure → passes.
-//          alpha-beta-gamma                 → passes (exactly 3 tokens).
-//          a-b                              → REJECTED (only 2 tokens).
+//
+//	alpha-beta-gamma                 → passes (exactly 3 tokens).
+//	a-b                              → REJECTED (only 2 tokens).
 var sessionIDPattern = regexp.MustCompile(`^[a-z0-9]+-[a-z0-9-]+-[a-z0-9-]+$`)
 
 // ValidateSessionID returns nil iff id matches the lowercase-hyphen format
@@ -193,9 +194,13 @@ func (r *SessionRegistry) Snapshot() []*SessionState {
 // outside the active window.
 //
 // If appendFn is non-nil it is invoked AFTER validation but BEFORE the
-// registry mutation is committed, while the registry lock is held. An error
-// from appendFn aborts the mutation and is returned verbatim — the registry
-// is left unchanged, preserving the bus-is-ground-truth invariant.
+// registry mutation is committed, while the registry lock is held. The
+// canonical RegisteredAt that will be stored on the row is passed to
+// appendFn so the caller can embed the correct lineage value in the bus
+// event payload — for a re-register of an active session this is the
+// original registration time (not `now`). An error from appendFn aborts
+// the mutation and is returned verbatim — the registry is left unchanged,
+// preserving the bus-is-ground-truth invariant.
 //
 // Returns the resulting state (copy), a flag indicating whether the registry
 // row was newly created vs updated, and an error.
@@ -203,7 +208,7 @@ func (r *SessionRegistry) ApplyRegister(
 	state SessionState,
 	activeWindow time.Duration,
 	now time.Time,
-	appendFn func() error,
+	appendFn func(canonicalRegisteredAt time.Time) error,
 ) (*SessionState, bool, error) {
 	if err := ValidateSessionID(state.SessionID); err != nil {
 		return nil, false, err
@@ -221,7 +226,9 @@ func (r *SessionRegistry) ApplyRegister(
 		// Live prior row — allow re-register only if heartbeat is stale.
 		if existing.IsActive(activeWindow, now) {
 			// Still active; accept as update. Preserve the original
-			// RegisteredAt to keep lineage.
+			// RegisteredAt to keep lineage. Fixes #44: the canonical value
+			// is passed to appendFn so the bus event payload also reflects
+			// the preserved timestamp rather than the caller's `now`.
 			state.RegisteredAt = existing.RegisteredAt
 		}
 	}
@@ -232,7 +239,7 @@ func (r *SessionRegistry) ApplyRegister(
 	state.EndHandoffID = ""
 	// Append to the bus FIRST — if that fails, the registry is unchanged.
 	if appendFn != nil {
-		if err := appendFn(); err != nil {
+		if err := appendFn(state.RegisteredAt); err != nil {
 			return nil, false, err
 		}
 	}
@@ -360,7 +367,7 @@ type HandoffState struct {
 	CompletedAt       time.Time `json:"completed_at,omitempty"`
 	CompletionOutcome string    `json:"outcome,omitempty"`
 	CompletionNotes   string    `json:"notes,omitempty"`
-	NextHandoffID    string    `json:"next_handoff_id,omitempty"`
+	NextHandoffID     string    `json:"next_handoff_id,omitempty"`
 }
 
 // IsExpired is true when TTL > 0 and now is past ExpiresAt.
@@ -457,7 +464,7 @@ func (r *HandoffRegistry) ApplyOffer(
 type ClaimRejection string
 
 const (
-	ClaimRejectedOfferNotFound ClaimRejection = "offer_not_found"
+	ClaimRejectedOfferNotFound  ClaimRejection = "offer_not_found"
 	ClaimRejectedAlreadyClaimed ClaimRejection = "already_claimed"
 	ClaimRejectedTTLExpired     ClaimRejection = "ttl_expired"
 	ClaimRejectedOutOfOrder     ClaimRejection = "out_of_order"
@@ -596,9 +603,22 @@ func ReplaySessionRegistry(mgr *BusSessionManager, reg *SessionRegistry) error {
 			if state == nil {
 				continue
 			}
-			if ts, err := parseBusTS(evt.Ts); err == nil {
-				state.RegisteredAt = ts
-				if state.LastSeen.IsZero() {
+			// Prefer the registered_at field embedded in the payload — after
+			// the #44 fix this value is the canonical preserved timestamp for
+			// re-registrations. Fall back to evt.Ts for events written before
+			// the fix (legacy shape: payload had registered_at=now, not T1).
+			if ra, _ := evt.Payload["registered_at"].(string); ra != "" {
+				if ts, err := parseBusTS(ra); err == nil {
+					state.RegisteredAt = ts
+				}
+			}
+			if state.RegisteredAt.IsZero() {
+				if ts, err := parseBusTS(evt.Ts); err == nil {
+					state.RegisteredAt = ts
+				}
+			}
+			if state.LastSeen.IsZero() {
+				if ts, err := parseBusTS(evt.Ts); err == nil {
 					state.LastSeen = ts
 				}
 			}

--- a/internal/engine/sessions_test.go
+++ b/internal/engine/sessions_test.go
@@ -648,7 +648,7 @@ func TestMCP_HandoffRoundTrip(t *testing.T) {
 
 	// 2. src offers a handoff.
 	offerResult, _, err := mcpSrv.toolOfferHandoff(ctx, nil, offerHandoffInput{
-		FromSession: "mcp-src-session",
+		FromSession:     "mcp-src-session",
 		BootstrapPrompt: "bp",
 		Task: map[string]interface{}{
 			"title": "T", "goal": "G", "next_steps": []interface{}{"step1"},
@@ -774,7 +774,10 @@ func TestRegistryUnchangedOnBusAppendFailure(t *testing.T) {
 	t.Parallel()
 	now := time.Now().UTC()
 	appendErr := errors.New("simulated bus append failure")
-	failFn := func() error { return appendErr }
+	// failFn matches ApplyRegister's updated signature: func(time.Time) error.
+	failFn := func(_ time.Time) error { return appendErr }
+	// failFnSimple matches ApplyHeartbeat/ApplyEnd/ApplyOffer/ApplyClaim/ApplyComplete: func() error.
+	failFnSimple := func() error { return appendErr }
 
 	t.Run("register on empty registry stays empty", func(t *testing.T) {
 		reg := NewSessionRegistry()
@@ -827,7 +830,7 @@ func TestRegistryUnchangedOnBusAppendFailure(t *testing.T) {
 		}
 		before, _ := reg.Get("bus-fail-heartbeat")
 		later := now.Add(30 * time.Second)
-		_, ok, err := reg.ApplyHeartbeat("bus-fail-heartbeat", 0.42, "busy", "task", later, failFn)
+		_, ok, err := reg.ApplyHeartbeat("bus-fail-heartbeat", 0.42, "busy", "task", later, failFnSimple)
 		if !ok {
 			t.Fatal("heartbeat saw unregistered session")
 		}
@@ -853,7 +856,7 @@ func TestRegistryUnchangedOnBusAppendFailure(t *testing.T) {
 		if _, _, err := reg.ApplyRegister(state, time.Minute, now, nil); err != nil {
 			t.Fatalf("seed: %v", err)
 		}
-		_, known, err := reg.ApplyEnd("bus-fail-endsess", "because", "", now.Add(time.Second), failFn)
+		_, known, err := reg.ApplyEnd("bus-fail-endsess", "because", "", now.Add(time.Second), failFnSimple)
 		if !known {
 			t.Fatal("end saw unknown session")
 		}
@@ -872,7 +875,7 @@ func TestRegistryUnchangedOnBusAppendFailure(t *testing.T) {
 			HandoffID: "ho-fail-offer-1", FromSession: "a-b-c",
 			TTLSeconds: 60, CreatedAt: now,
 		}
-		_, err := hreg.ApplyOffer(h, now, failFn)
+		_, err := hreg.ApplyOffer(h, now, failFnSimple)
 		if err == nil {
 			t.Fatal("expected err from failFn")
 		}
@@ -890,7 +893,7 @@ func TestRegistryUnchangedOnBusAppendFailure(t *testing.T) {
 		if _, err := hreg.ApplyOffer(h, now, nil); err != nil {
 			t.Fatalf("seed offer: %v", err)
 		}
-		result, err := hreg.ApplyClaim("ho-fail-claim-1", "claimant-x-y", now, failFn)
+		result, err := hreg.ApplyClaim("ho-fail-claim-1", "claimant-x-y", now, failFnSimple)
 		if err == nil {
 			t.Fatal("expected appendErr from failFn")
 		}
@@ -920,7 +923,7 @@ func TestRegistryUnchangedOnBusAppendFailure(t *testing.T) {
 			t.Fatalf("seed claim: %v", err)
 		}
 		_, reason, err := hreg.ApplyComplete("ho-fail-complete-1",
-			"claimant-x-y", "ok", "notes", "", now.Add(time.Second), failFn)
+			"claimant-x-y", "ok", "notes", "", now.Add(time.Second), failFnSimple)
 		if err == nil {
 			t.Fatal("expected appendErr from failFn")
 		}
@@ -1100,19 +1103,19 @@ func TestReplay_OutOfOrderSeq(t *testing.T) {
 	evts := []BusBlock{
 		{ // seq 3 — end
 			V: 2, BusID: BusSessions, Seq: 3,
-			Ts: time.Now().UTC().Add(2 * time.Second).Format(time.RFC3339Nano),
+			Ts:   time.Now().UTC().Add(2 * time.Second).Format(time.RFC3339Nano),
 			From: "order-test-session", Type: EvtSessionEnd,
 			Payload: map[string]interface{}{"session_id": "order-test-session", "reason": "r3"},
 		},
 		{ // seq 1 — register
 			V: 2, BusID: BusSessions, Seq: 1,
-			Ts: time.Now().UTC().Format(time.RFC3339Nano),
+			Ts:   time.Now().UTC().Format(time.RFC3339Nano),
 			From: "order-test-session", Type: EvtSessionRegister,
 			Payload: map[string]interface{}{"session_id": "order-test-session", "workspace": "w", "role": "r"},
 		},
 		{ // seq 2 — heartbeat
 			V: 2, BusID: BusSessions, Seq: 2,
-			Ts: time.Now().UTC().Add(time.Second).Format(time.RFC3339Nano),
+			Ts:   time.Now().UTC().Add(time.Second).Format(time.RFC3339Nano),
 			From: "order-test-session", Type: EvtSessionHeartbeat,
 			Payload: map[string]interface{}{"session_id": "order-test-session", "status": "working"},
 		},
@@ -1155,7 +1158,7 @@ func TestReplay_DuplicateSeqWithConflictingPayload(t *testing.T) {
 	evts := []BusBlock{
 		{ // seq 1, first occurrence — wins per first-write-wins de-dup
 			V: 2, BusID: BusSessions, Seq: 1,
-			Ts: time.Now().UTC().Format(time.RFC3339Nano),
+			Ts:   time.Now().UTC().Format(time.RFC3339Nano),
 			From: "dup-test-session", Type: EvtSessionRegister,
 			Payload: map[string]interface{}{
 				"session_id": "dup-test-session", "workspace": "w", "role": "r",
@@ -1164,7 +1167,7 @@ func TestReplay_DuplicateSeqWithConflictingPayload(t *testing.T) {
 		},
 		{ // seq 1, second occurrence with conflicting payload — should be ignored
 			V: 2, BusID: BusSessions, Seq: 1,
-			Ts: time.Now().UTC().Add(time.Second).Format(time.RFC3339Nano),
+			Ts:   time.Now().UTC().Add(time.Second).Format(time.RFC3339Nano),
 			From: "dup-test-session", Type: EvtSessionRegister,
 			Payload: map[string]interface{}{
 				"session_id": "dup-test-session", "workspace": "w2", "role": "r2",
@@ -1378,5 +1381,107 @@ func writeBusLinesForTest(t *testing.T, path string, evts []BusBlock) {
 		if _, err := f.Write(append(line, '\n')); err != nil {
 			t.Fatalf("write: %v", err)
 		}
+	}
+}
+
+// ─── 27. TestRegister_PreservesRegisteredAtAcrossReRegister (#44) ────────────
+//
+// Regression guard for issue #44: on re-register of an active session the
+// bus event payload must carry the ORIGINAL registered_at (T1), not the
+// current wall-clock time (T2). Before the fix, the payload was baked with
+// `now` before ApplyRegister had a chance to preserve the lineage, so the
+// bus and the in-memory SessionState disagreed. After a restart the registry
+// would replay from the bus and lose T1.
+//
+// Asserts:
+//  1. First registration → in-memory RegisteredAt = T1.
+//  2. Re-registration → in-memory RegisteredAt still = T1 (preserved).
+//  3. Re-registration → bus event seq=2 payload.registered_at = T1 (the fix).
+//  4. Cold-restart replay → replayed RegisteredAt = T1 (no lineage loss).
+func TestRegister_PreservesRegisteredAtAcrossReRegister(t *testing.T) {
+	t.Parallel()
+	srv, ts := newSessionsTestServer(t)
+
+	// First register — capture the initial registered_at from the response.
+	r1 := postJSON(t, ts.URL+"/v1/sessions/register", map[string]any{
+		"session_id": "lineage-test-session",
+		"workspace":  "w",
+		"role":       "r",
+		"task":       "initial",
+	})
+	var resp1 sessionWriteResponse
+	decodeJSON(t, r1, &resp1)
+	if !resp1.OK {
+		t.Fatalf("first register failed: %+v", resp1)
+	}
+	t1 := resp1.Session.RegisteredAt
+
+	// Pause to ensure wall clock advances (sub-millisecond races on fast machines).
+	time.Sleep(5 * time.Millisecond)
+
+	// Re-register the same session.
+	r2 := postJSON(t, ts.URL+"/v1/sessions/register", map[string]any{
+		"session_id": "lineage-test-session",
+		"workspace":  "w",
+		"role":       "r",
+		"task":       "updated",
+	})
+	var resp2 sessionWriteResponse
+	decodeJSON(t, r2, &resp2)
+	if !resp2.OK {
+		t.Fatalf("re-register failed: %+v", resp2)
+	}
+
+	// Assert 1: in-memory RegisteredAt is preserved.
+	if !resp2.Session.RegisteredAt.Equal(t1) {
+		t.Errorf("in-memory RegisteredAt changed on re-register: was %v, got %v (want T1 preserved)",
+			t1, resp2.Session.RegisteredAt)
+	}
+
+	// Assert 2: bus seq=2 payload.registered_at = T1 (the fix for #44).
+	events, err := srv.busSessions.ReadEvents(BusSessions)
+	if err != nil {
+		t.Fatalf("ReadEvents: %v", err)
+	}
+	if len(events) < 2 {
+		t.Fatalf("expected >=2 bus events, got %d", len(events))
+	}
+	var reRegEvt *BusBlock
+	for i := range events {
+		if events[i].Seq == 2 {
+			reRegEvt = &events[i]
+			break
+		}
+	}
+	if reRegEvt == nil {
+		t.Fatalf("no seq=2 event on bus")
+	}
+	busRA, _ := reRegEvt.Payload["registered_at"].(string)
+	if busRA == "" {
+		t.Fatalf("seq=2 event payload missing registered_at field")
+	}
+	busRATime, parseErr := time.Parse(time.RFC3339Nano, busRA)
+	if parseErr != nil {
+		t.Fatalf("parse bus registered_at %q: %v", busRA, parseErr)
+	}
+	if !busRATime.Equal(t1) {
+		t.Errorf("bus seq=2 registered_at = %v, want T1=%v (lineage not preserved in payload; refs #44)",
+			busRATime, t1)
+	}
+
+	// Assert 3: cold-restart replay produces RegisteredAt = T1.
+	root := srv.busSessions.WorkspaceRoot()
+	freshMgr := NewBusSessionManager(root)
+	freshReg := NewSessionRegistry()
+	if replayErr := ReplaySessionRegistry(freshMgr, freshReg); replayErr != nil {
+		t.Fatalf("replay: %v", replayErr)
+	}
+	replayed, ok := freshReg.Get("lineage-test-session")
+	if !ok {
+		t.Fatal("session not found after replay")
+	}
+	if !replayed.RegisteredAt.Equal(t1) {
+		t.Errorf("replayed RegisteredAt = %v, want T1=%v (lineage lost after restart; refs #44)",
+			replayed.RegisteredAt, t1)
 	}
 }


### PR DESCRIPTION
## What and why

Closes #44. The bus event for a re-register of an active session disagreed with the in-memory `SessionState` on `registered_at`: in-memory was correctly preserved at the original T1, but the bus payload always carried `now` (T2). A secondary gap: `ReplaySessionRegistry` read `evt.Ts` (block timestamp) for `RegisteredAt` rather than the payload's `registered_at` field, so even if the payload had been correct, a cold-restart replay would still have lost T1.

Confirmed reproducing on `main` (c3e22fc + 35765b0) and fixed. PR #83's `lastSeq`/`lastHash` cache changes are orthogonal and did not affect this path.

## Root cause

Both HTTP and MCP `register` handlers baked `"registered_at": now.Format(time.RFC3339Nano)` into the bus payload **before** calling `ApplyRegister`. `ApplyRegister` correctly preserves the original `RegisteredAt` for re-registrations of active sessions, but the payload was a closure variable captured before the registry logic ran. Result: in-memory state and bus event disagreed.

## How

| File | Change |
|---|---|
| `internal/engine/sessions.go` | `ApplyRegister`'s `appendFn` parameter changed from `func() error` to `func(canonicalRegisteredAt time.Time) error`. The method now passes the final (possibly-preserved) `RegisteredAt` to the closure just before invoking it. `ReplaySessionRegistry` updated to prefer `payload["registered_at"]` over `evt.Ts`, with fallback to `evt.Ts` for legacy events that pre-date this fix. |
| `internal/engine/serve_sessions_mgmt.go` | HTTP register handler's `appendFn` signature updated to accept `canonicalRegisteredAt time.Time`; payload now writes from that, not from the captured `now`. |
| `internal/engine/mcp_sessions.go` | Same fix on the MCP side. |
| `internal/engine/sessions_test.go` | New `TestRegister_PreservesRegisteredAtAcrossReRegister` exercises the full re-register flow and asserts three invariants: in-memory `SessionState.RegisteredAt == T1`, bus seq=2 `payload.registered_at == T1`, and cold-restart replay produces `RegisteredAt == T1`. Confirmed failing pre-fix, passing post-fix. Existing `failFn`/`failFnSimple` split mirrors the new signature. |

## Acceptance

- [x] Re-register of an active session: in-memory `RegisteredAt` and bus payload `registered_at` agree (both = T1).
- [x] Cold-restart replay: `RegisteredAt` recovers to T1 (not block-timestamp T2).
- [x] Legacy events (no `registered_at` in payload) still work via fallback to `evt.Ts`.
- [x] New test added; was confirmed failing on pre-fix code.

## Test evidence

```
$ go test ./internal/engine/... -run "TestRegister_PreservesRegisteredAtAcrossReRegister" -count=1 -v
--- PASS: TestRegister_PreservesRegisteredAtAcrossReRegister (0.01s)
PASS

$ go vet ./...               # clean
$ gofmt -l <changed files>   # clean
$ go test ./internal/engine/... -count=1 -race    # full suite passes (8.9s)
```

## Risk and rollback

Medium. Touches both HTTP and MCP register paths plus replay. The `appendFn` signature change is a small breaking change inside the package — only the two call sites updated in this PR are affected; nothing external. Replay behavior change is intentional and backward-compat: the `payload["registered_at"]` field has been written by the existing handlers (they were just writing the wrong value); legacy events without it still work via fallback.

Rollback: `git revert` of the single commit. Pre-fix bug returns; new test fails as expected.

## Out of scope

- Wider audit of other session-state fields that could exhibit the same "preserved in memory but baked into payload at handler-time" pattern. Worth a follow-up if other fields are found.
- Changing the bus-event format / payload schema (none changed; same fields, correct values).

## Related

- Closes #44
- Independent of PR #83 (today's bus-session work) — verified the new cache code did not affect the lineage path
- Sibling: PR for #75 (also opening today)