### PR TITLE
feat(engine): add substrate-level env isolation for provider child processes

### DIFF
--- a/internal/engine/provider_claudecode.go
+++ b/internal/engine/provider_claudecode.go
@@ -155,7 +155,7 @@ func (p *ClaudeCodeProvider) Complete(ctx context.Context, req *CompletionReques
 		"--include-partial-messages",
 	)
 
-	cmd := exec.CommandContext(ctx, p.cliBinary, args...)
+	cmd := NewProviderCommandContext(ctx, ManagedCommandOpts{EnvPolicy: EnvPolicyProviderChild}, p.cliBinary, args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.WaitDelay = claudeCodeKillGrace
 	cmd.Cancel = func() error {
@@ -260,7 +260,7 @@ func (p *ClaudeCodeProvider) Stream(ctx context.Context, req *CompletionRequest)
 		"--include-partial-messages",
 	)
 
-	cmd := exec.CommandContext(ctx, p.cliBinary, args...)
+	cmd := NewProviderCommandContext(ctx, ManagedCommandOpts{EnvPolicy: EnvPolicyProviderChild}, p.cliBinary, args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.WaitDelay = claudeCodeKillGrace
 	cmd.Cancel = func() error {
@@ -723,7 +723,7 @@ func (p *ClaudeCodeProvider) SpawnBackground(opts BackgroundTaskOpts) (string, e
 		ctx, cancel = context.WithTimeout(context.Background(), opts.Timeout)
 	}
 
-	cmd := exec.CommandContext(ctx, p.cliBinary, args...)
+	cmd := NewProviderCommandContext(ctx, ManagedCommandOpts{EnvPolicy: EnvPolicyProviderChild, Dir: opts.WorkDir}, p.cliBinary, args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.WaitDelay = claudeCodeKillGrace
 	cmd.Cancel = func() error {
@@ -737,9 +737,6 @@ func (p *ClaudeCodeProvider) SpawnBackground(opts BackgroundTaskOpts) (string, e
 		return syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
 	}
 	cmd.Stdin = strings.NewReader(opts.Prompt)
-	if opts.WorkDir != "" {
-		cmd.Dir = opts.WorkDir
-	}
 
 	proc := p.procMgr.Track(cmd, ManagedProcessOpts{
 		Kind:            ProcessBackground,

--- a/internal/engine/provider_codex.go
+++ b/internal/engine/provider_codex.go
@@ -217,10 +217,7 @@ func (p *CodexProvider) Complete(ctx context.Context, req *CompletionRequest) (*
 	if err != nil {
 		return nil, fmt.Errorf("codex binary not available: %w", err)
 	}
-	cmd := exec.CommandContext(ctx, binary, args...)
-	if p.workDir != "" {
-		cmd.Dir = p.workDir
-	}
+	cmd := NewProviderCommandContext(ctx, ManagedCommandOpts{EnvPolicy: EnvPolicyProviderChild, Dir: p.workDir}, binary, args...)
 
 	out, err := cmd.Output()
 	if err != nil {
@@ -276,10 +273,7 @@ func (p *CodexProvider) Stream(ctx context.Context, req *CompletionRequest) (<-c
 	if err != nil {
 		return nil, fmt.Errorf("codex binary not available: %w", err)
 	}
-	cmd := exec.CommandContext(ctx, binary, args...)
-	if p.workDir != "" {
-		cmd.Dir = p.workDir
-	}
+	cmd := NewProviderCommandContext(ctx, ManagedCommandOpts{EnvPolicy: EnvPolicyProviderChild, Dir: p.workDir}, binary, args...)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/internal/engine/provider_env.go
+++ b/internal/engine/provider_env.go
@@ -1,0 +1,81 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// EnvPolicy controls what environment a provider child process inherits.
+type EnvPolicy string
+
+const (
+	// EnvPolicyProviderChild starts from os.Environ() and strips known
+	// ingress/proxy variables that can redirect model clients back into CogOS.
+	EnvPolicyProviderChild EnvPolicy = "provider_child"
+
+	// EnvPolicyInherit passes the current process environment unchanged.
+	EnvPolicyInherit EnvPolicy = "inherit"
+)
+
+// ingressVars are environment keys stripped under EnvPolicyProviderChild.
+// These are routing/proxy variables that can cause a kernel-spawned provider
+// subprocess to route its own model calls back through the kernel.
+var ingressVars = []string{
+	"ANTHROPIC_BASE_URL",
+	"ANTHROPIC_AUTH_TOKEN",
+	"OPENAI_BASE_URL",
+	"OPENAI_API_BASE",
+	"OPENAI_COMPAT_BASE_URL",
+}
+
+// ManagedCommandOpts configures environment and working directory for a
+// provider child process created via NewProviderCommandContext.
+type ManagedCommandOpts struct {
+	EnvPolicy EnvPolicy
+	ExtraEnv  []string
+	Dir       string
+}
+
+// NewProviderCommandContext creates an exec.Cmd for a provider child process,
+// applying the env policy before the process starts.
+func NewProviderCommandContext(ctx context.Context, opts ManagedCommandOpts, binary string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, binary, args...)
+
+	switch opts.EnvPolicy {
+	case EnvPolicyInherit:
+		// cmd.Env == nil means inherit; nothing to do.
+	default:
+		cmd.Env = providerChildEnv(opts.ExtraEnv)
+	}
+
+	if opts.Dir != "" {
+		cmd.Dir = opts.Dir
+	}
+
+	return cmd
+}
+
+// providerChildEnv builds the sanitized environment for provider child
+// processes: os.Environ() minus ingressVars, plus any extras.
+func providerChildEnv(extra []string) []string {
+	base := os.Environ()
+	out := make([]string, 0, len(base)+len(extra))
+	for _, kv := range base {
+		if !isIngressVar(kv) {
+			out = append(out, kv)
+		}
+	}
+	out = append(out, extra...)
+	return out
+}
+
+func isIngressVar(kv string) bool {
+	for _, key := range ingressVars {
+		if strings.HasPrefix(kv, key+"=") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/engine/provider_env_test.go
+++ b/internal/engine/provider_env_test.go
@@ -1,0 +1,146 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestProviderChildEnv_StripsIngressVars(t *testing.T) {
+	t.Setenv("ANTHROPIC_BASE_URL", "http://localhost:6931")
+
+	env := providerChildEnv(nil)
+
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "ANTHROPIC_BASE_URL=") {
+			t.Errorf("ANTHROPIC_BASE_URL must be stripped from provider child env, got %q", kv)
+		}
+	}
+}
+
+func TestProviderChildEnv_PreservesUnrelatedVars(t *testing.T) {
+	t.Parallel()
+
+	path := os.Getenv("PATH")
+	if path == "" {
+		t.Skip("PATH not set in test environment")
+	}
+
+	env := providerChildEnv(nil)
+
+	found := false
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "PATH=") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("PATH must be preserved in provider child env")
+	}
+}
+
+func TestProviderChildEnv_ExtraEnvAppendsAfterSanitization(t *testing.T) {
+	t.Setenv("ANTHROPIC_BASE_URL", "http://localhost:6931")
+
+	extra := []string{"ANTHROPIC_BASE_URL=https://api.anthropic.com"}
+	env := providerChildEnv(extra)
+
+	var last string
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "ANTHROPIC_BASE_URL=") {
+			last = kv
+		}
+	}
+	if last != "ANTHROPIC_BASE_URL=https://api.anthropic.com" {
+		t.Errorf("ExtraEnv should win; got last ANTHROPIC_BASE_URL=%q", last)
+	}
+}
+
+func TestEnvPolicyInherit_PreservesEnv(t *testing.T) {
+	t.Setenv("ANTHROPIC_BASE_URL", "http://localhost:6931")
+
+	cmd := NewProviderCommandContext(context.Background(),
+		ManagedCommandOpts{EnvPolicy: EnvPolicyInherit},
+		"true",
+	)
+
+	// nil means inherit — the variable will be present when the process runs.
+	if cmd.Env != nil {
+		t.Errorf("EnvPolicyInherit should leave cmd.Env nil, got %v", cmd.Env)
+	}
+}
+
+func TestEnvPolicyProviderChild_StripsAllIngressKeys(t *testing.T) {
+	for _, key := range ingressVars {
+		t.Setenv(key, "http://should-be-stripped")
+	}
+
+	env := providerChildEnv(nil)
+
+	for _, kv := range env {
+		for _, key := range ingressVars {
+			if strings.HasPrefix(kv, key+"=") {
+				t.Errorf("ingress var %s must be stripped, found %q", key, kv)
+			}
+		}
+	}
+}
+
+// TestClaudeCodeComplete_DoesNotInheritBaseURL is the regression test for #59:
+// a kernel-spawned claude subprocess must not receive ANTHROPIC_BASE_URL even
+// when the parent process (the kernel) has it set.
+func TestClaudeCodeComplete_DoesNotInheritBaseURL(t *testing.T) {
+	t.Setenv("ANTHROPIC_BASE_URL", "http://localhost:6931")
+
+	// envfile is a temp file where the fake claude writes its environment.
+	envFile, err := os.CreateTemp(t.TempDir(), "env-*.txt")
+	if err != nil {
+		t.Fatalf("create env file: %v", err)
+	}
+	envFile.Close()
+
+	// Fake claude: record env to envfile, then emit valid provider stream-json output.
+	script, err := os.CreateTemp(t.TempDir(), "fake-claude-*.sh")
+	if err != nil {
+		t.Fatalf("create fake claude: %v", err)
+	}
+	_, _ = script.WriteString("#!/bin/sh\n")
+	_, _ = script.WriteString("env > " + envFile.Name() + "\n")
+	// Emit minimal valid stream-json: a result message.
+	_, _ = script.WriteString(`echo '{"type":"result","subtype":"success","result":"ok","is_error":false,"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}'` + "\n")
+	script.Close()
+	if err := os.Chmod(script.Name(), 0o755); err != nil {
+		t.Fatalf("chmod fake claude: %v", err)
+	}
+
+	procMgr := NewProcessManager(ProcessManagerConfig{})
+	p := &ClaudeCodeProvider{
+		name:      "test",
+		model:     "sonnet",
+		cliBinary: script.Name(),
+		procMgr:   procMgr,
+	}
+
+	req := &CompletionRequest{
+		Messages: []ProviderMessage{
+			{Role: "user", Content: "hello"},
+		},
+	}
+
+	if _, err := p.Complete(context.Background(), req); err != nil {
+		t.Fatalf("Complete returned unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(envFile.Name())
+	if err != nil {
+		t.Fatalf("read env file: %v", err)
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "ANTHROPIC_BASE_URL=") {
+			t.Errorf("child process received ANTHROPIC_BASE_URL: %q", line)
+		}
+	}
+}

--- a/internal/engine/provider_pi.go
+++ b/internal/engine/provider_pi.go
@@ -120,7 +120,7 @@ func (p *PiProvider) Complete(ctx context.Context, req *CompletionRequest) (*Com
 	prompt := p.buildPrompt(req)
 	args := p.buildArgs(req)
 
-	cmd := exec.CommandContext(ctx, p.piBinary, args...)
+	cmd := NewProviderCommandContext(ctx, ManagedCommandOpts{EnvPolicy: EnvPolicyProviderChild}, p.piBinary, args...)
 	cmd.Stdin = strings.NewReader(prompt)
 
 	proc := p.procMgr.Track(cmd, ManagedProcessOpts{
@@ -164,7 +164,7 @@ func (p *PiProvider) Stream(ctx context.Context, req *CompletionRequest) (<-chan
 		}
 	}
 
-	cmd := exec.CommandContext(ctx, p.piBinary, args...)
+	cmd := NewProviderCommandContext(ctx, ManagedCommandOpts{EnvPolicy: EnvPolicyProviderChild}, p.piBinary, args...)
 	cmd.Stdin = strings.NewReader(prompt)
 
 	stdout, err := cmd.StdoutPipe()


### PR DESCRIPTION
## Summary

- Introduces `EnvPolicy`, `ManagedCommandOpts`, and `NewProviderCommandContext` as a shared command factory for all CLI-backed provider subprocesses.
- `EnvPolicyProviderChild` strips five known ingress/proxy variables (`ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, `OPENAI_BASE_URL`, `OPENAI_API_BASE`, `OPENAI_COMPAT_BASE_URL`) from `os.Environ()` before launching a provider worker, preventing kernel routing state from leaking into egress workers.
- `ExtraEnv` appends after sanitization so providers can opt back into a specific value intentionally.
- `EnvPolicyInherit` leaves `cmd.Env` nil (unchanged from current behavior) for callers that need the full parent env.

## Changes

- `internal/engine/provider_env.go` — new shared command factory: `EnvPolicy`, `ManagedCommandOpts`, `NewProviderCommandContext`, `providerChildEnv`, `isIngressVar`.
- `internal/engine/provider_env_test.go` — unit tests for all four issue-specified scenarios plus the `ClaudeCodeProvider` regression test.
- `internal/engine/provider_claudecode.go` — `Complete`, `Stream`, and `SpawnBackground` use `NewProviderCommandContext`.
- `internal/engine/provider_pi.go` — `Complete` and `Stream` use `NewProviderCommandContext`.
- `internal/engine/provider_codex.go` — `Complete` and `Stream` use `NewProviderCommandContext`.

## Test plan

- [ ] `go test ./internal/engine/ -count=1 -timeout 90s` passes (verified locally).
- [ ] `TestProviderChildEnv_StripsIngressVars` — parent env has `ANTHROPIC_BASE_URL`; child env omits it.
- [ ] `TestProviderChildEnv_PreservesUnrelatedVars` — `PATH` survives sanitization.
- [ ] `TestProviderChildEnv_ExtraEnvAppendsAfterSanitization` — ExtraEnv wins over stripped key.
- [ ] `TestEnvPolicyInherit_PreservesEnv` — `cmd.Env` is nil under `EnvPolicyInherit`.
- [ ] `TestEnvPolicyProviderChild_StripsAllIngressKeys` — all five ingress keys stripped.
- [ ] `TestClaudeCodeComplete_DoesNotInheritBaseURL` — fake `claude` binary records its env; asserts `ANTHROPIC_BASE_URL` absent.

## Out of scope

- `Ping` methods on all three providers still use raw `exec.CommandContext` — they check binary availability only and do not run model inference, so env isolation is not needed there.
- `Available` helpers use `exec.LookPath` only — no subprocess, no isolation needed.
- Multi-provider integration test (one `/v1/messages` request producing one subprocess, no tool-loop recursion) noted as optional in the issue is deferred; unit and regression coverage satisfies the required acceptance criteria.
- CodexProvider has no `ProcessManager` integration; that is a pre-existing design gap outside this issue's scope.

Closes #59