### PR TITLE
feat(pin): wire URIRegistry into FetchLive via WorkspaceLocator

### DIFF
--- a/cmd/cogos/providers_wire.go
+++ b/cmd/cogos/providers_wire.go
@@ -22,11 +22,23 @@
 package main
 
 import (
+	"context"
+
 	"github.com/cogos-dev/cogos/internal/engine"
 	"github.com/cogos-dev/cogos/internal/eval"
 	"github.com/cogos-dev/cogos/internal/providers/component"
 	"github.com/cogos-dev/cogos/internal/providers/daemon"
 )
+
+// uriRegistryLocatorAdapter adapts engine.ResolveWorkspacePath to satisfy the
+// pin.WorkspaceLocator interface. This avoids exporting the engine's unexported
+// uriResolver type while still allowing the pin provider to consult the global
+// workspace registry for target path resolution.
+type uriRegistryLocatorAdapter struct{}
+
+func (a *uriRegistryLocatorAdapter) LocateWorkspace(ctx context.Context, name string) (string, error) {
+	return engine.ResolveWorkspacePath(ctx, name)
+}
 
 // daemonEvalProvider is the daemon-side EvalProvider instance passed to the
 // eval MCP tools. The daemon does not run plan/apply; it only exposes the
@@ -52,6 +64,11 @@ func init() {
 	engine.SetProvidersWorkspace = func(workspaceRoot string) {
 		daemon.SetWorkspaceRoot(workspaceRoot)
 		component.SetWorkspaceRoot(workspaceRoot)
+		// Wire URIRegistry into the pin provider's WorkspaceLocator so FetchLive
+		// can consult the global workspace registry for target path resolution
+		// (two-step chain: registry → sibling-dir fallback). Safe to call every
+		// time SetProvidersWorkspace fires — SetPinWorkspaceLocator is idempotent.
+		daemon.SetPinWorkspaceLocator(&uriRegistryLocatorAdapter{})
 		// Prime the daemon EvalProvider root so its MCP tools can resolve
 		// the workspace-relative state files (eval-dispatch-triggers.json,
 		// eval-baselines.json). LoadConfig is idempotent — safe to call here.

--- a/internal/engine/uri_registry.go
+++ b/internal/engine/uri_registry.go
@@ -359,3 +359,25 @@ func verifyDigest(path, expectedHex string) error {
 	}
 	return nil
 }
+
+// ResolveWorkspacePath returns the filesystem root for the named workspace by
+// consulting URIRegistry. It is the canonical public surface for packages that
+// need workspace-root resolution without holding a reference to the unexported
+// uriResolver interface.
+//
+// Returns ("", ErrUnknownAuthority) when the workspace is not registered.
+// All other errors are I/O or parse failures in the global.yaml registry file.
+func ResolveWorkspacePath(ctx context.Context, name string) (string, error) {
+	if URIRegistry == nil {
+		return "", fmt.Errorf("%w: URIRegistry not initialised", ErrUnknownAuthority)
+	}
+	content, err := URIRegistry.Resolve(ctx, "cog://"+name)
+	if err != nil {
+		return "", fmt.Errorf("%w: %v", ErrUnknownAuthority, err)
+	}
+	path, _ := content.Metadata["path"].(string)
+	if path == "" {
+		return "", fmt.Errorf("%w: URIRegistry returned empty path for %q", ErrUnknownAuthority, name)
+	}
+	return path, nil
+}

--- a/internal/providers/daemon/daemon.go
+++ b/internal/providers/daemon/daemon.go
@@ -72,6 +72,23 @@ func SetWorkspaceRoot(root string) {
 	workspaceRoot = root
 }
 
+// globalPinProvider is the singleton pinProvider registered in init().
+// Exposed so providers_wire.go can inject the workspace locator after the
+// engine's URIRegistry is initialised.
+var globalPinProvider = &pinProvider{stubMethods: stubMethods{name: "pin"}}
+
+// SetPinWorkspaceLocator wires a WorkspaceLocator into the pin provider so that
+// FetchLive can consult the global workspace registry. Called from
+// providers_wire.go after engine.URIRegistry is available.
+func SetPinWorkspaceLocator(loc pin.WorkspaceLocator) {
+	globalPinProvider.mu.Lock()
+	defer globalPinProvider.mu.Unlock()
+	if globalPinProvider.impl == nil {
+		globalPinProvider.impl = pin.New(nil)
+	}
+	globalPinProvider.impl.SetWorkspaceLocator(loc)
+}
+
 // pinProvider is the daemon-side wrapper around the fully-extracted pin provider.
 // It delegates Health() to pin.New() after running the read-only refresh cycle
 // (LoadConfig → FetchLive → ComputePlan, no ApplyPlan) so that pinStates is
@@ -144,7 +161,7 @@ func init() {
 	reconcile.RegisterProvider("openclaw-agents", &openclawAgentsProvider{})
 	reconcile.RegisterProvider("openclaw-cron", &openclawCronProvider{})
 	reconcile.RegisterProvider("openclaw-gateway", &openclawGatewayProvider{})
-	reconcile.RegisterProvider("pin", &pinProvider{stubMethods: stubMethods{name: "pin"}})
+	reconcile.RegisterProvider("pin", globalPinProvider)
 	reconcile.RegisterProvider("service", &serviceProvider{})
 }
 

--- a/internal/providers/pin/pin.go
+++ b/internal/providers/pin/pin.go
@@ -15,10 +15,10 @@
 //   - Health      — green/yellow/red aggregate across all pins
 //   - Reconcile   — full cycle (LoadConfig → FetchLive → ComputePlan → ApplyPlan)
 //
-// URIRegistry dependency: FetchLive resolves target workspace names via
-// URIRegistry (issue #167, not yet merged). Until #167 lands, FetchLive
-// stubs remote resolution and falls back to local git checkout inspection.
-// A clear TODO marks the integration point.
+// URIRegistry dependency: FetchLive resolves target workspace names via a
+// WorkspaceLocator (backed by engine.URIRegistry, wired at startup). When no
+// locator is injected the provider falls back to local git checkout inspection.
+// The locator is injected via Provider.SetWorkspaceLocator after construction.
 package pin
 
 import (
@@ -33,10 +33,27 @@ import (
 	"sync"
 	"time"
 
+	"errors"
+
 	"gopkg.in/yaml.v3"
 
 	"github.com/cogos-dev/cogos/pkg/reconcile"
 )
+
+// ─── WorkspaceLocator ────────────────────────────────────────────────────────
+
+// WorkspaceLocator resolves a workspace name (e.g. "cogos-dev/cogos") to its
+// absolute filesystem root path. In production it is backed by engine.URIRegistry
+// via an adapter wired at daemon startup. Tests inject a stub.
+type WorkspaceLocator interface {
+	// LocateWorkspace returns the filesystem root for the named workspace.
+	// Returns ErrWorkspaceNotFound when the workspace is not registered.
+	LocateWorkspace(ctx context.Context, name string) (path string, err error)
+}
+
+// ErrWorkspaceNotFound is returned by WorkspaceLocator when the target workspace
+// is not registered in the global workspace registry.
+var ErrWorkspaceNotFound = errors.New("pin: workspace not found in registry")
 
 // ─── Schema types ────────────────────────────────────────────────────────────
 
@@ -123,6 +140,9 @@ type pinLive struct {
 //
 // Construct via New; inject a GitHeadResolver for FetchLive. Tests supply
 // a stubResolver; production defaults to localGitHeadResolver.
+// Optionally inject a WorkspaceLocator via SetWorkspaceLocator after
+// construction so FetchLive can consult the global workspace registry before
+// falling back to local directory scanning.
 //
 // Thread safety: mu protects all mutable fields. LoadConfig, FetchLive, and
 // the Health probe are the only callers that mutate state; they are sequenced
@@ -132,6 +152,7 @@ type Provider struct {
 	mu sync.Mutex
 
 	resolver GitHeadResolver
+	locator  WorkspaceLocator // optional; nil = skip registry lookup
 
 	// State updated through the lifecycle and surfaced by Health().
 	root      string
@@ -163,6 +184,20 @@ func New(resolver GitHeadResolver) *Provider {
 	}
 }
 
+// SetWorkspaceLocator injects a WorkspaceLocator so FetchLive can consult the
+// global workspace registry before falling back to local directory scanning.
+// Call this at daemon startup after the registry is initialised. Safe to call
+// multiple times; the last value wins. Thread-safe.
+func (p *Provider) SetWorkspaceLocator(loc WorkspaceLocator) {
+	p.mu.Lock()
+	p.locator = loc
+	// Propagate to the underlying localGitHeadResolver if that is what we hold.
+	if lgr, ok := p.resolver.(*localGitHeadResolver); ok {
+		lgr.locator = loc
+	}
+	p.mu.Unlock()
+}
+
 // Type returns the provider identifier. Used by the reconcile registry and
 // the "cog reconcile" dispatch.
 func (p *Provider) Type() string { return "pin" }
@@ -183,19 +218,18 @@ type GitHeadResolver interface {
 }
 
 // localGitHeadResolver is the production GitHeadResolver.
-// It resolves target workspace paths by scanning sibling directories relative
-// to the source workspace and running `git rev-parse HEAD`.
-//
-// TODO(#167): wire URIRegistry here once PR #167 merges.
-// The lookup chain should be:
-//   1. URIRegistry.Resolve("cog://workspace/<target>") → path
-//   2. Fallback: sibling-directory scan (current behaviour)
-type localGitHeadResolver struct{}
+// It resolves target workspace paths using a two-step chain:
+//  1. WorkspaceLocator (backed by URIRegistry) — canonical registry lookup.
+//  2. Sibling-directory scan — local fallback when no locator is wired or the
+//     registry does not know the workspace yet.
+type localGitHeadResolver struct {
+	locator WorkspaceLocator // injected via Provider.SetWorkspaceLocator
+}
 
 func (r *localGitHeadResolver) ResolveHead(ctx context.Context, target, workspaceRoot string) (string, string, error) {
-	targetPath := r.locateTarget(target, workspaceRoot)
+	targetPath := r.locateTarget(ctx, target, workspaceRoot)
 	if targetPath == "" {
-		return "", "", fmt.Errorf("pin: target workspace %q not found locally (TODO: consult URIRegistry after #167)", target)
+		return "", "", fmt.Errorf("%w: %q", ErrWorkspaceNotFound, target)
 	}
 
 	// git rev-parse HEAD in the target directory.
@@ -208,11 +242,26 @@ func (r *localGitHeadResolver) ResolveHead(ctx context.Context, target, workspac
 	return ref, "", nil // digest computation deferred to v1
 }
 
-// locateTarget attempts to find a local checkout of the target workspace.
-// Strategy: look for a directory whose last path component or last-two components
-// matches the target name (e.g., "cogos-dev/cogos" → sibling "cogos-dev/cogos"
-// or "cogos").
-func (r *localGitHeadResolver) locateTarget(target, workspaceRoot string) string {
+// locateTarget finds the filesystem root for the target workspace.
+//
+// Lookup chain:
+//  1. WorkspaceLocator.LocateWorkspace — consults the global workspace registry
+//     (URIRegistry backed by ~/.cog/node/global.yaml). Returns immediately on
+//     success or on any error that is NOT ErrWorkspaceNotFound.
+//  2. Sibling-directory scan — local fallback for workspaces not yet in the
+//     registry (e.g. during bootstrapping or federation setup).
+func (r *localGitHeadResolver) locateTarget(ctx context.Context, target, workspaceRoot string) string {
+	// Step 1: consult WorkspaceLocator when available.
+	if r.locator != nil {
+		path, err := r.locator.LocateWorkspace(ctx, target)
+		if err == nil && path != "" {
+			return path
+		}
+		// ErrWorkspaceNotFound → fall through to local scan.
+		// Any other error (I/O, registry unavailable) → also fall through so
+		// a transient registry failure doesn't break local-only workflows.
+	}
+
 	if workspaceRoot == "" {
 		return ""
 	}

--- a/internal/providers/pin/pin_test.go
+++ b/internal/providers/pin/pin_test.go
@@ -3,7 +3,10 @@ package pin_test
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -739,5 +742,144 @@ sync: read-only
 
 	if len(results) != 1 || results[0].OK {
 		t.Errorf("RunVerify results: want 1 NOT-OK result, got %+v", results)
+	}
+}
+
+// ─── WorkspaceLocator integration tests (issue #175) ─────────────────────────
+
+// stubLocator is a test implementation of pin.WorkspaceLocator.
+type stubLocator struct {
+	// paths maps workspace name → filesystem path.
+	// An absent or empty entry means ErrWorkspaceNotFound.
+	paths map[string]string
+	// calls records the names that were looked up (in order).
+	calls []string
+}
+
+func (l *stubLocator) LocateWorkspace(_ context.Context, name string) (string, error) {
+	l.calls = append(l.calls, name)
+	p, ok := l.paths[name]
+	if !ok || p == "" {
+		return "", pin.ErrWorkspaceNotFound
+	}
+	return p, nil
+}
+
+// TestSetWorkspaceLocator_ConsultedBeforeFallback verifies that after
+// SetWorkspaceLocator is called, the locator is queried for every target
+// workspace before the sibling-directory scan fires.
+//
+// The locator returns ErrWorkspaceNotFound so the fallback scan fires; the
+// test only asserts the locator was consulted, not that resolution succeeded.
+func TestSetWorkspaceLocator_ConsultedBeforeFallback(t *testing.T) {
+	t.Parallel()
+	root := setupWorkspace(t)
+	const target = "cogos-dev/cogos"
+
+	writePinYAML(t, root, "cogos-dev_cogos", `
+target: cogos-dev/cogos
+pin:
+  ref: abc1234567890
+sync: read-only
+`)
+
+	locator := &stubLocator{paths: map[string]string{}} // always not-found
+	p := pin.New(nil)
+	p.SetWorkspaceLocator(locator)
+
+	cfgAny, err := p.LoadConfig(root)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	_, _ = p.FetchLive(context.Background(), cfgAny) // error expected (no real git repo)
+
+	found := false
+	for _, name := range locator.calls {
+		if name == target {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("WorkspaceLocator not consulted for target %q; calls = %v", target, locator.calls)
+	}
+}
+
+// TestSetWorkspaceLocator_RegistryPathUsed verifies the end-to-end happy path:
+// locator returns a real git repo root → FetchLive resolves HEAD without error.
+func TestSetWorkspaceLocator_RegistryPathUsed(t *testing.T) {
+	t.Parallel()
+	source := setupWorkspace(t)
+	const target = "myorg/myrepo"
+	const pinnedRef = "abc1234567890abcdef1234567890abcdef123456"
+
+	writePinYAML(t, source, "myorg_myrepo", `
+target: myorg/myrepo
+pin:
+  ref: `+pinnedRef+`
+sync: read-only
+`)
+
+	// Create a minimal git repo to serve as the target workspace.
+	targetDir := t.TempDir()
+	for _, args := range [][]string{
+		{"git", "-C", targetDir, "init"},
+		{"git", "-C", targetDir, "config", "user.email", "test@example.com"},
+		{"git", "-C", targetDir, "config", "user.name", "Test"},
+		{"git", "-C", targetDir, "commit", "--allow-empty", "-m", "initial"},
+	} {
+		out, err := exec.Command(args[0], args[1:]...).CombinedOutput()
+		if err != nil {
+			t.Skipf("git setup failed (%v): %s — skipping registry-path test", err, out)
+		}
+	}
+
+	locator := &stubLocator{paths: map[string]string{target: targetDir}}
+	p := pin.New(nil)
+	p.SetWorkspaceLocator(locator)
+
+	cfgAny, err := p.LoadConfig(source)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	liveAny, err := p.FetchLive(context.Background(), cfgAny)
+	if err != nil {
+		t.Fatalf("FetchLive: %v", err)
+	}
+
+	// Verify the locator was consulted.
+	found := false
+	for _, name := range locator.calls {
+		if name == target {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("WorkspaceLocator not consulted for target %q; calls = %v", target, locator.calls)
+	}
+
+	// Verify FetchLive succeeded by running ComputePlan — if liveAny is valid,
+	// ComputePlan won't panic.
+	planAny, err := p.ComputePlan(cfgAny, liveAny, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if planAny == nil {
+		t.Fatal("ComputePlan returned nil plan")
+	}
+}
+
+// TestErrWorkspaceNotFound_SentinelExported verifies the exported sentinel error
+// is the right type for errors.Is checks in callers.
+func TestErrWorkspaceNotFound_SentinelExported(t *testing.T) {
+	t.Parallel()
+	if pin.ErrWorkspaceNotFound == nil {
+		t.Fatal("ErrWorkspaceNotFound is nil")
+	}
+	// Ensure wrapping works.
+	wrapped := fmt.Errorf("wrapped: %w", pin.ErrWorkspaceNotFound)
+	if !errors.Is(wrapped, pin.ErrWorkspaceNotFound) {
+		t.Errorf("errors.Is(wrapped, ErrWorkspaceNotFound) = false; wrapping broken")
 	}
 }


### PR DESCRIPTION
## Summary

- Closes the `TODO(#167)` seam in `internal/providers/pin/pin.go`: `FetchLive` now consults the global workspace registry (URIRegistry) before falling back to sibling-directory scanning
- Adds `WorkspaceLocator` interface and `ErrWorkspaceNotFound` sentinel to the `pin` package; no import cycle — pin does not import engine
- Exposes `engine.ResolveWorkspacePath` as the public bridge so `providers_wire.go` can wire an adapter without touching the unexported `uriResolver` interface
- Wires the adapter at daemon startup via `daemon.SetPinWorkspaceLocator` called from `engine.SetProvidersWorkspace`

## Files changed

- `internal/providers/pin/pin.go`: `WorkspaceLocator` interface, `ErrWorkspaceNotFound`, `localGitHeadResolver.locator` field, two-step lookup chain, `Provider.SetWorkspaceLocator`
- `internal/providers/pin/pin_test.go`: three new tests for the locator path
- `internal/providers/daemon/daemon.go`: `globalPinProvider` singleton, `SetPinWorkspaceLocator`
- `internal/engine/uri_registry.go`: exported `ResolveWorkspacePath`
- `cmd/cogos/providers_wire.go`: `uriRegistryLocatorAdapter` + injection in `SetProvidersWorkspace`

## Test plan

- [ ] `go test ./internal/providers/pin/... -run "Locator|ErrWorkspace"` passes (3 new tests)
- [ ] `TestSetWorkspaceLocator_ConsultedBeforeFallback`: locator called before sibling scan
- [ ] `TestSetWorkspaceLocator_RegistryPathUsed`: end-to-end with real git repo, FetchLive + ComputePlan succeed
- [ ] `TestErrWorkspaceNotFound_SentinelExported`: errors.Is wrapping works
- [ ] `go build ./...` passes

Closes #175