### PR TITLE
kernel: reject fragment-before-query URIs to close digest fail-closed bypass

### DIFF
--- a/internal/engine/uri.go
+++ b/internal/engine/uri.go
@@ -171,20 +171,29 @@ func ResolveURI(workspaceRoot, uri string) (*URIResolution, error) {
 		rest = strings.TrimPrefix(uri, "cog:")
 	}
 
-	// Split off fragment.
-	fragment := ""
-	if idx := strings.IndexByte(rest, '#'); idx >= 0 {
-		fragment = rest[idx+1:]
-		rest = rest[:idx]
+	// RFC 3986 ordering requires ?query before #fragment.  Reject malformed
+	// URIs where '#' appears before '?' — they would cause the fragment stripper
+	// to consume the query string, silently bypassing digest fail-closed (ADR-067
+	// §170).  Malformed input is not required to be supported; rejecting it
+	// keeps the fail-closed contract unambiguous.
+	if qIdx := strings.IndexByte(rest, '?'); qIdx >= 0 {
+		if hIdx := strings.IndexByte(rest, '#'); hIdx >= 0 && hIdx < qIdx {
+			return nil, fmt.Errorf("malformed cog: URI (fragment before query): %q", uri)
+		}
 	}
 
-	// Split off query string and check for digest fail-closed (ADR-067 §170).
-	// A ?digest=sha256:... param signals an integrity constraint.  The local
-	// projection resolver does not verify content hashes, so it MUST error rather
-	// than silently ignoring the param.
+	// Split off query string first (RFC 3986: query precedes fragment).
+	// Check for digest fail-closed (ADR-067 §170): a ?digest=sha256:... param
+	// signals an integrity constraint.  The local projection resolver does not
+	// implement digest verification, so it MUST error rather than silently
+	// ignoring the integrity constraint.
 	if idx := strings.IndexByte(rest, '?'); idx >= 0 {
 		query := rest[idx+1:]
 		rest = rest[:idx]
+		// Strip fragment from query tail if present (well-formed: ?q#frag).
+		if fIdx := strings.IndexByte(query, '#'); fIdx >= 0 {
+			query = query[:fIdx]
+		}
 		for _, param := range strings.Split(query, "&") {
 			if strings.HasPrefix(param, "digest=") {
 				return nil, fmt.Errorf("%w: %q", ErrDigestNotVerified, uri)
@@ -192,6 +201,13 @@ func ResolveURI(workspaceRoot, uri string) (*URIResolution, error) {
 		}
 		// Other query params (e.g. ?ref=, ?format=) are silently ignored at the
 		// filesystem level; higher-level handlers may interpret them.
+	}
+
+	// Split off fragment (always follows query per RFC 3986).
+	fragment := ""
+	if idx := strings.IndexByte(rest, '#'); idx >= 0 {
+		fragment = rest[idx+1:]
+		rest = rest[:idx]
 	}
 
 	// For the authority form (cog://...) the first component might be a workspace

--- a/internal/engine/uri_adr067_test.go
+++ b/internal/engine/uri_adr067_test.go
@@ -222,3 +222,52 @@ func TestResolveURI_KnownProjectionAsAuthorityStillWorks(t *testing.T) {
 		t.Errorf("known projection in authority position: unexpected error %v", err)
 	}
 }
+
+// ── 5. Fragment-before-query rejection (issue #171) ───────────────────────────
+
+// TestResolveURI_FragmentBeforeQuery_Rejected verifies that a malformed URI
+// with '#' appearing before '?' is rejected rather than silently bypassing the
+// digest fail-closed check (ADR-067 §170).
+//
+// Without the fix: cog:adr/067#frag?digest=sha256:abc is parsed as
+// fragment="frag?digest=sha256:abc", leaving no '?' in rest, so
+// ErrDigestNotVerified is never returned.
+func TestResolveURI_FragmentBeforeQuery_Rejected(t *testing.T) {
+	t.Parallel()
+	root := "/workspace"
+
+	malformed := []string{
+		"cog:adr/067#frag?digest=sha256:abc",
+		"cog:mem/semantic/foo.cog.md#Section?digest=sha256:deadbeef",
+		"cog://mem/semantic/foo.cog.md#Anchor?ref=main",
+	}
+
+	for _, uri := range malformed {
+		uri := uri
+		t.Run(uri, func(t *testing.T) {
+			t.Parallel()
+			_, err := ResolveURI(root, uri)
+			if err == nil {
+				t.Fatalf("ResolveURI(%q): expected error for malformed fragment-before-query URI, got nil", uri)
+			}
+		})
+	}
+}
+
+// TestResolveURI_DigestWithFragment_WellFormed verifies that a well-formed URI
+// carrying both a query and a fragment in RFC 3986 order (?query#fragment) is
+// still correctly fail-closed on a digest param.
+func TestResolveURI_DigestWithFragment_WellFormed(t *testing.T) {
+	t.Parallel()
+	root := "/workspace"
+
+	// Well-formed: ?query#fragment — digest must still fail-closed.
+	uri := "cog:mem/semantic/foo.cog.md?digest=sha256:abc#Section"
+	_, err := ResolveURI(root, uri)
+	if err == nil {
+		t.Fatalf("ResolveURI(%q): expected ErrDigestNotVerified, got nil", uri)
+	}
+	if !errors.Is(err, ErrDigestNotVerified) {
+		t.Errorf("ResolveURI(%q): got %v; want errors.Is ErrDigestNotVerified", uri, err)
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes a corner-case bypass of the ADR-067 §170 digest fail-closed contract where malformed URIs with `#fragment` before `?query` caused the digest check to be silently skipped
- Reorders fragment/query stripping so query is always stripped before fragment (RFC 3986 compliant); adds pre-validation to reject fragment-before-query inputs immediately
- Adds two regression tests: `TestResolveURI_FragmentBeforeQuery_Rejected` and `TestResolveURI_DigestWithFragment_WellFormed`

## Test plan

- [ ] `go test ./internal/engine/ -run TestResolveURI` passes
- [ ] `TestResolveURI_FragmentBeforeQuery_Rejected`: all three malformed inputs return an error
- [ ] `TestResolveURI_DigestWithFragment_WellFormed`: RFC 3986-conforming `?digest#frag` still fail-closed
- [ ] Full engine test suite green

Closes #171