### PR TITLE
fix(provider/ollama): suppress tool schemas when tool_choice is "none"

### DIFF
--- a/internal/engine/provider_ollama.go
+++ b/internal/engine/provider_ollama.go
@@ -287,7 +287,7 @@ func buildOllamaRequest(model string, req *CompletionRequest, stream bool, conte
 	}
 
 	var tools []ollamaTool
-	if len(req.Tools) > 0 {
+	if len(req.Tools) > 0 && req.ToolChoice != "none" {
 		tools = make([]ollamaTool, 0, len(req.Tools))
 		for _, t := range req.Tools {
 			tools = append(tools, ollamaTool{

--- a/internal/engine/provider_ollama_test.go
+++ b/internal/engine/provider_ollama_test.go
@@ -867,6 +867,63 @@ func TestStreamNoToolCallsFinishReason(t *testing.T) {
 	}
 }
 
+// TestBuildOllamaRequestSuppressesToolsWhenNone verifies that the tools array
+// is omitted from the wire body when tool_choice is "none", and that it is
+// included for other values ("auto", "required", specific tool name).
+func TestBuildOllamaRequestSuppressesToolsWhenNone(t *testing.T) {
+	t.Parallel()
+
+	tools := []ToolDefinition{
+		{
+			Name:        "search",
+			Description: "Search the memory index",
+			InputSchema: map[string]interface{}{"type": "object"},
+		},
+	}
+	msgs := []ProviderMessage{{Role: "user", Content: "hi"}}
+
+	// tool_choice == "none" → tools field must be absent from the wire body.
+	t.Run("none suppresses tools", func(t *testing.T) {
+		req := &CompletionRequest{Messages: msgs, Tools: tools, ToolChoice: "none"}
+		r := buildOllamaRequest("m", req, false, 0)
+		if len(r.Tools) != 0 {
+			t.Errorf("tools len = %d; want 0 when tool_choice is none", len(r.Tools))
+		}
+		body, err := json.Marshal(r)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(body, &raw); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if _, present := raw["tools"]; present {
+			t.Errorf("wire body contains 'tools' key; want omitted when tool_choice is none")
+		}
+	})
+
+	// Other tool_choice values must still send the tools schema.
+	for _, tc := range []string{"auto", "required", "search"} {
+		tc := tc
+		t.Run("includes tools for "+tc, func(t *testing.T) {
+			req := &CompletionRequest{Messages: msgs, Tools: tools, ToolChoice: tc}
+			r := buildOllamaRequest("m", req, false, 0)
+			if len(r.Tools) != 1 {
+				t.Errorf("tools len = %d; want 1 for tool_choice=%q", len(r.Tools), tc)
+			}
+		})
+	}
+
+	// No tools in the request → tools field absent regardless of tool_choice.
+	t.Run("no tools always omits tools field", func(t *testing.T) {
+		req := &CompletionRequest{Messages: msgs, ToolChoice: "auto"}
+		r := buildOllamaRequest("m", req, false, 0)
+		if len(r.Tools) != 0 {
+			t.Errorf("tools len = %d; want 0 when no tools defined", len(r.Tools))
+		}
+	})
+}
+
 func TestOllamaCompleteToolCalls(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- Closes #76
- When `tool_choice == "none"`, `buildOllamaRequest` was still sending the full `tools` array to Ollama. This wastes tokens on the prompt and leaves the model in an ambiguous state where it can see tool schemas but is supposed to ignore them — in practice, Ollama models will sometimes call tools anyway.
- Fix: guard the tools-building block with `req.ToolChoice != "none"`. When suppressed, the field is `nil` and omits from the JSON payload via `omitempty`. All other values (`"auto"`, `"required"`, specific tool name, or unset) are unaffected.

## What changed

- `internal/engine/provider_ollama.go`: one-line guard added to `buildOllamaRequest`
- `internal/engine/provider_ollama_test.go`: `TestBuildOllamaRequestSuppressesToolsWhenNone` added; verifies the marshaled wire body omits the `tools` key for `"none"` and includes it for `"auto"`, `"required"`, and a specific tool name

## Test plan

- [x] `go test ./internal/engine/... -run TestBuildOllamaRequest` — all subtests pass
- [x] `go test ./internal/engine/...` — full package green
- [x] Unrelated `TestQueryConstellationWithIris_FallbackToStandard` flakiness confirmed pre-existing on main (unrelated to this change)

Cherry-picked from the request-building change in PR #74; adapted cleanly to current main (no `KeepAlive` field conflict).