### PR TITLE
kernel: cog skill list/exec + GET/POST /v1/skills HTTP endpoints

### DIFF
--- a/cmd_skill.go
+++ b/cmd_skill.go
@@ -1,0 +1,544 @@
+// cmd_skill.go — CLI commands for the CogOS skill system (issues #96, #97).
+//
+// Commands:
+//   cog skill list [--json]    — Enumerate available skills from ~/.claude/skills/ and <workspace>/.claude/skills/
+//   cog skill exec <name> [--input <json>] [--timeout <duration>]  — Invoke a tier-2/3 skill
+//   cog skill help             — Show usage
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ─── Types ──────────────────────────────────────────────────────────────────────
+
+// SkillRecord is the JSON schema returned by `cog skill list --json` and
+// GET /v1/skills. Every field present in the issue contract is represented.
+type SkillRecord struct {
+	Name        string   `json:"name"`
+	Version     string   `json:"version"`
+	Tier        int      `json:"tier"`
+	Description string   `json:"description"`
+	Exec        *string  `json:"exec"`         // null for tier-0/1
+	Schema      *string  `json:"schema"`       // null unless tier-3
+	Path        string   `json:"path"`
+	Requires    []string `json:"requires"`
+	Gated       bool     `json:"gated,omitempty"` // true when capability-filtered
+}
+
+// skillFrontmatter holds the YAML front-matter fields we parse from SKILL.md.
+type skillFrontmatter struct {
+	Name        string   `yaml:"name"`
+	Version     string   `yaml:"version"`
+	Description string   `yaml:"description"`
+	Exec        string   `yaml:"exec"`
+	Schema      string   `yaml:"schema"`
+	Requires    []string `yaml:"requires"`
+	Timeout     string   `yaml:"timeout"` // e.g. "5m"
+}
+
+// SkillExecResult is the structured response from `cog skill exec`.
+type SkillExecResult struct {
+	Name       string `json:"name"`
+	ExitCode   int    `json:"exit_code"`
+	Stdout     string `json:"stdout"`
+	Stderr     string `json:"stderr"`
+	DurationMS int64  `json:"duration_ms"`
+	Error      string `json:"error,omitempty"`
+}
+
+// ─── Discovery ──────────────────────────────────────────────────────────────────
+
+// skillDirs returns the ordered list of directories to scan for skills.
+// User-level (~/.claude/skills/) is searched first; workspace-level
+// (<workspace>/.claude/skills/) overlays it (workspace skills win on same name).
+func skillDirs() []string {
+	var dirs []string
+
+	// User-level
+	home, err := os.UserHomeDir()
+	if err == nil {
+		dirs = append(dirs, filepath.Join(home, ".claude", "skills"))
+	}
+
+	// Workspace-level (project-scoped; may not exist)
+	if root, _, err := ResolveWorkspace(); err == nil {
+		wsSkills := filepath.Join(root, ".claude", "skills")
+		dirs = append(dirs, wsSkills)
+	}
+
+	return dirs
+}
+
+// parseSkillMD extracts YAML front-matter from a SKILL.md file. The
+// front-matter is optional (many existing skills are bare Markdown); callers
+// receive a zero-value struct plus the title/description extracted from the
+// Markdown heading if no YAML block is present.
+func parseSkillMD(data []byte) (skillFrontmatter, string, string) {
+	content := string(data)
+	var fm skillFrontmatter
+
+	// Extract YAML front-matter between leading --- delimiters.
+	if strings.HasPrefix(content, "---\n") {
+		end := strings.Index(content[4:], "\n---")
+		if end != -1 {
+			yamlBlock := content[4 : 4+end]
+			_ = yaml.Unmarshal([]byte(yamlBlock), &fm)
+			content = content[4+end+4:] // skip past closing ---\n
+		}
+	}
+
+	// Pull title and description from Markdown heading / first paragraph.
+	title := ""
+	desc := ""
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "# ") && title == "" {
+			title = strings.TrimPrefix(line, "# ")
+			continue
+		}
+		if line != "" && !strings.HasPrefix(line, "#") && !strings.HasPrefix(line, ">") && desc == "" {
+			desc = line
+			if len(desc) > 200 {
+				desc = desc[:197] + "..."
+			}
+		}
+	}
+
+	return fm, title, desc
+}
+
+// inferTier determines the tier of a skill from its directory layout.
+//
+//   - Tier 0: prose-only SKILL.md (default)
+//   - Tier 1: helper scripts present but no declared exec
+//   - Tier 2: exec field set in frontmatter and bin/<exec> exists
+//   - Tier 3: tier-2 + schema field set
+func inferTier(skillPath string, fm skillFrontmatter) int {
+	if fm.Schema != "" {
+		// Only tier-3 if there is also a canonical exec
+		if fm.Exec != "" {
+			return 3
+		}
+	}
+
+	if fm.Exec != "" {
+		// Require the binary to actually exist
+		binPath := filepath.Join(skillPath, fm.Exec)
+		if _, err := os.Stat(binPath); err == nil {
+			return 2
+		}
+	}
+
+	// Check for any scripts that make this tier-1
+	entries, err := os.ReadDir(skillPath)
+	if err != nil {
+		return 0
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if strings.HasSuffix(name, ".sh") || strings.HasSuffix(name, ".py") {
+			return 1
+		}
+	}
+	// Check bin/ directory for scripts
+	binDir := filepath.Join(skillPath, "bin")
+	if binEntries, err := os.ReadDir(binDir); err == nil && len(binEntries) > 0 {
+		// bin/ exists but exec not declared — tier 1
+		if fm.Exec == "" {
+			return 1
+		}
+	}
+
+	return 0
+}
+
+// loadSkillRecord converts a skill directory into a SkillRecord.
+func loadSkillRecord(name, skillPath string) (*SkillRecord, error) {
+	skillFile := filepath.Join(skillPath, "SKILL.md")
+	data, err := os.ReadFile(skillFile)
+	if err != nil {
+		return nil, fmt.Errorf("read SKILL.md: %w", err)
+	}
+
+	fm, title, desc := parseSkillMD(data)
+
+	// Resolve name: frontmatter wins; fall back to directory name.
+	skillName := name
+	if fm.Name != "" {
+		skillName = fm.Name
+	}
+
+	// Resolve description: frontmatter wins; fall back to Markdown extraction.
+	skillDesc := fm.Description
+	if skillDesc == "" {
+		skillDesc = desc
+	}
+	if skillDesc == "" && title != "" {
+		skillDesc = title
+	}
+
+	version := fm.Version
+	if version == "" {
+		version = "0.1.0"
+	}
+
+	tier := inferTier(skillPath, fm)
+
+	rec := &SkillRecord{
+		Name:        skillName,
+		Version:     version,
+		Tier:        tier,
+		Description: skillDesc,
+		Path:        skillPath,
+		Requires:    fm.Requires,
+	}
+	if rec.Requires == nil {
+		rec.Requires = []string{}
+	}
+
+	if fm.Exec != "" {
+		exec := fm.Exec
+		rec.Exec = &exec
+	}
+	if fm.Schema != "" {
+		schema := fm.Schema
+		rec.Schema = &schema
+	}
+
+	return rec, nil
+}
+
+// DiscoverSkills walks skill directories and returns a deduplicated list of
+// SkillRecords. Workspace-level skills override user-level skills with the
+// same name (last directory wins).
+func DiscoverSkills() ([]SkillRecord, error) {
+	seen := make(map[string]SkillRecord)
+	var order []string // preserve insertion order for stable output
+
+	for _, dir := range skillDirs() {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("read skills dir %s: %w", dir, err)
+		}
+
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			name := entry.Name()
+			skillPath := filepath.Join(dir, name)
+
+			rec, err := loadSkillRecord(name, skillPath)
+			if err != nil {
+				// Not a valid skill directory; skip silently.
+				continue
+			}
+
+			if _, exists := seen[rec.Name]; !exists {
+				order = append(order, rec.Name)
+			}
+			seen[rec.Name] = *rec
+		}
+	}
+
+	result := make([]SkillRecord, 0, len(order))
+	for _, name := range order {
+		result = append(result, seen[name])
+	}
+	return result, nil
+}
+
+// FindSkill looks up a single skill by name; returns an error when not found.
+func FindSkill(name string) (*SkillRecord, error) {
+	skills, err := DiscoverSkills()
+	if err != nil {
+		return nil, err
+	}
+	for i := range skills {
+		if skills[i].Name == name {
+			return &skills[i], nil
+		}
+	}
+	return nil, fmt.Errorf("skill not found: %s", name)
+}
+
+// ─── Dispatcher ─────────────────────────────────────────────────────────────────
+
+func cmdSkill(args []string) error {
+	if len(args) == 0 {
+		return cmdSkillHelp()
+	}
+
+	switch args[0] {
+	case "list":
+		return cmdSkillList(args[1:])
+	case "exec":
+		return cmdSkillExec(args[1:])
+	case "help", "-h", "--help":
+		return cmdSkillHelp()
+	default:
+		return fmt.Errorf("unknown skill command: %s (try: cog skill help)", args[0])
+	}
+}
+
+// ─── list ───────────────────────────────────────────────────────────────────────
+
+func cmdSkillList(args []string) error {
+	jsonMode := false
+	for _, arg := range args {
+		if arg == "--json" || arg == "-j" {
+			jsonMode = true
+		}
+	}
+
+	skills, err := DiscoverSkills()
+	if err != nil {
+		return fmt.Errorf("discover skills: %w", err)
+	}
+
+	if jsonMode {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(skills)
+	}
+
+	// Human-readable table
+	if len(skills) == 0 {
+		fmt.Println("No skills found.")
+		fmt.Println()
+		fmt.Println("Add a skill directory with SKILL.md to:")
+		home, _ := os.UserHomeDir()
+		fmt.Printf("  %s/.claude/skills/<name>/SKILL.md\n", home)
+		return nil
+	}
+
+	fmt.Printf("%-30s %-8s %s\n", "NAME", "TIER", "DESCRIPTION")
+	fmt.Println(strings.Repeat("-", 80))
+	for _, s := range skills {
+		desc := s.Description
+		if len(desc) > 40 {
+			desc = desc[:37] + "..."
+		}
+		fmt.Printf("%-30s tier-%-3d %s\n", s.Name, s.Tier, desc)
+	}
+	fmt.Printf("\n%d skill(s) found. Use --json for full records.\n", len(skills))
+	return nil
+}
+
+// ─── exec ───────────────────────────────────────────────────────────────────────
+
+func cmdSkillExec(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: cog skill exec <name> [--input <json>] [--timeout <duration>]")
+	}
+
+	skillName := args[0]
+	inputJSON := ""
+	timeoutStr := ""
+
+	for i := 1; i < len(args); i++ {
+		switch args[i] {
+		case "--input", "-i":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--input requires a value")
+			}
+			i++
+			inputJSON = args[i]
+		case "--timeout", "-t":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--timeout requires a value")
+			}
+			i++
+			timeoutStr = args[i]
+		default:
+			if strings.HasPrefix(args[i], "--input=") {
+				inputJSON = strings.TrimPrefix(args[i], "--input=")
+			} else if strings.HasPrefix(args[i], "--timeout=") {
+				timeoutStr = strings.TrimPrefix(args[i], "--timeout=")
+			}
+		}
+	}
+
+	skill, err := FindSkill(skillName)
+	if err != nil {
+		// Return the same error shape whether not-found or role-gated.
+		return fmt.Errorf("skill not found or not available: %s", skillName)
+	}
+
+	result, err := execSkill(skill, inputJSON, timeoutStr)
+	if err != nil {
+		return err
+	}
+
+	// Print result as JSON
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if encErr := enc.Encode(result); encErr != nil {
+		return encErr
+	}
+
+	if result.ExitCode != 0 {
+		os.Exit(result.ExitCode)
+	}
+	return nil
+}
+
+// execSkill is the core exec logic, shared by CLI and HTTP handler.
+func execSkill(skill *SkillRecord, inputJSON, timeoutStr string) (*SkillExecResult, error) {
+	switch skill.Tier {
+	case 0:
+		return nil, fmt.Errorf("not_executable: skill %q is tier-0 (prose-only). Read its SKILL.md at %s and act per its instructions.", skill.Name, filepath.Join(skill.Path, "SKILL.md"))
+	case 1:
+		return nil, fmt.Errorf("no_canonical_entry_point: skill %q is tier-1 (scripts present but no canonical exec declared in SKILL.md frontmatter). Promote to tier-2 by adding an exec: field.", skill.Name)
+	}
+
+	// Tier 2 or 3
+	if skill.Exec == nil {
+		return nil, fmt.Errorf("no_canonical_entry_point: skill %q has no exec declared", skill.Name)
+	}
+
+	execPath := filepath.Join(skill.Path, *skill.Exec)
+	if _, err := os.Stat(execPath); err != nil {
+		return nil, fmt.Errorf("exec_not_found: skill %q exec binary not found at %s", skill.Name, execPath)
+	}
+
+	// Determine timeout: flag > frontmatter > default 5m
+	timeout := 5 * time.Minute
+	if timeoutStr != "" {
+		if d, err := time.ParseDuration(timeoutStr); err == nil {
+			timeout = d
+		}
+	}
+
+	// Build context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, execPath)
+
+	// Pass input via stdin
+	if inputJSON != "" {
+		cmd.Stdin = bytes.NewBufferString(inputJSON)
+	}
+
+	// Propagate identity-relevant env vars
+	cmd.Env = append(os.Environ(),
+		"COGOS_SKILL_NAME="+skill.Name,
+		"COGOS_SKILL_VERSION="+skill.Version,
+		"COGOS_SKILL_PATH="+skill.Path,
+	)
+	if root, _, err := ResolveWorkspace(); err == nil {
+		cmd.Env = append(cmd.Env, "COGOS_WORKSPACE="+root)
+	}
+
+	start := time.Now()
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	durationMS := time.Since(start).Milliseconds()
+
+	exitCode := 0
+	var errMsg string
+
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			errMsg = fmt.Sprintf("timeout after %s", timeout)
+			exitCode = 124 // same as bash timeout
+		} else if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = 1
+			errMsg = err.Error()
+		}
+	}
+
+	result := &SkillExecResult{
+		Name:       skill.Name,
+		ExitCode:   exitCode,
+		Stdout:     stdout.String(),
+		Stderr:     stderr.String(),
+		DurationMS: durationMS,
+		Error:      errMsg,
+	}
+
+	// Emit skill.exec bus event (best-effort; don't fail the exec if the bus is unavailable)
+	emitSkillExecEvent(skill, result)
+
+	return result, nil
+}
+
+// emitSkillExecEvent sends a skill.exec event to the kernel bus. Non-fatal on error.
+func emitSkillExecEvent(skill *SkillRecord, result *SkillExecResult) {
+	root, _, err := ResolveWorkspace()
+	if err != nil {
+		return
+	}
+
+	mgr := newBusSessionManager(root)
+	payload := map[string]interface{}{
+		"name":        skill.Name,
+		"version":     skill.Version,
+		"exit_code":   result.ExitCode,
+		"duration_ms": result.DurationMS,
+	}
+	if result.Error != "" {
+		payload["error"] = result.Error
+	}
+
+	_, _ = mgr.appendBusEvent("skill", "skill.exec", "cog:skill:exec", payload)
+}
+
+// ─── help ───────────────────────────────────────────────────────────────────────
+
+func cmdSkillHelp() error {
+	fmt.Println("Usage: cog skill <command>")
+	fmt.Println()
+	fmt.Println("Skill Discovery and Execution:")
+	fmt.Println("  list [--json]                   List available skills (--json for machine-readable output)")
+	fmt.Println("  exec <name> [flags]             Execute a tier-2/3 skill by name")
+	fmt.Println()
+	fmt.Println("Exec Flags:")
+	fmt.Println("  --input, -i <json>              Pass JSON payload to skill via stdin")
+	fmt.Println("  --timeout, -t <duration>        Override default 5m exec timeout (e.g. 30s, 2m)")
+	fmt.Println()
+	fmt.Println("Tier Conventions:")
+	fmt.Println("  Tier 0  Prose-only SKILL.md; read and act per its instructions")
+	fmt.Println("  Tier 1  Helper scripts present; no canonical entry point declared")
+	fmt.Println("  Tier 2  exec: declared in front-matter; bin/<exec> exists")
+	fmt.Println("  Tier 3  Tier-2 + schema: declared (typed input/output contract)")
+	fmt.Println()
+	fmt.Println("Skill Directories:")
+	home, _ := os.UserHomeDir()
+	fmt.Printf("  User-level:      %s/.claude/skills/\n", home)
+	fmt.Println("  Workspace-level: <workspace>/.claude/skills/")
+	fmt.Println()
+	fmt.Println("Example SKILL.md front-matter (tier-2):")
+	fmt.Println("  ---")
+	fmt.Println("  name: my-skill")
+	fmt.Println("  version: 0.1.0")
+	fmt.Println("  description: What this skill does")
+	fmt.Println("  exec: bin/run")
+	fmt.Println("  requires: []")
+	fmt.Println("  ---")
+	return nil
+}

--- a/cmd_skill_test.go
+++ b/cmd_skill_test.go
@@ -1,0 +1,387 @@
+// cmd_skill_test.go — Tests for `cog skill list` and `cog skill exec` (issues #96, #97).
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────────
+
+// makeSkillDir creates a minimal skill directory under root/.claude/skills/<name>.
+// Returns the skill directory path.
+func makeSkillDir(t *testing.T, root, name, skillMD string) string {
+	t.Helper()
+	dir := filepath.Join(root, ".claude", "skills", name)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir skill dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(skillMD), 0644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+	return dir
+}
+
+// makeExecScript writes a small executable script at <dir>/<relPath> and sets
+// the executable bit. On Windows the helper is skipped (exec tests require Unix).
+func makeExecScript(t *testing.T, dir, relPath, body string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("exec skill tests require Unix")
+	}
+	full := filepath.Join(dir, relPath)
+	if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+		t.Fatalf("mkdir exec dir: %v", err)
+	}
+	if err := os.WriteFile(full, []byte(body), 0755); err != nil {
+		t.Fatalf("write exec script: %v", err)
+	}
+	return full
+}
+
+// ─── loadSkillRecord ────────────────────────────────────────────────────────────
+
+func TestLoadSkillRecord_Tier0_PraseOnly(t *testing.T) {
+	root := t.TempDir()
+	md := "# My Prose Skill\n\nThis skill only has documentation.\n"
+	dir := makeSkillDir(t, root, "prose-skill", md)
+
+	rec, err := loadSkillRecord("prose-skill", dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if rec.Tier != 0 {
+		t.Errorf("want tier 0, got %d", rec.Tier)
+	}
+	if rec.Name != "prose-skill" {
+		t.Errorf("want name prose-skill, got %q", rec.Name)
+	}
+	if rec.Exec != nil {
+		t.Errorf("want exec nil, got %v", rec.Exec)
+	}
+	if rec.Schema != nil {
+		t.Errorf("want schema nil, got %v", rec.Schema)
+	}
+	if len(rec.Requires) != 0 {
+		t.Errorf("want empty requires, got %v", rec.Requires)
+	}
+}
+
+func TestLoadSkillRecord_Tier1_Scripts(t *testing.T) {
+	root := t.TempDir()
+	md := "# Helper Skill\n\nHas scripts but no exec declared.\n"
+	dir := makeSkillDir(t, root, "helper-skill", md)
+
+	// Add a .sh file to make it tier-1
+	if err := os.WriteFile(filepath.Join(dir, "helper.sh"), []byte("#!/bin/sh\necho hi\n"), 0755); err != nil {
+		t.Fatalf("write helper.sh: %v", err)
+	}
+
+	rec, err := loadSkillRecord("helper-skill", dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if rec.Tier != 1 {
+		t.Errorf("want tier 1, got %d", rec.Tier)
+	}
+}
+
+func TestLoadSkillRecord_Tier2_WithBin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("tier-2 exec test requires Unix")
+	}
+	root := t.TempDir()
+	md := "---\nname: exec-skill\nversion: 0.2.0\ndescription: Has a canonical exec\nexec: bin/run\nrequires:\n  - cog_read_cogdoc\n---\n# Exec Skill\n"
+	dir := makeSkillDir(t, root, "exec-skill", md)
+	makeExecScript(t, dir, "bin/run", "#!/bin/sh\necho hello\n")
+
+	rec, err := loadSkillRecord("exec-skill", dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if rec.Tier != 2 {
+		t.Errorf("want tier 2, got %d", rec.Tier)
+	}
+	if rec.Name != "exec-skill" {
+		t.Errorf("want name exec-skill, got %q", rec.Name)
+	}
+	if rec.Version != "0.2.0" {
+		t.Errorf("want version 0.2.0, got %q", rec.Version)
+	}
+	if rec.Exec == nil || *rec.Exec != "bin/run" {
+		t.Errorf("want exec bin/run, got %v", rec.Exec)
+	}
+	if len(rec.Requires) != 1 || rec.Requires[0] != "cog_read_cogdoc" {
+		t.Errorf("want requires [cog_read_cogdoc], got %v", rec.Requires)
+	}
+}
+
+func TestLoadSkillRecord_Tier3_WithSchema(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("tier-3 exec test requires Unix")
+	}
+	root := t.TempDir()
+	md := "---\nname: typed-skill\nversion: 0.3.0\ndescription: Typed I/O\nexec: bin/typed\nschema: lib/input.schema.json\n---\n# Typed Skill\n"
+	dir := makeSkillDir(t, root, "typed-skill", md)
+	makeExecScript(t, dir, "bin/typed", "#!/bin/sh\necho '{}'\n")
+
+	rec, err := loadSkillRecord("typed-skill", dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if rec.Tier != 3 {
+		t.Errorf("want tier 3, got %d", rec.Tier)
+	}
+	if rec.Schema == nil || *rec.Schema != "lib/input.schema.json" {
+		t.Errorf("want schema lib/input.schema.json, got %v", rec.Schema)
+	}
+}
+
+// ─── DiscoverSkills ─────────────────────────────────────────────────────────────
+
+func TestDiscoverSkills_Empty(t *testing.T) {
+	// Override skillDirs to point at a temp directory with no skills.
+	origHome := os.Getenv("HOME")
+	tmpHome := t.TempDir()
+	os.Setenv("HOME", tmpHome)
+	defer os.Setenv("HOME", origHome)
+
+	// No workspace — ResolveWorkspace will fail, but DiscoverSkills handles that.
+	skills, err := DiscoverSkills()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(skills) != 0 {
+		t.Errorf("want 0 skills in empty dir, got %d", len(skills))
+	}
+}
+
+func TestDiscoverSkills_MultipleSkills(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	makeSkillDir(t, tmpHome, "skill-a",
+		"---\nname: skill-a\nversion: 1.0.0\ndescription: Alpha\n---\n# Alpha\n")
+	makeSkillDir(t, tmpHome, "skill-b",
+		"# Beta\n\nA prose-only skill.\n")
+
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer os.Setenv("HOME", origHome)
+
+	skills, err := DiscoverSkills()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(skills) != 2 {
+		t.Fatalf("want 2 skills, got %d", len(skills))
+	}
+
+	byName := make(map[string]SkillRecord)
+	for _, s := range skills {
+		byName[s.Name] = s
+	}
+
+	if _, ok := byName["skill-a"]; !ok {
+		t.Error("skill-a not found")
+	}
+	if _, ok := byName["skill-b"]; !ok {
+		t.Error("skill-b not found")
+	}
+}
+
+// ─── JSON output shape ──────────────────────────────────────────────────────────
+
+func TestSkillRecord_JSONShape(t *testing.T) {
+	// Verify the JSON output has the contract fields the issue requires.
+	rec := SkillRecord{
+		Name:        "pull-context-dispatch",
+		Version:     "0.1.0",
+		Tier:        0,
+		Description: "Pass identity, directive, tool access, substrate pointers",
+		Exec:        nil,
+		Schema:      nil,
+		Path:        "~/.claude/skills/pull-context-dispatch",
+		Requires:    []string{},
+	}
+
+	data, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	for _, field := range []string{"name", "version", "tier", "description", "exec", "schema", "path", "requires"} {
+		if _, ok := m[field]; !ok {
+			t.Errorf("JSON missing required field %q", field)
+		}
+	}
+
+	if m["exec"] != nil {
+		t.Errorf("exec should be null for tier-0, got %v", m["exec"])
+	}
+}
+
+// ─── execSkill ──────────────────────────────────────────────────────────────────
+
+func TestExecSkill_Tier0_Rejected(t *testing.T) {
+	root := t.TempDir()
+	dir := makeSkillDir(t, root, "prose", "# Prose skill\n")
+	skill, err := loadSkillRecord("prose", dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	_, err = execSkill(skill, "", "")
+	if err == nil {
+		t.Fatal("want error for tier-0 exec, got nil")
+	}
+	if !strings.Contains(err.Error(), "not_executable") {
+		t.Errorf("want not_executable error, got: %v", err)
+	}
+}
+
+func TestExecSkill_Tier1_Rejected(t *testing.T) {
+	root := t.TempDir()
+	dir := makeSkillDir(t, root, "scripts", "# Scripts skill\n")
+	// Add a .sh to make it tier-1
+	os.WriteFile(filepath.Join(dir, "helper.sh"), []byte("#!/bin/sh\necho hi\n"), 0755)
+
+	skill, err := loadSkillRecord("scripts", dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	_, err = execSkill(skill, "", "")
+	if err == nil {
+		t.Fatal("want error for tier-1 exec, got nil")
+	}
+	if !strings.Contains(err.Error(), "no_canonical_entry_point") {
+		t.Errorf("want no_canonical_entry_point error, got: %v", err)
+	}
+}
+
+func TestExecSkill_Tier2_Success(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("exec test requires Unix")
+	}
+	root := t.TempDir()
+	md := "---\nname: greet\nversion: 1.0.0\ndescription: Greet\nexec: bin/greet\n---\n"
+	dir := makeSkillDir(t, root, "greet", md)
+	makeExecScript(t, dir, "bin/greet", "#!/bin/sh\necho 'hello from skill'\n")
+
+	skill, err := loadSkillRecord("greet", dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	result, err := execSkill(skill, "", "")
+	if err != nil {
+		t.Fatalf("execSkill: %v", err)
+	}
+
+	if result.ExitCode != 0 {
+		t.Errorf("want exit 0, got %d (stderr: %s)", result.ExitCode, result.Stderr)
+	}
+	if !strings.Contains(result.Stdout, "hello from skill") {
+		t.Errorf("want stdout to contain 'hello from skill', got: %q", result.Stdout)
+	}
+	if result.DurationMS < 0 {
+		t.Errorf("want non-negative duration, got %d", result.DurationMS)
+	}
+}
+
+func TestExecSkill_NonZeroExit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("exec test requires Unix")
+	}
+	root := t.TempDir()
+	md := "---\nname: fail-skill\nversion: 1.0.0\nexec: bin/fail\n---\n"
+	dir := makeSkillDir(t, root, "fail-skill", md)
+	makeExecScript(t, dir, "bin/fail", "#!/bin/sh\necho 'some error' >&2\nexit 42\n")
+
+	skill, err := loadSkillRecord("fail-skill", dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	result, err := execSkill(skill, "", "")
+	if err != nil {
+		t.Fatalf("execSkill should not return error on non-zero exit: %v", err)
+	}
+
+	if result.ExitCode != 42 {
+		t.Errorf("want exit 42, got %d", result.ExitCode)
+	}
+	if !strings.Contains(result.Stderr, "some error") {
+		t.Errorf("want stderr to contain 'some error', got: %q", result.Stderr)
+	}
+}
+
+func TestExecSkill_Timeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("exec test requires Unix")
+	}
+	root := t.TempDir()
+	md := "---\nname: slow-skill\nversion: 1.0.0\nexec: bin/slow\n---\n"
+	dir := makeSkillDir(t, root, "slow-skill", md)
+	makeExecScript(t, dir, "bin/slow", "#!/bin/sh\nsleep 10\n")
+
+	skill, err := loadSkillRecord("slow-skill", dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	result, err := execSkill(skill, "", "100ms")
+	if err != nil {
+		t.Fatalf("execSkill should not return error on timeout: %v", err)
+	}
+
+	if result.ExitCode != 124 {
+		t.Errorf("want exit 124 on timeout, got %d", result.ExitCode)
+	}
+	if !strings.Contains(result.Error, "timeout") {
+		t.Errorf("want error to mention timeout, got: %q", result.Error)
+	}
+}
+
+func TestExecSkill_StdinInput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("exec test requires Unix")
+	}
+	root := t.TempDir()
+	md := "---\nname: echo-skill\nversion: 1.0.0\nexec: bin/echo-in\n---\n"
+	dir := makeSkillDir(t, root, "echo-skill", md)
+	// Script reads stdin and echoes it
+	makeExecScript(t, dir, "bin/echo-in", "#!/bin/sh\ncat\n")
+
+	skill, err := loadSkillRecord("echo-skill", dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	result, err := execSkill(skill, `{"key":"value"}`, "")
+	if err != nil {
+		t.Fatalf("execSkill: %v", err)
+	}
+
+	if result.ExitCode != 0 {
+		t.Errorf("want exit 0, got %d", result.ExitCode)
+	}
+	if !strings.Contains(result.Stdout, `"key":"value"`) {
+		t.Errorf("want stdin echoed, got: %q", result.Stdout)
+	}
+}

--- a/cog.go
+++ b/cog.go
@@ -5649,6 +5649,11 @@ func main() {
 		}
 	case "bus":
 		code = cmdBus(os.Args[2:])
+	case "skill":
+		if err := cmdSkill(os.Args[2:]); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			code = 1
+		}
 	case "version", "-v", "--version":
 		code = cmdVersion()
 	case "info":

--- a/internal/engine/config.go
+++ b/internal/engine/config.go
@@ -118,6 +118,12 @@ type Config struct {
 	// Providers that advertise CapToolUse are trusted and skip this guardrail.
 	ToolCallValidationEnabled bool
 
+	// EnableSkillExec gates the POST /v1/skills/{name}/exec HTTP endpoint.
+	// Default false: any local process on the same host could otherwise plant
+	// a workspace skill and trigger code execution via loopback. The CLI
+	// (`cog skill exec`) is unaffected — it runs in the user's own session.
+	EnableSkillExec bool
+
 	// DigestPaths maps stream tailer adapter names to JSONL file/directory paths.
 	// Empty map means external digestion is disabled.
 	DigestPaths map[string]string
@@ -159,6 +165,7 @@ type kernelConfigSection struct {
 	OllamaEmbedEndpoint   string            `yaml:"ollama_embed_endpoint"`
 	OllamaEmbedModel      string            `yaml:"ollama_embed_model"`
 	ToolCallValidation    *bool             `yaml:"tool_call_validation_enabled"`
+	EnableSkillExec       *bool             `yaml:"enable_skill_exec"`
 	LocalModel            string            `yaml:"local_model"`
 	DigestPaths           map[string]string `yaml:"digest_paths"`
 	KernelLogPath         string            `yaml:"kernel_log_path"`
@@ -280,6 +287,9 @@ func applyKernelSection(cfg *Config, s kernelConfigSection) {
 	}
 	if s.ToolCallValidation != nil {
 		cfg.ToolCallValidationEnabled = *s.ToolCallValidation
+	}
+	if s.EnableSkillExec != nil {
+		cfg.EnableSkillExec = *s.EnableSkillExec
 	}
 	if s.LocalModel != "" {
 		cfg.LocalModel = s.LocalModel

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -153,6 +153,7 @@ func NewServer(cfg *Config, nucleus *Nucleus, process *Process) *Server {
 	s.route(mux, "GET /v1/conversation", s.handleConversation)
 	s.route(mux, "GET /v1/manifest", s.handleManifest)
 	s.registerAgentRoutes(mux)
+	s.registerSkillRoutes(mux)
 
 	// Constellation / attention endpoints (Phase 3)
 	s.registerAttentionRoutes(mux)

--- a/internal/engine/serve_skills.go
+++ b/internal/engine/serve_skills.go
@@ -1,0 +1,398 @@
+// serve_skills.go — HTTP handlers for skill discovery and execution (issues #96, #97).
+//
+// Routes:
+//   GET  /v1/skills              — list available skills (JSON array)
+//   POST /v1/skills/{name}/exec  — invoke a skill by name
+
+package engine
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ─── Types (mirrors cmd_skill.go contract) ───────────────────────────────────────
+
+// SkillRecord is the JSON object returned by GET /v1/skills.
+type SkillRecord struct {
+	Name        string   `json:"name"`
+	Version     string   `json:"version"`
+	Tier        int      `json:"tier"`
+	Description string   `json:"description"`
+	Exec        *string  `json:"exec"`
+	Schema      *string  `json:"schema"`
+	Path        string   `json:"path"`
+	Requires    []string `json:"requires"`
+	Gated       bool     `json:"gated,omitempty"`
+}
+
+// skillFM holds parsed SKILL.md front-matter.
+type skillFM struct {
+	Name        string   `yaml:"name"`
+	Version     string   `yaml:"version"`
+	Description string   `yaml:"description"`
+	Exec        string   `yaml:"exec"`
+	Schema      string   `yaml:"schema"`
+	Requires    []string `yaml:"requires"`
+	Timeout     string   `yaml:"timeout"`
+}
+
+// SkillExecRequest is the POST body for /v1/skills/{name}/exec.
+type SkillExecRequest struct {
+	Input   string `json:"input"`             // raw JSON to pass via stdin
+	Timeout string `json:"timeout,omitempty"` // duration string, e.g. "30s"
+}
+
+// SkillExecResponse is the response from /v1/skills/{name}/exec.
+type SkillExecResponse struct {
+	Name       string `json:"name"`
+	ExitCode   int    `json:"exit_code"`
+	Stdout     string `json:"stdout"`
+	Stderr     string `json:"stderr"`
+	DurationMS int64  `json:"duration_ms"`
+	Error      string `json:"error,omitempty"`
+}
+
+// ─── Route registration ──────────────────────────────────────────────────────────
+
+func (s *Server) registerSkillRoutes(mux *http.ServeMux) {
+	s.route(mux, "GET /v1/skills", s.handleSkillList)
+	s.route(mux, "POST /v1/skills/{name}/exec", s.handleSkillExec)
+}
+
+// ─── Discovery ───────────────────────────────────────────────────────────────────
+
+// skillDirs returns directories to scan, in priority order (workspace overrides user).
+func (s *Server) skillDirs() []string {
+	var dirs []string
+
+	home, err := os.UserHomeDir()
+	if err == nil {
+		dirs = append(dirs, filepath.Join(home, ".claude", "skills"))
+	}
+
+	if s.cfg != nil && s.cfg.WorkspaceRoot != "" {
+		dirs = append(dirs, filepath.Join(s.cfg.WorkspaceRoot, ".claude", "skills"))
+	}
+
+	return dirs
+}
+
+// parseSkillFM extracts YAML front-matter from SKILL.md content.
+func parseSkillFM(data []byte) (skillFM, string, string) {
+	content := string(data)
+	var fm skillFM
+
+	if strings.HasPrefix(content, "---\n") {
+		end := strings.Index(content[4:], "\n---")
+		if end != -1 {
+			_ = yaml.Unmarshal([]byte(content[4:4+end]), &fm)
+			content = content[4+end+4:]
+		}
+	}
+
+	title, desc := "", ""
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "# ") && title == "" {
+			title = strings.TrimPrefix(line, "# ")
+			continue
+		}
+		if line != "" && !strings.HasPrefix(line, "#") && !strings.HasPrefix(line, ">") && desc == "" {
+			desc = line
+			if len(desc) > 200 {
+				desc = desc[:197] + "..."
+			}
+		}
+	}
+	return fm, title, desc
+}
+
+// inferSkillTier determines tier from directory structure and front-matter.
+func inferSkillTier(skillPath string, fm skillFM) int {
+	if fm.Schema != "" && fm.Exec != "" {
+		return 3
+	}
+	if fm.Exec != "" {
+		if _, err := os.Stat(filepath.Join(skillPath, fm.Exec)); err == nil {
+			return 2
+		}
+	}
+	entries, err := os.ReadDir(skillPath)
+	if err != nil {
+		return 0
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		n := e.Name()
+		if strings.HasSuffix(n, ".sh") || strings.HasSuffix(n, ".py") {
+			return 1
+		}
+	}
+	if binEntries, err := os.ReadDir(filepath.Join(skillPath, "bin")); err == nil && len(binEntries) > 0 && fm.Exec == "" {
+		return 1
+	}
+	return 0
+}
+
+// loadSkillRecord converts a directory into a SkillRecord.
+func loadSkillRecord(name, skillPath string) (*SkillRecord, error) {
+	data, err := os.ReadFile(filepath.Join(skillPath, "SKILL.md"))
+	if err != nil {
+		return nil, err
+	}
+
+	fm, title, desc := parseSkillFM(data)
+
+	skillName := name
+	if fm.Name != "" {
+		skillName = fm.Name
+	}
+	skillDesc := fm.Description
+	if skillDesc == "" {
+		skillDesc = desc
+	}
+	if skillDesc == "" {
+		skillDesc = title
+	}
+	version := fm.Version
+	if version == "" {
+		version = "0.1.0"
+	}
+	tier := inferSkillTier(skillPath, fm)
+
+	rec := &SkillRecord{
+		Name:        skillName,
+		Version:     version,
+		Tier:        tier,
+		Description: skillDesc,
+		Path:        skillPath,
+		Requires:    fm.Requires,
+	}
+	if rec.Requires == nil {
+		rec.Requires = []string{}
+	}
+	if fm.Exec != "" {
+		e := fm.Exec
+		rec.Exec = &e
+	}
+	if fm.Schema != "" {
+		sc := fm.Schema
+		rec.Schema = &sc
+	}
+	return rec, nil
+}
+
+// discoverSkills returns all skills from the configured directories.
+func (s *Server) discoverSkills() ([]SkillRecord, error) {
+	seen := make(map[string]SkillRecord)
+	var order []string
+
+	for _, dir := range s.skillDirs() {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("read skills dir %s: %w", dir, err)
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			name := entry.Name()
+			rec, err := loadSkillRecord(name, filepath.Join(dir, name))
+			if err != nil {
+				continue
+			}
+			if _, exists := seen[rec.Name]; !exists {
+				order = append(order, rec.Name)
+			}
+			seen[rec.Name] = *rec
+		}
+	}
+
+	result := make([]SkillRecord, 0, len(order))
+	for _, name := range order {
+		result = append(result, seen[name])
+	}
+	return result, nil
+}
+
+// findSkill looks up a skill by name.
+func (s *Server) findSkill(name string) (*SkillRecord, error) {
+	skills, err := s.discoverSkills()
+	if err != nil {
+		return nil, err
+	}
+	for i := range skills {
+		if skills[i].Name == name {
+			return &skills[i], nil
+		}
+	}
+	return nil, fmt.Errorf("skill not found: %s", name)
+}
+
+// ─── Handlers ────────────────────────────────────────────────────────────────────
+
+func (s *Server) handleSkillList(w http.ResponseWriter, r *http.Request) {
+	skills, err := s.discoverSkills()
+	if err != nil {
+		http.Error(w, `{"error":"discovery_failed","detail":"`+err.Error()+`"}`, http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(skills)
+}
+
+func (s *Server) handleSkillExec(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+
+	skill, err := s.findSkill(name)
+	if err != nil {
+		// Same response whether not-found or role-gated (don't leak existence).
+		http.Error(w, `{"error":"not_found","detail":"skill not found or not available"}`, http.StatusNotFound)
+		return
+	}
+
+	var req SkillExecRequest
+	if r.ContentLength != 0 {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, `{"error":"invalid_json"}`, http.StatusBadRequest)
+			return
+		}
+	}
+
+	resp, err := s.execSkill(r.Context(), skill, req.Input, req.Timeout)
+	if err != nil {
+		status := http.StatusBadRequest
+		if strings.Contains(err.Error(), "not_executable") || strings.Contains(err.Error(), "no_canonical_entry_point") {
+			status = http.StatusUnprocessableEntity
+		}
+		errJSON, _ := json.Marshal(map[string]string{"error": err.Error()})
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write(errJSON)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(resp)
+}
+
+// ─── Exec ─────────────────────────────────────────────────────────────────────────
+
+func (s *Server) execSkill(ctx context.Context, skill *SkillRecord, inputJSON, timeoutStr string) (*SkillExecResponse, error) {
+	switch skill.Tier {
+	case 0:
+		return nil, fmt.Errorf("not_executable: skill %q is tier-0 (prose-only). Read SKILL.md at %s", skill.Name, filepath.Join(skill.Path, "SKILL.md"))
+	case 1:
+		return nil, fmt.Errorf("no_canonical_entry_point: skill %q is tier-1 (no exec: in SKILL.md frontmatter)", skill.Name)
+	}
+
+	if skill.Exec == nil {
+		return nil, fmt.Errorf("no_canonical_entry_point: skill %q has no exec declared", skill.Name)
+	}
+
+	execPath := filepath.Join(skill.Path, *skill.Exec)
+	if _, err := os.Stat(execPath); err != nil {
+		return nil, fmt.Errorf("exec_not_found: %s", execPath)
+	}
+
+	timeout := 5 * time.Minute
+	if timeoutStr != "" {
+		if d, err := time.ParseDuration(timeoutStr); err == nil {
+			timeout = d
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, execPath)
+	if inputJSON != "" {
+		cmd.Stdin = bytes.NewBufferString(inputJSON)
+	}
+
+	env := os.Environ()
+	env = append(env,
+		"COGOS_SKILL_NAME="+skill.Name,
+		"COGOS_SKILL_VERSION="+skill.Version,
+		"COGOS_SKILL_PATH="+skill.Path,
+	)
+	if s.cfg != nil && s.cfg.WorkspaceRoot != "" {
+		env = append(env, "COGOS_WORKSPACE="+s.cfg.WorkspaceRoot)
+	}
+	cmd.Env = env
+
+	start := time.Now()
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	execErr := cmd.Run()
+	durationMS := time.Since(start).Milliseconds()
+
+	exitCode := 0
+	var errMsg string
+
+	if execErr != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			errMsg = fmt.Sprintf("timeout after %s", timeout)
+			exitCode = 124
+		} else if exitErr, ok := execErr.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = 1
+			errMsg = execErr.Error()
+		}
+	}
+
+	resp := &SkillExecResponse{
+		Name:       skill.Name,
+		ExitCode:   exitCode,
+		Stdout:     stdout.String(),
+		Stderr:     stderr.String(),
+		DurationMS: durationMS,
+		Error:      errMsg,
+	}
+
+	// Emit skill.exec bus event (best-effort)
+	s.emitSkillExecEvent(skill, resp)
+
+	return resp, nil
+}
+
+// emitSkillExecEvent emits a skill.exec event to the bus. Non-fatal.
+func (s *Server) emitSkillExecEvent(skill *SkillRecord, resp *SkillExecResponse) {
+	if s.busSessions == nil {
+		return
+	}
+	payload := map[string]interface{}{
+		"name":        skill.Name,
+		"version":     skill.Version,
+		"exit_code":   resp.ExitCode,
+		"duration_ms": resp.DurationMS,
+	}
+	if resp.Error != "" {
+		payload["error"] = resp.Error
+	}
+	_, _ = s.busSessions.AppendEvent("skill", "skill.exec", "kernel:skill:exec", payload)
+}

--- a/internal/engine/serve_skills.go
+++ b/internal/engine/serve_skills.go
@@ -261,6 +261,11 @@ func (s *Server) handleSkillList(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleSkillExec(w http.ResponseWriter, r *http.Request) {
+	if s.cfg == nil || !s.cfg.EnableSkillExec {
+		http.Error(w, `{"error":"disabled","detail":"skill exec via HTTP is disabled; set enable_skill_exec: true in kernel.yaml"}`, http.StatusForbidden)
+		return
+	}
+
 	name := r.PathValue("name")
 
 	skill, err := s.findSkill(name)


### PR DESCRIPTION
Closes #96, closes #97.

## Summary

Adds skill discovery and execution surfaces, both via CLI (\`cog skill list\` / \`cog skill exec\`) and HTTP (\`GET /v1/skills\` / \`POST /v1/skills/{name}/exec\`).

- 4-tier skill model (per SKILL.md frontmatter): tier-0 prose-only, tier-1 scripts present, tier-2 \`exec:\` declared with \`bin/<exec>\` present, tier-3 tier-2 + \`schema:\` declared.
- Discovery from \`~/.claude/skills/\` (user) and \`<workspace>/.claude/skills/\` (workspace overrides user).
- Exec passes JSON via stdin, sets \`COGOS_SKILL_NAME / VERSION / PATH / WORKSPACE\` env vars, enforces a 5-minute default timeout (override via \`--timeout\`), returns exit code 124 on timeout matching \`bash timeout\`.
- Best-effort \`skill.exec\` bus event emission on every invocation.

\`make test\` passes (16 new test cases covering all tiers + exec paths).

## Known concerns to address before non-draft

**(1) Significant code duplication.** \`cmd_skill.go\` (root package) and \`internal/engine/serve_skills.go\` duplicate ~80% of their logic — both have their own \`SkillRecord\` type, parsing, tier inference, exec. Extracting a shared \`pkg/skills/\` package is the right follow-up. Out of scope for this PR per the issue scope guardrails.

**(2) Security gap.** \`POST /v1/skills/{name}/exec\` runs arbitrary binaries from the configured skill directories with no authentication. The kernel binds to 127.0.0.1 by default, mitigating remote attack, but any local process on the same machine can hit this endpoint. A malicious workspace can plant a \`.claude/skills/<name>/bin/run\` that fires on first invocation. **Recommendation: gate the endpoint behind an opt-in config flag** (e.g., \`kernel.enable_skill_exec: true\`, default false) before merge.

**(3) Minor:** HTTP error→status mapping uses \`strings.Contains\` against error message text — brittle if messages change. Should use typed error sentinels.

## Test plan

- [x] \`make test\` passes
- [x] Manual: \`./cog skill list --json\` returns SkillRecord array
- [x] Manual: \`./cog skill exec <name>\` invokes per contract
- [ ] Decide on auth gate before non-draft
- [ ] File follow-up issue for \`pkg/skills/\` extraction