### PR TITLE
refactor(skills): extract skill discovery and exec into pkg/skills

### DIFF
--- a/cmd_skill.go
+++ b/cmd_skill.go
@@ -8,57 +8,27 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 
-	"gopkg.in/yaml.v3"
+	"github.com/cogos-dev/cogos/pkg/skills"
 )
 
-// ─── Types ──────────────────────────────────────────────────────────────────────
+// ─── Re-exported types ───────────────────────────────────────────────────────
 
 // SkillRecord is the JSON schema returned by `cog skill list --json` and
-// GET /v1/skills. Every field present in the issue contract is represented.
-type SkillRecord struct {
-	Name        string   `json:"name"`
-	Version     string   `json:"version"`
-	Tier        int      `json:"tier"`
-	Description string   `json:"description"`
-	Exec        *string  `json:"exec"`         // null for tier-0/1
-	Schema      *string  `json:"schema"`       // null unless tier-3
-	Path        string   `json:"path"`
-	Requires    []string `json:"requires"`
-	Gated       bool     `json:"gated,omitempty"` // true when capability-filtered
-}
-
-// skillFrontmatter holds the YAML front-matter fields we parse from SKILL.md.
-type skillFrontmatter struct {
-	Name        string   `yaml:"name"`
-	Version     string   `yaml:"version"`
-	Description string   `yaml:"description"`
-	Exec        string   `yaml:"exec"`
-	Schema      string   `yaml:"schema"`
-	Requires    []string `yaml:"requires"`
-	Timeout     string   `yaml:"timeout"` // e.g. "5m"
-}
+// GET /v1/skills. Aliased from pkg/skills so existing callers compile unchanged.
+type SkillRecord = skills.Record
 
 // SkillExecResult is the structured response from `cog skill exec`.
-type SkillExecResult struct {
-	Name       string `json:"name"`
-	ExitCode   int    `json:"exit_code"`
-	Stdout     string `json:"stdout"`
-	Stderr     string `json:"stderr"`
-	DurationMS int64  `json:"duration_ms"`
-	Error      string `json:"error,omitempty"`
-}
+// Aliased from pkg/skills so existing callers compile unchanged.
+type SkillExecResult = skills.ExecResult
 
-// ─── Discovery ──────────────────────────────────────────────────────────────────
+// ─── Directory resolution ────────────────────────────────────────────────────
 
 // skillDirs returns the ordered list of directories to scan for skills.
 // User-level (~/.claude/skills/) is searched first; workspace-level
@@ -74,210 +44,24 @@ func skillDirs() []string {
 
 	// Workspace-level (project-scoped; may not exist)
 	if root, _, err := ResolveWorkspace(); err == nil {
-		wsSkills := filepath.Join(root, ".claude", "skills")
-		dirs = append(dirs, wsSkills)
+		dirs = append(dirs, filepath.Join(root, ".claude", "skills"))
 	}
 
 	return dirs
 }
 
-// parseSkillMD extracts YAML front-matter from a SKILL.md file. The
-// front-matter is optional (many existing skills are bare Markdown); callers
-// receive a zero-value struct plus the title/description extracted from the
-// Markdown heading if no YAML block is present.
-func parseSkillMD(data []byte) (skillFrontmatter, string, string) {
-	content := string(data)
-	var fm skillFrontmatter
-
-	// Extract YAML front-matter between leading --- delimiters.
-	if strings.HasPrefix(content, "---\n") {
-		end := strings.Index(content[4:], "\n---")
-		if end != -1 {
-			yamlBlock := content[4 : 4+end]
-			_ = yaml.Unmarshal([]byte(yamlBlock), &fm)
-			content = content[4+end+4:] // skip past closing ---\n
-		}
-	}
-
-	// Pull title and description from Markdown heading / first paragraph.
-	title := ""
-	desc := ""
-	for _, line := range strings.Split(content, "\n") {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "# ") && title == "" {
-			title = strings.TrimPrefix(line, "# ")
-			continue
-		}
-		if line != "" && !strings.HasPrefix(line, "#") && !strings.HasPrefix(line, ">") && desc == "" {
-			desc = line
-			if len(desc) > 200 {
-				desc = desc[:197] + "..."
-			}
-		}
-	}
-
-	return fm, title, desc
-}
-
-// inferTier determines the tier of a skill from its directory layout.
-//
-//   - Tier 0: prose-only SKILL.md (default)
-//   - Tier 1: helper scripts present but no declared exec
-//   - Tier 2: exec field set in frontmatter and bin/<exec> exists
-//   - Tier 3: tier-2 + schema field set
-func inferTier(skillPath string, fm skillFrontmatter) int {
-	if fm.Schema != "" {
-		// Only tier-3 if there is also a canonical exec
-		if fm.Exec != "" {
-			return 3
-		}
-	}
-
-	if fm.Exec != "" {
-		// Require the binary to actually exist
-		binPath := filepath.Join(skillPath, fm.Exec)
-		if _, err := os.Stat(binPath); err == nil {
-			return 2
-		}
-	}
-
-	// Check for any scripts that make this tier-1
-	entries, err := os.ReadDir(skillPath)
-	if err != nil {
-		return 0
-	}
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		name := e.Name()
-		if strings.HasSuffix(name, ".sh") || strings.HasSuffix(name, ".py") {
-			return 1
-		}
-	}
-	// Check bin/ directory for scripts
-	binDir := filepath.Join(skillPath, "bin")
-	if binEntries, err := os.ReadDir(binDir); err == nil && len(binEntries) > 0 {
-		// bin/ exists but exec not declared — tier 1
-		if fm.Exec == "" {
-			return 1
-		}
-	}
-
-	return 0
-}
-
-// loadSkillRecord converts a skill directory into a SkillRecord.
-func loadSkillRecord(name, skillPath string) (*SkillRecord, error) {
-	skillFile := filepath.Join(skillPath, "SKILL.md")
-	data, err := os.ReadFile(skillFile)
-	if err != nil {
-		return nil, fmt.Errorf("read SKILL.md: %w", err)
-	}
-
-	fm, title, desc := parseSkillMD(data)
-
-	// Resolve name: frontmatter wins; fall back to directory name.
-	skillName := name
-	if fm.Name != "" {
-		skillName = fm.Name
-	}
-
-	// Resolve description: frontmatter wins; fall back to Markdown extraction.
-	skillDesc := fm.Description
-	if skillDesc == "" {
-		skillDesc = desc
-	}
-	if skillDesc == "" && title != "" {
-		skillDesc = title
-	}
-
-	version := fm.Version
-	if version == "" {
-		version = "0.1.0"
-	}
-
-	tier := inferTier(skillPath, fm)
-
-	rec := &SkillRecord{
-		Name:        skillName,
-		Version:     version,
-		Tier:        tier,
-		Description: skillDesc,
-		Path:        skillPath,
-		Requires:    fm.Requires,
-	}
-	if rec.Requires == nil {
-		rec.Requires = []string{}
-	}
-
-	if fm.Exec != "" {
-		exec := fm.Exec
-		rec.Exec = &exec
-	}
-	if fm.Schema != "" {
-		schema := fm.Schema
-		rec.Schema = &schema
-	}
-
-	return rec, nil
-}
+// ─── Public API (thin wrappers over pkg/skills) ──────────────────────────────
 
 // DiscoverSkills walks skill directories and returns a deduplicated list of
 // SkillRecords. Workspace-level skills override user-level skills with the
 // same name (last directory wins).
 func DiscoverSkills() ([]SkillRecord, error) {
-	seen := make(map[string]SkillRecord)
-	var order []string // preserve insertion order for stable output
-
-	for _, dir := range skillDirs() {
-		entries, err := os.ReadDir(dir)
-		if err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
-			return nil, fmt.Errorf("read skills dir %s: %w", dir, err)
-		}
-
-		for _, entry := range entries {
-			if !entry.IsDir() {
-				continue
-			}
-			name := entry.Name()
-			skillPath := filepath.Join(dir, name)
-
-			rec, err := loadSkillRecord(name, skillPath)
-			if err != nil {
-				// Not a valid skill directory; skip silently.
-				continue
-			}
-
-			if _, exists := seen[rec.Name]; !exists {
-				order = append(order, rec.Name)
-			}
-			seen[rec.Name] = *rec
-		}
-	}
-
-	result := make([]SkillRecord, 0, len(order))
-	for _, name := range order {
-		result = append(result, seen[name])
-	}
-	return result, nil
+	return skills.Discover(skillDirs())
 }
 
 // FindSkill looks up a single skill by name; returns an error when not found.
 func FindSkill(name string) (*SkillRecord, error) {
-	skills, err := DiscoverSkills()
-	if err != nil {
-		return nil, err
-	}
-	for i := range skills {
-		if skills[i].Name == name {
-			return &skills[i], nil
-		}
-	}
-	return nil, fmt.Errorf("skill not found: %s", name)
+	return skills.FindByName(name, skillDirs())
 }
 
 // ─── Dispatcher ─────────────────────────────────────────────────────────────────
@@ -309,7 +93,7 @@ func cmdSkillList(args []string) error {
 		}
 	}
 
-	skills, err := DiscoverSkills()
+	skillList, err := DiscoverSkills()
 	if err != nil {
 		return fmt.Errorf("discover skills: %w", err)
 	}
@@ -317,11 +101,11 @@ func cmdSkillList(args []string) error {
 	if jsonMode {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
-		return enc.Encode(skills)
+		return enc.Encode(skillList)
 	}
 
 	// Human-readable table
-	if len(skills) == 0 {
+	if len(skillList) == 0 {
 		fmt.Println("No skills found.")
 		fmt.Println()
 		fmt.Println("Add a skill directory with SKILL.md to:")
@@ -332,14 +116,14 @@ func cmdSkillList(args []string) error {
 
 	fmt.Printf("%-30s %-8s %s\n", "NAME", "TIER", "DESCRIPTION")
 	fmt.Println(strings.Repeat("-", 80))
-	for _, s := range skills {
+	for _, s := range skillList {
 		desc := s.Description
 		if len(desc) > 40 {
 			desc = desc[:37] + "..."
 		}
 		fmt.Printf("%-30s tier-%-3d %s\n", s.Name, s.Tier, desc)
 	}
-	fmt.Printf("\n%d skill(s) found. Use --json for full records.\n", len(skills))
+	fmt.Printf("\n%d skill(s) found. Use --json for full records.\n", len(skillList))
 	return nil
 }
 
@@ -401,84 +185,18 @@ func cmdSkillExec(args []string) error {
 	return nil
 }
 
-// execSkill is the core exec logic, shared by CLI and HTTP handler.
+// execSkill is the CLI exec entry point. It resolves the workspace root for
+// COGOS_WORKSPACE injection, delegates to pkg/skills.Exec, then emits a
+// skill.exec bus event.
 func execSkill(skill *SkillRecord, inputJSON, timeoutStr string) (*SkillExecResult, error) {
-	switch skill.Tier {
-	case 0:
-		return nil, fmt.Errorf("not_executable: skill %q is tier-0 (prose-only). Read its SKILL.md at %s and act per its instructions.", skill.Name, filepath.Join(skill.Path, "SKILL.md"))
-	case 1:
-		return nil, fmt.Errorf("no_canonical_entry_point: skill %q is tier-1 (scripts present but no canonical exec declared in SKILL.md frontmatter). Promote to tier-2 by adding an exec: field.", skill.Name)
-	}
-
-	// Tier 2 or 3
-	if skill.Exec == nil {
-		return nil, fmt.Errorf("no_canonical_entry_point: skill %q has no exec declared", skill.Name)
-	}
-
-	execPath := filepath.Join(skill.Path, *skill.Exec)
-	if _, err := os.Stat(execPath); err != nil {
-		return nil, fmt.Errorf("exec_not_found: skill %q exec binary not found at %s", skill.Name, execPath)
-	}
-
-	// Determine timeout: flag > frontmatter > default 5m
-	timeout := 5 * time.Minute
-	if timeoutStr != "" {
-		if d, err := time.ParseDuration(timeoutStr); err == nil {
-			timeout = d
-		}
-	}
-
-	// Build context with timeout
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, execPath)
-
-	// Pass input via stdin
-	if inputJSON != "" {
-		cmd.Stdin = bytes.NewBufferString(inputJSON)
-	}
-
-	// Propagate identity-relevant env vars
-	cmd.Env = append(os.Environ(),
-		"COGOS_SKILL_NAME="+skill.Name,
-		"COGOS_SKILL_VERSION="+skill.Version,
-		"COGOS_SKILL_PATH="+skill.Path,
-	)
+	wsRoot := ""
 	if root, _, err := ResolveWorkspace(); err == nil {
-		cmd.Env = append(cmd.Env, "COGOS_WORKSPACE="+root)
+		wsRoot = root
 	}
 
-	start := time.Now()
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
-	durationMS := time.Since(start).Milliseconds()
-
-	exitCode := 0
-	var errMsg string
-
+	result, err := skills.Exec(context.Background(), skill, inputJSON, timeoutStr, wsRoot)
 	if err != nil {
-		if ctx.Err() == context.DeadlineExceeded {
-			errMsg = fmt.Sprintf("timeout after %s", timeout)
-			exitCode = 124 // same as bash timeout
-		} else if exitErr, ok := err.(*exec.ExitError); ok {
-			exitCode = exitErr.ExitCode()
-		} else {
-			exitCode = 1
-			errMsg = err.Error()
-		}
-	}
-
-	result := &SkillExecResult{
-		Name:       skill.Name,
-		ExitCode:   exitCode,
-		Stdout:     stdout.String(),
-		Stderr:     stderr.String(),
-		DurationMS: durationMS,
-		Error:      errMsg,
+		return nil, err
 	}
 
 	// Emit skill.exec bus event (best-effort; don't fail the exec if the bus is unavailable)

--- a/cmd_skill_test.go
+++ b/cmd_skill_test.go
@@ -1,4 +1,8 @@
-// cmd_skill_test.go — Tests for `cog skill list` and `cog skill exec` (issues #96, #97).
+// cmd_skill_test.go — Smoke tests for the `cog skill` CLI wrappers.
+//
+// The heavy lifting (discovery, tier classification, exec) is tested in
+// pkg/skills/skills_test.go. These tests verify that the CLI-level wrappers
+// (DiscoverSkills, FindSkill, execSkill) wire through correctly.
 
 package main
 
@@ -9,6 +13,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/cogos-dev/cogos/pkg/skills"
 )
 
 // ─── Fixtures ───────────────────────────────────────────────────────────────────
@@ -44,14 +50,14 @@ func makeExecScript(t *testing.T, dir, relPath, body string) string {
 	return full
 }
 
-// ─── loadSkillRecord ────────────────────────────────────────────────────────────
+// ─── skills.LoadRecord (via pkg/skills) ─────────────────────────────────────
 
 func TestLoadSkillRecord_Tier0_PraseOnly(t *testing.T) {
 	root := t.TempDir()
 	md := "# My Prose Skill\n\nThis skill only has documentation.\n"
 	dir := makeSkillDir(t, root, "prose-skill", md)
 
-	rec, err := loadSkillRecord("prose-skill", dir)
+	rec, err := skills.LoadRecord("prose-skill", dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -83,7 +89,7 @@ func TestLoadSkillRecord_Tier1_Scripts(t *testing.T) {
 		t.Fatalf("write helper.sh: %v", err)
 	}
 
-	rec, err := loadSkillRecord("helper-skill", dir)
+	rec, err := skills.LoadRecord("helper-skill", dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -102,7 +108,7 @@ func TestLoadSkillRecord_Tier2_WithBin(t *testing.T) {
 	dir := makeSkillDir(t, root, "exec-skill", md)
 	makeExecScript(t, dir, "bin/run", "#!/bin/sh\necho hello\n")
 
-	rec, err := loadSkillRecord("exec-skill", dir)
+	rec, err := skills.LoadRecord("exec-skill", dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -133,7 +139,7 @@ func TestLoadSkillRecord_Tier3_WithSchema(t *testing.T) {
 	dir := makeSkillDir(t, root, "typed-skill", md)
 	makeExecScript(t, dir, "bin/typed", "#!/bin/sh\necho '{}'\n")
 
-	rec, err := loadSkillRecord("typed-skill", dir)
+	rec, err := skills.LoadRecord("typed-skill", dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -146,7 +152,7 @@ func TestLoadSkillRecord_Tier3_WithSchema(t *testing.T) {
 	}
 }
 
-// ─── DiscoverSkills ─────────────────────────────────────────────────────────────
+// ─── DiscoverSkills ─────────────────────────────────────────────────────────
 
 func TestDiscoverSkills_Empty(t *testing.T) {
 	// Override skillDirs to point at a temp directory with no skills.
@@ -156,12 +162,12 @@ func TestDiscoverSkills_Empty(t *testing.T) {
 	defer os.Setenv("HOME", origHome)
 
 	// No workspace — ResolveWorkspace will fail, but DiscoverSkills handles that.
-	skills, err := DiscoverSkills()
+	skillList, err := DiscoverSkills()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(skills) != 0 {
-		t.Errorf("want 0 skills in empty dir, got %d", len(skills))
+	if len(skillList) != 0 {
+		t.Errorf("want 0 skills in empty dir, got %d", len(skillList))
 	}
 }
 
@@ -177,17 +183,17 @@ func TestDiscoverSkills_MultipleSkills(t *testing.T) {
 	os.Setenv("HOME", tmpHome)
 	defer os.Setenv("HOME", origHome)
 
-	skills, err := DiscoverSkills()
+	skillList, err := DiscoverSkills()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(skills) != 2 {
-		t.Fatalf("want 2 skills, got %d", len(skills))
+	if len(skillList) != 2 {
+		t.Fatalf("want 2 skills, got %d", len(skillList))
 	}
 
 	byName := make(map[string]SkillRecord)
-	for _, s := range skills {
+	for _, s := range skillList {
 		byName[s.Name] = s
 	}
 
@@ -199,7 +205,7 @@ func TestDiscoverSkills_MultipleSkills(t *testing.T) {
 	}
 }
 
-// ─── JSON output shape ──────────────────────────────────────────────────────────
+// ─── JSON output shape ──────────────────────────────────────────────────────
 
 func TestSkillRecord_JSONShape(t *testing.T) {
 	// Verify the JSON output has the contract fields the issue requires.
@@ -235,12 +241,12 @@ func TestSkillRecord_JSONShape(t *testing.T) {
 	}
 }
 
-// ─── execSkill ──────────────────────────────────────────────────────────────────
+// ─── execSkill (CLI wrapper) ─────────────────────────────────────────────────
 
 func TestExecSkill_Tier0_Rejected(t *testing.T) {
 	root := t.TempDir()
 	dir := makeSkillDir(t, root, "prose", "# Prose skill\n")
-	skill, err := loadSkillRecord("prose", dir)
+	skill, err := skills.LoadRecord("prose", dir)
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
@@ -260,7 +266,7 @@ func TestExecSkill_Tier1_Rejected(t *testing.T) {
 	// Add a .sh to make it tier-1
 	os.WriteFile(filepath.Join(dir, "helper.sh"), []byte("#!/bin/sh\necho hi\n"), 0755)
 
-	skill, err := loadSkillRecord("scripts", dir)
+	skill, err := skills.LoadRecord("scripts", dir)
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
@@ -283,7 +289,7 @@ func TestExecSkill_Tier2_Success(t *testing.T) {
 	dir := makeSkillDir(t, root, "greet", md)
 	makeExecScript(t, dir, "bin/greet", "#!/bin/sh\necho 'hello from skill'\n")
 
-	skill, err := loadSkillRecord("greet", dir)
+	skill, err := skills.LoadRecord("greet", dir)
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
@@ -313,7 +319,7 @@ func TestExecSkill_NonZeroExit(t *testing.T) {
 	dir := makeSkillDir(t, root, "fail-skill", md)
 	makeExecScript(t, dir, "bin/fail", "#!/bin/sh\necho 'some error' >&2\nexit 42\n")
 
-	skill, err := loadSkillRecord("fail-skill", dir)
+	skill, err := skills.LoadRecord("fail-skill", dir)
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
@@ -340,7 +346,7 @@ func TestExecSkill_Timeout(t *testing.T) {
 	dir := makeSkillDir(t, root, "slow-skill", md)
 	makeExecScript(t, dir, "bin/slow", "#!/bin/sh\nsleep 10\n")
 
-	skill, err := loadSkillRecord("slow-skill", dir)
+	skill, err := skills.LoadRecord("slow-skill", dir)
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
@@ -368,7 +374,7 @@ func TestExecSkill_StdinInput(t *testing.T) {
 	// Script reads stdin and echoes it
 	makeExecScript(t, dir, "bin/echo-in", "#!/bin/sh\ncat\n")
 
-	skill, err := loadSkillRecord("echo-skill", dir)
+	skill, err := skills.LoadRecord("echo-skill", dir)
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}

--- a/internal/engine/serve_skills.go
+++ b/internal/engine/serve_skills.go
@@ -7,45 +7,21 @@
 package engine
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 
-	"gopkg.in/yaml.v3"
+	"github.com/cogos-dev/cogos/pkg/skills"
 )
 
-// ─── Types (mirrors cmd_skill.go contract) ───────────────────────────────────────
+// ─── Re-exported types ────────────────────────────────────────────────────────
 
 // SkillRecord is the JSON object returned by GET /v1/skills.
-type SkillRecord struct {
-	Name        string   `json:"name"`
-	Version     string   `json:"version"`
-	Tier        int      `json:"tier"`
-	Description string   `json:"description"`
-	Exec        *string  `json:"exec"`
-	Schema      *string  `json:"schema"`
-	Path        string   `json:"path"`
-	Requires    []string `json:"requires"`
-	Gated       bool     `json:"gated,omitempty"`
-}
-
-// skillFM holds parsed SKILL.md front-matter.
-type skillFM struct {
-	Name        string   `yaml:"name"`
-	Version     string   `yaml:"version"`
-	Description string   `yaml:"description"`
-	Exec        string   `yaml:"exec"`
-	Schema      string   `yaml:"schema"`
-	Requires    []string `yaml:"requires"`
-	Timeout     string   `yaml:"timeout"`
-}
+// Aliased from pkg/skills so the engine package surface is unchanged.
+type SkillRecord = skills.Record
 
 // SkillExecRequest is the POST body for /v1/skills/{name}/exec.
 type SkillExecRequest struct {
@@ -54,14 +30,8 @@ type SkillExecRequest struct {
 }
 
 // SkillExecResponse is the response from /v1/skills/{name}/exec.
-type SkillExecResponse struct {
-	Name       string `json:"name"`
-	ExitCode   int    `json:"exit_code"`
-	Stdout     string `json:"stdout"`
-	Stderr     string `json:"stderr"`
-	DurationMS int64  `json:"duration_ms"`
-	Error      string `json:"error,omitempty"`
-}
+// Aliased from pkg/skills so the HTTP handler uses the same type.
+type SkillExecResponse = skills.ExecResult
 
 // ─── Route registration ──────────────────────────────────────────────────────────
 
@@ -70,7 +40,7 @@ func (s *Server) registerSkillRoutes(mux *http.ServeMux) {
 	s.route(mux, "POST /v1/skills/{name}/exec", s.handleSkillExec)
 }
 
-// ─── Discovery ───────────────────────────────────────────────────────────────────
+// ─── Discovery helpers ───────────────────────────────────────────────────────────
 
 // skillDirs returns directories to scan, in priority order (workspace overrides user).
 func (s *Server) skillDirs() []string {
@@ -88,167 +58,20 @@ func (s *Server) skillDirs() []string {
 	return dirs
 }
 
-// parseSkillFM extracts YAML front-matter from SKILL.md content.
-func parseSkillFM(data []byte) (skillFM, string, string) {
-	content := string(data)
-	var fm skillFM
-
-	if strings.HasPrefix(content, "---\n") {
-		end := strings.Index(content[4:], "\n---")
-		if end != -1 {
-			_ = yaml.Unmarshal([]byte(content[4:4+end]), &fm)
-			content = content[4+end+4:]
-		}
-	}
-
-	title, desc := "", ""
-	for _, line := range strings.Split(content, "\n") {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "# ") && title == "" {
-			title = strings.TrimPrefix(line, "# ")
-			continue
-		}
-		if line != "" && !strings.HasPrefix(line, "#") && !strings.HasPrefix(line, ">") && desc == "" {
-			desc = line
-			if len(desc) > 200 {
-				desc = desc[:197] + "..."
-			}
-		}
-	}
-	return fm, title, desc
-}
-
-// inferSkillTier determines tier from directory structure and front-matter.
-func inferSkillTier(skillPath string, fm skillFM) int {
-	if fm.Schema != "" && fm.Exec != "" {
-		return 3
-	}
-	if fm.Exec != "" {
-		if _, err := os.Stat(filepath.Join(skillPath, fm.Exec)); err == nil {
-			return 2
-		}
-	}
-	entries, err := os.ReadDir(skillPath)
-	if err != nil {
-		return 0
-	}
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		n := e.Name()
-		if strings.HasSuffix(n, ".sh") || strings.HasSuffix(n, ".py") {
-			return 1
-		}
-	}
-	if binEntries, err := os.ReadDir(filepath.Join(skillPath, "bin")); err == nil && len(binEntries) > 0 && fm.Exec == "" {
-		return 1
-	}
-	return 0
-}
-
-// loadSkillRecord converts a directory into a SkillRecord.
-func loadSkillRecord(name, skillPath string) (*SkillRecord, error) {
-	data, err := os.ReadFile(filepath.Join(skillPath, "SKILL.md"))
-	if err != nil {
-		return nil, err
-	}
-
-	fm, title, desc := parseSkillFM(data)
-
-	skillName := name
-	if fm.Name != "" {
-		skillName = fm.Name
-	}
-	skillDesc := fm.Description
-	if skillDesc == "" {
-		skillDesc = desc
-	}
-	if skillDesc == "" {
-		skillDesc = title
-	}
-	version := fm.Version
-	if version == "" {
-		version = "0.1.0"
-	}
-	tier := inferSkillTier(skillPath, fm)
-
-	rec := &SkillRecord{
-		Name:        skillName,
-		Version:     version,
-		Tier:        tier,
-		Description: skillDesc,
-		Path:        skillPath,
-		Requires:    fm.Requires,
-	}
-	if rec.Requires == nil {
-		rec.Requires = []string{}
-	}
-	if fm.Exec != "" {
-		e := fm.Exec
-		rec.Exec = &e
-	}
-	if fm.Schema != "" {
-		sc := fm.Schema
-		rec.Schema = &sc
-	}
-	return rec, nil
-}
-
 // discoverSkills returns all skills from the configured directories.
 func (s *Server) discoverSkills() ([]SkillRecord, error) {
-	seen := make(map[string]SkillRecord)
-	var order []string
-
-	for _, dir := range s.skillDirs() {
-		entries, err := os.ReadDir(dir)
-		if err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
-			return nil, fmt.Errorf("read skills dir %s: %w", dir, err)
-		}
-		for _, entry := range entries {
-			if !entry.IsDir() {
-				continue
-			}
-			name := entry.Name()
-			rec, err := loadSkillRecord(name, filepath.Join(dir, name))
-			if err != nil {
-				continue
-			}
-			if _, exists := seen[rec.Name]; !exists {
-				order = append(order, rec.Name)
-			}
-			seen[rec.Name] = *rec
-		}
-	}
-
-	result := make([]SkillRecord, 0, len(order))
-	for _, name := range order {
-		result = append(result, seen[name])
-	}
-	return result, nil
+	return skills.Discover(s.skillDirs())
 }
 
 // findSkill looks up a skill by name.
 func (s *Server) findSkill(name string) (*SkillRecord, error) {
-	skills, err := s.discoverSkills()
-	if err != nil {
-		return nil, err
-	}
-	for i := range skills {
-		if skills[i].Name == name {
-			return &skills[i], nil
-		}
-	}
-	return nil, fmt.Errorf("skill not found: %s", name)
+	return skills.FindByName(name, s.skillDirs())
 }
 
 // ─── Handlers ────────────────────────────────────────────────────────────────────
 
 func (s *Server) handleSkillList(w http.ResponseWriter, r *http.Request) {
-	skills, err := s.discoverSkills()
+	skillList, err := s.discoverSkills()
 	if err != nil {
 		http.Error(w, `{"error":"discovery_failed","detail":"`+err.Error()+`"}`, http.StatusInternalServerError)
 		return
@@ -257,7 +80,7 @@ func (s *Server) handleSkillList(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
-	_ = enc.Encode(skills)
+	_ = enc.Encode(skillList)
 }
 
 func (s *Server) handleSkillExec(w http.ResponseWriter, r *http.Request) {
@@ -304,85 +127,22 @@ func (s *Server) handleSkillExec(w http.ResponseWriter, r *http.Request) {
 
 // ─── Exec ─────────────────────────────────────────────────────────────────────────
 
+// execSkill delegates to pkg/skills.Exec and then emits a skill.exec bus event.
 func (s *Server) execSkill(ctx context.Context, skill *SkillRecord, inputJSON, timeoutStr string) (*SkillExecResponse, error) {
-	switch skill.Tier {
-	case 0:
-		return nil, fmt.Errorf("not_executable: skill %q is tier-0 (prose-only). Read SKILL.md at %s", skill.Name, filepath.Join(skill.Path, "SKILL.md"))
-	case 1:
-		return nil, fmt.Errorf("no_canonical_entry_point: skill %q is tier-1 (no exec: in SKILL.md frontmatter)", skill.Name)
+	wsRoot := ""
+	if s.cfg != nil {
+		wsRoot = s.cfg.WorkspaceRoot
 	}
 
-	if skill.Exec == nil {
-		return nil, fmt.Errorf("no_canonical_entry_point: skill %q has no exec declared", skill.Name)
+	result, err := skills.Exec(ctx, skill, inputJSON, timeoutStr, wsRoot)
+	if err != nil {
+		return nil, err
 	}
 
-	execPath := filepath.Join(skill.Path, *skill.Exec)
-	if _, err := os.Stat(execPath); err != nil {
-		return nil, fmt.Errorf("exec_not_found: %s", execPath)
-	}
+	// Emit skill.exec bus event (best-effort).
+	s.emitSkillExecEvent(skill, result)
 
-	timeout := 5 * time.Minute
-	if timeoutStr != "" {
-		if d, err := time.ParseDuration(timeoutStr); err == nil {
-			timeout = d
-		}
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, execPath)
-	if inputJSON != "" {
-		cmd.Stdin = bytes.NewBufferString(inputJSON)
-	}
-
-	env := os.Environ()
-	env = append(env,
-		"COGOS_SKILL_NAME="+skill.Name,
-		"COGOS_SKILL_VERSION="+skill.Version,
-		"COGOS_SKILL_PATH="+skill.Path,
-	)
-	if s.cfg != nil && s.cfg.WorkspaceRoot != "" {
-		env = append(env, "COGOS_WORKSPACE="+s.cfg.WorkspaceRoot)
-	}
-	cmd.Env = env
-
-	start := time.Now()
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	execErr := cmd.Run()
-	durationMS := time.Since(start).Milliseconds()
-
-	exitCode := 0
-	var errMsg string
-
-	if execErr != nil {
-		if ctx.Err() == context.DeadlineExceeded {
-			errMsg = fmt.Sprintf("timeout after %s", timeout)
-			exitCode = 124
-		} else if exitErr, ok := execErr.(*exec.ExitError); ok {
-			exitCode = exitErr.ExitCode()
-		} else {
-			exitCode = 1
-			errMsg = execErr.Error()
-		}
-	}
-
-	resp := &SkillExecResponse{
-		Name:       skill.Name,
-		ExitCode:   exitCode,
-		Stdout:     stdout.String(),
-		Stderr:     stderr.String(),
-		DurationMS: durationMS,
-		Error:      errMsg,
-	}
-
-	// Emit skill.exec bus event (best-effort)
-	s.emitSkillExecEvent(skill, resp)
-
-	return resp, nil
+	return result, nil
 }
 
 // emitSkillExecEvent emits a skill.exec event to the bus. Non-fatal.
@@ -401,3 +161,4 @@ func (s *Server) emitSkillExecEvent(skill *SkillRecord, resp *SkillExecResponse)
 	}
 	_, _ = s.busSessions.AppendEvent("skill", "skill.exec", "kernel:skill:exec", payload)
 }
+

--- a/pkg/skills/skills.go
+++ b/pkg/skills/skills.go
@@ -1,0 +1,356 @@
+// Package skills provides shared skill discovery, frontmatter parsing, tier
+// classification, and execution logic used by both the CLI (cmd_skill.go) and
+// the HTTP handler (internal/engine/serve_skills.go).
+//
+// The package is stateless: all functions accept the skill directories (or
+// workspace root) as parameters so callers control workspace resolution and
+// there are no global side-effects.
+package skills
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+// Frontmatter holds the YAML front-matter fields parsed from a SKILL.md file.
+// The front-matter block is optional; callers receive a zero-value struct when
+// no front-matter is present.
+type Frontmatter struct {
+	Name        string   `yaml:"name"`
+	Version     string   `yaml:"version"`
+	Description string   `yaml:"description"`
+	Exec        string   `yaml:"exec"`
+	Schema      string   `yaml:"schema"`
+	Requires    []string `yaml:"requires"`
+	Timeout     string   `yaml:"timeout"` // e.g. "5m"
+}
+
+// Record is the canonical skill descriptor used by both surfaces.  Its JSON
+// shape is the contract returned by `cog skill list --json` and
+// GET /v1/skills.
+type Record struct {
+	Name        string   `json:"name"`
+	Version     string   `json:"version"`
+	Tier        int      `json:"tier"`
+	Description string   `json:"description"`
+	Exec        *string  `json:"exec"`            // null for tier-0/1
+	Schema      *string  `json:"schema"`          // null unless tier-3
+	Path        string   `json:"path"`
+	Requires    []string `json:"requires"`
+	Gated       bool     `json:"gated,omitempty"` // true when capability-filtered
+}
+
+// ExecResult is the structured outcome of running a skill.
+type ExecResult struct {
+	Name       string `json:"name"`
+	ExitCode   int    `json:"exit_code"`
+	Stdout     string `json:"stdout"`
+	Stderr     string `json:"stderr"`
+	DurationMS int64  `json:"duration_ms"`
+	Error      string `json:"error,omitempty"`
+}
+
+// ─── Frontmatter parsing ─────────────────────────────────────────────────────
+
+// ParseFrontmatter extracts YAML front-matter from raw SKILL.md bytes. It also
+// pulls a title and description from the first Markdown heading and leading
+// paragraph, used as fallbacks when the YAML block is absent or incomplete.
+//
+// Returns: (frontmatter, title, firstParagraph).
+func ParseFrontmatter(data []byte) (Frontmatter, string, string) {
+	content := string(data)
+	var fm Frontmatter
+
+	// Extract YAML block between leading --- delimiters.
+	if strings.HasPrefix(content, "---\n") {
+		end := strings.Index(content[4:], "\n---")
+		if end != -1 {
+			_ = yaml.Unmarshal([]byte(content[4:4+end]), &fm)
+			content = content[4+end+4:] // skip past closing ---\n
+		}
+	}
+
+	// Extract title from the first Markdown # heading and description from
+	// the first non-empty, non-heading, non-blockquote line.
+	title := ""
+	desc := ""
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "# ") && title == "" {
+			title = strings.TrimPrefix(line, "# ")
+			continue
+		}
+		if line != "" && !strings.HasPrefix(line, "#") && !strings.HasPrefix(line, ">") && desc == "" {
+			desc = line
+			if len(desc) > 200 {
+				desc = desc[:197] + "..."
+			}
+		}
+	}
+
+	return fm, title, desc
+}
+
+// ─── Tier classification ─────────────────────────────────────────────────────
+
+// InferTier determines the tier of a skill from its directory layout and
+// parsed front-matter.
+//
+//   - Tier 0: prose-only SKILL.md (default)
+//   - Tier 1: helper scripts present but no declared exec
+//   - Tier 2: exec field set in frontmatter and bin/<exec> exists
+//   - Tier 3: tier-2 + schema field set
+func InferTier(skillPath string, fm Frontmatter) int {
+	if fm.Schema != "" && fm.Exec != "" {
+		return 3
+	}
+
+	if fm.Exec != "" {
+		binPath := filepath.Join(skillPath, fm.Exec)
+		if _, err := os.Stat(binPath); err == nil {
+			return 2
+		}
+	}
+
+	// Check for any scripts at the skill root that make this tier-1.
+	entries, err := os.ReadDir(skillPath)
+	if err != nil {
+		return 0
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if strings.HasSuffix(name, ".sh") || strings.HasSuffix(name, ".py") {
+			return 1
+		}
+	}
+	// bin/ exists with files but exec not declared — tier 1.
+	if binEntries, err := os.ReadDir(filepath.Join(skillPath, "bin")); err == nil && len(binEntries) > 0 && fm.Exec == "" {
+		return 1
+	}
+
+	return 0
+}
+
+// ─── Record loading ──────────────────────────────────────────────────────────
+
+// LoadRecord reads a skill directory and returns a populated Record, or an
+// error if the directory does not contain a valid SKILL.md.
+func LoadRecord(name, skillPath string) (*Record, error) {
+	data, err := os.ReadFile(filepath.Join(skillPath, "SKILL.md"))
+	if err != nil {
+		return nil, fmt.Errorf("read SKILL.md: %w", err)
+	}
+
+	fm, title, desc := ParseFrontmatter(data)
+
+	// Name: frontmatter wins; fall back to directory name.
+	skillName := name
+	if fm.Name != "" {
+		skillName = fm.Name
+	}
+
+	// Description: frontmatter wins; fall back to Markdown extraction.
+	skillDesc := fm.Description
+	if skillDesc == "" {
+		skillDesc = desc
+	}
+	if skillDesc == "" && title != "" {
+		skillDesc = title
+	}
+
+	version := fm.Version
+	if version == "" {
+		version = "0.1.0"
+	}
+
+	tier := InferTier(skillPath, fm)
+
+	rec := &Record{
+		Name:        skillName,
+		Version:     version,
+		Tier:        tier,
+		Description: skillDesc,
+		Path:        skillPath,
+		Requires:    fm.Requires,
+	}
+	if rec.Requires == nil {
+		rec.Requires = []string{}
+	}
+	if fm.Exec != "" {
+		e := fm.Exec
+		rec.Exec = &e
+	}
+	if fm.Schema != "" {
+		s := fm.Schema
+		rec.Schema = &s
+	}
+
+	return rec, nil
+}
+
+// ─── Discovery ───────────────────────────────────────────────────────────────
+
+// Discover walks dirs in order and returns a deduplicated list of Records.
+// Later directories in the slice override earlier ones for skills with the
+// same name (workspace-level skills win over user-level skills when the caller
+// passes user-level dirs first).
+//
+// Non-existent directories are silently skipped; other I/O errors are returned.
+func Discover(dirs []string) ([]Record, error) {
+	seen := make(map[string]Record)
+	var order []string // preserve stable insertion order
+
+	for _, dir := range dirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("read skills dir %s: %w", dir, err)
+		}
+
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			name := entry.Name()
+			rec, err := LoadRecord(name, filepath.Join(dir, name))
+			if err != nil {
+				// Not a valid skill directory; skip silently.
+				continue
+			}
+
+			if _, exists := seen[rec.Name]; !exists {
+				order = append(order, rec.Name)
+			}
+			seen[rec.Name] = *rec
+		}
+	}
+
+	result := make([]Record, 0, len(order))
+	for _, name := range order {
+		result = append(result, seen[name])
+	}
+	return result, nil
+}
+
+// FindByName looks up a single skill by name across dirs.
+// Returns an error when the skill is not found.
+func FindByName(name string, dirs []string) (*Record, error) {
+	skills, err := Discover(dirs)
+	if err != nil {
+		return nil, err
+	}
+	for i := range skills {
+		if skills[i].Name == name {
+			return &skills[i], nil
+		}
+	}
+	return nil, fmt.Errorf("skill not found: %s", name)
+}
+
+// ─── Execution ───────────────────────────────────────────────────────────────
+
+// Exec runs a tier-2 or tier-3 skill and returns the structured result.
+//
+// Parameters:
+//   - ctx: parent context; Exec derives a child context with the resolved timeout.
+//   - skill: the Record to execute.
+//   - inputJSON: raw JSON payload forwarded to the skill via stdin (empty = no stdin).
+//   - timeoutStr: duration string overriding the default 5-minute timeout (empty = use default).
+//   - workspaceRoot: propagated as COGOS_WORKSPACE env var (empty = omitted).
+//
+// Tier-0 and tier-1 skills are rejected with a structured error prefix so
+// callers can map them to appropriate HTTP status codes.
+//
+// Non-zero exit codes are captured in ExecResult.ExitCode and do NOT cause Exec
+// to return a non-nil error.
+func Exec(ctx context.Context, skill *Record, inputJSON, timeoutStr, workspaceRoot string) (*ExecResult, error) {
+	switch skill.Tier {
+	case 0:
+		return nil, fmt.Errorf("not_executable: skill %q is tier-0 (prose-only). Read its SKILL.md at %s and act per its instructions.", skill.Name, filepath.Join(skill.Path, "SKILL.md"))
+	case 1:
+		return nil, fmt.Errorf("no_canonical_entry_point: skill %q is tier-1 (scripts present but no canonical exec declared in SKILL.md frontmatter). Promote to tier-2 by adding an exec: field.", skill.Name)
+	}
+
+	// Tier 2 or 3.
+	if skill.Exec == nil {
+		return nil, fmt.Errorf("no_canonical_entry_point: skill %q has no exec declared", skill.Name)
+	}
+
+	execPath := filepath.Join(skill.Path, *skill.Exec)
+	if _, err := os.Stat(execPath); err != nil {
+		return nil, fmt.Errorf("exec_not_found: skill %q exec binary not found at %s", skill.Name, execPath)
+	}
+
+	// Resolve timeout: parameter > default 5m.
+	timeout := 5 * time.Minute
+	if timeoutStr != "" {
+		if d, err := time.ParseDuration(timeoutStr); err == nil {
+			timeout = d
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, execPath)
+	if inputJSON != "" {
+		cmd.Stdin = bytes.NewBufferString(inputJSON)
+	}
+
+	// Propagate identity-relevant env vars.
+	cmd.Env = append(os.Environ(),
+		"COGOS_SKILL_NAME="+skill.Name,
+		"COGOS_SKILL_VERSION="+skill.Version,
+		"COGOS_SKILL_PATH="+skill.Path,
+	)
+	if workspaceRoot != "" {
+		cmd.Env = append(cmd.Env, "COGOS_WORKSPACE="+workspaceRoot)
+	}
+
+	start := time.Now()
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	runErr := cmd.Run()
+	durationMS := time.Since(start).Milliseconds()
+
+	exitCode := 0
+	var errMsg string
+
+	if runErr != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			errMsg = fmt.Sprintf("timeout after %s", timeout)
+			exitCode = 124 // same as bash timeout
+		} else if exitErr, ok := runErr.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = 1
+			errMsg = runErr.Error()
+		}
+	}
+
+	return &ExecResult{
+		Name:       skill.Name,
+		ExitCode:   exitCode,
+		Stdout:     stdout.String(),
+		Stderr:     stderr.String(),
+		DurationMS: durationMS,
+		Error:      errMsg,
+	}, nil
+}

--- a/pkg/skills/skills_test.go
+++ b/pkg/skills/skills_test.go
@@ -1,0 +1,480 @@
+// Package skills — unit tests for discovery, tier classification,
+// frontmatter parsing, and execution.
+package skills_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/cogos-dev/cogos/pkg/skills"
+)
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+func makeSkillDir(t *testing.T, root, name, skillMD string) string {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir skill dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(skillMD), 0644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+	return dir
+}
+
+func makeExecScript(t *testing.T, dir, relPath, body string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("exec skill tests require Unix")
+	}
+	full := filepath.Join(dir, relPath)
+	if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+		t.Fatalf("mkdir exec dir: %v", err)
+	}
+	if err := os.WriteFile(full, []byte(body), 0755); err != nil {
+		t.Fatalf("write exec script: %v", err)
+	}
+	return full
+}
+
+// ─── ParseFrontmatter ────────────────────────────────────────────────────────
+
+func TestParseFrontmatter_NoYAML(t *testing.T) {
+	data := []byte("# My Prose Skill\n\nThis skill only has documentation.\n")
+	fm, title, desc := skills.ParseFrontmatter(data)
+
+	if fm.Name != "" {
+		t.Errorf("want empty name, got %q", fm.Name)
+	}
+	if title != "My Prose Skill" {
+		t.Errorf("want title 'My Prose Skill', got %q", title)
+	}
+	if desc != "This skill only has documentation." {
+		t.Errorf("want desc 'This skill only has documentation.', got %q", desc)
+	}
+}
+
+func TestParseFrontmatter_WithYAML(t *testing.T) {
+	data := []byte("---\nname: my-skill\nversion: 0.2.0\ndescription: Does things\nexec: bin/run\n---\n# My Skill\n")
+	fm, _, _ := skills.ParseFrontmatter(data)
+
+	if fm.Name != "my-skill" {
+		t.Errorf("want name 'my-skill', got %q", fm.Name)
+	}
+	if fm.Version != "0.2.0" {
+		t.Errorf("want version '0.2.0', got %q", fm.Version)
+	}
+	if fm.Exec != "bin/run" {
+		t.Errorf("want exec 'bin/run', got %q", fm.Exec)
+	}
+}
+
+func TestParseFrontmatter_DescTruncated(t *testing.T) {
+	long := strings.Repeat("x", 250)
+	data := []byte("# Title\n\n" + long + "\n")
+	_, _, desc := skills.ParseFrontmatter(data)
+
+	if len(desc) > 200 {
+		t.Errorf("want desc truncated to 200, got len %d", len(desc))
+	}
+	if !strings.HasSuffix(desc, "...") {
+		t.Errorf("want desc to end with '...', got %q", desc[len(desc)-5:])
+	}
+}
+
+// ─── InferTier ───────────────────────────────────────────────────────────────
+
+func TestInferTier_Tier0(t *testing.T) {
+	dir := t.TempDir()
+	fm := skills.Frontmatter{}
+	if got := skills.InferTier(dir, fm); got != 0 {
+		t.Errorf("want tier 0, got %d", got)
+	}
+}
+
+func TestInferTier_Tier1_ShScript(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "helper.sh"), []byte("#!/bin/sh\n"), 0755)
+	fm := skills.Frontmatter{}
+	if got := skills.InferTier(dir, fm); got != 1 {
+		t.Errorf("want tier 1, got %d", got)
+	}
+}
+
+func TestInferTier_Tier1_BinDir(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "bin"), 0755)
+	os.WriteFile(filepath.Join(dir, "bin", "helper"), []byte("#!/bin/sh\n"), 0755)
+	fm := skills.Frontmatter{} // no exec declared
+	if got := skills.InferTier(dir, fm); got != 1 {
+		t.Errorf("want tier 1, got %d", got)
+	}
+}
+
+func TestInferTier_Tier2(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires Unix")
+	}
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "bin"), 0755)
+	os.WriteFile(filepath.Join(dir, "bin", "run"), []byte("#!/bin/sh\necho hi\n"), 0755)
+	fm := skills.Frontmatter{Exec: "bin/run"}
+	if got := skills.InferTier(dir, fm); got != 2 {
+		t.Errorf("want tier 2, got %d", got)
+	}
+}
+
+func TestInferTier_Tier3(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires Unix")
+	}
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "bin"), 0755)
+	os.WriteFile(filepath.Join(dir, "bin", "run"), []byte("#!/bin/sh\necho hi\n"), 0755)
+	fm := skills.Frontmatter{Exec: "bin/run", Schema: "schema.json"}
+	if got := skills.InferTier(dir, fm); got != 3 {
+		t.Errorf("want tier 3, got %d", got)
+	}
+}
+
+// ─── LoadRecord ──────────────────────────────────────────────────────────────
+
+func TestLoadRecord_Tier0_ProseOnly(t *testing.T) {
+	root := t.TempDir()
+	md := "# My Prose Skill\n\nThis skill only has documentation.\n"
+	dir := makeSkillDir(t, root, "prose-skill", md)
+
+	rec, err := skills.LoadRecord("prose-skill", dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Tier != 0 {
+		t.Errorf("want tier 0, got %d", rec.Tier)
+	}
+	if rec.Name != "prose-skill" {
+		t.Errorf("want name prose-skill, got %q", rec.Name)
+	}
+	if rec.Exec != nil {
+		t.Errorf("want exec nil, got %v", rec.Exec)
+	}
+	if rec.Schema != nil {
+		t.Errorf("want schema nil, got %v", rec.Schema)
+	}
+	if len(rec.Requires) != 0 {
+		t.Errorf("want empty requires, got %v", rec.Requires)
+	}
+}
+
+func TestLoadRecord_Tier1_Scripts(t *testing.T) {
+	root := t.TempDir()
+	md := "# Helper Skill\n\nHas scripts but no exec declared.\n"
+	dir := makeSkillDir(t, root, "helper-skill", md)
+	os.WriteFile(filepath.Join(dir, "helper.sh"), []byte("#!/bin/sh\necho hi\n"), 0755)
+
+	rec, err := skills.LoadRecord("helper-skill", dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Tier != 1 {
+		t.Errorf("want tier 1, got %d", rec.Tier)
+	}
+}
+
+func TestLoadRecord_Tier2_WithBin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("tier-2 exec test requires Unix")
+	}
+	root := t.TempDir()
+	md := "---\nname: exec-skill\nversion: 0.2.0\ndescription: Has a canonical exec\nexec: bin/run\nrequires:\n  - cog_read_cogdoc\n---\n# Exec Skill\n"
+	dir := makeSkillDir(t, root, "exec-skill", md)
+	makeExecScript(t, dir, "bin/run", "#!/bin/sh\necho hello\n")
+
+	rec, err := skills.LoadRecord("exec-skill", dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Tier != 2 {
+		t.Errorf("want tier 2, got %d", rec.Tier)
+	}
+	if rec.Name != "exec-skill" {
+		t.Errorf("want name exec-skill, got %q", rec.Name)
+	}
+	if rec.Version != "0.2.0" {
+		t.Errorf("want version 0.2.0, got %q", rec.Version)
+	}
+	if rec.Exec == nil || *rec.Exec != "bin/run" {
+		t.Errorf("want exec bin/run, got %v", rec.Exec)
+	}
+	if len(rec.Requires) != 1 || rec.Requires[0] != "cog_read_cogdoc" {
+		t.Errorf("want requires [cog_read_cogdoc], got %v", rec.Requires)
+	}
+}
+
+func TestLoadRecord_Tier3_WithSchema(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("tier-3 exec test requires Unix")
+	}
+	root := t.TempDir()
+	md := "---\nname: typed-skill\nversion: 0.3.0\ndescription: Typed I/O\nexec: bin/typed\nschema: lib/input.schema.json\n---\n# Typed Skill\n"
+	dir := makeSkillDir(t, root, "typed-skill", md)
+	makeExecScript(t, dir, "bin/typed", "#!/bin/sh\necho '{}'\n")
+
+	rec, err := skills.LoadRecord("typed-skill", dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Tier != 3 {
+		t.Errorf("want tier 3, got %d", rec.Tier)
+	}
+	if rec.Schema == nil || *rec.Schema != "lib/input.schema.json" {
+		t.Errorf("want schema lib/input.schema.json, got %v", rec.Schema)
+	}
+}
+
+func TestLoadRecord_MissingSKILLMD(t *testing.T) {
+	dir := t.TempDir()
+	_, err := skills.LoadRecord("no-skill", dir)
+	if err == nil {
+		t.Fatal("want error for missing SKILL.md, got nil")
+	}
+}
+
+// ─── Discover ────────────────────────────────────────────────────────────────
+
+func TestDiscover_Empty(t *testing.T) {
+	dir := t.TempDir()
+	recs, err := skills.Discover([]string{dir})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(recs) != 0 {
+		t.Errorf("want 0 skills, got %d", len(recs))
+	}
+}
+
+func TestDiscover_NonExistentDirSkipped(t *testing.T) {
+	recs, err := skills.Discover([]string{"/does/not/exist/at/all"})
+	if err != nil {
+		t.Fatalf("want non-existent dir skipped, got error: %v", err)
+	}
+	if len(recs) != 0 {
+		t.Errorf("want 0 skills, got %d", len(recs))
+	}
+}
+
+func TestDiscover_MultipleSkills(t *testing.T) {
+	root := t.TempDir()
+	makeSkillDir(t, root, "skill-a", "---\nname: skill-a\nversion: 1.0.0\ndescription: Alpha\n---\n# Alpha\n")
+	makeSkillDir(t, root, "skill-b", "# Beta\n\nA prose-only skill.\n")
+
+	recs, err := skills.Discover([]string{root})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(recs) != 2 {
+		t.Fatalf("want 2 skills, got %d", len(recs))
+	}
+	byName := make(map[string]skills.Record)
+	for _, r := range recs {
+		byName[r.Name] = r
+	}
+	if _, ok := byName["skill-a"]; !ok {
+		t.Error("skill-a not found")
+	}
+	if _, ok := byName["skill-b"]; !ok {
+		t.Error("skill-b not found")
+	}
+}
+
+func TestDiscover_WorkspaceOverridesUser(t *testing.T) {
+	userDir := t.TempDir()
+	wsDir := t.TempDir()
+
+	// Same name in both; workspace (wsDir) should win because it's last.
+	makeSkillDir(t, userDir, "my-skill", "---\nname: my-skill\nversion: 1.0.0\ndescription: user version\n---\n")
+	makeSkillDir(t, wsDir, "my-skill", "---\nname: my-skill\nversion: 2.0.0\ndescription: workspace version\n---\n")
+
+	recs, err := skills.Discover([]string{userDir, wsDir})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("want 1 deduped skill, got %d", len(recs))
+	}
+	if recs[0].Version != "2.0.0" {
+		t.Errorf("want workspace version 2.0.0, got %q", recs[0].Version)
+	}
+}
+
+// ─── FindByName ──────────────────────────────────────────────────────────────
+
+func TestFindByName_Found(t *testing.T) {
+	root := t.TempDir()
+	makeSkillDir(t, root, "target", "---\nname: target\nversion: 1.0.0\ndescription: Target skill\n---\n")
+
+	rec, err := skills.FindByName("target", []string{root})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Name != "target" {
+		t.Errorf("want name 'target', got %q", rec.Name)
+	}
+}
+
+func TestFindByName_NotFound(t *testing.T) {
+	root := t.TempDir()
+	_, err := skills.FindByName("missing", []string{root})
+	if err == nil {
+		t.Fatal("want error for missing skill, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("want 'not found' in error, got: %v", err)
+	}
+}
+
+// ─── Exec ────────────────────────────────────────────────────────────────────
+
+func TestExec_Tier0_Rejected(t *testing.T) {
+	root := t.TempDir()
+	dir := makeSkillDir(t, root, "prose", "# Prose skill\n")
+	skill, _ := skills.LoadRecord("prose", dir)
+
+	_, err := skills.Exec(context.Background(), skill, "", "", "")
+	if err == nil {
+		t.Fatal("want error for tier-0 exec, got nil")
+	}
+	if !strings.Contains(err.Error(), "not_executable") {
+		t.Errorf("want not_executable error, got: %v", err)
+	}
+}
+
+func TestExec_Tier1_Rejected(t *testing.T) {
+	root := t.TempDir()
+	dir := makeSkillDir(t, root, "scripts", "# Scripts skill\n")
+	os.WriteFile(filepath.Join(dir, "helper.sh"), []byte("#!/bin/sh\necho hi\n"), 0755)
+	skill, _ := skills.LoadRecord("scripts", dir)
+
+	_, err := skills.Exec(context.Background(), skill, "", "", "")
+	if err == nil {
+		t.Fatal("want error for tier-1 exec, got nil")
+	}
+	if !strings.Contains(err.Error(), "no_canonical_entry_point") {
+		t.Errorf("want no_canonical_entry_point error, got: %v", err)
+	}
+}
+
+func TestExec_Tier2_Success(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("exec test requires Unix")
+	}
+	root := t.TempDir()
+	md := "---\nname: greet\nversion: 1.0.0\ndescription: Greet\nexec: bin/greet\n---\n"
+	dir := makeSkillDir(t, root, "greet", md)
+	makeExecScript(t, dir, "bin/greet", "#!/bin/sh\necho 'hello from skill'\n")
+	skill, _ := skills.LoadRecord("greet", dir)
+
+	result, err := skills.Exec(context.Background(), skill, "", "", "")
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("want exit 0, got %d (stderr: %s)", result.ExitCode, result.Stderr)
+	}
+	if !strings.Contains(result.Stdout, "hello from skill") {
+		t.Errorf("want stdout to contain 'hello from skill', got: %q", result.Stdout)
+	}
+	if result.DurationMS < 0 {
+		t.Errorf("want non-negative duration, got %d", result.DurationMS)
+	}
+}
+
+func TestExec_NonZeroExit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("exec test requires Unix")
+	}
+	root := t.TempDir()
+	md := "---\nname: fail-skill\nversion: 1.0.0\nexec: bin/fail\n---\n"
+	dir := makeSkillDir(t, root, "fail-skill", md)
+	makeExecScript(t, dir, "bin/fail", "#!/bin/sh\necho 'some error' >&2\nexit 42\n")
+	skill, _ := skills.LoadRecord("fail-skill", dir)
+
+	result, err := skills.Exec(context.Background(), skill, "", "", "")
+	if err != nil {
+		t.Fatalf("Exec should not return error on non-zero exit: %v", err)
+	}
+	if result.ExitCode != 42 {
+		t.Errorf("want exit 42, got %d", result.ExitCode)
+	}
+	if !strings.Contains(result.Stderr, "some error") {
+		t.Errorf("want stderr to contain 'some error', got: %q", result.Stderr)
+	}
+}
+
+func TestExec_Timeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("exec test requires Unix")
+	}
+	root := t.TempDir()
+	md := "---\nname: slow-skill\nversion: 1.0.0\nexec: bin/slow\n---\n"
+	dir := makeSkillDir(t, root, "slow-skill", md)
+	makeExecScript(t, dir, "bin/slow", "#!/bin/sh\nsleep 10\n")
+	skill, _ := skills.LoadRecord("slow-skill", dir)
+
+	result, err := skills.Exec(context.Background(), skill, "", "100ms", "")
+	if err != nil {
+		t.Fatalf("Exec should not return error on timeout: %v", err)
+	}
+	if result.ExitCode != 124 {
+		t.Errorf("want exit 124 on timeout, got %d", result.ExitCode)
+	}
+	if !strings.Contains(result.Error, "timeout") {
+		t.Errorf("want error to mention timeout, got: %q", result.Error)
+	}
+}
+
+func TestExec_StdinInput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("exec test requires Unix")
+	}
+	root := t.TempDir()
+	md := "---\nname: echo-skill\nversion: 1.0.0\nexec: bin/echo-in\n---\n"
+	dir := makeSkillDir(t, root, "echo-skill", md)
+	makeExecScript(t, dir, "bin/echo-in", "#!/bin/sh\ncat\n")
+	skill, _ := skills.LoadRecord("echo-skill", dir)
+
+	result, err := skills.Exec(context.Background(), skill, `{"key":"value"}`, "", "")
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("want exit 0, got %d", result.ExitCode)
+	}
+	if !strings.Contains(result.Stdout, `"key":"value"`) {
+		t.Errorf("want stdin echoed, got: %q", result.Stdout)
+	}
+}
+
+func TestExec_WorkspaceEnv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("exec test requires Unix")
+	}
+	root := t.TempDir()
+	md := "---\nname: env-skill\nversion: 1.0.0\nexec: bin/printenv\n---\n"
+	dir := makeSkillDir(t, root, "env-skill", md)
+	makeExecScript(t, dir, "bin/printenv", "#!/bin/sh\necho \"WS=$COGOS_WORKSPACE\"\n")
+	skill, _ := skills.LoadRecord("env-skill", dir)
+
+	wsRoot := "/tmp/fake-workspace"
+	result, err := skills.Exec(context.Background(), skill, "", "", wsRoot)
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if !strings.Contains(result.Stdout, "WS="+wsRoot) {
+		t.Errorf("want COGOS_WORKSPACE in env, got stdout: %q", result.Stdout)
+	}
+}


### PR DESCRIPTION
## Summary

- Extracts the shared skill discovery, frontmatter parsing, tier classification, and exec orchestration duplicated across `cmd_skill.go` and `internal/engine/serve_skills.go` into a new `pkg/skills` package.
- Both call sites are now thin wrappers over the shared package. Bus emission (which is infrastructure-specific) stays at each call site.
- This is a pure extraction — no behavior change at either surface.

## Changes

**Added:**
- `pkg/skills/skills.go` — canonical implementation; exports `Frontmatter`, `Record`, `ExecResult`, `ParseFrontmatter`, `InferTier`, `LoadRecord`, `Discover`, `FindByName`, `Exec`
- `pkg/skills/skills_test.go` — full unit-test coverage for the new package (all tier levels, deduplication/override semantics, timeout, stdin, workspace env)

**Modified (behavior-preserving wrappers only):**
- `cmd_skill.go` — `DiscoverSkills`/`FindSkill` delegate to `skills.Discover`/`FindByName`; `execSkill` delegates to `skills.Exec`; `SkillRecord`/`SkillExecResult` are type aliases
- `internal/engine/serve_skills.go` — `discoverSkills`/`findSkill` delegate to `skills.Discover`/`FindByName`; `execSkill` delegates to `skills.Exec`; `SkillRecord`/`SkillExecResponse` are type aliases
- `cmd_skill_test.go` — `LoadRecord`/`Exec` tests now call `pkg/skills` directly; CLI-wrapper tests remain in `package main`

**Removed symbols (consolidated into pkg/skills):**
- `skillFrontmatter` / `skillFM` (private structs) → `skills.Frontmatter`
- `parseSkillMD` / `parseSkillFM` (private funcs) → `skills.ParseFrontmatter`
- `inferTier` / `inferSkillTier` (private funcs) → `skills.InferTier`
- `loadSkillRecord` (private func, duplicated in both files) → `skills.LoadRecord`
- Inline `discoverSkills` / `DiscoverSkills` loop → `skills.Discover`
- Inline `findSkill` / `FindSkill` loop → `skills.FindByName`
- Inline `execSkill` body (both files) → `skills.Exec`

## Test plan

- [x] `go test ./pkg/skills/... -count=1` — 19 tests, all pass
- [x] `go test ./... -count=1 -timeout 120s` — all packages pass
- [x] `go build ./...` — clean compile, no vet warnings

## Out of scope

- The `Frontmatter.Timeout` field is parsed but never used to set a per-skill default timeout (both call sites ignored it before this PR). Using it as a fallback would be a behavior change; flagged for a follow-up issue.
- The CLI `execSkill` wrapper creates `context.Background()` rather than threading a cancellable context from `cmdSkillExec`. This was the pre-PR behavior; changing it is out of scope for a pure extraction.

Closes #125