### PR TITLE
services: read-only /v1/services API + kind discriminator on ServiceDef

### DIFF
--- a/.cog/config/node/manifest.yaml
+++ b/.cog/config/node/manifest.yaml
@@ -1,0 +1,110 @@
+# Node Manifest — single source of truth for services, ports, and consumers.
+# All port references in the workspace derive from this file via `cog node sync`.
+apiVersion: cog.os/v1
+kind: NodeManifest
+
+services:
+  kernel:
+    port: 6931
+    binary: /Users/slowbro/.cogos/bin/cogos-v3
+    command: "{{binary}} serve --workspace {{workspace}} --port {{port}}"
+    health: /health
+    restart: always
+    launchd: com.cogos.kernel
+    depends_on: []
+    consumers:
+      - path: .mcp.json
+        type: json
+        jsonpath: ".mcpServers.cogos.url"
+        template: "http://localhost:{{port}}/mcp"
+      - path: .cog/config/openclaw-gateway/config.yaml
+        type: sed
+        match: "localhost:6931"
+        replace: "localhost:{{port}}"
+      - path: scripts/cog
+        type: sed
+        match: "COG_KERNEL_PORT:-[0-9]*"
+        replace: "COG_KERNEL_PORT:-{{port}}"
+      - path: "~/Library/LaunchAgents/com.cogos.kernel.plist"
+        type: plist
+        key: ProgramArguments
+        # Port argument is at index 5 in the ProgramArguments array
+
+  mod3:
+    port: 7860
+    workdir: apps/tts-mcp
+    venv: apps/tts-mcp/.venv
+    command: "{{venv}}/bin/python {{workdir}}/server.py --all --port {{port}}"
+    health: /health
+    restart: on-failure
+    depends_on: []
+    consumers:
+      - path: .mcp.json
+        type: json
+        jsonpath: ".mcpServers.mod3.args[3]"
+        template: "{{port}}"
+      - path: .cog/config/openclaw-gateway/config.yaml
+        type: sed
+        match: "localhost:7860"
+        replace: "localhost:{{port}}"
+      - path: .cog/config/services/mod3.service.yaml
+        type: sed
+        match: "7860"
+        replace: "{{port}}"
+
+  # gateway is the openclaw binary — kernel knows it for dependency-graph
+  # purposes but does not probe or control it. kind: external.
+  gateway:
+    kind: external
+    port: 18789
+    binary: "~/.openclaw/bin/openclaw"
+    command: "{{binary}} gateway"
+    health: /health
+    restart: always
+    depends_on: [kernel]
+    consumers:
+      - path: .cog/config/node/node.json
+        type: json
+        jsonpath: ".network.gateway_port"
+        template: "{{port}}"
+      - path: .cog/config/openclaw-gateway/config.yaml
+        type: sed
+        match: "port: 18789"
+        replace: "port: {{port}}"
+
+  cog-chat:
+    port: 8765
+    binary: apps/web/bin/cog-chat
+    command: "{{binary}}"
+    health: /api/health
+    restart: on-failure
+    depends_on: [kernel]
+    consumers: []
+
+  dashboard:
+    port: 5180
+    command: "cogctl dashboard start"
+    health: /api/status
+    restart: manual
+    depends_on: [kernel]
+    consumers: []
+
+  # ollama is user-managed (install via Homebrew or `ollama serve`).
+  # Kernel probes health but does not control the lifecycle. kind: observed.
+  ollama:
+    kind: observed
+    port: 11434
+    health: /api/tags
+    restart: ""
+    depends_on: []
+    consumers: []
+
+  # openclaw is the OpenClaw server when externally launched (not via gateway).
+  # Kernel probes health but does not control the lifecycle. kind: observed.
+  openclaw:
+    kind: observed
+    port: 18790
+    health: /health
+    restart: ""
+    depends_on: []
+    consumers: []

--- a/internal/engine/node_manifest.go
+++ b/internal/engine/node_manifest.go
@@ -17,8 +17,31 @@ type NodeManifest struct {
 	Services   map[string]ServiceDef `yaml:"services" json:"services"`
 }
 
+// ServiceKind classifies a service by ownership and observability.
+//
+//   - "managed"  (default): kernel orchestrates the lifecycle via a supervisor.
+//   - "observed": kernel probes health but does not control start/stop/restart.
+//   - "external": kernel knows the service exists for dependency-graph purposes
+//     only; it does not probe and does not control.
+type ServiceKind string
+
+const (
+	ServiceKindManaged  ServiceKind = "managed"
+	ServiceKindObserved ServiceKind = "observed"
+	ServiceKindExternal ServiceKind = "external"
+)
+
+// EffectiveKind returns the resolved kind, defaulting to "managed" when unset.
+func (k ServiceKind) EffectiveKind() ServiceKind {
+	if k == "" {
+		return ServiceKindManaged
+	}
+	return k
+}
+
 // ServiceDef describes a single managed service.
 type ServiceDef struct {
+	Kind      ServiceKind     `yaml:"kind,omitempty" json:"kind,omitempty"`
 	Port      int             `yaml:"port" json:"port"`
 	Binary    string          `yaml:"binary,omitempty" json:"binary,omitempty"`
 	Workdir   string          `yaml:"workdir,omitempty" json:"workdir,omitempty"`

--- a/internal/engine/process.go
+++ b/internal/engine/process.go
@@ -765,6 +765,11 @@ func (p *Process) NodeHealth() *NodeHealth {
 	return p.nodeHealth
 }
 
+// NodeManifest returns the parsed node manifest (nil if not loaded).
+func (p *Process) NodeManifest() *NodeManifest {
+	return p.nodeManifest
+}
+
 // emitHeartbeat fires during the dormant state.
 func (p *Process) emitHeartbeat() {
 	// Only emit heartbeat if not already in an active state.

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -184,6 +184,10 @@ func NewServer(cfg *Config, nucleus *Nucleus, process *Process) *Server {
 	// ambient-awareness loop; Phase 1A populates channel.<sid>.activity).
 	s.registerPeerAwarenessRoutes(mux)
 
+	// Read-only services API: GET /v1/services and GET /v1/services/{name}.
+	// Phase 2 will add mutations (start/stop/restart).
+	s.registerServiceRoutes(mux)
+
 	// Replay bus_sessions + bus_handoffs into the in-memory registries so
 	// the kernel starts with an accurate derived view. Bus is authoritative
 	// either way; this just warms the read path.

--- a/internal/engine/serve_manifest.go
+++ b/internal/engine/serve_manifest.go
@@ -123,6 +123,7 @@ func classifyHTTPFamily(path string) string {
 		{"/v1/constellation", "attention"},
 		{"/v1/observer", "attention"},
 		{"/v1/lightcone", "attention"},
+		{"/v1/services", "services"},
 		{"/v1/card", "compat"},
 		{"/v1/providers", "compat"},
 		{"/v1/taa", "compat"},

--- a/internal/engine/serve_services.go
+++ b/internal/engine/serve_services.go
@@ -1,0 +1,182 @@
+// serve_services.go — read-only /v1/services API.
+//
+// Routes:
+//
+//	GET /v1/services         — list all declared services with live health
+//	GET /v1/services/{name}  — single service projection
+//
+// Design:
+//   - Projects from two read sources: the parsed *NodeManifest (static
+//     declaration) and *NodeHealth (last probe snapshot). Both are held on
+//     *Process and accessed through NodeManifest() / NodeHealth() accessors.
+//   - Read-only. Mutations (start / stop / restart) are Phase 2.
+//   - "kind" defaults to "managed" when omitted from the manifest.
+//   - "controllable" is false for observed and external services.
+//
+// Registered via s.route() so the routes auto-appear in GET /v1/manifest.
+package engine
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+// serviceView is the JSON projection returned by /v1/services.
+type serviceView struct {
+	Name            string          `json:"name"`
+	Kind            ServiceKind     `json:"kind"`
+	Port            int             `json:"port"`
+	Supervisor      string          `json:"supervisor"`
+	SupervisorLabel string          `json:"supervisor_label,omitempty"`
+	Controllable    bool            `json:"controllable"`
+	Running         bool            `json:"running"`
+	PID             *int            `json:"pid"`
+	ExitCode        int             `json:"exit_code"`
+	Health          *serviceHealthV `json:"health,omitempty"`
+	DependsOn       []string        `json:"depends_on"`
+	Command         string          `json:"command,omitempty"`
+	RestartPolicy   string          `json:"restart_policy,omitempty"`
+}
+
+// serviceHealthV is the health sub-object embedded in serviceView.
+type serviceHealthV struct {
+	Status   string    `json:"status"`
+	Endpoint string    `json:"endpoint"`
+	ProbedAt time.Time `json:"probed_at"`
+}
+
+// registerServiceRoutes wires GET /v1/services and GET /v1/services/{name}.
+func (s *Server) registerServiceRoutes(mux *http.ServeMux) {
+	s.route(mux, "GET /v1/services", s.handleServicesList)
+	s.route(mux, "GET /v1/services/{name}", s.handleServicesGet)
+}
+
+// handleServicesList returns all declared services sorted by name.
+//
+//	GET /v1/services
+//	200 → { services: [...] }
+func (s *Server) handleServicesList(w http.ResponseWriter, r *http.Request) {
+	manifest := s.process.NodeManifest()
+	if manifest == nil {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"services": []serviceView{},
+		})
+		return
+	}
+
+	healthSnap := s.process.NodeHealth().Snapshot()
+
+	names := make([]string, 0, len(manifest.Services))
+	for name := range manifest.Services {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	views := make([]serviceView, 0, len(names))
+	for _, name := range names {
+		def := manifest.Services[name]
+		views = append(views, projectService(name, def, healthSnap[name]))
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"services": views,
+	})
+}
+
+// handleServicesGet returns a single service by name.
+//
+//	GET /v1/services/{name}
+//	200 → serviceView
+//	404 → { error: "..." }
+func (s *Server) handleServicesGet(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+
+	manifest := s.process.NodeManifest()
+	if manifest == nil {
+		http.Error(w, `{"error":"manifest not loaded"}`, http.StatusNotFound)
+		return
+	}
+
+	def, ok := manifest.Services[name]
+	if !ok {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "service not found: " + name})
+		return
+	}
+
+	healthSnap := s.process.NodeHealth().Snapshot()
+	view := projectService(name, def, healthSnap[name])
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(view)
+}
+
+// projectService converts a ServiceDef + live ServiceHealth into a serviceView.
+// All fields not yet tracked in the manifest (pid, exit_code) are defaulted;
+// Phase 2 will wire live process state.
+func projectService(name string, def ServiceDef, h ServiceHealth) serviceView {
+	kind := def.Kind.EffectiveKind()
+	controllable := kind == ServiceKindManaged
+
+	// Supervisor classification: launchctl if a launchd label is present;
+	// "observer" for observed/external (kernel doesn't supervise them);
+	// "direct" for managed services launched without launchd.
+	var supervisor string
+	switch kind {
+	case ServiceKindObserved, ServiceKindExternal:
+		supervisor = "observer"
+	default:
+		if def.Launchd != "" {
+			supervisor = "launchctl"
+		} else {
+			supervisor = "direct"
+		}
+	}
+
+	// running is inferred from the last health probe. A zero-value
+	// ServiceHealth (no probe yet) reports status "" which is treated as not
+	// running. Phase 2 will wire live pid/exit_code from the supervisor.
+	running := h.Status == "healthy" || h.Status == "degraded"
+
+	var healthV *serviceHealthV
+	if h.Status != "" {
+		healthV = &serviceHealthV{
+			Status:   h.Status,
+			Endpoint: def.Health,
+			ProbedAt: h.At,
+		}
+	}
+
+	dependsOn := def.DependsOn
+	if dependsOn == nil {
+		dependsOn = []string{}
+	}
+
+	// Resolve command template placeholder: {{venv}} → def.Venv path.
+	cmd := def.Command
+	if def.Venv != "" {
+		cmd = strings.ReplaceAll(cmd, "{{venv}}", def.Venv)
+	}
+
+	return serviceView{
+		Name:            name,
+		Kind:            kind,
+		Port:            def.Port,
+		Supervisor:      supervisor,
+		SupervisorLabel: def.Launchd,
+		Controllable:    controllable,
+		Running:         running,
+		PID:             nil, // Phase 2: live process state
+		ExitCode:        0,   // Phase 2: live process state
+		Health:          healthV,
+		DependsOn:       dependsOn,
+		Command:         cmd,
+		RestartPolicy:   def.Restart,
+	}
+}

--- a/internal/engine/serve_services_test.go
+++ b/internal/engine/serve_services_test.go
@@ -1,0 +1,340 @@
+// serve_services_test.go — HTTP handler tests for GET /v1/services.
+//
+// Covers:
+//
+//	GET /v1/services         — list all declared services (list, count, fields)
+//	GET /v1/services/{name}  — single-service projection
+//	kind defaulting           — omitted kind defaults to "managed"
+//	controllable              — false on observed and external services
+//	404                       — unknown service name
+//	nil manifest              — empty response when process has no manifest
+package engine
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// newServicesTestServer returns an HTTP handler backed by a Server wired with
+// the supplied manifest. health is optional; pass nil to skip health wiring.
+func newServicesTestServer(t *testing.T, manifest *NodeManifest, health *NodeHealth) http.Handler {
+	t.Helper()
+	root := t.TempDir()
+	cfg := makeConfig(t, root)
+	nucleus := makeNucleus("Test", "tester")
+	proc := NewProcess(cfg, nucleus)
+
+	// Inject the test manifest and health directly so we don't depend on
+	// disk layout or the heartbeat ticker.
+	proc.nodeManifest = manifest
+	if health != nil {
+		proc.nodeHealth = health
+	}
+
+	srv := NewServer(cfg, nucleus, proc)
+	t.Cleanup(func() {
+		if b := proc.Broker(); b != nil {
+			_ = b.Close()
+		}
+	})
+	return srv.Handler()
+}
+
+// testManifest builds a small NodeManifest for use in multiple test cases.
+func testManifest() *NodeManifest {
+	return &NodeManifest{
+		APIVersion: "cog.os/v1",
+		Kind:       "NodeManifest",
+		Services: map[string]ServiceDef{
+			"kernel": {
+				Port:      6931,
+				Command:   "cogos serve",
+				Health:    "/health",
+				Restart:   "always",
+				Launchd:   "com.cogos.kernel",
+				DependsOn: []string{},
+			},
+			"mod3": {
+				Port:      7860,
+				Command:   "{{venv}}/bin/python server.py",
+				Venv:      "apps/tts-mcp/.venv",
+				Health:    "/health",
+				Restart:   "on-failure",
+				DependsOn: []string{},
+			},
+			"ollama": {
+				Kind:      ServiceKindObserved,
+				Port:      11434,
+				Health:    "/api/tags",
+				DependsOn: []string{},
+			},
+			"gateway": {
+				Kind:      ServiceKindExternal,
+				Port:      18789,
+				Command:   "openclaw gateway",
+				Health:    "/health",
+				Restart:   "always",
+				DependsOn: []string{"kernel"},
+			},
+		},
+	}
+}
+
+// TestServicesList_Count verifies the list endpoint returns all declared services.
+func TestServicesList_Count(t *testing.T) {
+	t.Parallel()
+	handler := newServicesTestServer(t, testManifest(), nil)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/services", nil)
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200; body=%q", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Services []serviceView `json:"services"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Services) != 4 {
+		t.Errorf("len(services) = %d; want 4", len(resp.Services))
+	}
+}
+
+// TestServicesList_SortedByName confirms the list is returned in sorted order.
+func TestServicesList_SortedByName(t *testing.T) {
+	t.Parallel()
+	handler := newServicesTestServer(t, testManifest(), nil)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/services", nil)
+	handler.ServeHTTP(rec, req)
+
+	var resp struct {
+		Services []serviceView `json:"services"`
+	}
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
+
+	names := make([]string, len(resp.Services))
+	for i, s := range resp.Services {
+		names[i] = s.Name
+	}
+	for i := 1; i < len(names); i++ {
+		if names[i-1] > names[i] {
+			t.Errorf("services not sorted: %q before %q", names[i-1], names[i])
+		}
+	}
+}
+
+// TestServicesGet_Single verifies the single-service endpoint returns the
+// correct service and 200 status.
+func TestServicesGet_Single(t *testing.T) {
+	t.Parallel()
+	handler := newServicesTestServer(t, testManifest(), nil)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/services/kernel", nil)
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200; body=%q", rec.Code, rec.Body.String())
+	}
+
+	var view serviceView
+	if err := json.NewDecoder(rec.Body).Decode(&view); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if view.Name != "kernel" {
+		t.Errorf("name = %q; want %q", view.Name, "kernel")
+	}
+	if view.Port != 6931 {
+		t.Errorf("port = %d; want 6931", view.Port)
+	}
+}
+
+// TestServicesGet_NotFound verifies 404 for an unknown service name.
+func TestServicesGet_NotFound(t *testing.T) {
+	t.Parallel()
+	handler := newServicesTestServer(t, testManifest(), nil)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/services/nonexistent", nil)
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d; want 404", rec.Code)
+	}
+}
+
+// TestServicesKindDefaulting verifies that a service with no explicit kind
+// returns "managed" and controllable=true.
+func TestServicesKindDefaulting(t *testing.T) {
+	t.Parallel()
+	// "kernel" and "mod3" have no explicit kind in testManifest().
+	handler := newServicesTestServer(t, testManifest(), nil)
+
+	for _, name := range []string{"kernel", "mod3"} {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/v1/services/"+name, nil)
+			handler.ServeHTTP(rec, req)
+
+			var view serviceView
+			if err := json.NewDecoder(rec.Body).Decode(&view); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if view.Kind != ServiceKindManaged {
+				t.Errorf("kind = %q; want %q", view.Kind, ServiceKindManaged)
+			}
+			if !view.Controllable {
+				t.Errorf("controllable = false; want true for managed service %q", name)
+			}
+		})
+	}
+}
+
+// TestServicesControllableFalseOnObserved verifies controllable=false for
+// "observed" kind services.
+func TestServicesControllableFalseOnObserved(t *testing.T) {
+	t.Parallel()
+	handler := newServicesTestServer(t, testManifest(), nil)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/services/ollama", nil)
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200; body=%q", rec.Code, rec.Body.String())
+	}
+
+	var view serviceView
+	if err := json.NewDecoder(rec.Body).Decode(&view); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if view.Kind != ServiceKindObserved {
+		t.Errorf("kind = %q; want %q", view.Kind, ServiceKindObserved)
+	}
+	if view.Controllable {
+		t.Errorf("controllable = true; want false for observed service")
+	}
+	if view.Supervisor != "observer" {
+		t.Errorf("supervisor = %q; want %q", view.Supervisor, "observer")
+	}
+}
+
+// TestServicesControllableFalseOnExternal verifies controllable=false for
+// "external" kind services.
+func TestServicesControllableFalseOnExternal(t *testing.T) {
+	t.Parallel()
+	handler := newServicesTestServer(t, testManifest(), nil)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/services/gateway", nil)
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200", rec.Code)
+	}
+
+	var view serviceView
+	if err := json.NewDecoder(rec.Body).Decode(&view); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if view.Kind != ServiceKindExternal {
+		t.Errorf("kind = %q; want %q", view.Kind, ServiceKindExternal)
+	}
+	if view.Controllable {
+		t.Errorf("controllable = true; want false for external service")
+	}
+}
+
+// TestServicesList_NilManifest verifies the list endpoint returns an empty
+// services array (not an error) when no manifest is loaded.
+func TestServicesList_NilManifest(t *testing.T) {
+	t.Parallel()
+	handler := newServicesTestServer(t, nil, nil)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/services", nil)
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200", rec.Code)
+	}
+
+	var resp struct {
+		Services []serviceView `json:"services"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Services) != 0 {
+		t.Errorf("len(services) = %d; want 0 for nil manifest", len(resp.Services))
+	}
+}
+
+// TestServicesHealthProjection verifies that health probe data is surfaced
+// in the response when available.
+func TestServicesHealthProjection(t *testing.T) {
+	t.Parallel()
+
+	nh := NewNodeHealth()
+	// Manually inject a health snapshot for "mod3".
+	nh.mu.Lock()
+	nh.services["mod3"] = ServiceHealth{
+		Port:   7860,
+		Status: "healthy",
+	}
+	nh.mu.Unlock()
+
+	handler := newServicesTestServer(t, testManifest(), nh)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/services/mod3", nil)
+	handler.ServeHTTP(rec, req)
+
+	var view serviceView
+	if err := json.NewDecoder(rec.Body).Decode(&view); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !view.Running {
+		t.Errorf("running = false; want true when health status is 'healthy'")
+	}
+	if view.Health == nil {
+		t.Fatal("health = nil; want non-nil when probe data is available")
+	}
+	if view.Health.Status != "healthy" {
+		t.Errorf("health.status = %q; want %q", view.Health.Status, "healthy")
+	}
+	if view.Health.Endpoint != "/health" {
+		t.Errorf("health.endpoint = %q; want %q", view.Health.Endpoint, "/health")
+	}
+}
+
+// TestServicesLaunchdSupervisor verifies supervisor="launchctl" when
+// the service has a launchd label.
+func TestServicesLaunchdSupervisor(t *testing.T) {
+	t.Parallel()
+	handler := newServicesTestServer(t, testManifest(), nil)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/services/kernel", nil)
+	handler.ServeHTTP(rec, req)
+
+	var view serviceView
+	_ = json.NewDecoder(rec.Body).Decode(&view)
+
+	if view.Supervisor != "launchctl" {
+		t.Errorf("supervisor = %q; want %q", view.Supervisor, "launchctl")
+	}
+	if view.SupervisorLabel != "com.cogos.kernel" {
+		t.Errorf("supervisor_label = %q; want %q", view.SupervisorLabel, "com.cogos.kernel")
+	}
+}


### PR DESCRIPTION
Closes #99. Part of #98.

## Summary

Implements Phase 1 of the services umbrella: exposes the existing \`NodeManifest\` + \`NodeHealth.Probe()\` data through HTTP. Read-only. No new dependencies, no design risk.

- New \`GET /v1/services\` and \`GET /v1/services/{name}\` endpoints in \`internal/engine/serve_services.go\`.
- \`ServiceDef.Kind\` discriminator added with \`omitempty\` semantics (default \`managed\`; values \`managed | observed | external\`).
- Manifest YAML updated: \`gateway\` reclassified as \`external\`; stub \`ollama\` and \`openclaw\` entries added as \`observed\`.
- \`family: \"services\"\` added to \`classifyHTTPFamily\` so the routes auto-appear in \`/v1/manifest\`.
- 10 \`TestServices*\` cases covering list, single, sorting, kind defaulting, controllable=false on observed/external, nil manifest, health projection, launchd supervisor.

\`make test\` passes (engine package green; pre-existing root-package \`TestQueryConstellationWithIris_FallbackToStandard\` failure is unrelated and tracked separately).

## Notes for review

- This commit adds \`.cog/config/node/manifest.yaml\` to the repo (was previously workspace-local). Revert commit \`2b1ceca\` if that wasn't intended.
- Phase 2 (#100) will wire live \`pid\` / \`exit_code\` from the supervisor; today they're nil/0.
- Command-template substitution currently only resolves \`{{venv}}\`; \`{{port}}\`, \`{{workspace}}\`, \`{{binary}}\` remain literal in API responses.
- Out of scope: mutation endpoints, \`LaunchctlController\`. Phase 2.

## Test plan

- [x] \`make test\` passes
- [ ] Manual: \`curl localhost:6931/v1/services\` returns the four declared services + observed entries
- [ ] Manual: \`controllable: false\` on observed/external entries
- [ ] Manual: \`/v1/services/mod3\` returns single-service projection