### PR TITLE
refactor(provider/ollama): extract listModels helper from Available

### DIFF
--- a/internal/engine/provider_ollama.go
+++ b/internal/engine/provider_ollama.go
@@ -89,29 +89,13 @@ func (p *OllamaProvider) Model() string { return p.model }
 
 // Available checks if Ollama is running and the configured model is loaded.
 func (p *OllamaProvider) Available(ctx context.Context) bool {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.endpoint+"/api/tags", nil)
+	models, err := p.listModels(ctx)
 	if err != nil {
-		return false
-	}
-	resp, err := p.client.Do(req)
-	if err != nil {
-		return false
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return false
-	}
-	var tags struct {
-		Models []struct {
-			Name string `json:"name"`
-		} `json:"models"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&tags); err != nil {
 		return false
 	}
 	// Accept exact name or prefix (e.g. "qwen2.5:9b" matches "qwen2.5:9b-instruct").
-	for _, m := range tags.Models {
-		if m.Name == p.model || strings.HasPrefix(m.Name, p.model) {
+	for _, m := range models {
+		if m == p.model || strings.HasPrefix(m, p.model) {
 			return true
 		}
 	}
@@ -162,6 +146,41 @@ func (p *OllamaProvider) Ping(ctx context.Context) (time.Duration, error) {
 	}
 	resp.Body.Close()
 	return time.Since(start), nil
+}
+
+// listModels queries GET /api/tags and returns the names of all locally
+// available Ollama models. Empty names are filtered out. This is the shared
+// implementation used by Available() and any future listing callers, extracted
+// to avoid duplicating the HTTP + JSON decode logic.
+func (p *OllamaProvider) listModels(ctx context.Context) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.endpoint+"/api/tags", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("ollama: /api/tags status %d", resp.StatusCode)
+	}
+	var tags struct {
+		Models []struct {
+			Name string `json:"name"`
+		} `json:"models"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tags); err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(tags.Models))
+	for _, m := range tags.Models {
+		if m.Name == "" {
+			continue
+		}
+		names = append(names, m.Name)
+	}
+	return names, nil
 }
 
 // ── Ollama wire types ─────────────────────────────────────────────────────────

--- a/internal/engine/provider_ollama_test.go
+++ b/internal/engine/provider_ollama_test.go
@@ -170,6 +170,43 @@ func TestOllamaAvailableServerDown(t *testing.T) {
 	}
 }
 
+// ── listModels ────────────────────────────────────────────────────────────────
+
+// TestOllamaListModels verifies that listModels() correctly returns model names
+// from /api/tags and filters out any entry with an empty name.
+func TestOllamaListModels(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/tags" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"models": []map[string]any{
+				{"name": "llama3:8b"},
+				{"name": ""},          // should be filtered out
+				{"name": "gemma4:e4b"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	p := NewOllamaProvider("ollama", ProviderConfig{Endpoint: srv.URL, Model: "llama3:8b"})
+	names, err := p.listModels(context.Background())
+	if err != nil {
+		t.Fatalf("listModels: %v", err)
+	}
+	if len(names) != 2 {
+		t.Fatalf("len(names) = %d; want 2 (empty entry filtered)", len(names))
+	}
+	if names[0] != "llama3:8b" {
+		t.Errorf("names[0] = %q; want llama3:8b", names[0])
+	}
+	if names[1] != "gemma4:e4b" {
+		t.Errorf("names[1] = %q; want gemma4:e4b", names[1])
+	}
+}
+
 // ── Ping ──────────────────────────────────────────────────────────────────────
 
 func TestOllamaPing(t *testing.T) {


### PR DESCRIPTION
## What

Extracts a `listModels(ctx context.Context) ([]string, error)` method from the inline HTTP + JSON decode logic that was embedded in `OllamaProvider.Available()`.

`Available()` previously owned the full `/api/tags` request lifecycle: build request, do HTTP, check status, decode JSON, iterate models. That logic is now a standalone helper. `Available()` calls `listModels` and checks membership — identical semantics, no inlined plumbing.

Empty model names (which Ollama can return in edge cases) are filtered in `listModels` so callers never see them.

## Why

The inline decode in `Available()` was a maintenance liability: any caller that needs the model list had to duplicate the HTTP + decode cycle. Extracting `listModels` makes it reusable (the remaining cherry-picks from #74 rely on it) and keeps `Available()` at a readable level of abstraction.

## Test

Adds `TestOllamaListModels` using `httptest.NewServer` with a fake `/api/tags` response that includes one empty-name entry. Asserts:
- two names are returned (empty filtered out)
- correct ordering preserved

All pre-existing `internal/engine` tests pass.

## Context

This is **one of seven focused cherry-picks** from closed PR #74 (`cogos-dev/cogos#74`), which attempted a sweeping Ollama refactor that did not build. The umbrella for this salvage work is issue #76. Each cherry-pick is a standalone, compilable, tested change.