### PR TITLE
fix(provider/ollama): normalize tool argument JSON across object and string shapes

### DIFF
--- a/internal/engine/provider_ollama.go
+++ b/internal/engine/provider_ollama.go
@@ -229,10 +229,11 @@ func buildOllamaRequest(model string, req *CompletionRequest, stream bool, conte
 		}
 		if m.Role == "assistant" && len(m.ToolCalls) > 0 {
 			for _, tc := range m.ToolCalls {
-				rawArgs := json.RawMessage(tc.Arguments)
-				if len(rawArgs) == 0 || !json.Valid(rawArgs) {
-					rawArgs = json.RawMessage("{}")
-				}
+				// Normalize arguments to a stable JSON object before sending
+				// back to Ollama. Some models return arguments as a JSON string
+				// rather than an object; decodeOllamaToolArguments unwraps both.
+				normalizedArgs := decodeOllamaToolArguments(tc.Arguments)
+				rawArgs := json.RawMessage(encodeOllamaToolArguments(normalizedArgs))
 				msg.ToolCalls = append(msg.ToolCalls, ollamaToolCall{
 					ID:   tc.ID,
 					Type: "function",
@@ -283,6 +284,59 @@ func buildOllamaRequest(model string, req *CompletionRequest, stream bool, conte
 		Think:    false, // prevent silent token burn in qwen3 thinking mode
 		Options:  opts,
 	}
+}
+
+// decodeOllamaToolArguments normalizes the raw argument value that Ollama
+// returns for a tool call. Ollama's /api/chat returns tool-call arguments as
+// either a JSON object or a JSON string whose content is itself a JSON object
+// — the shape varies by model and version. This function handles both:
+//
+//   - Object: `{"query":"x"}` → map[string]any{"query":"x"}
+//   - String: `"{\"query\":\"x\"}"` → map[string]any{"query":"x"}
+//   - Empty / blank → empty map
+//   - Malformed → the original string value (caller must tolerate this)
+func decodeOllamaToolArguments(raw string) interface{} {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return map[string]interface{}{}
+	}
+	dec := json.NewDecoder(strings.NewReader(raw))
+	dec.UseNumber()
+	var value interface{}
+	if err := dec.Decode(&value); err != nil {
+		// Not valid JSON at all — return as-is; caller sees the raw string.
+		return raw
+	}
+	// If Ollama encoded the arguments as a JSON string, unwrap one layer.
+	if s, ok := value.(string); ok {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return map[string]interface{}{}
+		}
+		dec2 := json.NewDecoder(strings.NewReader(s))
+		dec2.UseNumber()
+		var inner interface{}
+		if err := dec2.Decode(&inner); err != nil {
+			// The string content isn't JSON; return the unwrapped string.
+			return s
+		}
+		return inner
+	}
+	return value
+}
+
+// encodeOllamaToolArguments serializes a normalized argument value (as
+// returned by decodeOllamaToolArguments) back to a JSON string suitable for
+// downstream callers. Returns "{}" on nil or marshal failure.
+func encodeOllamaToolArguments(v interface{}) string {
+	if v == nil {
+		return "{}"
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		return "{}"
+	}
+	return string(data)
 }
 
 // effectiveModel returns the model to send to Ollama: request override if set,
@@ -343,10 +397,10 @@ func (p *OllamaProvider) Complete(ctx context.Context, req *CompletionRequest) (
 	if len(or.Message.ToolCalls) > 0 {
 		out.StopReason = "tool_use"
 		for _, tc := range or.Message.ToolCalls {
-			args := string(tc.Function.Arguments)
-			if args == "" || args == "null" {
-				args = "{}"
-			}
+			// Ollama may return arguments as a JSON object or a JSON string
+			// wrapping a JSON object depending on the model. Normalize both.
+			decoded := decodeOllamaToolArguments(string(tc.Function.Arguments))
+			args := encodeOllamaToolArguments(decoded)
 			out.ToolCalls = append(out.ToolCalls, ToolCall{
 				ID:        tc.ID,
 				Name:      tc.Function.Name,

--- a/internal/engine/provider_ollama_test.go
+++ b/internal/engine/provider_ollama_test.go
@@ -521,6 +521,134 @@ func TestOllamaCapabilitiesUseKnownModelProfile(t *testing.T) {
 	}
 }
 
+// ── decodeOllamaToolArguments ─────────────────────────────────────────────────
+
+func TestDecodeOllamaToolArguments(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   string
+		wantMap map[string]interface{} // non-nil means we expect a map with these keys/values
+		wantStr string                 // non-empty means we expect a raw string back
+	}{
+		{
+			name:    "object input",
+			input:   `{"query":"hello","limit":5}`,
+			wantMap: map[string]interface{}{"query": "hello", "limit": json.Number("5")},
+		},
+		{
+			name:    "string input wrapping JSON object",
+			input:   `"{\"query\":\"hello\",\"limit\":5}"`,
+			wantMap: map[string]interface{}{"query": "hello", "limit": json.Number("5")},
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			wantMap: map[string]interface{}{},
+		},
+		{
+			name:    "whitespace only",
+			input:   "   ",
+			wantMap: map[string]interface{}{},
+		},
+		{
+			name:    "null literal",
+			input:   "null",
+			wantMap: nil, // null decodes to nil interface; encodeOllamaToolArguments must handle it
+		},
+		{
+			name:    "malformed JSON",
+			input:   `{not valid json`,
+			wantStr: `{not valid json`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := decodeOllamaToolArguments(tc.input)
+
+			if tc.wantStr != "" {
+				s, ok := got.(string)
+				if !ok {
+					t.Fatalf("expected string result, got %T: %v", got, got)
+				}
+				if s != tc.wantStr {
+					t.Errorf("got %q; want %q", s, tc.wantStr)
+				}
+				return
+			}
+
+			if tc.wantMap == nil {
+				// null input — result should be nil or an empty/null interface
+				// encodeOllamaToolArguments should still produce valid JSON
+				encoded := encodeOllamaToolArguments(got)
+				if encoded != "null" && encoded != "{}" {
+					t.Errorf("encodeOllamaToolArguments(nil) = %q; want null or {}", encoded)
+				}
+				return
+			}
+
+			gotMap, ok := got.(map[string]interface{})
+			if !ok {
+				t.Fatalf("expected map[string]interface{}, got %T: %v", got, got)
+			}
+			for k, wantV := range tc.wantMap {
+				gotV, exists := gotMap[k]
+				if !exists {
+					t.Errorf("key %q missing from decoded map", k)
+					continue
+				}
+				if fmt.Sprintf("%v", gotV) != fmt.Sprintf("%v", wantV) {
+					t.Errorf("key %q: got %v (%T); want %v (%T)", k, gotV, gotV, wantV, wantV)
+				}
+			}
+			// Also verify round-trip through encodeOllamaToolArguments produces valid JSON.
+			encoded := encodeOllamaToolArguments(got)
+			var roundtrip map[string]interface{}
+			if err := json.Unmarshal([]byte(encoded), &roundtrip); err != nil {
+				t.Errorf("encodeOllamaToolArguments round-trip not valid JSON: %v (got %q)", err, encoded)
+			}
+		})
+	}
+}
+
+// TestEncodeOllamaToolArgumentsNil verifies nil input produces "{}".
+func TestEncodeOllamaToolArgumentsNil(t *testing.T) {
+	t.Parallel()
+	got := encodeOllamaToolArguments(nil)
+	if got != "{}" {
+		t.Errorf("encodeOllamaToolArguments(nil) = %q; want {}", got)
+	}
+}
+
+// TestDecodeEncodeRoundTrip verifies that the string-wrapped shape commonly
+// produced by Ollama (e.g. llama3.1, qwen2.5 tool calls) normalizes to the
+// same object shape as a direct JSON object input.
+func TestDecodeEncodeRoundTrip(t *testing.T) {
+	t.Parallel()
+	objectInput := `{"query":"test","n":3}`
+	// Simulate Ollama wrapping the JSON object in a string.
+	stringInput := `"{\"query\":\"test\",\"n\":3}"`
+
+	decodedObj := decodeOllamaToolArguments(objectInput)
+	decodedStr := decodeOllamaToolArguments(stringInput)
+
+	encodedObj := encodeOllamaToolArguments(decodedObj)
+	encodedStr := encodeOllamaToolArguments(decodedStr)
+
+	var mapObj, mapStr map[string]interface{}
+	if err := json.Unmarshal([]byte(encodedObj), &mapObj); err != nil {
+		t.Fatalf("encodedObj not valid JSON: %v", err)
+	}
+	if err := json.Unmarshal([]byte(encodedStr), &mapStr); err != nil {
+		t.Fatalf("encodedStr not valid JSON: %v", err)
+	}
+	if fmt.Sprintf("%v", mapObj) != fmt.Sprintf("%v", mapStr) {
+		t.Errorf("object path and string path produce different results:\n  obj: %v\n  str: %v", mapObj, mapStr)
+	}
+}
+
 func containsCapability(caps []Capability, want Capability) bool {
 	for _, cap := range caps {
 		if cap == want {


### PR DESCRIPTION
## Problem

Ollama's `/api/chat` endpoint returns tool-call `arguments` in two shapes depending on the model:

- **Object shape** (standard): `{"query": "x", "limit": 5}`
- **String shape** (llama3.1, some qwen2.5 builds): `"{\"query\": \"x\", \"limit\": 5}"` — a JSON string wrapping a JSON object

The previous code either passed the raw `json.RawMessage` through unchanged or did a `json.Valid` guard that accepted the string shape as-is. Downstream callers received a double-encoded string in `ToolCall.Arguments`, which broke argument parsing in the tool loop.

Closes #76.

## Solution

- **`decodeOllamaToolArguments(raw string) interface{}`** — normalizes both shapes. Object → `map[string]any`. String-wrapped object → unwraps one layer and decodes the inner JSON. Empty → empty map. Malformed → original string (safe fallback).
- **`encodeOllamaToolArguments(v interface{}) string`** — marshals the normalized value back to a canonical JSON string. Nil → `{}`.

Both helpers are wired into:
1. **`Complete`** — when converting Ollama's response tool calls to `ToolCall` structs
2. **`buildOllamaRequest`** — when serializing stored `ToolCall.Arguments` back to Ollama for multi-turn conversations

## Test coverage

`TestDecodeOllamaToolArguments` (table-driven, parallel):
- Object input
- String input wrapping a JSON object
- Empty string
- Whitespace-only
- `null` literal
- Malformed JSON → error path

`TestEncodeOllamaToolArgumentsNil` — nil produces `{}`
`TestDecodeEncodeRoundTrip` — object path and string-wrapped path produce identical output

## Which models trigger the string-arg case

Based on community reports and the closed PR #74 discussion: **llama3.1**, **llama3.2**, and certain **qwen2.5** checkpoint builds are known to emit the string-wrapped form. The issue is model-specific and non-deterministic (same model can return either shape across calls), so normalization at the provider boundary is the correct fix.

## Diff stat

```
internal/engine/provider_ollama.go      | +62 / -8
internal/engine/provider_ollama_test.go | +128 / 0
```