### PR TITLE
fix(bus): return 416 when since>0 on an empty bus

### DIFF
--- a/internal/engine/serve_bus.go
+++ b/internal/engine/serve_bus.go
@@ -511,10 +511,14 @@ func (s *Server) handleBusStream(w http.ResponseWriter, r *http.Request, busID s
 	}
 
 	// Validate since range before upgrading to SSE — must not exceed current tip.
+	// An empty bus has tip=0, so any since>0 is out of range (RFC 7233 / 416).
 	if hasSince && s.busSessions != nil {
 		events, err := s.busSessions.ReadEvents(busID)
-		if err == nil && len(events) > 0 {
-			maxSeq := events[len(events)-1].Seq
+		if err == nil {
+			var maxSeq int // tip=0 for an empty bus
+			if len(events) > 0 {
+				maxSeq = events[len(events)-1].Seq
+			}
 			if sinceSeq > maxSeq {
 				http.Error(w, `{"error":"since exceeds current tip","code":"range_not_satisfiable"}`, http.StatusRequestedRangeNotSatisfiable)
 				return

--- a/internal/engine/serve_bus_test.go
+++ b/internal/engine/serve_bus_test.go
@@ -937,6 +937,39 @@ func TestBusStreamSincePastTip(t *testing.T) {
 	}
 }
 
+// TestBusStreamSinceEmptyBus is a regression test for issue #136: an empty bus
+// with ?since=1 (or any positive value) must return 416 Range Not Satisfiable,
+// not silently fall through to a 200 SSE stream. The empty bus has tip=0, so
+// any since>0 is out of range per RFC 7233.
+func TestBusStreamSinceEmptyBus(t *testing.T) {
+	t.Parallel()
+	handler, _, _ := newEventsTestServer(t)
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	const busID = "since-empty-bus"
+	openResp, _ := http.Post(srv.URL+"/v1/bus/open", "application/json",
+		strings.NewReader(`{"bus_id":"`+busID+`"}`))
+	openResp.Body.Close()
+
+	// Bus has no events (tip=0). since=1 must return 416.
+	resp, err := http.Get(srv.URL + "/v1/bus/" + busID + "/stream?since=1")
+	if err != nil {
+		t.Fatalf("GET stream: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusRequestedRangeNotSatisfiable {
+		t.Errorf("status = %d, want 416 (empty bus + since=1 must not fall through to 200)", resp.StatusCode)
+	}
+
+	var body map[string]interface{}
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if _, ok := body["error"]; !ok {
+		t.Errorf("response missing 'error' field: %+v", body)
+	}
+}
+
 // TestBusStreamSinceMutualExclusion verifies that passing both ?since=N and
 // ?no_replay=1 returns 400 Bad Request.
 func TestBusStreamSinceMutualExclusion(t *testing.T) {


### PR DESCRIPTION
## Summary

- Empty buses have `tip=0`. The previous guard (`len(events) > 0`) on line 516 of `internal/engine/serve_bus.go` skipped the range check entirely when the bus had no events, letting any `?since=N` (N>0) fall through to a 200 SSE stream.
- Fix: when `ReadEvents` succeeds (no error), default `maxSeq` to `0` for an empty bus. The existing `sinceSeq > maxSeq` comparison then correctly rejects any positive `since` value with 416 Range Not Satisfiable (RFC 7233).
- Adds `TestBusStreamSinceEmptyBus` as a regression test (empty bus + `?since=1` asserts 416).

## Test plan

- [ ] `go test -tags fts5 ./internal/engine/ -run TestBusStreamSinceEmptyBus` passes (new regression test)
- [ ] `go test -tags fts5 ./...` all green (no regressions)

Closes #136