### PR TITLE
feat(bus): add ?since=<seq> query param to bound replay on /v1/bus/{id}/stream

### DIFF
--- a/internal/engine/serve_bus.go
+++ b/internal/engine/serve_bus.go
@@ -458,9 +458,14 @@ const (
 //
 // Replay query params:
 //
-//	no_replay=1  skip historical events (only live from this point forward)
-//	consumer_id  optional identity for dedup (replaces any prior connection
-//	             with the same ID)
+//	no_replay=1   skip historical events (only live from this point forward)
+//	since=<N>     replay only events with seq > N; mutually exclusive with no_replay=1
+//	consumer_id   optional identity for dedup (replaces any prior connection
+//	              with the same ID)
+//
+// since=<N> edge cases:
+//   - N == current highest seq: replay is skipped, stream proceeds live
+//   - N > current highest seq: 416 Range Not Satisfiable (before SSE upgrade)
 //
 // The stream runs until the client disconnects or the server shuts down.
 // There is no max_duration cap on bus streams — they are intended for
@@ -478,13 +483,44 @@ func (s *Server) handleBusStream(w http.ResponseWriter, r *http.Request, busID s
 		return
 	}
 
+	q := r.URL.Query()
+	noReplay := q.Get("no_replay") == "1"
+	sinceRaw := q.Get("since")
+	consumerID := q.Get("consumer_id")
+
+	// since and no_replay are mutually exclusive.
+	if sinceRaw != "" && noReplay {
+		http.Error(w, `{"error":"since and no_replay are mutually exclusive"}`, http.StatusBadRequest)
+		return
+	}
+
+	var sinceSeq int
+	hasSince := sinceRaw != ""
+	if hasSince {
+		n, err := strconv.Atoi(sinceRaw)
+		if err != nil || n < 0 {
+			http.Error(w, `{"error":"since must be a non-negative integer"}`, http.StatusBadRequest)
+			return
+		}
+		sinceSeq = n
+	}
+
+	// Validate since range before upgrading to SSE — must not exceed current tip.
+	if hasSince && s.busSessions != nil {
+		events, err := s.busSessions.ReadEvents(busID)
+		if err == nil && len(events) > 0 {
+			maxSeq := events[len(events)-1].Seq
+			if sinceSeq > maxSeq {
+				http.Error(w, `{"error":"since exceeds current tip","code":"range_not_satisfiable"}`, http.StatusRequestedRangeNotSatisfiable)
+				return
+			}
+		}
+	}
+
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("X-Accel-Buffering", "no")
 	w.Header().Set("Connection", "keep-alive")
-
-	noReplay := r.URL.Query().Get("no_replay") == "1"
-	consumerID := r.URL.Query().Get("consumer_id")
 
 	rc := http.NewResponseController(w)
 
@@ -504,13 +540,25 @@ func (s *Server) handleBusStream(w http.ResponseWriter, r *http.Request, busID s
 		busID, time.Now().UTC().Format(time.RFC3339))
 	flusher.Flush()
 
-	// Replay historical events from disk so the subscriber sees the full
-	// tail on connect (mirrors cog bus tail behaviour). Skip if no_replay=1.
+	// Replay historical events from disk. Behaviour depends on query params:
+	//   default       replay all events
+	//   no_replay=1   skip replay
+	//   since=N       replay only events with seq > N
 	if !noReplay && s.busSessions != nil {
 		events, err := s.busSessions.ReadEvents(busID)
 		if err == nil {
-			for i := range events {
-				evt := &events[i]
+			var replayEvents []BusBlock
+			if hasSince {
+				for _, e := range events {
+					if e.Seq > sinceSeq {
+						replayEvents = append(replayEvents, e)
+					}
+				}
+			} else {
+				replayEvents = events
+			}
+			for i := range replayEvents {
+				evt := &replayEvents[i]
 				env := busSSEEnvelope{
 					ID:        "replay_" + evt.Hash,
 					Type:      evt.Type,
@@ -525,7 +573,7 @@ func (s *Server) handleBusStream(w http.ResponseWriter, r *http.Request, busID s
 				fmt.Fprintf(w, "data: %s\n\n", b)
 				broker.TouchWrite(busID, ch)
 			}
-			if len(events) > 0 {
+			if len(replayEvents) > 0 {
 				flusher.Flush()
 			}
 		}

--- a/internal/engine/serve_bus_test.go
+++ b/internal/engine/serve_bus_test.go
@@ -702,3 +702,254 @@ func TestConsumerRegistryAckAndList(t *testing.T) {
 		t.Error("Remove twice should return false")
 	}
 }
+
+// TestBusStreamSinceReplayFromMid verifies that ?since=N replays only events
+// with seq > N, not the full history.
+func TestBusStreamSinceReplayFromMid(t *testing.T) {
+	t.Parallel()
+	handler, _, _ := newEventsTestServer(t)
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	const busID = "since-mid-bus"
+	openBody := `{"bus_id":"` + busID + `"}`
+	openResp, _ := http.Post(srv.URL+"/v1/bus/open", "application/json", strings.NewReader(openBody))
+	openResp.Body.Close()
+
+	// Append 5 events (seq 1..5).
+	for i := 0; i < 5; i++ {
+		body := fmt.Sprintf(`{"bus_id":%q,"from":"test","message":"m%d"}`, busID, i)
+		r, _ := http.Post(srv.URL+"/v1/bus/send", "application/json", strings.NewReader(body))
+		r.Body.Close()
+	}
+
+	// Connect with ?since=2 — expect replay of seq 3, 4, 5 only.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet,
+		srv.URL+"/v1/bus/"+busID+"/stream?since=2", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET stream: %v", err)
+	}
+	t.Cleanup(func() { resp.Body.Close() })
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	// Collect replay frames (prefixed "replay_") until we've seen all expected
+	// or the deadline fires.
+	var replayed []float64
+	scanner := bufio.NewScanner(resp.Body)
+	timeout := time.After(3 * time.Second)
+	lineCh := make(chan string, 32)
+	go func() {
+		for scanner.Scan() {
+			lineCh <- scanner.Text()
+		}
+		close(lineCh)
+	}()
+	for len(replayed) < 3 {
+		select {
+		case line, ok := <-lineCh:
+			if !ok {
+				goto done
+			}
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			var env map[string]interface{}
+			if err := json.Unmarshal([]byte(line[6:]), &env); err != nil {
+				continue
+			}
+			id, _ := env["id"].(string)
+			if !strings.HasPrefix(id, "replay_") {
+				continue
+			}
+			data, ok := env["data"].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			seq, _ := data["seq"].(float64)
+			replayed = append(replayed, seq)
+		case <-timeout:
+			goto done
+		}
+	}
+done:
+	cancel()
+
+	if len(replayed) != 3 {
+		t.Fatalf("replayed %d events, want 3 (seq 3,4,5 after since=2)", len(replayed))
+	}
+	for _, seq := range replayed {
+		if seq <= 2 {
+			t.Errorf("replay included seq=%v which should be filtered by since=2", seq)
+		}
+	}
+}
+
+// TestBusStreamSinceReplayFromTip verifies that ?since=N where N equals the
+// current tip skips replay entirely and proceeds directly to live.
+func TestBusStreamSinceReplayFromTip(t *testing.T) {
+	t.Parallel()
+	handler, _, _ := newEventsTestServer(t)
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	const busID = "since-tip-bus"
+	openResp, _ := http.Post(srv.URL+"/v1/bus/open", "application/json",
+		strings.NewReader(`{"bus_id":"`+busID+`"}`))
+	openResp.Body.Close()
+
+	// Append 3 events (seq 1..3). Tip is seq 3.
+	for i := 0; i < 3; i++ {
+		body := fmt.Sprintf(`{"bus_id":%q,"from":"test","message":"m%d"}`, busID, i)
+		r, _ := http.Post(srv.URL+"/v1/bus/send", "application/json", strings.NewReader(body))
+		r.Body.Close()
+	}
+
+	// ?since=3 (the tip) — no replay frames expected, only connected + live.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet,
+		srv.URL+"/v1/bus/"+busID+"/stream?since=3", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET stream: %v", err)
+	}
+	t.Cleanup(func() { resp.Body.Close() })
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	// Read the stream for a short window; no replay_ frames should appear.
+	replayCount := 0
+	liveReceived := make(chan struct{}, 1)
+	lineCh := make(chan string, 32)
+	scanner := bufio.NewScanner(resp.Body)
+	go func() {
+		for scanner.Scan() {
+			lineCh <- scanner.Text()
+		}
+		close(lineCh)
+	}()
+
+	// Send a live event after the connection is established.
+	time.Sleep(50 * time.Millisecond)
+	liveBody := fmt.Sprintf(`{"bus_id":%q,"from":"test","message":"live"}`, busID)
+	lr, _ := http.Post(srv.URL+"/v1/bus/send", "application/json", strings.NewReader(liveBody))
+	lr.Body.Close()
+
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case line, ok := <-lineCh:
+			if !ok {
+				goto checkTip
+			}
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			var env map[string]interface{}
+			if err := json.Unmarshal([]byte(line[6:]), &env); err != nil {
+				continue
+			}
+			id, _ := env["id"].(string)
+			if strings.HasPrefix(id, "replay_") {
+				replayCount++
+			} else if id != "" {
+				select {
+				case liveReceived <- struct{}{}:
+				default:
+				}
+				goto checkTip
+			}
+		case <-deadline:
+			goto checkTip
+		}
+	}
+checkTip:
+	cancel()
+
+	if replayCount != 0 {
+		t.Errorf("replay frames = %d, want 0 (since=tip)", replayCount)
+	}
+	select {
+	case <-liveReceived:
+	default:
+		t.Error("no live event received after since=tip connection")
+	}
+}
+
+// TestBusStreamSincePastTip verifies that ?since=N where N exceeds the current
+// tip returns 416 Range Not Satisfiable before upgrading to SSE.
+func TestBusStreamSincePastTip(t *testing.T) {
+	t.Parallel()
+	handler, _, _ := newEventsTestServer(t)
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	const busID = "since-past-tip-bus"
+	openResp, _ := http.Post(srv.URL+"/v1/bus/open", "application/json",
+		strings.NewReader(`{"bus_id":"`+busID+`"}`))
+	openResp.Body.Close()
+
+	// Append 2 events (tip = seq 2).
+	for i := 0; i < 2; i++ {
+		body := fmt.Sprintf(`{"bus_id":%q,"from":"test","message":"m%d"}`, busID, i)
+		r, _ := http.Post(srv.URL+"/v1/bus/send", "application/json", strings.NewReader(body))
+		r.Body.Close()
+	}
+
+	// ?since=99 (beyond tip) — expect 416.
+	resp, err := http.Get(srv.URL + "/v1/bus/" + busID + "/stream?since=99")
+	if err != nil {
+		t.Fatalf("GET stream: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusRequestedRangeNotSatisfiable {
+		t.Errorf("status = %d, want 416", resp.StatusCode)
+	}
+
+	var body map[string]interface{}
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if _, ok := body["error"]; !ok {
+		t.Errorf("response missing 'error' field: %+v", body)
+	}
+}
+
+// TestBusStreamSinceMutualExclusion verifies that passing both ?since=N and
+// ?no_replay=1 returns 400 Bad Request.
+func TestBusStreamSinceMutualExclusion(t *testing.T) {
+	t.Parallel()
+	handler, _, _ := newEventsTestServer(t)
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	const busID = "since-mutex-bus"
+	openResp, _ := http.Post(srv.URL+"/v1/bus/open", "application/json",
+		strings.NewReader(`{"bus_id":"`+busID+`"}`))
+	openResp.Body.Close()
+
+	resp, err := http.Get(srv.URL + "/v1/bus/" + busID + "/stream?since=1&no_replay=1")
+	if err != nil {
+		t.Fatalf("GET stream: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+
+	var body map[string]interface{}
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if _, ok := body["error"]; !ok {
+		t.Errorf("response missing 'error' field: %+v", body)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `?since=N` query parameter to `GET /v1/bus/{id}/stream` so clients can reconnect and replay only events they haven't seen, rather than forcing a full-history replay on every connect.
- `?since=N` and `?no_replay=1` are mutually exclusive (400 if both supplied).
- `?since=N` where N exceeds the current tip returns 416 Range Not Satisfiable before the SSE upgrade, so the client gets a clean error rather than a silent empty stream.

## Changes

- `internal/engine/serve_bus.go` — `handleBusStream`: parse `since` query param; validate mutual exclusion with `no_replay`; 416 on over-range; filter replay slice to `seq > sinceSeq`.
- `internal/engine/serve_bus_test.go` — four new tests matching the issue's named cases:
  - `TestBusStreamSinceReplayFromMid` — since=2 on a 5-event bus replays seq 3,4,5 only
  - `TestBusStreamSinceReplayFromTip` — since=tip yields zero replay frames, live event still arrives
  - `TestBusStreamSincePastTip` — since=99 on a 2-event bus returns 416 with JSON error body
  - `TestBusStreamSinceMutualExclusion` — since=1&no_replay=1 returns 400 with JSON error body

## Test plan

- [ ] `go test ./internal/engine/ -run TestBusStreamSince -v` — all four new tests pass
- [ ] `go test ./internal/engine/ -count=1 -timeout 90s` — full engine suite passes

## Out of scope

- Cursor-based (`?after=<event_id>`) and time-based (`?since_ts=<RFC3339>`) variants (noted in the issue as separate follow-ups).
- Flush-per-frame during replay (issue #126 problem 3, backpressure); orthogonal concern, filed separately if needed.

Closes #126