### PR TITLE
fix(engine): thread provider-config timeout through buildLocalProvider

### DIFF
--- a/internal/engine/local_agent_harness.go
+++ b/internal/engine/local_agent_harness.go
@@ -141,6 +141,12 @@ type LocalHarnessController struct {
 	started  time.Time
 	interval time.Duration
 
+	// localProviderTimeout is the HTTP timeout (seconds) applied to providers
+	// constructed by buildLocalProvider for this controller's dispatches.
+	// Resolved once at construction time from providers(.local).yaml; 0 means
+	// "fall back to localProviderDefaultTimeoutSec".
+	localProviderTimeout int
+
 	// autonomicCfg holds escalation-predicate tunables. Safe to read from
 	// multiple goroutines — written once before Start().
 	autonomicCfg AutonomicConfig
@@ -209,15 +215,16 @@ func NewLocalHarnessControllerWithScope(cfg *Config, nucleus *Nucleus, process *
 	}
 
 	return &LocalHarnessController{
-		cfg:             cfg,
-		nucleus:         nucleus,
-		process:         process,
-		toolRegistry:    registry,
-		dispatchTools:   dispatchTools,
-		backgroundTools: dispatchTools,
-		agentID:         DefaultAgentID,
-		started:         time.Now().UTC(),
-		interval:        interval,
+		cfg:                  cfg,
+		nucleus:              nucleus,
+		process:              process,
+		toolRegistry:         registry,
+		dispatchTools:        dispatchTools,
+		backgroundTools:      dispatchTools,
+		agentID:              DefaultAgentID,
+		started:              time.Now().UTC(),
+		interval:             interval,
+		localProviderTimeout: resolveLocalProviderTimeout(cfg),
 	}, nil
 }
 
@@ -409,7 +416,7 @@ func (c *LocalHarnessController) runCycle(parent context.Context, reason string,
 	}
 	outcome.record.Model = model
 
-	provider := buildLocalProvider(target, model)
+	provider := buildLocalProvider(target, model, c.localProviderTimeout)
 	assessment, err := c.assessCycle(ctx, provider, outcome.record.Observation)
 	if err != nil {
 		outcome.record.Action = "error"
@@ -816,7 +823,7 @@ func (c *LocalHarnessController) DispatchToHarness(ctx context.Context, req Disp
 		}
 	}
 
-	provider := buildLocalProvider(target, model)
+	provider := buildLocalProvider(target, model, c.localProviderTimeout)
 	batch := &DispatchBatchResult{
 		Results: make([]DispatchResult, req.N),
 	}

--- a/internal/engine/local_llm.go
+++ b/internal/engine/local_llm.go
@@ -123,11 +123,22 @@ func probeOpenAICompatModels(ctx context.Context, baseURL string) ([]string, err
 	return out, nil
 }
 
-func buildLocalProvider(target LocalLLMTarget, model string) Provider {
+// localProviderDefaultTimeoutSec is the fallback HTTP client timeout (in
+// seconds) used when no provider config is available or the configured
+// provider's timeout is unset/zero. Sized to cover cold-load of an 8B-class
+// quantized model on Apple Silicon under memory pressure (~110s clean,
+// ~150-180s under load). Operators can override per provider via
+// providers(.local).yaml — see resolveLocalProviderTimeout.
+const localProviderDefaultTimeoutSec = 300
+
+func buildLocalProvider(target LocalLLMTarget, model string, timeoutSec int) Provider {
+	if timeoutSec <= 0 {
+		timeoutSec = localProviderDefaultTimeoutSec
+	}
 	cfg := ProviderConfig{
 		Endpoint: target.BaseURL,
 		Model:    model,
-		Timeout:  120,
+		Timeout:  timeoutSec,
 	}
 	switch target.Backend {
 	case LocalLLMBackendOllama:
@@ -137,6 +148,56 @@ func buildLocalProvider(target LocalLLMTarget, model string) Provider {
 		cfg.MaxTokens = openaiCompatDefaultMaxToks
 		return NewOpenAICompatProvider("agent-local", cfg)
 	}
+}
+
+// resolveLocalProviderTimeout returns the HTTP timeout (in seconds) configured
+// for the local-tier provider, honoring the providers.yaml + providers.local.yaml
+// merge so operators have a single source of truth.
+//
+// Lookup order:
+//
+//   - "ollama" provider entry (preferred — detectLocalLLMTarget probes the
+//     Ollama API shape first)
+//   - any other enabled provider whose Endpoint resolves to a localhost URL
+//   - 0 (caller falls back to localProviderDefaultTimeoutSec)
+//
+// Returns 0 on missing/unreadable config; callers must tolerate that.
+func resolveLocalProviderTimeout(cfg *Config) int {
+	if cfg == nil {
+		return 0
+	}
+	pcfg, err := loadProvidersConfig(cfg)
+	if err != nil {
+		return 0
+	}
+	if pc, ok := pcfg.Providers["ollama"]; ok && pc.IsEnabled() && pc.Timeout > 0 {
+		return pc.Timeout
+	}
+	for _, pc := range pcfg.Providers {
+		if !pc.IsEnabled() || pc.Timeout <= 0 {
+			continue
+		}
+		if isLocalEndpoint(pc.Endpoint) {
+			return pc.Timeout
+		}
+	}
+	return 0
+}
+
+// isLocalEndpoint reports whether an endpoint URL points at a loopback host.
+// Used to find a sensible fallback timeout source when no "ollama" provider
+// entry is configured.
+func isLocalEndpoint(endpoint string) bool {
+	endpoint = strings.ToLower(strings.TrimSpace(endpoint))
+	if endpoint == "" {
+		return false
+	}
+	for _, marker := range []string{"localhost", "127.0.0.1", "::1", "0.0.0.0"} {
+		if strings.Contains(endpoint, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func resolvePreferredLocalModel(models []string, preferred string) string {

--- a/internal/engine/local_llm_test.go
+++ b/internal/engine/local_llm_test.go
@@ -1,0 +1,214 @@
+package engine
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestResolveLocalProviderTimeoutNilConfig: nil cfg yields 0 (caller falls
+// back to localProviderDefaultTimeoutSec). Important for unit-test paths and
+// the brief window during construction before cfg is wired.
+func TestResolveLocalProviderTimeoutNilConfig(t *testing.T) {
+	t.Parallel()
+	if got := resolveLocalProviderTimeout(nil); got != 0 {
+		t.Errorf("nil cfg: got %d; want 0", got)
+	}
+}
+
+// TestResolveLocalProviderTimeoutMissingFiles: a Config rooted at a workspace
+// without providers.yaml returns 0 (loadProvidersConfig errors are swallowed
+// — the dispatch path then falls back to the default timeout).
+func TestResolveLocalProviderTimeoutMissingFiles(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg, err := LoadConfig(root, 0)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if got := resolveLocalProviderTimeout(cfg); got != 0 {
+		t.Errorf("missing providers.yaml: got %d; want 0", got)
+	}
+}
+
+// TestResolveLocalProviderTimeoutPrefersOllama: when an "ollama" provider is
+// configured, its Timeout wins regardless of other entries' values. This is
+// the common-case operator setup.
+func TestResolveLocalProviderTimeoutPrefersOllama(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	writeTestFile(t, filepath.Join(root, ".cog", "config", "providers.yaml"), `providers:
+  ollama:
+    type: ollama
+    endpoint: http://localhost:11434
+    model: gemma4:e4b
+    timeout: 600
+  claude-code:
+    type: claude-code
+    model: sonnet
+    timeout: 30
+routing:
+  default: ollama
+  fallback_chain: [ollama]
+`)
+	cfg, err := LoadConfig(root, 0)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if got := resolveLocalProviderTimeout(cfg); got != 600 {
+		t.Errorf("ollama timeout: got %d; want 600", got)
+	}
+}
+
+// TestResolveLocalProviderTimeoutLocalYAMLOverlay: providers.local.yaml's
+// timeout overrides providers.yaml via the existing deep-merge, so operator
+// node-specific overrides take effect without copying the entire defaults
+// file. This is the path the bug originally hid: hardcoded 120s shadowed
+// whatever operators configured here.
+func TestResolveLocalProviderTimeoutLocalYAMLOverlay(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	writeTestFile(t, filepath.Join(root, ".cog", "config", "providers.yaml"), `providers:
+  ollama:
+    type: ollama
+    endpoint: http://localhost:11434
+    model: gemma4:e4b
+    timeout: 60
+routing:
+  default: ollama
+  fallback_chain: [ollama]
+`)
+	writeTestFile(t, filepath.Join(root, ".cog", "config", "providers.local.yaml"), `providers:
+  ollama:
+    timeout: 480
+`)
+	cfg, err := LoadConfig(root, 0)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if got := resolveLocalProviderTimeout(cfg); got != 480 {
+		t.Errorf("local-yaml overlay: got %d; want 480", got)
+	}
+}
+
+// TestResolveLocalProviderTimeoutFallsBackToOtherLocal: if no "ollama" entry
+// exists (operator removed it; runs MLX or LM Studio only) the resolver falls
+// back to any other localhost-pointed provider's timeout.
+func TestResolveLocalProviderTimeoutFallsBackToOtherLocal(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	writeTestFile(t, filepath.Join(root, ".cog", "config", "providers.yaml"), `providers:
+  lmstudio-mlx:
+    type: openai
+    endpoint: http://localhost:1234
+    model: gemma-mlx
+    timeout: 240
+  claude-code:
+    type: claude-code
+    model: sonnet
+    timeout: 30
+routing:
+  default: claude-code
+  fallback_chain: [claude-code, lmstudio-mlx]
+`)
+	cfg, err := LoadConfig(root, 0)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if got := resolveLocalProviderTimeout(cfg); got != 240 {
+		t.Errorf("local fallback: got %d; want 240", got)
+	}
+}
+
+// TestResolveLocalProviderTimeoutSkipsRemoteProviders: a remote provider's
+// timeout must not be picked up as the local-tier timeout. Otherwise a
+// 30-second claude-code timeout would shadow whatever Ollama needs.
+func TestResolveLocalProviderTimeoutSkipsRemoteProviders(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	writeTestFile(t, filepath.Join(root, ".cog", "config", "providers.yaml"), `providers:
+  claude-code:
+    type: claude-code
+    model: sonnet
+    timeout: 30
+routing:
+  default: claude-code
+  fallback_chain: [claude-code]
+`)
+	cfg, err := LoadConfig(root, 0)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if got := resolveLocalProviderTimeout(cfg); got != 0 {
+		t.Errorf("only-remote providers: got %d; want 0 (signal default)", got)
+	}
+}
+
+// TestResolveLocalProviderTimeoutSkipsDisabledOllama: an explicitly disabled
+// "ollama" entry must not contribute its timeout. Ensures the IsEnabled gate
+// matches BuildRouter's behavior — operators expect "enabled: false" to
+// remove a provider entirely from consideration.
+func TestResolveLocalProviderTimeoutSkipsDisabledOllama(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	writeTestFile(t, filepath.Join(root, ".cog", "config", "providers.yaml"), `providers:
+  ollama:
+    type: ollama
+    enabled: false
+    endpoint: http://localhost:11434
+    model: gemma4:e4b
+    timeout: 60
+  lmstudio-mlx:
+    type: openai
+    endpoint: http://localhost:1234
+    model: gemma-mlx
+    timeout: 240
+routing:
+  default: lmstudio-mlx
+  fallback_chain: [lmstudio-mlx]
+`)
+	cfg, err := LoadConfig(root, 0)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if got := resolveLocalProviderTimeout(cfg); got != 240 {
+		t.Errorf("disabled ollama should be skipped: got %d; want 240 (lmstudio fallback)", got)
+	}
+}
+
+// TestBuildLocalProviderUsesProvidedTimeout: pass-through verification —
+// if buildLocalProvider's caller supplies a timeout, that's what the
+// constructed OllamaProvider's HTTP client sees.
+func TestBuildLocalProviderUsesProvidedTimeout(t *testing.T) {
+	t.Parallel()
+	target := LocalLLMTarget{
+		BaseURL: "http://localhost:11434",
+		Backend: LocalLLMBackendOllama,
+	}
+	p := buildLocalProvider(target, "gemma4:e4b", 480)
+	op, ok := p.(*OllamaProvider)
+	if !ok {
+		t.Fatalf("expected *OllamaProvider, got %T", p)
+	}
+	if got := int(op.timeout.Seconds()); got != 480 {
+		t.Errorf("ollama HTTP timeout: got %ds; want 480s", got)
+	}
+}
+
+// TestBuildLocalProviderDefaultsTo300: when caller passes 0 (no config
+// override available) buildLocalProvider must apply the 300s default — that's
+// the literal value the original 120s bug was raised against. Covers both
+// negative (treated as zero) and zero inputs.
+func TestBuildLocalProviderDefaultsTo300(t *testing.T) {
+	t.Parallel()
+	target := LocalLLMTarget{
+		BaseURL: "http://localhost:11434",
+		Backend: LocalLLMBackendOllama,
+	}
+	for _, in := range []int{0, -1} {
+		p := buildLocalProvider(target, "gemma4:e4b", in)
+		op := p.(*OllamaProvider)
+		if got := int(op.timeout.Seconds()); got != localProviderDefaultTimeoutSec {
+			t.Errorf("input %d: got %ds; want %ds", in, got, localProviderDefaultTimeoutSec)
+		}
+	}
+}


### PR DESCRIPTION
Closes #144. **Supersedes #145** — that PR's one-line bump is subsumed by this one's threading fix.

## What

Two coupled bugs in the local-provider construction path:

1. `buildLocalProvider` (`local_llm.go:126`) hardcoded a 120-second HTTP client timeout on every dispatch. Gemma4:e4b cold-load on Apple Silicon is ~110 s clean and ~150–180 s under memory pressure, so the HTTP client closes the connection right as Ollama is finalizing the load. Result: the `client connection closed before server finished loading, aborting load` loop documented in #144.
2. The hardcoded literal silently shadowed whatever `timeout:` the operator had set in `providers.yaml` / `providers.local.yaml`. The dispatch path never read that config — it was effectively dead code.

## Changes

- **`buildLocalProvider`** now takes an explicit `timeoutSec int` parameter. Zero / negative inputs fall back to `localProviderDefaultTimeoutSec` (300s — sized to cover cold-load under pressure).
- **`resolveLocalProviderTimeout`** reads `providers(.local).yaml` via the same `loadProvidersConfig` merge that `BuildRouter` uses. Prefers the `ollama` provider entry; falls back to any enabled provider whose endpoint resolves to a localhost URL; returns 0 on missing/unreadable config so callers apply the default.
- **`LocalHarnessController`** resolves the timeout once at construction (`NewLocalHarnessControllerWithScope`) and threads it into both `buildLocalProvider` call sites:
  - `runCycle` (autonomic dispatch, line 412)
  - `DispatchToHarness` (MCP dispatch, line 819)

## Why this scope

#145 was a one-line stop-gap (120 → 300) that did not address the deeper bug — operator config was being silently dropped. This PR fixes both: cold-load survives, and operators get the single source of truth they expected. Same blast radius (the same two call sites), strictly more correct.

## Tests

New `internal/engine/local_llm_test.go` covering 8 scenarios:

- `TestResolveLocalProviderTimeoutNilConfig` — nil cfg yields 0
- `TestResolveLocalProviderTimeoutMissingFiles` — missing `providers.yaml` yields 0
- `TestResolveLocalProviderTimeoutPrefersOllama` — `ollama` entry's timeout wins over others
- `TestResolveLocalProviderTimeoutLocalYAMLOverlay` — `providers.local.yaml`'s `timeout: 480` overrides base's `60`
- `TestResolveLocalProviderTimeoutFallsBackToOtherLocal` — no `ollama` entry → picks an enabled localhost provider's timeout
- `TestResolveLocalProviderTimeoutSkipsRemoteProviders` — claude-code's 30s does not become the local timeout
- `TestResolveLocalProviderTimeoutSkipsDisabledOllama` — `enabled: false` skips the entry, falls back to others
- `TestBuildLocalProviderUsesProvidedTimeout` — pass-through to the constructed `OllamaProvider`'s HTTP client
- `TestBuildLocalProviderDefaultsTo300` — input 0 / -1 → 300s default

Plus full `go test ./internal/engine/` is green (7.244s).

## Out of scope

- Long-term audit Tier 3 (kernel-supervised in-host inference via `mlx_lm.server` under `ProcessManager`) — multi-month, will be tracked in a separate issue.
- The operator-side defense-in-depth (`OLLAMA_KEEP_ALIVE=-1` env var, removing duplicate `homebrew.mxcl.ollama` plist) is already applied on the diagnosis host out-of-band; documenting that in setup docs is a separate small PR.

## Diff stat

- `internal/engine/local_llm.go`: +65 / -3
- `internal/engine/local_agent_harness.go`: +16 / -10
- `internal/engine/local_llm_test.go`: +214 / 0 (new file)