### PR TITLE
fix(test): correct irisPressure in FallbackToStandard to stop environment-dependent flake

### DIFF
--- a/tier4_semantic_test.go
+++ b/tier4_semantic_test.go
@@ -377,6 +377,12 @@ func TestQueryConstellationWithIris_FallbackToStandard(t *testing.T) {
 	// is equivalent when the constellation DB has the same availability.
 	// We verify that the iris variant produces the same result+error pair as
 	// the standard variant for several inputs.
+	//
+	// irisPressure must be <= 0.05 so the whitespace-compression branch inside
+	// QueryConstellationWithIris's heuristic fallback is skipped.  Using a
+	// non-zero pressure (e.g. 0.5) causes compression to run, producing output
+	// that diverges from QueryConstellation whenever the constellation DB
+	// returns actual content — making the test environment-dependent and flaky.
 	tmpDir := t.TempDir()
 
 	// Reset cached config so LoadTAAConfig picks up defaults (embedding disabled)
@@ -397,7 +403,9 @@ func TestQueryConstellationWithIris_FallbackToStandard(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			irisResult, irisErr := QueryConstellationWithIris(tmpDir, tc.anchor, tc.goal, 5000, 0.5)
+			// irisPressure=0.0: no iris signal, so heuristic fallback skips whitespace
+			// compression (pressure <= 0.05 guard) and the two functions are identical.
+			irisResult, irisErr := QueryConstellationWithIris(tmpDir, tc.anchor, tc.goal, 5000, 0.0)
 			stdResult, stdErr := QueryConstellation(tmpDir, tc.anchor, tc.goal, 5000)
 
 			// Both should produce the same result (either both empty or both with content)


### PR DESCRIPTION
## Summary

- `TestQueryConstellationWithIris_FallbackToStandard` was called with `irisPressure=0.5`, which causes `QueryConstellationWithIris` to run `compressWhitespace` on the result in its heuristic fallback path
- The test asserts the iris result equals the standard `QueryConstellation` result, but that's only true when the content is empty or when pressure is below the 0.05 guard
- When the test binary runs inside a workspace where `getConstellation()` finds a real constellation DB, non-empty queries ("anchor only", "goal only", "both set") get content back, the iris path compresses its whitespace, and the two results diverge — test fails
- Fix: set `irisPressure=0.0`; the `pressure <= 0.05` guard in the fallback branch is never entered, both functions return identical bytes regardless of environment

## Changes

- `tier4_semantic_test.go`: change `irisPressure` from `0.5` to `0.0` in `TestQueryConstellationWithIris_FallbackToStandard`; add inline comments explaining the constraint

## Test plan

- `-count=20` sweep (no race detector): `ok github.com/cogos-dev/cogos 0.421s` — 20/20 pass
- `-race -count=10` sweep: `ok github.com/cogos-dev/cogos 1.473s` — 10/10 pass, no race detector findings
- Full root package `go test -count=1 .`: `ok github.com/cogos-dev/cogos 10.978s`

## Out of scope

- The whitespace compression behavior under real iris pressure is not tested anywhere; a separate test covering `irisPressure=0.5` with mocked or empty constellation would be a reasonable follow-up

Closes #113