### PR TITLE
feat(pin): resolve slash-bearing workspace names + propagate registry errors

### DIFF
--- a/internal/engine/pin_adapter_test.go
+++ b/internal/engine/pin_adapter_test.go
@@ -1,0 +1,136 @@
+// pin_adapter_test.go — integration tests for the production pin locator adapter.
+//
+// These tests exercise the full adapter path:
+//
+//	engine.ResolveWorkspacePath (production adapter) →
+//	uriRegistryImpl.resolveAuthority (direct name lookup) →
+//	lookupWorkspaceRoot (reads global.yaml)
+//
+// They are the tests that would have caught the bug reported in the Codex
+// review of PR #180 (#175 fixup): ResolveWorkspacePath was building
+// "cog://"+name and calling URIRegistry.Resolve, which splits the authority
+// at the first slash, so "cogos-dev/cogos" was looked up as "cogos-dev"
+// instead of the full slash-bearing key.
+//
+// These tests must fail on the pre-fix code (Resolve round-trip) and pass
+// on the post-fix code (direct resolveAuthority call).
+package engine
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/cogos-dev/cogos/internal/providers/pin"
+)
+
+// realAdapterLocator adapts engine.ResolveWorkspacePath to pin.WorkspaceLocator.
+// This is the same shape as cmd/cogos/providers_wire.go:uriRegistryLocatorAdapter.
+// Defined here (package engine) so tests can swap URIRegistry and observe the
+// real adapter path without export tricks.
+type realAdapterLocator struct{}
+
+func (a *realAdapterLocator) LocateWorkspace(ctx context.Context, name string) (string, error) {
+	path, err := ResolveWorkspacePath(ctx, name)
+	if err != nil {
+		return "", pin.ErrWorkspaceNotFound
+	}
+	return path, nil
+}
+
+// setupSlashNameRegistry writes a global.yaml with "cogos-dev/cogos" as a
+// workspace, swaps URIRegistry for the duration of the test, creates the
+// workspace directory, and returns its path.
+func setupSlashNameRegistry(t *testing.T) (targetDir string) {
+	t.Helper()
+	base := t.TempDir()
+	nd := filepath.Join(base, "node")
+	if err := os.MkdirAll(nd, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	targetDir = filepath.Join(base, "cogos-dev", "cogos")
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	global := "version: \"1.0\"\nworkspaces:\n" +
+		"  cogos-dev/cogos:\n    path: " + targetDir + "\n"
+	if err := os.WriteFile(filepath.Join(nd, "global.yaml"), []byte(global), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	testReg := &uriRegistryImpl{nodeDirFn: func() string { return nd }}
+	orig := URIRegistry
+	URIRegistry = testReg
+	t.Cleanup(func() { URIRegistry = orig })
+
+	return targetDir
+}
+
+// TestPinAdapter_SlashBearingWorkspaceName is the load-bearing regression test
+// for the Codex finding on PR #180.
+//
+// It wires the real engine.ResolveWorkspacePath adapter (not a stub) against a
+// registry containing "cogos-dev/cogos" (slash-bearing), creates a minimal git
+// repo at that path, and asserts that pin FetchLive resolves HEAD without
+// error.
+//
+// Without the fix, ResolveWorkspacePath calls URIRegistry.Resolve("cog://cogos-dev/cogos"),
+// which splits authority at "/" → looks up "cogos-dev" → workspace not found →
+// returns ErrUnknownAuthority → pin.LocateWorkspace returns ErrWorkspaceNotFound
+// → FetchLive falls back to sibling scan → no sibling found → error.
+//
+// With the fix, ResolveWorkspacePath calls resolveAuthority("cogos-dev/cogos")
+// directly → global.yaml lookup succeeds → returns targetDir → FetchLive resolves HEAD.
+func TestPinAdapter_SlashBearingWorkspaceName(t *testing.T) {
+	targetDir := setupSlashNameRegistry(t)
+
+	// Initialise a real git repo so git rev-parse HEAD succeeds.
+	for _, args := range [][]string{
+		{"git", "-C", targetDir, "init"},
+		{"git", "-C", targetDir, "config", "user.email", "test@example.com"},
+		{"git", "-C", targetDir, "config", "user.name", "Test"},
+		{"git", "-C", targetDir, "commit", "--allow-empty", "-m", "initial"},
+	} {
+		out, err := exec.Command(args[0], args[1:]...).CombinedOutput()
+		if err != nil {
+			t.Skipf("git setup failed (%v): %s — skipping pin adapter integration test", err, out)
+		}
+	}
+
+	// Set up source workspace with a pin targeting "cogos-dev/cogos".
+	source := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(source, ".cog", "pins"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	pinYAML := "target: cogos-dev/cogos\npin:\n  ref: abc1234567890abcdef1234567890abcdef123456\nsync: read-only\n"
+	if err := os.WriteFile(filepath.Join(source, ".cog", "pins", "cogos-dev_cogos.yaml"), []byte(pinYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wire the real adapter — same shape as production cmd/cogos/providers_wire.go.
+	p := pin.New(nil)
+	p.SetWorkspaceLocator(&realAdapterLocator{})
+
+	cfgAny, err := p.LoadConfig(source)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	liveAny, err := p.FetchLive(context.Background(), cfgAny)
+	if err != nil {
+		t.Fatalf("FetchLive with real adapter on slash-bearing name: %v", err)
+	}
+
+	// Verify the plan computes without panic — confirms liveAny is well-formed.
+	planAny, err := p.ComputePlan(cfgAny, liveAny, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if planAny == nil {
+		t.Fatal("ComputePlan returned nil plan")
+	}
+}

--- a/internal/engine/uri_registry.go
+++ b/internal/engine/uri_registry.go
@@ -378,17 +378,37 @@ func verifyDigest(path, expectedHex string) error {
 //
 // Returns ("", ErrUnknownAuthority) when the workspace is not registered.
 // All other errors are I/O or parse failures in the global.yaml registry file.
+//
+// name must be the raw workspace name as registered in global.yaml (e.g.
+// "cogos-dev/cogos"). It must NOT be constructed as a URI authority component:
+// synthesising "cog://"+name and re-parsing would split the authority at the
+// first slash, looking up "cogos-dev" instead of "cogos-dev/cogos".
 func ResolveWorkspacePath(ctx context.Context, name string) (string, error) {
 	if URIRegistry == nil {
 		return "", fmt.Errorf("%w: URIRegistry not initialised", ErrUnknownAuthority)
 	}
-	content, err := URIRegistry.Resolve(ctx, "cog://"+name)
+	// Type-assert to *uriRegistryImpl so we can call resolveAuthority directly
+	// with the raw name.  This avoids the "cog://"+name round-trip through
+	// Resolve → strings.Cut(rest, "/") which splits "cogos-dev/cogos" into
+	// authority="cogos-dev" and path="cogos", losing the slash-bearing key.
+	impl, ok := URIRegistry.(*uriRegistryImpl)
+	if !ok {
+		// Fallback for test doubles that only implement uriResolver.
+		// The name is treated as a single-component authority (no slash).
+		content, err := URIRegistry.Resolve(ctx, "cog://"+name)
+		if err != nil {
+			return "", fmt.Errorf("%w: %v", ErrUnknownAuthority, err)
+		}
+		path, _ := content.Metadata["path"].(string)
+		if path == "" {
+			return "", fmt.Errorf("%w: URIRegistry returned empty path for %q", ErrUnknownAuthority, name)
+		}
+		return path, nil
+	}
+	nodeDir := impl.nodeDirFn()
+	wsRoot, err := impl.resolveAuthority(nodeDir, name)
 	if err != nil {
 		return "", fmt.Errorf("%w: %v", ErrUnknownAuthority, err)
 	}
-	path, _ := content.Metadata["path"].(string)
-	if path == "" {
-		return "", fmt.Errorf("%w: URIRegistry returned empty path for %q", ErrUnknownAuthority, name)
-	}
-	return path, nil
+	return wsRoot, nil
 }

--- a/internal/engine/uri_registry_test.go
+++ b/internal/engine/uri_registry_test.go
@@ -292,3 +292,69 @@ func TestResolveFragmentBeforeQuery_Rejected(t *testing.T) {
 		t.Fatalf("Resolve(%q): expected error for fragment-before-query, got nil (digest bypass)", malformed)
 	}
 }
+
+// ── ResolveWorkspacePath: slash-bearing name regression (#175 fixup) ─────────
+
+// testNodeSetupWithSlashName creates a node dir whose global.yaml has a
+// slash-bearing workspace name ("cogos-dev/cogos"), swaps URIRegistry for the
+// duration of the test, and returns the node dir and workspace root.
+func testNodeSetupWithSlashName(t *testing.T) (nd, wsSlash string) {
+	t.Helper()
+	base := t.TempDir()
+	nd = filepath.Join(base, "node")
+	if err := os.MkdirAll(nd, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	wsSlash = filepath.Join(base, "cogos-dev", "cogos")
+	if err := os.MkdirAll(wsSlash, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	global := "version: \"1.0\"\nworkspaces:\n" +
+		"  cogos-dev/cogos:\n    path: " + wsSlash + "\n"
+	if err := os.WriteFile(filepath.Join(nd, "global.yaml"), []byte(global), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	testReg := &uriRegistryImpl{nodeDirFn: func() string { return nd }}
+	orig := URIRegistry
+	URIRegistry = testReg
+	t.Cleanup(func() { URIRegistry = orig })
+
+	return nd, wsSlash
+}
+
+// TestResolveWorkspacePathSlashBearing is the regression test for the bug found
+// by Codex review of PR #180.
+//
+// Before the fix, ResolveWorkspacePath built "cog://cogos-dev/cogos" and called
+// URIRegistry.Resolve, which split the authority at the first slash and looked
+// up workspace "cogos-dev" instead of "cogos-dev/cogos". The test would have
+// returned ErrUnknownAuthority.
+//
+// After the fix, ResolveWorkspacePath resolves the raw name directly via
+// resolveAuthority, bypassing URI authority splitting.
+func TestResolveWorkspacePathSlashBearing(t *testing.T) {
+	_, wsSlash := testNodeSetupWithSlashName(t)
+
+	got, err := ResolveWorkspacePath(context.Background(), "cogos-dev/cogos")
+	if err != nil {
+		t.Fatalf("ResolveWorkspacePath(cogos-dev/cogos): %v", err)
+	}
+	if got != wsSlash {
+		t.Errorf("path: got %q, want %q", got, wsSlash)
+	}
+}
+
+// TestResolveWorkspacePathSlashBearing_NotFound verifies that looking up a
+// name not in the registry returns ErrUnknownAuthority (not a panic or empty
+// string).
+func TestResolveWorkspacePathSlashBearing_NotFound(t *testing.T) {
+	testNodeSetupWithSlashName(t) // sets up URIRegistry with cogos-dev/cogos only
+
+	_, err := ResolveWorkspacePath(context.Background(), "cogos-dev/other-repo")
+	if err == nil {
+		t.Fatal("expected ErrUnknownAuthority for unknown slash-bearing name, got nil")
+	}
+}

--- a/internal/providers/pin/pin.go
+++ b/internal/providers/pin/pin.go
@@ -227,7 +227,10 @@ type localGitHeadResolver struct {
 }
 
 func (r *localGitHeadResolver) ResolveHead(ctx context.Context, target, workspaceRoot string) (string, string, error) {
-	targetPath := r.locateTarget(ctx, target, workspaceRoot)
+	targetPath, locErr := r.locateTarget(ctx, target, workspaceRoot)
+	if locErr != nil {
+		return "", "", fmt.Errorf("pin: locating target %q: %w", target, locErr)
+	}
 	if targetPath == "" {
 		return "", "", fmt.Errorf("%w: %q", ErrWorkspaceNotFound, target)
 	}
@@ -250,20 +253,28 @@ func (r *localGitHeadResolver) ResolveHead(ctx context.Context, target, workspac
 //     success or on any error that is NOT ErrWorkspaceNotFound.
 //  2. Sibling-directory scan — local fallback for workspaces not yet in the
 //     registry (e.g. during bootstrapping or federation setup).
-func (r *localGitHeadResolver) locateTarget(ctx context.Context, target, workspaceRoot string) string {
+//
+// Returns ("", nil) when the workspace is simply not found anywhere.
+// Returns ("", err) when the locator signals a hard registry failure.
+func (r *localGitHeadResolver) locateTarget(ctx context.Context, target, workspaceRoot string) (string, error) {
 	// Step 1: consult WorkspaceLocator when available.
 	if r.locator != nil {
 		path, err := r.locator.LocateWorkspace(ctx, target)
 		if err == nil && path != "" {
-			return path
+			return path, nil
 		}
-		// ErrWorkspaceNotFound → fall through to local scan.
-		// Any other error (I/O, registry unavailable) → also fall through so
-		// a transient registry failure doesn't break local-only workflows.
+		if err != nil && !errors.Is(err, ErrWorkspaceNotFound) {
+			// Non-not-found error (I/O failure, parse error, registry
+			// unavailable): propagate immediately so the registry failure
+			// is visible to the caller rather than silently masked by a
+			// stale sibling-directory scan.
+			return "", err
+		}
+		// ErrWorkspaceNotFound → fall through to local sibling-directory scan.
 	}
 
 	if workspaceRoot == "" {
-		return ""
+		return "", nil
 	}
 
 	// Normalise target: convert "/" to OS separator.
@@ -279,21 +290,21 @@ func (r *localGitHeadResolver) locateTarget(ctx context.Context, target, workspa
 		// single-component target (e.g., "cogos") — look as a sibling dir.
 		candidate := filepath.Join(parent, parts[0])
 		if isGitRepo(candidate) {
-			return candidate
+			return candidate, nil
 		}
 	case 2:
 		// two-component target (e.g., "cogos-dev/cogos") — look one level up.
 		candidate := filepath.Join(grandParent, parts[0], parts[1])
 		if isGitRepo(candidate) {
-			return candidate
+			return candidate, nil
 		}
 		// Also try: sibling with last-segment name.
 		candidateFlat := filepath.Join(parent, parts[1])
 		if isGitRepo(candidateFlat) {
-			return candidateFlat
+			return candidateFlat, nil
 		}
 	}
-	return ""
+	return "", nil
 }
 
 // isGitRepo returns true when path is a directory containing a .git entry.

--- a/internal/providers/pin/pin_test.go
+++ b/internal/providers/pin/pin_test.go
@@ -870,6 +870,124 @@ sync: read-only
 	}
 }
 
+// ─── Locator error-propagation tests (PR #180 fixup) ─────────────────────────
+
+// errLocator is a stub WorkspaceLocator that always returns a hard error that
+// is NOT ErrWorkspaceNotFound (simulates I/O failure / corrupt registry file).
+type errLocator struct {
+	err error
+}
+
+func (l *errLocator) LocateWorkspace(_ context.Context, _ string) (string, error) {
+	return "", l.err
+}
+
+// TestLocatorNonNotFoundError_Propagated is the regression test for the
+// silent-swallow bug found by Codex review of PR #180.
+//
+// Before the fix, any error from WorkspaceLocator.LocateWorkspace (other than
+// ErrWorkspaceNotFound) was silently swallowed and the sibling-directory
+// fallback always ran. The comment at locateTarget:247-250 said non-not-found
+// errors should return immediately — but the code didn't match.
+//
+// After the fix, a hard registry error (e.g. I/O failure) propagates out of
+// FetchLive so the caller knows the registry is broken, not just empty.
+func TestLocatorNonNotFoundError_Propagated(t *testing.T) {
+	t.Parallel()
+	source := setupWorkspace(t)
+	const target = "cogos-dev/cogos"
+
+	writePinYAML(t, source, "cogos-dev_cogos", `
+target: cogos-dev/cogos
+pin:
+  ref: abc1234567890abcdef1234567890abcdef123456
+sync: read-only
+`)
+
+	registryErr := errors.New("simulated registry I/O failure")
+	p := pin.New(nil)
+	p.SetWorkspaceLocator(&errLocator{err: registryErr})
+
+	cfgAny, err := p.LoadConfig(source)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	liveAny, fetchErr := p.FetchLive(context.Background(), cfgAny)
+	if fetchErr != nil {
+		t.Fatalf("FetchLive unexpected top-level error: %v", fetchErr)
+	}
+
+	// ComputePlan stores lr.Error.Error() in the plan action details["error"].
+	// This is the observable surface for what error message was captured.
+	plan, planErr := p.ComputePlan(cfgAny, liveAny, nil)
+	if planErr != nil {
+		t.Fatalf("ComputePlan unexpected error: %v", planErr)
+	}
+
+	// After the fix: the registry error propagates through locateTarget →
+	// ResolveHead (wrapped as "pin: locating target …: simulated registry I/O
+	// failure") → LiveRef.Error → plan action details["error"].
+	// The original registryErr.Error() string must appear in the action details.
+	//
+	// Without the fix: locateTarget silently falls through to sibling scan,
+	// which also fails but produces a generic ErrWorkspaceNotFound message —
+	// "pin: workspace not found …" — that does NOT contain the original registry
+	// error text. The test would fail on pre-fix code because the error string
+	// "simulated registry I/O failure" is absent from the action details.
+	if len(plan.Actions) == 0 {
+		t.Fatal("ComputePlan returned no actions; expected at least one for the unreachable target")
+	}
+	actionErr, _ := plan.Actions[0].Details["error"].(string)
+	if !strings.Contains(actionErr, registryErr.Error()) {
+		t.Errorf("plan action error %q does not contain registry error %q; "+
+			"registry I/O error was silently swallowed and replaced by fallback error",
+			actionErr, registryErr.Error())
+	}
+}
+
+// TestLocatorErrWorkspaceNotFound_FallsBack verifies the complementary case:
+// ErrWorkspaceNotFound from the locator still falls through to the sibling scan
+// (not treated as a hard failure). This ensures the fallback logic is intact.
+func TestLocatorErrWorkspaceNotFound_FallsBack(t *testing.T) {
+	t.Parallel()
+	source := setupWorkspace(t)
+	const target = "some-workspace"
+
+	writePinYAML(t, source, "some_workspace", `
+target: some-workspace
+pin:
+  ref: abc1234567890abcdef1234567890abcdef123456
+sync: read-only
+`)
+
+	// Locator returns ErrWorkspaceNotFound — should fall through, not hard-fail.
+	notFoundLocator := &stubLocator{paths: map[string]string{}} // empty → not found
+	p := pin.New(nil)
+	p.SetWorkspaceLocator(notFoundLocator)
+
+	cfgAny, err := p.LoadConfig(source)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	// FetchLive should not propagate an error from ErrWorkspaceNotFound alone;
+	// the sibling scan fires (and finds nothing), then localGitHeadResolver
+	// wraps the absence as ErrWorkspaceNotFound in the LiveRef.
+	_, err = p.FetchLive(context.Background(), cfgAny)
+	if err != nil {
+		// Acceptable — may wrap ErrWorkspaceNotFound from git resolution.
+		// What is NOT acceptable is a hard error.
+		if !errors.Is(err, pin.ErrWorkspaceNotFound) && !strings.Contains(err.Error(), "not found") {
+			t.Errorf("FetchLive returned unexpected error (want workspace-not-found, got): %v", err)
+		}
+	}
+	// Locator must have been consulted.
+	if len(notFoundLocator.calls) == 0 {
+		t.Error("locator was not consulted at all")
+	}
+}
+
 // TestErrWorkspaceNotFound_SentinelExported verifies the exported sentinel error
 // is the right type for errors.Is checks in callers.
 func TestErrWorkspaceNotFound_SentinelExported(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix-up of PR #180 (which closed #175 — wire URIRegistry into pin Reconcilable's local resolver). Two blockers found by Codex review at `/tmp/codex-wave2-review-summary.txt` in the section **#180 / #175 — pin URIRegistry wiring**:

> **Blocker:** the production adapter calls `engine.ResolveWorkspacePath(ctx, name)` (`cmd/cogos/providers_wire.go:39-40`), which builds `cog://` + name (`internal/engine/uri_registry.go:370-374`). Pin target names are documented as slash-bearing names like `cogos-dev/cogos` (`internal/providers/pin/pin.go:45-51`, `:87-89`), and global parsing supports that key. But `URIRegistry.Resolve` splits authority at the first slash (`internal/engine/uri_registry.go:139-140`), so `cog://cogos-dev/cogos` looks up workspace `cogos-dev`, not `cogos-dev/cogos`. The tests use a stub locator (`internal/providers/pin/pin_test.go:837-839`), so they miss the real adapter path.
>
> Also, registry errors are silently swallowed and fallback always runs (`internal/providers/pin/pin.go:255-263`), contradicting the comment that non-not-found errors return immediately (`internal/providers/pin/pin.go:247-250`).

### Fix 1: `internal/engine/uri_registry.go` — bypass URI authority splitting for workspace name lookup

`ResolveWorkspacePath` was building `"cog://"+name` and calling `URIRegistry.Resolve`, which splits the authority component at the first `/`. For a name like `cogos-dev/cogos` this looked up workspace `cogos-dev` and returned `ErrUnknownAuthority`.

Fix: type-assert `URIRegistry` to `*uriRegistryImpl` and call `resolveAuthority(nodeDir, name)` directly with the raw name, bypassing the URI round-trip. A fallback path using `Resolve` is preserved for test doubles that only implement the `uriResolver` interface.

### Fix 2: `internal/providers/pin/pin.go` — propagate non-ErrWorkspaceNotFound locator errors

`locateTarget` was swallowing all errors from `WorkspaceLocator.LocateWorkspace` and falling through to the sibling-directory scan, contradicting the comment at `:247-250`. A hard registry failure (I/O error, corrupt `global.yaml`) was indistinguishable from "workspace not registered".

Fix: change `locateTarget` signature to `(string, error)`. Non-`ErrWorkspaceNotFound` errors propagate immediately. `ErrWorkspaceNotFound` still falls through to the sibling scan (bootstrap / federation workflows).

## Tests

Both tests must fail on the un-fixed code:

- `internal/engine/pin_adapter_test.go` — `TestPinAdapter_SlashBearingWorkspaceName`: integration test wiring the real `engine.ResolveWorkspacePath` adapter (same shape as `cmd/cogos/providers_wire.go`) with a registry containing `cogos-dev/cogos` and a real git repo; this is the test PR #180 was missing.
- `internal/providers/pin/pin_test.go` — `TestLocatorNonNotFoundError_Propagated`: simulates a hard registry I/O error and asserts the original error text appears in the `ComputePlan` action details (pre-fix: silently replaced by `ErrWorkspaceNotFound` from sibling scan).
- `TestLocatorErrWorkspaceNotFound_FallsBack`: companion test confirming `ErrWorkspaceNotFound` still falls through as intended.
- `TestResolveWorkspacePathSlashBearing` / `TestResolveWorkspacePathSlashBearing_NotFound`: unit tests for the `ResolveWorkspacePath` fix directly.

`go test -tags fts5 ./...` — all green.

## Relation to #175 / #180

#175 is already closed by #180. This PR does not reopen it. It ships the two correctness gaps that the Codex wave-2 review identified as left open after the merge.