### PR TITLE
fix(bus): wire BusEventBroker to /v1/bus/{id}/stream SSE endpoint

### DIFF
--- a/bus_watch.go
+++ b/bus_watch.go
@@ -42,9 +42,12 @@ func (w *BusWatcher) Run(ctx context.Context) error {
 
 // runLive connects to the kernel SSE endpoint and streams events.
 func (w *BusWatcher) runLive(ctx context.Context) error {
-	url := fmt.Sprintf("http://%s/v1/events/stream?bus_id=%s", w.kernelAddr, w.busID)
+	rawURL := fmt.Sprintf("http://%s/v1/bus/%s/stream", w.kernelAddr, w.busID)
+	if w.filter.NoReplay {
+		rawURL += "?no_replay=1"
+	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}

--- a/internal/engine/serve_bus.go
+++ b/internal/engine/serve_bus.go
@@ -14,6 +14,7 @@
 //	GET    /v1/bus/{bus_id}/events            — per-bus events, filtered
 //	GET    /v1/bus/{bus_id}/events/{seq}      — single event by seq
 //	GET    /v1/bus/{bus_id}/stats             — bus statistics
+//	GET    /v1/bus/{bus_id}/stream            — live SSE stream for a bus
 //	GET    /v1/bus/consumers                  — list consumer cursors (ADR-061)
 //	DELETE /v1/bus/consumers/{consumer_id}    — remove a consumer cursor
 package engine
@@ -25,6 +26,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cogos-dev/cogos/pkg/cogfield"
 )
@@ -320,8 +322,10 @@ func (s *Server) handleBusRoute(w http.ResponseWriter, r *http.Request) {
 		}
 	case "stats":
 		s.handleBusStats(w, r, busID)
+	case "stream":
+		s.handleBusStream(w, r, busID)
 	default:
-		http.Error(w, `{"error":"expected /v1/bus/{bus_id}/events or /v1/bus/{bus_id}/stats"}`, http.StatusBadRequest)
+		http.Error(w, `{"error":"expected /v1/bus/{bus_id}/events, /v1/bus/{bus_id}/stats, or /v1/bus/{bus_id}/stream"}`, http.StatusBadRequest)
 	}
 }
 
@@ -419,6 +423,147 @@ func (s *Server) handleBusStats(w http.ResponseWriter, r *http.Request, busID st
 		stats.LastEventAt = e.Ts
 	}
 	_ = json.NewEncoder(w).Encode(stats)
+}
+
+// ─── GET /v1/bus/{bus_id}/stream — live SSE ──────────────────────────────────
+
+// busSSEEnvelope is the wire format emitted on the bus SSE stream. The shape
+// matches the busEventEnvelope type in bus_watch.go (root package) so the CLI
+// watcher can decode it without changes.
+//
+//	{"id":"<hash>","type":"<event_type>","timestamp":"<RFC3339Nano>","data":{…BusBlock…}}
+//
+// The `data` field is the full BusBlock so callers have access to seq, from,
+// payload, hash, and the full type — identical to the polling response from
+// GET /v1/bus/{bus_id}/events.
+type busSSEEnvelope struct {
+	ID        string    `json:"id"`
+	Type      string    `json:"type"`
+	Timestamp string    `json:"timestamp"`
+	Data      *BusBlock `json:"data"`
+}
+
+const (
+	busSSEHeartbeatInterval = 30 * time.Second
+	busSSEWriteDeadline     = 10 * time.Second
+)
+
+// handleBusStream serves GET /v1/bus/{bus_id}/stream — the live SSE endpoint
+// for a per-bus event stream. Subscribers receive:
+//
+//   - `event: connected` on open (one-shot)
+//   - `data: {busSSEEnvelope JSON}` per event (no named event type, so
+//     EventSource fires onmessage)
+//   - `: heartbeat` every 30 s (SSE comment — invisible to EventSource)
+//
+// Replay query params:
+//
+//	no_replay=1  skip historical events (only live from this point forward)
+//	consumer_id  optional identity for dedup (replaces any prior connection
+//	             with the same ID)
+//
+// The stream runs until the client disconnects or the server shuts down.
+// There is no max_duration cap on bus streams — they are intended for
+// long-lived dashboard / hook consumers.
+func (s *Server) handleBusStream(w http.ResponseWriter, r *http.Request, busID string) {
+	broker := s.busBroker
+	if broker == nil {
+		http.Error(w, `{"error":"bus broker not initialised"}`, http.StatusInternalServerError)
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.Header().Set("Connection", "keep-alive")
+
+	noReplay := r.URL.Query().Get("no_replay") == "1"
+	consumerID := r.URL.Query().Get("consumer_id")
+
+	rc := http.NewResponseController(w)
+
+	// Subscribe to the bus BEFORE replaying so we don't miss events that
+	// arrive between the snapshot and the live subscription.
+	ch := make(chan *BusBlock, 64)
+	ctx := r.Context()
+	if !broker.Subscribe(busID, ch, ctx, consumerID) {
+		http.Error(w, `{"error":"bus at subscriber capacity"}`, http.StatusServiceUnavailable)
+		return
+	}
+	defer broker.Unsubscribe(busID, ch)
+
+	// Connected handshake.
+	_ = rc.SetWriteDeadline(time.Now().Add(busSSEWriteDeadline))
+	fmt.Fprintf(w, "event: connected\ndata: {\"bus_id\":%q,\"at\":%q}\n\n",
+		busID, time.Now().UTC().Format(time.RFC3339))
+	flusher.Flush()
+
+	// Replay historical events from disk so the subscriber sees the full
+	// tail on connect (mirrors cog bus tail behaviour). Skip if no_replay=1.
+	if !noReplay && s.busSessions != nil {
+		events, err := s.busSessions.ReadEvents(busID)
+		if err == nil {
+			for i := range events {
+				evt := &events[i]
+				env := busSSEEnvelope{
+					ID:        "replay_" + evt.Hash,
+					Type:      evt.Type,
+					Timestamp: evt.Ts,
+					Data:      evt,
+				}
+				b, err := json.Marshal(env)
+				if err != nil {
+					continue
+				}
+				_ = rc.SetWriteDeadline(time.Now().Add(busSSEWriteDeadline))
+				fmt.Fprintf(w, "data: %s\n\n", b)
+				broker.TouchWrite(busID, ch)
+			}
+			if len(events) > 0 {
+				flusher.Flush()
+			}
+		}
+	}
+
+	// Live loop.
+	hb := time.NewTicker(busSSEHeartbeatInterval)
+	defer hb.Stop()
+
+	for {
+		select {
+		case evt, ok := <-ch:
+			if !ok {
+				// Channel closed by broker (shutdown or reaper).
+				return
+			}
+			env := busSSEEnvelope{
+				ID:        evt.Hash,
+				Type:      evt.Type,
+				Timestamp: evt.Ts,
+				Data:      evt,
+			}
+			b, err := json.Marshal(env)
+			if err != nil {
+				continue
+			}
+			_ = rc.SetWriteDeadline(time.Now().Add(busSSEWriteDeadline))
+			fmt.Fprintf(w, "data: %s\n\n", b)
+			flusher.Flush()
+			broker.TouchWrite(busID, ch)
+		case <-hb.C:
+			_ = rc.SetWriteDeadline(time.Now().Add(busSSEWriteDeadline))
+			fmt.Fprintf(w, ": heartbeat\n\n")
+			flusher.Flush()
+		case <-ctx.Done():
+			return
+		}
+	}
 }
 
 // ─── GET /v1/bus/events (cross-bus search) ───────────────────────────────────

--- a/internal/engine/serve_bus_test.go
+++ b/internal/engine/serve_bus_test.go
@@ -5,6 +5,7 @@
 package engine
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -496,8 +497,7 @@ func TestSessionsListAndDetail(t *testing.T) {
 }
 
 // TestBusStreamBrokerPublishSubscribe verifies that AppendEvent fans out to
-// a subscribed channel (library-level test — the port doesn't register an
-// HTTP route for bus SSE because PR #16 owns /v1/events/stream).
+// a subscribed channel via BusEventBroker (library-level test).
 func TestBusStreamBrokerPublishSubscribe(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
@@ -535,6 +535,114 @@ func TestBusStreamBrokerPublishSubscribe(t *testing.T) {
 	broker.Unsubscribe("bus-s", ch)
 	if broker.SubscriberCount("bus-s") != 0 {
 		t.Errorf("subscriber count = %d after unsubscribe, want 0", broker.SubscriberCount("bus-s"))
+	}
+}
+
+// TestBusStreamSSEEndToEnd is the regression test for issue #51: bus events
+// must reach GET /v1/bus/{bus_id}/stream as SSE frames. Before the fix,
+// BusEventBroker had no HTTP route and every client using the stream endpoint
+// would sit silent indefinitely.
+func TestBusStreamSSEEndToEnd(t *testing.T) {
+	t.Parallel()
+	handler, _, _ := newEventsTestServer(t)
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	const busID = "sse-regression-bus"
+
+	// Pre-create the bus so the stream handler sees it exists.
+	openBody := `{"bus_id":"` + busID + `"}`
+	openResp, err := http.Post(srv.URL+"/v1/bus/open", "application/json", strings.NewReader(openBody))
+	if err != nil {
+		t.Fatalf("POST /v1/bus/open: %v", err)
+	}
+	openResp.Body.Close()
+
+	// Open the SSE stream. no_replay=1 so we only see live events.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		srv.URL+"/v1/bus/"+busID+"/stream?no_replay=1", nil)
+	if err != nil {
+		t.Fatalf("build SSE request: %v", err)
+	}
+	req.Header.Set("Accept", "text/event-stream")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("GET /v1/bus/%s/stream: %v", busID, err)
+	}
+	t.Cleanup(func() { resp.Body.Close() })
+
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Errorf("Content-Type=%q; want text/event-stream", ct)
+	}
+
+	// Collect SSE envelopes in the background.
+	type sseEnvelope struct {
+		ID        string          `json:"id"`
+		Type      string          `json:"type"`
+		Timestamp string          `json:"timestamp"`
+		Data      json.RawMessage `json:"data"`
+	}
+	received := make(chan sseEnvelope, 8)
+	go func() {
+		defer close(received)
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			var env sseEnvelope
+			if err := json.Unmarshal([]byte(line[6:]), &env); err != nil || env.Data == nil {
+				continue
+			}
+			received <- env
+		}
+	}()
+
+	// Give the subscriber a moment to register, then send two events.
+	time.Sleep(50 * time.Millisecond)
+	for _, msg := range []string{"hello-stream", "world-stream"} {
+		body := `{"bus_id":"` + busID + `","from":"test","message":"` + msg + `"}`
+		postResp, err := http.Post(srv.URL+"/v1/bus/send", "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("POST /v1/bus/send (%s): %v", msg, err)
+		}
+		postResp.Body.Close()
+	}
+
+	// Expect both events on the stream.
+	var got []sseEnvelope
+	deadline := time.After(3 * time.Second)
+collect:
+	for len(got) < 2 {
+		select {
+		case env, ok := <-received:
+			if !ok {
+				break collect
+			}
+			got = append(got, env)
+		case <-deadline:
+			t.Fatalf("timed out: received %d/2 events on /v1/bus/%s/stream (issue #51 regression)", len(got), busID)
+		}
+	}
+
+	if len(got) < 2 {
+		t.Fatalf("received %d events; want 2", len(got))
+	}
+
+	// Both envelopes must have a non-empty ID (hash) and non-nil data.
+	for i, env := range got {
+		if env.ID == "" {
+			t.Errorf("got[%d].ID empty — hash not forwarded", i)
+		}
+		if env.Data == nil {
+			t.Errorf("got[%d].Data nil — BusBlock not embedded", i)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #51.

## Summary

\`BusEventBroker\` was fully functional and received published events from every \`POST /v1/bus/send\` call but had no HTTP route registered. The \`bus_watch.go\` client was connecting to \`/v1/events/stream\` (the ledger SSE endpoint) which only emits \`ledger.appended\` frames, never bus-domain events.

The header comment in \`bus_stream.go\` itself stated: \"No HTTP route is registered in this phase.\"

- Adds \`handleBusStream\` to \`serve_bus.go\` (~100 lines): subscribes to \`BusEventBroker\`, optionally replays disk history on connect (gated by \`?no_replay=1\`), then streams live events in the \`{id, type, timestamp, data}\` envelope shape that \`bus_watch.go\` already expects.
- Adds \`busSSEEnvelope\` wire type matching the existing \`busEventEnvelope\` in \`bus_watch.go\`.
- Mounted under the existing \`/v1/bus/\` catch-all as \`case \"stream\"\` — no new top-level route registration needed.
- Updates \`bus_watch.go runLive\` from \`/v1/events/stream?bus_id=<id>\` to \`/v1/bus/<id>/stream\`, propagates \`no_replay=1\` when \`--no-replay\` is set.
- \`TestBusStreamSSEEndToEnd\` opens a bus, subscribes with \`no_replay=1\`, sends two events via \`POST /v1/bus/send\`, asserts both arrive on the stream with non-empty IDs and non-nil data.

\`make test\` passes (full engine suite green; pre-existing root-package failure unrelated).

## Strategic note

This unblocks SSE-based dashboard updates. Any consumer of \`GET /v1/bus/{id}/stream\` now gets true push delivery. The \`BusEventBroker\`'s per-bus fan-out (with backpressure drop and idle reaper) is already production-quality — the missing piece was only the HTTP surface.

## Notes for review

- Subscription happens before replay so no events are lost in the seam between snapshot and live subscription.
- Replay reads ALL historical events on connect via \`ReadEvents(busID)\`. For long-lived buses with thousands of events this is O(N); consider a \`?since=<seq>\` parameter as follow-up. Not a blocker.
- The \`replay_\` prefix on replay event IDs is a string convention; could be a sentinel const.
- Heartbeat at 30s (\`busSSEHeartbeatInterval\`); per-frame write deadline at 10s.

## Test plan

- [x] \`make test\` passes
- [x] Regression test \`TestBusStreamSSEEndToEnd\` covers the path
- [ ] Manual: \`curl -N localhost:6931/v1/bus/<id>/stream\` and emit an event