### PR TITLE
refactor(kernel): relocate global workspace registry to ~/.cog/node/global.yaml

### DIFF
--- a/cog.go
+++ b/cog.go
@@ -867,7 +867,8 @@ type CacheStats struct {
 
 // === GLOBAL CONFIG (Multi-Workspace Support) ===
 
-// GlobalConfig represents ~/.cog/config for multi-workspace management
+// GlobalConfig represents the global workspace registry stored at
+// ~/.cog/node/global.yaml for multi-workspace management.
 type GlobalConfig struct {
 	Version          string                     `yaml:"version"`
 	CurrentWorkspace string                     `yaml:"current-workspace,omitempty"`
@@ -881,8 +882,22 @@ type WorkspaceEntry struct {
 	Description string `yaml:"description,omitempty"`
 }
 
-// globalConfigPath returns the path to ~/.cog/config
+// globalConfigPath returns the path to ~/.cog/node/global.yaml.
+// The registry lives under node/ because it is node-local state (which
+// workspaces this node knows about). This frees ~/.cog/config/ to be the
+// workspace config directory for the home-directory workspace.
 func globalConfigPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".cog", "node", "global.yaml")
+}
+
+// globalConfigLegacyPath returns the old path (~/.cog/config) used before
+// the migration introduced in cogos-dev/cogos#161. Used only by the one-time
+// migration helper; callers must not persist to this path.
+func globalConfigLegacyPath() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return ""
@@ -890,9 +905,82 @@ func globalConfigPath() string {
 	return filepath.Join(home, ".cog", "config")
 }
 
-// loadGlobalConfig loads ~/.cog/config, returning empty config if missing
+// migrateGlobalConfig performs a one-time, idempotent migration of the global
+// workspace registry from the old flat file at ~/.cog/config to the new
+// location at ~/.cog/node/global.yaml.
+//
+// Behaviour:
+//   - Old exists, new does not: move the file, log a notice.
+//   - Old does not exist: nothing to do (no-op, no log).
+//   - New already exists (with or without old): no-op; if old also exists, log
+//     a warning naming it so the user can inspect/remove it manually.
+//   - Move fails (permissions, disk full, etc.): log an error, return the
+//     error. The caller (loadGlobalConfig) falls back to the old path so the
+//     kernel still starts.
+func migrateGlobalConfig() error {
+	oldPath := globalConfigLegacyPath()
+	newPath := globalConfigPath()
+	if oldPath == "" || newPath == "" {
+		return nil // can't determine home dir; nothing we can do
+	}
+
+	oldExists := fileExists(oldPath)
+	newExists := fileExists(newPath)
+
+	switch {
+	case newExists && oldExists:
+		// Both present: prefer new (already migrated or manually created).
+		// Warn so user can clean up the orphaned old file.
+		fmt.Fprintf(os.Stderr, "[kernel] WARN: global workspace registry exists at both old path (%s) and new path (%s); using new path. You may safely remove the old file.\n", oldPath, newPath)
+		return nil
+
+	case newExists:
+		// New already exists, old gone — fully migrated; pure no-op.
+		return nil
+
+	case oldExists:
+		// Old exists, new does not — perform the migration.
+		// Ensure the destination directory exists.
+		if err := os.MkdirAll(filepath.Dir(newPath), 0755); err != nil {
+			fmt.Fprintf(os.Stderr, "[kernel] ERROR: failed to create directory for global config migration (%s): %v — falling back to old path\n", filepath.Dir(newPath), err)
+			return err
+		}
+		if err := os.Rename(oldPath, newPath); err != nil {
+			fmt.Fprintf(os.Stderr, "[kernel] ERROR: failed to migrate global config from %s to %s: %v — falling back to old path\n", oldPath, newPath, err)
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "[kernel] INFO: migrated global workspace registry from %s to %s\n", oldPath, newPath)
+		return nil
+
+	default:
+		// Neither exists — fresh install; no migration needed.
+		return nil
+	}
+}
+
+// fileExists returns true if path names a regular file (not a directory).
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+// loadGlobalConfig loads ~/.cog/node/global.yaml, returning empty config if missing.
+// On first call after a kernel upgrade it transparently migrates the old
+// ~/.cog/config flat file to the new location (see migrateGlobalConfig).
 func loadGlobalConfig() (*GlobalConfig, error) {
+	// One-time migration: move old flat file → new path.
+	// If migration fails we fall back to the old path below so the kernel
+	// still starts — loadGlobalConfig is not fatal on migration error.
+	migErr := migrateGlobalConfig()
+
 	path := globalConfigPath()
+	if migErr != nil {
+		// Migration failed; try the old path so we don't silently lose workspaces.
+		if old := globalConfigLegacyPath(); old != "" && fileExists(old) {
+			path = old
+		}
+	}
+
 	if path == "" {
 		return &GlobalConfig{
 			Version:    "1.0",
@@ -926,14 +1014,14 @@ func loadGlobalConfig() (*GlobalConfig, error) {
 	return &config, nil
 }
 
-// saveGlobalConfig writes ~/.cog/config atomically
+// saveGlobalConfig writes ~/.cog/node/global.yaml atomically.
 func saveGlobalConfig(config *GlobalConfig) error {
 	path := globalConfigPath()
 	if path == "" {
 		return fmt.Errorf("could not determine home directory")
 	}
 
-	// Ensure ~/.cog/ exists
+	// Ensure ~/.cog/node/ exists
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("failed to create config directory: %w", err)

--- a/global_config_migration_test.go
+++ b/global_config_migration_test.go
@@ -1,0 +1,209 @@
+// global_config_migration_test.go
+// Tests for the one-time migration of ~/.cog/config → ~/.cog/node/global.yaml.
+//
+// All tests use t.TempDir() as a fake HOME so the real ~/.cog/ is never touched.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// setupFakeHome creates a temporary directory, sets $HOME to it, and returns
+// (fakeHome, oldPath, newPath). The test's t.Cleanup / t.TempDir handles teardown.
+func setupFakeHome(t *testing.T) (fakeHome, oldPath, newPath string) {
+	t.Helper()
+	fakeHome = t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	oldPath = filepath.Join(fakeHome, ".cog", "config")
+	newPath = filepath.Join(fakeHome, ".cog", "node", "global.yaml")
+	return
+}
+
+// writeFile creates parent dirs and writes content to path.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}
+
+const sampleGlobalConfig = `version: "1.0"
+current-workspace: myws
+workspaces:
+  myws:
+    path: /home/user/myws
+    name: myws
+`
+
+// TestMigrateGlobalConfig_OldExists_NewAbsent verifies that when only the old
+// file exists the migration moves it to the new path with content preserved and
+// the old path removed.
+func TestMigrateGlobalConfig_OldExists_NewAbsent(t *testing.T) {
+	_, oldPath, newPath := setupFakeHome(t)
+
+	writeFile(t, oldPath, sampleGlobalConfig)
+
+	if err := migrateGlobalConfig(); err != nil {
+		t.Fatalf("migrateGlobalConfig() returned error: %v", err)
+	}
+
+	// New path must exist with original content.
+	got, err := os.ReadFile(newPath)
+	if err != nil {
+		t.Fatalf("new path not readable after migration: %v", err)
+	}
+	if string(got) != sampleGlobalConfig {
+		t.Errorf("content mismatch\ngot:  %q\nwant: %q", string(got), sampleGlobalConfig)
+	}
+
+	// Old path must be gone.
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Errorf("old path still exists after migration: %s", oldPath)
+	}
+}
+
+// TestMigrateGlobalConfig_Idempotent verifies that running migration a second
+// time (new exists, old gone) is a no-op and returns nil.
+func TestMigrateGlobalConfig_Idempotent(t *testing.T) {
+	_, oldPath, newPath := setupFakeHome(t)
+
+	writeFile(t, newPath, sampleGlobalConfig)
+
+	// Old path does not exist (already migrated state).
+	if err := migrateGlobalConfig(); err != nil {
+		t.Fatalf("second run of migrateGlobalConfig() returned error: %v", err)
+	}
+
+	// New path must still contain the original content.
+	got, err := os.ReadFile(newPath)
+	if err != nil {
+		t.Fatalf("new path not readable: %v", err)
+	}
+	if string(got) != sampleGlobalConfig {
+		t.Errorf("new path content was modified by second run")
+	}
+
+	// Old path must still not exist.
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Errorf("old path appeared unexpectedly: %s", oldPath)
+	}
+}
+
+// TestMigrateGlobalConfig_BothExist verifies that when both files exist the
+// migration keeps the new file intact and returns nil (no error, no overwrite).
+func TestMigrateGlobalConfig_BothExist(t *testing.T) {
+	_, oldPath, newPath := setupFakeHome(t)
+
+	const newContent = `version: "1.0"
+current-workspace: newws
+workspaces:
+  newws:
+    path: /home/user/newws
+`
+	writeFile(t, oldPath, sampleGlobalConfig)
+	writeFile(t, newPath, newContent)
+
+	if err := migrateGlobalConfig(); err != nil {
+		t.Fatalf("migrateGlobalConfig() returned error when both files exist: %v", err)
+	}
+
+	// New path must retain its own content (not overwritten by old).
+	got, err := os.ReadFile(newPath)
+	if err != nil {
+		t.Fatalf("new path not readable: %v", err)
+	}
+	if string(got) != newContent {
+		t.Errorf("new path content was overwritten; got %q want %q", string(got), newContent)
+	}
+
+	// Old path is still present (we don't delete it in the both-exist case).
+	if _, err := os.Stat(oldPath); err != nil {
+		t.Errorf("old path unexpectedly absent: %v", err)
+	}
+}
+
+// TestMigrateGlobalConfig_NeitherExists verifies that a fresh install (no
+// files at either path) is a no-op and returns nil.
+func TestMigrateGlobalConfig_NeitherExists(t *testing.T) {
+	setupFakeHome(t) // sets $HOME only; no files written
+
+	if err := migrateGlobalConfig(); err != nil {
+		t.Fatalf("migrateGlobalConfig() returned error on fresh install: %v", err)
+	}
+}
+
+// TestMigrateGlobalConfig_MoveFails verifies that when os.Rename fails (e.g.
+// permission error) the function returns an error rather than panicking, and
+// loadGlobalConfig falls back to the old path so the kernel still starts.
+func TestMigrateGlobalConfig_MoveFails(t *testing.T) {
+	_, oldPath, newPath := setupFakeHome(t)
+
+	writeFile(t, oldPath, sampleGlobalConfig)
+
+	// Make the destination directory read-only so Rename into it fails.
+	nodeDir := filepath.Dir(newPath)
+	if err := os.MkdirAll(nodeDir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Chmod(nodeDir, 0555); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	t.Cleanup(func() { os.Chmod(nodeDir, 0755) }) // restore so TempDir cleanup works
+
+	err := migrateGlobalConfig()
+	if err == nil {
+		t.Fatal("expected migrateGlobalConfig to return an error when Rename fails, got nil")
+	}
+
+	// loadGlobalConfig must still work by falling back to the old path.
+	cfg, loadErr := loadGlobalConfig()
+	if loadErr != nil {
+		t.Fatalf("loadGlobalConfig() failed after migration error: %v", loadErr)
+	}
+	if cfg.CurrentWorkspace != "myws" {
+		t.Errorf("expected current-workspace=myws from fallback, got %q", cfg.CurrentWorkspace)
+	}
+}
+
+// TestLoadGlobalConfig_NewPath verifies that loadGlobalConfig reads from the
+// new path when no old file exists (happy-path after migration).
+func TestLoadGlobalConfig_NewPath(t *testing.T) {
+	_, _, newPath := setupFakeHome(t)
+
+	writeFile(t, newPath, sampleGlobalConfig)
+
+	cfg, err := loadGlobalConfig()
+	if err != nil {
+		t.Fatalf("loadGlobalConfig(): %v", err)
+	}
+	if cfg.CurrentWorkspace != "myws" {
+		t.Errorf("CurrentWorkspace = %q; want myws", cfg.CurrentWorkspace)
+	}
+	if _, ok := cfg.Workspaces["myws"]; !ok {
+		t.Error("Workspaces[myws] not present")
+	}
+}
+
+// TestGlobalConfigPath_NewLocation verifies that globalConfigPath() returns a
+// path under ~/.cog/node/ (not ~/.cog/config).
+func TestGlobalConfigPath_NewLocation(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	got := globalConfigPath()
+	want := filepath.Join(fakeHome, ".cog", "node", "global.yaml")
+
+	if got != want {
+		t.Errorf("globalConfigPath() = %q; want %q", got, want)
+	}
+	if strings.Contains(got, filepath.Join(".cog", "config")) {
+		t.Errorf("globalConfigPath() still points into .cog/config: %q", got)
+	}
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -4,7 +4,7 @@
 //  1. COG_ROOT environment variable (explicit)
 //  2. COG_WORKSPACE env var (lookup in global config)
 //  3. Local git repo detection (if inside a workspace)
-//  4. current-workspace from ~/.cog/config
+//  4. current-workspace from ~/.cog/node/global.yaml
 //
 // This package is dependency-injected: the main package wires global-config
 // loading and git-root detection at init time. This avoids pulling the full
@@ -35,7 +35,7 @@ type ConfigProvider interface {
 // hook before ResolveWorkspace is called. If either is nil, the corresponding
 // resolution tier is skipped gracefully.
 var (
-	// LoadConfig loads the global config (~/.cog/config).
+	// LoadConfig loads the global config (~/.cog/node/global.yaml).
 	LoadConfig func() (ConfigProvider, error)
 	// GitRoot returns the path of the enclosing git repository.
 	GitRoot func() (string, error)
@@ -55,7 +55,7 @@ var workspaceCache struct {
 //  1. COG_ROOT environment variable (explicit)
 //  2. COG_WORKSPACE env var (lookup in global config)
 //  3. Local git repo detection (if inside a workspace)
-//  4. current-workspace from ~/.cog/config
+//  4. current-workspace from ~/.cog/node/global.yaml
 //
 // Returns (workspaceRoot, source, error) where source describes how it was
 // resolved.


### PR DESCRIPTION
## What moved

`globalConfigPath()` now returns `~/.cog/node/global.yaml` instead of `~/.cog/config` (flat file). This frees `~/.cog/config/` to function as a workspace config directory, making the home directory itself a valid CogOS workspace.

## Why

`~/.cog/config` was a flat file that collided with the directory convention used by `findWorkspaceRoot()` and `.cog/config/` workspace layout. Relocating it to `~/.cog/node/global.yaml` is also conceptually correct: the registry is node-local state (which workspaces _this node_ knows about), so it belongs under `node/`.

## Migration story

On first run after this change, `loadGlobalConfig()` calls `migrateGlobalConfig()`:

| State | Behaviour |
|---|---|
| Old `~/.cog/config` exists, new absent | Moves file to new path; logs `INFO` to stderr. |
| New `~/.cog/node/global.yaml` exists, old absent | Silent no-op (idempotent — second run). |
| Both exist | Keeps new, logs `WARN` naming the old path; does not delete it. |
| Neither exists | Silent no-op (fresh install). |
| `os.Rename` fails | Logs `ERROR`, returns error; `loadGlobalConfig` falls back to old path so the kernel still starts — no panic. |

## Files touched

- `cog.go` — `globalConfigPath()` new return value; new helpers `globalConfigLegacyPath()`, `migrateGlobalConfig()`, `fileExists()`; `loadGlobalConfig()` wired to call migration; `saveGlobalConfig()` comment updated.
- `internal/workspace/workspace.go` — comment references updated (no logic change).
- `global_config_migration_test.go` — new file, 6 test cases covering all migration branches including the fallback-on-failure path.

## Other sites hardcoding the old path

Grepped the repo for `\.cog/config` references. All other occurrences refer to workspace-internal `.cog/config/` directories (relative paths), not the global `~/.cog/config` flat file. No other sites needed updating.

## Tests

```
ok  github.com/cogos-dev/cogos           11.5s
ok  github.com/cogos-dev/cogos/internal/engine  7.9s
ok  github.com/cogos-dev/cogos/internal/eval    0.4s
ok  github.com/cogos-dev/cogos/internal/providers/daemon  0.2s
ok  github.com/cogos-dev/cogos/pkg/skills  11.5s
```

Closes #161