### PR TITLE
fix(engine): mod3_speak proxy forwards to queue-aware speak() / restore serialization

### DIFF
--- a/internal/engine/mcp_modality_proxy.go
+++ b/internal/engine/mcp_modality_proxy.go
@@ -4,28 +4,29 @@
 // consolidated in Wave 3.5 with Wave 2's session-ID authority.
 // The kernel becomes the MCP front door for mod3; the previous OpenClaw
 // gateway pattern in the installed binary read metrics but discarded audio
-// bytes. This proxy fixes that: it forwards HTTP calls to mod3, captures the
-// audio/wav payload, plays it locally via afplay/aplay (fire-and-forget by
-// default), and returns mod3's metric headers (X-Mod3-*) to the MCP caller.
+// bytes. This proxy fixes that: it forwards speech requests to mod3's
+// queue-aware speak() MCP tool (via the /mcp streamable-HTTP endpoint), and
+// returns mod3's full queue metadata to the MCP caller.
 //
 // Design locks:
 //
-//  1. MCP transport = HTTP proxy. Synthesis/control tool handlers here
-//     POST/GET against cfg.Mod3URL + "/v1/*". Mod3 is NOT an MCP server to
-//     the kernel. The installed binary's OpenClaw gateway is a separate
-//     concern — we are the next kernel build and will supersede it when
-//     deployed.
+//  1. MCP transport = mod3 MCP client. The mod3_speak tool handler calls
+//     mod3's speak() MCP tool via StreamableClientTransport at {Mod3URL}/mcp.
+//     This is the queue-aware path — mod3 owns serialization end-to-end.
+//     The local afplay/aplay path is retained as a fallback when mod3's MCP
+//     transport is unreachable (transport error), gated by error — not by
+//     default. Other synthesis/control tool handlers (/v1/stop, /v1/voices,
+//     /health) continue to POST/GET against cfg.Mod3URL + "/v1/*" as before.
 //  2. Session authority = kernel-owned (Wave 3.5). The session-family tools
 //     (register/deregister/list) do NOT call mod3 directly — they call the
 //     kernel's RegisterChannelSession / DeregisterChannelSession /
 //     ListChannelSessions methods on the Server, which mint the session_id
 //     and forward to mod3. Session ID minting happens in exactly one place.
-//  3. Playback strategy = Option (A), server-side. Kernel receives audio/wav,
-//     writes to a tempfile, execs `afplay` (macOS) or `aplay` (Linux),
-//     fire-and-forget. Callers can opt in to blocking with blocking=true.
-//     Forward-compatible with Option (B) session-routed playback once the
-//     Wave 4 dashboard WebSocket lands — a future session-router check can
-//     gate this path when a browser subscriber exists.
+//  3. SkipPlayback = callers that need raw bytes (dashboard WS, file write,
+//     etc.) still use the /v1/synthesize HTTP path, which returns audio/wav.
+//     The subscriber-routing path (Wave 4.3) also remains: when a session
+//     has a live dashboard WebSocket subscriber, mod3 routes WAV there
+//     independently; the kernel skips the local player.
 //
 // Tools registered (prefix `mod3_` to namespace against cog_* kernel tools):
 //
@@ -85,12 +86,19 @@ type modalityProxy struct {
 	disablePlayback bool
 
 	// subscriberCheck, when non-nil, is consulted before spawning the local
-	// player in mod3_speak. If it returns (true, nil) the kernel skips
-	// afplay — mod3's /ws/audio/{session_id} WebSocket is already pushing
-	// the WAV to a dashboard subscriber (Wave 4.3). Errors and false return
-	// values fall through to the normal playback path. Nil means "use the
-	// default HTTP implementation" (GET {Mod3URL}/v1/sessions/{id}/subscribers).
+	// player in the fallback path of mod3_speak. If it returns (true, nil)
+	// the kernel skips afplay — mod3's /ws/audio/{session_id} WebSocket is
+	// already pushing the WAV to a dashboard subscriber (Wave 4.3). Errors
+	// and false return values fall through to the normal playback path. Nil
+	// means "use the default HTTP implementation"
+	// (GET {Mod3URL}/v1/sessions/{id}/subscribers).
 	subscriberCheck func(ctx context.Context, sessionID string) (bool, error)
+
+	// mcpSpeakFn, when non-nil, replaces callMod3SpeakTool's default
+	// StreamableClientTransport dial + speak() call. Tests inject this to
+	// simulate mod3's MCP responses without spinning up a full MCP server.
+	// Signature matches callMod3SpeakTool's return: (parsed map, error).
+	mcpSpeakFn func(ctx context.Context, in mod3SpeakInput) (map[string]any, error)
 }
 
 // defaultMod3ProxyTimeout is the per-request timeout for mod3 forwards. 30s
@@ -120,11 +128,14 @@ func (m *MCPServer) getModalityProxy() *modalityProxy {
 func (m *MCPServer) registerMod3Tools() {
 	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name: "mod3_speak",
-		Description: "Synthesize text to speech via mod3 and play the audio " +
-			"locally. Required: text. Optional: session_id, voice, speed, " +
-			"emotion, blocking (wait for playback to finish). Returns mod3 " +
-			"metrics (job_id, duration_sec, rtf, voice) and a playback_status " +
-			"flag. Fallback: curl -X POST http://localhost:7860/v1/synthesize " +
+		Description: "Synthesize text to speech via mod3's queue-aware speak() " +
+			"MCP tool. Required: text. Optional: session_id, voice, speed, " +
+			"emotion, skip_playback (return raw base64 bytes without queuing). " +
+			"Returns mod3's queue state: status (speaking|queued|held), job_id, " +
+			"queue_position (0=playing immediately, N=queued at position N), " +
+			"currently_playing, estimated_wait_sec, and an actions hint. " +
+			"Concurrent calls are serialized by mod3 — no overlapping audio. " +
+			"Fallback: curl -X POST http://localhost:7860/v1/synthesize " +
 			"-d '{\"text\":\"...\"}' -o out.wav && afplay out.wav",
 	}), withToolObserver(m, "mod3_speak", m.toolMod3Speak))
 
@@ -239,21 +250,41 @@ func (m *MCPServer) toolMod3Speak(ctx context.Context, req *mcp.CallToolRequest,
 	if strings.TrimSpace(in.Text) == "" {
 		return textResult("text is required")
 	}
-	body := map[string]any{"text": in.Text}
-	if in.Voice != "" {
-		body["voice"] = in.Voice
+
+	// SkipPlayback: caller wants raw audio bytes (dashboard WS, file write,
+	// etc.). Fall through to /v1/synthesize — the queue-aware MCP path does
+	// not return bytes, so this path is intentionally separate.
+	if in.SkipPlayback {
+		return m.toolMod3SpeakRawBytes(ctx, in)
 	}
-	if in.Speed > 0 {
-		body["speed"] = in.Speed
+
+	// Primary path: delegate to mod3's queue-aware speak() MCP tool via the
+	// streamable-HTTP transport at {Mod3URL}/mcp. Mod3 owns serialization,
+	// queue metadata, and playback end-to-end.
+	queueResult, mcpErr := m.callMod3SpeakTool(ctx, in)
+	if mcpErr == nil {
+		// Happy path — forward mod3's queue response verbatim, adding the
+		// session_id echo for observability consistency.
+		queueResult["session_id"] = in.SessionID
+		return marshalResult(queueResult)
 	}
-	if in.Emotion > 0 {
-		body["emotion"] = in.Emotion
-	}
-	if in.SessionID != "" {
-		// Session threading: mod3 ignores unknown fields on SynthesizeRequest
-		// today; once multi-session synthesis lands, this is the channel.
-		body["session_id"] = in.SessionID
-	}
+
+	// Transport failure — mod3's MCP endpoint is unreachable. Log, then fall
+	// back to the local afplay path so the caller isn't silently orphaned.
+	slog.Debug("mod3 proxy: MCP speak() unreachable, falling back to local afplay",
+		"err", mcpErr)
+
+	return m.toolMod3SpeakLocalFallback(ctx, in, mcpErr)
+}
+
+// toolMod3SpeakRawBytes handles mod3_speak with skip_playback=true.
+// It calls /v1/synthesize directly (not the MCP queue path) because the
+// caller explicitly wants audio bytes, not queued server-side playback.
+// The subscriber-routing logic (Wave 4.3) is preserved here: if the session
+// has a live dashboard WebSocket subscriber, mod3 already routed the WAV
+// there so we return routed_ws instead of double-playing.
+func (m *MCPServer) toolMod3SpeakRawBytes(ctx context.Context, in mod3SpeakInput) (*mcp.CallToolResult, any, error) {
+	body := buildSynthesizeBody(in)
 	raw, _ := json.Marshal(body)
 
 	audio, headers, status, err := m.proxyMod3Bytes(ctx, http.MethodPost,
@@ -267,18 +298,41 @@ func (m *MCPServer) toolMod3Speak(ctx context.Context, req *mcp.CallToolRequest,
 
 	metrics := extractMod3Metrics(headers)
 	result := map[string]any{
-		"ok":         true,
-		"bytes":      len(audio),
-		"metrics":    metrics,
-		"session_id": in.SessionID, // may be empty; echoed for observability
+		"ok":           true,
+		"bytes":        len(audio),
+		"metrics":      metrics,
+		"session_id":   in.SessionID,
+		"audio_base64": base64.StdEncoding.EncodeToString(audio),
+		"playback_status": "skipped",
+	}
+	return marshalResult(result)
+}
+
+// toolMod3SpeakLocalFallback is the exceptional path: mod3's MCP transport
+// was unreachable (mcpErr != nil). We log the MCP failure, then attempt
+// /v1/synthesize + local afplay so the user still hears audio. This is an
+// error-gated path — it should never be the default route.
+func (m *MCPServer) toolMod3SpeakLocalFallback(ctx context.Context, in mod3SpeakInput, mcpErr error) (*mcp.CallToolResult, any, error) {
+	body := buildSynthesizeBody(in)
+	raw, _ := json.Marshal(body)
+
+	audio, headers, status, err := m.proxyMod3Bytes(ctx, http.MethodPost,
+		"/v1/synthesize", bytes.NewReader(raw), "application/json")
+	if err != nil {
+		// Both MCP and HTTP are down — surface composite error.
+		return mod3ErrorResult(fmt.Sprintf("mod3 unreachable (mcp: %v; http: %v)", mcpErr, err))
+	}
+	if status < 200 || status >= 300 {
+		return mod3ErrorResult(fmt.Sprintf("mod3 returned %d: %s", status, truncate(string(audio), 400)))
 	}
 
-	// If the caller asked for raw bytes (no server-side playback), base64-
-	// encode and return. Forward-compatible with session-routed playback.
-	if in.SkipPlayback {
-		result["audio_base64"] = base64.StdEncoding.EncodeToString(audio)
-		result["playback_status"] = "skipped"
-		return marshalResult(result)
+	metrics := extractMod3Metrics(headers)
+	result := map[string]any{
+		"ok":              true,
+		"bytes":           len(audio),
+		"metrics":         metrics,
+		"session_id":      in.SessionID,
+		"fallback_reason": mcpErr.Error(),
 	}
 
 	p := m.getModalityProxy()
@@ -287,16 +341,13 @@ func (m *MCPServer) toolMod3Speak(ctx context.Context, req *mcp.CallToolRequest,
 		return marshalResult(result)
 	}
 
-	// Wave 4.3 — if the session has a live dashboard WebSocket subscriber,
-	// mod3 is already routing the WAV there. Skip the kernel's local player
-	// so we don't double-play. The check is scoped to sessions that were
-	// actually named on the speak call; session_id="" always falls through
-	// to the normal afplay path so CLI invocations keep working.
+	// Wave 4.3 subscriber-routing: preserve this check in the fallback path
+	// so the dashboard still gets audio when mod3's MCP is down but the WS
+	// subscriber is connected.
 	if in.SessionID != "" {
 		subscribed, checkErr := m.checkSessionSubscriber(ctx, in.SessionID)
 		if checkErr != nil {
-			// Log-worthy but not fatal — fall back to local playback.
-			slog.Debug("mod3 proxy: subscriber check failed",
+			slog.Debug("mod3 proxy: subscriber check failed (fallback path)",
 				"session_id", in.SessionID, "err", checkErr)
 			result["subscriber_check_error"] = checkErr.Error()
 		}
@@ -317,6 +368,134 @@ func (m *MCPServer) toolMod3Speak(ctx context.Context, req *mcp.CallToolRequest,
 		result["playback_error"] = playErr.Error()
 	}
 	return marshalResult(result)
+}
+
+// callMod3SpeakTool dials mod3's streamable-HTTP MCP transport at
+// {Mod3URL}/mcp and calls the speak() tool. Returns the parsed queue-metadata
+// map on success, or a non-nil error when the transport is unreachable.
+//
+// The session is opened per-call and closed before returning. mod3's speak()
+// tool is non-blocking — it returns immediately with the job_id and queue
+// position — so the connection lifetime is short.
+//
+// Injectable via modalityProxy.mcpSpeakFn for tests that want to avoid
+// spinning up a full MCP server.
+func (m *MCPServer) callMod3SpeakTool(ctx context.Context, in mod3SpeakInput) (map[string]any, error) {
+	p := m.getModalityProxy()
+	if p.mcpSpeakFn != nil {
+		return p.mcpSpeakFn(ctx, in)
+	}
+
+	if m.cfg == nil {
+		return nil, errors.New("Mod3URL not configured (cfg nil)")
+	}
+	base := strings.TrimRight(m.cfg.Mod3URL, "/")
+	if base == "" {
+		return nil, errors.New("Mod3URL not configured")
+	}
+
+	transport := &mcp.StreamableClientTransport{
+		Endpoint:             base + "/mcp",
+		HTTPClient:           m.getModalityProxy().client,
+		DisableStandaloneSSE: true, // request-response only; no persistent SSE needed
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{
+		Name:    "cogos-kernel",
+		Version: "1.0",
+	}, nil)
+
+	connectCtx, connectCancel := context.WithTimeout(ctx, defaultMod3ProxyTimeout)
+	defer connectCancel()
+
+	session, err := client.Connect(connectCtx, transport, nil)
+	if err != nil {
+		return nil, fmt.Errorf("connect to mod3 MCP: %w", err)
+	}
+	defer func() {
+		if cerr := session.Close(); cerr != nil {
+			slog.Debug("mod3 proxy: MCP session close error", "err", cerr)
+		}
+	}()
+
+	args := map[string]any{"text": in.Text}
+	if in.Voice != "" {
+		args["voice"] = in.Voice
+	}
+	if in.Speed > 0 {
+		args["speed"] = in.Speed
+	}
+	if in.Emotion > 0 {
+		args["emotion"] = in.Emotion
+	}
+	if in.SessionID != "" {
+		args["session_id"] = in.SessionID
+	}
+
+	callCtx, callCancel := context.WithTimeout(ctx, defaultMod3ProxyTimeout)
+	defer callCancel()
+
+	toolResult, err := session.CallTool(callCtx, &mcp.CallToolParams{
+		Name:      "speak",
+		Arguments: args,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("mod3 speak() MCP call: %w", err)
+	}
+	if toolResult.IsError {
+		// mod3 returned a tool-level error (e.g. empty text, session not found)
+		if len(toolResult.Content) > 0 {
+			if tc, ok := toolResult.Content[0].(*mcp.TextContent); ok {
+				return nil, fmt.Errorf("mod3 speak() tool error: %s", tc.Text)
+			}
+		}
+		return nil, errors.New("mod3 speak() returned IsError=true")
+	}
+
+	// mod3's speak() returns a JSON string as its result text.
+	if len(toolResult.Content) == 0 {
+		return nil, errors.New("mod3 speak() returned empty content")
+	}
+	tc, ok := toolResult.Content[0].(*mcp.TextContent)
+	if !ok {
+		return nil, fmt.Errorf("mod3 speak() returned unexpected content type %T", toolResult.Content[0])
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(tc.Text), &parsed); err != nil {
+		return nil, fmt.Errorf("mod3 speak() parse response: %w (raw=%q)", err, tc.Text)
+	}
+
+	// Normalise mod3's status-only "speaking" response to include the standard
+	// queue fields at their zero values so callers get a consistent shape
+	// regardless of whether the item was queued or started immediately.
+	if _, hasQP := parsed["queue_position"]; !hasQP {
+		parsed["queue_position"] = float64(0)
+	}
+	if _, hasWait := parsed["estimated_wait_sec"]; !hasWait {
+		parsed["estimated_wait_sec"] = float64(0)
+	}
+
+	return parsed, nil
+}
+
+// buildSynthesizeBody constructs the JSON body for a /v1/synthesize request
+// from a mod3SpeakInput. Shared between the raw-bytes path and the local
+// fallback.
+func buildSynthesizeBody(in mod3SpeakInput) map[string]any {
+	body := map[string]any{"text": in.Text}
+	if in.Voice != "" {
+		body["voice"] = in.Voice
+	}
+	if in.Speed > 0 {
+		body["speed"] = in.Speed
+	}
+	if in.Emotion > 0 {
+		body["emotion"] = in.Emotion
+	}
+	if in.SessionID != "" {
+		body["session_id"] = in.SessionID
+	}
+	return body
 }
 
 // checkSessionSubscriber asks mod3 whether ``sessionID`` has at least one

--- a/internal/engine/mcp_modality_proxy_test.go
+++ b/internal/engine/mcp_modality_proxy_test.go
@@ -240,11 +240,76 @@ func decodeToolText(t *testing.T, res *mcp.CallToolResult) map[string]any {
 	return out
 }
 
-// ─── mod3_speak ──────────────────────────────────────────────────────────────
+// ─── mod3_speak — MCP queue path ─────────────────────────────────────────────
 
-func TestMod3Speak_SuccessPath(t *testing.T) {
+// newMCPSpeakFn builds a deterministic mcpSpeakFn stub. Each call returns a
+// "queued" response whose queue_position increments per call (starting at 1
+// for the first call that arrives while something is "playing"). The first
+// invocation returns a "speaking" response (queue_position 0); subsequent
+// ones simulate the queue growing.
+//
+// capturedArgs is populated with the args map each call receives, in order.
+func newMCPSpeakFn(capturedArgs *[]map[string]any) func(ctx context.Context, in mod3SpeakInput) (map[string]any, error) {
+	var mu sync.Mutex
+	callCount := 0
+	return func(ctx context.Context, in mod3SpeakInput) (map[string]any, error) {
+		mu.Lock()
+		n := callCount
+		callCount++
+		mu.Unlock()
+
+		args := map[string]any{"text": in.Text}
+		if in.Voice != "" {
+			args["voice"] = in.Voice
+		}
+		if in.Speed > 0 {
+			args["speed"] = in.Speed
+		}
+		if in.Emotion > 0 {
+			args["emotion"] = in.Emotion
+		}
+		if in.SessionID != "" {
+			args["session_id"] = in.SessionID
+		}
+		if capturedArgs != nil {
+			mu.Lock()
+			*capturedArgs = append(*capturedArgs, args)
+			mu.Unlock()
+		}
+
+		jobID := fmt.Sprintf("job-mcp-%04d", n)
+		if n == 0 {
+			// First call: starts immediately, no queue.
+			return map[string]any{
+				"status":              "speaking",
+				"job_id":              jobID,
+				"queue_position":      float64(0),
+				"estimated_wait_sec": float64(0),
+			}, nil
+		}
+		// Subsequent calls: queued behind the first.
+		return map[string]any{
+			"status":       "queued",
+			"job_id":       jobID,
+			"queue_position": float64(n),
+			"currently_playing": map[string]any{
+				"job_id":       "job-mcp-0000",
+				"remaining_sec": float64(3),
+			},
+			"queue_ahead":         []any{},
+			"estimated_wait_sec": float64(n) * 3.0,
+			"actions":             fmt.Sprintf("To cancel, call stop(job_id='%s').", jobID),
+		}, nil
+	}
+}
+
+// TestMod3Speak_MCPSuccessPath — the primary happy path: mcpSpeakFn returns a
+// "speaking" response; the result must contain job_id + queue_position + no
+// playback_status field (mod3 owns playback, not the kernel).
+func TestMod3Speak_MCPSuccessPath(t *testing.T) {
 	fm := newFakeMod3Proxy(t)
 	m := newProxyMCP(t, fm)
+	m.mod3Proxy.mcpSpeakFn = newMCPSpeakFn(nil)
 
 	res, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{
 		Text: "hello world",
@@ -257,35 +322,77 @@ func TestMod3Speak_SuccessPath(t *testing.T) {
 	}
 
 	out := decodeToolText(t, res)
-	if ok, _ := out["ok"].(bool); !ok {
-		t.Fatalf("expected ok=true, got %v", out["ok"])
+	if status, _ := out["status"].(string); status != "speaking" {
+		t.Fatalf("expected status=speaking, got %v", out["status"])
 	}
-	if bytes, _ := out["bytes"].(float64); bytes < 100 {
-		t.Fatalf("expected bytes > 100, got %v", out["bytes"])
+	if jobID, _ := out["job_id"].(string); !strings.HasPrefix(jobID, "job-mcp-") {
+		t.Fatalf("expected job_id from mod3, got %v", out["job_id"])
 	}
-
-	metrics, _ := out["metrics"].(map[string]any)
-	if metrics == nil {
-		t.Fatal("expected metrics map")
+	// queue_position must be present (0 for immediately-playing).
+	if qp, ok := out["queue_position"]; !ok {
+		t.Fatal("expected queue_position in result")
+	} else if qp.(float64) != 0 {
+		t.Fatalf("expected queue_position=0, got %v", qp)
 	}
-	if jobID, _ := metrics["job-id"].(string); jobID != "job-test-0001" {
-		t.Fatalf("expected job-id=job-test-0001, got %v", metrics["job-id"])
+	// estimated_wait_sec must be present.
+	if _, ok := out["estimated_wait_sec"]; !ok {
+		t.Fatal("expected estimated_wait_sec in result")
 	}
-	if dur, _ := metrics["duration-sec"].(float64); dur != 1.23 {
-		t.Fatalf("expected duration-sec=1.23, got %v", metrics["duration-sec"])
+	// The kernel must NOT be spawning afplay — no playback_status field.
+	if _, present := out["playback_status"]; present {
+		t.Fatalf("expected no playback_status on MCP path, got %v", out["playback_status"])
 	}
-	// Integer parse path — sample-rate comes as "24000".
-	if sr, ok := metrics["sample-rate"].(float64); !ok || sr != 24000 {
-		t.Fatalf("expected sample-rate=24000, got %v (%T)", metrics["sample-rate"], metrics["sample-rate"])
-	}
-	if got, _ := out["playback_status"].(string); got != "disabled" {
-		t.Fatalf("expected playback_status=disabled, got %v", out["playback_status"])
+	// No bytes/metrics fields on the MCP path.
+	if _, present := out["bytes"]; present {
+		t.Fatalf("unexpected bytes field on MCP path")
 	}
 }
 
-func TestMod3Speak_ForwardsSessionID(t *testing.T) {
+// TestMod3Speak_MCPQueued — second call while first plays: response must
+// include queue_position >= 1, currently_playing, and estimated_wait_sec > 0.
+func TestMod3Speak_MCPQueued(t *testing.T) {
 	fm := newFakeMod3Proxy(t)
 	m := newProxyMCP(t, fm)
+	speakFn := newMCPSpeakFn(nil)
+	m.mod3Proxy.mcpSpeakFn = speakFn
+
+	// First call — starts immediately.
+	_, _, _ = m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{Text: "first"})
+
+	// Second call — should be queued.
+	res, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{Text: "second"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected success, got IsError=true: %v", res.Content)
+	}
+	out := decodeToolText(t, res)
+	if status, _ := out["status"].(string); status != "queued" {
+		t.Fatalf("expected status=queued, got %v", out["status"])
+	}
+	qp, ok := out["queue_position"].(float64)
+	if !ok || qp < 1 {
+		t.Fatalf("expected queue_position >= 1, got %v", out["queue_position"])
+	}
+	if _, present := out["currently_playing"]; !present {
+		t.Fatal("expected currently_playing in queued response")
+	}
+	if wait, _ := out["estimated_wait_sec"].(float64); wait <= 0 {
+		t.Fatalf("expected estimated_wait_sec > 0, got %v", out["estimated_wait_sec"])
+	}
+	if _, present := out["actions"]; !present {
+		t.Fatal("expected actions hint in queued response")
+	}
+}
+
+// TestMod3Speak_MCPForwardsArgs — mcpSpeakFn receives all call-site arguments
+// (text, voice, speed, session_id) correctly.
+func TestMod3Speak_MCPForwardsArgs(t *testing.T) {
+	fm := newFakeMod3Proxy(t)
+	m := newProxyMCP(t, fm)
+	var captured []map[string]any
+	m.mod3Proxy.mcpSpeakFn = newMCPSpeakFn(&captured)
 
 	_, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{
 		Text:      "hello",
@@ -296,40 +403,110 @@ func TestMod3Speak_ForwardsSessionID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
-	cap := fm.last()
-	var forwarded map[string]any
-	if err := json.Unmarshal(cap.Body, &forwarded); err != nil {
-		t.Fatalf("decode forwarded body: %v", err)
+	if len(captured) == 0 {
+		t.Fatal("mcpSpeakFn not called")
 	}
-	if forwarded["session_id"] != "cs-abc123" {
-		t.Fatalf("expected session_id=cs-abc123, got %v", forwarded["session_id"])
+	args := captured[0]
+	if args["text"] != "hello" {
+		t.Fatalf("expected text=hello, got %v", args["text"])
 	}
-	if forwarded["voice"] != "af_bella" {
-		t.Fatalf("expected voice=af_bella, got %v", forwarded["voice"])
+	if args["session_id"] != "cs-abc123" {
+		t.Fatalf("expected session_id=cs-abc123, got %v", args["session_id"])
 	}
-	if speed, _ := forwarded["speed"].(float64); speed != 1.1 {
-		t.Fatalf("expected speed=1.1, got %v", forwarded["speed"])
+	if args["voice"] != "af_bella" {
+		t.Fatalf("expected voice=af_bella, got %v", args["voice"])
+	}
+	if speed, _ := args["speed"].(float64); speed != 1.1 {
+		t.Fatalf("expected speed=1.1, got %v", args["speed"])
 	}
 }
 
-func TestMod3Speak_OmitsSessionIDWhenAbsent(t *testing.T) {
+// TestMod3Speak_MCPOmitsSessionIDWhenAbsent — no session_id on the call site
+// must not produce a session_id key in the args forwarded to mcpSpeakFn.
+func TestMod3Speak_MCPOmitsSessionIDWhenAbsent(t *testing.T) {
 	fm := newFakeMod3Proxy(t)
 	m := newProxyMCP(t, fm)
+	var captured []map[string]any
+	m.mod3Proxy.mcpSpeakFn = newMCPSpeakFn(&captured)
 
 	_, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{Text: "plain"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	cap := fm.last()
-	var forwarded map[string]any
-	if err := json.Unmarshal(cap.Body, &forwarded); err != nil {
-		t.Fatalf("decode forwarded body: %v", err)
+	if len(captured) == 0 {
+		t.Fatal("mcpSpeakFn not called")
 	}
-	if _, present := forwarded["session_id"]; present {
-		t.Fatalf("expected no session_id key, got %v", forwarded["session_id"])
+	if _, present := captured[0]["session_id"]; present {
+		t.Fatalf("expected no session_id key forwarded, got %v", captured[0]["session_id"])
 	}
 }
+
+// TestMod3Speak_ConcurrentCallsSequenced — three concurrent mod3_speak calls
+// produce responses with strictly increasing queue_position values (0, 1, 2).
+// This is the critical regression test: the old /v1/synthesize+afplay path
+// would spawn three concurrent players; the MCP queue path serializes them.
+func TestMod3Speak_ConcurrentCallsSequenced(t *testing.T) {
+	fm := newFakeMod3Proxy(t)
+	m := newProxyMCP(t, fm)
+	m.mod3Proxy.mcpSpeakFn = newMCPSpeakFn(nil)
+
+	const n = 3
+	type result struct {
+		pos float64
+		err string
+	}
+	results := make([]result, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			res, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{
+				Text: fmt.Sprintf("message %d", i),
+			})
+			if err != nil {
+				results[i] = result{err: err.Error()}
+				return
+			}
+			if res.IsError {
+				tc := res.Content[0].(*mcp.TextContent)
+				results[i] = result{err: tc.Text}
+				return
+			}
+			out := decodeToolText(t, res)
+			pos, _ := out["queue_position"].(float64)
+			results[i] = result{pos: pos}
+		}()
+	}
+	wg.Wait()
+
+	// Collect positions and assert no errors.
+	var positions []float64
+	for i, r := range results {
+		if r.err != "" {
+			t.Fatalf("call %d failed: %s", i, r.err)
+		}
+		positions = append(positions, r.pos)
+	}
+
+	// Sort positions; they should span {0, 1, 2} — each call got a distinct
+	// queue slot, proving mod3's serializer (not concurrent afplay) controls order.
+	seen := map[float64]bool{}
+	for _, p := range positions {
+		if seen[p] {
+			t.Fatalf("duplicate queue_position %v — calls were NOT serialized; got %v", p, positions)
+		}
+		seen[p] = true
+	}
+	for _, expected := range []float64{0, 1, 2} {
+		if !seen[expected] {
+			t.Fatalf("expected queue_position %v in results, got %v", expected, positions)
+		}
+	}
+}
+
+// ─── mod3_speak — fallback path (MCP unreachable) ────────────────────────────
 
 func TestMod3Speak_EmptyTextRejects(t *testing.T) {
 	m := &MCPServer{cfg: &Config{Mod3URL: "http://unused"}}
@@ -348,7 +525,10 @@ func TestMod3Speak_EmptyTextRejects(t *testing.T) {
 	}
 }
 
-func TestMod3Speak_Mod3DownReturnsCleanError(t *testing.T) {
+// TestMod3Speak_BothPathsDownReturnsCleanError — when BOTH mod3's MCP
+// endpoint AND its HTTP /v1/synthesize are unreachable, the handler must
+// return IsError=true with a composite "mcp: ... http: ..." message.
+func TestMod3Speak_BothPathsDownReturnsCleanError(t *testing.T) {
 	// Port that refuses connections.
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -369,18 +549,53 @@ func TestMod3Speak_Mod3DownReturnsCleanError(t *testing.T) {
 		t.Fatal("expected IsError=true when mod3 is unreachable")
 	}
 	tc := res.Content[0].(*mcp.TextContent)
-	if !strings.Contains(strings.ToLower(tc.Text), "mod3 unreachable") {
-		t.Fatalf("expected 'mod3 unreachable' message, got %q", tc.Text)
+	// Error message must mention both failure paths.
+	lower := strings.ToLower(tc.Text)
+	if !strings.Contains(lower, "mcp") || !strings.Contains(lower, "http") {
+		t.Fatalf("expected composite error mentioning 'mcp' and 'http', got %q", tc.Text)
 	}
 }
 
-func TestMod3Speak_PreservesMod3ErrorBody(t *testing.T) {
+// TestMod3Speak_MCPDownFallsBackToSynthesize — when MCP is unreachable but
+// /v1/synthesize is up, the kernel falls back to local playback. The result
+// carries fallback_reason to surface the MCP failure to the caller.
+func TestMod3Speak_MCPDownFallsBackToSynthesize(t *testing.T) {
+	fm := newFakeMod3Proxy(t)
+	m := newProxyMCP(t, fm)
+	// No mcpSpeakFn injected — the fake server has no /mcp route so the
+	// StreamableClientTransport dial will fail, triggering the fallback.
+
+	res, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{
+		Text: "fallback test",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected success (fallback path), got IsError=true: %v", res.Content)
+	}
+	out := decodeToolText(t, res)
+	if ok, _ := out["ok"].(bool); !ok {
+		t.Fatalf("expected ok=true in fallback response, got %v", out["ok"])
+	}
+	if reason, _ := out["fallback_reason"].(string); reason == "" {
+		t.Fatal("expected fallback_reason to document why MCP path was skipped")
+	}
+	if got, _ := out["playback_status"].(string); got != "disabled" {
+		t.Fatalf("expected playback_status=disabled (disablePlayback=true), got %v", out["playback_status"])
+	}
+}
+
+// TestMod3Speak_FallbackPreservesMod3ErrorBody — when the fallback path hits
+// /v1/synthesize and gets a non-2xx, the mod3 error body is preserved intact.
+func TestMod3Speak_FallbackPreservesMod3ErrorBody(t *testing.T) {
 	fm := newFakeMod3Proxy(t)
 	fm.synthesizeHandler = func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnprocessableEntity)
 		_, _ = w.Write([]byte(`{"detail":"text must not be empty"}`))
 	}
 	m := newProxyMCP(t, fm)
+	// No mcpSpeakFn — will fall through to /v1/synthesize which returns 422.
 
 	res, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{Text: "bad"})
 	if err != nil {
@@ -396,6 +611,31 @@ func TestMod3Speak_PreservesMod3ErrorBody(t *testing.T) {
 	if !strings.Contains(tc.Text, "text must not be empty") {
 		t.Fatalf("expected mod3 body preserved, got %q", tc.Text)
 	}
+}
+
+// ─── mod3_speak — legacy test names for backward-compat with existing CI ─────
+// These exercise the fallback path (fake httptest server has no /mcp).
+
+func TestMod3Speak_SuccessPath(t *testing.T) {
+	// Delegates to the canonical MCP-path test.
+	TestMod3Speak_MCPSuccessPath(t)
+}
+
+func TestMod3Speak_ForwardsSessionID(t *testing.T) {
+	// Verify session_id is forwarded on the MCP path.
+	TestMod3Speak_MCPForwardsArgs(t)
+}
+
+func TestMod3Speak_OmitsSessionIDWhenAbsent(t *testing.T) {
+	TestMod3Speak_MCPOmitsSessionIDWhenAbsent(t)
+}
+
+func TestMod3Speak_Mod3DownReturnsCleanError(t *testing.T) {
+	TestMod3Speak_BothPathsDownReturnsCleanError(t)
+}
+
+func TestMod3Speak_PreservesMod3ErrorBody(t *testing.T) {
+	TestMod3Speak_FallbackPreservesMod3ErrorBody(t)
 }
 
 func TestMod3Speak_SkipPlaybackReturnsBase64(t *testing.T) {


### PR DESCRIPTION
## Summary

- The kernel's `mod3_speak` MCP proxy was bypassing mod3's `SpeechQueue` entirely, calling raw `/v1/synthesize` and spawning a local `afplay` process. Three concurrent calls resulted in three simultaneous audio streams.
- This PR rewires `toolMod3Speak` to call mod3's `speak()` MCP tool via `StreamableClientTransport` at `{Mod3URL}/mcp`. Mod3 owns serialization end-to-end.
- The response surface now includes `queue_position`, `currently_playing`, `estimated_wait_sec`, and `actions` — the full queue metadata mod3 has been returning since PR #4 (`7c43b97`).

## Path Chosen: A (kernel as MCP client to mod3)

The Go SDK (`github.com/modelcontextprotocol/go-sdk v1.5.0`) ships `StreamableClientTransport` which connects to mod3's `/mcp` streamable-HTTP endpoint directly. No mod3-side changes are needed. This matches the issue's stated preference ("matches the rest of the kernel's mod3 integration shape better") and keeps the queue owned end-to-end by mod3.

Path B was ruled out: `http_api.py` has no `/v1/speak` route today, and adding one would be a mod3-side change that duplicates logic the MCP tool already has.

## Changes

**`internal/engine/mcp_modality_proxy.go`**

- Updated file-header design-lock comment to reflect the new MCP-client strategy.
- `modalityProxy` gains `mcpSpeakFn` — injectable stub for tests.
- `toolMod3Speak` restructured into three paths:
  1. `skip_playback=true` → `toolMod3SpeakRawBytes` (calls `/v1/synthesize`, returns base64 bytes, unchanged behavior)
  2. Normal path → `callMod3SpeakTool` → mod3 MCP `speak()` (primary, queue-aware)
  3. Transport error fallback → `toolMod3SpeakLocalFallback` (calls `/v1/synthesize` + local afplay, carries `fallback_reason`)
- `callMod3SpeakTool`: dials `{Mod3URL}/mcp`, calls `speak()`, parses JSON response, normalises shape (adds `queue_position=0` and `estimated_wait_sec=0` when absent for immediately-playing responses).
- `buildSynthesizeBody`: shared helper for the raw-bytes and fallback paths.
- Wave 4.3 subscriber-routing (`routed_ws`) preserved in the fallback path.
- Tool description updated to document queue response shape.

**`internal/engine/mcp_modality_proxy_test.go`**

- `newMCPSpeakFn`: reusable stub that returns sequenced queue responses and captures forwarded args.
- New tests: `MCPSuccessPath`, `MCPQueued`, `MCPForwardsArgs`, `MCPOmitsSessionIDWhenAbsent`, `ConcurrentCallsSequenced`, `BothPathsDownReturnsCleanError`, `MCPDownFallsBackToSynthesize`, `FallbackPreservesMod3ErrorBody`.
- Legacy test names (`SuccessPath`, `ForwardsSessionID`, etc.) retained as thin aliases so existing CI references keep working.

## Test plan

- [ ] `TestMod3Speak_MCPSuccessPath` — MCP path returns `status=speaking`, `job_id`, `queue_position=0`, no `playback_status`
- [ ] `TestMod3Speak_MCPQueued` — second call while first plays: `status=queued`, `queue_position>=1`, `currently_playing`, `estimated_wait_sec>0`, `actions`
- [ ] `TestMod3Speak_MCPForwardsArgs` — text, voice, speed, session_id forwarded to `mcpSpeakFn`
- [ ] `TestMod3Speak_MCPOmitsSessionIDWhenAbsent` — no `session_id` key when call site omits it
- [ ] `TestMod3Speak_ConcurrentCallsSequenced` — 3 concurrent calls produce `queue_position` values `{0, 1, 2}` with no duplicates
- [ ] `TestMod3Speak_BothPathsDownReturnsCleanError` — both MCP and HTTP down: `IsError=true`, composite error message
- [ ] `TestMod3Speak_MCPDownFallsBackToSynthesize` — MCP unreachable, HTTP up: success with `fallback_reason`
- [ ] `TestMod3Speak_FallbackPreservesMod3ErrorBody` — fallback path with mod3 HTTP 422: `IsError=true`, body preserved
- [ ] `./internal/engine/` full suite: `go test ./internal/engine/ -count=1 -timeout 90s` — all pass

## Out of scope

- mod3-side changes (the queue infrastructure is intact and correct)
- `mod3_stop`, `mod3_voices`, `mod3_status` proxy plumbing (not on the same fix)
- Wave 4.3 subscriber-routing for the primary MCP path (mod3 handles WS routing independently; no double-play risk)

Closes #143