### PR TITLE
fix(engine): pin Ollama model in VRAM via keep_alive=-1

### DIFF
--- a/agent_harness.go
+++ b/agent_harness.go
@@ -128,6 +128,13 @@ type agentChatRequest struct {
 	Think    bool                   `json:"think"`             // explicit thinking control
 	Format   string                 `json:"format,omitempty"`  // "json" for structured output
 	Options  map[string]interface{} `json:"options,omitempty"` // Ollama model options (num_ctx, temperature, etc.)
+	// KeepAlive controls how long Ollama keeps the model resident after the
+	// request completes. -1 keeps the model loaded indefinitely, 0 unloads
+	// immediately. Set to -1 by callers so dispatch cycles spaced past
+	// Ollama's 5-minute default keep-alive don't pay cold-start. Dropped
+	// on the OpenAI-compat path (chatCompletionOpenAI translates to its
+	// own struct that does not forward this field).
+	KeepAlive any `json:"keep_alive,omitempty"`
 }
 
 // agentChatMessage is a single message in the conversation.
@@ -249,12 +256,13 @@ func (h *AgentHarness) Assess(ctx context.Context, systemPrompt, observation str
 	}
 
 	req := agentChatRequest{
-		Model:    h.model,
-		Messages: messages,
-		Stream:   false,
-		Think:    false, // disable thinking — we want clean JSON output
-		Format:   "json",
-		Options:  map[string]interface{}{"num_ctx": 8192}, // 8K context is plenty for assessment
+		Model:     h.model,
+		Messages:  messages,
+		Stream:    false,
+		Think:     false, // disable thinking — we want clean JSON output
+		Format:    "json",
+		Options:   map[string]interface{}{"num_ctx": 8192}, // 8K context is plenty for assessment
+		KeepAlive: -1,                                      // pin model in VRAM between cycles
 	}
 
 	resp, err := h.chatCompletion(ctx, req)
@@ -292,12 +300,13 @@ func (h *AgentHarness) Execute(ctx context.Context, systemPrompt, task string) (
 
 	for turn := 0; turn < h.maxTurns; turn++ {
 		req := agentChatRequest{
-			Model:    h.model,
-			Messages: messages,
-			Tools:    h.tools,
-			Stream:   false,
-			Think:    false,                                   // disable thinking for tool loop
-			Options:  map[string]interface{}{"num_ctx": 8192}, // 8K context for tool loop
+			Model:     h.model,
+			Messages:  messages,
+			Tools:     h.tools,
+			Stream:    false,
+			Think:     false,                                   // disable thinking for tool loop
+			Options:   map[string]interface{}{"num_ctx": 8192}, // 8K context for tool loop
+			KeepAlive: -1,                                      // pin model in VRAM between turns
 		}
 
 		resp, err := h.chatCompletion(ctx, req)
@@ -572,12 +581,13 @@ func (h *AgentHarness) ExecuteScoped(ctx context.Context, task string, opts Exec
 
 	for turn := 0; turn < maxTurns; turn++ {
 		req := agentChatRequest{
-			Model:    model,
-			Messages: messages,
-			Tools:    allowedDefs,
-			Stream:   false,
-			Think:    think,
-			Options:  map[string]interface{}{"num_ctx": 8192},
+			Model:     model,
+			Messages:  messages,
+			Tools:     allowedDefs,
+			Stream:    false,
+			Think:     think,
+			Options:   map[string]interface{}{"num_ctx": 8192},
+			KeepAlive: -1, // pin model in VRAM across dispatch turns
 		}
 
 		resp, err := h.chatCompletionTo(ctx, backendURL, backendKind, req)

--- a/agent_harness_test.go
+++ b/agent_harness_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -148,6 +149,47 @@ func TestAgentHarness_Assess_MessageBuilding(t *testing.T) {
 	}
 	if receivedReq.Format != "json" {
 		t.Error("expected format 'json' for assess")
+	}
+}
+
+// TestAgentHarness_Assess_KeepAlivePinsModel asserts the wire body sent to
+// /api/chat carries keep_alive=-1 by default — i.e., between cycles Ollama is
+// told to keep the model resident in VRAM. Decodes the raw body so a refactor
+// that drops the field (or changes its JSON tag) fails this test.
+func TestAgentHarness_Assess_KeepAlivePinsModel(t *testing.T) {
+	var rawBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		rawBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		resp := agentChatResponse{Model: "test-model", Done: true, DoneReason: "stop"}
+		resp.Message.Role = "assistant"
+		resp.Message.Content = `{"action":"sleep","reason":"x","urgency":0,"target":""}`
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	h := NewAgentHarness(AgentHarnessConfig{OllamaURL: server.URL, Model: "test-model"})
+	if _, err := h.Assess(context.Background(), "sys", "obs"); err != nil {
+		t.Fatalf("assess: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(rawBody, &decoded); err != nil {
+		t.Fatalf("decode body: %v (raw=%s)", err, rawBody)
+	}
+	ka, ok := decoded["keep_alive"]
+	if !ok {
+		t.Fatalf("keep_alive missing from request body: %s", rawBody)
+	}
+	// JSON numbers decode as float64 in a map[string]any.
+	f, ok := ka.(float64)
+	if !ok || f != -1 {
+		t.Errorf("keep_alive = %v (%T); want -1 (float64)", ka, ka)
 	}
 }
 

--- a/internal/engine/provider_ollama.go
+++ b/internal/engine/provider_ollama.go
@@ -202,6 +202,12 @@ type ollamaChatRequest struct {
 	Stream   bool            `json:"stream"`
 	Think    bool            `json:"think"` // false = disable thinking mode (qwen3)
 	Options  map[string]any  `json:"options,omitempty"`
+	// KeepAlive controls how long Ollama keeps the model resident after the
+	// request completes. Accepts a Go duration string ("5m", "1h") or a
+	// number of seconds; -1 keeps the model loaded indefinitely, 0 unloads
+	// immediately. Defaulted to -1 in buildOllamaRequest so cycles spaced
+	// past Ollama's 5-minute default keep-alive don't pay cold-start.
+	KeepAlive any `json:"keep_alive,omitempty"`
 }
 
 type ollamaChatResponse struct {
@@ -276,12 +282,13 @@ func buildOllamaRequest(model string, req *CompletionRequest, stream bool, conte
 	}
 
 	return &ollamaChatRequest{
-		Model:    model,
-		Messages: msgs,
-		Tools:    tools,
-		Stream:   stream,
-		Think:    false, // prevent silent token burn in qwen3 thinking mode
-		Options:  opts,
+		Model:     model,
+		Messages:  msgs,
+		Tools:     tools,
+		Stream:    stream,
+		Think:     false, // prevent silent token burn in qwen3 thinking mode
+		Options:   opts,
+		KeepAlive: -1, // pin model in VRAM; Ollama's 5m default evicts between cycles
 	}
 }
 

--- a/internal/engine/provider_ollama_test.go
+++ b/internal/engine/provider_ollama_test.go
@@ -5,6 +5,7 @@
 package engine
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -94,6 +95,22 @@ func TestBuildOllamaRequestNumCtx(t *testing.T) {
 	r2 := buildOllamaRequest("m", req, false, 0)
 	if _, ok := r2.Options["num_ctx"]; ok {
 		t.Errorf("num_ctx should be absent when contextWindow=0, got %v", r2.Options["num_ctx"])
+	}
+}
+
+func TestBuildOllamaRequestKeepAlivePinsModel(t *testing.T) {
+	t.Parallel()
+	req := &CompletionRequest{
+		Messages: []ProviderMessage{{Role: "user", Content: "hi"}},
+	}
+	r := buildOllamaRequest("m", req, false, 0)
+	// Compare via JSON shape so the test is robust to any/int interface boxing.
+	body, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !bytes.Contains(body, []byte(`"keep_alive":-1`)) {
+		t.Errorf("request body should pin model with keep_alive=-1; got %s", body)
 	}
 }
 


### PR DESCRIPTION
## Summary

Sets `keep_alive: -1` on every Ollama `/api/chat` request the kernel issues — both via `OllamaProvider` (metabolic loop) and `AgentHarness` (`cog_dispatch_to_harness` MCP path) — so the local model stays resident between cycles.

## Context

Every Ollama request from the kernel today omits `keep_alive`, so Ollama applies its default 5-minute window. The metabolic loop's adaptive cadence and `cog_dispatch_to_harness` arrivals are both bursty: any wake past 5 min pays a full cold-load (~110s for `gemma4:e4b`). That's the user-visible "every message takes forever to start" symptom.

## Changes

**Commit 1** — `internal/engine/provider_ollama.go` (`OllamaProvider`, used by the metabolic loop and the local-harness `runCycle`):
- New top-level `KeepAlive any` field on `ollamaChatRequest` (`keep_alive,omitempty`).
- `buildOllamaRequest` defaults it to `-1`.
- `TestBuildOllamaRequestKeepAlivePinsModel` asserts the marshaled body contains `"keep_alive":-1`.

**Commit 2** — `agent_harness.go` (`AgentHarness`, used by the `cog_dispatch_to_harness` MCP path via `HarnessDispatcher`):
- `KeepAlive any` added to `agentChatRequest`.
- Set to `-1` at all three construction sites: `Assess`, `Execute`, `ExecuteScoped`.
- On the OpenAI-compat `/v1/chat/completions` path the field is silently dropped (`chatCompletionOpenAI` translates to its own struct that doesn't forward it) — desired behavior; LM Studio and the like don't honor `keep_alive` anyway.
- `TestAgentHarness_Assess_KeepAlivePinsModel` is a wire-level test: decodes the raw POST body and asserts `keep_alive` parses as `-1`. A refactor that drops the field or changes its JSON tag fails this test rather than silently regressing.

## Correction to prior PR description

The first revision of this PR claimed `agent_harness.go` was orphaned. That was wrong — `agent_dispatch.go` holds a live `*AgentHarness` and is the MCP dispatch path users actually hit. Commit 2 fixes that gap.

## Out of scope (not in this PR)

The actual *stacking* symptom (multiple model copies resident when several user messages arrive close together) has a separate root cause: `LocalHarnessController.runCycle` and `LocalHarnessController.DispatchToHarness` both build their own provider with no shared serialization, and `DispatchToHarness` itself fans out `req.N` goroutines per call. Tracked in #107.

## Test plan

- [x] `go vet ./...`
- [x] `go build -o cogos ./cmd/cogos`
- [x] `go build -tags mcpserver -o cogos-mcp ./cmd/cogos`
- [x] `go test -race -count=1 ./...` (root + `internal/engine` packages)
- [ ] Smoke test against a real Ollama: a second request issued >5 min after the first should not show `load_duration` > 0 in the response metrics.