### PR TITLE
fix(provider/openai-compat): suppress tool schemas when tool_choice is "none"

### DIFF
--- a/internal/engine/provider_openai.go
+++ b/internal/engine/provider_openai.go
@@ -343,8 +343,10 @@ func buildOpenAIRequest(model string, req *CompletionRequest, stream bool, maxTo
 		or.MaxTokens = req.MaxTokens
 	}
 
-	// Map tools.
-	if len(req.Tools) > 0 {
+	// Map tools. Skip when tool_choice is "none" — the caller has explicitly
+	// opted out of tool use for this turn; sending schemas wastes tokens and
+	// can bias models toward tool calls they should ignore.
+	if len(req.Tools) > 0 && req.ToolChoice != "none" {
 		or.Tools = make([]openaiTool, len(req.Tools))
 		for i, t := range req.Tools {
 			or.Tools[i] = openaiTool{

--- a/internal/engine/provider_openai_test.go
+++ b/internal/engine/provider_openai_test.go
@@ -168,6 +168,66 @@ func TestBuildOpenAIRequestTools(t *testing.T) {
 	}
 }
 
+// TestBuildOpenAIRequestSuppressesToolsWhenNone verifies that the tools array
+// is omitted from the wire body when tool_choice is "none", and that it is
+// included for other values ("auto", "required", specific tool name).
+func TestBuildOpenAIRequestSuppressesToolsWhenNone(t *testing.T) {
+	t.Parallel()
+
+	tools := []ToolDefinition{
+		{
+			Name:        "search",
+			Description: "Search the memory index",
+			InputSchema: map[string]interface{}{"type": "object"},
+		},
+	}
+	msgs := []ProviderMessage{{Role: "user", Content: "hi"}}
+
+	// tool_choice == "none" → tools field must be absent from the wire body.
+	t.Run("none suppresses tools", func(t *testing.T) {
+		t.Parallel()
+		req := &CompletionRequest{Messages: msgs, Tools: tools, ToolChoice: "none"}
+		r := buildOpenAIRequest("m", req, false, 4096)
+		if len(r.Tools) != 0 {
+			t.Errorf("tools len = %d; want 0 when tool_choice is none", len(r.Tools))
+		}
+		body, err := json.Marshal(r)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(body, &raw); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if _, present := raw["tools"]; present {
+			t.Errorf("wire body contains 'tools' key; want omitted when tool_choice is none")
+		}
+	})
+
+	// Other tool_choice values must still send the tools schema.
+	for _, tc := range []string{"auto", "required", "search"} {
+		tc := tc
+		t.Run("includes tools for "+tc, func(t *testing.T) {
+			t.Parallel()
+			req := &CompletionRequest{Messages: msgs, Tools: tools, ToolChoice: tc}
+			r := buildOpenAIRequest("m", req, false, 4096)
+			if len(r.Tools) != 1 {
+				t.Errorf("tools len = %d; want 1 for tool_choice=%q", len(r.Tools), tc)
+			}
+		})
+	}
+
+	// No tools in the request → tools field absent regardless of tool_choice.
+	t.Run("no tools always omits tools field", func(t *testing.T) {
+		t.Parallel()
+		req := &CompletionRequest{Messages: msgs, ToolChoice: "auto"}
+		r := buildOpenAIRequest("m", req, false, 4096)
+		if len(r.Tools) != 0 {
+			t.Errorf("tools len = %d; want 0 when no tools defined", len(r.Tools))
+		}
+	})
+}
+
 // ── parseOpenAIResponse ──────────────────────────────────────────────────────
 
 func TestParseOpenAIResponseBasic(t *testing.T) {


### PR DESCRIPTION
## Summary

- Gates the `tools` array in `buildOpenAIRequest` behind `req.ToolChoice != "none"`, matching the guard introduced for the Ollama provider in #120.
- Adds `TestBuildOpenAIRequestSuppressesToolsWhenNone` with five subtests mirroring `TestBuildOllamaRequestSuppressesToolsWhenNone` from the Ollama provider.

## Changes

- `internal/engine/provider_openai.go`: changed `if len(req.Tools) > 0` to `if len(req.Tools) > 0 && req.ToolChoice != "none"` in `buildOpenAIRequest`.
- `internal/engine/provider_openai_test.go`: added `TestBuildOpenAIRequestSuppressesToolsWhenNone` covering: `none` omits the `tools` key from the JSON wire body; `auto`, `required`, and a specific tool name still include tools; no tools defined omits the field regardless of `tool_choice`.

## Test plan

- [ ] `go test ./internal/engine/ -count=1 -timeout 90s` passes (verified locally).
- [ ] `TestBuildOpenAIRequestSuppressesToolsWhenNone` and all 5 subtests pass.
- [ ] Existing `TestBuildOpenAIRequestTools` (auto path) continues to pass — no regression.

## Out of scope

- Streaming path: `buildOpenAIRequest` is shared by both `Complete` and `Stream`, so the guard covers both without any additional changes.
- No changes to the `tool_choice` pass-through logic — `"none"` still flows to the wire correctly when no tools are present or when tools are suppressed.

Closes #127