### PR TITLE
ci(engine): extend namespace drift test to cover isProjectionNamespace

### DIFF
--- a/internal/engine/namespace_sync_test.go
+++ b/internal/engine/namespace_sync_test.go
@@ -1,20 +1,23 @@
 package engine_test
 
-// namespace_sync_test.go — CI guard that sdk.Namespaces and pkg/uri.Namespaces
-// never drift from each other (issue #173).
+// namespace_sync_test.go — CI guard that all manual namespace lists never drift
+// from the canonical pkg/uri.Namespaces table (issues #173, #183).
+//
+// Three manual copies of the namespace set must stay in sync:
+//
+//	pkg/uri/namespace.go              — canonical definition (Namespaces map)
+//	sdk/uri.go                        — copy (sdk.Namespaces, lines tagged "SINGLE SOURCE")
+//	internal/engine/uri_registry.go   — isProjectionNamespace switch statement
 //
 // The sdk module cannot import pkg/uri directly (separate Go modules; importing
-// would create an import cycle via the main module). Both namespace maps are
-// therefore maintained as manual copies with a comment documenting the
-// single-source-of-truth relationship:
+// would create an import cycle via the main module). The engine package's
+// isProjectionNamespace predicate is likewise a manually maintained copy
+// pending #166 (direct namespace-registry import).
 //
-//	pkg/uri/namespace.go   — canonical definition
-//	sdk/uri.go             — copy (sdk.Namespaces, lines tagged "SINGLE SOURCE")
-//
-// This test parses both source files with go/ast and extracts the map literal
-// keys, then asserts they are identical sets. It runs as part of `go test
-// ./internal/engine/` and will fail CI if a key is added to one map but not
-// the other.
+// This test parses all three source files with go/ast, extracts the namespace
+// keys from each, and asserts they are identical sets. It runs as part of
+// `go test ./internal/engine/` and will fail CI if a key is added to one list
+// but not the others.
 
 import (
 	"go/ast"
@@ -133,6 +136,106 @@ func TestNamespaces_SDKAndPkgURI_NeverDrift(t *testing.T) {
 	if t.Failed() {
 		t.Logf("pkg/uri keys (%d): %v", len(pkgKeys), sortedKeys(pkgKeys))
 		t.Logf("sdk keys    (%d): %v", len(sdkKeys), sortedKeys(sdkKeys))
+	}
+}
+
+// extractProjectionNamespaceKeys parses a Go source file and returns the set
+// of string literals enumerated in the switch statement inside the function
+// named "isProjectionNamespace".  The function body is expected to be a single
+// switch with one or more case clauses whose List entries are string BasicLits
+// (possibly comma-joined in source: case "a", "b", "c":).
+func extractProjectionNamespaceKeys(t *testing.T, srcPath string) map[string]struct{} {
+	t.Helper()
+
+	src, err := os.ReadFile(srcPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", srcPath, err)
+	}
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, srcPath, src, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", srcPath, err)
+	}
+
+	keys := make(map[string]struct{})
+	found := false
+
+	ast.Inspect(f, func(n ast.Node) bool {
+		// Locate the function declaration named "isProjectionNamespace".
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Name == nil || fn.Name.Name != "isProjectionNamespace" {
+			return true
+		}
+		found = true
+
+		// Walk its body to find the switch statement.
+		ast.Inspect(fn.Body, func(inner ast.Node) bool {
+			sw, ok := inner.(*ast.SwitchStmt)
+			if !ok {
+				return true
+			}
+			// Each case clause may list multiple expressions (comma-separated).
+			for _, stmt := range sw.Body.List {
+				cc, ok := stmt.(*ast.CaseClause)
+				if !ok || cc.List == nil {
+					continue // skip default clause
+				}
+				for _, expr := range cc.List {
+					lit, ok := expr.(*ast.BasicLit)
+					if !ok || lit.Kind != token.STRING {
+						continue
+					}
+					key := lit.Value
+					if len(key) >= 2 && key[0] == '"' && key[len(key)-1] == '"' {
+						key = key[1 : len(key)-1]
+					}
+					keys[key] = struct{}{}
+				}
+			}
+			return false // no need to descend further into the switch
+		})
+
+		return false // no need to visit siblings
+	})
+
+	if !found {
+		t.Fatalf("function isProjectionNamespace not found in %s", srcPath)
+	}
+	if len(keys) == 0 {
+		t.Fatalf("no case values found in isProjectionNamespace in %s — check the switch is still present", srcPath)
+	}
+	return keys
+}
+
+func TestNamespaces_IsProjectionNamespace_NeverDrift(t *testing.T) {
+	root := repoRoot(t)
+
+	pkgURIFile := filepath.Join(root, "pkg", "uri", "namespace.go")
+	uriRegistryFile := filepath.Join(root, "internal", "engine", "uri_registry.go")
+
+	pkgKeys := extractNamespaceKeys(t, pkgURIFile)
+	switchKeys := extractProjectionNamespaceKeys(t, uriRegistryFile)
+
+	// Check: every pkg/uri key must be in isProjectionNamespace.
+	for k := range pkgKeys {
+		if _, ok := switchKeys[k]; !ok {
+			t.Errorf("namespace %q is in pkg/uri.Namespaces but missing from isProjectionNamespace in uri_registry.go\n"+
+				"  add it to the switch in internal/engine/uri_registry.go:isProjectionNamespace", k)
+		}
+	}
+
+	// Check: every isProjectionNamespace key must be in pkg/uri.
+	for k := range switchKeys {
+		if _, ok := pkgKeys[k]; !ok {
+			t.Errorf("namespace %q is in isProjectionNamespace but missing from pkg/uri.Namespaces\n"+
+				"  add it to pkg/uri/namespace.go Namespaces map", k)
+		}
+	}
+
+	if t.Failed() {
+		t.Logf("pkg/uri keys          (%d): %v", len(pkgKeys), sortedKeys(pkgKeys))
+		t.Logf("isProjectionNamespace (%d): %v", len(switchKeys), sortedKeys(switchKeys))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Closes #183
- Extends `internal/engine/namespace_sync_test.go` (from PR #178) with a new `extractProjectionNamespaceKeys()` helper and `TestNamespaces_IsProjectionNamespace_NeverDrift` test
- The new test AST-parses the `switch` statement in `internal/engine/uri_registry.go:isProjectionNamespace` and asserts its case values match `pkg/uri.Namespaces` exactly
- Updates the file-level comment to document all three manual namespace copies now under CI guard

## How the AST parse works

`isProjectionNamespace` is a bare `switch s { case "a", "b", "c": return true }` — no tag expression matching against a variable. The parser walks the file AST to locate the `*ast.FuncDecl` named `isProjectionNamespace`, then descends into its body to find the `*ast.SwitchStmt`. Each `*ast.CaseClause` has a `List []ast.Expr`; the comma-separated string literals in a single `case` line each appear as a separate `*ast.BasicLit` of kind `token.STRING` in that slice. The helper collects all of them into a `map[string]struct{}` for set-comparison.

## Test plan

- [x] `go test -tags fts5 ./internal/engine/ -run TestNamespaces -v` — both tests PASS
- [x] `go test -tags fts5 ./...` — full suite green