### PR TITLE
fix(provider/ollama): align streaming finish_reason vocabulary to tool_use

### DIFF
--- a/internal/engine/provider_ollama.go
+++ b/internal/engine/provider_ollama.go
@@ -525,7 +525,7 @@ func (p *OllamaProvider) Stream(ctx context.Context, req *CompletionRequest) (<-
 					Model:    model,
 				}
 				if sawToolCalls {
-					sc.StopReason = "tool_calls"
+					sc.StopReason = "tool_use"
 				}
 			}
 			select {

--- a/internal/engine/provider_ollama_test.go
+++ b/internal/engine/provider_ollama_test.go
@@ -752,9 +752,8 @@ func TestBuildOllamaRequestToolsAndToolReplies(t *testing.T) {
 }
 
 // TestStreamSetsToolCallsFinishReason asserts that when the Ollama stream
-// contains tool_call chunks, the final StreamChunk has StopReason="tool_calls".
-// Regression: issue #76 — streaming path omitted finish_reason entirely when
-// tool calls were present, breaking OpenAI-compatible consumers.
+// contains tool_call chunks, the final StreamChunk has StopReason="tool_use",
+// matching the non-streaming Complete path's vocabulary.
 func TestStreamSetsToolCallsFinishReason(t *testing.T) {
 	t.Parallel()
 
@@ -814,14 +813,14 @@ func TestStreamSetsToolCallsFinishReason(t *testing.T) {
 	if !lastChunk.Done {
 		t.Fatal("last chunk should have Done=true")
 	}
-	if lastChunk.StopReason != "tool_calls" {
-		t.Errorf("StopReason = %q; want \"tool_calls\" when tool calls were streamed", lastChunk.StopReason)
+	if lastChunk.StopReason != "tool_use" {
+		t.Errorf("StopReason = %q; want \"tool_use\" when tool calls were streamed", lastChunk.StopReason)
 	}
 }
 
 // TestStreamNoToolCallsFinishReason asserts that when the Ollama stream
 // contains no tool_calls, the final chunk's StopReason is empty (not
-// overridden to "tool_calls").
+// overridden to "tool_use").
 func TestStreamNoToolCallsFinishReason(t *testing.T) {
 	t.Parallel()
 
@@ -863,8 +862,8 @@ func TestStreamNoToolCallsFinishReason(t *testing.T) {
 	if !lastChunk.Done {
 		t.Fatal("last chunk should have Done=true")
 	}
-	if lastChunk.StopReason == "tool_calls" {
-		t.Errorf("StopReason = %q; want non-tool_calls when no tool calls were streamed", lastChunk.StopReason)
+	if lastChunk.StopReason == "tool_use" {
+		t.Errorf("StopReason = %q; want non-tool_use when no tool calls were streamed", lastChunk.StopReason)
 	}
 }
 


### PR DESCRIPTION
Closes #124.

## Summary

The Ollama streaming path was emitting `StopReason: "tool_calls"` while the non-streaming `Complete()` path used `"tool_use"`. This PR aligns streaming with the codebase-wide internal vocabulary (Anthropic-style `tool_use`).

The original `sawToolCalls` tracker landed in #118 (which had a misleading title and was supposed to add `mapOllamaDoneReason()`, but actually shipped this branch's diff instead). After that merge, the streaming path's finish_reason stayed at `tool_calls`, divergent from `Complete()`. This PR completes the reconciliation.

## Changes

- `internal/engine/provider_ollama.go` — line 528: `"tool_calls"` → `"tool_use"`
- `internal/engine/provider_ollama_test.go` — `TestStreamSetsToolCallsFinishReason` and `TestStreamNoToolCallsFinishReason` asserts updated to the new vocabulary; comments rewritten to match.

## Test plan

- [x] `go test ./internal/engine/ -run TestStream` passes
- [x] `go test ./internal/engine/` passes (full engine suite green locally before push)

## Out of scope

- Adding the actual `mapOllamaDoneReason()` function that #118's body promised — `done_reason` mapping for `length`/`load`/`unload` etc. is not currently wired. Worth a follow-up issue if anyone hits the gap (today the only divergent vocabulary is the `tool_use`/`tool_calls` one this PR closes).