### PR TITLE
docs: formalize PR-as-changelog policy + PR title/body conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,26 @@
 # Changelog
 
+> **Going forward (v0.4.0 onward):** this project does not maintain hand-curated changelog entries. PR titles and bodies are the canonical record; auto-generated GitHub release notes are the per-release projection.
+>
+> - **Per-release summaries:** [Releases page](https://github.com/cogos-dev/cogos/releases)
+> - **Detailed PR list per release:** auto-generated from PR titles since the previous tag (via `gh release create --generate-notes`)
+> - **Per-PR rationale:** the linked PR's description and discussion
+>
+> See [CONTRIBUTING.md](CONTRIBUTING.md) ("Pull request titles and bodies") for the conventions that make those notes readable.
+
+## Versioning
+
+Pre-1.0. Per semver convention, breaking changes can land at any minor-version bump (`0.x` → `0.(x+1)`). When the project commits to external compatibility, a `v1.0.0` will be tagged. Until then, expect changes at minor boundaries.
+
+---
+
+# Historical entries
+
+The entries below predate the changelog policy above and are preserved as the historical record. For releases at v0.4.0 or later, see the [Releases page](https://github.com/cogos-dev/cogos/releases).
+
 ## [Unreleased]
 
-_(no entries yet)_
+_(no entries — see Releases page going forward)_
 
 ## [0.3.0] - 2026-04-22 — Track 5 consolidation + Agent F gap closure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,20 @@ The bar for "ready for review":
 - Test evidence is concrete: new tests are named, command output is pasted, CI status is linked. "Tests pass" by itself doesn't count.
 - Out-of-scope is stated. Reviewers should never have to guess whether you intentionally left something for a follow-up or just forgot.
 
+## Pull request titles and bodies
+
+PR titles and bodies are this project's changelog. The auto-generated GitHub release notes pull every PR title since the previous tag verbatim, so PR title quality is a load-bearing concern for the project's history.
+
+Conventions:
+
+- **Title is a complete imperative-mood sentence with a conventional-commit prefix.** Example: `fix(chat): execute injected cog_* MCP tools server-side` -- not `Tool fix` or `various improvements`. Anyone reading the release notes should understand what the PR did from the title alone.
+- **Use a conventional-commit prefix:** `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, `test:`, `perf:`. Optionally scope it: `fix(provider/ollama):`. Prefixes group release notes naturally and scan well in `git log`.
+- **Body explains the why, not the what.** The diff shows the what; the body should answer "why is this the right change here?" and "what is this NOT trying to do?" -- out-of-scope is as informative as in-scope.
+- **Link the issue** with `Closes #N` so the PR-issue chain is queryable. The issue's acceptance criteria become the merge bar.
+- **Out-of-scope deserves a section.** If you noticed something during the work that you intentionally didn't fix, name it -- otherwise reviewers can't tell whether you missed it or chose to defer.
+
+See [CHANGELOG.md](CHANGELOG.md) for the rationale.
+
 ## RFCs and ADRs
 
 For substantial design changes -- new subsystems, protocol changes, breaking behavior, or anything that touches the kernel's persistence or routing -- open an RFC before opening a PR:

--- a/README.md
+++ b/README.md
@@ -428,6 +428,12 @@ CogOS is one piece of a larger system. Each component is its own repo with indep
 
 ---
 
+## Releases & Changelog
+
+Per-release summaries: the [Releases page](https://github.com/cogos-dev/cogos/releases) (auto-generated from PR titles since the previous tag). See [CHANGELOG.md](CHANGELOG.md) for the policy and the historical entries (pre-v0.4.0).
+
+---
+
 ## Design documents
 
 - [System Specification](docs/SYSTEM-SPEC.md): Multi-level spec from ontology to deployment


### PR DESCRIPTION
Documents the going-forward changelog convention discussed for v0.4.0+.

## Three coordinated additions

### \`CHANGELOG.md\`
Prepends a policy section explaining that hand-curated entries stop at v0.3.0. Going forward, releases use auto-generated GitHub release notes from PR titles. Existing v0.3.0 entries + pre-reset v2.x history are preserved unchanged below as "Historical entries."

### \`README.md\`
Small "Releases & Changelog" section pointing at the Releases page and CHANGELOG.md for the policy. Inserted just before the existing Design documents section.

### \`CONTRIBUTING.md\`
New "Pull request titles and bodies" section between "Submitting changes" and "RFCs and ADRs". Conventions:
- Title is a complete imperative-mood sentence with a conventional-commit prefix
- \`feat:\` / \`fix:\` / \`refactor:\` / \`chore:\` / \`docs:\` / \`test:\` / \`perf:\` (optionally scoped)
- Body explains the why, not the what
- Link the issue with \`Closes #N\`
- Out-of-scope deserves a section

## Rationale

Maintaining a separate hand-curated changelog duplicates information that already lives in PR descriptions and commit messages. The duplicate inevitably drifts; git history + GitHub release notes are the canonical record. Pre-1.0 already signals "expect breaking changes at minor bumps" via standard semver convention, so no separate "in-development" label is needed.

## Composes with

- #102 (cut v0.4.0 release): the policy takes effect as of this release.
- #122 (Makefile bump to 0.4.0): the version-line correction this policy is anchored to.

## Test plan

- [x] No code changes; docs only
- [x] Markdown renders cleanly (verified locally)
- [ ] Reviewer reads the three changes for tone + clarity