### PR TITLE
wire MLXSupervisedProvider into the autonomic self-heal loop

### DIFF
--- a/internal/engine/autonomic_ticker.go
+++ b/internal/engine/autonomic_ticker.go
@@ -247,6 +247,88 @@ func snapshotFingerprint(snap KernelHealthSnapshot) string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
+// --- Self-healing reconcile loop ---------------------------------------------
+
+// healDegradedProviders iterates all registered Reconcilables and, for any
+// whose Health() is not Healthy, runs the full plan/apply cycle:
+//
+//  1. FetchLive — probe actual state.
+//  2. ComputePlan — diff declared vs live.
+//  3. ApplyPlan — execute any corrective actions (e.g. start a crashed process).
+//
+// This is the deterministic self-healing path. It runs on every tick before the
+// LLM escalation predicate so that transient crashes (mlx_lm.server exited) are
+// corrected autonomically without waking the LLM. Errors are logged but never
+// propagate — a failed apply leaves Health() degraded, which will trigger the
+// LLM escalation predicate on the same tick if needed.
+func healDegradedProviders(ctx context.Context) {
+	names := reconcile.ListProviders()
+	for _, name := range names {
+		p, err := reconcile.GetProvider(name)
+		if err != nil {
+			continue
+		}
+		h := p.Health()
+		// Only attempt self-heal when the provider is non-healthy (Degraded,
+		// Missing, OutOfSync). Suspended and Progressing providers are either
+		// intentionally paused or already converging — skip them.
+		needsHeal := h.Health == reconcile.HealthDegraded ||
+			h.Health == reconcile.HealthMissing ||
+			h.Sync == reconcile.SyncStatusOutOfSync
+
+		if !needsHeal {
+			continue
+		}
+
+		slog.Info("autonomic: self-heal: starting reconcile cycle",
+			"provider", name,
+			"health", string(h.Health),
+			"sync", string(h.Sync),
+		)
+
+		// Load config (no-op for most providers that parse config at construction).
+		cfg, err := p.LoadConfig("")
+		if err != nil {
+			slog.Warn("autonomic: self-heal: LoadConfig failed", "provider", name, "err", err)
+			continue
+		}
+
+		// Fetch live state.
+		live, err := p.FetchLive(ctx, cfg)
+		if err != nil {
+			slog.Warn("autonomic: self-heal: FetchLive failed", "provider", name, "err", err)
+			continue
+		}
+
+		// Compute plan.
+		plan, err := p.ComputePlan(cfg, live, nil)
+		if err != nil {
+			slog.Warn("autonomic: self-heal: ComputePlan failed", "provider", name, "err", err)
+			continue
+		}
+		if plan == nil || !plan.Summary.HasChanges() {
+			slog.Debug("autonomic: self-heal: no changes needed", "provider", name)
+			continue
+		}
+
+		// Apply plan.
+		results, err := p.ApplyPlan(ctx, plan)
+		if err != nil {
+			slog.Warn("autonomic: self-heal: ApplyPlan failed",
+				"provider", name,
+				"err", err,
+				"results", len(results),
+			)
+			continue
+		}
+		slog.Info("autonomic: self-heal: apply complete",
+			"provider", name,
+			"actions", len(plan.Actions),
+			"results", len(results),
+		)
+	}
+}
+
 // snapshotToPayload serialises KernelHealthSnapshot into the map[string]any
 // shape expected by BusSessionManager.AppendEvent.
 func snapshotToPayload(snap KernelHealthSnapshot) (map[string]any, error) {

--- a/internal/engine/autonomic_ticker_test.go
+++ b/internal/engine/autonomic_ticker_test.go
@@ -718,6 +718,210 @@ func TestAutonomicTick_DedupeReleasesOnReturnToGreen(t *testing.T) {
 	})
 }
 
+// --- healDegradedProviders unit tests ----------------------------------------
+
+// selfHealableProvider is a Reconcilable stub that records whether
+// FetchLive, ComputePlan, and ApplyPlan were called. Its Health() returns the
+// injected status. Used to verify that healDegradedProviders calls the full
+// plan/apply cycle for unhealthy providers.
+type selfHealableProvider struct {
+	name           string
+	status         reconcile.ResourceStatus
+	fetchLiveCalls int
+	computePlanCalls int
+	applyPlanCalls int
+	// planHasChanges controls whether ComputePlan returns a non-empty plan.
+	planHasChanges bool
+}
+
+func (s *selfHealableProvider) Type() string { return s.name }
+
+func (s *selfHealableProvider) LoadConfig(string) (any, error) { return nil, nil }
+
+func (s *selfHealableProvider) FetchLive(context.Context, any) (any, error) {
+	s.fetchLiveCalls++
+	return struct{}{}, nil
+}
+
+func (s *selfHealableProvider) ComputePlan(_ any, _ any, _ *reconcile.State) (*reconcile.Plan, error) {
+	s.computePlanCalls++
+	plan := &reconcile.Plan{ResourceType: s.name}
+	if s.planHasChanges {
+		plan.Actions = []reconcile.Action{{
+			Action:       reconcile.ActionUpdate,
+			ResourceType: s.name,
+			Name:         s.name + "/heal",
+		}}
+		plan.Summary.Updates = 1
+	}
+	return plan, nil
+}
+
+func (s *selfHealableProvider) ApplyPlan(_ context.Context, _ *reconcile.Plan) ([]reconcile.Result, error) {
+	s.applyPlanCalls++
+	return []reconcile.Result{{
+		Phase:  "apply",
+		Action: string(reconcile.ActionUpdate),
+		Name:   s.name + "/heal",
+		Status: reconcile.ApplySucceeded,
+	}}, nil
+}
+
+func (s *selfHealableProvider) BuildState(_ any, _ any, _ *reconcile.State) (*reconcile.State, error) {
+	return nil, nil
+}
+
+func (s *selfHealableProvider) Health() reconcile.ResourceStatus { return s.status }
+
+// withSelfHealableProviders registers selfHealableProvider instances in the
+// global reconcile registry for the duration of fn(). Uses healthRegistryMu
+// (same lock as withProviders) to avoid concurrent mutation.
+func withSelfHealableProviders(t *testing.T, providers []*selfHealableProvider, fn func()) {
+	t.Helper()
+	healthRegistryMu.Lock()
+	defer healthRegistryMu.Unlock()
+
+	reconcile.ResetProviders()
+	defer reconcile.ResetProviders()
+
+	for _, p := range providers {
+		reconcile.RegisterProvider(p.name, p)
+	}
+	fn()
+}
+
+// TestHealDegradedProviders_CallsReconcileOnUnhealthy verifies that
+// healDegradedProviders calls FetchLive→ComputePlan→ApplyPlan for providers
+// whose Health() is Degraded. This is the regression test for issue #150:
+// the autonomic ticker must self-heal mlx-supervised providers on crash.
+func TestHealDegradedProviders_CallsReconcileOnUnhealthy(t *testing.T) {
+	degraded := &selfHealableProvider{
+		name: "mlx-supervised/test",
+		status: reconcile.ResourceStatus{
+			Sync:    reconcile.SyncStatusOutOfSync,
+			Health:  reconcile.HealthDegraded,
+			Message: "process not running",
+		},
+		planHasChanges: true,
+	}
+
+	withSelfHealableProviders(t, []*selfHealableProvider{degraded}, func() {
+		ctx := context.Background()
+		healDegradedProviders(ctx)
+
+		if degraded.fetchLiveCalls != 1 {
+			t.Errorf("FetchLive calls: got %d; want 1", degraded.fetchLiveCalls)
+		}
+		if degraded.computePlanCalls != 1 {
+			t.Errorf("ComputePlan calls: got %d; want 1", degraded.computePlanCalls)
+		}
+		if degraded.applyPlanCalls != 1 {
+			t.Errorf("ApplyPlan calls: got %d; want 1", degraded.applyPlanCalls)
+		}
+	})
+}
+
+// TestHealDegradedProviders_SkipsHealthyProviders verifies that
+// healDegradedProviders does NOT call plan/apply for providers that are Healthy
+// and Synced. Self-heal must be a no-op on the happy path.
+func TestHealDegradedProviders_SkipsHealthyProviders(t *testing.T) {
+	healthy := &selfHealableProvider{
+		name:   "mlx-supervised/healthy",
+		status: greenStatus(),
+	}
+
+	withSelfHealableProviders(t, []*selfHealableProvider{healthy}, func() {
+		ctx := context.Background()
+		healDegradedProviders(ctx)
+
+		if healthy.fetchLiveCalls != 0 {
+			t.Errorf("FetchLive should not be called for healthy provider: got %d calls", healthy.fetchLiveCalls)
+		}
+		if healthy.computePlanCalls != 0 {
+			t.Errorf("ComputePlan should not be called for healthy provider: got %d calls", healthy.computePlanCalls)
+		}
+		if healthy.applyPlanCalls != 0 {
+			t.Errorf("ApplyPlan should not be called for healthy provider: got %d calls", healthy.applyPlanCalls)
+		}
+	})
+}
+
+// TestHealDegradedProviders_SkipsWhenNoPlanChanges verifies that when
+// ComputePlan produces an empty plan (no drift), ApplyPlan is NOT called.
+// Self-heal must not make spurious applies.
+func TestHealDegradedProviders_SkipsWhenNoPlanChanges(t *testing.T) {
+	degraded := &selfHealableProvider{
+		name: "mlx-supervised/nochanges",
+		status: reconcile.ResourceStatus{
+			Sync:   reconcile.SyncStatusOutOfSync,
+			Health: reconcile.HealthDegraded,
+		},
+		planHasChanges: false, // ComputePlan will return an empty plan.
+	}
+
+	withSelfHealableProviders(t, []*selfHealableProvider{degraded}, func() {
+		ctx := context.Background()
+		healDegradedProviders(ctx)
+
+		if degraded.fetchLiveCalls != 1 {
+			t.Errorf("FetchLive calls: got %d; want 1", degraded.fetchLiveCalls)
+		}
+		if degraded.computePlanCalls != 1 {
+			t.Errorf("ComputePlan calls: got %d; want 1", degraded.computePlanCalls)
+		}
+		if degraded.applyPlanCalls != 0 {
+			t.Errorf("ApplyPlan should not be called when plan is empty: got %d calls", degraded.applyPlanCalls)
+		}
+	})
+}
+
+// TestAutonomicTick_HealsDegradedBeforeSnapshot verifies the end-to-end path:
+// when autonomicTick fires with a degraded provider registered, it calls
+// healDegradedProviders. We confirm FetchLive was called (proof the heal loop
+// ran). This test does not use a live LLM — the snapshot degradation is enough
+// to assert the deterministic path.
+func TestAutonomicTick_HealsDegradedBeforeSnapshot(t *testing.T) {
+	degraded := &selfHealableProvider{
+		name: "mlx-supervised/tick-heal",
+		status: reconcile.ResourceStatus{
+			Sync:    reconcile.SyncStatusOutOfSync,
+			Health:  reconcile.HealthDegraded,
+			Message: "process crashed",
+		},
+		planHasChanges: true,
+	}
+
+	withSelfHealableProviders(t, []*selfHealableProvider{degraded}, func() {
+		root := makeWorkspace(t)
+		cfg := makeConfig(t, root)
+		cfg.LocalModel = "gemma4:e4b"
+		proc := NewProcess(cfg, makeNucleus("Cog", "tester"))
+		srv := NewServer(cfg, makeNucleus("Cog", "tester"), proc)
+
+		ctrl, err := NewLocalHarnessController(cfg, makeNucleus("Cog", "tester"), proc, srv.mcpServer)
+		if err != nil {
+			t.Fatalf("NewLocalHarnessController: %v", err)
+		}
+		// Suppress LLM escalation by setting a recent lastLLMCycle with a long
+		// idle window. This isolates the deterministic heal path.
+		ctrl.mu.Lock()
+		ctrl.lastLLMCycle = time.Now().UTC()
+		ctrl.mu.Unlock()
+		ctrl.autonomicCfg = AutonomicConfig{IdleRecheckIn: 24 * time.Hour}
+
+		// Run one tick. The degraded provider is not-green, so healDegradedProviders
+		// must run and call FetchLive → ComputePlan → ApplyPlan.
+		ctrl.autonomicTick(context.Background())
+
+		if degraded.fetchLiveCalls == 0 {
+			t.Error("autonomicTick: FetchLive not called — self-heal loop did not run")
+		}
+		if degraded.applyPlanCalls == 0 {
+			t.Error("autonomicTick: ApplyPlan not called — self-heal did not apply corrective action")
+		}
+	})
+}
+
 // --- snapshotToPayload unit test -------------------------------------------
 
 func TestSnapshotToPayload_Roundtrip(t *testing.T) {

--- a/internal/engine/local_agent_harness.go
+++ b/internal/engine/local_agent_harness.go
@@ -279,6 +279,15 @@ func (c *LocalHarnessController) autonomicTick(ctx context.Context) {
 	// 2. Emit snapshot to bus regardless of health state.
 	emitHealthSnapshot(ctx, c.busSessions, snap)
 
+	// 2a. Run deterministic self-heal for any degraded provider that supports
+	// the full plan/apply Reconcilable contract (e.g. MLXSupervisedProvider).
+	// This runs BEFORE the escalation predicate so that transient crashes are
+	// repaired autonomically without waking the LLM. If self-heal succeeds,
+	// the next snapshot will be green and no escalation fires.
+	if !snap.AllGreen() {
+		healDegradedProviders(ctx)
+	}
+
 	// 3. Consume the triggerPending flag atomically.
 	c.triggerPendingMu.Lock()
 	triggerPending := c.triggerPending

--- a/internal/engine/router.go
+++ b/internal/engine/router.go
@@ -23,6 +23,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cogos-dev/cogos/pkg/reconcile"
 	"gopkg.in/yaml.v3"
 )
 
@@ -542,6 +543,12 @@ func makeProvider(name string, pc ProviderConfig, procMgr *ProcessManager) (Prov
 		if err != nil {
 			return nil, fmt.Errorf("mlx-supervised %q: %w", name, err)
 		}
+		// Register in the global reconcile registry so the autonomic ticker can
+		// run the full plan/apply self-heal cycle. UpsertProvider is used instead
+		// of RegisterProvider to allow safe re-registration (e.g. on config reload
+		// or in tests that call BuildRouter multiple times).
+		reconcile.UpsertProvider(mlxSupervisedType+"/"+name, p)
+		slog.Info("router: registered mlx-supervised provider in reconcile registry", "name", name)
 		return p, nil
 	default:
 		return nil, fmt.Errorf("unknown provider type %q", t)

--- a/pkg/reconcile/registry.go
+++ b/pkg/reconcile/registry.go
@@ -62,6 +62,16 @@ func HasProvider(name string) bool {
 	return ok
 }
 
+// UpsertProvider adds or replaces a reconciliation provider in the global
+// registry. Unlike RegisterProvider, this does not panic on duplicate names —
+// the new provider replaces the existing one. Used by BuildRouter to register
+// MLXSupervisedProvider instances without conflicting with daemon-side stubs.
+func UpsertProvider(name string, provider Reconcilable) {
+	providersMu.Lock()
+	defer providersMu.Unlock()
+	providers[name] = provider
+}
+
 // ResetProviders clears the registry (for testing only).
 func ResetProviders() {
 	providersMu.Lock()


### PR DESCRIPTION
## Summary

- `MLXSupervisedProvider` implements full `Reconcilable` (FetchLive/ComputePlan/ApplyPlan) but those methods were only reachable via `cog apply` CLI — the kernel's autonomic ticker only called `Health()`.
- `BuildRouter` now registers each `mlx-supervised` provider in `pkg/reconcile` as `"mlx-supervised/<name>"` via a new `UpsertProvider` (non-panicking upsert, avoids collision with the daemon's `mlxInferenceProvider` stub).
- `autonomicTick` now calls `healDegradedProviders()` before the LLM escalation predicate. Any registered Reconcilable that is Degraded/Missing/OutOfSync gets `FetchLive`→`ComputePlan`→`ApplyPlan` run deterministically — mlx_lm.server crashes self-heal without waking the LLM.

Closes #150

## Test plan

- [ ] `TestHealDegradedProviders_CallsReconcileOnUnhealthy` — degraded provider receives full plan/apply cycle
- [ ] `TestHealDegradedProviders_SkipsHealthyProviders` — no spurious applies on healthy providers
- [ ] `TestHealDegradedProviders_SkipsWhenNoPlanChanges` — empty plan suppresses ApplyPlan
- [ ] `TestAutonomicTick_HealsDegradedBeforeSnapshot` — end-to-end path through `autonomicTick`
- [ ] `go test -tags fts5 ./...` — full suite green (confirmed locally)