### PR TITLE
docs(sdk): ADR-067 bare-form URI sweep across sdk/ tree

### DIFF
--- a/sdk/clients/clients.go
+++ b/sdk/clients/clients.go
@@ -31,22 +31,22 @@ import (
 // Thread-safety: All clients are goroutine-safe because the underlying
 // kernel is goroutine-safe.
 type Clients struct {
-	// Memory provides ergonomic access to cog://mem/*
+	// Memory provides ergonomic access to cog:mem/*
 	Memory *MemoryClient
 
-	// Signal provides ergonomic access to cog://signals/*
+	// Signal provides ergonomic access to cog:signals/*
 	Signal *SignalClient
 
-	// Thread provides ergonomic access to cog://thread/*
+	// Thread provides ergonomic access to cog:thread/*
 	Thread *ThreadClient
 
-	// Inference provides ergonomic access to cog://inference
+	// Inference provides ergonomic access to cog:inference
 	Inference *InferenceClient
 
 	// Context provides context building for inference
 	Context *ContextClient
 
-	// Event provides event emission to cog://events
+	// Event provides event emission to cog:events
 	Event *EventClient
 
 	// kernel is the underlying kernel (kept for direct access if needed)

--- a/sdk/clients/clients_test.go
+++ b/sdk/clients/clients_test.go
@@ -111,7 +111,7 @@ func TestInferenceClientBuilder(t *testing.T) {
 	}
 
 	// Test WithContext
-	withCtx := base.WithContext("cog://memory", "cog://identity")
+	withCtx := base.WithContext("cog:mem", "cog:identity")
 	if len(withCtx.contextURIs) != 2 {
 		t.Errorf("WithContext: expected 2 URIs, got %d", len(withCtx.contextURIs))
 	}
@@ -129,7 +129,7 @@ func TestInferenceRequestBuilding(t *testing.T) {
 		model:       "opus",
 		maxTokens:   4096,
 		temperature: 0.7,
-		contextURIs: []string{"cog://memory"},
+		contextURIs: []string{"cog:mem"},
 	}
 
 	req := client.buildRequest("Hello world")
@@ -146,8 +146,8 @@ func TestInferenceRequestBuilding(t *testing.T) {
 	if req.Temperature != 0.7 {
 		t.Errorf("Temperature: expected 0.7, got %f", req.Temperature)
 	}
-	if len(req.Context) != 1 || req.Context[0] != "cog://memory" {
-		t.Errorf("Context: expected [cog://memory], got %v", req.Context)
+	if len(req.Context) != 1 || req.Context[0] != "cog:mem" {
+		t.Errorf("Context: expected [cog:mem], got %v", req.Context)
 	}
 }
 

--- a/sdk/clients/context.go
+++ b/sdk/clients/context.go
@@ -124,9 +124,9 @@ func (c *ContextClient) BuildContext(ctx context.Context, opts ...ContextOption)
 		params.Add("exclude", pattern)
 	}
 
-	uri := "cog://context"
+	uri := "cog:context"
 	if len(params) > 0 {
-		uri = fmt.Sprintf("cog://context?%s", params.Encode())
+		uri = fmt.Sprintf("cog:context?%s", params.Encode())
 	}
 
 	resource, err := c.kernel.ResolveContext(ctx, uri)
@@ -208,7 +208,7 @@ func (c *ContextClient) FeedbackContext(ctx context.Context) (*types.ContextTier
 
 // getTier fetches a specific tier from the context projector.
 func (c *ContextClient) getTier(ctx context.Context, tier types.ContextTierName) (*types.ContextTier, error) {
-	uri := fmt.Sprintf("cog://context?tier=%s", tier)
+	uri := fmt.Sprintf("cog:context?tier=%s", tier)
 	resource, err := c.kernel.ResolveContext(ctx, uri)
 	if err != nil {
 		return nil, err

--- a/sdk/clients/inference.go
+++ b/sdk/clients/inference.go
@@ -9,14 +9,14 @@ import (
 	"github.com/cogos-dev/cogos/sdk/types"
 )
 
-// InferenceClient provides ergonomic access to cog://inference
+// InferenceClient provides ergonomic access to cog:inference
 //
 // This client wraps the inference projector, which invokes the Claude CLI
 // for LLM completions. It supports:
 //   - Single prompts with Complete()
 //   - Streaming responses with Stream()
 //   - Chat-style multi-turn with Chat()
-//   - Context injection from cog:// URIs
+//   - Context injection from cog: URIs
 //
 // All methods are goroutine-safe.
 type InferenceClient struct {
@@ -67,7 +67,7 @@ func (c *InferenceClient) WithTemperature(t float64) *InferenceClient {
 //
 // Example:
 //
-//	client := c.Inference.WithContext("cog://mem/semantic/insights/eigenform", "cog://identity")
+//	client := c.Inference.WithContext("cog:mem/semantic/insights/eigenform", "cog:identity")
 //	resp, err := client.Complete("Summarize the eigenform concept.")
 func (c *InferenceClient) WithContext(uris ...string) *InferenceClient {
 	clone := *c
@@ -94,7 +94,7 @@ func (c *InferenceClient) CompleteContext(ctx context.Context, prompt string) (*
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}
 
-	uri := "cog://inference"
+	uri := "cog:inference"
 	mutation := sdk.NewSetMutation(content)
 
 	if err := c.kernel.MutateContext(ctx, uri, mutation); err != nil {
@@ -149,7 +149,7 @@ func (c *InferenceClient) StreamContext(ctx context.Context, prompt string) (<-c
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}
 
-	uri := "cog://inference?stream=true"
+	uri := "cog:inference?stream=true"
 	mutation := sdk.NewSetMutation(content)
 
 	if err := c.kernel.MutateContext(ctx, uri, mutation); err != nil {
@@ -245,7 +245,7 @@ func (c *InferenceClient) Status() (*types.InferenceStatus, error) {
 
 // StatusContext is like Status but accepts a context.
 func (c *InferenceClient) StatusContext(ctx context.Context) (*types.InferenceStatus, error) {
-	resource, err := c.kernel.ResolveContext(ctx, "cog://inference?status=true")
+	resource, err := c.kernel.ResolveContext(ctx, "cog:inference?status=true")
 	if err != nil {
 		return nil, err
 	}
@@ -310,7 +310,7 @@ func (c *InferenceClient) Ask(prompt string) (string, error) {
 //
 // Example:
 //
-//	answer, err := c.Inference.AskWithContext("Summarize this.", "cog://mem/semantic/insights/eigenform")
+//	answer, err := c.Inference.AskWithContext("Summarize this.", "cog:mem/semantic/insights/eigenform")
 func (c *InferenceClient) AskWithContext(prompt string, uris ...string) (string, error) {
 	return c.WithContext(uris...).Ask(prompt)
 }

--- a/sdk/clients/memory.go
+++ b/sdk/clients/memory.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cogos-dev/cogos/sdk/types"
 )
 
-// MemoryClient provides ergonomic access to cog://mem/*
+// MemoryClient provides ergonomic access to cog:mem/*
 //
 // The Memory namespace contains the Holographic Memory Domain (HMD):
 //   - semantic/ - Knowledge, architecture, insights
@@ -89,7 +89,7 @@ func (c *MemoryClient) Get(path string) (*sdk.Resource, error) {
 
 // GetContext is like Get but accepts a context.
 func (c *MemoryClient) GetContext(ctx context.Context, path string) (*sdk.Resource, error) {
-	uri := fmt.Sprintf("cog://mem/%s", strings.TrimPrefix(path, "/"))
+	uri := fmt.Sprintf("cog:mem/%s", strings.TrimPrefix(path, "/"))
 	return c.kernel.ResolveContext(ctx, uri)
 }
 
@@ -131,7 +131,7 @@ func (c *MemoryClient) List(sector string) ([]*sdk.Resource, error) {
 
 // ListContext is like List but accepts a context.
 func (c *MemoryClient) ListContext(ctx context.Context, sector string) ([]*sdk.Resource, error) {
-	uri := fmt.Sprintf("cog://mem/%s", sector)
+	uri := fmt.Sprintf("cog:mem/%s", sector)
 	resource, err := c.kernel.ResolveContext(ctx, uri)
 	if err != nil {
 		return nil, err
@@ -186,7 +186,7 @@ func (c *MemoryClient) SearchContext(ctx context.Context, query string, opts ...
 		}
 	}
 
-	uri := fmt.Sprintf("cog://memory?%s", params.Encode())
+	uri := fmt.Sprintf("cog:mem?%s", params.Encode())
 	resource, err := c.kernel.ResolveContext(ctx, uri)
 	if err != nil {
 		return nil, err
@@ -215,7 +215,7 @@ func (c *MemoryClient) Write(path string, content []byte) error {
 
 // WriteContext is like Write but accepts a context.
 func (c *MemoryClient) WriteContext(ctx context.Context, path string, content []byte) error {
-	uri := fmt.Sprintf("cog://mem/%s", strings.TrimPrefix(path, "/"))
+	uri := fmt.Sprintf("cog:mem/%s", strings.TrimPrefix(path, "/"))
 	mutation := sdk.NewSetMutation(content)
 	return c.kernel.MutateContext(ctx, uri, mutation)
 }
@@ -260,7 +260,7 @@ func (c *MemoryClient) Delete(path string) error {
 
 // DeleteContext is like Delete but accepts a context.
 func (c *MemoryClient) DeleteContext(ctx context.Context, path string) error {
-	uri := fmt.Sprintf("cog://mem/%s", strings.TrimPrefix(path, "/"))
+	uri := fmt.Sprintf("cog:mem/%s", strings.TrimPrefix(path, "/"))
 	mutation := sdk.NewDeleteMutation()
 	return c.kernel.MutateContext(ctx, uri, mutation)
 }
@@ -346,8 +346,10 @@ func (c *MemoryClient) resourceToCogdoc(r *sdk.Resource, doc *types.Cogdoc) erro
 	doc.Content = string(r.Content)
 	doc.Hash = r.Hash
 
-	// Extract path from URI
-	if strings.HasPrefix(r.URI, "cog://mem/") {
+	// Extract path from URI (accept both bare and legacy authority form)
+	if strings.HasPrefix(r.URI, "cog:mem/") {
+		doc.Path = strings.TrimPrefix(r.URI, "cog:mem/")
+	} else if strings.HasPrefix(r.URI, "cog://mem/") {
 		doc.Path = strings.TrimPrefix(r.URI, "cog://mem/")
 	}
 

--- a/sdk/clients/signal.go
+++ b/sdk/clients/signal.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cogos-dev/cogos/sdk/types"
 )
 
-// SignalClient provides ergonomic access to cog://signals/*
+// SignalClient provides ergonomic access to cog:signals/*
 //
 // Signals are the stigmergic coordination mechanism - ephemeral markers
 // that decay over time and indicate workspace activity.
@@ -57,7 +57,7 @@ func (c *SignalClient) Field() (*SignalField, error) {
 
 // FieldContext is like Field but accepts a context.
 func (c *SignalClient) FieldContext(ctx context.Context) (*SignalField, error) {
-	resource, err := c.kernel.ResolveContext(ctx, "cog://signals")
+	resource, err := c.kernel.ResolveContext(ctx, "cog:signals")
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func (c *SignalClient) Get(location string) ([]*types.Signal, error) {
 
 // GetContext is like Get but accepts a context.
 func (c *SignalClient) GetContext(ctx context.Context, location string) ([]*types.Signal, error) {
-	uri := fmt.Sprintf("cog://signals/%s", location)
+	uri := fmt.Sprintf("cog:signals/%s", location)
 	resource, err := c.kernel.ResolveContext(ctx, uri)
 	if err != nil {
 		return nil, err
@@ -125,7 +125,7 @@ func (c *SignalClient) Above(threshold float64) ([]*types.Signal, error) {
 
 // AboveContext is like Above but accepts a context.
 func (c *SignalClient) AboveContext(ctx context.Context, threshold float64) ([]*types.Signal, error) {
-	uri := fmt.Sprintf("cog://signals?above=%f", threshold)
+	uri := fmt.Sprintf("cog:signals?above=%f", threshold)
 	resource, err := c.kernel.ResolveContext(ctx, uri)
 	if err != nil {
 		return nil, err
@@ -200,7 +200,7 @@ func (c *SignalClient) DepositContext(ctx context.Context, signal types.Signal) 
 		return fmt.Errorf("marshal signal: %w", err)
 	}
 
-	uri := fmt.Sprintf("cog://signals/%s", signal.Location)
+	uri := fmt.Sprintf("cog:signals/%s", signal.Location)
 	mutation := sdk.NewSetMutation(content)
 	return c.kernel.MutateContext(ctx, uri, mutation)
 }
@@ -244,7 +244,7 @@ func (c *SignalClient) RemoveContext(ctx context.Context, location, signalType s
 		}
 	}
 
-	uri := fmt.Sprintf("cog://signals/%s", location)
+	uri := fmt.Sprintf("cog:signals/%s", location)
 	mutation := sdk.NewDeleteMutation()
 	mutation.Content = content
 	return c.kernel.MutateContext(ctx, uri, mutation)

--- a/sdk/clients/thread.go
+++ b/sdk/clients/thread.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cogos-dev/cogos/sdk/types"
 )
 
-// ThreadClient provides ergonomic access to cog://thread/*
+// ThreadClient provides ergonomic access to cog:thread/*
 //
 // Threads are conversation histories that persist across sessions.
 // They contain messages with roles (user, assistant, system, tool).
@@ -37,7 +37,7 @@ func (c *ThreadClient) Get(id string) (*types.Thread, error) {
 
 // GetContext is like Get but accepts a context.
 func (c *ThreadClient) GetContext(ctx context.Context, id string) (*types.Thread, error) {
-	uri := fmt.Sprintf("cog://thread/%s", id)
+	uri := fmt.Sprintf("cog:thread/%s", id)
 	resource, err := c.kernel.ResolveContext(ctx, uri)
 	if err != nil {
 		return nil, err
@@ -62,7 +62,7 @@ func (c *ThreadClient) Current() (*types.Thread, error) {
 
 // CurrentContext is like Current but accepts a context.
 func (c *ThreadClient) CurrentContext(ctx context.Context) (*types.Thread, error) {
-	resource, err := c.kernel.ResolveContext(ctx, "cog://thread/current")
+	resource, err := c.kernel.ResolveContext(ctx, "cog:thread/current")
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +89,7 @@ func (c *ThreadClient) List() ([]*types.Thread, error) {
 
 // ListContext is like List but accepts a context.
 func (c *ThreadClient) ListContext(ctx context.Context) ([]*types.Thread, error) {
-	resource, err := c.kernel.ResolveContext(ctx, "cog://thread")
+	resource, err := c.kernel.ResolveContext(ctx, "cog:thread")
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func (c *ThreadClient) CreateContext(ctx context.Context, title string) (*types.
 		return nil, fmt.Errorf("marshal thread: %w", err)
 	}
 
-	uri := fmt.Sprintf("cog://thread/%s", id)
+	uri := fmt.Sprintf("cog:thread/%s", id)
 	mutation := sdk.NewSetMutation(content)
 	if err := c.kernel.MutateContext(ctx, uri, mutation); err != nil {
 		return nil, err
@@ -178,7 +178,7 @@ func (c *ThreadClient) ArchiveContext(ctx context.Context, id string) error {
 		return fmt.Errorf("marshal thread: %w", err)
 	}
 
-	uri := fmt.Sprintf("cog://thread/%s", id)
+	uri := fmt.Sprintf("cog:thread/%s", id)
 	mutation := sdk.NewSetMutation(content)
 	return c.kernel.MutateContext(ctx, uri, mutation)
 }
@@ -194,7 +194,7 @@ func (c *ThreadClient) Delete(id string) error {
 
 // DeleteContext is like Delete but accepts a context.
 func (c *ThreadClient) DeleteContext(ctx context.Context, id string) error {
-	uri := fmt.Sprintf("cog://thread/%s", id)
+	uri := fmt.Sprintf("cog:thread/%s", id)
 	mutation := sdk.NewDeleteMutation()
 	return c.kernel.MutateContext(ctx, uri, mutation)
 }
@@ -221,7 +221,7 @@ func (c *ThreadClient) AppendContext(ctx context.Context, threadID string, msg t
 		return fmt.Errorf("marshal message: %w", err)
 	}
 
-	uri := fmt.Sprintf("cog://thread/%s", threadID)
+	uri := fmt.Sprintf("cog:thread/%s", threadID)
 	mutation := sdk.NewAppendMutation(content)
 	return c.kernel.MutateContext(ctx, uri, mutation)
 }
@@ -264,7 +264,7 @@ func (c *ThreadClient) LastN(threadID string, n int) ([]*types.Message, error) {
 
 // LastNContext is like LastN but accepts a context.
 func (c *ThreadClient) LastNContext(ctx context.Context, threadID string, n int) ([]*types.Message, error) {
-	uri := fmt.Sprintf("cog://thread/%s#last-%d", threadID, n)
+	uri := fmt.Sprintf("cog:thread/%s#last-%d", threadID, n)
 	resource, err := c.kernel.ResolveContext(ctx, uri)
 	if err != nil {
 		return nil, err
@@ -342,7 +342,7 @@ func (c *ThreadClient) SetTitleContext(ctx context.Context, threadID, title stri
 		return fmt.Errorf("marshal thread: %w", err)
 	}
 
-	uri := fmt.Sprintf("cog://thread/%s", threadID)
+	uri := fmt.Sprintf("cog:thread/%s", threadID)
 	mutation := sdk.NewSetMutation(content)
 	return c.kernel.MutateContext(ctx, uri, mutation)
 }

--- a/sdk/cogos.go
+++ b/sdk/cogos.go
@@ -12,31 +12,31 @@
 //	defer kernel.Close()
 //
 //	// Resolve a URI
-//	resource, _ := kernel.Resolve("cog://mem/semantic/insights")
+//	resource, _ := kernel.Resolve("cog:mem/semantic/insights")
 //
 //	// Project into typed struct
 //	var coherence types.CoherenceState
-//	kernel.Project("cog://coherence", &coherence)
+//	kernel.Project("cog:coherence", &coherence)
 //
 // # URI Scheme
 //
-// All workspace access is through cog:// URIs:
+// All workspace access is through cog: URIs:
 //
-//	cog://mem/*         - Cogdocs (knowledge, sessions, etc.)
-//	cog://signals/*     - Signal field (stigmergic coordination)
-//	cog://context       - Four-tier context for inference
-//	cog://thread/*      - Conversation threads
-//	cog://coherence     - Workspace coherence state
-//	cog://identity      - Workspace identity
-//	cog://src           - SRC constants (immutable)
-//	cog://adr/*         - Architecture Decision Records
-//	cog://ledger/*      - Event ledger
+//	cog:mem/*         - Cogdocs (knowledge, sessions, etc.)
+//	cog:signals/*     - Signal field (stigmergic coordination)
+//	cog:context       - Four-tier context for inference
+//	cog:thread/*      - Conversation threads
+//	cog:coherence     - Workspace coherence state
+//	cog:identity      - Workspace identity
+//	cog:src           - SRC constants (immutable)
+//	cog:adr/*         - Architecture Decision Records
+//	cog:ledger/*      - Event ledger
 //
 // Query parameters act as projections (filters, shapes):
 //
-//	cog://mem/semantic?q=topic&limit=10
-//	cog://signals/inference?above=0.3
-//	cog://context?budget=50000
+//	cog:mem/semantic?q=topic&limit=10
+//	cog:signals/inference?above=0.3
+//	cog:context?budget=50000
 //
 // # SRC Constants
 //
@@ -199,7 +199,7 @@ func registerBuiltinProjectors(k *Kernel) {
 
 // --- Phase 1 Projector Implementations ---
 
-// srcProjector handles cog://src
+// srcProjector handles cog:src
 type srcProjector struct {
 	BaseProjector
 }
@@ -209,7 +209,7 @@ func (p *srcProjector) Resolve(_ context.Context, uri *ParsedURI) (*Resource, er
 	return NewJSONResource(uri.Raw, src)
 }
 
-// identityProjector handles cog://identity
+// identityProjector handles cog:identity
 type identityProjector struct {
 	BaseProjector
 	kernel *Kernel
@@ -227,7 +227,7 @@ func (p *identityProjector) Resolve(_ context.Context, uri *ParsedURI) (*Resourc
 	return resource, nil
 }
 
-// coherenceProjector handles cog://coherence
+// coherenceProjector handles cog:coherence
 type coherenceProjector struct {
 	BaseProjector
 	kernel *Kernel
@@ -250,7 +250,7 @@ func (p *coherenceProjector) Resolve(_ context.Context, uri *ParsedURI) (*Resour
 	return NewJSONResource(uri.Raw, state)
 }
 
-// memoryProjector handles cog://mem/*
+// memoryProjector handles cog:mem/*
 type memoryProjector struct {
 	BaseProjector
 	kernel *Kernel
@@ -310,7 +310,7 @@ func (p *memoryProjector) listSectors(uri *ParsedURI) (*Resource, error) {
 	for _, sector := range sectors {
 		sectorPath := filepath.Join(p.kernel.MemoryDir(), sector)
 		if info, err := os.Stat(sectorPath); err == nil && info.IsDir() {
-			child := NewResource("cog://mem/"+sector, nil)
+			child := NewResource("cog:mem/"+sector, nil)
 			child.SetMetadata("sector", sector)
 			children = append(children, child)
 		}
@@ -361,7 +361,7 @@ func (p *memoryProjector) listDirectory(uri *ParsedURI, dirPath string) (*Resour
 // Cogdocs are validated before writing if the path ends in .cog.md.
 func (p *memoryProjector) Mutate(ctx context.Context, uri *ParsedURI, m *Mutation) error {
 	if uri.Path == "" {
-		return NewURIError("Mutate", uri.Raw, fmt.Errorf("memory path required (e.g., cog://mem/semantic/insights/new-insight)"))
+		return NewURIError("Mutate", uri.Raw, fmt.Errorf("memory path required (e.g., cog:mem/semantic/insights/new-insight)"))
 	}
 
 	switch m.Op {
@@ -479,7 +479,7 @@ func writeAtomicFile(path string, data []byte, perm os.FileMode) error {
 
 // --- Extended Projector Implementations (ported from kernel) ---
 
-// adrProjector handles cog://adr/*
+// adrProjector handles cog:adr/*
 type adrProjector struct {
 	BaseProjector
 	kernel *Kernel
@@ -532,7 +532,7 @@ func (p *adrProjector) listADRs(uri *ParsedURI, adrDir string) (*Resource, error
 			continue
 		}
 		name := entry.Name()
-		childURI := "cog://adr/" + name[:len(name)-3] // Remove .md
+		childURI := "cog:adr/" + name[:len(name)-3] // Remove .md
 		child := NewResource(childURI, nil)
 		child.SetMetadata("name", name)
 		children = append(children, child)
@@ -543,7 +543,7 @@ func (p *adrProjector) listADRs(uri *ParsedURI, adrDir string) (*Resource, error
 	return resource, nil
 }
 
-// specProjector handles cog://spec/* and cog://specs/*
+// specProjector handles cog:spec/* and cog:specs/*
 type specProjector struct {
 	BaseProjector
 	kernel *Kernel
@@ -594,7 +594,7 @@ func (p *specProjector) listDirectory(uri *ParsedURI, dirPath string) (*Resource
 	return resource, nil
 }
 
-// statusProjector handles cog://status/*
+// statusProjector handles cog:status/*
 type statusProjector struct {
 	BaseProjector
 	kernel *Kernel
@@ -644,7 +644,7 @@ func (p *statusProjector) listDirectory(uri *ParsedURI, dirPath string) (*Resour
 	return resource, nil
 }
 
-// canonicalProjector handles cog://canonical
+// canonicalProjector handles cog:canonical
 type canonicalProjector struct {
 	BaseProjector
 	kernel *Kernel
@@ -671,7 +671,7 @@ func (p *canonicalProjector) Resolve(_ context.Context, uri *ParsedURI) (*Resour
 	return NewJSONResource(uri.Raw, state)
 }
 
-// handoffProjector handles cog://handoff/* and cog://handoffs/*
+// handoffProjector handles cog:handoff/* and cog:handoffs/*
 type handoffProjector struct {
 	BaseProjector
 	kernel *Kernel
@@ -735,7 +735,7 @@ func (p *handoffProjector) listDirectory(uri *ParsedURI, dirPath string) (*Resou
 	return resource, nil
 }
 
-// crystalProjector handles cog://crystal/*
+// crystalProjector handles cog:crystal/*
 type crystalProjector struct {
 	BaseProjector
 	kernel *Kernel
@@ -760,7 +760,7 @@ func (p *crystalProjector) Resolve(_ context.Context, uri *ParsedURI) (*Resource
 	return resource, nil
 }
 
-// ledgerProjector handles cog://ledger/*
+// ledgerProjector handles cog:ledger/*
 type ledgerProjector struct {
 	BaseProjector
 	kernel *Kernel
@@ -829,7 +829,7 @@ func (p *ledgerProjector) listDirectory(uri *ParsedURI, dirPath string) (*Resour
 // Operations:
 //   - Append: Append an event to the session's event log
 //
-// The URI path should be the session ID: cog://ledger/{session-id}
+// The URI path should be the session ID: cog:ledger/{session-id}
 //
 // For Append, content should be an Event:
 //
@@ -838,7 +838,7 @@ func (p *ledgerProjector) listDirectory(uri *ParsedURI, dirPath string) (*Resour
 // The event will be assigned a sequence number and timestamp automatically.
 func (p *ledgerProjector) Mutate(ctx context.Context, uri *ParsedURI, m *Mutation) error {
 	if uri.Path == "" {
-		return NewURIError("Mutate", uri.Raw, fmt.Errorf("session ID required (e.g., cog://ledger/{session-id})"))
+		return NewURIError("Mutate", uri.Raw, fmt.Errorf("session ID required (e.g., cog:ledger/{session-id})"))
 	}
 
 	// Extract session ID from path (e.g., "abc123" or "abc123/events.jsonl")
@@ -883,7 +883,7 @@ func (p *ledgerProjector) appendEvent(sessionID string, content []byte) error {
 	return fs.AppendLine(eventsPath, line)
 }
 
-// roleProjector handles cog://role/* and cog://roles/*
+// roleProjector handles cog:role/* and cog:roles/*
 type roleProjector struct {
 	BaseProjector
 	kernel *Kernel
@@ -942,7 +942,7 @@ func (p *roleProjector) listDirectory(uri *ParsedURI, dirPath string) (*Resource
 	return resource, nil
 }
 
-// skillProjector handles cog://skill/* and cog://skills/*
+// skillProjector handles cog:skill/* and cog:skills/*
 type skillProjector struct {
 	BaseProjector
 	kernel *Kernel
@@ -1001,7 +1001,7 @@ func (p *skillProjector) listDirectory(uri *ParsedURI, dirPath string) (*Resourc
 	return resource, nil
 }
 
-// agentProjector handles cog://agent/* and cog://agents/*
+// agentProjector handles cog:agent/* and cog:agents/*
 type agentProjector struct {
 	BaseProjector
 	kernel *Kernel
@@ -1060,7 +1060,7 @@ func (p *agentProjector) listDirectory(uri *ParsedURI, dirPath string) (*Resourc
 	return resource, nil
 }
 
-// kernelProjector handles cog://kernel/*
+// kernelProjector handles cog:kernel/*
 type kernelProjector struct {
 	BaseProjector
 	kernel *Kernel

--- a/sdk/constellation/indexer.go
+++ b/sdk/constellation/indexer.go
@@ -459,19 +459,20 @@ func parseCogdoc(data []byte, path string) (*Cogdoc, error) {
 }
 
 // Fix 1: Implement URI Resolution
-// resolveURIToID attempts to resolve a cog:// URI to a document ID.
+// resolveURIToID attempts to resolve a cog: URI to a document ID.
+// Accepts both bare (cog:X/Y) and legacy authority form (cog://X/Y).
 //
 // Supported URI patterns:
-//   - cog://mem/semantic/path/to/doc → .cog/mem/semantic/path/to/doc.cog.md
-//   - cog://adr/004 → .cog/adr/004-*.cog.md (glob pattern)
-//   - cog://kernel/path → .cog/kernel/path.cog.md
-//   - cog://type/identifier → ID lookup
+//   - cog:mem/semantic/path/to/doc → .cog/mem/semantic/path/to/doc.cog.md
+//   - cog:adr/004 → .cog/adr/004-*.cog.md (glob pattern)
+//   - cog:kernel/path → .cog/kernel/path.cog.md
+//   - cog:type/identifier → ID lookup
 func resolveURIToID(tx *sql.Tx, uri string) sql.NullString {
 	if !strings.HasPrefix(uri, "cog://") {
 		return sql.NullString{Valid: false}
 	}
 
-	// PREREQ-2: normalize cog://memory/ → cog://mem/ (D-14 canonical prefix)
+	// PREREQ-2: normalize legacy cog://memory/ → cog://mem/ (D-14 canonical prefix)
 	uri = strings.Replace(uri, "cog://memory/", "cog://mem/", 1)
 
 	// Strip cog:// prefix
@@ -490,13 +491,13 @@ func resolveURIToID(tx *sql.Tx, uri string) sql.NullString {
 
 	switch uriType {
 	case "mem":
-		// cog://mem/semantic/insights/foo
+		// cog:mem/semantic/insights/foo
 		// → .cog/mem/semantic/insights/foo.cog.md
 		return resolveByPath(tx, filepath.Join(".cog", path)+".cog.md")
 
 	case "adr":
-		// cog://adr/004 → .cog/adr/004-*.cog.md (glob pattern)
-		// cog://adr/004-cogdoc-format → .cog/adr/004-cogdoc-format.cog.md (exact)
+		// cog:adr/004 → .cog/adr/004-*.cog.md (glob pattern)
+		// cog:adr/004-cogdoc-format → .cog/adr/004-cogdoc-format.cog.md (exact)
 		if len(parts) < 2 {
 			return sql.NullString{Valid: false}
 		}
@@ -509,11 +510,11 @@ func resolveURIToID(tx *sql.Tx, uri string) sql.NullString {
 		return resolveByPattern(tx, ".cog/adr", adrID+"-*")
 
 	case "kernel":
-		// cog://kernel/path
+		// cog:kernel/path
 		return resolveByPath(tx, filepath.Join(".cog", path)+".cog.md")
 
 	case "term":
-		// cog://term/thermal-time-world → .cog/ontology/vocabulary.cog.md (all terms in one file)
+		// cog:term/thermal-time-world → .cog/ontology/vocabulary.cog.md (all terms in one file)
 		// For now, try to resolve by ID (term name)
 		if len(parts) < 2 {
 			return sql.NullString{Valid: false}
@@ -522,13 +523,13 @@ func resolveURIToID(tx *sql.Tx, uri string) sql.NullString {
 		return resolveByID(tx, termName)
 
 	case "work":
-		// cog://work/councils/xyz/synthesis → .cog/work/councils/xyz/synthesis.cog.md
+		// cog:work/councils/xyz/synthesis → .cog/work/councils/xyz/synthesis.cog.md
 		return resolveByPath(tx, filepath.Join(".cog", path)+".cog.md")
 
 	case "rfc":
-		// PREREQ-2: cog://rfc/NNN → .cog/conf/spec/rfc/RFC-NNN-*.cog.md (glob pattern)
-		// cog://rfc/030 → .cog/conf/spec/rfc/RFC-030-*.cog.md
-		// cog://rfc/30 → .cog/conf/spec/rfc/RFC-030-*.cog.md (zero-padded)
+		// PREREQ-2: cog:rfc/NNN → .cog/conf/spec/rfc/RFC-NNN-*.cog.md (glob pattern)
+		// cog:rfc/030 → .cog/conf/spec/rfc/RFC-030-*.cog.md
+		// cog:rfc/30 → .cog/conf/spec/rfc/RFC-030-*.cog.md (zero-padded)
 		if len(parts) < 2 {
 			return sql.NullString{Valid: false}
 		}
@@ -544,7 +545,7 @@ func resolveURIToID(tx *sql.Tx, uri string) sql.NullString {
 		return resolveByPattern(tx, ".cog/conf/spec/rfc", rfcPrefix+"-*")
 
 	case "conf":
-		// cog://conf/spec/foo → .cog/conf/spec/foo.cog.md
+		// cog:conf/spec/foo → .cog/conf/spec/foo.cog.md
 		return resolveByPath(tx, filepath.Join(".cog", path)+".cog.md")
 
 	default:

--- a/sdk/context.go
+++ b/sdk/context.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cogos-dev/cogos/sdk/types"
 )
 
-// contextProjector handles cog://context namespace.
+// contextProjector handles cog:context namespace.
 // Projects the 4-tier context pipeline for inference.
 type contextProjector struct {
 	BaseProjector
@@ -28,10 +28,10 @@ type contextProjector struct {
 //
 // Example URIs:
 //
-//	cog://context                     -> Full 4-tier context
-//	cog://context?budget=30000        -> With custom budget
-//	cog://context?tier=identity       -> Identity tier only
-//	cog://context?include=cog://adr/021,cog://adr/033
+//	cog:context                     -> Full 4-tier context
+//	cog:context?budget=30000        -> With custom budget
+//	cog:context?tier=identity       -> Identity tier only
+//	cog:context?include=cog:adr/021,cog:adr/033
 func (p *contextProjector) Resolve(ctx context.Context, uri *ParsedURI) (*Resource, error) {
 	// Parse configuration from query params
 	config := types.DefaultContextConfig()
@@ -101,7 +101,7 @@ func (p *contextProjector) assembleContext(ctx context.Context, config *types.Co
 	}
 
 	// Get coherence score
-	coherenceRes, err := p.kernel.ResolveContext(ctx, "cog://coherence")
+	coherenceRes, err := p.kernel.ResolveContext(ctx, "cog:coherence")
 	if err == nil {
 		var coherence map[string]any
 		if err := coherenceRes.JSON(&coherence); err == nil {
@@ -298,7 +298,7 @@ func (b *ContextBuilder) WithSession(sessionID string) *ContextBuilder {
 func (b *ContextBuilder) Build(ctx context.Context) (*types.ContextState, error) {
 	// Build query string
 	var parts []string
-	parts = append(parts, "cog://context")
+	parts = append(parts, "cog:context")
 
 	var queryParts []string
 	if b.config.Budget != 50000 {
@@ -314,7 +314,7 @@ func (b *ContextBuilder) Build(ctx context.Context) (*types.ContextState, error)
 		queryParts = append(queryParts, "exclude="+strings.Join(b.exclude, ","))
 	}
 
-	uri := "cog://context"
+	uri := "cog:context"
 	if len(queryParts) > 0 {
 		uri += "?" + strings.Join(queryParts, "&")
 	}

--- a/sdk/context_test.go
+++ b/sdk/context_test.go
@@ -223,8 +223,8 @@ func TestContextURISource(t *testing.T) {
 
 	// Check identity tier includes identity URI
 	identityURIs := types.ContextURISource[types.TierIdentity]
-	if !slices.Contains(identityURIs, "cog://identity") {
-		t.Error("Identity tier should include cog://identity")
+	if !slices.Contains(identityURIs, "cog:identity") {
+		t.Error("Identity tier should include cog:identity")
 	}
 }
 

--- a/sdk/httputil/client.go
+++ b/sdk/httputil/client.go
@@ -24,7 +24,7 @@ import (
 // Example:
 //
 //	client := httputil.NewClient("http://localhost:8080")
-//	resource, err := client.Resolve(ctx, "cog://mem/semantic/insights")
+//	resource, err := client.Resolve(ctx, "cog:mem/semantic/insights")
 type Client struct {
 	baseURL    string
 	httpClient *http.Client

--- a/sdk/httputil/openai.go
+++ b/sdk/httputil/openai.go
@@ -14,7 +14,7 @@ import (
 // OpenAIHandler provides an OpenAI-compatible /v1/chat/completions endpoint.
 //
 // This allows tools that speak OpenAI API to use the CogOS inference system.
-// The handler translates between OpenAI format and cog://inference.
+// The handler translates between OpenAI format and cog:inference.
 type OpenAIHandler struct {
 	kernel *sdk.Kernel
 }

--- a/sdk/httputil/server.go
+++ b/sdk/httputil/server.go
@@ -234,7 +234,7 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check coherence
-	coherence, err := s.kernel.Resolve("cog://coherence")
+	coherence, err := s.kernel.Resolve("cog:coherence")
 	if err == nil {
 		var state map[string]any
 		if err := coherence.JSON(&state); err == nil {
@@ -370,7 +370,7 @@ func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get coherence state via SDK
-	coherence, err := s.kernel.Resolve("cog://coherence")
+	coherence, err := s.kernel.Resolve("cog:coherence")
 	if err == nil {
 		var cohState map[string]any
 		if err := coherence.JSON(&cohState); err == nil {
@@ -396,7 +396,7 @@ func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get signals via SDK
-	signals, err := s.kernel.Resolve("cog://signals")
+	signals, err := s.kernel.Resolve("cog:signals")
 	if err == nil {
 		var sigField map[string]any
 		if err := signals.JSON(&sigField); err == nil {
@@ -450,7 +450,7 @@ func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get session ID via SDK
-	identity, err := s.kernel.Resolve("cog://identity")
+	identity, err := s.kernel.Resolve("cog:identity")
 	if err == nil {
 		var idData map[string]any
 		if err := identity.JSON(&idData); err == nil {
@@ -480,7 +480,7 @@ func (s *Server) handleSignals(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get signals via SDK
-	signals, err := s.kernel.Resolve("cog://signals")
+	signals, err := s.kernel.Resolve("cog:signals")
 	if err != nil {
 		// Return empty signals rather than error
 		writeJSON(w, http.StatusOK, result)

--- a/sdk/index.go
+++ b/sdk/index.go
@@ -35,7 +35,7 @@ var ValidRefRelations = map[string]bool{
 
 // IndexedCogdoc represents a cogdoc with full metadata for indexing.
 type IndexedCogdoc struct {
-	URI        string            `json:"uri"`         // cog://mem/episodic/decisions/foo
+	URI        string            `json:"uri"`         // cog:mem/episodic/decisions/foo
 	Path       string            `json:"path"`        // .cog/mem/episodic/decisions/foo.cog.md
 	Type       types.CogdocType  `json:"type"`        // decision, session, guide, etc.
 	ID         string            `json:"id"`          // kebab-case identifier
@@ -174,14 +174,14 @@ func parseCogdocForIndex(path, cogRoot string) (*IndexedCogdoc, error) {
 	}
 
 	// Convert path to URI
-	// .cog/mem/episodic/decisions/foo.cog.md -> cog://mem/episodic/decisions/foo
+	// .cog/mem/episodic/decisions/foo.cog.md -> cog:mem/episodic/decisions/foo
 	relPath, err := filepath.Rel(cogRoot, path)
 	if err != nil {
 		return nil, err
 	}
 	// Remove .cog.md extension
 	relPath = strings.TrimSuffix(relPath, ".cog.md")
-	uri := "cog://" + relPath
+	uri := "cog:" + relPath
 
 	// Parse refs
 	refs := parseRefs(doc.Refs)

--- a/sdk/inference.go
+++ b/sdk/inference.go
@@ -14,7 +14,7 @@ import (
 	"github.com/cogos-dev/cogos/sdk/types"
 )
 
-// inferenceProjector handles cog://inference namespace.
+// inferenceProjector handles cog:inference namespace.
 // Provides the SDK interface to the Claude CLI inference engine.
 type inferenceProjector struct {
 	BaseProjector
@@ -31,9 +31,9 @@ func (p *inferenceProjector) CanMutate() bool {
 //
 // URIs:
 //
-//	cog://inference           -> Engine status
-//	cog://inference/status    -> Detailed status
-//	cog://inference/config    -> Current configuration
+//	cog:inference           -> Engine status
+//	cog:inference/status    -> Detailed status
+//	cog:inference/config    -> Current configuration
 func (p *inferenceProjector) Resolve(ctx context.Context, uri *ParsedURI) (*Resource, error) {
 	switch uri.Path {
 	case "", "status":
@@ -83,7 +83,7 @@ func (p *inferenceProjector) resolveConfig(uri *ParsedURI) (*Resource, error) {
 //	}
 //	data, _ := json.Marshal(req)
 //	mutation := sdk.NewSetMutation(data)
-//	kernel.Mutate("cog://inference", mutation)
+//	kernel.Mutate("cog:inference", mutation)
 func (p *inferenceProjector) Mutate(ctx context.Context, uri *ParsedURI, m *Mutation) error {
 	if m.Op != MutationSet {
 		return NewURIError("Mutate", uri.Raw, fmt.Errorf("only 'set' operation supported for inference"))

--- a/sdk/kernel.go
+++ b/sdk/kernel.go
@@ -113,16 +113,16 @@ func (k *Kernel) NextEventSeq() int64 {
 // Examples:
 //
 //	// Read a single cogdoc
-//	resource, err := kernel.Resolve("cog://mem/semantic/insights/eigenform")
+//	resource, err := kernel.Resolve("cog:mem/semantic/insights/eigenform")
 //
 //	// Search memory with query
-//	resource, err := kernel.Resolve("cog://mem/semantic?q=topic&limit=10")
+//	resource, err := kernel.Resolve("cog:mem/semantic?q=topic&limit=10")
 //
 //	// Get active signals
-//	resource, err := kernel.Resolve("cog://signals/inference?above=0.3")
+//	resource, err := kernel.Resolve("cog:signals/inference?above=0.3")
 //
 //	// Get coherence state
-//	resource, err := kernel.Resolve("cog://coherence")
+//	resource, err := kernel.Resolve("cog:coherence")
 func (k *Kernel) Resolve(uri string) (*Resource, error) {
 	return k.ResolveContext(context.Background(), uri)
 }
@@ -156,7 +156,7 @@ func (k *Kernel) ResolveContext(ctx context.Context, uri string) (*Resource, err
 // Example:
 //
 //	var coherence types.CoherenceState
-//	err := kernel.Project("cog://coherence", &coherence)
+//	err := kernel.Project("cog:coherence", &coherence)
 func (k *Kernel) Project(uri string, into any) error {
 	return k.ProjectContext(context.Background(), uri, into)
 }
@@ -190,7 +190,7 @@ func (k *Kernel) ProjectContext(ctx context.Context, uri string, into any) error
 // Example:
 //
 //	mutation := sdk.NewSetMutation([]byte("# New Content\n..."))
-//	err := kernel.Mutate("cog://mem/semantic/insights/new-insight", mutation)
+//	err := kernel.Mutate("cog:mem/semantic/insights/new-insight", mutation)
 func (k *Kernel) Mutate(uri string, mutation *Mutation) error {
 	return k.MutateContext(context.Background(), uri, mutation)
 }

--- a/sdk/mutation_test.go
+++ b/sdk/mutation_test.go
@@ -269,7 +269,7 @@ func TestNewEvent(t *testing.T) {
 func TestEventWithData(t *testing.T) {
 	event := types.NewEvent(types.EventTypeMessage, "session").
 		WithSource("cog-chat").
-		WithURI("cog://thread/current").
+		WithURI("cog:thread/current").
 		WithData(types.MessageEventData{
 			Role:    "user",
 			Content: "Hello",
@@ -279,8 +279,8 @@ func TestEventWithData(t *testing.T) {
 	if event.Source != "cog-chat" {
 		t.Errorf("Source = %q, want 'cog-chat'", event.Source)
 	}
-	if event.URI != "cog://thread/current" {
-		t.Errorf("URI = %q, want 'cog://thread/current'", event.URI)
+	if event.URI != "cog:thread/current" {
+		t.Errorf("URI = %q, want 'cog:thread/current'", event.URI)
 	}
 
 	var data types.MessageEventData

--- a/sdk/signals.go
+++ b/sdk/signals.go
@@ -43,7 +43,7 @@ func (ps *persistedSignal) toTypesSignal(location string) *types.Signal {
 	}
 }
 
-// signalProjector handles cog://signals/* namespace.
+// signalProjector handles cog:signals/* namespace.
 // Provides stigmergic coordination through signal field access.
 type signalProjector struct {
 	BaseProjector
@@ -58,10 +58,10 @@ func (p *signalProjector) CanMutate() bool {
 // Resolve reads signals from the signal field.
 //
 // URI patterns:
-//   - cog://signals - List all signals
-//   - cog://signals/inference - Signals at 'inference' location
-//   - cog://signals/inference?above=0.3 - Only signals with relevance > 0.3
-//   - cog://signals?location=inference - Same as above
+//   - cog:signals - List all signals
+//   - cog:signals/inference - Signals at 'inference' location
+//   - cog:signals/inference?above=0.3 - Only signals with relevance > 0.3
+//   - cog:signals?location=inference - Same as above
 func (p *signalProjector) Resolve(ctx context.Context, uri *ParsedURI) (*Resource, error) {
 	state, err := p.loadSignalField()
 	if err != nil {
@@ -135,7 +135,7 @@ func (p *signalProjector) Resolve(ctx context.Context, uri *ParsedURI) (*Resourc
 //	}
 func (p *signalProjector) Mutate(ctx context.Context, uri *ParsedURI, m *Mutation) error {
 	if uri.Path == "" {
-		return NewURIError("Mutate", uri.Raw, fmt.Errorf("signal location required (e.g., cog://signals/inference)"))
+		return NewURIError("Mutate", uri.Raw, fmt.Errorf("signal location required (e.g., cog:signals/inference)"))
 	}
 
 	location := uri.Path

--- a/sdk/thread.go
+++ b/sdk/thread.go
@@ -15,7 +15,7 @@ import (
 	"github.com/cogos-dev/cogos/sdk/types"
 )
 
-// threadProjector handles cog://thread/* namespace.
+// threadProjector handles cog:thread/* namespace.
 // Provides conversation thread storage and retrieval.
 type threadProjector struct {
 	BaseProjector
@@ -30,11 +30,11 @@ func (p *threadProjector) CanMutate() bool {
 // Resolve reads threads from storage.
 //
 // URI patterns:
-//   - cog://thread - List all threads
-//   - cog://thread/current - Get the current active thread
-//   - cog://thread/{id} - Get a specific thread by ID
-//   - cog://thread/{id}?last=10 - Get last 10 messages only
-//   - cog://thread/{id}?summarize=true - Get thread summary only
+//   - cog:thread - List all threads
+//   - cog:thread/current - Get the current active thread
+//   - cog:thread/{id} - Get a specific thread by ID
+//   - cog:thread/{id}?last=10 - Get last 10 messages only
+//   - cog:thread/{id}?summarize=true - Get thread summary only
 func (p *threadProjector) Resolve(ctx context.Context, uri *ParsedURI) (*Resource, error) {
 	if uri.Path == "" {
 		return p.listThreads(uri)
@@ -50,7 +50,7 @@ func (p *threadProjector) Resolve(ctx context.Context, uri *ParsedURI) (*Resourc
 		}
 		if activeID == "" {
 			return nil, NotFoundError("Resolve", uri.Raw).
-				WithRecover("No active thread. Create one with cog://thread mutation.")
+				WithRecover("No active thread. Create one with cog:thread mutation.")
 		}
 		threadID = activeID
 	}
@@ -288,7 +288,7 @@ func (p *threadProjector) archiveThread(uri *ParsedURI) error {
 	patchURI := &ParsedURI{
 		Namespace: uri.Namespace,
 		Path:      threadID,
-		Raw:       "cog://thread/" + threadID,
+		Raw:       "cog:thread/" + threadID,
 	}
 	return p.patchThread(patchURI, patchContent)
 }

--- a/sdk/types/context.go
+++ b/sdk/types/context.go
@@ -38,7 +38,7 @@ type ContextTierName string
 
 const (
 	// TierIdentity is the stable identity tier (~1/3 of budget).
-	// Contains: cog://identity, agent cards, roles
+	// Contains: cog:identity, agent cards, roles
 	TierIdentity ContextTierName = "identity"
 
 	// TierTemporal is the session-aware tier.
@@ -204,20 +204,20 @@ func (cs *ContextState) BuildMetrics() *ContextMetrics {
 // ContextURISource maps tier names to their default URI sources.
 var ContextURISource = map[ContextTierName][]string{
 	TierIdentity: {
-		"cog://identity",
-		"cog://roles",
-		"cog://agents",
+		"cog:identity",
+		"cog:roles",
+		"cog:agents",
 	},
 	TierTemporal: {
-		"cog://handoffs",
-		"cog://ledger",
+		"cog:handoffs",
+		"cog:ledger",
 	},
 	TierPresent: {
-		"cog://thread/current",
-		"cog://signals",
+		"cog:thread/current",
+		"cog:signals",
 	},
 	TierFeedback: {
-		"cog://coherence",
-		"cog://mem/episodic/decisions",
+		"cog:coherence",
+		"cog:mem/episodic/decisions",
 	},
 }

--- a/sdk/uri.go
+++ b/sdk/uri.go
@@ -6,18 +6,18 @@ import (
 	"strings"
 )
 
-// ParsedURI represents a parsed cog:// URI with its components.
+// ParsedURI represents a parsed cog: URI with its components.
 //
-// URI format: cog://namespace/path[?query][#fragment]
+// URI format: cog:namespace/path[?query][#fragment]
 //
 // Examples:
 //
-//	cog://mem/semantic/insights/eigenform
-//	cog://signals/inference?above=0.3
-//	cog://context?budget=50000&model=sonnet
-//	cog://thread/current#last-10
-//	cog://coherence
-//	cog://src
+//	cog:mem/semantic/insights/eigenform
+//	cog:signals/inference?above=0.3
+//	cog:context?budget=50000&model=sonnet
+//	cog:thread/current#last-10
+//	cog:coherence
+//	cog:src
 type ParsedURI struct {
 	// Namespace is the first path component (memory, signals, context, etc.)
 	Namespace string

--- a/sdk/watch.go
+++ b/sdk/watch.go
@@ -92,9 +92,9 @@ func (w *Watcher) Close() error {
 // WatchURI subscribes to changes on a URI pattern.
 //
 // Supports wildcards in the path:
-//   - cog://mem/semantic/* watches all files in semantic/
-//   - cog://mem/semantic/** watches all files recursively
-//   - cog://signals/* watches all signal namespaces
+//   - cog:mem/semantic/* watches all files in semantic/
+//   - cog:mem/semantic/** watches all files recursively
+//   - cog:signals/* watches all signal namespaces
 //
 // The returned Watcher's Events channel will emit WatchEvents
 // when resources matching the pattern change.
@@ -103,7 +103,7 @@ func (w *Watcher) Close() error {
 //
 // Example:
 //
-//	watcher, err := kernel.WatchURI(ctx, "cog://mem/semantic/*")
+//	watcher, err := kernel.WatchURI(ctx, "cog:mem/semantic/*")
 //	if err != nil {
 //	    return err
 //	}
@@ -358,12 +358,12 @@ func parseWatchPattern(pattern string) (*watchPattern, error) {
 	if len(parts) > 1 {
 		path := parts[1]
 		if path == "**" {
-			// cog://namespace/** - recursive wildcard at root
+			// cog:namespace/** - recursive wildcard at root
 			wp.path = ""
 			wp.wildcard = true
 			wp.recursive = true
 		} else if path == "*" {
-			// cog://namespace/* - wildcard at root
+			// cog:namespace/* - wildcard at root
 			wp.path = ""
 			wp.wildcard = true
 			wp.recursive = false


### PR DESCRIPTION
## Summary

- Replaces all `cog://projection/path` legacy forms with canonical `cog:projection/path` bare form throughout the `sdk/` subtree (doc comments, functional strings, error messages, test assertions)
- Adds backward-compat dual-prefix guard in `sdk/clients/memory.go` (`resourceToCogdoc`) to handle resources created with the legacy URI form
- Leaves legacy-form test inputs unchanged (tests specifically validating `cog://` backward-compat parsing still pass)
- `sdk/constellation/indexer.go` `resolveURIToID` implementation left functionally unchanged (accepts legacy form by design); doc comments updated only

## Files changed (23)

`sdk/uri.go`, `sdk/cogos.go`, `sdk/kernel.go`, `sdk/signals.go`, `sdk/context.go`, `sdk/thread.go`, `sdk/index.go`, `sdk/inference.go`, `sdk/watch.go`, `sdk/clients/memory.go`, `sdk/clients/signal.go`, `sdk/clients/thread.go`, `sdk/clients/inference.go`, `sdk/clients/context.go`, `sdk/clients/clients.go`, `sdk/httputil/server.go`, `sdk/httputil/openai.go`, `sdk/httputil/client.go`, `sdk/types/context.go`, `sdk/constellation/indexer.go`, `sdk/context_test.go`, `sdk/mutation_test.go`, `sdk/clients/clients_test.go`

## Test plan

- [x] `go test -tags fts5 ./sdk/...` — all packages pass; one pre-existing failure (`TestCogdocTypeValidation` in `sdk_test.go:245`) is unrelated to this change (present on baseline before any edits)
- [x] Legacy `cog://` parse tests in `sdk/sdk_test.go` and `sdk/watch_test.go` continue to pass (backward-compat preserved)
- [x] `sdk/constellation` and `sdk/httputil` packages pass cleanly

Closes #181