### PR TITLE
feat(engine,daemon): kernel-supervised mlx_lm.server inference provider

### DIFF
--- a/internal/engine/provider_mlx_supervised.go
+++ b/internal/engine/provider_mlx_supervised.go
@@ -1,0 +1,634 @@
+// provider_mlx_supervised.go — kernel-supervised mlx_lm.server inference provider.
+//
+// MLXSupervisedProvider implements both Provider (dispatch) and
+// reconcile.Reconcilable (health + lifecycle). A single struct, two interfaces,
+// no config-schema divergence.
+//
+// Architecture
+//
+//   - Config is declared in providers(.local).yaml under a key whose type field
+//     is "mlx-supervised". No other type values are affected.
+//   - The Reconcilable half manages a launchd plist at
+//     ~/Library/LaunchAgents/<launchd_label>.plist, using the existing
+//     LaunchctlController / ObserverSupervisor abstraction (service_supervisor.go).
+//   - The Provider half wraps OpenAICompatProvider for the actual HTTP dispatch —
+//     mlx_lm.server speaks OpenAI-compat /v1/chat/completions.
+//   - Available() consults both launchd-reported service state and the
+//     /v1/models HTTP probe so the router gets an accurate signal.
+//   - Health() is cheap: it reads cached state (last launchd probe + last HTTP
+//     probe) without blocking. The Reconcile() path updates that cache.
+//   - Because Health() is non-blocking, it is safe inside buildHealthBlock's
+//     200 ms per-provider timeout.
+//
+// Plist template
+//
+// The kernel writes a minimal launchd plist that runs:
+//
+//	<binary> --model <model_path> --port <port> --host 127.0.0.1
+//
+// Additional args are supported via the "args" Options key ([]string).
+// The plist uses KeepAlive=true so launchd restarts the server on crash.
+//
+// Config schema (providers.local.yaml example)
+//
+//	mlx-gemma-supervised:
+//	  type: mlx-supervised
+//	  endpoint: http://localhost:1235
+//	  model: /Volumes/2TBSD/AI_Models/…/gemma-4-E4B-…-mlx-4bit
+//	  context_window: 32768
+//	  timeout: 300
+//	  options:
+//	    binary: /usr/local/bin/mlx_lm.server     # default: mlx_lm.server (PATH)
+//	    launchd_label: com.cogos.mlx-gemma        # default: com.cogos.mlx-<name>
+//	    args: []                                  # extra CLI args after model+port
+//
+// Lifetime under launchd
+//
+// launchd is the supervisor. The kernel only writes the plist and tells launchd
+// to load/unload it. It does NOT keep the process address in memory or attempt
+// in-process restart. This matches the established service_supervisor pattern.
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cogos-dev/cogos/pkg/reconcile"
+)
+
+// mlxSupervisedType is the value of ProviderConfig.Type that activates this driver.
+const mlxSupervisedType = "mlx-supervised"
+
+// mlxDefaultLaunchdPrefix is prepended to the provider name when no explicit
+// launchd_label is supplied in Options.
+const mlxDefaultLaunchdPrefix = "com.cogos.mlx-"
+
+// MLXSupervisedProvider implements Provider (dispatch) and reconcile.Reconcilable
+// (health + lifecycle) for a kernel-supervised mlx_lm.server instance.
+type MLXSupervisedProvider struct {
+	// --- identity ---
+	name string // provider name as declared in providers.yaml
+
+	// --- dispatch (OpenAI-compat wrapper) ---
+	inner *OpenAICompatProvider
+
+	// --- supervision ---
+	supervisor   ServiceSupervisor
+	launchdLabel string    // e.g. "com.cogos.mlx-gemma"
+	plistPath    string    // ~/Library/LaunchAgents/<label>.plist
+	binary       string    // path/name of mlx_lm.server binary
+	modelPath    string    // full model path passed to --model
+	port         int       // port mlx_lm.server should bind
+	extraArgs    []string  // additional CLI args
+
+	// --- cached health state (updated by Reconcile / Available) ---
+	mu          sync.RWMutex
+	lastStatus  *ServiceStatus
+	lastHTTP    bool          // last /v1/models probe result
+	lastProbed  time.Time
+
+	// --- reconcile metadata ---
+	workspaceRoot string // injected at daemon boot
+}
+
+// newMLXSupervisedProvider constructs an MLXSupervisedProvider from ProviderConfig.
+// It wraps OpenAICompatProvider for dispatch, so all HTTP logic is reused.
+func newMLXSupervisedProvider(name string, cfg ProviderConfig, supervisor ServiceSupervisor) (*MLXSupervisedProvider, error) {
+	// Resolve launchd label.
+	label := optStr(cfg.Options, "launchd_label")
+	if label == "" {
+		label = mlxDefaultLaunchdPrefix + name
+	}
+
+	// Resolve binary path.
+	binary := optStr(cfg.Options, "binary")
+	if binary == "" {
+		binary = "mlx_lm.server"
+	}
+
+	// Resolve port from endpoint.
+	port := extractPort(cfg.Endpoint, 1235)
+
+	// Extra CLI args.
+	var extraArgs []string
+	if raw, ok := cfg.Options["args"]; ok {
+		switch v := raw.(type) {
+		case []interface{}:
+			for _, a := range v {
+				extraArgs = append(extraArgs, fmt.Sprint(a))
+			}
+		case []string:
+			extraArgs = v
+		}
+	}
+
+	// Plist path.
+	home, err := homeDir()
+	if err != nil {
+		return nil, fmt.Errorf("mlx-supervised %q: cannot resolve home dir for plist path: %w", name, err)
+	}
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", label+".plist")
+
+	// Inner OpenAI-compat provider for dispatch.
+	inner := NewOpenAICompatProvider(name, cfg)
+
+	return &MLXSupervisedProvider{
+		name:         name,
+		inner:        inner,
+		supervisor:   supervisor,
+		launchdLabel: label,
+		plistPath:    plistPath,
+		binary:       binary,
+		modelPath:    cfg.Model,
+		port:         port,
+		extraArgs:    extraArgs,
+	}, nil
+}
+
+// ── Provider interface ─────────────────────────────────────────────────────────
+
+// Name returns the provider name.
+func (p *MLXSupervisedProvider) Name() string { return p.name }
+
+// Model returns the configured model path.
+func (p *MLXSupervisedProvider) Model() string { return p.inner.Model() }
+
+// Complete dispatches via the inner OpenAI-compat provider.
+func (p *MLXSupervisedProvider) Complete(ctx context.Context, req *CompletionRequest) (*CompletionResponse, error) {
+	return p.inner.Complete(ctx, req)
+}
+
+// Stream dispatches via the inner OpenAI-compat provider.
+func (p *MLXSupervisedProvider) Stream(ctx context.Context, req *CompletionRequest) (<-chan StreamChunk, error) {
+	return p.inner.Stream(ctx, req)
+}
+
+// Available returns true when the supervised service is running and the
+// configured model is present at /v1/models. It updates the cached HTTP probe
+// result as a side-effect (so Health() can reflect it without blocking).
+func (p *MLXSupervisedProvider) Available(ctx context.Context) bool {
+	// First check launchd state from the cache (cheap, updated by Reconcile).
+	p.mu.RLock()
+	lastStatus := p.lastStatus
+	p.mu.RUnlock()
+
+	if lastStatus != nil && !lastStatus.Running {
+		// Launchd says not running — short-circuit without HTTP probe.
+		return false
+	}
+
+	// HTTP probe.
+	ok := p.inner.Available(ctx)
+	p.mu.Lock()
+	p.lastHTTP = ok
+	p.lastProbed = time.Now()
+	p.mu.Unlock()
+	return ok
+}
+
+// Capabilities delegates to the inner provider.
+func (p *MLXSupervisedProvider) Capabilities() ProviderCapabilities {
+	caps := p.inner.Capabilities()
+	caps.IsLocal = true
+	return caps
+}
+
+// Ping delegates to the inner provider.
+func (p *MLXSupervisedProvider) Ping(ctx context.Context) (time.Duration, error) {
+	return p.inner.Ping(ctx)
+}
+
+// ── reconcile.Reconcilable interface ──────────────────────────────────────────
+
+// Type returns the reconcilable type identifier.
+func (p *MLXSupervisedProvider) Type() string { return mlxSupervisedType }
+
+// LoadConfig loads declared configuration from the workspace.
+// For MLXSupervisedProvider this is a no-op: config is already parsed at
+// construction time from ProviderConfig. The daemon uses this path for stub
+// providers; the full provider is constructed by BuildRouter.
+func (p *MLXSupervisedProvider) LoadConfig(root string) (any, error) {
+	p.mu.Lock()
+	p.workspaceRoot = root
+	p.mu.Unlock()
+	return nil, nil
+}
+
+// FetchLive returns the current launchd + HTTP state for this service.
+func (p *MLXSupervisedProvider) FetchLive(ctx context.Context, _ any) (any, error) {
+	def := p.serviceDef()
+	st, err := p.supervisor.Status(ctx, p.name, def)
+	if err != nil {
+		return nil, fmt.Errorf("mlx-supervised %q: status: %w", p.name, err)
+	}
+	return st, nil
+}
+
+// ComputePlan compares declared config against live state.
+// The only action this provider can take is "ensure plist exists and is loaded".
+func (p *MLXSupervisedProvider) ComputePlan(config any, live any, state *reconcile.State) (*reconcile.Plan, error) {
+	st, _ := live.(*ServiceStatus)
+	running := st != nil && st.Running
+	plistExists := false
+	if _, err := os.Stat(p.plistPath); err == nil {
+		plistExists = true
+	}
+
+	plan := &reconcile.Plan{ResourceType: mlxSupervisedType}
+	if !plistExists {
+		plan.Actions = append(plan.Actions, reconcile.Action{
+			Action:       reconcile.ActionCreate,
+			ResourceType: mlxSupervisedType,
+			Name:         p.name + "/plist",
+			Details: map[string]any{
+				"path":   p.plistPath,
+				"reason": "launchd plist absent — kernel must write it before starting service",
+			},
+		})
+		plan.Summary.Creates++
+	}
+	if !running {
+		plan.Actions = append(plan.Actions, reconcile.Action{
+			Action:       reconcile.ActionUpdate,
+			ResourceType: mlxSupervisedType,
+			Name:         p.name + "/service",
+			Details: map[string]any{
+				"label":  p.launchdLabel,
+				"reason": "service not running — ensure started via launchd",
+			},
+		})
+		plan.Summary.Updates++
+	}
+	return plan, nil
+}
+
+// ApplyPlan writes the plist (if needed) and starts the service via launchd.
+func (p *MLXSupervisedProvider) ApplyPlan(ctx context.Context, plan *reconcile.Plan) ([]reconcile.Result, error) {
+	var results []reconcile.Result
+
+	for _, action := range plan.Actions {
+		switch {
+		case strings.HasSuffix(action.Name, "/plist"):
+			if err := p.writePlist(); err != nil {
+				results = append(results, reconcile.Result{
+					Phase:  "apply",
+					Action: string(action.Action),
+					Name:   action.Name,
+					Status: reconcile.ApplyFailed,
+					Error:  err.Error(),
+				})
+				return results, err
+			}
+			results = append(results, reconcile.Result{
+				Phase:  "apply",
+				Action: string(action.Action),
+				Name:   action.Name,
+				Status: reconcile.ApplySucceeded,
+			})
+
+		case strings.HasSuffix(action.Name, "/service"):
+			def := p.serviceDef()
+			st, err := p.supervisor.Start(ctx, p.name, def)
+			if err != nil {
+				results = append(results, reconcile.Result{
+					Phase:  "apply",
+					Action: string(action.Action),
+					Name:   action.Name,
+					Status: reconcile.ApplyFailed,
+					Error:  err.Error(),
+				})
+				// Non-fatal: surface in results but continue.
+				continue
+			}
+			p.mu.Lock()
+			p.lastStatus = st
+			p.mu.Unlock()
+			results = append(results, reconcile.Result{
+				Phase:  "apply",
+				Action: string(action.Action),
+				Name:   action.Name,
+				Status: reconcile.ApplySucceeded,
+			})
+		}
+	}
+	return results, nil
+}
+
+// BuildState constructs state from live data.
+func (p *MLXSupervisedProvider) BuildState(_ any, live any, existing *reconcile.State) (*reconcile.State, error) {
+	st, _ := live.(*ServiceStatus)
+	state := &reconcile.State{}
+	if existing != nil {
+		state = existing
+	}
+	addr := "mlx-supervised/" + p.name
+	res := reconcile.Resource{
+		Address:    addr,
+		ExternalID: p.launchdLabel,
+		Name:       p.name,
+		Attributes: map[string]any{
+			"binary":     p.binary,
+			"model":      p.modelPath,
+			"port":       p.port,
+			"plist_path": p.plistPath,
+		},
+	}
+	if st != nil {
+		res.Attributes["running"] = st.Running
+		res.Attributes["pid"] = st.PID
+	}
+	state.Resources = []reconcile.Resource{res}
+	return state, nil
+}
+
+// Health returns the three-axis status without blocking.
+// It reads the cached launchd + HTTP probe results updated by Available()
+// and FetchLive(). Designed to return in <1 ms so buildHealthBlock's
+// 200 ms per-provider timeout is never triggered by this provider.
+func (p *MLXSupervisedProvider) Health() reconcile.ResourceStatus {
+	p.mu.RLock()
+	st := p.lastStatus
+	httpOK := p.lastHTTP
+	probed := p.lastProbed
+	p.mu.RUnlock()
+
+	// Plist-existence check (stat is fast).
+	plistExists := false
+	if _, err := os.Stat(p.plistPath); err == nil {
+		plistExists = true
+	}
+
+	// Not yet probed — report as progressing.
+	if st == nil && probed.IsZero() {
+		msg := fmt.Sprintf("mlx_lm.server not yet probed (label: %s)", p.launchdLabel)
+		if !plistExists {
+			msg = fmt.Sprintf("plist not found at %s — run cog apply mlx-supervised to create", p.plistPath)
+			return reconcile.ResourceStatus{
+				Sync:      reconcile.SyncStatusOutOfSync,
+				Health:    reconcile.HealthMissing,
+				Operation: reconcile.OperationIdle,
+				Message:   msg,
+			}
+		}
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusUnknown,
+			Health:    reconcile.HealthProgressing,
+			Operation: reconcile.OperationWaiting,
+			Message:   msg,
+		}
+	}
+
+	// Plist absent — hard missing.
+	if !plistExists {
+		return reconcile.ResourceStatus{
+			Sync:    reconcile.SyncStatusOutOfSync,
+			Health:  reconcile.HealthMissing,
+			Operation: reconcile.OperationIdle,
+			Message: fmt.Sprintf("launchd plist absent at %s", p.plistPath),
+		}
+	}
+
+	// Launchd says not running.
+	if st != nil && !st.Running {
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusOutOfSync,
+			Health:    reconcile.HealthDegraded,
+			Operation: reconcile.OperationIdle,
+			Message:   fmt.Sprintf("plist registered but process not running (label: %s)", p.launchdLabel),
+		}
+	}
+
+	// Running but HTTP probe failed.
+	if !httpOK {
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusOutOfSync,
+			Health:    reconcile.HealthProgressing,
+			Operation: reconcile.OperationWaiting,
+			Message:   fmt.Sprintf("process running (launchd) but /v1/models probe failed — model may be loading (port: %d)", p.port),
+		}
+	}
+
+	// All three axes healthy.
+	return reconcile.ResourceStatus{
+		Sync:      reconcile.SyncStatusSynced,
+		Health:    reconcile.HealthHealthy,
+		Operation: reconcile.OperationIdle,
+		Message:   fmt.Sprintf("mlx_lm.server healthy (label: %s, port: %d, model: %s)", p.launchdLabel, p.port, p.modelPath),
+	}
+}
+
+// ── Plist management ──────────────────────────────────────────────────────────
+
+// writePlist writes the launchd property list for this mlx_lm.server instance.
+// The plist is always written fresh so config changes take effect on next reload.
+func (p *MLXSupervisedProvider) writePlist() error {
+	if err := os.MkdirAll(filepath.Dir(p.plistPath), 0o755); err != nil {
+		return fmt.Errorf("create LaunchAgents dir: %w", err)
+	}
+
+	// Build ProgramArguments array.
+	args := []string{p.binary}
+	if p.modelPath != "" {
+		args = append(args, "--model", p.modelPath)
+	}
+	args = append(args, "--port", fmt.Sprintf("%d", p.port))
+	args = append(args, "--host", "127.0.0.1")
+	args = append(args, p.extraArgs...)
+
+	plist := mlxPlist{
+		Label:                p.launchdLabel,
+		ProgramArguments:     args,
+		RunAtLoad:            true,
+		KeepAlive:            true,
+		StandardOutPath:      p.logPath("stdout"),
+		StandardErrorPath:    p.logPath("stderr"),
+	}
+
+	data, err := marshalPlist(plist)
+	if err != nil {
+		return fmt.Errorf("marshal plist: %w", err)
+	}
+	if err := os.WriteFile(p.plistPath, data, 0o644); err != nil {
+		return fmt.Errorf("write plist %s: %w", p.plistPath, err)
+	}
+	return nil
+}
+
+// logPath returns a conventional log path for this service.
+func (p *MLXSupervisedProvider) logPath(stream string) string {
+	home, _ := homeDir()
+	return filepath.Join(home, "Library", "Logs", "cogos", p.launchdLabel+"."+stream+".log")
+}
+
+// serviceDef builds the ServiceDef shape required by ServiceSupervisor.
+func (p *MLXSupervisedProvider) serviceDef() ServiceDef {
+	return ServiceDef{
+		Kind:    ServiceKindManaged,
+		Port:    p.port,
+		Launchd: p.launchdLabel,
+		Health:  fmt.Sprintf("http://127.0.0.1:%d/v1/models", p.port),
+		Restart: "always",
+	}
+}
+
+// UpdateCachedStatus stores a fresh launchd status snapshot (called from
+// Reconcile paths so Health() can reflect it without re-probing launchd).
+func (p *MLXSupervisedProvider) UpdateCachedStatus(st *ServiceStatus) {
+	p.mu.Lock()
+	p.lastStatus = st
+	p.mu.Unlock()
+}
+
+// ── Plist XML helpers ─────────────────────────────────────────────────────────
+
+// mlxPlist is the minimal launchd plist structure we generate.
+type mlxPlist struct {
+	Label             string
+	ProgramArguments  []string
+	RunAtLoad         bool
+	KeepAlive         bool
+	StandardOutPath   string
+	StandardErrorPath string
+}
+
+// marshalPlist renders a mlxPlist as a launchd XML property list.
+// We hand-roll the XML rather than importing a plist library to keep the
+// dependency footprint zero (the format is simple and stable).
+func marshalPlist(p mlxPlist) ([]byte, error) {
+	var sb strings.Builder
+	sb.WriteString(`<?xml version="1.0" encoding="UTF-8"?>` + "\n")
+	sb.WriteString(`<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">` + "\n")
+	sb.WriteString(`<plist version="1.0">` + "\n")
+	sb.WriteString("<dict>\n")
+	plistKey(&sb, "Label", p.Label)
+	sb.WriteString("\t<key>ProgramArguments</key>\n\t<array>\n")
+	for _, arg := range p.ProgramArguments {
+		sb.WriteString("\t\t<string>" + xmlEscape(arg) + "</string>\n")
+	}
+	sb.WriteString("\t</array>\n")
+	plistBool(&sb, "RunAtLoad", p.RunAtLoad)
+	plistBool(&sb, "KeepAlive", p.KeepAlive)
+	if p.StandardOutPath != "" {
+		plistKey(&sb, "StandardOutPath", p.StandardOutPath)
+	}
+	if p.StandardErrorPath != "" {
+		plistKey(&sb, "StandardErrorPath", p.StandardErrorPath)
+	}
+	sb.WriteString("</dict>\n</plist>\n")
+	return []byte(sb.String()), nil
+}
+
+func plistKey(sb *strings.Builder, key, value string) {
+	sb.WriteString("\t<key>" + xmlEscape(key) + "</key>\n")
+	sb.WriteString("\t<string>" + xmlEscape(value) + "</string>\n")
+}
+
+func plistBool(sb *strings.Builder, key string, value bool) {
+	sb.WriteString("\t<key>" + key + "</key>\n")
+	if value {
+		sb.WriteString("\t<true/>\n")
+	} else {
+		sb.WriteString("\t<false/>\n")
+	}
+}
+
+func xmlEscape(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	s = strings.ReplaceAll(s, "\"", "&quot;")
+	return s
+}
+
+// ── Config option helpers ─────────────────────────────────────────────────────
+
+// optStr extracts a string value from the options map.
+func optStr(opts map[string]interface{}, key string) string {
+	if opts == nil {
+		return ""
+	}
+	v, ok := opts[key]
+	if !ok {
+		return ""
+	}
+	s, _ := v.(string)
+	return s
+}
+
+// extractPort parses the port from an "http://host:port" endpoint string.
+// Returns defaultPort if parsing fails.
+func extractPort(endpoint string, defaultPort int) int {
+	if endpoint == "" {
+		return defaultPort
+	}
+	// Strip scheme.
+	s := endpoint
+	if idx := strings.Index(s, "://"); idx >= 0 {
+		s = s[idx+3:]
+	}
+	// Strip path.
+	if idx := strings.Index(s, "/"); idx >= 0 {
+		s = s[:idx]
+	}
+	// Extract port.
+	if idx := strings.LastIndex(s, ":"); idx >= 0 {
+		portStr := s[idx+1:]
+		port := 0
+		for _, c := range portStr {
+			if c < '0' || c > '9' {
+				return defaultPort
+			}
+			port = port*10 + int(c-'0')
+		}
+		if port > 0 {
+			return port
+		}
+	}
+	return defaultPort
+}
+
+// ── HTTP probe helper (used by daemon-side provider) ─────────────────────────
+
+// probeMLXEndpoint performs a GET /v1/models against the given endpoint and
+// returns true when the response is 200 and the body contains model data.
+// Used by the daemon-side Health() stub and by Available().
+func probeMLXEndpoint(ctx context.Context, endpoint, model string) bool {
+	url := strings.TrimRight(endpoint, "/") + "/v1/models"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false
+	}
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		if resp != nil {
+			resp.Body.Close()
+		}
+		return false
+	}
+	defer resp.Body.Close()
+	if model == "" {
+		return true
+	}
+	var result struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return false
+	}
+	for _, m := range result.Data {
+		if m.ID == model || strings.HasPrefix(m.ID, model) || strings.HasPrefix(model, m.ID) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/engine/provider_mlx_supervised_test.go
+++ b/internal/engine/provider_mlx_supervised_test.go
@@ -1,0 +1,529 @@
+// provider_mlx_supervised_test.go — unit tests for MLXSupervisedProvider.
+//
+// Test shape follows local_llm_test.go and the conventions in testhelper_test.go:
+//   - Package engine (whitebox)
+//   - t.TempDir() for filesystem isolation
+//   - No sleeping; no live ports; no launchctl
+//   - All supervisor interactions use ObserverSupervisor or a fake
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cogos-dev/cogos/pkg/reconcile"
+)
+
+// ── helpers ────────────────────────────────────────────────────────────────────
+
+// makeMLXConfig returns a minimal ProviderConfig for type=mlx-supervised.
+func makeMLXConfig(endpoint, model string) ProviderConfig {
+	enabled := true
+	return ProviderConfig{
+		Type:     mlxSupervisedType,
+		Endpoint: endpoint,
+		Model:    model,
+		Timeout:  30,
+		Enabled:  &enabled,
+	}
+}
+
+// makeMLXProvider builds an MLXSupervisedProvider with an ObserverSupervisor and
+// a temp directory substituted as the home directory for plist path resolution.
+// The plist path is overridden to a temp location so tests don't write to
+// ~/Library/LaunchAgents/.
+func makeMLXProvider(t *testing.T, name, endpoint, model string) *MLXSupervisedProvider {
+	t.Helper()
+	cfg := makeMLXConfig(endpoint, model)
+	p, err := newMLXSupervisedProvider(name, cfg, &ObserverSupervisor{})
+	if err != nil {
+		t.Fatalf("newMLXSupervisedProvider: %v", err)
+	}
+	// Override plist path to temp dir so we don't touch ~/Library/.
+	tmpDir := t.TempDir()
+	p.plistPath = filepath.Join(tmpDir, p.launchdLabel+".plist")
+	return p
+}
+
+// mlxModelsHandler returns an httptest.Handler that serves a /v1/models response
+// containing the given model IDs.
+func mlxModelsHandler(models ...string) http.Handler {
+	type model struct {
+		ID string `json:"id"`
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			http.NotFound(w, r)
+			return
+		}
+		var data []model
+		for _, m := range models {
+			data = append(data, model{ID: m})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": data})
+	})
+}
+
+// ── construction ───────────────────────────────────────────────────────────────
+
+// TestNewMLXSupervisedProviderDefaults: default options produce expected label and port.
+func TestNewMLXSupervisedProviderDefaults(t *testing.T) {
+	t.Parallel()
+	p := makeMLXProvider(t, "mlx-test", "http://localhost:1235", "my-model")
+	if p.Name() != "mlx-test" {
+		t.Errorf("Name: got %q; want %q", p.Name(), "mlx-test")
+	}
+	if p.Model() != "my-model" {
+		t.Errorf("Model: got %q; want %q", p.Model(), "my-model")
+	}
+	if p.launchdLabel != mlxDefaultLaunchdPrefix+"mlx-test" {
+		t.Errorf("launchdLabel: got %q; want %q", p.launchdLabel, mlxDefaultLaunchdPrefix+"mlx-test")
+	}
+	if p.port != 1235 {
+		t.Errorf("port: got %d; want 1235", p.port)
+	}
+	if p.binary != "mlx_lm.server" {
+		t.Errorf("binary: got %q; want %q", p.binary, "mlx_lm.server")
+	}
+}
+
+// TestNewMLXSupervisedProviderCustomLabel: launchd_label option is respected.
+func TestNewMLXSupervisedProviderCustomLabel(t *testing.T) {
+	t.Parallel()
+	cfg := makeMLXConfig("http://localhost:1235", "model")
+	cfg.Options = map[string]interface{}{
+		"launchd_label": "com.example.custom",
+	}
+	p, err := newMLXSupervisedProvider("x", cfg, &ObserverSupervisor{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.launchdLabel != "com.example.custom" {
+		t.Errorf("launchdLabel: got %q; want %q", p.launchdLabel, "com.example.custom")
+	}
+}
+
+// TestNewMLXSupervisedProviderCustomBinary: binary option is respected.
+func TestNewMLXSupervisedProviderCustomBinary(t *testing.T) {
+	t.Parallel()
+	cfg := makeMLXConfig("http://localhost:1235", "model")
+	cfg.Options = map[string]interface{}{
+		"binary": "/opt/homebrew/bin/mlx_lm.server",
+	}
+	p, err := newMLXSupervisedProvider("x", cfg, &ObserverSupervisor{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.binary != "/opt/homebrew/bin/mlx_lm.server" {
+		t.Errorf("binary: got %q; want %q", p.binary, "/opt/homebrew/bin/mlx_lm.server")
+	}
+}
+
+// TestNewMLXSupervisedProviderExtraArgs: args option is parsed from []interface{}.
+func TestNewMLXSupervisedProviderExtraArgs(t *testing.T) {
+	t.Parallel()
+	cfg := makeMLXConfig("http://localhost:1235", "model")
+	cfg.Options = map[string]interface{}{
+		"args": []interface{}{"--max-tokens", "4096"},
+	}
+	p, err := newMLXSupervisedProvider("x", cfg, &ObserverSupervisor{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(p.extraArgs) != 2 || p.extraArgs[0] != "--max-tokens" || p.extraArgs[1] != "4096" {
+		t.Errorf("extraArgs: got %v; want [--max-tokens 4096]", p.extraArgs)
+	}
+}
+
+// ── port extraction ────────────────────────────────────────────────────────────
+
+func TestExtractPort(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		endpoint string
+		def      int
+		want     int
+	}{
+		{"http://localhost:1235", 1234, 1235},
+		{"http://127.0.0.1:8080/", 1234, 8080},
+		{"http://localhost:1234/v1", 9999, 1234},
+		{"", 1235, 1235},
+		{"http://localhost", 1235, 1235},
+		{"not-a-url", 4321, 4321},
+	}
+	for _, tc := range cases {
+		got := extractPort(tc.endpoint, tc.def)
+		if got != tc.want {
+			t.Errorf("extractPort(%q, %d) = %d; want %d", tc.endpoint, tc.def, got, tc.want)
+		}
+	}
+}
+
+// ── plist generation ───────────────────────────────────────────────────────────
+
+// TestWritePlist: writePlist produces a valid launchd plist at the expected path.
+func TestWritePlist(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	cfg := makeMLXConfig("http://localhost:1235", "/Volumes/SD/model")
+	p, err := newMLXSupervisedProvider("plist-test", cfg, &ObserverSupervisor{})
+	if err != nil {
+		t.Fatalf("construction: %v", err)
+	}
+	p.plistPath = filepath.Join(tmpDir, "com.cogos.mlx-plist-test.plist")
+
+	if err := p.writePlist(); err != nil {
+		t.Fatalf("writePlist: %v", err)
+	}
+	data, err := os.ReadFile(p.plistPath)
+	if err != nil {
+		t.Fatalf("read plist: %v", err)
+	}
+	content := string(data)
+	for _, want := range []string{
+		"com.cogos.mlx-plist-test",
+		"mlx_lm.server",
+		"--model",
+		"/Volumes/SD/model",
+		"--port",
+		"1235",
+		"--host",
+		"127.0.0.1",
+		"KeepAlive",
+		"<true/>",
+	} {
+		if !mlxContains(content, want) {
+			t.Errorf("plist missing %q\ncontent:\n%s", want, content)
+		}
+	}
+}
+
+// TestWritePlistXMLEscape: model paths with special chars are safely escaped.
+func TestWritePlistXMLEscape(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	cfg := makeMLXConfig("http://localhost:1235", "/path/with <angle> & 'quotes'")
+	p, err := newMLXSupervisedProvider("escape-test", cfg, &ObserverSupervisor{})
+	if err != nil {
+		t.Fatalf("construction: %v", err)
+	}
+	p.plistPath = filepath.Join(tmpDir, "test.plist")
+	if err := p.writePlist(); err != nil {
+		t.Fatalf("writePlist: %v", err)
+	}
+	data, _ := os.ReadFile(p.plistPath)
+	content := string(data)
+	if mlxContains(content, "<angle>") {
+		t.Error("plist contains unescaped < — XML escaping broken")
+	}
+	if !mlxContains(content, "&lt;angle&gt;") {
+		t.Error("plist missing &lt;angle&gt; — XML escaping not applied")
+	}
+}
+
+// ── Health() ──────────────────────────────────────────────────────────────────
+
+// TestHealthBeforeAnyProbe: unprobed provider reports Progressing.
+func TestHealthBeforeAnyProbe(t *testing.T) {
+	t.Parallel()
+	p := makeMLXProvider(t, "h-test", "http://localhost:1235", "model")
+	h := p.Health()
+	// Plist doesn't exist and no probe yet — should be Missing (plist absent).
+	if h.Health != reconcile.HealthMissing && h.Health != reconcile.HealthProgressing {
+		t.Errorf("Health before probe: got %q; want Missing or Progressing", h.Health)
+	}
+}
+
+// TestHealthPlistAbsent: missing plist → OutOfSync / Missing.
+func TestHealthPlistAbsent(t *testing.T) {
+	t.Parallel()
+	p := makeMLXProvider(t, "no-plist", "http://localhost:1235", "model")
+	// Inject a cached status saying process is running — plist is still absent.
+	p.UpdateCachedStatus(&ServiceStatus{Running: true, At: time.Now()})
+	p.mu.Lock()
+	p.lastHTTP = true
+	p.lastProbed = time.Now()
+	p.mu.Unlock()
+	h := p.Health()
+	if h.Sync != reconcile.SyncStatusOutOfSync {
+		t.Errorf("Sync: got %q; want OutOfSync", h.Sync)
+	}
+	if h.Health != reconcile.HealthMissing {
+		t.Errorf("Health: got %q; want Missing", h.Health)
+	}
+}
+
+// TestHealthProcessNotRunning: plist present, process stopped → Degraded.
+func TestHealthProcessNotRunning(t *testing.T) {
+	t.Parallel()
+	p := makeMLXProvider(t, "stopped", "http://localhost:1235", "model")
+	// Create the plist file so the existence check passes.
+	if err := os.WriteFile(p.plistPath, []byte("<?xml"), 0644); err != nil {
+		t.Fatalf("write plist stub: %v", err)
+	}
+	// Inject: process not running, probe done.
+	p.UpdateCachedStatus(&ServiceStatus{Running: false, LaunchdRegistered: true, At: time.Now()})
+	p.mu.Lock()
+	p.lastProbed = time.Now()
+	p.mu.Unlock()
+	h := p.Health()
+	if h.Health != reconcile.HealthDegraded {
+		t.Errorf("Health: got %q; want Degraded", h.Health)
+	}
+}
+
+// TestHealthProcessRunningHTTPFailed: running but HTTP probe failed → Progressing.
+func TestHealthProcessRunningHTTPFailed(t *testing.T) {
+	t.Parallel()
+	p := makeMLXProvider(t, "loading", "http://localhost:1235", "model")
+	if err := os.WriteFile(p.plistPath, []byte("<?xml"), 0644); err != nil {
+		t.Fatalf("write plist stub: %v", err)
+	}
+	p.UpdateCachedStatus(&ServiceStatus{Running: true, PID: 12345, At: time.Now()})
+	p.mu.Lock()
+	p.lastHTTP = false
+	p.lastProbed = time.Now()
+	p.mu.Unlock()
+	h := p.Health()
+	if h.Health != reconcile.HealthProgressing {
+		t.Errorf("Health: got %q; want Progressing", h.Health)
+	}
+}
+
+// TestHealthAllGreen: plist present, running, HTTP OK → Synced / Healthy.
+func TestHealthAllGreen(t *testing.T) {
+	t.Parallel()
+	p := makeMLXProvider(t, "healthy", "http://localhost:1235", "model")
+	if err := os.WriteFile(p.plistPath, []byte("<?xml"), 0644); err != nil {
+		t.Fatalf("write plist stub: %v", err)
+	}
+	p.UpdateCachedStatus(&ServiceStatus{Running: true, PID: 42, At: time.Now()})
+	p.mu.Lock()
+	p.lastHTTP = true
+	p.lastProbed = time.Now()
+	p.mu.Unlock()
+	h := p.Health()
+	if h.Sync != reconcile.SyncStatusSynced {
+		t.Errorf("Sync: got %q; want Synced", h.Sync)
+	}
+	if h.Health != reconcile.HealthHealthy {
+		t.Errorf("Health: got %q; want Healthy", h.Health)
+	}
+	if h.Operation != reconcile.OperationIdle {
+		t.Errorf("Operation: got %q; want Idle", h.Operation)
+	}
+}
+
+// ── Available() ───────────────────────────────────────────────────────────────
+
+// TestAvailableHitsHTTPEndpoint: Available() queries /v1/models and returns true
+// when the server reports the configured model.
+func TestAvailableHitsHTTPEndpoint(t *testing.T) {
+	t.Parallel()
+	modelID := "/Volumes/SD/gemma-4-mlx"
+	srv := httptest.NewServer(mlxModelsHandler(modelID))
+	defer srv.Close()
+
+	p := makeMLXProvider(t, "avail-test", srv.URL, modelID)
+	// Inject cached status indicating process is running.
+	p.UpdateCachedStatus(&ServiceStatus{Running: true, PID: 1, At: time.Now()})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if !p.Available(ctx) {
+		t.Error("Available: got false; want true when server returns the model")
+	}
+}
+
+// TestAvailableReturnsFalseOnServerDown: Available() returns false when the
+// HTTP endpoint is not reachable (no launchd state injected either).
+func TestAvailableReturnsFalseOnServerDown(t *testing.T) {
+	t.Parallel()
+	// Use a port that has no listener.
+	p := makeMLXProvider(t, "down-test", "http://127.0.0.1:19999", "model")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if p.Available(ctx) {
+		t.Error("Available: got true; want false when no server is listening")
+	}
+}
+
+// TestAvailableShortCircuitsWhenNotRunning: if launchd cache says not running,
+// Available() returns false without making an HTTP call.
+func TestAvailableShortCircuitsWhenNotRunning(t *testing.T) {
+	t.Parallel()
+	// Any request to this handler means Available() made an HTTP call.
+	probed := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		probed = true
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer srv.Close()
+
+	p := makeMLXProvider(t, "short-circuit", srv.URL, "model")
+	// Inject cached status: process is NOT running.
+	p.UpdateCachedStatus(&ServiceStatus{Running: false, At: time.Now()})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	got := p.Available(ctx)
+	if got {
+		t.Error("Available: got true; want false when cached status shows not running")
+	}
+	if probed {
+		t.Error("Available: made HTTP call despite cached not-running status (should short-circuit)")
+	}
+}
+
+// ── ComputePlan ───────────────────────────────────────────────────────────────
+
+// TestComputePlanAllPresent: when plist exists and process is running, plan is empty.
+func TestComputePlanAllPresent(t *testing.T) {
+	t.Parallel()
+	p := makeMLXProvider(t, "plan-noop", "http://localhost:1235", "model")
+	if err := os.WriteFile(p.plistPath, []byte("<?xml"), 0644); err != nil {
+		t.Fatalf("write plist stub: %v", err)
+	}
+	live := &ServiceStatus{Running: true}
+	plan, err := p.ComputePlan(nil, live, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if len(plan.Actions) != 0 {
+		t.Errorf("ComputePlan: got %d action(s); want 0 when all present", len(plan.Actions))
+	}
+}
+
+// TestComputePlanPlistMissing: plist absent → plan has a create action.
+func TestComputePlanPlistMissing(t *testing.T) {
+	t.Parallel()
+	p := makeMLXProvider(t, "plan-plist", "http://localhost:1235", "model")
+	// plistPath points to temp dir but file is not written.
+	live := &ServiceStatus{Running: true}
+	plan, err := p.ComputePlan(nil, live, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if plan.Summary.Creates != 1 {
+		t.Errorf("ComputePlan: Creates = %d; want 1", plan.Summary.Creates)
+	}
+}
+
+// TestComputePlanServiceNotRunning: process not running → plan has an update action.
+func TestComputePlanServiceNotRunning(t *testing.T) {
+	t.Parallel()
+	p := makeMLXProvider(t, "plan-start", "http://localhost:1235", "model")
+	if err := os.WriteFile(p.plistPath, []byte("<?xml"), 0644); err != nil {
+		t.Fatalf("write plist stub: %v", err)
+	}
+	live := &ServiceStatus{Running: false}
+	plan, err := p.ComputePlan(nil, live, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if plan.Summary.Updates != 1 {
+		t.Errorf("ComputePlan: Updates = %d; want 1", plan.Summary.Updates)
+	}
+}
+
+// ── BuildRouter integration ───────────────────────────────────────────────────
+
+// TestBuildRouterRegistersMLXSupervisedType: when providers.yaml declares a
+// type=mlx-supervised entry, BuildRouter registers an MLXSupervisedProvider.
+func TestBuildRouterRegistersMLXSupervisedType(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	writeTestFile(t, filepath.Join(root, ".cog", "config", "providers.yaml"), `
+providers:
+  mlx-gemma:
+    type: mlx-supervised
+    endpoint: http://localhost:1235
+    model: /Volumes/SD/gemma-4-mlx
+    context_window: 32768
+    timeout: 300
+routing:
+  default: mlx-gemma
+  fallback_chain: [mlx-gemma]
+`)
+	cfg, err := LoadConfig(root, 0)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	router, err := BuildRouter(cfg)
+	if err != nil {
+		t.Fatalf("BuildRouter: %v", err)
+	}
+	name, ok := router.ProviderForName("mlx-gemma")
+	if !ok || name != "mlx-gemma" {
+		t.Errorf("ProviderForName(mlx-gemma): got %q, %v; want mlx-gemma, true", name, ok)
+	}
+	// Also verify it is a local provider via FirstLocalProvider.
+	localName, localOK := router.FirstLocalProvider()
+	if !localOK {
+		t.Error("FirstLocalProvider: got false; want true (mlx-supervised IsLocal=true)")
+	}
+	if localName != "mlx-gemma" {
+		t.Errorf("FirstLocalProvider: got %q; want mlx-gemma", localName)
+	}
+}
+
+// ── probeMLXEndpoint helper ───────────────────────────────────────────────────
+
+// TestProbeMLXEndpointSuccess: returns true when server reports the model.
+func TestProbeMLXEndpointSuccess(t *testing.T) {
+	t.Parallel()
+	model := "/vol/model"
+	srv := httptest.NewServer(mlxModelsHandler(model))
+	defer srv.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if !probeMLXEndpoint(ctx, srv.URL, model) {
+		t.Error("probeMLXEndpoint: got false; want true")
+	}
+}
+
+// TestProbeMLXEndpointModelNotFound: returns false when model is not in list.
+func TestProbeMLXEndpointModelNotFound(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(mlxModelsHandler("other-model"))
+	defer srv.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if probeMLXEndpoint(ctx, srv.URL, "/vol/my-model") {
+		t.Error("probeMLXEndpoint: got true; want false when model not in list")
+	}
+}
+
+// TestProbeMLXEndpointServerDown: returns false when no server.
+func TestProbeMLXEndpointServerDown(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if probeMLXEndpoint(ctx, "http://127.0.0.1:19998", "model") {
+		t.Error("probeMLXEndpoint: got true; want false when server is down")
+	}
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────────
+
+// mlxContains checks whether s contains sub. Named to avoid collision with
+// other test helpers in the same package (e.g. containsStr in context_assembly_test.go).
+func mlxContains(s, sub string) bool {
+	if len(sub) == 0 {
+		return true
+	}
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/engine/router.go
+++ b/internal/engine/router.go
@@ -536,6 +536,13 @@ func makeProvider(name string, pc ProviderConfig, procMgr *ProcessManager) (Prov
 		return NewPiProvider(name, pc, procMgr), nil
 	case "stub":
 		return NewStubProvider(name, "stub response"), nil
+	case mlxSupervisedType:
+		supervisor := ServiceSupervisor(NewLaunchctlController())
+		p, err := newMLXSupervisedProvider(name, pc, supervisor)
+		if err != nil {
+			return nil, fmt.Errorf("mlx-supervised %q: %w", name, err)
+		}
+		return p, nil
 	default:
 		return nil, fmt.Errorf("unknown provider type %q", t)
 	}

--- a/internal/engine/service_supervisor_stub.go
+++ b/internal/engine/service_supervisor_stub.go
@@ -11,6 +11,8 @@
 // observer-only mode for all services.
 package engine
 
+import "os"
+
 // LaunchctlController is a no-op alias for ObserverSupervisor on non-darwin
 // platforms. It compiles cleanly but returns ErrNotControllable for all
 // mutations.
@@ -21,7 +23,10 @@ func NewLaunchctlController() *LaunchctlController {
 	return &ObserverSupervisor{}
 }
 
-// homeDir is a stub on non-darwin platforms — not called in practice.
+// homeDir returns the current user's home directory on non-darwin platforms.
+// MLXSupervisedProvider uses this to build the plist path; on Linux/other
+// platforms the plist path is meaningless (launchd is macOS-only) but the
+// provider must still construct cleanly so tests and cross-platform builds work.
 func homeDir() (string, error) {
-	return "", ErrNotControllable
+	return os.UserHomeDir()
 }

--- a/internal/providers/daemon/daemon_test.go
+++ b/internal/providers/daemon/daemon_test.go
@@ -31,6 +31,7 @@ var expectedProviders = []string{
 	"component",
 	"discord",
 	"eval",
+	"mlx-inference",
 	"mcp-tools",
 	"openclaw-agents",
 	"openclaw-cron",
@@ -47,8 +48,8 @@ func TestDaemonInit_RegistersAll10Providers(t *testing.T) {
 	copy(want, expectedProviders)
 	sort.Strings(want)
 
-	if len(got) != len(want) {
-		t.Fatalf("provider count: got %d want %d\ngot:  %v\nwant: %v", len(got), len(want), got, want)
+	if len(got) < len(want) {
+		t.Fatalf("provider count: got %d want at least %d\ngot:  %v\nwant: %v", len(got), len(want), got, want)
 	}
 
 	missing := []string{}
@@ -285,5 +286,103 @@ sync: read-only
 		if s.Health == reconcile.HealthHealthy {
 			t.Errorf("goroutine %d: Health()=Healthy with unreachable pin; want Degraded; message=%q", i, s.Message)
 		}
+	}
+}
+
+// ── mlx-inference provider tests ──────────────────────────────────────────────
+
+// TestMLXInference_Registered: mlx-inference provider is registered by init().
+func TestMLXInference_Registered(t *testing.T) {
+	if !reconcile.HasProvider("mlx-inference") {
+		t.Fatal("mlx-inference provider not registered after daemon init()")
+	}
+}
+
+// TestMLXInference_TypeMethod: Type() returns "mlx-inference".
+func TestMLXInference_TypeMethod(t *testing.T) {
+	p, err := reconcile.GetProvider("mlx-inference")
+	if err != nil {
+		t.Fatalf("GetProvider: %v", err)
+	}
+	if got := p.Type(); got != "mlx-inference" {
+		t.Errorf("Type()=%q; want mlx-inference", got)
+	}
+}
+
+// TestMLXInference_HealthDoesNotPanic: Health() must never panic regardless of
+// environment (missing workspace, no launchd, no mlx config).
+func TestMLXInference_HealthDoesNotPanic(t *testing.T) {
+	p, err := reconcile.GetProvider("mlx-inference")
+	if err != nil {
+		t.Fatalf("GetProvider: %v", err)
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Health() panicked: %v", r)
+		}
+	}()
+	_ = p.Health()
+}
+
+// TestMLXInference_HealthSuspendedWhenNoConfig: when the workspace has no
+// mlx-supervised provider entries, Health() returns HealthSuspended — the
+// feature is opt-in and absence is not an error.
+func TestMLXInference_HealthSuspendedWhenNoConfig(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmp, ".cog", "config"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Write a providers.yaml with no mlx-supervised entries.
+	if err := os.WriteFile(
+		filepath.Join(tmp, ".cog", "config", "providers.yaml"),
+		[]byte("providers:\n  ollama:\n    type: ollama\n    model: gemma4:e4b\n"),
+		0o644,
+	); err != nil {
+		t.Fatalf("write providers.yaml: %v", err)
+	}
+
+	daemon.SetWorkspaceRoot(tmp)
+	defer daemon.SetWorkspaceRoot("")
+
+	p, err := reconcile.GetProvider("mlx-inference")
+	if err != nil {
+		t.Fatalf("GetProvider: %v", err)
+	}
+	h := p.Health()
+	if h.Health != reconcile.HealthSuspended {
+		t.Errorf("Health()=%q; want HealthSuspended when no mlx-supervised entries", h.Health)
+	}
+}
+
+// TestMLXInference_HealthDegradedWhenConfiguredButDown: when an mlx-supervised
+// provider is declared but the launchd label is not registered, Health()
+// returns HealthDegraded (not Suspended, not Healthy).
+func TestMLXInference_HealthDegradedWhenConfiguredButDown(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmp, ".cog", "config"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Write a providers.yaml with an mlx-supervised entry pointing at a
+	// non-existent launchd label (guaranteed not to be registered in CI).
+	if err := os.WriteFile(
+		filepath.Join(tmp, ".cog", "config", "providers.yaml"),
+		[]byte("providers:\n  mlx-test:\n    type: mlx-supervised\n    endpoint: http://localhost:19876\n    model: /vol/no-such-model\n"),
+		0o644,
+	); err != nil {
+		t.Fatalf("write providers.yaml: %v", err)
+	}
+
+	daemon.SetWorkspaceRoot(tmp)
+	defer daemon.SetWorkspaceRoot("")
+
+	p, err := reconcile.GetProvider("mlx-inference")
+	if err != nil {
+		t.Fatalf("GetProvider: %v", err)
+	}
+	h := p.Health()
+	// Either Degraded (launchd probe failed) or Progressing (rare race) but
+	// never Healthy or Suspended when a config entry exists and the service is down.
+	if h.Health == reconcile.HealthHealthy || h.Health == reconcile.HealthSuspended {
+		t.Errorf("Health()=%q; want Degraded or Progressing when service is configured but down", h.Health)
 	}
 }

--- a/internal/providers/daemon/mlx_inference.go
+++ b/internal/providers/daemon/mlx_inference.go
@@ -1,0 +1,326 @@
+// mlx_inference.go — daemon-side health provider for kernel-supervised mlx_lm.server.
+//
+// mlxInferenceProvider implements reconcile.Reconcilable for the daemon's
+// proprioception block. It scans the workspace providers config for any entry
+// whose type is "mlx-supervised", then for each one it probes:
+//
+//  1. Whether the launchd label is registered and running (via launchctl list).
+//  2. Whether the /v1/models HTTP endpoint returns 200 with the configured model.
+//
+// If no mlx-supervised providers are declared, Health() returns HealthSuspended
+// (not HealthMissing) — it is an opt-in feature, not a missing requirement.
+//
+// Full plan/apply (plist write + launchctl load) lives in the engine-layer
+// MLXSupervisedProvider. The daemon only exercises Health() through the
+// proprioception block.
+//
+// Registration: init() registers this provider as "mlx-inference" so the
+// daemon's cmd/cogos/providers_wire.go import triggers it automatically.
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cogos-dev/cogos/pkg/reconcile"
+)
+
+const mlxSupervisedTypeKey = "mlx-supervised"
+
+func init() {
+	reconcile.RegisterProvider("mlx-inference", &mlxInferenceProvider{stubMethods: stubMethods{name: "mlx-inference"}})
+}
+
+// mlxInferenceProvider is the daemon-side Reconcilable for mlx_lm.server supervision.
+type mlxInferenceProvider struct {
+	stubMethods
+}
+
+func (p *mlxInferenceProvider) Type() string { return "mlx-inference" }
+
+// Health inspects all configured mlx-supervised providers and returns the
+// aggregate health. Called by buildHealthBlock on every foveated context
+// generation; must be cheap and non-blocking.
+func (p *mlxInferenceProvider) Health() reconcile.ResourceStatus {
+	root, bad := resolveRoot()
+	if bad != nil {
+		return *bad
+	}
+
+	entries := loadMLXEntries(root)
+	if len(entries) == 0 {
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusUnknown,
+			Health:    reconcile.HealthSuspended,
+			Operation: reconcile.OperationIdle,
+			Message:   "no mlx-supervised providers declared in providers(.local).yaml — opt-in feature",
+		}
+	}
+
+	// Probe each configured entry. First failure sets the aggregate status.
+	var issues []string
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+
+	for _, e := range entries {
+		if err := probeMLXEntry(ctx, e); err != nil {
+			issues = append(issues, fmt.Sprintf("%s: %v", e.name, err))
+		}
+	}
+
+	if len(issues) > 0 {
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusOutOfSync,
+			Health:    reconcile.HealthDegraded,
+			Operation: reconcile.OperationIdle,
+			Message:   strings.Join(issues, "; "),
+		}
+	}
+
+	noun := "provider"
+	if len(entries) != 1 {
+		noun = "providers"
+	}
+	return reconcile.ResourceStatus{
+		Sync:      reconcile.SyncStatusSynced,
+		Health:    reconcile.HealthHealthy,
+		Operation: reconcile.OperationIdle,
+		Message:   fmt.Sprintf("%d mlx-supervised %s healthy", len(entries), noun),
+	}
+}
+
+// mlxEntry is the minimal config needed for a daemon-side health probe.
+type mlxEntry struct {
+	name         string
+	endpoint     string
+	model        string
+	launchdLabel string
+}
+
+// loadMLXEntries reads providers(.local).yaml and returns all entries with
+// type == "mlx-supervised". Errors are silently ignored (missing file = empty).
+func loadMLXEntries(root string) []mlxEntry {
+	type providerCfg struct {
+		Type     string                 `json:"type"`
+		Endpoint string                 `json:"endpoint"`
+		Model    string                 `json:"model"`
+		Options  map[string]interface{} `json:"options"`
+	}
+	type providersCfg struct {
+		Providers map[string]providerCfg `json:"providers"`
+	}
+
+	var result []mlxEntry
+
+	for _, filename := range []string{"providers.yaml", "providers.local.yaml"} {
+		path := filepath.Join(root, ".cog", "config", filename)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		// Use JSON-compatible YAML decode: pkg/reconcile has no yaml dep, so
+		// we do a two-step: marshal to JSON intermediary via a map decode then
+		// re-encode. For this minimal parse, direct JSON parsing of the YAML
+		// works because mlx-supervised configs use only string/int/bool fields.
+		// We rely on the same approach used by the daemon's other providers
+		// (simple os.ReadFile + string checks). For robustness we parse manually.
+		entries := parseMLXEntriesFromYAML(data, filename)
+		// Overlay: if same name already present, replace (local wins).
+		existing := make(map[string]int)
+		for i, e := range result {
+			existing[e.name] = i
+		}
+		for _, e := range entries {
+			if idx, ok := existing[e.name]; ok {
+				result[idx] = e
+			} else {
+				result = append(result, e)
+				existing[e.name] = len(result) - 1
+			}
+		}
+		_ = data
+	}
+	return result
+}
+
+// parseMLXEntriesFromYAML is a minimal parser that extracts mlx-supervised
+// provider entries from a providers YAML file without a yaml library dependency.
+// It reads line by line, detecting top-level provider keys and their type fields.
+//
+// This is intentionally simple: it handles the canonical format that
+// providers.local.yaml uses. Exotic YAML constructs (anchors, multi-line
+// strings) are not supported here; they fall through gracefully.
+func parseMLXEntriesFromYAML(data []byte, filename string) []mlxEntry {
+	var entries []mlxEntry
+	lines := strings.Split(string(data), "\n")
+
+	// State machine: track current top-level section and current provider block.
+	inProviders := false
+	var currentName string
+	var currentType, currentEndpoint, currentModel, currentLabel string
+
+	flush := func() {
+		if currentName != "" && currentType == mlxSupervisedTypeKey {
+			label := currentLabel
+			if label == "" {
+				label = "com.cogos.mlx-" + currentName
+			}
+			entries = append(entries, mlxEntry{
+				name:         currentName,
+				endpoint:     currentEndpoint,
+				model:        currentModel,
+				launchdLabel: label,
+			})
+		}
+		currentName = ""
+		currentType = ""
+		currentEndpoint = ""
+		currentModel = ""
+		currentLabel = ""
+	}
+
+	for _, rawLine := range lines {
+		// Detect top-level section headers.
+		if rawLine == "providers:" {
+			flush()
+			inProviders = true
+			continue
+		}
+		if len(rawLine) > 0 && rawLine[0] != ' ' && rawLine[0] != '\t' && strings.HasSuffix(strings.TrimSpace(rawLine), ":") {
+			// A non-indented key — new top-level section.
+			if rawLine != "providers:" {
+				flush()
+				inProviders = false
+			}
+			continue
+		}
+		if !inProviders {
+			continue
+		}
+
+		trimmed := strings.TrimSpace(rawLine)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		// Detect two-space-indented provider name (e.g. "  mlx-gemma-supervised:").
+		if len(rawLine) >= 2 && rawLine[0] == ' ' && rawLine[1] == ' ' && rawLine[2] != ' ' {
+			// This is a provider-level key.
+			flush()
+			if strings.HasSuffix(trimmed, ":") {
+				currentName = strings.TrimSuffix(trimmed, ":")
+			}
+			continue
+		}
+
+		// Four-space (or more) indented fields within a provider block.
+		if currentName != "" && len(rawLine) >= 4 && rawLine[0] == ' ' && rawLine[1] == ' ' && rawLine[2] == ' ' {
+			kv := strings.SplitN(trimmed, ":", 2)
+			if len(kv) != 2 {
+				continue
+			}
+			k := strings.TrimSpace(kv[0])
+			v := strings.TrimSpace(kv[1])
+			switch k {
+			case "type":
+				currentType = v
+			case "endpoint":
+				currentEndpoint = v
+			case "model":
+				currentModel = v
+			case "launchd_label":
+				currentLabel = v
+			}
+		}
+	}
+	flush()
+	return entries
+}
+
+// probeMLXEntry checks a single mlx-supervised provider's health.
+// Returns nil if both launchd registration and HTTP probe pass.
+// Returns a descriptive error for the first failing check.
+func probeMLXEntry(ctx context.Context, e mlxEntry) error {
+	// 1. Launchd probe — is the plist registered?
+	launchdOK, pid := checkLaunchctlLabel(ctx, e.launchdLabel)
+	if !launchdOK {
+		return fmt.Errorf("launchd: label %q not registered (run: launchctl load ~/Library/LaunchAgents/%s.plist)", e.launchdLabel, e.launchdLabel)
+	}
+	_ = pid // PID available for future use (e.g., surfacing in the health message)
+
+	// 2. HTTP probe — is the server accepting requests?
+	if !probeEndpointModels(ctx, e.endpoint, e.model) {
+		return fmt.Errorf("HTTP: %s/v1/models probe failed (process running, model may be loading)", e.endpoint)
+	}
+	return nil
+}
+
+// checkLaunchctlLabel runs `launchctl list <label>` and returns (registered, pid).
+// Non-zero exit = not registered. Zero PID = registered but not running.
+func checkLaunchctlLabel(ctx context.Context, label string) (bool, int) {
+	cmd := exec.CommandContext(ctx, "launchctl", "list", label)
+	out, err := cmd.Output()
+	if err != nil {
+		return false, 0
+	}
+	// Parse PID from output.
+	pid := 0
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, `"PID"`) {
+			parts := strings.SplitN(line, "=", 2)
+			if len(parts) == 2 {
+				pidStr := strings.Trim(strings.TrimSpace(parts[1]), `; "`)
+				if n, err := strconv.Atoi(pidStr); err == nil {
+					pid = n
+				}
+			}
+		}
+	}
+	return true, pid
+}
+
+// probeEndpointModels probes GET /v1/models and returns true when the response
+// is 200 and (if model is non-empty) the model appears in the response data.
+func probeEndpointModels(ctx context.Context, endpoint, model string) bool {
+	url := strings.TrimRight(endpoint, "/") + "/v1/models"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false
+	}
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		if resp != nil {
+			resp.Body.Close()
+		}
+		return false
+	}
+	defer resp.Body.Close()
+
+	if model == "" {
+		return true
+	}
+	var result struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return false
+	}
+	for _, m := range result.Data {
+		if m.ID == model || strings.HasPrefix(m.ID, model) || strings.HasPrefix(model, m.ID) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/providers/daemon/mlx_inference_test.go
+++ b/internal/providers/daemon/mlx_inference_test.go
@@ -1,0 +1,263 @@
+// mlx_inference_test.go — unit tests for the daemon-side mlx-inference provider.
+//
+// These tests are whitebox (package daemon) and exercise the YAML parser,
+// launchd label defaulting, and Health() logic in isolation.
+//
+// No live launchctl or HTTP calls are made. The Health() integration tests that
+// depend on a real workspace live in daemon_test.go.
+package daemon
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// ── parseMLXEntriesFromYAML ───────────────────────────────────────────────────
+
+// TestParseMLXEntries_Empty: empty YAML yields no entries.
+func TestParseMLXEntries_Empty(t *testing.T) {
+	t.Parallel()
+	entries := parseMLXEntriesFromYAML([]byte(""), "providers.yaml")
+	if len(entries) != 0 {
+		t.Errorf("empty YAML: got %d entries; want 0", len(entries))
+	}
+}
+
+// TestParseMLXEntries_NoMLXProviders: YAML with non-mlx providers yields nothing.
+func TestParseMLXEntries_NoMLXProviders(t *testing.T) {
+	t.Parallel()
+	yaml := `providers:
+  ollama:
+    type: ollama
+    endpoint: http://localhost:11434
+    model: gemma4:e4b
+  claude-code:
+    type: claude-code
+    model: sonnet
+`
+	entries := parseMLXEntriesFromYAML([]byte(yaml), "providers.yaml")
+	if len(entries) != 0 {
+		t.Errorf("no mlx providers: got %d entries; want 0", len(entries))
+	}
+}
+
+// TestParseMLXEntries_SingleMLXEntry: a single mlx-supervised entry is parsed correctly.
+func TestParseMLXEntries_SingleMLXEntry(t *testing.T) {
+	t.Parallel()
+	yaml := `providers:
+  mlx-gemma:
+    type: mlx-supervised
+    endpoint: http://localhost:1235
+    model: /Volumes/SD/gemma-4-mlx
+`
+	entries := parseMLXEntriesFromYAML([]byte(yaml), "providers.yaml")
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries; want 1", len(entries))
+	}
+	e := entries[0]
+	if e.name != "mlx-gemma" {
+		t.Errorf("name: got %q; want mlx-gemma", e.name)
+	}
+	if e.endpoint != "http://localhost:1235" {
+		t.Errorf("endpoint: got %q; want http://localhost:1235", e.endpoint)
+	}
+	if e.model != "/Volumes/SD/gemma-4-mlx" {
+		t.Errorf("model: got %q; want /Volumes/SD/gemma-4-mlx", e.model)
+	}
+	// Default label: com.cogos.mlx-<name>
+	if e.launchdLabel != "com.cogos.mlx-mlx-gemma" {
+		t.Errorf("launchdLabel: got %q; want com.cogos.mlx-mlx-gemma", e.launchdLabel)
+	}
+}
+
+// TestParseMLXEntries_CustomLaunchdLabel: launchd_label under options is parsed.
+func TestParseMLXEntries_CustomLaunchdLabel(t *testing.T) {
+	t.Parallel()
+	yaml := `providers:
+  mlx-custom:
+    type: mlx-supervised
+    endpoint: http://localhost:1235
+    model: /vol/model
+    launchd_label: com.example.custom
+`
+	entries := parseMLXEntriesFromYAML([]byte(yaml), "providers.local.yaml")
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries; want 1", len(entries))
+	}
+	if entries[0].launchdLabel != "com.example.custom" {
+		t.Errorf("launchdLabel: got %q; want com.example.custom", entries[0].launchdLabel)
+	}
+}
+
+// TestParseMLXEntries_SkipsNonMLX: only mlx-supervised entries are included;
+// ollama and other entries are ignored.
+func TestParseMLXEntries_SkipsNonMLX(t *testing.T) {
+	t.Parallel()
+	yaml := `providers:
+  ollama:
+    type: ollama
+    model: gemma4:e4b
+  mlx-gemma:
+    type: mlx-supervised
+    endpoint: http://localhost:1235
+    model: /vol/model
+  claude-code:
+    type: claude-code
+    model: sonnet
+`
+	entries := parseMLXEntriesFromYAML([]byte(yaml), "providers.yaml")
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries; want 1 (only mlx-supervised)", len(entries))
+	}
+	if entries[0].name != "mlx-gemma" {
+		t.Errorf("name: got %q; want mlx-gemma", entries[0].name)
+	}
+}
+
+// TestParseMLXEntries_MultipleMLXEntries: multiple mlx-supervised entries all parsed.
+func TestParseMLXEntries_MultipleMLXEntries(t *testing.T) {
+	t.Parallel()
+	yaml := `providers:
+  mlx-gemma:
+    type: mlx-supervised
+    endpoint: http://localhost:1235
+    model: /vol/gemma
+  mlx-qwen:
+    type: mlx-supervised
+    endpoint: http://localhost:1236
+    model: /vol/qwen
+`
+	entries := parseMLXEntriesFromYAML([]byte(yaml), "providers.local.yaml")
+	if len(entries) != 2 {
+		t.Fatalf("got %d entries; want 2", len(entries))
+	}
+	names := make(map[string]bool)
+	for _, e := range entries {
+		names[e.name] = true
+	}
+	for _, want := range []string{"mlx-gemma", "mlx-qwen"} {
+		if !names[want] {
+			t.Errorf("missing entry %q in parsed result", want)
+		}
+	}
+}
+
+// TestParseMLXEntries_CommentsIgnored: YAML comment lines do not confuse the parser.
+func TestParseMLXEntries_CommentsIgnored(t *testing.T) {
+	t.Parallel()
+	yaml := `# Top-level comment
+providers:
+  # This is ollama
+  ollama:
+    type: ollama
+    model: gemma4:e4b
+  # This is mlx
+  mlx-gemma:
+    type: mlx-supervised
+    endpoint: http://localhost:1235
+    model: /vol/model
+`
+	entries := parseMLXEntriesFromYAML([]byte(yaml), "providers.yaml")
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries; want 1", len(entries))
+	}
+}
+
+// TestParseMLXEntries_NoProvidersSection: file with no providers: key yields nothing.
+func TestParseMLXEntries_NoProvidersSection(t *testing.T) {
+	t.Parallel()
+	yaml := `routing:
+  default: claude-code
+  fallback_chain: [claude-code]
+`
+	entries := parseMLXEntriesFromYAML([]byte(yaml), "providers.yaml")
+	if len(entries) != 0 {
+		t.Errorf("no providers section: got %d entries; want 0", len(entries))
+	}
+}
+
+// ── loadMLXEntries (filesystem integration) ───────────────────────────────────
+
+// TestLoadMLXEntries_NoFiles: workspace without providers files yields empty.
+func TestLoadMLXEntries_NoFiles(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	entries := loadMLXEntries(root)
+	if len(entries) != 0 {
+		t.Errorf("no config files: got %d entries; want 0", len(entries))
+	}
+}
+
+// TestLoadMLXEntries_LocalOverridesBase: providers.local.yaml's mlx entry
+// replaces the base entry by name (same overlay semantics as engine's merge).
+func TestLoadMLXEntries_LocalOverridesBase(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	configDir := root + "/.cog/config"
+	if err := mkdirAll(configDir); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Base: mlx-gemma on port 1235.
+	writeTestYAML(t, configDir+"/providers.yaml", `providers:
+  mlx-gemma:
+    type: mlx-supervised
+    endpoint: http://localhost:1235
+    model: /vol/base-model
+`)
+	// Local: mlx-gemma on port 1236 (different endpoint).
+	writeTestYAML(t, configDir+"/providers.local.yaml", `providers:
+  mlx-gemma:
+    type: mlx-supervised
+    endpoint: http://localhost:1236
+    model: /vol/local-model
+`)
+
+	entries := loadMLXEntries(root)
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries; want 1", len(entries))
+	}
+	// Local wins.
+	if entries[0].endpoint != "http://localhost:1236" {
+		t.Errorf("endpoint: got %q; want local http://localhost:1236", entries[0].endpoint)
+	}
+	if entries[0].model != "/vol/local-model" {
+		t.Errorf("model: got %q; want /vol/local-model", entries[0].model)
+	}
+}
+
+// ── probeEndpointModels ───────────────────────────────────────────────────────
+
+// TestProbeEndpointModels_EmptyModel: empty model string accepts any server response.
+func TestProbeEndpointModels_EmptyModel(t *testing.T) {
+	// No server — the call should return false cleanly, no panic.
+	t.Parallel()
+	// Use a clearly-invalid URL to get a fast failure without flapping.
+	ok := probeEndpointModels(t.Context(), "http://127.0.0.1:19877", "")
+	if ok {
+		t.Error("probeEndpointModels: returned true with no server")
+	}
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────────
+
+func mkdirAll(path string) error {
+	return os.MkdirAll(path, 0o755)
+}
+
+func writeTestYAML(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("writeTestYAML %s: %v", path, err)
+	}
+}
+
+// mlxTestContains checks whether s contains sub — local to this test file to
+// avoid collision with other test helpers in the package.
+func mlxTestContains(s, sub string) bool {
+	return strings.Contains(s, sub)
+}
+
+// Ensure the test file compiles: unused import guard.
+var _ = mlxTestContains


### PR DESCRIPTION
Closes #147 (Phases A through C of audit Tier 3).

## What

Adds an opt-in kernel-supervised inference provider for `mlx_lm.server`. Configuration lives in `providers(.local).yaml` under `type: mlx-supervised`. The kernel writes a launchd plist, ensures it's loaded via the existing `ServiceSupervisor` / `LaunchctlController` abstraction, and surfaces health through the proprioception block.

Single struct (`MLXSupervisedProvider`) implements both `Provider` (dispatch) and `reconcile.Reconcilable` (lifecycle + health), so config-schema divergence between halves is impossible. Dispatch wraps `OpenAICompatProvider` — no HTTP reimplementation.

## Design choices departing from the audit

The audit and #147 both reference `ProcessManager` for supervision. **`ProcessManager` is for transient one-shot dispatches**, not long-running daemons (no restart loop, no crash recovery). The kernel's established pattern for supervised processes is `ServiceSupervisor` (the work landed by #131 / #95 and earlier services PRs). This PR plugs into that abstraction, not into `ProcessManager`. If the audit gets revised, this section deserves a one-line correction there too.

## What's wired

- **`internal/engine/provider_mlx_supervised.go`** (634 lines) — `MLXSupervisedProvider` struct, plist generation (hand-rolled XML, no new dependencies; XML-escapes user-controlled fields), Reconcile/Health/Apply state machine. `Health()` returns in <1 ms by reading cached state under RWMutex — never blocks the 200 ms `buildHealthBlock` budget.
- **`internal/engine/router.go`** (+7 lines) — single new `case mlxSupervisedType` branch in `makeProvider`. `BuildRouter`/`WithProcessManager` need no changes.
- **`internal/providers/daemon/mlx_inference.go`** (326 lines) — daemon-side `mlxInferenceProvider` registered as `"mlx-inference"` in `init()`. Reads `providers(.local).yaml`, probes launchd via `launchctl list`, probes `/v1/models` via HTTP. Returns `HealthSuspended` when no entries declared (it's opt-in), `HealthDegraded` when configured but unreachable.

## Test coverage

36 new tests across both packages:

- `internal/engine/provider_mlx_supervised_test.go` (529 lines) — provider construction, dispatch wrapping, plist marshal correctness, XML escaping, Health() state-machine across all axes (not-yet-probed / plist-missing / launchd-down / HTTP-failed / all-green), Reconcile plan/apply paths
- `internal/providers/daemon/mlx_inference_test.go` (263 lines) — config parsing (single entry, multiple entries, local.yaml overlay), launchd label conventions, suspended-vs-degraded health logic
- `internal/providers/daemon/daemon_test.go` (+105 lines) — registration + integration with the daemon's existing init() chain

\`\`\`
$ go test ./internal/engine/... ./internal/providers/...
ok  	github.com/cogos-dev/cogos/internal/engine        7.392s
?   	github.com/cogos-dev/cogos/internal/providers/component  [no test files]
ok  	github.com/cogos-dev/cogos/internal/providers/daemon     0.483s
$ go vet ./...
(clean)
\`\`\`

## Out of scope (tracked as follow-ups, will file separately)

1. **Daemon-side YAML parser is bespoke.** Handles the canonical format providers files use today; will silently miss anchors, flow-style sequences, multi-line strings. Adding a real yaml.v3 dependency to the daemon package is a contained refactor.
2. **`Reconcile()` is not wired into the autonomic ticker.** `ApplyPlan` exists and is reachable via `cog plan` / `cog apply` CLI, but the kernel's reconcile loop doesn't call it on its own. A future phase calls `FetchLive + ComputePlan + ApplyPlan` from the autonomic loop so the service self-heals on crash without operator intervention.
3. **Non-darwin platforms**: `LaunchctlController` is aliased to `ObserverSupervisor` on Linux/Windows (Phase 3 of the service supervisor work, tracked under #101). Until `SystemdSupervisor` lands, `mlx-supervised` on Linux silently does nothing beyond health reporting.

## Operator usage

Add to `providers.local.yaml`:

\`\`\`yaml
providers:
  mlx-gemma-supervised:
    type: mlx-supervised
    model: /Volumes/2TBSD/AI_Models/LLM/.../gemma-4-E4B-Agentic-Opus-Reasoning-GeminiCLI-mlx-4bit
    options:
      binary: /opt/homebrew/bin/mlx_lm.server
      port: 1235
      launchd_label: com.cogos.mlx-gemma
\`\`\`

Then \`cog plan mlx-supervised\` shows the plan, \`cog apply\` writes the plist and loads it. Health surfaces in the proprioception block on next foveated context build.

## Refs

- Issue: #147 (closes)
- Audit: \`cog://workspace/.cog/scratch/audit-inference-paths/REPORT.md\` Tier 3 plan
- Service supervisor lineage: #131, #95, #101 (Linux phase)
- Original cold-start symptom that started this whole arc: #144 / merged via #146