### PR TITLE
kernel: lower fragment-before-query check into pkg/uri parser + preserve fragment

### DIFF
--- a/internal/engine/uri.go
+++ b/internal/engine/uri.go
@@ -187,11 +187,20 @@ func ResolveURI(workspaceRoot, uri string) (*URIResolution, error) {
 	// signals an integrity constraint.  The local projection resolver does not
 	// implement digest verification, so it MUST error rather than silently
 	// ignoring the integrity constraint.
+	//
+	// Fragment capture: when the URI is well-formed (?query#fragment), the
+	// fragment follows the query string in the tail.  We capture it here so that
+	// truncating `rest` at '?' does not lose the fragment (the subsequent
+	// fragment-extraction pass below would find no '#' in the already-truncated
+	// rest and silently drop it — regression introduced by PR #176).
+	fragment := ""
 	if idx := strings.IndexByte(rest, '?'); idx >= 0 {
 		query := rest[idx+1:]
 		rest = rest[:idx]
-		// Strip fragment from query tail if present (well-formed: ?q#frag).
+		// Separate fragment from query tail if present (well-formed: ?q#frag).
+		// Capture the fragment text before stripping it from the query.
 		if fIdx := strings.IndexByte(query, '#'); fIdx >= 0 {
+			fragment = query[fIdx+1:]
 			query = query[:fIdx]
 		}
 		for _, param := range strings.Split(query, "&") {
@@ -204,7 +213,9 @@ func ResolveURI(workspaceRoot, uri string) (*URIResolution, error) {
 	}
 
 	// Split off fragment (always follows query per RFC 3986).
-	fragment := ""
+	// This handles the no-query case: cog:mem/foo#section.
+	// If a fragment was already captured from the query tail above, this block
+	// is a no-op (rest contains no '#' after the query was stripped).
 	if idx := strings.IndexByte(rest, '#'); idx >= 0 {
 		fragment = rest[idx+1:]
 		rest = rest[:idx]

--- a/internal/engine/uri_adr067_test.go
+++ b/internal/engine/uri_adr067_test.go
@@ -291,3 +291,37 @@ func TestResolveURI_DigestWithFragment_WellFormed(t *testing.T) {
 		t.Errorf("ResolveURI(%q): got %v; want errors.Is ErrDigestNotVerified", uri, err)
 	}
 }
+
+// ── 6. Fragment preserved on well-formed ?query#fragment URI (PR #176 regression) ─
+
+// TestResolveURI_FragmentPreservedWithQuery verifies that a well-formed URI
+// carrying both a non-digest query param and a fragment in RFC 3986 order
+// (?query#fragment) correctly preserves the fragment in the returned
+// URIResolution.
+//
+// PR #176 introduced a regression: rest was truncated at '?' before the
+// fragment-extraction pass, so the fragment was silently dropped.
+// Concretely: cog:adr/074?ref=main#section-2 would return Fragment="" instead
+// of Fragment="section-2".
+func TestResolveURI_FragmentPreservedWithQuery(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	// adr uses glob pattern — create the file so ResolveURI can find it.
+	if err := os.MkdirAll(filepath.Join(root, ".cog", "adr"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	adrFile := filepath.Join(root, ".cog", "adr", "074-some-decision.md")
+	if err := os.WriteFile(adrFile, []byte("# ADR-074\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	uri := "cog:adr/074?ref=main#section-2"
+	res, err := ResolveURI(root, uri)
+	if err != nil {
+		t.Fatalf("ResolveURI(%q): unexpected error %v", uri, err)
+	}
+	if res.Fragment != "section-2" {
+		t.Errorf("Fragment = %q; want %q (fragment was dropped — PR #176 regression)", res.Fragment, "section-2")
+	}
+}

--- a/internal/engine/uri_registry.go
+++ b/internal/engine/uri_registry.go
@@ -114,6 +114,17 @@ func (r *uriRegistryImpl) Resolve(ctx context.Context, rawURI string) (*uriConte
 	// cog://authority/path form — parse authority and path.
 	rest := strings.TrimPrefix(rawURI, "cog://")
 
+	// RFC 3986 §3: query precedes fragment.  Reject URIs where '#' appears
+	// before '?' — the previous stripping order (fragment first, then query)
+	// meant that cog://ws/mem/x#frag?digest=... would have "#frag?digest=..."
+	// stripped as the fragment, leaving no '?' in rest and thus digestHex
+	// would never be set, silently bypassing digest verification (ADR-067 §170).
+	if qIdx := strings.IndexByte(rest, '?'); qIdx >= 0 {
+		if hIdx := strings.IndexByte(rest, '#'); hIdx >= 0 && hIdx < qIdx {
+			return nil, fmt.Errorf("uri_registry: malformed URI (fragment before query): %q", rawURI)
+		}
+	}
+
 	// RFC 3986 §3: URI = scheme ":" hier-part ["?" query] ["#" fragment]
 	// Fragment always trails query; strip #fragment FIRST so the query value
 	// never accidentally includes the fragment text (e.g. ?digest=hex#frag

--- a/internal/engine/uri_registry_test.go
+++ b/internal/engine/uri_registry_test.go
@@ -265,3 +265,30 @@ func TestResolveBareLocalForm(t *testing.T) {
 		t.Errorf("path: got %v, want %q", content.Metadata["path"], doc)
 	}
 }
+
+// ── Resolve: fragment-before-query rejection (issue #171 follow-up) ───────────
+
+// TestResolveFragmentBeforeQuery_Rejected verifies that URIRegistry.Resolve
+// rejects a URI where '#' appears before '?' in the cog://authority form.
+//
+// PR #176 added the rejection only inside ResolveURI; the registry-direct path
+// was not covered.  Without this fix, cog://ws/mem/x#frag?digest=... reaches
+// the digest-verification block with digestHex="" because the earlier
+// fragment-strip consumed the entire tail including the query string.
+func TestResolveFragmentBeforeQuery_Rejected(t *testing.T) {
+	_, wsA, _, reg := testNodeSetup(t)
+
+	doc := filepath.Join(wsA, ".cog", "mem", "semantic", "bypass.cog.md")
+	if err := os.WriteFile(doc, []byte("# bypass attempt\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	digest := fileDigest(t, doc)
+
+	// Fragment-before-query: the '#frag' should NOT cause the digest param to be
+	// ignored.  The registry must reject this URI as malformed.
+	malformed := "cog://ws-a/mem/semantic/bypass.cog.md#frag?digest=" + digest
+	_, err := reg.Resolve(context.Background(), malformed)
+	if err == nil {
+		t.Fatalf("Resolve(%q): expected error for fragment-before-query, got nil (digest bypass)", malformed)
+	}
+}

--- a/pkg/uri/uri.go
+++ b/pkg/uri/uri.go
@@ -55,6 +55,16 @@ func Parse(rawURI string) (*URI, error) {
 		return nil, &Error{Op: "Parse", URI: rawURI, Err: fmt.Errorf("%w: must start with %s", ErrInvalidURI, Scheme)}
 	}
 
+	// RFC 3986 §3: query precedes fragment.  Reject URIs where '#' appears before
+	// '?' — without this check url.Parse would fold the query into the fragment
+	// field and the digest fail-closed check below would never fire, silently
+	// bypassing the integrity constraint (ADR-067 §170).
+	if qIdx := strings.IndexByte(rawURI, '?'); qIdx >= 0 {
+		if hIdx := strings.IndexByte(rawURI, '#'); hIdx >= 0 && hIdx < qIdx {
+			return nil, &Error{Op: "Parse", URI: rawURI, Err: fmt.Errorf("%w: fragment before query (RFC 3986 violation)", ErrInvalidURI)}
+		}
+	}
+
 	// Fail-closed on digest integrity constraint (ADR-067 §170).
 	if idx := strings.IndexByte(rawURI, '?'); idx >= 0 {
 		query := rawURI[idx+1:]

--- a/pkg/uri/uri_test.go
+++ b/pkg/uri/uri_test.go
@@ -381,3 +381,33 @@ func TestParseBothFormsRoundTrip(t *testing.T) {
 		})
 	}
 }
+
+// ── Fragment-before-query rejection in canonical parser (issue #171 follow-up) ──
+
+// TestParseFragmentBeforeQuery_Rejected verifies that pkg/uri.Parse rejects a URI
+// where '#' appears before '?' — the canonical parser must enforce RFC 3986 ordering
+// so every caller (resolver, registry, future callers) gets consistent protection.
+//
+// Without the fix: url.Parse folds "?digest=..." into the Fragment field, so the
+// digest fail-closed check never fires and digest verification can be bypassed.
+func TestParseFragmentBeforeQuery_Rejected(t *testing.T) {
+	t.Parallel()
+	malformed := []string{
+		"cog:mem/foo.cog.md#Section?digest=sha256:abc",
+		"cog://mem/semantic/x#Anchor?digest=sha256:deadbeef",
+		"cog:conf/kernel.yaml#top?ref=main",
+	}
+	for _, raw := range malformed {
+		raw := raw
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+			_, err := Parse(raw)
+			if err == nil {
+				t.Fatalf("Parse(%q): expected error for fragment-before-query URI, got nil", raw)
+			}
+			if !errors.Is(err, ErrInvalidURI) {
+				t.Errorf("Parse(%q): got %v; want errors.Is ErrInvalidURI", raw, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this fixes

This is a fix-up of PR #176 (which closed issue #171 — fragment-before-query digest bypass). Codex wave-2 review found that #176's fix was incomplete and introduced a regression.

Quoting the Codex finding:

> The fix is only in `internal/engine/uri.go:174-183`, not the lower parser. Direct `URIRegistry.Resolve` still strips `#fragment` before query handling at `internal/engine/uri_registry.go:121-137`, so `cog://ws/mem/x#frag?digest=...` can still bypass digest verification on registry-direct callers. `pkg/uri.Parse` also has no general `#` before `?` rejection; it only scans digest after `?` at `pkg/uri/uri.go:58-69` before `url.Parse` at `pkg/uri/uri.go:79-100`.
>
> The new test only calls `ResolveURI` and does not cover `URIRegistry.Resolve`. Also, well-formed non-digest `?query#fragment` now loses the fragment: `rest` is truncated before `?` at `internal/engine/uri.go:190-195`, then fragment extraction runs on the already-truncated `rest` at `internal/engine/uri.go:206-210`.

## Three fixes in this PR

1. **`pkg/uri.Parse` — add `#`-before-`?` rejection (canonical parser layer)**: Without this, `url.Parse` folds `?query` into the `Fragment` field when `#` precedes `?`, so the digest fail-closed scan never fires. Every caller that goes through the canonical parser now gets consistent protection.

2. **`URIRegistry.Resolve` — mirror the rejection before fragment-strip**: The registry stripped `#fragment` first, which meant `cog://ws/mem/x#frag?digest=<hex>` would fold the entire `?digest=<hex>` into the fragment string, leaving `digestHex = ""` and bypassing step-6 digest verification on the registry-direct path.

3. **`internal/engine/uri.go` — fix fragment-loss regression from PR #176**: `rest` was truncated at `?` before the fragment-extraction pass, so a well-formed `cog:adr/074?ref=main#section-2` returned `Fragment = ""` instead of `"section-2"`. The fragment is now captured from the query tail at the same time as the query is stripped.

## Tests added

Each new test fails on the un-fixed code:

- `pkg/uri/uri_test.go`: `TestParseFragmentBeforeQuery_Rejected` — Parse rejects `#` before `?` at the canonical parser
- `internal/engine/uri_registry_test.go`: `TestResolveFragmentBeforeQuery_Rejected` — registry-direct path also rejects (gap from PR #176's test coverage)
- `internal/engine/uri_adr067_test.go`: `TestResolveURI_FragmentPreservedWithQuery` — well-formed `?query#fragment` preserves the fragment (regression guard)

Full suite: `go test -tags fts5 ./...` and `go test -tags fts5 ./pkg/uri/...` — all green.

Note: issue #171 is already closed; this PR does not reopen it.