### PR TITLE
harness: strip ingress vars from spawned subprocesses

### DIFF
--- a/harness/harness.go
+++ b/harness/harness.go
@@ -70,16 +70,35 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// filteredEnviron returns a copy of os.Environ() with the CLAUDECODE variable
-// removed. Claude Code sets CLAUDECODE in its process environment; if a child
-// `claude` CLI inherits it, the CLI refuses to start ("cannot be launched inside
-// another Claude Code session"). Filtering it out allows CogOS to spawn Claude
-// CLI from within a Claude Code session (e.g. during development/testing).
+// harnessIngressVars are environment variable prefixes that, if inherited by a
+// spawned subprocess, can redirect the child's model client back through the
+// CogOS kernel (routing loop). These mirror the ingressVars list in
+// internal/engine/provider_env.go; keep both lists in sync.
+var harnessIngressVars = []string{
+	"ANTHROPIC_BASE_URL",
+	"ANTHROPIC_AUTH_TOKEN",
+	"OPENAI_BASE_URL",
+	"OPENAI_API_BASE",
+	"OPENAI_COMPAT_BASE_URL",
+}
+
+// filteredEnviron returns a copy of os.Environ() with variables that would
+// cause routing loops stripped out:
+//   - CLAUDECODE: Claude Code sets this in its process env; a child `claude`
+//     CLI that inherits it refuses to start ("cannot be launched inside another
+//     Claude Code session").
+//   - The five ingress/proxy routing vars (ANTHROPIC_BASE_URL, etc.): these
+//     can redirect a kernel-spawned provider subprocess back through the kernel,
+//     producing recursive inference loops (same bug fixed in internal/engine/
+//     via PR #130 / issue #59).
 func filteredEnviron() []string {
 	env := os.Environ()
 	out := make([]string, 0, len(env)+1)
 	for _, e := range env {
 		if strings.HasPrefix(e, "CLAUDECODE=") {
+			continue
+		}
+		if isHarnessIngressVar(e) {
 			continue
 		}
 		out = append(out, e)
@@ -88,6 +107,17 @@ func filteredEnviron() []string {
 	// so they can skip context injection (the kernel handles it natively).
 	out = append(out, "COGOS_HARNESS=1")
 	return out
+}
+
+// isHarnessIngressVar reports whether the KEY=VALUE string kv corresponds to
+// one of the known ingress routing variables.
+func isHarnessIngressVar(kv string) bool {
+	for _, key := range harnessIngressVars {
+		if strings.HasPrefix(kv, key+"=") {
+			return true
+		}
+	}
+	return false
 }
 
 // Harness is the inference execution engine. Create one with [New] and call

--- a/harness/harness_test.go
+++ b/harness/harness_test.go
@@ -5,9 +5,16 @@ package harness
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 )
+
+// execCommand returns an exec.Cmd for the given binary with no arguments.
+// It exists as a thin wrapper so tests can call it without importing os/exec directly.
+func execCommand(binary string) *exec.Cmd {
+	return exec.Command(binary) //nolint:gosec
+}
 
 // === BuildClaudeArgs TESTS ===
 
@@ -417,3 +424,144 @@ func TestClassifyHTTPError(t *testing.T) {
 type errorString string
 
 func (e errorString) Error() string { return string(e) }
+
+// === filteredEnviron / env-isolation TESTS (regression for issue #137) ===
+
+// TestFilteredEnviron_StripsIngressVars asserts that filteredEnviron() drops
+// the five routing/proxy keys that can redirect a spawned provider subprocess
+// back into the CogOS kernel (the same bug fixed for internal/engine/ in
+// issue #59 / PR #130).
+func TestFilteredEnviron_StripsIngressVars(t *testing.T) {
+	for _, key := range harnessIngressVars {
+		t.Setenv(key, "http://should-be-stripped.example.com")
+	}
+
+	env := filteredEnviron()
+
+	for _, kv := range env {
+		for _, key := range harnessIngressVars {
+			if strings.HasPrefix(kv, key+"=") {
+				t.Errorf("ingress var %s must be stripped from filteredEnviron, found %q", key, kv)
+			}
+		}
+	}
+}
+
+// TestFilteredEnviron_StripsCLAUDECODE asserts that CLAUDECODE is removed so
+// that a spawned `claude` CLI can start inside a Claude Code session.
+func TestFilteredEnviron_StripsCLAUDECODE(t *testing.T) {
+	t.Setenv("CLAUDECODE", "1")
+
+	env := filteredEnviron()
+
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "CLAUDECODE=") {
+			t.Errorf("CLAUDECODE must be stripped from filteredEnviron, found %q", kv)
+		}
+	}
+}
+
+// TestFilteredEnviron_PreservesUnrelatedVars asserts that PATH and similar
+// unrelated variables are retained after filtering.
+func TestFilteredEnviron_PreservesUnrelatedVars(t *testing.T) {
+	t.Parallel()
+
+	path := os.Getenv("PATH")
+	if path == "" {
+		t.Skip("PATH not set in test environment")
+	}
+
+	env := filteredEnviron()
+
+	found := false
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "PATH=") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("PATH must be preserved in filteredEnviron")
+	}
+}
+
+// TestFilteredEnviron_InjectsHarnessMarker asserts that COGOS_HARNESS=1 is
+// appended so Python hooks know they are running under the kernel.
+func TestFilteredEnviron_InjectsHarnessMarker(t *testing.T) {
+	env := filteredEnviron()
+
+	found := false
+	for _, kv := range env {
+		if kv == "COGOS_HARNESS=1" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("COGOS_HARNESS=1 must be present in filteredEnviron output")
+	}
+}
+
+// TestSpawnedProcess_DoesNotInheritIngressVars is the end-to-end regression
+// test for issue #137. It spawns a real subprocess via a fake shell script that
+// writes its environment to a temp file, then asserts none of the ingress vars
+// (nor CLAUDECODE) are present in the child env. This mirrors
+// TestClaudeCodeComplete_DoesNotInheritBaseURL in internal/engine/provider_env_test.go
+// but exercises the harness filteredEnviron() path used by claude.go and codex.go.
+func TestSpawnedProcess_DoesNotInheritIngressVars(t *testing.T) {
+	// Set all ingress vars + CLAUDECODE in the parent process.
+	for _, key := range harnessIngressVars {
+		t.Setenv(key, "http://kernel.local:6931/should-not-leak")
+	}
+	t.Setenv("CLAUDECODE", "1")
+
+	// Temp file for the child to record its environment into.
+	envFile, err := os.CreateTemp(t.TempDir(), "child-env-*.txt")
+	if err != nil {
+		t.Fatalf("create env file: %v", err)
+	}
+	envFile.Close()
+
+	// Fake binary: write env to envFile then exit 0.
+	script, err := os.CreateTemp(t.TempDir(), "fake-provider-*.sh")
+	if err != nil {
+		t.Fatalf("create script: %v", err)
+	}
+	_, _ = script.WriteString("#!/bin/sh\n")
+	_, _ = script.WriteString("env > " + envFile.Name() + "\n")
+	script.Close()
+	if err := os.Chmod(script.Name(), 0o755); err != nil {
+		t.Fatalf("chmod script: %v", err)
+	}
+
+	// Verify filteredEnviron() itself contains no forbidden vars (unit check).
+	childEnv := filteredEnviron()
+	forbidden := append([]string{"CLAUDECODE"}, harnessIngressVars...)
+	for _, kv := range childEnv {
+		for _, key := range forbidden {
+			if strings.HasPrefix(kv, key+"=") {
+				t.Errorf("filteredEnviron: var %s must be stripped, got %q", key, kv)
+			}
+		}
+	}
+
+	// Spawn a real subprocess with filteredEnviron() applied and read what it saw.
+	cmd := execCommand(script.Name())
+	cmd.Env = childEnv
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("fake provider failed: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(envFile.Name())
+	if err != nil {
+		t.Fatalf("read env file: %v", err)
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		for _, key := range forbidden {
+			if strings.HasPrefix(line, key+"=") {
+				t.Errorf("child process received %s: %q", key, line)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `filteredEnviron()` in `harness/harness.go` previously stripped only `CLAUDECODE`. This PR adds the same five ingress/proxy routing keys already stripped by `internal/engine/provider_env.go` (fixed for the engine layer in #59 / PR #130).
- The same recursive-routing risk exists through `harness/` paths: a kernel-spawned `claude` or `codex` subprocess inheriting `ANTHROPIC_BASE_URL=http://localhost:6931` would route its own model calls back into the kernel.
- New helper `isHarnessIngressVar()` mirrors `isIngressVar()` from `provider_env.go`.
- Five regression tests added to `harness/harness_test.go` plus one end-to-end subprocess test.

Closes #137

## Test plan

- [x] `TestFilteredEnviron_StripsIngressVars` — all five keys removed
- [x] `TestFilteredEnviron_StripsCLAUDECODE` — existing CLAUDECODE behavior preserved
- [x] `TestFilteredEnviron_PreservesUnrelatedVars` — PATH not dropped
- [x] `TestFilteredEnviron_InjectsHarnessMarker` — COGOS_HARNESS=1 still injected
- [x] `TestSpawnedProcess_DoesNotInheritIngressVars` — real subprocess via fake shell binary receives no forbidden keys
- [x] `GOWORK=off go test -tags fts5 ./...` green in `harness/` (42 tests)
- [x] `go test -tags fts5 ./...` green at repo root (all workspace packages)