### PR TITLE
test(provider/ollama): align tool_choice=none subtest parallelism with openai-compat

### DIFF
--- a/internal/engine/provider_ollama_test.go
+++ b/internal/engine/provider_ollama_test.go
@@ -884,6 +884,7 @@ func TestBuildOllamaRequestSuppressesToolsWhenNone(t *testing.T) {
 
 	// tool_choice == "none" → tools field must be absent from the wire body.
 	t.Run("none suppresses tools", func(t *testing.T) {
+		t.Parallel()
 		req := &CompletionRequest{Messages: msgs, Tools: tools, ToolChoice: "none"}
 		r := buildOllamaRequest("m", req, false, 0)
 		if len(r.Tools) != 0 {
@@ -906,6 +907,7 @@ func TestBuildOllamaRequestSuppressesToolsWhenNone(t *testing.T) {
 	for _, tc := range []string{"auto", "required", "search"} {
 		tc := tc
 		t.Run("includes tools for "+tc, func(t *testing.T) {
+			t.Parallel()
 			req := &CompletionRequest{Messages: msgs, Tools: tools, ToolChoice: tc}
 			r := buildOllamaRequest("m", req, false, 0)
 			if len(r.Tools) != 1 {
@@ -916,6 +918,7 @@ func TestBuildOllamaRequestSuppressesToolsWhenNone(t *testing.T) {
 
 	// No tools in the request → tools field absent regardless of tool_choice.
 	t.Run("no tools always omits tools field", func(t *testing.T) {
+		t.Parallel()
 		req := &CompletionRequest{Messages: msgs, ToolChoice: "auto"}
 		r := buildOllamaRequest("m", req, false, 0)
 		if len(r.Tools) != 0 {


### PR DESCRIPTION
## Summary

- Adds `t.Parallel()` to all three leaf subtests inside `TestBuildOllamaRequestSuppressesToolsWhenNone` in `internal/engine/provider_ollama_test.go`
- Matches the pattern already used in `TestBuildOpenAIRequestSuppressesToolsWhenNone` in `internal/engine/provider_openai_test.go`
- Pure test hygiene — no behavior change, no production code touched

## Test plan

- [x] `go test -tags fts5 ./...` green (all packages pass)
- [x] Subtests now show PAUSE/CONT pattern confirming parallel execution

Closes #135