### PR TITLE
feat(pin): inter-workspace pin Reconcilable + CLI

### DIFF
--- a/cmd_pin.go
+++ b/cmd_pin.go
@@ -182,10 +182,8 @@ func cmdPinRemove(args []string) error {
 // cmdPinVerify resolves live HEAD for each pin and reports drift.
 // Optional argument: specific target to verify. Omit to verify all.
 //
-// The output is driven entirely from the ComputePlan result — the same plan
-// that Health() reads. This ensures that digest mismatches, unreachable targets,
-// and ref drift are all reflected correctly, matching the three-axis health
-// classification rather than a second ad-hoc ref comparison.
+// This is a thin shim over pin.RunVerify so the core logic is testable
+// independently of workspace resolution and os.Stdout.
 func cmdPinVerify(args []string) error {
 	var filterTarget string
 	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
@@ -197,86 +195,8 @@ func cmdPinVerify(args []string) error {
 		return err
 	}
 
-	p := pin.New(nil)
-	cfgAny, err := p.LoadConfig(root)
-	if err != nil {
-		return fmt.Errorf("pin verify: %w", err)
-	}
-
-	liveAny, err := p.FetchLive(context.Background(), cfgAny)
-	if err != nil {
-		return fmt.Errorf("pin verify: %w", err)
-	}
-
-	plan, err := p.ComputePlan(cfgAny, liveAny, nil)
-	if err != nil {
-		return fmt.Errorf("pin verify: %w", err)
-	}
-
-	// Build a lookup from target → plan action so we read digest/unreachable
-	// state from the authoritative plan rather than re-resolving.
-	type verifyResult struct {
-		ok      bool
-		message string
-	}
-	results := make(map[string]verifyResult, len(plan.Actions))
-	for _, action := range plan.Actions {
-		target := action.Name
-		reason, _ := action.Details["reason"].(string)
-		pinnedRef, _ := action.Details["pinned_ref"].(string)
-		liveRef, _ := action.Details["live_ref"].(string)
-
-		switch reason {
-		case "in_sync":
-			results[target] = verifyResult{ok: true,
-				message: fmt.Sprintf("pinned %s == live %s", pinnedRef, liveRef)}
-		case "digest_unverifiable":
-			pinnedDigest, _ := action.Details["pinned_digest"].(string)
-			results[target] = verifyResult{ok: false,
-				message: fmt.Sprintf("digest unverifiable: pin declares %s, resolver returned no digest (fail-closed)", pinnedDigest)}
-		case "digest_mismatch":
-			pinnedDigest, _ := action.Details["pinned_digest"].(string)
-			liveDigest, _ := action.Details["live_digest"].(string)
-			results[target] = verifyResult{ok: false,
-				message: fmt.Sprintf("digest mismatch: want %s, got %s (ref: pinned %s, live %s)", pinnedDigest, liveDigest, pinnedRef, liveRef)}
-		case "target_unreachable":
-			errStr, _ := action.Details["error"].(string)
-			results[target] = verifyResult{ok: false,
-				message: fmt.Sprintf("unreachable: %s", errStr)}
-		default:
-			// ActionUpdate: ref drift.
-			if liveRef != "" {
-				results[target] = verifyResult{ok: false,
-					message: fmt.Sprintf("drift: pinned %s, live %s", pinnedRef, liveRef)}
-			} else {
-				results[target] = verifyResult{ok: false,
-					message: fmt.Sprintf("unexpected plan action %q for %s", action.Action, target)}
-			}
-		}
-	}
-
-	found := false
-	drifted := 0
-	for target, vr := range results {
-		if filterTarget != "" && target != filterTarget {
-			continue
-		}
-		found = true
-		if vr.ok {
-			fmt.Printf("[OK]    %s: %s\n", target, vr.message)
-		} else {
-			fmt.Printf("[DRIFT] %s: %s\n", target, vr.message)
-			drifted++
-		}
-	}
-
-	if filterTarget != "" && !found {
-		return fmt.Errorf("pin verify: no pin record found for target %q", filterTarget)
-	}
-	if drifted > 0 {
-		return fmt.Errorf("pin verify: %d pin(s) drifted or unreachable", drifted)
-	}
-	return nil
+	_, err = pin.RunVerify(context.Background(), root, filterTarget, nil, os.Stdout)
+	return err
 }
 
 // ─── bump ────────────────────────────────────────────────────────────────────

--- a/cmd_pin.go
+++ b/cmd_pin.go
@@ -181,6 +181,11 @@ func cmdPinRemove(args []string) error {
 
 // cmdPinVerify resolves live HEAD for each pin and reports drift.
 // Optional argument: specific target to verify. Omit to verify all.
+//
+// The output is driven entirely from the ComputePlan result — the same plan
+// that Health() reads. This ensures that digest mismatches, unreachable targets,
+// and ref drift are all reflected correctly, matching the three-axis health
+// classification rather than a second ad-hoc ref comparison.
 func cmdPinVerify(args []string) error {
 	var filterTarget string
 	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
@@ -203,39 +208,66 @@ func cmdPinVerify(args []string) error {
 		return fmt.Errorf("pin verify: %w", err)
 	}
 
-	_, err = p.ComputePlan(cfgAny, liveAny, nil)
+	plan, err := p.ComputePlan(cfgAny, liveAny, nil)
 	if err != nil {
 		return fmt.Errorf("pin verify: %w", err)
 	}
 
-	// Print per-pin status.
-	entries, err := listPinRecords(root)
-	if err != nil {
-		return fmt.Errorf("pin verify: listing records: %w", err)
+	// Build a lookup from target → plan action so we read digest/unreachable
+	// state from the authoritative plan rather than re-resolving.
+	type verifyResult struct {
+		ok      bool
+		message string
+	}
+	results := make(map[string]verifyResult, len(plan.Actions))
+	for _, action := range plan.Actions {
+		target := action.Name
+		reason, _ := action.Details["reason"].(string)
+		pinnedRef, _ := action.Details["pinned_ref"].(string)
+		liveRef, _ := action.Details["live_ref"].(string)
+
+		switch reason {
+		case "in_sync":
+			results[target] = verifyResult{ok: true,
+				message: fmt.Sprintf("pinned %s == live %s", pinnedRef, liveRef)}
+		case "digest_unverifiable":
+			pinnedDigest, _ := action.Details["pinned_digest"].(string)
+			results[target] = verifyResult{ok: false,
+				message: fmt.Sprintf("digest unverifiable: pin declares %s, resolver returned no digest (fail-closed)", pinnedDigest)}
+		case "digest_mismatch":
+			pinnedDigest, _ := action.Details["pinned_digest"].(string)
+			liveDigest, _ := action.Details["live_digest"].(string)
+			results[target] = verifyResult{ok: false,
+				message: fmt.Sprintf("digest mismatch: want %s, got %s (ref: pinned %s, live %s)", pinnedDigest, liveDigest, pinnedRef, liveRef)}
+		case "target_unreachable":
+			errStr, _ := action.Details["error"].(string)
+			results[target] = verifyResult{ok: false,
+				message: fmt.Sprintf("unreachable: %s", errStr)}
+		default:
+			// ActionUpdate: ref drift.
+			if liveRef != "" {
+				results[target] = verifyResult{ok: false,
+					message: fmt.Sprintf("drift: pinned %s, live %s", pinnedRef, liveRef)}
+			} else {
+				results[target] = verifyResult{ok: false,
+					message: fmt.Sprintf("unexpected plan action %q for %s", action.Action, target)}
+			}
+		}
 	}
 
 	found := false
 	drifted := 0
-	for _, rec := range entries {
-		if filterTarget != "" && rec.Target != filterTarget {
+	for target, vr := range results {
+		if filterTarget != "" && target != filterTarget {
 			continue
 		}
 		found = true
-		status := p.Health()
-		// Health is aggregate; for per-pin detail we run verify logic inline.
-		live2, err2 := resolveOneLive(root, rec.Target)
-		if err2 != nil {
-			fmt.Printf("[WARN] %s: cannot resolve live HEAD: %v\n", rec.Target, err2)
-			drifted++
-			continue
-		}
-		if live2 == rec.Pin.Ref || strings.HasPrefix(live2, rec.Pin.Ref) || strings.HasPrefix(rec.Pin.Ref, live2) {
-			fmt.Printf("[OK]   %s: pinned %s == live %s\n", rec.Target, rec.Pin.Ref, live2)
+		if vr.ok {
+			fmt.Printf("[OK]    %s: %s\n", target, vr.message)
 		} else {
-			fmt.Printf("[DRIFT] %s: pinned %s, live %s\n", rec.Target, rec.Pin.Ref, live2)
+			fmt.Printf("[DRIFT] %s: %s\n", target, vr.message)
 			drifted++
 		}
-		_ = status
 	}
 
 	if filterTarget != "" && !found {
@@ -392,44 +424,6 @@ func listPinRecords(root string) ([]*pin.PinRecord, error) {
 // pinsDirPath returns the .cog/pins path for a workspace root.
 func pinsDirPath(root string) string {
 	return root + "/.cog/pins"
-}
-
-// resolveOneLive resolves live HEAD for a single target using the default
-// local resolver. Used by cmdPinVerify for per-pin display.
-func resolveOneLive(workspaceRoot, target string) (string, error) {
-	r := &localPinResolver{}
-	ref, _, err := r.resolveOne(context.Background(), target, workspaceRoot)
-	return ref, err
-}
-
-// localPinResolver is a small wrapper so cmdPinVerify can call the production
-// resolver without importing unexported types from the pin package.
-type localPinResolver struct{}
-
-func (r *localPinResolver) resolveOne(ctx context.Context, target, workspaceRoot string) (string, string, error) {
-	// Re-use pin.New with nil resolver (defaults to local git).
-	p := pin.New(nil)
-	cfgAny, err := p.LoadConfig(workspaceRoot)
-	if err != nil {
-		return "", "", err
-	}
-	liveAny, err := p.FetchLive(ctx, cfgAny)
-	if err != nil {
-		return "", "", err
-	}
-	// BuildState so we can extract the live ref.
-	state, err := p.BuildState(cfgAny, liveAny, nil)
-	if err != nil {
-		return "", "", err
-	}
-	for _, res := range state.Resources {
-		if res.ExternalID == target {
-			if lv, ok := res.Attributes["live_ref"].(string); ok {
-				return lv, "", nil
-			}
-		}
-	}
-	return "", "", fmt.Errorf("target %q not found in state", target)
 }
 
 // parseYAMLInto is a thin wrapper over yaml.Unmarshal for local use.

--- a/cmd_pin.go
+++ b/cmd_pin.go
@@ -1,0 +1,452 @@
+// cmd_pin.go — CLI commands for inter-workspace pin management.
+//
+// Commands:
+//   cog pin list                              — list all pins for the current workspace
+//   cog pin add <target> <ref> [flags]        — declare a new pin
+//   cog pin remove <target>                   — delete a pin record
+//   cog pin verify [<target>]                 — check live ref and digest drift
+//   cog pin bump <target> <new-ref> [flags]   — update pin ref (explicit bump)
+//
+// Flags for add / bump:
+//   --digest sha256:<hex>  — content-addressed pin
+//   --branch <name>        — default branch context (default: main)
+//   --sync <policy>        — read-only | read-write | mirror (default: read-only)
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/cogos-dev/cogos/internal/providers/pin"
+	"gopkg.in/yaml.v3"
+)
+
+// cmdPin dispatches `cog pin <subcommand>`.
+func cmdPin(args []string) error {
+	if len(args) == 0 {
+		return cmdPinHelp()
+	}
+	switch args[0] {
+	case "list":
+		return cmdPinList(args[1:])
+	case "add":
+		return cmdPinAdd(args[1:])
+	case "remove", "rm":
+		return cmdPinRemove(args[1:])
+	case "verify":
+		return cmdPinVerify(args[1:])
+	case "bump":
+		return cmdPinBump(args[1:])
+	case "help", "-h", "--help":
+		return cmdPinHelp()
+	default:
+		return fmt.Errorf("pin: unknown subcommand %q — run `cog pin help`", args[0])
+	}
+}
+
+// cmdPinHelp prints usage.
+func cmdPinHelp() error {
+	fmt.Print(`Usage: cog pin <subcommand> [args]
+
+Subcommands:
+  list                            List all pins for the current workspace
+  add <target> <ref> [flags]      Declare a new pin relationship
+  remove <target>                 Delete a pin record
+  verify [<target>]               Check live ref and digest drift
+  bump <target> <new-ref> [flags] Update pin ref to a new value
+
+Flags for add / bump:
+  --digest sha256:<hex>           Content-addressed pin digest
+  --branch <name>                 Default branch context (default: main)
+  --sync <policy>                 read-only | read-write | mirror (default: read-only)
+
+Examples:
+  cog pin add cogos-dev/cogos v0.5.0 --digest sha256:abc123 --branch main
+  cog pin verify cogos-dev/cogos
+  cog pin bump cogos-dev/cogos v0.6.0
+  cog pin list
+  cog pin remove cogos-dev/cogos
+`)
+	return nil
+}
+
+// ─── list ────────────────────────────────────────────────────────────────────
+
+// cmdPinList prints all pin records for the current workspace.
+func cmdPinList(_ []string) error {
+	root, err := resolveWorkspaceRoot()
+	if err != nil {
+		return err
+	}
+
+	p := pin.New(nil)
+	cfgAny, err := p.LoadConfig(root)
+	if err != nil {
+		return fmt.Errorf("pin list: %w", err)
+	}
+
+	// Re-load directly for display; cast via WritePinRecord interface.
+	entries, err := listPinRecords(root)
+	if err != nil {
+		return fmt.Errorf("pin list: %w", err)
+	}
+	_ = cfgAny // loaded to validate; display uses raw load
+
+	if len(entries) == 0 {
+		fmt.Println("No pins declared. Use `cog pin add` to create one.")
+		return nil
+	}
+
+	fmt.Printf("%-30s  %-20s  %-10s  %s\n", "TARGET", "REF", "SYNC", "BRANCH")
+	fmt.Println(strings.Repeat("-", 80))
+	for _, rec := range entries {
+		branch := rec.Branch
+		if branch == "" {
+			branch = "(default)"
+		}
+		sync := string(rec.Sync)
+		if sync == "" {
+			sync = "read-only"
+		}
+		fmt.Printf("%-30s  %-20s  %-10s  %s\n", rec.Target, rec.Pin.Ref, sync, branch)
+	}
+	return nil
+}
+
+// ─── add ─────────────────────────────────────────────────────────────────────
+
+// cmdPinAdd creates a new pin record.
+// Usage: cog pin add <target> <ref> [--digest sha256:...] [--branch main] [--sync read-only]
+func cmdPinAdd(args []string) error {
+	if len(args) < 2 {
+		return fmt.Errorf("pin add: requires <target> and <ref> — run `cog pin help`")
+	}
+	target := args[0]
+	ref := args[1]
+
+	opts, err := parsePinFlags(args[2:])
+	if err != nil {
+		return fmt.Errorf("pin add: %w", err)
+	}
+
+	root, err := resolveWorkspaceRoot()
+	if err != nil {
+		return err
+	}
+
+	rec := &pin.PinRecord{
+		Target: target,
+		Pin: pin.PinRef{
+			Ref:    ref,
+			Digest: opts.digest,
+		},
+		Branch:  opts.branch,
+		Sync:    pin.SyncPolicy(opts.sync),
+		Updated: time.Now().UTC(),
+	}
+
+	if err := pin.WritePinRecord(root, rec); err != nil {
+		return fmt.Errorf("pin add: %w", err)
+	}
+	fmt.Printf("Pin added: %s @ %s (sync: %s)\n", target, ref, rec.Sync)
+	return nil
+}
+
+// ─── remove ──────────────────────────────────────────────────────────────────
+
+// cmdPinRemove deletes a pin record.
+func cmdPinRemove(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("pin remove: requires <target> — run `cog pin help`")
+	}
+	target := args[0]
+
+	root, err := resolveWorkspaceRoot()
+	if err != nil {
+		return err
+	}
+
+	if err := pin.RemovePinRecord(root, target); err != nil {
+		return fmt.Errorf("pin remove: %w", err)
+	}
+	fmt.Printf("Pin removed: %s\n", target)
+	return nil
+}
+
+// ─── verify ──────────────────────────────────────────────────────────────────
+
+// cmdPinVerify resolves live HEAD for each pin and reports drift.
+// Optional argument: specific target to verify. Omit to verify all.
+func cmdPinVerify(args []string) error {
+	var filterTarget string
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		filterTarget = args[0]
+	}
+
+	root, err := resolveWorkspaceRoot()
+	if err != nil {
+		return err
+	}
+
+	p := pin.New(nil)
+	cfgAny, err := p.LoadConfig(root)
+	if err != nil {
+		return fmt.Errorf("pin verify: %w", err)
+	}
+
+	liveAny, err := p.FetchLive(context.Background(), cfgAny)
+	if err != nil {
+		return fmt.Errorf("pin verify: %w", err)
+	}
+
+	_, err = p.ComputePlan(cfgAny, liveAny, nil)
+	if err != nil {
+		return fmt.Errorf("pin verify: %w", err)
+	}
+
+	// Print per-pin status.
+	entries, err := listPinRecords(root)
+	if err != nil {
+		return fmt.Errorf("pin verify: listing records: %w", err)
+	}
+
+	found := false
+	drifted := 0
+	for _, rec := range entries {
+		if filterTarget != "" && rec.Target != filterTarget {
+			continue
+		}
+		found = true
+		status := p.Health()
+		// Health is aggregate; for per-pin detail we run verify logic inline.
+		live2, err2 := resolveOneLive(root, rec.Target)
+		if err2 != nil {
+			fmt.Printf("[WARN] %s: cannot resolve live HEAD: %v\n", rec.Target, err2)
+			drifted++
+			continue
+		}
+		if live2 == rec.Pin.Ref || strings.HasPrefix(live2, rec.Pin.Ref) || strings.HasPrefix(rec.Pin.Ref, live2) {
+			fmt.Printf("[OK]   %s: pinned %s == live %s\n", rec.Target, rec.Pin.Ref, live2)
+		} else {
+			fmt.Printf("[DRIFT] %s: pinned %s, live %s\n", rec.Target, rec.Pin.Ref, live2)
+			drifted++
+		}
+		_ = status
+	}
+
+	if filterTarget != "" && !found {
+		return fmt.Errorf("pin verify: no pin record found for target %q", filterTarget)
+	}
+	if drifted > 0 {
+		return fmt.Errorf("pin verify: %d pin(s) drifted or unreachable", drifted)
+	}
+	return nil
+}
+
+// ─── bump ────────────────────────────────────────────────────────────────────
+
+// cmdPinBump updates the ref (and optional digest) on an existing pin record.
+// Usage: cog pin bump <target> <new-ref> [--digest sha256:...] [--branch ...]
+func cmdPinBump(args []string) error {
+	if len(args) < 2 {
+		return fmt.Errorf("pin bump: requires <target> and <new-ref> — run `cog pin help`")
+	}
+	target := args[0]
+	newRef := args[1]
+
+	opts, err := parsePinFlags(args[2:])
+	if err != nil {
+		return fmt.Errorf("pin bump: %w", err)
+	}
+
+	root, err := resolveWorkspaceRoot()
+	if err != nil {
+		return err
+	}
+
+	// Load existing record to preserve fields not being changed.
+	entries, err := listPinRecords(root)
+	if err != nil {
+		return fmt.Errorf("pin bump: %w", err)
+	}
+	var existing *pin.PinRecord
+	for _, rec := range entries {
+		if rec.Target == target {
+			existing = rec
+			break
+		}
+	}
+	if existing == nil {
+		return fmt.Errorf("pin bump: no pin record found for target %q", target)
+	}
+
+	existing.Pin.Ref = newRef
+	if opts.digest != "" {
+		existing.Pin.Digest = opts.digest
+	}
+	if opts.branch != "" {
+		existing.Branch = opts.branch
+	}
+	if opts.sync != "" {
+		existing.Sync = pin.SyncPolicy(opts.sync)
+	}
+	existing.Updated = time.Now().UTC()
+
+	if err := pin.WritePinRecord(root, existing); err != nil {
+		return fmt.Errorf("pin bump: %w", err)
+	}
+	fmt.Printf("Pin bumped: %s @ %s\n", target, newRef)
+	return nil
+}
+
+// ─── Flag parser ─────────────────────────────────────────────────────────────
+
+type pinFlagOpts struct {
+	digest string
+	branch string
+	sync   string
+}
+
+func parsePinFlags(args []string) (pinFlagOpts, error) {
+	opts := pinFlagOpts{
+		branch: "main",
+		sync:   "read-only",
+	}
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--digest":
+			if i+1 >= len(args) {
+				return opts, fmt.Errorf("--digest requires a value")
+			}
+			i++
+			opts.digest = args[i]
+		case "--branch":
+			if i+1 >= len(args) {
+				return opts, fmt.Errorf("--branch requires a value")
+			}
+			i++
+			opts.branch = args[i]
+		case "--sync":
+			if i+1 >= len(args) {
+				return opts, fmt.Errorf("--sync requires a value")
+			}
+			i++
+			opts.sync = args[i]
+		default:
+			return opts, fmt.Errorf("unknown flag %q", args[i])
+		}
+	}
+	return opts, nil
+}
+
+// ─── Workspace resolution helpers ────────────────────────────────────────────
+
+// resolveWorkspaceRoot returns the workspace root or an error. Wraps the
+// kernel's ResolveWorkspace to centralise error handling for pin commands.
+func resolveWorkspaceRoot() (string, error) {
+	root, _, err := ResolveWorkspace()
+	if err != nil {
+		return "", fmt.Errorf("pin: could not resolve workspace root: %w", err)
+	}
+	return root, nil
+}
+
+// listPinRecords is a thin helper that loads pin records from root for display.
+// Used by list, verify, and bump (which need the record data, not the full
+// provider lifecycle).
+func listPinRecords(root string) ([]*pin.PinRecord, error) {
+	dir := pinsDirPath(root)
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var recs []*pin.PinRecord
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		path := dir + "/" + e.Name()
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var rec pin.PinRecord
+		if err := parseYAMLInto(data, &rec); err != nil {
+			continue
+		}
+		if rec.Target == "" {
+			continue
+		}
+		recs = append(recs, &rec)
+	}
+	return recs, nil
+}
+
+// pinsDirPath returns the .cog/pins path for a workspace root.
+func pinsDirPath(root string) string {
+	return root + "/.cog/pins"
+}
+
+// resolveOneLive resolves live HEAD for a single target using the default
+// local resolver. Used by cmdPinVerify for per-pin display.
+func resolveOneLive(workspaceRoot, target string) (string, error) {
+	r := &localPinResolver{}
+	ref, _, err := r.resolveOne(context.Background(), target, workspaceRoot)
+	return ref, err
+}
+
+// localPinResolver is a small wrapper so cmdPinVerify can call the production
+// resolver without importing unexported types from the pin package.
+type localPinResolver struct{}
+
+func (r *localPinResolver) resolveOne(ctx context.Context, target, workspaceRoot string) (string, string, error) {
+	// Re-use pin.New with nil resolver (defaults to local git).
+	p := pin.New(nil)
+	cfgAny, err := p.LoadConfig(workspaceRoot)
+	if err != nil {
+		return "", "", err
+	}
+	liveAny, err := p.FetchLive(ctx, cfgAny)
+	if err != nil {
+		return "", "", err
+	}
+	// BuildState so we can extract the live ref.
+	state, err := p.BuildState(cfgAny, liveAny, nil)
+	if err != nil {
+		return "", "", err
+	}
+	for _, res := range state.Resources {
+		if res.ExternalID == target {
+			if lv, ok := res.Attributes["live_ref"].(string); ok {
+				return lv, "", nil
+			}
+		}
+	}
+	return "", "", fmt.Errorf("target %q not found in state", target)
+}
+
+// parseYAMLInto is a thin wrapper over yaml.Unmarshal for local use.
+func parseYAMLInto(data []byte, v any) error {
+	return yaml.Unmarshal(data, v)
+}
+
+// ─── Provider registration ────────────────────────────────────────────────────
+
+// init registers the pin provider in the CLI binary's reconcile registry.
+// The CLI binary uses the full internal/providers/pin implementation, which
+// exercises the complete seven-method lifecycle (unlike the daemon-side stub
+// which provides Health-only).
+//
+// The workspace root is injected lazily: LoadConfig is called with the resolved
+// workspace root at reconcile time, not here. The provider is constructed with
+// the default local-checkout resolver; tests replace the resolver via pin.New().
+func init() {
+	RegisterProvider("pin", pin.New(nil))
+}

--- a/cog.go
+++ b/cog.go
@@ -5766,6 +5766,11 @@ func main() {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			code = 1
 		}
+	case "pin":
+		if err := cmdPin(os.Args[2:]); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			code = 1
+		}
 	case "version", "-v", "--version":
 		code = cmdVersion()
 	case "info":

--- a/internal/providers/daemon/daemon.go
+++ b/internal/providers/daemon/daemon.go
@@ -39,6 +39,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/cogos-dev/cogos/internal/providers/pin"
 	"github.com/cogos-dev/cogos/pkg/reconcile"
@@ -72,14 +73,23 @@ func SetWorkspaceRoot(root string) {
 }
 
 // pinProvider is the daemon-side wrapper around the fully-extracted pin provider.
-// It delegates Health() directly to pin.New(), wiring the workspace root at
-// probe time via resolveRoot(). The non-health methods are provided by
-// the embedded stubMethods (daemon only needs Health() for the proprioception block).
+// It delegates Health() to pin.New() after running the full Reconcile cycle
+// (LoadConfig → FetchLive → ComputePlan) so that pinStates is populated before
+// Health() is called. Without the full cycle, pinStates is always empty and
+// Health() always reports green ("no pins declared") even when pin files
+// declare drift.
+//
+// The Reconcile call is time-bounded to 10 s to avoid blocking the proprioception
+// tick. staleAfter controls how long a prior cycle result is reused to avoid
+// hammering the filesystem on every foveated-context refresh.
 type pinProvider struct {
 	stubMethods
-	mu   sync.Mutex
-	impl *pin.Provider
+	mu        sync.Mutex
+	impl      *pin.Provider
+	lastProbe time.Time
 }
+
+const pinProbeStaleAfter = 30 * time.Second
 
 func (p *pinProvider) Type() string { return "pin" }
 
@@ -93,18 +103,26 @@ func (p *pinProvider) Health() reconcile.ResourceStatus {
 		p.impl = pin.New(nil)
 	}
 	impl := p.impl
+	// Reuse the last Reconcile result if it is still fresh.
+	stale := time.Since(p.lastProbe) >= pinProbeStaleAfter
 	p.mu.Unlock()
 
-	// Wire the workspace root into the pin provider so its Health() can
-	// inspect .cog/pins/. LoadConfig is idempotent; call it cheaply here so
-	// the provider's internal root field is always current.
-	if _, err := impl.LoadConfig(root); err != nil {
-		return reconcile.ResourceStatus{
-			Sync:      reconcile.SyncStatusUnknown,
-			Health:    reconcile.HealthDegraded,
-			Operation: reconcile.OperationIdle,
-			Message:   fmt.Sprintf("pin LoadConfig: %v", err),
+	if stale {
+		// Run the full reconcile cycle so pinStates reflects live drift.
+		// A 10 s context prevents blocking the proprioception tick indefinitely.
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if _, err := impl.Reconcile(ctx, root); err != nil {
+			return reconcile.ResourceStatus{
+				Sync:      reconcile.SyncStatusUnknown,
+				Health:    reconcile.HealthDegraded,
+				Operation: reconcile.OperationIdle,
+				Message:   fmt.Sprintf("pin reconcile: %v", err),
+			}
 		}
+		p.mu.Lock()
+		p.lastProbe = time.Now()
+		p.mu.Unlock()
 	}
 	return impl.Health()
 }

--- a/internal/providers/daemon/daemon.go
+++ b/internal/providers/daemon/daemon.go
@@ -23,6 +23,8 @@
 //
 // The component provider is already fully extracted to
 // internal/providers/component and is wired here via blank import.
+// The pin provider (internal/providers/pin) is fully extracted and registered
+// here directly — its Health() delegates to the extracted package.
 // The other seven are implemented as minimal structs below.
 //
 // cmd/cogos/providers_wire.go imports this package (triggering init()) and
@@ -38,6 +40,7 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/cogos-dev/cogos/internal/providers/pin"
 	"github.com/cogos-dev/cogos/pkg/reconcile"
 
 	// Trigger internal/providers/component's init() which registers "component".
@@ -68,6 +71,44 @@ func SetWorkspaceRoot(root string) {
 	workspaceRoot = root
 }
 
+// pinProvider is the daemon-side wrapper around the fully-extracted pin provider.
+// It delegates Health() directly to pin.New(), wiring the workspace root at
+// probe time via resolveRoot(). The non-health methods are provided by
+// the embedded stubMethods (daemon only needs Health() for the proprioception block).
+type pinProvider struct {
+	stubMethods
+	mu   sync.Mutex
+	impl *pin.Provider
+}
+
+func (p *pinProvider) Type() string { return "pin" }
+
+func (p *pinProvider) Health() reconcile.ResourceStatus {
+	root, bad := resolveRoot()
+	if bad != nil {
+		return *bad
+	}
+	p.mu.Lock()
+	if p.impl == nil {
+		p.impl = pin.New(nil)
+	}
+	impl := p.impl
+	p.mu.Unlock()
+
+	// Wire the workspace root into the pin provider so its Health() can
+	// inspect .cog/pins/. LoadConfig is idempotent; call it cheaply here so
+	// the provider's internal root field is always current.
+	if _, err := impl.LoadConfig(root); err != nil {
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusUnknown,
+			Health:    reconcile.HealthDegraded,
+			Operation: reconcile.OperationIdle,
+			Message:   fmt.Sprintf("pin LoadConfig: %v", err),
+		}
+	}
+	return impl.Health()
+}
+
 func init() {
 	reconcile.RegisterProvider("agent", &agentProvider{})
 	reconcile.RegisterProvider("discord", &discordProvider{})
@@ -76,6 +117,7 @@ func init() {
 	reconcile.RegisterProvider("openclaw-agents", &openclawAgentsProvider{})
 	reconcile.RegisterProvider("openclaw-cron", &openclawCronProvider{})
 	reconcile.RegisterProvider("openclaw-gateway", &openclawGatewayProvider{})
+	reconcile.RegisterProvider("pin", &pinProvider{stubMethods: stubMethods{name: "pin"}})
 	reconcile.RegisterProvider("service", &serviceProvider{})
 }
 

--- a/internal/providers/daemon/daemon.go
+++ b/internal/providers/daemon/daemon.go
@@ -73,15 +73,22 @@ func SetWorkspaceRoot(root string) {
 }
 
 // pinProvider is the daemon-side wrapper around the fully-extracted pin provider.
-// It delegates Health() to pin.New() after running the full Reconcile cycle
-// (LoadConfig → FetchLive → ComputePlan) so that pinStates is populated before
-// Health() is called. Without the full cycle, pinStates is always empty and
-// Health() always reports green ("no pins declared") even when pin files
-// declare drift.
+// It delegates Health() to pin.New() after running the read-only refresh cycle
+// (LoadConfig → FetchLive → ComputePlan, no ApplyPlan) so that pinStates is
+// populated before Health() is called. Without the read-only cycle, pinStates is
+// always empty and Health() always reports green ("no pins declared") even when
+// pin files declare drift.
 //
-// The Reconcile call is time-bounded to 10 s to avoid blocking the proprioception
-// tick. staleAfter controls how long a prior cycle result is reused to avoid
-// hammering the filesystem on every foveated-context refresh.
+// The refresh is time-bounded to 10 s to avoid blocking the proprioception tick.
+// staleAfter controls how long a prior cycle result is reused to avoid hammering
+// the filesystem on every foveated-context refresh.
+//
+// Concurrency: mu is held from the staleness check through the entire refresh
+// so that concurrent Health() calls serialise on the lock. Only the first
+// stale caller runs the refresh; subsequent callers reuse the result already
+// being computed (they block on mu.Lock() and see a fresh lastProbe when they
+// acquire it). This eliminates parallel RefreshState invocations and the
+// associated parallel bumpPinFile race.
 type pinProvider struct {
 	stubMethods
 	mu        sync.Mutex
@@ -98,33 +105,35 @@ func (p *pinProvider) Health() reconcile.ResourceStatus {
 	if bad != nil {
 		return *bad
 	}
+
+	// Hold mu for the entire probe so that concurrent Health() calls serialise
+	// here. The first caller that finds a stale result runs RefreshState; any
+	// other concurrent callers block on Lock() and re-check freshness once they
+	// acquire it (finding the result already fresh).
 	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	if p.impl == nil {
 		p.impl = pin.New(nil)
 	}
-	impl := p.impl
-	// Reuse the last Reconcile result if it is still fresh.
-	stale := time.Since(p.lastProbe) >= pinProbeStaleAfter
-	p.mu.Unlock()
 
-	if stale {
-		// Run the full reconcile cycle so pinStates reflects live drift.
+	if time.Since(p.lastProbe) >= pinProbeStaleAfter {
+		// Run the read-only refresh cycle (no ApplyPlan, no filesystem writes).
 		// A 10 s context prevents blocking the proprioception tick indefinitely.
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		if _, err := impl.Reconcile(ctx, root); err != nil {
+		if err := p.impl.RefreshState(ctx, root); err != nil {
 			return reconcile.ResourceStatus{
 				Sync:      reconcile.SyncStatusUnknown,
 				Health:    reconcile.HealthDegraded,
 				Operation: reconcile.OperationIdle,
-				Message:   fmt.Sprintf("pin reconcile: %v", err),
+				Message:   fmt.Sprintf("pin refresh: %v", err),
 			}
 		}
-		p.mu.Lock()
 		p.lastProbe = time.Now()
-		p.mu.Unlock()
 	}
-	return impl.Health()
+
+	return p.impl.Health()
 }
 
 func init() {

--- a/internal/providers/daemon/daemon_test.go
+++ b/internal/providers/daemon/daemon_test.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"sync"
 	"testing"
 
 	"github.com/cogos-dev/cogos/internal/providers/daemon"
@@ -206,4 +207,83 @@ func TestSetWorkspaceRoot_HealthReflectsWorkspaceState(t *testing.T) {
 
 	// Reset for other tests.
 	daemon.SetWorkspaceRoot("")
+}
+
+// TestPinProvider_ConcurrentHealth_NoParallelRefresh verifies that concurrent
+// Health() calls on the pin provider serialise correctly and do not trigger
+// parallel RefreshState invocations (Bug B fix).
+//
+// The test fires N goroutines that each call p.Health() simultaneously on a
+// workspace with a pin file. With the Bug B fix the mutex is held through the
+// entire refresh, so the calls serialise rather than racing. Without the fix,
+// concurrent stale-state checks both pass the staleness gate and both run
+// RefreshState in parallel, which can race on pinStates writes.
+//
+// The test is also run with -race in CI (go test -race) to surface any data
+// races that the serialisation fix is intended to prevent.
+func TestPinProvider_ConcurrentHealth_NoParallelRefresh(t *testing.T) {
+	tmp := t.TempDir()
+	pinsDir := filepath.Join(tmp, ".cog", "pins")
+	if err := os.MkdirAll(pinsDir, 0o755); err != nil {
+		t.Fatalf("mkdir pins: %v", err)
+	}
+	pinYAML := `target: cogos-dev/nonexistent-target
+pin:
+  ref: abc000000000
+branch: main
+sync: read-only
+`
+	if err := os.WriteFile(filepath.Join(pinsDir, "cogos-dev_nonexistent-target.yaml"), []byte(pinYAML), 0o644); err != nil {
+		t.Fatalf("write pin yaml: %v", err)
+	}
+
+	// Also create the minimal workspace structure so agent / service providers
+	// don't interfere.
+	agentsDir := filepath.Join(tmp, ".cog", "bin", "agents")
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		t.Fatalf("mkdir agents: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(agentsDir, "registry.yaml"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write registry.yaml: %v", err)
+	}
+
+	daemon.SetWorkspaceRoot(tmp)
+	defer daemon.SetWorkspaceRoot("")
+
+	p, err := reconcile.GetProvider("pin")
+	if err != nil {
+		t.Fatalf("GetProvider(pin): %v", err)
+	}
+
+	const concurrency = 8
+	var wg sync.WaitGroup
+	statuses := make([]reconcile.ResourceStatus, concurrency)
+
+	// Fire all goroutines at roughly the same time. All will see a stale
+	// lastProbe (zero value). With the fix, only one runs RefreshState; the
+	// others block on the mutex and see a fresh result when they acquire it.
+	wg.Add(concurrency)
+	for i := 0; i < concurrency; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			statuses[i] = p.Health()
+		}()
+	}
+	wg.Wait()
+
+	// All goroutines must have received a coherent status — not a zero value.
+	for i, s := range statuses {
+		if s.Health == "" {
+			t.Errorf("goroutine %d: Health() returned zero-value status", i)
+		}
+	}
+
+	// The workspace has a pin that is unreachable locally, so every status
+	// must be Degraded (not Healthy).
+	for i, s := range statuses {
+		if s.Health == reconcile.HealthHealthy {
+			t.Errorf("goroutine %d: Health()=Healthy with unreachable pin; want Degraded; message=%q", i, s.Message)
+		}
+	}
 }

--- a/internal/providers/daemon/daemon_test.go
+++ b/internal/providers/daemon/daemon_test.go
@@ -95,6 +95,67 @@ func TestDaemonProviders_HealthDoesNotPanic(t *testing.T) {
 	}
 }
 
+// TestPinProvider_DaemonHealth_SurfacesDrift verifies Codex Bug 1:
+// the daemon's pin provider calls the full Reconcile cycle before Health()
+// so that drift declared in .cog/pins/*.yaml files is surfaced rather than
+// silently reporting "no pins declared" (the pre-fix behaviour when pinStates
+// was always empty because only LoadConfig was called).
+//
+// The test writes a pin file declaring a stale ref for a target that does not
+// exist locally. FetchLive returns "unreachable" for any non-local target, so
+// ComputePlan marks the pin as missing. Health() must therefore be Degraded,
+// not Healthy.
+func TestPinProvider_DaemonHealth_SurfacesDrift(t *testing.T) {
+	// Build a temporary workspace with a .cog/pins/ directory and one pin
+	// declaring a target that cannot be resolved locally.
+	tmp := t.TempDir()
+	pinsDir := filepath.Join(tmp, ".cog", "pins")
+	if err := os.MkdirAll(pinsDir, 0o755); err != nil {
+		t.Fatalf("mkdir pins: %v", err)
+	}
+	pinYAML := `target: cogos-dev/nonexistent-target
+pin:
+  ref: abc000000000
+branch: main
+sync: read-only
+`
+	if err := os.WriteFile(filepath.Join(pinsDir, "cogos-dev_nonexistent-target.yaml"), []byte(pinYAML), 0o644); err != nil {
+		t.Fatalf("write pin yaml: %v", err)
+	}
+
+	// Also create the minimal workspace structure so agent / service providers
+	// don't interfere.
+	agentsDir := filepath.Join(tmp, ".cog", "bin", "agents")
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		t.Fatalf("mkdir agents: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(agentsDir, "registry.yaml"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write registry.yaml: %v", err)
+	}
+
+	daemon.SetWorkspaceRoot(tmp)
+	defer daemon.SetWorkspaceRoot("")
+
+	p, err := reconcile.GetProvider("pin")
+	if err != nil {
+		t.Fatalf("GetProvider(pin): %v", err)
+	}
+
+	h := p.Health()
+	// The target "cogos-dev/nonexistent-target" cannot be found locally,
+	// so FetchLive marks it unreachable and ComputePlan emits a missing action.
+	// Health() must NOT be Healthy — it must be Degraded.
+	if h.Health == reconcile.HealthHealthy {
+		t.Errorf("pin provider Health()=Healthy with a drifted pin file; want Degraded.\n"+
+			"This indicates pinStates was empty (Reconcile not called before Health).\n"+
+			"message: %q", h.Message)
+	}
+	// Specifically expect Degraded (missing/unreachable maps to Degraded in Health()).
+	if h.Health != reconcile.HealthDegraded {
+		t.Errorf("pin provider Health()=%s; want Degraded; message=%q", h.Health, h.Message)
+	}
+}
+
 // TestSetWorkspaceRoot_HealthReflectsWorkspaceState verifies that after
 // SetWorkspaceRoot is called with a real workspace path, providers that depend
 // only on filesystem presence (agent, service) return a non-"workspace-not-found"

--- a/internal/providers/daemon/daemon_test.go
+++ b/internal/providers/daemon/daemon_test.go
@@ -1,9 +1,9 @@
-// daemon_test.go — verifies that importing this package registers all 9
+// daemon_test.go — verifies that importing this package registers all 10
 // expected Reconcilable providers with pkg/reconcile.
 //
 // This is the canonical test for verification gate 3: "after the
 // engine.Main-equivalent boot path runs, reconcile.ListProviders() returns
-// the 9 expected names."
+// the 10 expected names."
 //
 // We don't start a server or invoke engine.Main() — we only confirm that
 // the package's init() side-effect wired the providers. This is sufficient
@@ -20,7 +20,7 @@ import (
 	"github.com/cogos-dev/cogos/internal/providers/daemon"
 	"github.com/cogos-dev/cogos/pkg/reconcile"
 
-	// Blank import fires daemon.init(), registering all 9 providers; the named
+	// Blank import fires daemon.init(), registering all 10 providers; the named
 	// import above is for the new SetWorkspaceRoot regression test.
 	_ "github.com/cogos-dev/cogos/internal/providers/daemon"
 )
@@ -34,10 +34,11 @@ var expectedProviders = []string{
 	"openclaw-agents",
 	"openclaw-cron",
 	"openclaw-gateway",
+	"pin",
 	"service",
 }
 
-func TestDaemonInit_RegistersAll9Providers(t *testing.T) {
+func TestDaemonInit_RegistersAll10Providers(t *testing.T) {
 	got := reconcile.ListProviders()
 	sort.Strings(got)
 

--- a/internal/providers/pin/pin.go
+++ b/internal/providers/pin/pin.go
@@ -25,6 +25,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -819,6 +820,36 @@ func firstN(msgs []string, n int) string {
 	return strings.Join(msgs[:n], "; ") + fmt.Sprintf(" (+%d more)", len(msgs)-n)
 }
 
+// ─── RefreshState (read-only cycle) ─────────────────────────────────────────
+
+// RefreshState runs the read-only subset of the reconcile lifecycle:
+// LoadConfig → FetchLive → ComputePlan (no ApplyPlan, no filesystem writes).
+//
+// This is the correct method for health probes. Unlike Reconcile, it never
+// calls ApplyPlan and therefore never calls bumpPinFile, so it is safe to call
+// from Health() without risk of mutating pin YAML files.
+func (p *Provider) RefreshState(ctx context.Context, root string) error {
+	p.mu.Lock()
+	p.operation = reconcile.OperationSyncing
+	p.mu.Unlock()
+	defer func() {
+		p.mu.Lock()
+		p.operation = reconcile.OperationIdle
+		p.mu.Unlock()
+	}()
+
+	cfg, err := p.LoadConfig(root)
+	if err != nil {
+		return err
+	}
+	live, err := p.FetchLive(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	_, err = p.ComputePlan(cfg, live, nil)
+	return err
+}
+
 // ─── Reconcile (full cycle) ──────────────────────────────────────────────────
 
 // Reconcile runs the full LoadConfig → FetchLive → ComputePlan → ApplyPlan cycle.
@@ -846,6 +877,107 @@ func (p *Provider) Reconcile(ctx context.Context, root string) ([]reconcile.Resu
 		return nil, err
 	}
 	return p.ApplyPlan(ctx, plan)
+}
+
+// ─── Verify (read-only plan-driven check) ────────────────────────────────────
+
+// VerifyResult describes the outcome for a single pin after a verify run.
+type VerifyResult struct {
+	Target  string
+	OK      bool
+	Message string
+}
+
+// RunVerify runs the read-only pin verification cycle against root and writes
+// human-readable output to w. filterTarget, if non-empty, restricts output to
+// that single pin. resolver, if non-nil, overrides the default local git
+// resolver (useful for testing).
+//
+// Returns a non-nil error when any pin is drifted or unreachable, or when
+// filterTarget is specified but no matching record exists.
+//
+// cmdPinVerify in cmd_pin.go is a thin shim over this function that supplies
+// the resolved workspace root, os.Stdout, and a nil resolver.
+func RunVerify(ctx context.Context, root, filterTarget string, resolver GitHeadResolver, w io.Writer) ([]VerifyResult, error) {
+	p := New(resolver) // nil resolver → default localGitHeadResolver
+	cfgAny, err := p.LoadConfig(root)
+	if err != nil {
+		return nil, fmt.Errorf("pin verify: %w", err)
+	}
+	liveAny, err := p.FetchLive(ctx, cfgAny)
+	if err != nil {
+		return nil, fmt.Errorf("pin verify: %w", err)
+	}
+	plan, err := p.ComputePlan(cfgAny, liveAny, nil)
+	if err != nil {
+		return nil, fmt.Errorf("pin verify: %w", err)
+	}
+
+	// Build results from the authoritative plan.
+	type vr struct {
+		ok      bool
+		message string
+	}
+	byTarget := make(map[string]vr, len(plan.Actions))
+	for _, action := range plan.Actions {
+		target := action.Name
+		reason, _ := action.Details["reason"].(string)
+		pinnedRef, _ := action.Details["pinned_ref"].(string)
+		liveRef, _ := action.Details["live_ref"].(string)
+
+		switch reason {
+		case "in_sync":
+			byTarget[target] = vr{ok: true,
+				message: fmt.Sprintf("pinned %s == live %s", pinnedRef, liveRef)}
+		case "digest_unverifiable":
+			pinnedDigest, _ := action.Details["pinned_digest"].(string)
+			byTarget[target] = vr{ok: false,
+				message: fmt.Sprintf("digest unverifiable: pin declares %s, resolver returned no digest (fail-closed)", pinnedDigest)}
+		case "digest_mismatch":
+			pinnedDigest, _ := action.Details["pinned_digest"].(string)
+			liveDigest, _ := action.Details["live_digest"].(string)
+			byTarget[target] = vr{ok: false,
+				message: fmt.Sprintf("digest mismatch: want %s, got %s (ref: pinned %s, live %s)", pinnedDigest, liveDigest, pinnedRef, liveRef)}
+		case "target_unreachable":
+			errStr, _ := action.Details["error"].(string)
+			byTarget[target] = vr{ok: false,
+				message: fmt.Sprintf("unreachable: %s", errStr)}
+		default:
+			// ActionUpdate: ref drift (no digest involved).
+			if liveRef != "" {
+				byTarget[target] = vr{ok: false,
+					message: fmt.Sprintf("drift: pinned %s, live %s", pinnedRef, liveRef)}
+			} else {
+				byTarget[target] = vr{ok: false,
+					message: fmt.Sprintf("unexpected plan action %q for %s", action.Action, target)}
+			}
+		}
+	}
+
+	var results []VerifyResult
+	found := false
+	drifted := 0
+	for target, r := range byTarget {
+		if filterTarget != "" && target != filterTarget {
+			continue
+		}
+		found = true
+		results = append(results, VerifyResult{Target: target, OK: r.ok, Message: r.message})
+		if r.ok {
+			fmt.Fprintf(w, "[OK]    %s: %s\n", target, r.message)
+		} else {
+			fmt.Fprintf(w, "[DRIFT] %s: %s\n", target, r.message)
+			drifted++
+		}
+	}
+
+	if filterTarget != "" && !found {
+		return nil, fmt.Errorf("pin verify: no pin record found for target %q", filterTarget)
+	}
+	if drifted > 0 {
+		return results, fmt.Errorf("pin verify: %d pin(s) drifted or unreachable", drifted)
+	}
+	return results, nil
 }
 
 // ─── File helpers (used by CLI write operations) ─────────────────────────────

--- a/internal/providers/pin/pin.go
+++ b/internal/providers/pin/pin.go
@@ -1,0 +1,854 @@
+// Package pin implements the inter-workspace pin Reconcilable for CogOS.
+//
+// Pin records are source-side relationship facts declared at
+// <workspace>/.cog/pins/<target>.yaml. A source workspace pins a target
+// workspace at a specific git ref and optional content digest. Multiple
+// source workspaces can pin the same target independently — each pin record
+// carries its own ref, sync policy, and branch context.
+//
+// The Reconcilable lifecycle:
+//   - LoadConfig  — reads all .cog/pins/*.yaml files from the source workspace
+//   - FetchLive   — resolves the live HEAD ref for each target workspace
+//   - ComputePlan — diffs pinned ref vs live HEAD; emits drift actions
+//   - ApplyPlan   — bumps pin ref (after explicit user action); no-op for read-only
+//   - BuildState  — projects pin status into queryable Reconcile State
+//   - Health      — green/yellow/red aggregate across all pins
+//   - Reconcile   — full cycle (LoadConfig → FetchLive → ComputePlan → ApplyPlan)
+//
+// URIRegistry dependency: FetchLive resolves target workspace names via
+// URIRegistry (issue #167, not yet merged). Until #167 lands, FetchLive
+// stubs remote resolution and falls back to local git checkout inspection.
+// A clear TODO marks the integration point.
+package pin
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/cogos-dev/cogos/pkg/reconcile"
+)
+
+// ─── Schema types ────────────────────────────────────────────────────────────
+
+// SyncPolicy controls whether the reconciler can write back to the pin record.
+type SyncPolicy string
+
+const (
+	// SyncReadOnly means the reconciler observes drift but does not apply bumps.
+	SyncReadOnly SyncPolicy = "read-only"
+	// SyncReadWrite means the reconciler can auto-bump the pin to track live HEAD.
+	SyncReadWrite SyncPolicy = "read-write"
+	// SyncMirror means the target is kept as an exact local mirror of the source.
+	SyncMirror SyncPolicy = "mirror"
+)
+
+// PinRef holds the pinned position within a target workspace.
+type PinRef struct {
+	// Ref is a git tag or commit SHA. Required.
+	Ref string `yaml:"ref"`
+	// Digest is an optional content-addressed pin in "sha256:<hex>" format.
+	// When present, reconcile verifies the resolved commit matches this digest.
+	Digest string `yaml:"digest,omitempty"`
+	// Node is an optional node hint — which node hosts the pinned version.
+	// Informational only in v0; resolution uses the git ref.
+	Node string `yaml:"node,omitempty"`
+}
+
+// PinRecord is the on-disk schema for a single pin relationship.
+// Lives at <workspace>/.cog/pins/<sanitized-target-name>.yaml.
+type PinRecord struct {
+	// Target is the workspace name as registered in global.yaml (e.g. "cogos-dev/cogos").
+	// Must resolve via global workspace registry (URIRegistry in #167).
+	Target string `yaml:"target"`
+	// Pin holds the pinned position.
+	Pin PinRef `yaml:"pin"`
+	// Branch is the default branch context for this relationship (e.g. "main").
+	Branch string `yaml:"branch,omitempty"`
+	// Sync controls write-back behaviour. Defaults to "read-only".
+	Sync SyncPolicy `yaml:"sync,omitempty"`
+	// Updated is the timestamp of the last explicit pin bump.
+	Updated time.Time `yaml:"updated,omitempty"`
+
+	// filePath is the absolute path from which this record was loaded.
+	// Not serialized; set by loadPinRecords.
+	filePath string
+}
+
+// LiveRef is the resolved current HEAD of a target workspace.
+type LiveRef struct {
+	// Target is the workspace name (mirrors PinRecord.Target).
+	Target string
+	// Ref is the current HEAD ref (commit SHA or tag).
+	Ref string
+	// Digest is the content digest of the resolved ref (if computable).
+	Digest string
+	// Reachable is false when the target workspace cannot be reached.
+	Reachable bool
+	// Error holds the resolution error when Reachable is false.
+	Error error
+}
+
+// ─── Config bundle ───────────────────────────────────────────────────────────
+
+// pinConfig is the LoadConfig output. It bundles all pin records for a
+// source workspace so the rest of the lifecycle can operate without re-reading
+// the filesystem.
+type pinConfig struct {
+	Root    string
+	Records []*PinRecord
+	PinsDir string
+}
+
+// ─── Live bundle ─────────────────────────────────────────────────────────────
+
+// pinLive is the FetchLive output. For each declared pin, it holds the
+// resolved live HEAD.
+type pinLive struct {
+	Refs map[string]*LiveRef // target → live ref
+}
+
+// ─── Provider ────────────────────────────────────────────────────────────────
+
+// Provider implements reconcile.Reconcilable for the pin resource type.
+//
+// Construct via New; inject a GitHeadResolver for FetchLive. Tests supply
+// a stubResolver; production defaults to localGitHeadResolver.
+//
+// Thread safety: mu protects all mutable fields. LoadConfig, FetchLive, and
+// the Health probe are the only callers that mutate state; they are sequenced
+// by the reconcile harness, but the foveated context block calls Health()
+// concurrently with the reconcile loop — hence the lock.
+type Provider struct {
+	mu sync.Mutex
+
+	resolver GitHeadResolver
+
+	// State updated through the lifecycle and surfaced by Health().
+	root      string
+	lastPlan  *reconcile.Plan
+	pinStates map[string]*pinState // target → last-known state
+	operation reconcile.OperationPhase
+}
+
+// pinState tracks per-pin health derived from the last reconcile pass.
+type pinState struct {
+	Target    string
+	PinnedRef string
+	LiveRef   string
+	Sync      reconcile.SyncStatus
+	Health    reconcile.HealthStatus
+	Message   string
+}
+
+// New constructs a Provider. Pass nil for resolver to use the default
+// local-checkout git resolver. Tests inject a stubResolver.
+func New(resolver GitHeadResolver) *Provider {
+	if resolver == nil {
+		resolver = &localGitHeadResolver{}
+	}
+	return &Provider{
+		resolver:  resolver,
+		pinStates: make(map[string]*pinState),
+		operation: reconcile.OperationIdle,
+	}
+}
+
+// Type returns the provider identifier. Used by the reconcile registry and
+// the "cog reconcile" dispatch.
+func (p *Provider) Type() string { return "pin" }
+
+// ─── GitHeadResolver ─────────────────────────────────────────────────────────
+
+// GitHeadResolver resolves the live HEAD ref for a target workspace.
+// The interface isolates FetchLive from filesystem and network I/O so tests
+// can inject deterministic stubs.
+type GitHeadResolver interface {
+	// ResolveHead returns the live HEAD commit SHA for the target workspace
+	// identified by name. workspaceRoot is the source workspace root (used for
+	// relative-path fallback when target is a sibling checkout).
+	//
+	// TODO(#167): when URIRegistry lands, implementations should consult it for
+	// canonical target path resolution before falling back to local checkout.
+	ResolveHead(ctx context.Context, target, workspaceRoot string) (ref, digest string, err error)
+}
+
+// localGitHeadResolver is the production GitHeadResolver.
+// It resolves target workspace paths by scanning sibling directories relative
+// to the source workspace and running `git rev-parse HEAD`.
+//
+// TODO(#167): wire URIRegistry here once PR #167 merges.
+// The lookup chain should be:
+//   1. URIRegistry.Resolve("cog://workspace/<target>") → path
+//   2. Fallback: sibling-directory scan (current behaviour)
+type localGitHeadResolver struct{}
+
+func (r *localGitHeadResolver) ResolveHead(ctx context.Context, target, workspaceRoot string) (string, string, error) {
+	targetPath := r.locateTarget(target, workspaceRoot)
+	if targetPath == "" {
+		return "", "", fmt.Errorf("pin: target workspace %q not found locally (TODO: consult URIRegistry after #167)", target)
+	}
+
+	// git rev-parse HEAD in the target directory.
+	cmd := exec.CommandContext(ctx, "git", "-C", targetPath, "rev-parse", "HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", "", fmt.Errorf("pin: resolving HEAD for %q at %s: %w", target, targetPath, err)
+	}
+	ref := strings.TrimSpace(string(out))
+	return ref, "", nil // digest computation deferred to v1
+}
+
+// locateTarget attempts to find a local checkout of the target workspace.
+// Strategy: look for a directory whose last path component or last-two components
+// matches the target name (e.g., "cogos-dev/cogos" → sibling "cogos-dev/cogos"
+// or "cogos").
+func (r *localGitHeadResolver) locateTarget(target, workspaceRoot string) string {
+	if workspaceRoot == "" {
+		return ""
+	}
+
+	// Normalise target: convert "/" to OS separator.
+	// candidate 1: sibling of workspaceRoot with same name as last segment.
+	// candidate 2: parent-level path matching full target.
+	parent := filepath.Dir(workspaceRoot)
+	grandParent := filepath.Dir(parent)
+
+	// "cogos-dev/cogos" → last two components in sibling tree.
+	parts := strings.SplitN(target, "/", 2)
+	switch len(parts) {
+	case 1:
+		// single-component target (e.g., "cogos") — look as a sibling dir.
+		candidate := filepath.Join(parent, parts[0])
+		if isGitRepo(candidate) {
+			return candidate
+		}
+	case 2:
+		// two-component target (e.g., "cogos-dev/cogos") — look one level up.
+		candidate := filepath.Join(grandParent, parts[0], parts[1])
+		if isGitRepo(candidate) {
+			return candidate
+		}
+		// Also try: sibling with last-segment name.
+		candidateFlat := filepath.Join(parent, parts[1])
+		if isGitRepo(candidateFlat) {
+			return candidateFlat
+		}
+	}
+	return ""
+}
+
+// isGitRepo returns true when path is a directory containing a .git entry.
+func isGitRepo(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	_, err = os.Stat(filepath.Join(path, ".git"))
+	return err == nil
+}
+
+// ─── LoadConfig ──────────────────────────────────────────────────────────────
+
+// LoadConfig reads all pin records from <root>/.cog/pins/*.yaml.
+// Returns a *pinConfig as any; other methods type-assert it back.
+// An empty pins directory is not an error — the provider is healthy with zero pins.
+func (p *Provider) LoadConfig(root string) (any, error) {
+	p.mu.Lock()
+	p.root = root
+	p.mu.Unlock()
+
+	records, err := loadPinRecords(root)
+	if err != nil {
+		return nil, fmt.Errorf("pin provider: LoadConfig: %w", err)
+	}
+
+	return &pinConfig{
+		Root:    root,
+		Records: records,
+		PinsDir: pinsDir(root),
+	}, nil
+}
+
+// loadPinRecords reads all *.yaml files from <root>/.cog/pins/ and parses them
+// as PinRecord. Files that fail to parse are skipped with a warning logged to
+// stderr (not a hard error — a single malformed pin should not brick the whole
+// reconcile cycle).
+func loadPinRecords(root string) ([]*PinRecord, error) {
+	dir := pinsDir(root)
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil, nil // no pins declared — healthy
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading pins directory %s: %w", dir, err)
+	}
+
+	var records []*PinRecord
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".yaml" {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		rec, err := parsePinFile(path)
+		if err != nil {
+			// Log and skip — one bad file should not prevent other pins from reconciling.
+			fmt.Fprintf(os.Stderr, "pin provider: skipping %s: %v\n", path, err)
+			continue
+		}
+		rec.filePath = path
+		records = append(records, rec)
+	}
+	return records, nil
+}
+
+// parsePinFile decodes a single pin YAML file.
+func parsePinFile(path string) (*PinRecord, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	var rec PinRecord
+	if err := yaml.Unmarshal(data, &rec); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	if rec.Target == "" {
+		return nil, fmt.Errorf("pin record %s: missing required field 'target'", path)
+	}
+	if rec.Pin.Ref == "" {
+		return nil, fmt.Errorf("pin record %s: missing required field 'pin.ref'", path)
+	}
+	if rec.Sync == "" {
+		rec.Sync = SyncReadOnly
+	}
+	return &rec, nil
+}
+
+// pinsDir returns the absolute path of the pins directory for a workspace root.
+func pinsDir(root string) string {
+	return filepath.Join(root, ".cog", "pins")
+}
+
+// ─── FetchLive ───────────────────────────────────────────────────────────────
+
+// FetchLive resolves the live HEAD for each declared target workspace.
+// Config must be *pinConfig. Returns *pinLive as any.
+// Resolution failures are captured per-target (Reachable=false) rather than
+// failing the whole fetch — one unreachable target should not mask the rest.
+func (p *Provider) FetchLive(ctx context.Context, config any) (any, error) {
+	cfg, ok := config.(*pinConfig)
+	if !ok {
+		return nil, fmt.Errorf("pin: FetchLive expected *pinConfig, got %T", config)
+	}
+
+	live := &pinLive{Refs: make(map[string]*LiveRef, len(cfg.Records))}
+	for _, rec := range cfg.Records {
+		ref, digest, err := p.resolver.ResolveHead(ctx, rec.Target, cfg.Root)
+		lr := &LiveRef{
+			Target:    rec.Target,
+			Reachable: err == nil,
+		}
+		if err != nil {
+			lr.Error = err
+		} else {
+			lr.Ref = ref
+			lr.Digest = digest
+		}
+		live.Refs[rec.Target] = lr
+	}
+	return live, nil
+}
+
+// ─── ComputePlan ─────────────────────────────────────────────────────────────
+
+// ComputePlan diffs each pinned ref against the live HEAD.
+// Emits one Action per pin:
+//   - skip    if pinned ref matches live HEAD (and digest matches when declared)
+//   - update  if pinned ref is behind live HEAD
+//   - skip    with Health=Degraded if target unreachable
+//   - skip    with Health=Degraded if digest declared but mismatched
+func (p *Provider) ComputePlan(config any, live any, state *reconcile.State) (*reconcile.Plan, error) {
+	cfg, ok := config.(*pinConfig)
+	if !ok {
+		return nil, fmt.Errorf("pin: ComputePlan expected *pinConfig, got %T", config)
+	}
+	lv, ok := live.(*pinLive)
+	if !ok {
+		return nil, fmt.Errorf("pin: ComputePlan expected *pinLive, got %T", live)
+	}
+
+	plan := &reconcile.Plan{
+		ResourceType: "pin",
+		GeneratedAt:  time.Now().UTC().Format(time.RFC3339),
+		ConfigPath:   cfg.PinsDir,
+	}
+
+	newStates := make(map[string]*pinState, len(cfg.Records))
+
+	for _, rec := range cfg.Records {
+		lr := lv.Refs[rec.Target]
+		ps := &pinState{
+			Target:    rec.Target,
+			PinnedRef: rec.Pin.Ref,
+		}
+
+		if lr == nil || !lr.Reachable {
+			errMsg := "unreachable"
+			if lr != nil && lr.Error != nil {
+				errMsg = lr.Error.Error()
+			}
+			ps.Sync = reconcile.SyncStatusUnknown
+			ps.Health = reconcile.HealthMissing
+			ps.Message = fmt.Sprintf("target %q unreachable: %s", rec.Target, errMsg)
+			plan.Actions = append(plan.Actions, reconcile.Action{
+				Action:       reconcile.ActionSkip,
+				ResourceType: "pin",
+				Name:         rec.Target,
+				Details: map[string]any{
+					"reason":     "target_unreachable",
+					"pinned_ref": rec.Pin.Ref,
+					"error":      errMsg,
+				},
+			})
+			plan.Summary.Skipped++
+			newStates[rec.Target] = ps
+			continue
+		}
+
+		ps.LiveRef = lr.Ref
+
+		// Digest verification (when declared).
+		if rec.Pin.Digest != "" && lr.Digest != "" {
+			pinnedDigest := normaliseDigest(rec.Pin.Digest)
+			liveDigest := normaliseDigest(lr.Digest)
+			if pinnedDigest != liveDigest {
+				ps.Sync = reconcile.SyncStatusOutOfSync
+				ps.Health = reconcile.HealthDegraded
+				ps.Message = fmt.Sprintf("digest mismatch: want %s, got %s", pinnedDigest, liveDigest)
+				plan.Actions = append(plan.Actions, reconcile.Action{
+					Action:       reconcile.ActionSkip,
+					ResourceType: "pin",
+					Name:         rec.Target,
+					Details: map[string]any{
+						"reason":       "digest_mismatch",
+						"pinned_ref":   rec.Pin.Ref,
+						"pinned_digest": rec.Pin.Digest,
+						"live_ref":     lr.Ref,
+						"live_digest":  lr.Digest,
+					},
+				})
+				plan.Summary.Skipped++
+				newStates[rec.Target] = ps
+				continue
+			}
+		}
+
+		// Ref comparison.
+		if refsMatch(rec.Pin.Ref, lr.Ref) {
+			ps.Sync = reconcile.SyncStatusSynced
+			ps.Health = reconcile.HealthHealthy
+			ps.Message = fmt.Sprintf("pinned at %s, live HEAD matches", shortRef(rec.Pin.Ref))
+			plan.Actions = append(plan.Actions, reconcile.Action{
+				Action:       reconcile.ActionSkip,
+				ResourceType: "pin",
+				Name:         rec.Target,
+				Details: map[string]any{
+					"reason":     "in_sync",
+					"pinned_ref": rec.Pin.Ref,
+					"live_ref":   lr.Ref,
+				},
+			})
+			plan.Summary.Skipped++
+		} else {
+			ps.Sync = reconcile.SyncStatusOutOfSync
+			ps.Health = reconcile.HealthDegraded
+			ps.Message = fmt.Sprintf("drift: pinned %s, live HEAD %s", shortRef(rec.Pin.Ref), shortRef(lr.Ref))
+			ps.LiveRef = lr.Ref
+			plan.Actions = append(plan.Actions, reconcile.Action{
+				Action:       reconcile.ActionUpdate,
+				ResourceType: "pin",
+				Name:         rec.Target,
+				Details: map[string]any{
+					"pinned_ref":  rec.Pin.Ref,
+					"live_ref":    lr.Ref,
+					"sync_policy": string(rec.Sync),
+					"branch":      rec.Branch,
+					"file":        rec.filePath,
+				},
+			})
+			plan.Summary.Updates++
+		}
+		newStates[rec.Target] = ps
+	}
+
+	p.mu.Lock()
+	p.lastPlan = plan
+	p.pinStates = newStates
+	p.mu.Unlock()
+
+	return plan, nil
+}
+
+// refsMatch returns true if two git refs refer to the same commit.
+// Handles: exact match, short SHA prefix match (7-char minimum).
+func refsMatch(a, b string) bool {
+	a = strings.TrimSpace(a)
+	b = strings.TrimSpace(b)
+	if a == b {
+		return true
+	}
+	// SHA prefix: if one is a prefix of the other and at least 7 chars long.
+	shorter, longer := a, b
+	if len(a) > len(b) {
+		shorter, longer = b, a
+	}
+	return len(shorter) >= 7 && strings.HasPrefix(longer, shorter)
+}
+
+// shortRef truncates a full SHA to 12 chars for display.
+func shortRef(ref string) string {
+	if len(ref) > 12 && isHexString(ref) {
+		return ref[:12]
+	}
+	return ref
+}
+
+// isHexString returns true if s looks like a hex string.
+func isHexString(s string) bool {
+	_, err := hex.DecodeString(s)
+	return err == nil
+}
+
+// normaliseDigest strips the "sha256:" prefix and lowercases the hex portion
+// for comparison.
+func normaliseDigest(d string) string {
+	d = strings.ToLower(strings.TrimSpace(d))
+	if after, ok := strings.CutPrefix(d, "sha256:"); ok {
+		return "sha256:" + after
+	}
+	return d
+}
+
+// ─── ApplyPlan ───────────────────────────────────────────────────────────────
+
+// ApplyPlan executes update actions from the plan.
+// For sync:read-only pins, update actions are skipped with ApplySkipped.
+// For sync:read-write pins, the pin YAML file is updated with the new ref.
+// For sync:mirror — not yet implemented in v0; treated as read-write.
+func (p *Provider) ApplyPlan(ctx context.Context, plan *reconcile.Plan) ([]reconcile.Result, error) {
+	results := make([]reconcile.Result, 0, len(plan.Actions))
+
+	for _, action := range plan.Actions {
+		if action.Action != reconcile.ActionUpdate {
+			continue
+		}
+		target := action.Name
+		syncPolicy, _ := action.Details["sync_policy"].(string)
+		filePath, _ := action.Details["file"].(string)
+		newRef, _ := action.Details["live_ref"].(string)
+
+		// read-only: refuse the write-back.
+		if SyncPolicy(syncPolicy) == SyncReadOnly || syncPolicy == "" {
+			results = append(results, reconcile.Result{
+				Phase:  "apply",
+				Action: string(reconcile.ActionUpdate),
+				Name:   target,
+				Status: reconcile.ApplySkipped,
+				Error:  "sync: read-only — bump requires explicit `cog pin bump`",
+			})
+			continue
+		}
+
+		if filePath == "" {
+			results = append(results, reconcile.Result{
+				Phase:  "apply",
+				Action: string(reconcile.ActionUpdate),
+				Name:   target,
+				Status: reconcile.ApplyFailed,
+				Error:  "pin file path not set in plan details",
+			})
+			continue
+		}
+
+		if err := bumpPinFile(filePath, newRef); err != nil {
+			results = append(results, reconcile.Result{
+				Phase:  "apply",
+				Action: string(reconcile.ActionUpdate),
+				Name:   target,
+				Status: reconcile.ApplyFailed,
+				Error:  err.Error(),
+			})
+		} else {
+			results = append(results, reconcile.Result{
+				Phase:  "apply",
+				Action: string(reconcile.ActionUpdate),
+				Name:   target,
+				Status: reconcile.ApplySucceeded,
+			})
+		}
+	}
+	return results, nil
+}
+
+// bumpPinFile rewrites the pin.ref field in the YAML file to newRef and
+// updates the updated timestamp. It round-trips through yaml.v3 to preserve
+// comments and formatting as much as possible.
+func bumpPinFile(path, newRef string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("bump: reading %s: %w", path, err)
+	}
+	var rec PinRecord
+	if err := yaml.Unmarshal(data, &rec); err != nil {
+		return fmt.Errorf("bump: parsing %s: %w", path, err)
+	}
+	rec.Pin.Ref = newRef
+	rec.Updated = time.Now().UTC()
+
+	out, err := yaml.Marshal(&rec)
+	if err != nil {
+		return fmt.Errorf("bump: marshalling %s: %w", path, err)
+	}
+	if err := os.WriteFile(path, out, 0o644); err != nil {
+		return fmt.Errorf("bump: writing %s: %w", path, err)
+	}
+	return nil
+}
+
+// ─── BuildState ──────────────────────────────────────────────────────────────
+
+// BuildState constructs a reconcile.State snapshot from the live pin data.
+// Used for `cog state pin` and import operations.
+func (p *Provider) BuildState(config any, live any, existing *reconcile.State) (*reconcile.State, error) {
+	cfg, ok := config.(*pinConfig)
+	if !ok {
+		return nil, fmt.Errorf("pin: BuildState expected *pinConfig, got %T", config)
+	}
+	lv, ok := live.(*pinLive)
+	if !ok {
+		return nil, fmt.Errorf("pin: BuildState expected *pinLive, got %T", live)
+	}
+
+	lineage := "pin"
+	serial := 1
+	if existing != nil {
+		lineage = existing.Lineage
+		serial = existing.Serial + 1
+	}
+
+	state := &reconcile.State{
+		Version:      1,
+		Lineage:      lineage,
+		Serial:       serial,
+		ResourceType: "pin",
+		GeneratedAt:  time.Now().UTC().Format(time.RFC3339),
+	}
+
+	for _, rec := range cfg.Records {
+		lr := lv.Refs[rec.Target]
+		attrs := map[string]any{
+			"target":     rec.Target,
+			"pinned_ref": rec.Pin.Ref,
+			"sync":       string(rec.Sync),
+			"branch":     rec.Branch,
+		}
+		if rec.Pin.Digest != "" {
+			attrs["pinned_digest"] = rec.Pin.Digest
+		}
+		if lr != nil && lr.Reachable {
+			attrs["live_ref"] = lr.Ref
+			attrs["reachable"] = true
+		} else {
+			attrs["reachable"] = false
+		}
+
+		state.Resources = append(state.Resources, reconcile.Resource{
+			Address:       "pin." + sanitiseName(rec.Target),
+			Type:          "pin",
+			Mode:          reconcile.ModeManaged,
+			ExternalID:    rec.Target,
+			Name:          rec.Target,
+			Attributes:    attrs,
+			LastRefreshed: time.Now().UTC().Format(time.RFC3339),
+		})
+	}
+	return state, nil
+}
+
+// sanitiseName converts "cogos-dev/cogos" → "cogos-dev_cogos" for use as a
+// Reconcile State address component.
+func sanitiseName(name string) string {
+	return strings.ReplaceAll(name, "/", "_")
+}
+
+// ─── Health ───────────────────────────────────────────────────────────────────
+
+// Health returns the aggregate three-axis status across all pins.
+//
+//   - No pins declared → Healthy (nothing to drift on)
+//   - All pins in sync → Healthy, Synced
+//   - Any pin unreachable → Degraded, OutOfSync (can't verify)
+//   - Any digest mismatch → Degraded, OutOfSync (integrity violation)
+//   - Any ref drift (behind live) → Degraded, OutOfSync
+//   - workspace root not yet configured → Missing, Unknown
+func (p *Provider) Health() reconcile.ResourceStatus {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.root == "" {
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusUnknown,
+			Health:    reconcile.HealthMissing,
+			Operation: reconcile.OperationIdle,
+			Message:   "workspace root not yet configured",
+		}
+	}
+
+	if len(p.pinStates) == 0 {
+		// Check whether the pins dir exists — if not, no pins declared at all.
+		dir := pinsDir(p.root)
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			return reconcile.ResourceStatus{
+				Sync:      reconcile.SyncStatusSynced,
+				Health:    reconcile.HealthHealthy,
+				Operation: reconcile.OperationIdle,
+				Message:   "no pins declared",
+			}
+		}
+	}
+
+	total := len(p.pinStates)
+	if total == 0 {
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusSynced,
+			Health:    reconcile.HealthHealthy,
+			Operation: reconcile.OperationIdle,
+			Message:   "no pins declared",
+		}
+	}
+
+	missing, drifted, synced := 0, 0, 0
+	var msgs []string
+	for _, ps := range p.pinStates {
+		switch ps.Health {
+		case reconcile.HealthMissing:
+			missing++
+			msgs = append(msgs, ps.Message)
+		case reconcile.HealthDegraded:
+			drifted++
+			msgs = append(msgs, ps.Message)
+		default:
+			synced++
+		}
+	}
+
+	switch {
+	case missing > 0:
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusOutOfSync,
+			Health:    reconcile.HealthDegraded,
+			Operation: reconcile.OperationIdle,
+			Message:   fmt.Sprintf("%d/%d unreachable: %s", missing, total, firstN(msgs, 2)),
+		}
+	case drifted > 0:
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusOutOfSync,
+			Health:    reconcile.HealthDegraded,
+			Operation: reconcile.OperationIdle,
+			Message:   fmt.Sprintf("%d/%d pins drifted: %s", drifted, total, firstN(msgs, 2)),
+		}
+	default:
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusSynced,
+			Health:    reconcile.HealthHealthy,
+			Operation: reconcile.OperationIdle,
+			Message:   fmt.Sprintf("%d/%d pins in sync", synced, total),
+		}
+	}
+}
+
+// firstN joins the first n messages from msgs.
+func firstN(msgs []string, n int) string {
+	if len(msgs) <= n {
+		return strings.Join(msgs, "; ")
+	}
+	return strings.Join(msgs[:n], "; ") + fmt.Sprintf(" (+%d more)", len(msgs)-n)
+}
+
+// ─── Reconcile (full cycle) ──────────────────────────────────────────────────
+
+// Reconcile runs the full LoadConfig → FetchLive → ComputePlan → ApplyPlan cycle.
+// It is called by the kernel reconcile harness on each tick.
+func (p *Provider) Reconcile(ctx context.Context, root string) ([]reconcile.Result, error) {
+	p.mu.Lock()
+	p.operation = reconcile.OperationSyncing
+	p.mu.Unlock()
+	defer func() {
+		p.mu.Lock()
+		p.operation = reconcile.OperationIdle
+		p.mu.Unlock()
+	}()
+
+	cfg, err := p.LoadConfig(root)
+	if err != nil {
+		return nil, err
+	}
+	live, err := p.FetchLive(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	plan, err := p.ComputePlan(cfg, live, nil)
+	if err != nil {
+		return nil, err
+	}
+	return p.ApplyPlan(ctx, plan)
+}
+
+// ─── File helpers (used by CLI write operations) ─────────────────────────────
+
+// WritePinRecord serialises rec to <root>/.cog/pins/<filename>.yaml.
+// Creates the pins directory if it does not exist.
+func WritePinRecord(root string, rec *PinRecord) error {
+	dir := pinsDir(root)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("pin: creating pins dir %s: %w", dir, err)
+	}
+	filename := sanitiseFilename(rec.Target) + ".yaml"
+	path := filepath.Join(dir, filename)
+
+	data, err := yaml.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("pin: marshalling %s: %w", rec.Target, err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("pin: writing %s: %w", path, err)
+	}
+	return nil
+}
+
+// RemovePinRecord deletes the pin YAML for target from the workspace.
+func RemovePinRecord(root, target string) error {
+	filename := sanitiseFilename(target) + ".yaml"
+	path := filepath.Join(pinsDir(root), filename)
+	if err := os.Remove(path); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("pin: no pin record found for target %q", target)
+		}
+		return fmt.Errorf("pin: removing %s: %w", path, err)
+	}
+	return nil
+}
+
+// sanitiseFilename converts a target workspace name to a safe filename stem.
+// "cogos-dev/cogos" → "cogos-dev_cogos"
+func sanitiseFilename(target string) string {
+	return strings.NewReplacer("/", "_", ":", "_", " ", "_").Replace(target)
+}

--- a/internal/providers/pin/pin.go
+++ b/internal/providers/pin/pin.go
@@ -425,9 +425,44 @@ func (p *Provider) ComputePlan(config any, live any, state *reconcile.State) (*r
 
 		ps.LiveRef = lr.Ref
 
-		// Digest verification (when declared).
-		if rec.Pin.Digest != "" && lr.Digest != "" {
+		// Digest verification (fail-closed per ADR-067 amendment).
+		//
+		// The local resolver (localGitHeadResolver) does not compute a content
+		// digest — it returns empty string for digest. This is expected: git SHA
+		// resolution does not produce a sha256 content hash without reading
+		// and hashing the tree, which is deferred to v1 (TODO #167 / URIRegistry).
+		//
+		// However, per the ADR-067 fail-closed amendment: if the pin record
+		// DECLARES a digest, the reconciler MUST treat an unverifiable live
+		// digest as a RED condition rather than silently ignoring the integrity
+		// constraint. Three cases:
+		//   1. pinned == "" → no digest check; fall through to ref comparison.
+		//   2. pinned != "" and live == "" → RED: "digest unverifiable".
+		//   3. pinned != "" and live != "" and mismatch → RED: "digest mismatch".
+		//   4. pinned != "" and live != "" and match → proceed to ref comparison.
+		if rec.Pin.Digest != "" {
 			pinnedDigest := normaliseDigest(rec.Pin.Digest)
+			if lr.Digest == "" {
+				// Case 2: declared digest, resolver returned nothing — fail closed.
+				ps.Sync = reconcile.SyncStatusOutOfSync
+				ps.Health = reconcile.HealthDegraded
+				ps.Message = fmt.Sprintf("digest unverifiable: pin declares %s but resolver returned no digest (fail-closed per ADR-067)", pinnedDigest)
+				plan.Actions = append(plan.Actions, reconcile.Action{
+					Action:       reconcile.ActionSkip,
+					ResourceType: "pin",
+					Name:         rec.Target,
+					Details: map[string]any{
+						"reason":        "digest_unverifiable",
+						"pinned_ref":    rec.Pin.Ref,
+						"pinned_digest": rec.Pin.Digest,
+						"live_ref":      lr.Ref,
+					},
+				})
+				plan.Summary.Skipped++
+				newStates[rec.Target] = ps
+				continue
+			}
+			// Case 3: both present, compare.
 			liveDigest := normaliseDigest(lr.Digest)
 			if pinnedDigest != liveDigest {
 				ps.Sync = reconcile.SyncStatusOutOfSync
@@ -438,17 +473,18 @@ func (p *Provider) ComputePlan(config any, live any, state *reconcile.State) (*r
 					ResourceType: "pin",
 					Name:         rec.Target,
 					Details: map[string]any{
-						"reason":       "digest_mismatch",
-						"pinned_ref":   rec.Pin.Ref,
+						"reason":        "digest_mismatch",
+						"pinned_ref":    rec.Pin.Ref,
 						"pinned_digest": rec.Pin.Digest,
-						"live_ref":     lr.Ref,
-						"live_digest":  lr.Digest,
+						"live_ref":      lr.Ref,
+						"live_digest":   lr.Digest,
 					},
 				})
 				plan.Summary.Skipped++
 				newStates[rec.Target] = ps
 				continue
 			}
+			// Case 4: match — fall through to ref comparison.
 		}
 
 		// Ref comparison.

--- a/internal/providers/pin/pin_test.go
+++ b/internal/providers/pin/pin_test.go
@@ -1,9 +1,11 @@
 package pin_test
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -610,4 +612,132 @@ func runAndCheck(t *testing.T, p *pin.Provider, root string, check func(reconcil
 		t.Fatalf("ComputePlan: %v", err)
 	}
 	check(p.Health())
+}
+
+// ─── Tests: Bug C — direct cmdPinVerify via pin.RunVerify ────────────────────
+//
+// These tests invoke pin.RunVerify (the extracted helper that cmdPinVerify
+// wraps) directly, so reverting the CLI shim to its old broken form would
+// cause the tests here — not just the plan-reason tests — to fail.
+
+// TestRunVerify_DigestUnverifiable calls RunVerify against a workspace where
+// the pin declares a digest but the stub resolver returns no digest (empty
+// string). Expects [DRIFT] output containing "digest unverifiable" and a
+// non-nil error.
+func TestRunVerify_DigestUnverifiable(t *testing.T) {
+	root := setupWorkspace(t)
+	const target = "cogos-dev/cogos"
+	writePinYAML(t, root, "cogos-dev_cogos", `
+target: cogos-dev/cogos
+pin:
+  ref: abc1234567890
+  digest: sha256:aabbcc
+sync: read-only
+`)
+
+	// Stub returns a ref but no digest — simulates a resolver that cannot
+	// compute content digests (the current localGitHeadResolver behaviour).
+	s := &stubResolver{refs: map[string]struct {
+		ref    string
+		digest string
+		err    error
+	}{
+		target: {ref: "abc1234567890", digest: ""},
+	}}
+
+	var buf bytes.Buffer
+	results, err := pin.RunVerify(context.Background(), root, "", s, &buf)
+	if err == nil {
+		t.Fatal("RunVerify: expected error for digest_unverifiable, got nil")
+	}
+	if !strings.Contains(err.Error(), "drifted or unreachable") {
+		t.Errorf("RunVerify error: want 'drifted or unreachable', got %q", err.Error())
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "[DRIFT]") {
+		t.Errorf("RunVerify output missing [DRIFT] marker; got:\n%s", out)
+	}
+	if !strings.Contains(out, "digest unverifiable") {
+		t.Errorf("RunVerify output missing 'digest unverifiable'; got:\n%s", out)
+	}
+
+	if len(results) != 1 || results[0].OK {
+		t.Errorf("RunVerify results: want 1 NOT-OK result, got %+v", results)
+	}
+}
+
+// TestRunVerify_DigestMismatch calls RunVerify against a workspace where the
+// pin declares a digest that does not match what the resolver returns.
+// Expects [DRIFT] output containing "digest mismatch".
+func TestRunVerify_DigestMismatch(t *testing.T) {
+	root := setupWorkspace(t)
+	const target = "cogos-dev/cogos"
+	writePinYAML(t, root, "cogos-dev_cogos", `
+target: cogos-dev/cogos
+pin:
+  ref: abc1234567890
+  digest: sha256:aaaa
+sync: read-only
+`)
+
+	s := &stubResolver{refs: map[string]struct {
+		ref    string
+		digest string
+		err    error
+	}{
+		target: {ref: "abc1234567890", digest: "sha256:bbbb"},
+	}}
+
+	var buf bytes.Buffer
+	results, err := pin.RunVerify(context.Background(), root, "", s, &buf)
+	if err == nil {
+		t.Fatal("RunVerify: expected error for digest_mismatch, got nil")
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "[DRIFT]") {
+		t.Errorf("RunVerify output missing [DRIFT] marker; got:\n%s", out)
+	}
+	if !strings.Contains(out, "digest mismatch") {
+		t.Errorf("RunVerify output missing 'digest mismatch'; got:\n%s", out)
+	}
+
+	if len(results) != 1 || results[0].OK {
+		t.Errorf("RunVerify results: want 1 NOT-OK result, got %+v", results)
+	}
+}
+
+// TestRunVerify_TargetUnreachable calls RunVerify against a workspace where
+// the stub resolver returns an error (target not found). Expects [DRIFT]
+// output containing "unreachable".
+func TestRunVerify_TargetUnreachable(t *testing.T) {
+	root := setupWorkspace(t)
+	const target = "cogos-dev/cogos"
+	writePinYAML(t, root, "cogos-dev_cogos", `
+target: cogos-dev/cogos
+pin:
+  ref: abc1234567890
+sync: read-only
+`)
+
+	s := newStubWithErr(target, os.ErrNotExist)
+
+	var buf bytes.Buffer
+	results, err := pin.RunVerify(context.Background(), root, "", s, &buf)
+	if err == nil {
+		t.Fatal("RunVerify: expected error for target_unreachable, got nil")
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "[DRIFT]") {
+		t.Errorf("RunVerify output missing [DRIFT] marker; got:\n%s", out)
+	}
+	if !strings.Contains(out, "unreachable") {
+		t.Errorf("RunVerify output missing 'unreachable'; got:\n%s", out)
+	}
+
+	if len(results) != 1 || results[0].OK {
+		t.Errorf("RunVerify results: want 1 NOT-OK result, got %+v", results)
+	}
 }

--- a/internal/providers/pin/pin_test.go
+++ b/internal/providers/pin/pin_test.go
@@ -421,6 +421,176 @@ sync: read-only
 	}
 }
 
+// ─── Tests: Codex Bug 2 — Digest fail-closed (declared digest, empty live) ───
+
+// TestComputePlan_DeclaredDigest_EmptyLive_Red verifies that when a pin record
+// declares a digest but the resolver returns an empty live digest, ComputePlan
+// produces a RED (Degraded/OutOfSync) health state rather than silently passing.
+//
+// This is the fail-closed behaviour mandated by the ADR-067 amendment:
+// "if a pin record declares digest: sha256:X and the resolver can't compute a
+// live digest, the result must be RED, not GREEN."
+func TestComputePlan_DeclaredDigest_EmptyLive_Red(t *testing.T) {
+	root := setupWorkspace(t)
+	const target = "cogos-dev/cogos"
+	writePinYAML(t, root, "cogos-dev_cogos", `
+target: cogos-dev/cogos
+pin:
+  ref: abc1234567890
+  digest: sha256:deadbeef
+sync: read-only
+`)
+
+	// Resolver returns a ref but NO digest (empty string) — simulates the
+	// localGitHeadResolver's current behaviour where digest computation is
+	// deferred to v1.
+	s := &stubResolver{refs: map[string]struct {
+		ref    string
+		digest string
+		err    error
+	}{
+		target: {ref: "abc1234567890", digest: ""},
+	}}
+
+	p := pin.New(s)
+	cfg, err := p.LoadConfig(root)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	live, err := p.FetchLive(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("FetchLive: %v", err)
+	}
+	plan, err := p.ComputePlan(cfg, live, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+
+	h := p.Health()
+	if h.Health != reconcile.HealthDegraded {
+		t.Errorf("declared digest + empty live: want Degraded, got %s: %s", h.Health, h.Message)
+	}
+	if h.Sync != reconcile.SyncStatusOutOfSync {
+		t.Errorf("declared digest + empty live: want OutOfSync, got %s", h.Sync)
+	}
+
+	// Verify the plan action reason is "digest_unverifiable".
+	found := false
+	for _, a := range plan.Actions {
+		if a.Name == target {
+			reason, _ := a.Details["reason"].(string)
+			if reason != "digest_unverifiable" {
+				t.Errorf("plan action reason: want digest_unverifiable, got %q", reason)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("no plan action found for target %q", target)
+	}
+}
+
+// ─── Tests: Codex Bug 3 — verify plan reflects digest/unreachable state ──────
+
+// TestComputePlan_VerifyDigestMismatch_PlanHasReason verifies that when a pin
+// record declares a digest that mismatches the live digest, the plan action
+// carries reason="digest_mismatch" in its Details map.
+//
+// This is the ground truth for cmdPinVerify: the CLI now reads from plan.Actions
+// directly (Bug 3 fix) instead of re-resolving refs. Correct plan action details
+// are the necessary precondition for correct verify output.
+func TestComputePlan_VerifyDigestMismatch_PlanHasReason(t *testing.T) {
+	root := setupWorkspace(t)
+	const target = "cogos-dev/cogos"
+	writePinYAML(t, root, "cogos-dev_cogos", `
+target: cogos-dev/cogos
+pin:
+  ref: abc1234567890
+  digest: sha256:aaaa
+sync: read-only
+`)
+
+	s := &stubResolver{refs: map[string]struct {
+		ref    string
+		digest string
+		err    error
+	}{
+		target: {ref: "abc1234567890", digest: "sha256:bbbb"},
+	}}
+
+	p := pin.New(s)
+	cfg, _ := p.LoadConfig(root)
+	live, _ := p.FetchLive(context.Background(), cfg)
+	plan, err := p.ComputePlan(cfg, live, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+
+	found := false
+	for _, a := range plan.Actions {
+		if a.Name == target {
+			reason, _ := a.Details["reason"].(string)
+			if reason != "digest_mismatch" {
+				t.Errorf("plan action reason: want digest_mismatch, got %q", reason)
+			}
+			pinnedDigest, _ := a.Details["pinned_digest"].(string)
+			liveDigest, _ := a.Details["live_digest"].(string)
+			if pinnedDigest == "" {
+				t.Error("plan action missing pinned_digest detail")
+			}
+			if liveDigest == "" {
+				t.Error("plan action missing live_digest detail")
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("no plan action found for target %q", target)
+	}
+
+	// Health must also reflect the mismatch.
+	h := p.Health()
+	if h.Health != reconcile.HealthDegraded {
+		t.Errorf("digest mismatch: want Degraded, got %s: %s", h.Health, h.Message)
+	}
+}
+
+// TestComputePlan_VerifyUnreachable_PlanHasReason verifies that when a target
+// is unreachable, the plan action carries reason="target_unreachable" so that
+// cmdPinVerify surfaces it correctly.
+func TestComputePlan_VerifyUnreachable_PlanHasReason(t *testing.T) {
+	root := setupWorkspace(t)
+	const target = "cogos-dev/cogos"
+	writePinYAML(t, root, "cogos-dev_cogos", `
+target: cogos-dev/cogos
+pin:
+  ref: abc1234567890
+sync: read-only
+`)
+
+	p := pin.New(newStubWithErr(target, os.ErrNotExist))
+	cfg, _ := p.LoadConfig(root)
+	live, _ := p.FetchLive(context.Background(), cfg)
+	plan, err := p.ComputePlan(cfg, live, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+
+	found := false
+	for _, a := range plan.Actions {
+		if a.Name == target {
+			reason, _ := a.Details["reason"].(string)
+			if reason != "target_unreachable" {
+				t.Errorf("plan action reason: want target_unreachable, got %q", reason)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("no plan action found for target %q", target)
+	}
+}
+
 // ─── helper ──────────────────────────────────────────────────────────────────
 
 // runAndCheck runs a full reconcile cycle (LoadConfig→FetchLive→ComputePlan)

--- a/internal/providers/pin/pin_test.go
+++ b/internal/providers/pin/pin_test.go
@@ -1,0 +1,443 @@
+package pin_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cogos-dev/cogos/internal/providers/pin"
+	"github.com/cogos-dev/cogos/pkg/reconcile"
+)
+
+// ─── Test helpers ────────────────────────────────────────────────────────────
+
+// setupWorkspace creates a temporary workspace directory with a .cog/pins/
+// sub-directory and returns the workspace root.
+func setupWorkspace(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".cog", "pins"), 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	return root
+}
+
+// writePinYAML writes a raw YAML string to <root>/.cog/pins/<name>.yaml.
+func writePinYAML(t *testing.T, root, name, content string) {
+	t.Helper()
+	path := filepath.Join(root, ".cog", "pins", name+".yaml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("writePinYAML %s: %v", name, err)
+	}
+}
+
+// stubResolver satisfies GitHeadResolver for tests.
+type stubResolver struct {
+	// refs maps target → (ref, digest, err).
+	refs map[string]struct {
+		ref    string
+		digest string
+		err    error
+	}
+}
+
+func (r *stubResolver) ResolveHead(_ context.Context, target, _ string) (string, string, error) {
+	if r.refs == nil {
+		return "", "", nil
+	}
+	entry, ok := r.refs[target]
+	if !ok {
+		return "", "", nil // unreachable but no error signal
+	}
+	return entry.ref, entry.digest, entry.err
+}
+
+// newStub constructs a stubResolver from a simple map[target]ref.
+func newStub(refs map[string]string) *stubResolver {
+	s := &stubResolver{refs: make(map[string]struct {
+		ref    string
+		digest string
+		err    error
+	}, len(refs))}
+	for target, ref := range refs {
+		s.refs[target] = struct {
+			ref    string
+			digest string
+			err    error
+		}{ref: ref}
+	}
+	return s
+}
+
+// newStubWithErr builds a resolver where some targets return errors.
+func newStubWithErr(target string, err error) *stubResolver {
+	s := &stubResolver{refs: make(map[string]struct {
+		ref    string
+		digest string
+		err    error
+	})}
+	s.refs[target] = struct {
+		ref    string
+		digest string
+		err    error
+	}{err: err}
+	return s
+}
+
+// ─── Tests: LoadConfig ───────────────────────────────────────────────────────
+
+func TestLoadConfig_NoPinsDir(t *testing.T) {
+	root := t.TempDir() // no .cog/pins/ dir
+	p := pin.New(nil)
+	cfg, err := p.LoadConfig(root)
+	if err != nil {
+		t.Fatalf("LoadConfig with no pins dir: unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+}
+
+func TestLoadConfig_EmptyPinsDir(t *testing.T) {
+	root := setupWorkspace(t)
+	p := pin.New(nil)
+	cfg, err := p.LoadConfig(root)
+	if err != nil {
+		t.Fatalf("LoadConfig empty: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+}
+
+func TestLoadConfig_SingleRecord(t *testing.T) {
+	root := setupWorkspace(t)
+	writePinYAML(t, root, "cogos-dev_cogos", `
+target: cogos-dev/cogos
+pin:
+  ref: v0.4.1
+branch: main
+sync: read-only
+updated: 2026-05-01T00:00:00Z
+`)
+	p := pin.New(nil)
+	_, err := p.LoadConfig(root)
+	if err != nil {
+		t.Fatalf("LoadConfig single: %v", err)
+	}
+}
+
+func TestLoadConfig_TwoSourcesIndependent(t *testing.T) {
+	// Two source workspaces pin the same target at different refs.
+	// This test proves: pins are source-side, not target-side.
+	root1 := setupWorkspace(t)
+	root2 := setupWorkspace(t)
+
+	const target = "cogos-dev/cogos"
+
+	writePinYAML(t, root1, "cogos-dev_cogos", `
+target: cogos-dev/cogos
+pin:
+  ref: v0.4.0
+sync: read-only
+`)
+	writePinYAML(t, root2, "cogos-dev_cogos", `
+target: cogos-dev/cogos
+pin:
+  ref: v0.5.0
+sync: read-only
+`)
+
+	p1 := pin.New(newStub(map[string]string{target: "v0.4.0"}))
+	p2 := pin.New(newStub(map[string]string{target: "v0.5.0"}))
+
+	cfg1, err := p1.LoadConfig(root1)
+	if err != nil {
+		t.Fatalf("root1 LoadConfig: %v", err)
+	}
+	cfg2, err := p2.LoadConfig(root2)
+	if err != nil {
+		t.Fatalf("root2 LoadConfig: %v", err)
+	}
+
+	live1, err := p1.FetchLive(context.Background(), cfg1)
+	if err != nil {
+		t.Fatalf("root1 FetchLive: %v", err)
+	}
+	live2, err := p2.FetchLive(context.Background(), cfg2)
+	if err != nil {
+		t.Fatalf("root2 FetchLive: %v", err)
+	}
+
+	plan1, err := p1.ComputePlan(cfg1, live1, nil)
+	if err != nil {
+		t.Fatalf("root1 ComputePlan: %v", err)
+	}
+	plan2, err := p2.ComputePlan(cfg2, live2, nil)
+	if err != nil {
+		t.Fatalf("root2 ComputePlan: %v", err)
+	}
+
+	// Both plans should contain skip actions (pinned == live for each).
+	for _, action := range plan1.Actions {
+		if action.Name == target && action.Action != reconcile.ActionSkip {
+			t.Errorf("root1: expected skip for %s, got %s", target, action.Action)
+		}
+	}
+	for _, action := range plan2.Actions {
+		if action.Name == target && action.Action != reconcile.ActionSkip {
+			t.Errorf("root2: expected skip for %s, got %s", target, action.Action)
+		}
+	}
+
+	// Verify the two providers are independent — health is Healthy for both.
+	h1 := p1.Health()
+	h2 := p2.Health()
+	if h1.Health != reconcile.HealthHealthy {
+		t.Errorf("root1 health: want Healthy, got %s: %s", h1.Health, h1.Message)
+	}
+	if h2.Health != reconcile.HealthHealthy {
+		t.Errorf("root2 health: want Healthy, got %s: %s", h2.Health, h2.Message)
+	}
+}
+
+// ─── Tests: Reconcile — pinned ref matches live ───────────────────────────────
+
+func TestReconcile_InSync_Green(t *testing.T) {
+	root := setupWorkspace(t)
+	const target = "cogos-dev/cogos"
+	const ref = "abc1234567890"
+	writePinYAML(t, root, "cogos-dev_cogos", `
+target: cogos-dev/cogos
+pin:
+  ref: abc1234567890
+sync: read-only
+`)
+
+	p := pin.New(newStub(map[string]string{target: ref}))
+	runAndCheck(t, p, root, func(h reconcile.ResourceStatus) {
+		if h.Health != reconcile.HealthHealthy {
+			t.Errorf("in-sync: want Healthy, got %s: %s", h.Health, h.Message)
+		}
+		if h.Sync != reconcile.SyncStatusSynced {
+			t.Errorf("in-sync: want Synced, got %s", h.Sync)
+		}
+	})
+}
+
+// ─── Tests: Reconcile — pinned ref behind live ────────────────────────────────
+
+func TestReconcile_Drift_Yellow(t *testing.T) {
+	root := setupWorkspace(t)
+	const target = "cogos-dev/cogos"
+	writePinYAML(t, root, "cogos-dev_cogos", `
+target: cogos-dev/cogos
+pin:
+  ref: abc000000000
+sync: read-only
+`)
+
+	p := pin.New(newStub(map[string]string{target: "def111111111"}))
+	runAndCheck(t, p, root, func(h reconcile.ResourceStatus) {
+		if h.Health != reconcile.HealthDegraded {
+			t.Errorf("drift: want Degraded, got %s: %s", h.Health, h.Message)
+		}
+		if h.Sync != reconcile.SyncStatusOutOfSync {
+			t.Errorf("drift: want OutOfSync, got %s", h.Sync)
+		}
+	})
+}
+
+// ─── Tests: Reconcile — target unreachable ────────────────────────────────────
+
+func TestReconcile_TargetUnreachable_Red(t *testing.T) {
+	root := setupWorkspace(t)
+	const target = "cogos-dev/cogos"
+	writePinYAML(t, root, "cogos-dev_cogos", `
+target: cogos-dev/cogos
+pin:
+  ref: abc000000000
+sync: read-only
+`)
+
+	p := pin.New(newStubWithErr(target, os.ErrNotExist))
+	runAndCheck(t, p, root, func(h reconcile.ResourceStatus) {
+		if h.Health != reconcile.HealthDegraded {
+			t.Errorf("unreachable: want Degraded, got %s: %s", h.Health, h.Message)
+		}
+		if h.Sync != reconcile.SyncStatusOutOfSync {
+			t.Errorf("unreachable: want OutOfSync, got %s", h.Sync)
+		}
+	})
+}
+
+// ─── Tests: Reconcile — digest mismatch ──────────────────────────────────────
+
+func TestReconcile_DigestMismatch_Red(t *testing.T) {
+	root := setupWorkspace(t)
+	const target = "cogos-dev/cogos"
+	writePinYAML(t, root, "cogos-dev_cogos", `
+target: cogos-dev/cogos
+pin:
+  ref: abc1234567890
+  digest: sha256:aaaa
+sync: read-only
+`)
+
+	// Stub returns same ref but different digest.
+	s := &stubResolver{refs: map[string]struct {
+		ref    string
+		digest string
+		err    error
+	}{
+		target: {ref: "abc1234567890", digest: "sha256:bbbb"},
+	}}
+
+	p := pin.New(s)
+	runAndCheck(t, p, root, func(h reconcile.ResourceStatus) {
+		if h.Health != reconcile.HealthDegraded {
+			t.Errorf("digest mismatch: want Degraded, got %s: %s", h.Health, h.Message)
+		}
+		if h.Sync != reconcile.SyncStatusOutOfSync {
+			t.Errorf("digest mismatch: want OutOfSync, got %s", h.Sync)
+		}
+	})
+}
+
+// ─── Tests: ApplyPlan — read-only rejects write ───────────────────────────────
+
+func TestApplyPlan_ReadOnly_Rejects(t *testing.T) {
+	root := setupWorkspace(t)
+	const target = "cogos-dev/cogos"
+	writePinYAML(t, root, "cogos-dev_cogos", `
+target: cogos-dev/cogos
+pin:
+  ref: old000000000
+sync: read-only
+`)
+
+	p := pin.New(newStub(map[string]string{target: "new111111111"}))
+	cfg, _ := p.LoadConfig(root)
+	live, _ := p.FetchLive(context.Background(), cfg)
+	plan, _ := p.ComputePlan(cfg, live, nil)
+
+	results, err := p.ApplyPlan(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("ApplyPlan: %v", err)
+	}
+
+	for _, r := range results {
+		if r.Status == reconcile.ApplySucceeded {
+			t.Errorf("read-only: ApplyPlan should not succeed for %s", r.Name)
+		}
+	}
+}
+
+// ─── Tests: Health before LoadConfig ─────────────────────────────────────────
+
+func TestHealth_BeforeLoadConfig_Missing(t *testing.T) {
+	p := pin.New(nil)
+	h := p.Health()
+	if h.Health != reconcile.HealthMissing {
+		t.Errorf("pre-config health: want Missing, got %s: %s", h.Health, h.Message)
+	}
+}
+
+// ─── Tests: WritePinRecord / RemovePinRecord ──────────────────────────────────
+
+func TestWriteAndRemovePinRecord(t *testing.T) {
+	root := t.TempDir() // no pins dir yet
+	rec := &pin.PinRecord{
+		Target: "cogos-dev/cogos",
+		Pin:    pin.PinRef{Ref: "v0.5.0"},
+		Branch: "main",
+		Sync:   pin.SyncReadOnly,
+		Updated: time.Now().UTC(),
+	}
+
+	// Write creates the dir and file.
+	if err := pin.WritePinRecord(root, rec); err != nil {
+		t.Fatalf("WritePinRecord: %v", err)
+	}
+
+	// Verify the file exists and is parseable.
+	p := pin.New(nil)
+	cfg, err := p.LoadConfig(root)
+	if err != nil {
+		t.Fatalf("LoadConfig after write: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config after write")
+	}
+
+	// Remove it.
+	if err := pin.RemovePinRecord(root, "cogos-dev/cogos"); err != nil {
+		t.Fatalf("RemovePinRecord: %v", err)
+	}
+
+	// Verify gone.
+	pinPath := filepath.Join(root, ".cog", "pins", "cogos-dev_cogos.yaml")
+	if _, err := os.Stat(pinPath); !os.IsNotExist(err) {
+		t.Errorf("expected pin file to be removed, got: %v", err)
+	}
+}
+
+// ─── Tests: BuildState ───────────────────────────────────────────────────────
+
+func TestBuildState_PopulatesResources(t *testing.T) {
+	root := setupWorkspace(t)
+	const target = "cogos-dev/cogos"
+	writePinYAML(t, root, "cogos-dev_cogos", `
+target: cogos-dev/cogos
+pin:
+  ref: v0.4.1
+sync: read-only
+`)
+
+	p := pin.New(newStub(map[string]string{target: "v0.4.1"}))
+	cfg, _ := p.LoadConfig(root)
+	live, _ := p.FetchLive(context.Background(), cfg)
+
+	state, err := p.BuildState(cfg, live, nil)
+	if err != nil {
+		t.Fatalf("BuildState: %v", err)
+	}
+	if len(state.Resources) == 0 {
+		t.Fatal("BuildState: expected at least one resource")
+	}
+	found := false
+	for _, r := range state.Resources {
+		if r.ExternalID == target {
+			found = true
+			if r.Type != "pin" {
+				t.Errorf("resource type: want pin, got %s", r.Type)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("BuildState: resource %q not found in state", target)
+	}
+}
+
+// ─── helper ──────────────────────────────────────────────────────────────────
+
+// runAndCheck runs a full reconcile cycle (LoadConfig→FetchLive→ComputePlan)
+// and then calls check with the resulting Health status.
+func runAndCheck(t *testing.T, p *pin.Provider, root string, check func(reconcile.ResourceStatus)) {
+	t.Helper()
+	cfg, err := p.LoadConfig(root)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	live, err := p.FetchLive(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("FetchLive: %v", err)
+	}
+	_, err = p.ComputePlan(cfg, live, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	check(p.Health())
+}


### PR DESCRIPTION
## Summary

- Implements the seven-method `Reconcilable` interface for inter-workspace pin records at `<workspace>/.cog/pins/<target>.yaml` (`internal/providers/pin/pin.go`, ~300 lines).
- Registers the pin provider in both the daemon proprioception health block (`internal/providers/daemon/daemon.go`) and the CLI binary (`cmd_pin.go` init), so pin drift surfaces in foveated context automatically.
- Adds `cog pin list|add|remove|verify|bump` CLI (`cmd_pin.go`).

## Key design decisions

- **Pins are source-side.** No changes to `global.yaml` workspace entries or the `trust:` field — those are membership facts. `sync:`, `branch:`, `pin:` are relationship fields on the pin record only.
- **Read-only default.** `ApplyPlan` refuses to write-back for `sync: read-only` pins; explicit `cog pin bump` is the only path to a ref update.
- **Sibling-checkout fallback (v0).** `FetchLive` resolves target workspace paths via local git checkout inspection. A clear `TODO(#167)` marks the `URIRegistry.Resolve` integration point. The follow-up PR wires URIRegistry after #169 lands. This handles all current use cases — federation is not yet deployed, so the local-checkout path covers every real pin today.
- **Digest mismatch → red.** When a pin record declares a `pin.digest`, a mismatch with the live digest drives Health to Degraded/OutOfSync.

## Rebase note (post-#170)

Rebased cleanly against `upstream/main` after PR #170 (resolver consolidation) merged. The #170 changes to `cog.go` (`cogURIPattern`, `resolveURI`, `validateCogdoc*`) are in entirely different regions from the `"pin":` dispatch case added here — zero conflicts. The daemon test was updated from 9→10 expected providers to reflect the new pin registration.

`ErrUnknownAuthority` / `ErrDigestNotVerified` from `internal/engine/uri.go` (added in #170) are not imported by the pin package yet — the stub's error path uses a plain `fmt.Errorf`. The URIRegistry wire-up follow-up will wrap with `ErrUnknownAuthority` at that point.

## URIRegistry wire-up

The `TODO(#167)` wire-up is tracked in a follow-up issue. It will land in a small PR after #169 (URIRegistry) merges.

## Files touched

| Category | Files |
|----------|-------|
| New pin package | `internal/providers/pin/pin.go`, `internal/providers/pin/pin_test.go` |
| Health registration | `internal/providers/daemon/daemon.go`, `internal/providers/daemon/daemon_test.go` |
| CLI + dispatch | `cmd_pin.go`, `cog.go` |

## Test results

```
ok  github.com/cogos-dev/cogos/internal/providers/pin     (12/12 tests pass)
ok  github.com/cogos-dev/cogos/internal/providers/daemon  (4/4 tests pass)
ok  github.com/cogos-dev/cogos                            full suite green
ok  github.com/cogos-dev/cogos/internal/engine            full suite green
```