### PR TITLE
chore(release): bump VERSION to 0.4.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 #   make e2e      - Run e2e test in a container
 #   make e2e-local - Run e2e test locally
 
-VERSION := 0.4.0
+VERSION := 0.4.1
 BUILD_TIME := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -s -w -X github.com/cogos-dev/cogos/internal/engine.BuildTime=$(BUILD_TIME)
 BUILD_TAGS := fts5


### PR DESCRIPTION
Mid-release checkpoint after today's PR wave (services API Phases 1+2, bus SSE + replay bound, env isolation, skill discovery extraction, openai-compat tool_choice parity, iris flake fix).

v0.5.0 work continues with services Phase 3 ([#101](https://github.com/cogos-dev/cogos/issues/101)) and the root package refactor ([#104](https://github.com/cogos-dev/cogos/issues/104), RFC in flight).