### PR TITLE
fix(engine): raise local-provider HTTP timeout to cover Ollama cold-load

### DIFF
--- a/internal/engine/local_llm.go
+++ b/internal/engine/local_llm.go
@@ -127,7 +127,11 @@ func buildLocalProvider(target LocalLLMTarget, model string) Provider {
 	cfg := ProviderConfig{
 		Endpoint: target.BaseURL,
 		Model:    model,
-		Timeout:  120,
+		// 300s covers cold-load of an 8B-class quantized model on Apple Silicon
+		// under memory pressure (~110s clean, ~150-180s under load). 120s
+		// closed the connection mid-load, aborting Ollama's load and forcing
+		// a retry on the next dispatch. See cogos-dev/cogos#144.
+		Timeout: 300,
 	}
 	switch target.Backend {
 	case LocalLLMBackendOllama:


### PR DESCRIPTION
Closes #144 (in part — operator-side `OLLAMA_KEEP_ALIVE=-1` guidance is separate, applied out-of-band on the diagnosis host).

## What

`buildLocalProvider` (`local_llm.go:130`) was hardcoding `Timeout: 120` on the per-dispatch `ProviderConfig`. The resulting `OllamaProvider` constructed `&http.Client{Timeout: 120 * time.Second}`. Two problems:

1. 120 s is below gemma4:e4b's cold-load on Apple Silicon (~110 s clean, ~150–180 s under memory pressure). The HTTP client closes the connection mid-load → Ollama logs `client connection closed before server finished loading, aborting load` → next dispatch triggers a fresh load → amplified memory spike.
2. The hardcoded literal silently shadowed the operator's `timeout: 300` in `providers.local.yaml` — that config was effectively dead code on this path.

This bumps the literal to 300 s, matching what operators already had configured.

## Why this is the right scope

Threading the configured timeout through `buildLocalProvider` (so YAML actually wins) is the principled fix, but `buildLocalProvider`'s signature only receives `target LocalLLMTarget` and `model string` — it has no access to the workspace provider config. Plumbing it requires changing both call sites in `local_agent_harness.go` (lines 412 and 819) and threading config through. Worth doing, but separate. This PR is the one-line stop-gap that immediately ends the reload thrash observed in #144.

## Evidence from the diagnosis host

Server log on the day this was filed:

```
10:35:23  WARN  client connection closed before server finished loading, aborting load
10:35:23  ERROR error loading llama server: timed out waiting for llama runner to start: context canceled
10:49:24  INFO  loading model "model layers"=43 requested=-1
10:49:36  WARN  client connection closed before server finished loading, aborting load
11:03:36  INFO  loading model ... [eventually succeeds]
```

The 11–14 second gap between load-start and "client closed" matches a 120 s timeout firing partway into a cold-load that started ~108 s earlier in a previous (failed) request and was still in-flight when the next dispatch arrived.

## Test

`go build ./...` ✓
`go test ./internal/engine/...` ✓ (7.069s)

No new tests — the change is a single-literal value bump and existing OllamaProvider tests cover the construction path.

## Follow-up tracked separately

- Thread `cfg.Timeout` from workspace provider config through `buildLocalProvider` so YAML config isn't shadowed.
- Long-term: kernel-supervised in-host inference (audit Tier 3) so model lifetime is observable to the kernel, not negotiated through Ollama's "last request wins" semantics.