### PR TITLE
feat(context): default_budget config + exclude_globs path filter + per-request budget header

### DIFF
--- a/internal/engine/config.go
+++ b/internal/engine/config.go
@@ -83,13 +83,14 @@ type Config struct {
 	// Set via default_budget in kernel.yaml.
 	DefaultBudget int
 
-	// ExcludeGlobs is a list of path substrings. Any CogDoc whose slash-normalised
-	// path contains one of these substrings is excluded from the foveated context
-	// window for chat requests. Useful to keep large or sensitive path trees
-	// (e.g. /inbox/, /archive/, /vendor/) out of ambient context without
-	// removing the files from the corpus entirely.
-	// Configured via exclude_globs in kernel.yaml.
-	ExcludeGlobs []string
+	// ExcludeSubstrings is a list of path substrings. Any CogDoc whose
+	// slash-normalised path contains one of these substrings is excluded from
+	// the foveated context window for chat requests. Useful to keep large or
+	// sensitive path trees (e.g. /inbox/, /archive/, /vendor/) out of ambient
+	// context without removing the files from the corpus entirely.
+	// Configured via exclude_substrings in kernel.yaml. Substring (not glob)
+	// semantics — implementation uses strings.Contains, not filepath.Match.
+	ExcludeSubstrings []string
 
 	// gatingMu guards the gating knobs above for hot-update via the
 	// /v1/settings/context endpoints.
@@ -151,7 +152,7 @@ type kernelConfigSection struct {
 	MaxFovealDocs         int               `yaml:"max_foveal_docs"`
 	SalienceFloor         *float64          `yaml:"salience_floor"`
 	DefaultBudget         int               `yaml:"default_budget"`
-	ExcludeGlobs          []string          `yaml:"exclude_globs"`
+	ExcludeSubstrings     []string          `yaml:"exclude_substrings"`
 	TRMWeightsPath        string            `yaml:"trm_weights_path"`
 	TRMEmbeddingsPath     string            `yaml:"trm_embeddings_path"`
 	TRMChunksPath         string            `yaml:"trm_chunks_path"`
@@ -259,8 +260,8 @@ func applyKernelSection(cfg *Config, s kernelConfigSection) {
 	if s.DefaultBudget != 0 {
 		cfg.DefaultBudget = s.DefaultBudget
 	}
-	if len(s.ExcludeGlobs) > 0 {
-		cfg.ExcludeGlobs = s.ExcludeGlobs
+	if len(s.ExcludeSubstrings) > 0 {
+		cfg.ExcludeSubstrings = s.ExcludeSubstrings
 	}
 	if s.TRMWeightsPath != "" {
 		cfg.TRMWeightsPath = s.TRMWeightsPath
@@ -329,16 +330,17 @@ func (c *Config) EffectiveBudget() int {
 	return DefaultBudget
 }
 
-// ContextExcludeGlobs returns a snapshot of the configured exclude-glob list.
-// The returned slice is safe for the caller to iterate without holding a lock.
-func (c *Config) ContextExcludeGlobs() []string {
+// ContextExcludeSubstrings returns a snapshot of the configured
+// exclude-substring list. The returned slice is safe for the caller to iterate
+// without holding a lock.
+func (c *Config) ContextExcludeSubstrings() []string {
 	c.gatingMu.RLock()
 	defer c.gatingMu.RUnlock()
-	if len(c.ExcludeGlobs) == 0 {
+	if len(c.ExcludeSubstrings) == 0 {
 		return nil
 	}
-	out := make([]string, len(c.ExcludeGlobs))
-	copy(out, c.ExcludeGlobs)
+	out := make([]string, len(c.ExcludeSubstrings))
+	copy(out, c.ExcludeSubstrings)
 	return out
 }
 

--- a/internal/engine/config.go
+++ b/internal/engine/config.go
@@ -19,6 +19,11 @@ import (
 const (
 	DefaultMaxFovealDocs = 10
 	DefaultSalienceFloor = 0.3
+	// DefaultBudget is the fallback token budget for context assembly when no
+	// per-request override (X-Cogos-Context-Budget header or MCP budget field)
+	// or kernel.yaml default_budget is provided. Matches the default provider
+	// context_window in providers.yaml.
+	DefaultBudget = 32768
 )
 
 // hasUsableCogConfig reports whether dir looks like a real workspace root for
@@ -72,7 +77,21 @@ type Config struct {
 	// files. 0 means use DefaultSalienceFloor.
 	SalienceFloor float64
 
-	// gatingMu guards the two knobs above for hot-update via the
+	// DefaultBudget is the token budget used when the caller does not supply
+	// a per-request override (X-Cogos-Context-Budget header or MCP budget
+	// field). 0 means use the package-level DefaultBudget constant (32768).
+	// Set via default_budget in kernel.yaml.
+	DefaultBudget int
+
+	// ExcludeGlobs is a list of path substrings. Any CogDoc whose slash-normalised
+	// path contains one of these substrings is excluded from the foveated context
+	// window for chat requests. Useful to keep large or sensitive path trees
+	// (e.g. /inbox/, /archive/, /vendor/) out of ambient context without
+	// removing the files from the corpus entirely.
+	// Configured via exclude_globs in kernel.yaml.
+	ExcludeGlobs []string
+
+	// gatingMu guards the gating knobs above for hot-update via the
 	// /v1/settings/context endpoints.
 	gatingMu sync.RWMutex
 
@@ -131,6 +150,8 @@ type kernelConfigSection struct {
 	OutputReserve         int               `yaml:"output_reserve"`
 	MaxFovealDocs         int               `yaml:"max_foveal_docs"`
 	SalienceFloor         *float64          `yaml:"salience_floor"`
+	DefaultBudget         int               `yaml:"default_budget"`
+	ExcludeGlobs          []string          `yaml:"exclude_globs"`
 	TRMWeightsPath        string            `yaml:"trm_weights_path"`
 	TRMEmbeddingsPath     string            `yaml:"trm_embeddings_path"`
 	TRMChunksPath         string            `yaml:"trm_chunks_path"`
@@ -235,6 +256,12 @@ func applyKernelSection(cfg *Config, s kernelConfigSection) {
 	if s.SalienceFloor != nil {
 		cfg.SalienceFloor = *s.SalienceFloor
 	}
+	if s.DefaultBudget != 0 {
+		cfg.DefaultBudget = s.DefaultBudget
+	}
+	if len(s.ExcludeGlobs) > 0 {
+		cfg.ExcludeGlobs = s.ExcludeGlobs
+	}
 	if s.TRMWeightsPath != "" {
 		cfg.TRMWeightsPath = s.TRMWeightsPath
 	}
@@ -288,6 +315,31 @@ func (c *Config) ContextGating() (maxDocs int, salienceFloor float64) {
 		salienceFloor = DefaultSalienceFloor
 	}
 	return maxDocs, salienceFloor
+}
+
+// EffectiveBudget returns the token budget to use for context assembly when no
+// per-request override is provided. Falls back to DefaultBudget (32768) when
+// the config field is zero (i.e. not set in kernel.yaml).
+func (c *Config) EffectiveBudget() int {
+	c.gatingMu.RLock()
+	defer c.gatingMu.RUnlock()
+	if c.DefaultBudget > 0 {
+		return c.DefaultBudget
+	}
+	return DefaultBudget
+}
+
+// ContextExcludeGlobs returns a snapshot of the configured exclude-glob list.
+// The returned slice is safe for the caller to iterate without holding a lock.
+func (c *Config) ContextExcludeGlobs() []string {
+	c.gatingMu.RLock()
+	defer c.gatingMu.RUnlock()
+	if len(c.ExcludeGlobs) == 0 {
+		return nil
+	}
+	out := make([]string, len(c.ExcludeGlobs))
+	copy(out, c.ExcludeGlobs)
+	return out
 }
 
 // SetContextGating hot-updates the foveated-assembler gating knobs. Pass a

--- a/internal/engine/context_assembly.go
+++ b/internal/engine/context_assembly.go
@@ -297,7 +297,7 @@ func (p *Process) assembleContextInnerWithOpts(ctx context.Context, convID strin
 	// half-apply mid-assembly. See .cog/scratch/audit-dashboard-context/REPORT.md
 	// §4 — without these the chat path admits every doc above zero salience.
 	maxFovealDocs, salienceFloor := p.cfg.ContextGating()
-	excludeGlobs := p.cfg.ContextExcludeGlobs()
+	excludeSubstrings := p.cfg.ContextExcludeSubstrings()
 
 	var docCandidates []FovealDoc
 	usedTRM := false
@@ -341,7 +341,7 @@ func (p *Process) assembleContextInnerWithOpts(ctx context.Context, convID strin
 			if strings.Contains(filepath.ToSlash(doc.Path), "/archive/") {
 				continue
 			}
-			if pathMatchesExcludeGlobs(doc.Path, excludeGlobs) {
+			if pathMatchesExcludeSubstrings(doc.Path, excludeSubstrings) {
 				continue
 			}
 
@@ -750,18 +750,18 @@ func extractKeywords(query string) []string {
 	return keywords
 }
 
-// pathMatchesExcludeGlobs reports whether the slash-normalised path contains
-// any of the configured exclude substrings. Each entry in globs is treated as
+// pathMatchesExcludeSubstrings reports whether the slash-normalised path
+// contains any of the configured exclude substrings. Each entry is treated as
 // a literal path substring (not a shell glob), consistent with the existing
 // /archive/ and /inbox/ exclusion rules used elsewhere in the assembler.
-// An empty globs list always returns false.
-func pathMatchesExcludeGlobs(path string, globs []string) bool {
-	if len(globs) == 0 {
+// An empty list always returns false.
+func pathMatchesExcludeSubstrings(path string, substrings []string) bool {
+	if len(substrings) == 0 {
 		return false
 	}
 	slashed := filepath.ToSlash(path)
-	for _, g := range globs {
-		if g != "" && strings.Contains(slashed, g) {
+	for _, sub := range substrings {
+		if sub != "" && strings.Contains(slashed, sub) {
 			return true
 		}
 	}

--- a/internal/engine/context_assembly.go
+++ b/internal/engine/context_assembly.go
@@ -224,7 +224,7 @@ func WithManifestMode(enabled bool) AssembleOption {
 
 func (p *Process) assembleContextInnerWithOpts(ctx context.Context, convID string, query string, messages []ProviderMessage, budget int, manifestMode bool, iris irisSignal) (*ContextPackage, error) {
 	if budget <= 0 {
-		budget = 32768
+		budget = p.cfg.EffectiveBudget()
 	}
 
 	estimateTokens := estTokens
@@ -297,6 +297,7 @@ func (p *Process) assembleContextInnerWithOpts(ctx context.Context, convID strin
 	// half-apply mid-assembly. See .cog/scratch/audit-dashboard-context/REPORT.md
 	// §4 — without these the chat path admits every doc above zero salience.
 	maxFovealDocs, salienceFloor := p.cfg.ContextGating()
+	excludeGlobs := p.cfg.ContextExcludeGlobs()
 
 	var docCandidates []FovealDoc
 	usedTRM := false
@@ -338,6 +339,9 @@ func (p *Process) assembleContextInnerWithOpts(ctx context.Context, convID strin
 				continue
 			}
 			if strings.Contains(filepath.ToSlash(doc.Path), "/archive/") {
+				continue
+			}
+			if pathMatchesExcludeGlobs(doc.Path, excludeGlobs) {
 				continue
 			}
 
@@ -744,6 +748,24 @@ func extractKeywords(query string) []string {
 		}
 	}
 	return keywords
+}
+
+// pathMatchesExcludeGlobs reports whether the slash-normalised path contains
+// any of the configured exclude substrings. Each entry in globs is treated as
+// a literal path substring (not a shell glob), consistent with the existing
+// /archive/ and /inbox/ exclusion rules used elsewhere in the assembler.
+// An empty globs list always returns false.
+func pathMatchesExcludeGlobs(path string, globs []string) bool {
+	if len(globs) == 0 {
+		return false
+	}
+	slashed := filepath.ToSlash(path)
+	for _, g := range globs {
+		if g != "" && strings.Contains(slashed, g) {
+			return true
+		}
+	}
+	return false
 }
 
 // queryRelevance scores a CogDoc against a keyword set.

--- a/internal/engine/context_assembly_test.go
+++ b/internal/engine/context_assembly_test.go
@@ -635,6 +635,149 @@ func TestEvictForBudgetSingletonsPreferHighCombinedScore(t *testing.T) {
 	}
 }
 
+// ── default_budget and exclude_globs (issue #77) ────────────────────────────
+
+// TestEffectiveBudgetFallback verifies that EffectiveBudget() returns the
+// package-level DefaultBudget constant when the config field is zero (not
+// explicitly set via kernel.yaml).
+func TestEffectiveBudgetFallback(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{}
+	if got := cfg.EffectiveBudget(); got != DefaultBudget {
+		t.Errorf("EffectiveBudget with zero config = %d; want DefaultBudget=%d", got, DefaultBudget)
+	}
+}
+
+// TestEffectiveBudgetFromConfig verifies that a non-zero DefaultBudget in
+// the Config is respected by EffectiveBudget() and flows through to the
+// assembled context package's Budget field.
+func TestEffectiveBudgetFromConfig(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	cfg.DefaultBudget = 8192
+	p := NewProcess(cfg, makeNucleus("T", "r"))
+
+	pkg, err := p.AssembleContext("hello", nil, 0)
+	if err != nil {
+		t.Fatalf("AssembleContext: %v", err)
+	}
+	// Budget in the returned package must reflect the configured ceiling.
+	if pkg.Budget != 8192 {
+		t.Errorf("pkg.Budget = %d; want 8192 (from cfg.DefaultBudget)", pkg.Budget)
+	}
+}
+
+// TestExplicitBudgetOverridesDefault verifies that a positive budget passed
+// directly to AssembleContext takes precedence over cfg.DefaultBudget.
+func TestExplicitBudgetOverridesDefault(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	cfg.DefaultBudget = 8192
+	p := NewProcess(cfg, makeNucleus("T", "r"))
+
+	const explicitBudget = 4096
+	pkg, err := p.AssembleContext("hello", nil, explicitBudget)
+	if err != nil {
+		t.Fatalf("AssembleContext: %v", err)
+	}
+	if pkg.Budget != explicitBudget {
+		t.Errorf("pkg.Budget = %d; want %d (explicit caller override)", pkg.Budget, explicitBudget)
+	}
+}
+
+// TestExcludeGlobsFiltersMatchingPaths verifies that paths matching any entry
+// in cfg.ExcludeGlobs are excluded from the foveated candidate set even when
+// they score above the salience floor.
+func TestExcludeGlobsFiltersMatchingPaths(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	cfg.SalienceFloor = 0 // floor off so exclusion is the only filter
+	cfg.ExcludeGlobs = []string{"/sensitive/"}
+	p := NewProcess(cfg, makeNucleus("T", "r"))
+
+	memDir := filepath.Join(root, ".cog", "mem")
+	sensitiveDir := filepath.Join(memDir, "sensitive")
+	if err := os.MkdirAll(sensitiveDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	semanticDir := filepath.Join(memDir, "semantic")
+
+	// Sensitive doc: should be excluded by the glob.
+	writeTestFile(t, filepath.Join(sensitiveDir, "secret.cog.md"),
+		"---\ntitle: Secret Sensitive\nstatus: active\n---\n\nsensitive secret content\n")
+	// Normal doc: should pass through.
+	writeTestFile(t, filepath.Join(semanticDir, "normal.cog.md"),
+		"---\ntitle: Normal Doc\nstatus: active\n---\n\nnormal content\n")
+
+	idx, err := BuildIndex(root)
+	if err != nil {
+		t.Fatalf("BuildIndex: %v", err)
+	}
+	p.indexMu.Lock()
+	p.index = idx
+	p.indexMu.Unlock()
+
+	pkg, err := p.AssembleContext("sensitive secret normal", nil, 0)
+	if err != nil {
+		t.Fatalf("AssembleContext: %v", err)
+	}
+
+	for _, doc := range pkg.FovealDocs {
+		if strings.Contains(filepath.ToSlash(doc.Path), "/sensitive/") {
+			t.Errorf("excluded glob path leaked into foveal context: %s", doc.Path)
+		}
+	}
+}
+
+// TestPathMatchesExcludeGlobs exercises the helper directly with edge cases.
+func TestPathMatchesExcludeGlobs(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		path   string
+		globs  []string
+		expect bool
+	}{
+		{"/workspace/.cog/mem/inbox/foo.cog.md", []string{"/inbox/"}, true},
+		{"/workspace/.cog/mem/semantic/foo.cog.md", []string{"/inbox/"}, false},
+		{"/workspace/.cog/mem/semantic/foo.cog.md", nil, false},
+		{"/workspace/.cog/mem/sensitive/bar.cog.md", []string{"/inbox/", "/sensitive/"}, true},
+		{"/workspace/.cog/mem/semantic/foo.cog.md", []string{""}, false}, // empty entry ignored
+	}
+	for _, tc := range cases {
+		got := pathMatchesExcludeGlobs(tc.path, tc.globs)
+		if got != tc.expect {
+			t.Errorf("pathMatchesExcludeGlobs(%q, %v) = %v; want %v", tc.path, tc.globs, got, tc.expect)
+		}
+	}
+}
+
+// TestContextExcludeGlobsSnapshot verifies that ContextExcludeGlobs returns a
+// copy of the configured slice (not the live pointer) and handles nil safely.
+func TestContextExcludeGlobsSnapshot(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{}
+	if globs := cfg.ContextExcludeGlobs(); globs != nil {
+		t.Errorf("empty config: ContextExcludeGlobs = %v; want nil", globs)
+	}
+
+	cfg.ExcludeGlobs = []string{"/inbox/", "/sensitive/"}
+	got := cfg.ContextExcludeGlobs()
+	if len(got) != 2 || got[0] != "/inbox/" || got[1] != "/sensitive/" {
+		t.Errorf("ContextExcludeGlobs = %v; want [/inbox/ /sensitive/]", got)
+	}
+
+	// Mutation of the returned slice must not affect the config.
+	got[0] = "/mutated/"
+	if cfg.ExcludeGlobs[0] != "/inbox/" {
+		t.Error("ContextExcludeGlobs returned live slice instead of copy")
+	}
+}
+
+// ── TestDebugZoneItemExposesCombinedScore ────────────────────────────────────
+
 // TestDebugZoneItemExposesCombinedScore verifies the debug-snapshot pipeline
 // surfaces CombinedScore on conversation zone items so the /v1/debug/last
 // endpoint can render it instead of defaulting to 0.00.

--- a/internal/engine/context_assembly_test.go
+++ b/internal/engine/context_assembly_test.go
@@ -635,7 +635,7 @@ func TestEvictForBudgetSingletonsPreferHighCombinedScore(t *testing.T) {
 	}
 }
 
-// ── default_budget and exclude_globs (issue #77) ────────────────────────────
+// ── default_budget and exclude_substrings (issue #77) ──────────────────────
 
 // TestEffectiveBudgetFallback verifies that EffectiveBudget() returns the
 // package-level DefaultBudget constant when the config field is zero (not
@@ -687,15 +687,15 @@ func TestExplicitBudgetOverridesDefault(t *testing.T) {
 	}
 }
 
-// TestExcludeGlobsFiltersMatchingPaths verifies that paths matching any entry
-// in cfg.ExcludeGlobs are excluded from the foveated candidate set even when
-// they score above the salience floor.
-func TestExcludeGlobsFiltersMatchingPaths(t *testing.T) {
+// TestExcludeSubstringsFiltersMatchingPaths verifies that paths matching any
+// entry in cfg.ExcludeSubstrings are excluded from the foveated candidate set
+// even when they score above the salience floor.
+func TestExcludeSubstringsFiltersMatchingPaths(t *testing.T) {
 	t.Parallel()
 	root := makeWorkspace(t)
 	cfg := makeConfig(t, root)
 	cfg.SalienceFloor = 0 // floor off so exclusion is the only filter
-	cfg.ExcludeGlobs = []string{"/sensitive/"}
+	cfg.ExcludeSubstrings = []string{"/sensitive/"}
 	p := NewProcess(cfg, makeNucleus("T", "r"))
 
 	memDir := filepath.Join(root, ".cog", "mem")
@@ -727,18 +727,18 @@ func TestExcludeGlobsFiltersMatchingPaths(t *testing.T) {
 
 	for _, doc := range pkg.FovealDocs {
 		if strings.Contains(filepath.ToSlash(doc.Path), "/sensitive/") {
-			t.Errorf("excluded glob path leaked into foveal context: %s", doc.Path)
+			t.Errorf("excluded substring path leaked into foveal context: %s", doc.Path)
 		}
 	}
 }
 
-// TestPathMatchesExcludeGlobs exercises the helper directly with edge cases.
-func TestPathMatchesExcludeGlobs(t *testing.T) {
+// TestPathMatchesExcludeSubstrings exercises the helper directly with edge cases.
+func TestPathMatchesExcludeSubstrings(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		path   string
-		globs  []string
-		expect bool
+		path       string
+		substrings []string
+		expect     bool
 	}{
 		{"/workspace/.cog/mem/inbox/foo.cog.md", []string{"/inbox/"}, true},
 		{"/workspace/.cog/mem/semantic/foo.cog.md", []string{"/inbox/"}, false},
@@ -747,32 +747,33 @@ func TestPathMatchesExcludeGlobs(t *testing.T) {
 		{"/workspace/.cog/mem/semantic/foo.cog.md", []string{""}, false}, // empty entry ignored
 	}
 	for _, tc := range cases {
-		got := pathMatchesExcludeGlobs(tc.path, tc.globs)
+		got := pathMatchesExcludeSubstrings(tc.path, tc.substrings)
 		if got != tc.expect {
-			t.Errorf("pathMatchesExcludeGlobs(%q, %v) = %v; want %v", tc.path, tc.globs, got, tc.expect)
+			t.Errorf("pathMatchesExcludeSubstrings(%q, %v) = %v; want %v", tc.path, tc.substrings, got, tc.expect)
 		}
 	}
 }
 
-// TestContextExcludeGlobsSnapshot verifies that ContextExcludeGlobs returns a
-// copy of the configured slice (not the live pointer) and handles nil safely.
-func TestContextExcludeGlobsSnapshot(t *testing.T) {
+// TestContextExcludeSubstringsSnapshot verifies that ContextExcludeSubstrings
+// returns a copy of the configured slice (not the live pointer) and handles
+// nil safely.
+func TestContextExcludeSubstringsSnapshot(t *testing.T) {
 	t.Parallel()
 	cfg := &Config{}
-	if globs := cfg.ContextExcludeGlobs(); globs != nil {
-		t.Errorf("empty config: ContextExcludeGlobs = %v; want nil", globs)
+	if subs := cfg.ContextExcludeSubstrings(); subs != nil {
+		t.Errorf("empty config: ContextExcludeSubstrings = %v; want nil", subs)
 	}
 
-	cfg.ExcludeGlobs = []string{"/inbox/", "/sensitive/"}
-	got := cfg.ContextExcludeGlobs()
+	cfg.ExcludeSubstrings = []string{"/inbox/", "/sensitive/"}
+	got := cfg.ContextExcludeSubstrings()
 	if len(got) != 2 || got[0] != "/inbox/" || got[1] != "/sensitive/" {
-		t.Errorf("ContextExcludeGlobs = %v; want [/inbox/ /sensitive/]", got)
+		t.Errorf("ContextExcludeSubstrings = %v; want [/inbox/ /sensitive/]", got)
 	}
 
 	// Mutation of the returned slice must not affect the config.
 	got[0] = "/mutated/"
-	if cfg.ExcludeGlobs[0] != "/inbox/" {
-		t.Error("ContextExcludeGlobs returned live slice instead of copy")
+	if cfg.ExcludeSubstrings[0] != "/inbox/" {
+		t.Error("ContextExcludeSubstrings returned live slice instead of copy")
 	}
 }
 

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -800,7 +800,17 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if p, err := s.process.AssembleContext(query, clientMsgs, 0,
+	// Allow per-request budget override via the X-Cogos-Context-Budget header.
+	// A value of 0 (absent or unparseable) defers to the kernel's configured
+	// default_budget (or the package-level DefaultBudget fallback).
+	contextBudget := 0
+	if hv := r.Header.Get("X-Cogos-Context-Budget"); hv != "" {
+		if v, err := strconv.Atoi(hv); err == nil && v > 0 {
+			contextBudget = v
+		}
+	}
+
+	if p, err := s.process.AssembleContext(query, clientMsgs, contextBudget,
 		WithContext(r.Context()),
 		WithConversationID(creq.Metadata.RequestID),
 		WithManifestMode(true),

--- a/internal/engine/serve_anthropic.go
+++ b/internal/engine/serve_anthropic.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -168,7 +169,17 @@ func (s *Server) handleAnthropicMessages(w http.ResponseWriter, r *http.Request)
 		creq.ModelOverride = oaiReq.Model
 	}
 
-	if pkg, err := s.process.AssembleContext(query, clientMsgs, 0,
+	// Allow per-request budget override via the X-Cogos-Context-Budget header.
+	// A value of 0 (absent or unparseable) defers to the kernel's configured
+	// default_budget (or the package-level DefaultBudget fallback).
+	contextBudget := 0
+	if hv := r.Header.Get("X-Cogos-Context-Budget"); hv != "" {
+		if v, err := strconv.Atoi(hv); err == nil && v > 0 {
+			contextBudget = v
+		}
+	}
+
+	if pkg, err := s.process.AssembleContext(query, clientMsgs, contextBudget,
 		WithContext(r.Context()),
 		WithConversationID(creq.Metadata.RequestID),
 		WithManifestMode(true),


### PR DESCRIPTION
Closes #77.

## Summary

Issue #77 had three sub-problems. Two were already fixed on \`main\` by PRs #88 (gating knobs \`max_foveal_docs\` / \`salience_floor\`) and #90 (split inbox boosts out of chat-read salience). The remaining gap: token budget was hardcoded to 32768 in \`assembleContextInnerWithOpts\` with no kernel.yaml override or per-request mechanism, and there was no path-based exclusion beyond the hardcoded \`/archive/\` substring check.

- New \`DefaultBudget = 32768\` named constant (was a literal).
- New \`Config.DefaultBudget int\` (\`default_budget\` YAML key).
- New \`Config.ExcludeGlobs []string\` (\`exclude_globs\` YAML key — substring match against slash-normalised paths, parallel to the existing \`/archive/\` filter).
- \`EffectiveBudget()\` and \`ContextExcludeGlobs()\` accessors — RWMutex-guarded, same pattern as \`ContextGating()\`.
- \`X-Cogos-Context-Budget\` request header support in BOTH \`/v1/chat/completions\` and \`/v1/messages\` (Anthropic-compat).
- 6 new tests covering fallback, config-driven budget, explicit caller precedence, glob exclusion, helper edge cases, snapshot independence.

\`make test\` passes.

## Naming concern

The config key \`exclude_globs\` and helper \`pathMatchesExcludeGlobs\` use \"globs\" terminology but actually do \`strings.Contains\` substring matching, not \`filepath.Match\` glob matching. Worth either renaming to \`exclude_substrings\` or implementing actual glob matching. Glob matching is more useful and matches the public-facing name.

## Out of scope (filed as follow-ups)

- Per-client policies (dashboard vs Claude Code vs MCP — needs identity-routing layer).
- \`/v1/context/last\` debug endpoint.
- Hot-tunable \`exclude_globs\` via PATCH (extending the existing \`/v1/settings/context\` surface).

## Notes for review

- The hardcoded \`/archive/\` substring check still exists alongside the new mechanism. Once \`exclude_globs\` defaults include \`/archive/\`, the hardcoded check can be removed — minor maintenance debt.
- Invalid \`X-Cogos-Context-Budget\` header values are silently ignored (\`strconv.Atoi\` failure or value \`<= 0\`). Should log a warning so misconfigured clients can debug.

## Test plan

- [x] \`make test\` passes
- [x] 6 new test cases cover the new code paths
- [ ] Decide on glob vs substring semantics before non-draft (rename or implement)