### PR TITLE
chore(release): bump VERSION to 0.4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 #   make e2e      - Run e2e test in a container
 #   make e2e-local - Run e2e test locally
 
-VERSION := 2.4.0
+VERSION := 0.4.0
 BUILD_TIME := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -s -w -X github.com/cogos-dev/cogos/internal/engine.BuildTime=$(BUILD_TIME)
 BUILD_TAGS := fts5


### PR DESCRIPTION
One-line Makefile bump in preparation for the v0.4.0 release tag (#102).

Aligns the Makefile with the public version line on \`cogos-dev/cogos\` upstream (continuing \`v0.1.0\` / \`v0.2.0\` / \`v0.3.0\`). The previous local \`2.x.x\` progression was a private development line that was never published; the v0.x line is the canonical public version.

Pre-1.0 semantics: breaking changes at minor-version bumps are normal under semver convention. No separate "in-development" label needed.

## Sequence

1. **This PR** (one-line bump) → merge
2. Tag main HEAD as \`v0.4.0\`
3. Cut GitHub release with auto-generated notes (per session changelog discussion: PRs are the canonical changelog; release notes auto-generate from PR titles)

Closes nothing on its own; #102 closes when the tag is cut.