### PR TITLE
docs: update URI examples from cog:// to bare cog: form per ADR-067

### DIFF
--- a/internal/engine/local_agent_harness.go
+++ b/internal/engine/local_agent_harness.go
@@ -82,24 +82,26 @@ const localHarnessExecutePrompt = `You are the resident local CogOS maintenance 
 Stay local-only. Use the provided kernel tools when they materially improve the answer.
 Prefer inspection and diagnosis over mutation. Finish with a concise plain-text result.
 
-CogDoc URIs use the form cog://<type>/<path>. Valid types:
+CogDoc URIs use the bare form cog:<type>/<path>. Valid types:
   mem, adr, role, skill, agent, spec, status, ledger, crystal,
   kernel, canonical, config, ontology, work, handoff, artifact, docs, hooks
 Examples:
-  cog://adr/077                    (ADRs resolve by numeric prefix)
-  cog://mem/semantic/foo/bar       (memory under .cog/mem/<sector>/...)
-  cog://spec/rfc-022-foo           (specs under .cog/specs/)
-Invalid: cog://adrs/..., cog://workspace/..., cog://docs/... with raw fs paths.
+  cog:adr/077                    (ADRs resolve by numeric prefix)
+  cog:mem/semantic/foo/bar       (memory under .cog/mem/<sector>/...)
+  cog:spec/rfc-022-foo           (specs under .cog/specs/)
+Cross-workspace refs use authority form: cog://other-workspace/mem/...
+Invalid: cog://adrs/..., cog://docs/... with raw fs paths.
 If cog_search_memory returns a bus event path (".cog/.state/buses/.../events.jsonl#N"),
 that is a chat log entry, not a readable CogDoc — do not try to read it.`
 
 const localHarnessDispatchPrompt = `You are the resident local CogOS harness.
 Stay local-only. Use only the provided kernel tools. Be concise and finish with a direct answer.
 
-CogDoc URIs use the form cog://<type>/<path>. Valid types:
+CogDoc URIs use the bare form cog:<type>/<path>. Valid types:
   mem, adr, role, skill, agent, spec, status, ledger, crystal,
   kernel, canonical, config, ontology, work, handoff, artifact, docs, hooks
-Example: cog://adr/077 (ADRs resolve by numeric prefix).
+Example: cog:adr/077 (ADRs resolve by numeric prefix).
+Cross-workspace refs use authority form: cog://other-workspace/mem/...
 If cog_search_memory returns ".cog/.state/buses/.../events.jsonl#N", that's a chat log entry,
 not a readable CogDoc — do not try to read it.`
 

--- a/internal/engine/mcp_stubs.go
+++ b/internal/engine/mcp_stubs.go
@@ -93,7 +93,7 @@ func searchMemoryFTS(dbPath, workspaceRoot, query string, limit int, sector stri
 			return nil, fmt.Errorf("scan row: %w", err)
 		}
 
-		// Derive a cog:// URI from the filesystem path.
+		// Derive a cog: URI from the filesystem path (bare form per ADR-067).
 		uri := pathToMemURI(workspaceRoot, path)
 
 		// Normalise BM25 rank to a 0–1 relevance score.
@@ -194,7 +194,7 @@ func searchMemoryGrep(workspaceRoot, query string, limit int, sector string) (ma
 		title := extractTitleFromFrontmatter(content)
 
 		results = append(results, map[string]any{
-			"uri":   "cog://mem/" + rel,
+			"uri":   "cog:mem/" + rel,
 			"path":  path,
 			"title": title,
 			"score": 0.0, // no relevance scoring in grep fallback

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -4,7 +4,7 @@
 //
 //	GET  /health                           — liveness + readiness probe
 //	GET  /v1/context                       — current attentional field (debug)
-//	GET  /v1/resolve                       — resolve a cog:// URI to a filesystem path
+//	GET  /v1/resolve                       — resolve a cog: URI to a filesystem path
 //	POST /v1/chat/completions              — OpenAI-compatible chat (streaming + non-streaming)
 //	POST /v1/messages                      — Anthropic Messages-compatible chat
 //	POST /v1/context/foveated              — foveated context assembly for Claude Code hook
@@ -369,9 +369,9 @@ func (s *Server) handleContext(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// handleResolve resolves a cog:// URI to a filesystem path.
+// handleResolve resolves a cog: URI to a filesystem path.
 //
-// GET /v1/resolve?uri=cog://mem/semantic/foo.cog.md
+// GET /v1/resolve?uri=cog:mem/semantic/foo.cog.md
 //
 //	200 → { uri, path, fragment, exists }
 //	400 → { error }
@@ -402,9 +402,9 @@ func (s *Server) handleResolve(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// handleCogDocRead resolves a cog:// URI and returns the file content as text.
+// handleCogDocRead resolves a cog: URI and returns the file content as text.
 //
-//	GET /v1/cogdoc/read?uri=cog://mem/semantic/insights/foo.md
+//	GET /v1/cogdoc/read?uri=cog:mem/semantic/insights/foo.md
 //	200 → { uri, path, content, exists }
 func (s *Server) handleCogDocRead(w http.ResponseWriter, r *http.Request) {
 	uri := r.URL.Query().Get("uri")

--- a/pkg/uri/doc.go
+++ b/pkg/uri/doc.go
@@ -1,20 +1,25 @@
-// Package uri provides parsing, formatting, and validation of cog:// URIs.
+// Package uri provides parsing, formatting, and validation of cog: URIs.
 //
-// A cog:// URI addresses a workspace resource (memory document, agent definition,
+// A cog: URI addresses a workspace resource (memory document, agent definition,
 // configuration file, etc.) without coupling to its filesystem location.
 //
-// URI format:
+// URI format (ADR-067):
 //
-//	cog://namespace/path[?query][#fragment]
+//	cog:namespace/path[?query][#fragment]          (local — bare canonical form)
+//	cog://workspace/namespace/path[?query][#fragment]  (cross-workspace authority form)
+//
+// The bare form is canonical for local references; the authority form is used
+// for cross-workspace references where the workspace name is the authority.
 //
 // Examples:
 //
-//	cog://mem/semantic/insights/eigenform.cog.md
-//	cog://mem/semantic/insights/eigenform.cog.md#Seed
-//	cog://conf/kernel.yaml
-//	cog://crystal
-//	cog://signals/inference?above=0.3
+//	cog:mem/semantic/insights/eigenform.cog.md
+//	cog:mem/semantic/insights/eigenform.cog.md#Seed
+//	cog:conf/kernel.yaml
+//	cog:crystal
+//	cog:signals/inference?above=0.3
+//	cog://other-workspace/mem/semantic/foo.cog.md  (cross-workspace)
 //
-// This package answers "what is a cog:// URI and how do I parse/format one?"
+// This package answers "what is a cog: URI and how do I parse/format one?"
 // Resolution — looking up what a URI points to on disk — stays in the kernel.
 package uri


### PR DESCRIPTION
## Summary

- Updates MCP tool schema descriptions and harness system-prompt strings to use canonical bare `cog:projection/path` form instead of the legacy `cog://projection/path` form
- Cross-workspace authority examples (`cog://workspace/path`) kept as-is — those are intentional and correct
- Updates `pkg/uri/doc.go` package docstring to document both forms clearly

## Files changed

- `internal/engine/local_agent_harness.go`: both execute and dispatch system-prompt URI examples
- `internal/engine/mcp_stubs.go`: grep-fallback runtime URI construction + comment
- `internal/engine/serve.go`: `handleResolve` and `handleCogDocRead` doc comments
- `pkg/uri/doc.go`: package-level docstring

## Test plan

- [ ] `go build ./...` passes (no functional code changes)
- [ ] Grep for `cog://mem/`, `cog://adr/`, `cog://conf/` in non-test, non-comment-URL Go files returns only intentional cross-workspace or legacy-compat occurrences

Closes #172