### PR TITLE
feat(tool_loop): normalize blank tool-call IDs from any provider

### DIFF
--- a/internal/engine/tool_loop.go
+++ b/internal/engine/tool_loop.go
@@ -403,6 +403,7 @@ func RunToolLoopWithTranscript(
 	var transcript []ToolCallRecord
 
 	for i := 0; i < maxToolLoopIterations; i++ {
+		resp.ToolCalls = normalizeToolCallIDs(provider.Name(), i+1, resp.ToolCalls)
 		if len(resp.ToolCalls) == 0 {
 			return resp, clientToolCalls, transcript, nil
 		}
@@ -550,6 +551,58 @@ func RunToolLoopWithTranscript(
 
 	slog.Warn("tool_loop: max iterations reached", "max", maxToolLoopIterations)
 	return resp, clientToolCalls, transcript, nil
+}
+
+// normalizeToolCallIDs assigns stable IDs to any tool calls that arrived
+// without one. Any provider may omit IDs; this ensures downstream code never
+// has to handle blank ToolCall.ID values.
+func normalizeToolCallIDs(providerName string, iteration int, calls []ToolCall) []ToolCall {
+	if len(calls) == 0 {
+		return nil
+	}
+	prefix := sanitizeToolCallIDPrefix(providerName)
+	for i := range calls {
+		if strings.TrimSpace(calls[i].ID) != "" {
+			continue
+		}
+		calls[i].ID = fmt.Sprintf("%s-call-%d-%d", prefix, iteration, i)
+	}
+	return calls
+}
+
+// sanitizeToolCallIDPrefix converts an arbitrary provider name into a
+// lowercase alphanumeric-plus-dash string suitable for use in a generated ID.
+func sanitizeToolCallIDPrefix(providerName string) string {
+	providerName = strings.TrimSpace(providerName)
+	if providerName == "" {
+		return "provider"
+	}
+	var b strings.Builder
+	prevDash := false
+	for _, r := range providerName {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+			prevDash = false
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r + ('a' - 'A'))
+			prevDash = false
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+			prevDash = false
+		default:
+			if prevDash {
+				continue
+			}
+			b.WriteByte('-')
+			prevDash = true
+		}
+	}
+	sanitized := strings.Trim(b.String(), "-")
+	if sanitized == "" {
+		return "provider"
+	}
+	return sanitized
 }
 
 // ── Schema helpers ───────────────────────────────────────────────────────────

--- a/internal/engine/tool_loop_test.go
+++ b/internal/engine/tool_loop_test.go
@@ -279,6 +279,77 @@ func TestRunToolLoopTracksToolCallRejections(t *testing.T) {
 	}
 }
 
+func TestNormalizeToolCallIDs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("all blank gets unique IDs", func(t *testing.T) {
+		t.Parallel()
+		calls := []ToolCall{
+			{Name: "tool_a", Arguments: "{}"},
+			{Name: "tool_b", Arguments: "{}"},
+			{Name: "tool_c", Arguments: "{}"},
+		}
+		got := normalizeToolCallIDs("myprovider", 1, calls)
+		ids := make(map[string]bool, len(got))
+		for _, c := range got {
+			if c.ID == "" {
+				t.Fatalf("expected non-empty ID for tool %q", c.Name)
+			}
+			if ids[c.ID] {
+				t.Fatalf("duplicate ID %q generated", c.ID)
+			}
+			ids[c.ID] = true
+		}
+	})
+
+	t.Run("mix of blank and set keeps set ones", func(t *testing.T) {
+		t.Parallel()
+		calls := []ToolCall{
+			{ID: "existing-id", Name: "tool_a", Arguments: "{}"},
+			{Name: "tool_b", Arguments: "{}"},
+		}
+		got := normalizeToolCallIDs("myprovider", 2, calls)
+		if got[0].ID != "existing-id" {
+			t.Fatalf("existing ID was overwritten: got %q, want %q", got[0].ID, "existing-id")
+		}
+		if got[1].ID == "" {
+			t.Fatal("blank ID was not assigned for tool_b")
+		}
+		if got[1].ID == "existing-id" {
+			t.Fatal("generated ID collides with existing ID")
+		}
+	})
+
+	t.Run("all set passes through unchanged", func(t *testing.T) {
+		t.Parallel()
+		calls := []ToolCall{
+			{ID: "id-1", Name: "tool_a", Arguments: "{}"},
+			{ID: "id-2", Name: "tool_b", Arguments: "{}"},
+		}
+		got := normalizeToolCallIDs("myprovider", 1, calls)
+		if got[0].ID != "id-1" || got[1].ID != "id-2" {
+			t.Fatalf("IDs changed: got %q %q, want id-1 id-2", got[0].ID, got[1].ID)
+		}
+	})
+
+	t.Run("empty slice returns nil", func(t *testing.T) {
+		t.Parallel()
+		got := normalizeToolCallIDs("myprovider", 1, nil)
+		if got != nil {
+			t.Fatalf("expected nil for nil input, got %v", got)
+		}
+	})
+
+	t.Run("empty provider name uses fallback prefix", func(t *testing.T) {
+		t.Parallel()
+		calls := []ToolCall{{Name: "tool_a", Arguments: "{}"}}
+		got := normalizeToolCallIDs("", 1, calls)
+		if got[0].ID == "" {
+			t.Fatal("expected non-empty ID even with empty provider name")
+		}
+	})
+}
+
 func testToolDefinition() ToolDefinition {
 	return ToolDefinition{
 		Name: "lookup",


### PR DESCRIPTION
## Summary

- Adds `normalizeToolCallIDs(providerName, iteration, calls)` to `internal/engine/tool_loop.go`, called at the top of each `RunToolLoopWithTranscript` iteration before any dispatch happens.
- Adds `sanitizeToolCallIDPrefix` helper that collapses the provider name to a safe lowercase alphanumeric-plus-dash string (falls back to `"provider"` for empty names).
- Generated ID format: `<sanitized-provider>-call-<iteration>-<index>` (e.g. `ollama-call-1-0`).
- Adds `TestNormalizeToolCallIDs` covering: all-blank input gets unique IDs, mixed blank-and-set preserves existing IDs, all-set passes through unchanged, nil input returns nil, empty provider name uses fallback prefix.

## Why provider-agnostic (vs the Ollama-specific cherry-pick)

The Ollama-specific cherry-pick (`ollamaToolCallID`) addresses ID generation inside the Ollama wire adapter. This PR is the orthogonal, tool-loop-layer fix: **any** provider (OpenAI-compat, Codex, ClaudeCode, future providers) may return tool calls with blank IDs. Normalizing at the tool-loop boundary ensures downstream dispatch code — kernel tool execution, transcript recording, `ProviderMessage.ToolCallID` correlation — never has to branch on blank IDs regardless of which provider is active.

Closes #76.

## What was NOT touched

- `KernelToolRegistry.Scoped()` is preserved (PR #74's removal of it was the semantic conflict that closed the original PR).
- `cog_read_file` and `cog_grep_files` audit-scope tools are preserved.
- No other files modified.

## Test plan

- [x] `go test ./internal/engine/ -run TestNormalizeToolCallIDs` — all 5 subtests pass
- [x] `make test` — `internal/engine` package green; root-package failure is pre-existing and unrelated to this change