### PR TITLE
fix(engine,filelock): platform-split syscalls for windows release builds

### DIFF
--- a/internal/engine/process_group_unix.go
+++ b/internal/engine/process_group_unix.go
@@ -1,0 +1,34 @@
+//go:build unix
+
+// process_group_unix.go — Unix process-group helpers for ClaudeCodeProvider.
+//
+// claude(1) commonly spawns dash-style shells that fork helper processes
+// (mcp servers, tool sandboxes). Killing only the direct child orphans
+// those grandchildren, which keeps stdout open and blocks drainStreamJSON
+// until they exit naturally. Setpgid + negative-PID kill signals the whole
+// process tree atomically.
+
+package engine
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setProcessGroup configures cmd to start in its own process group so the
+// whole subprocess tree can be signalled together via killProcessGroup.
+func setProcessGroup(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}
+
+// killProcessGroup sends SIGTERM to the entire process group rooted at
+// cmd's process. Returns nil if the process has not been started yet.
+func killProcessGroup(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	return syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+}

--- a/internal/engine/process_group_windows.go
+++ b/internal/engine/process_group_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+// process_group_windows.go — Windows fallbacks for process-group helpers.
+//
+// Windows lacks Unix process groups; subprocess-tree termination would
+// require a Job Object via golang.org/x/sys/windows. ClaudeCodeProvider
+// builds and runs on Windows but may orphan grandchildren on context
+// cancellation; the direct child is still terminated.
+
+package engine
+
+import "os/exec"
+
+// setProcessGroup is a no-op on Windows.
+func setProcessGroup(cmd *exec.Cmd) {}
+
+// killProcessGroup terminates the direct child process. Grandchildren are
+// not signalled.
+func killProcessGroup(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	return cmd.Process.Kill()
+}

--- a/internal/engine/provider_claudecode.go
+++ b/internal/engine/provider_claudecode.go
@@ -25,7 +25,6 @@ import (
 	"log/slog"
 	"os/exec"
 	"strings"
-	"syscall"
 	"time"
 )
 
@@ -156,17 +155,10 @@ func (p *ClaudeCodeProvider) Complete(ctx context.Context, req *CompletionReques
 	)
 
 	cmd := NewProviderCommandContext(ctx, ManagedCommandOpts{EnvPolicy: EnvPolicyProviderChild}, p.cliBinary, args...)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	setProcessGroup(cmd)
 	cmd.WaitDelay = claudeCodeKillGrace
 	cmd.Cancel = func() error {
-		if cmd.Process == nil {
-			return nil
-		}
-		// Signal the whole process group so any helpers `claude` spawned
-		// die too. Without Setpgid+negative-PID kill, dash-style shells
-		// orphan their children on SIGTERM, the orphans keep stdout open,
-		// and our drainStreamJSON read blocks until they exit naturally.
-		return syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+		return killProcessGroup(cmd)
 	}
 	cmd.Stdin = strings.NewReader(prompt)
 
@@ -261,17 +253,10 @@ func (p *ClaudeCodeProvider) Stream(ctx context.Context, req *CompletionRequest)
 	)
 
 	cmd := NewProviderCommandContext(ctx, ManagedCommandOpts{EnvPolicy: EnvPolicyProviderChild}, p.cliBinary, args...)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	setProcessGroup(cmd)
 	cmd.WaitDelay = claudeCodeKillGrace
 	cmd.Cancel = func() error {
-		if cmd.Process == nil {
-			return nil
-		}
-		// Signal the whole process group so any helpers `claude` spawned
-		// die too. Without Setpgid+negative-PID kill, dash-style shells
-		// orphan their children on SIGTERM, the orphans keep stdout open,
-		// and our drainStreamJSON read blocks until they exit naturally.
-		return syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+		return killProcessGroup(cmd)
 	}
 	cmd.Stdin = strings.NewReader(prompt)
 
@@ -724,17 +709,10 @@ func (p *ClaudeCodeProvider) SpawnBackground(opts BackgroundTaskOpts) (string, e
 	}
 
 	cmd := NewProviderCommandContext(ctx, ManagedCommandOpts{EnvPolicy: EnvPolicyProviderChild, Dir: opts.WorkDir}, p.cliBinary, args...)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	setProcessGroup(cmd)
 	cmd.WaitDelay = claudeCodeKillGrace
 	cmd.Cancel = func() error {
-		if cmd.Process == nil {
-			return nil
-		}
-		// Signal the whole process group so any helpers `claude` spawned
-		// die too. Without Setpgid+negative-PID kill, dash-style shells
-		// orphan their children on SIGTERM, the orphans keep stdout open,
-		// and our drainStreamJSON read blocks until they exit naturally.
-		return syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+		return killProcessGroup(cmd)
 	}
 	cmd.Stdin = strings.NewReader(opts.Prompt)
 

--- a/pkg/filelock/lock.go
+++ b/pkg/filelock/lock.go
@@ -1,4 +1,9 @@
-// Package filelock provides advisory file locking using syscall.Flock.
+// Package filelock provides advisory file locking with cross-platform
+// semantics.
+//
+// On Unix the lock is implemented via flock(2); on Windows via
+// LockFileEx (golang.org/x/sys/windows). The public API is identical on
+// both: Acquire returns a *FileLock, Release returns the descriptor.
 //
 // This package is used by pkg/alias and any other component that needs
 // exclusive write access to node-local YAML files (aliases.yaml, global.yaml).
@@ -19,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"syscall"
 	"time"
 )
 
@@ -27,8 +31,13 @@ import (
 // the requested timeout.
 var ErrLockTimeout = errors.New("filelock: timed out waiting for lock")
 
+// errLockBusy is the internal sentinel returned by tryLock when another
+// process currently holds the lock. Acquire converts it to ErrLockTimeout
+// after the deadline elapses.
+var errLockBusy = errors.New("filelock: lock busy")
+
 // lockPollInterval is how often Acquire retries after a failed non-blocking
-// flock attempt.
+// lock attempt.
 const lockPollInterval = 50 * time.Millisecond
 
 // FileLock holds an open file descriptor that has been exclusively locked.
@@ -37,15 +46,10 @@ type FileLock struct {
 	file *os.File
 }
 
-// Acquire opens (or creates) the file at path and takes an exclusive advisory
-// lock on it, retrying until the lock is obtained or timeout elapses.
-//
-// On darwin and Linux, the lock is implemented via syscall.Flock(LOCK_EX).
-// The lock file itself is typically a dedicated ".lock" companion file next
-// to the protected YAML, not the YAML file itself (though locking the YAML
-// directly is also safe).
-//
-// Returns ErrLockTimeout if the lock cannot be obtained before timeout.
+// Acquire opens (or creates) the file at path and takes an exclusive
+// advisory lock on it, retrying until the lock is obtained or timeout
+// elapses. Returns ErrLockTimeout if the lock cannot be obtained before
+// the deadline.
 func Acquire(path string, timeout time.Duration) (*FileLock, error) {
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
 	if err != nil {
@@ -54,18 +58,14 @@ func Acquire(path string, timeout time.Duration) (*FileLock, error) {
 
 	deadline := time.Now().Add(timeout)
 	for {
-		// LOCK_EX | LOCK_NB — exclusive, non-blocking.
-		err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		err := tryLock(f.Fd())
 		if err == nil {
-			// Lock acquired.
 			return &FileLock{file: f}, nil
 		}
-		if !errors.Is(err, syscall.EWOULDBLOCK) {
-			// Unexpected error — not just "another process holds the lock".
+		if !errors.Is(err, errLockBusy) {
 			f.Close()
-			return nil, fmt.Errorf("filelock: flock %q: %w", path, err)
+			return nil, fmt.Errorf("filelock: lock %q: %w", path, err)
 		}
-		// Another process holds the lock. Wait and retry until deadline.
 		if time.Now().After(deadline) {
 			f.Close()
 			return nil, fmt.Errorf("%w: %s", ErrLockTimeout, path)
@@ -80,10 +80,7 @@ func (l *FileLock) Release() error {
 	if l == nil || l.file == nil {
 		return nil
 	}
-	// Unlock first, then close. Flock releases automatically on close anyway,
-	// but being explicit is clearer and avoids relying on that behaviour.
-	if err := syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN); err != nil {
-		// Best-effort: still try to close.
+	if err := unlock(l.file.Fd()); err != nil {
 		l.file.Close()
 		l.file = nil
 		return fmt.Errorf("filelock: unlock: %w", err)

--- a/pkg/filelock/lock_unix.go
+++ b/pkg/filelock/lock_unix.go
@@ -1,0 +1,28 @@
+//go:build unix
+
+// lock_unix.go — flock(2)-backed lock primitives for Unix platforms.
+
+package filelock
+
+import (
+	"errors"
+	"syscall"
+)
+
+// tryLock attempts a non-blocking exclusive lock on fd. Returns nil on
+// success, errLockBusy if another process holds the lock, or a fatal error.
+func tryLock(fd uintptr) error {
+	err := syscall.Flock(int(fd), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, syscall.EWOULDBLOCK) {
+		return errLockBusy
+	}
+	return err
+}
+
+// unlock releases a lock held on fd.
+func unlock(fd uintptr) error {
+	return syscall.Flock(int(fd), syscall.LOCK_UN)
+}

--- a/pkg/filelock/lock_windows.go
+++ b/pkg/filelock/lock_windows.go
@@ -1,0 +1,42 @@
+//go:build windows
+
+// lock_windows.go — LockFileEx-backed lock primitives for Windows.
+
+package filelock
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+// lockWholeFile locks every byte; LockFileEx accepts a 64-bit length split
+// into two uint32 halves.
+const lockWholeFile = ^uint32(0)
+
+// tryLock attempts a non-blocking exclusive lock on fd. Returns nil on
+// success, errLockBusy if another process holds the lock, or a fatal error.
+func tryLock(fd uintptr) error {
+	overlapped := &windows.Overlapped{}
+	err := windows.LockFileEx(
+		windows.Handle(fd),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0, lockWholeFile, lockWholeFile, overlapped,
+	)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, windows.ERROR_LOCK_VIOLATION) || errors.Is(err, windows.ERROR_IO_PENDING) {
+		return errLockBusy
+	}
+	return err
+}
+
+// unlock releases a lock held on fd.
+func unlock(fd uintptr) error {
+	overlapped := &windows.Overlapped{}
+	return windows.UnlockFileEx(
+		windows.Handle(fd),
+		0, lockWholeFile, lockWholeFile, overlapped,
+	)
+}


### PR DESCRIPTION
## What and why

Restores windows binaries on the release pipeline. `release.yml` builds linux/darwin/windows × amd64/arm64 in a single bash step under `set -e`; when the windows leg fails, the step exits before `softprops/action-gh-release` uploads any artifacts. Two consecutive releases shipped zero assets:

- v0.4.0 — run [25234431608](https://github.com/cogos-dev/cogos/actions/runs/25234431608), failed 2026-05-01
- v0.4.1 — run [25256317404](https://github.com/cogos-dev/cogos/actions/runs/25256317404), failed 2026-05-02

In both runs the linux and darwin binaries built successfully; windows-amd64 then broke compilation:

```
internal/engine/provider_claudecode.go:159:41: unknown field Setpgid in struct literal of type "syscall".SysProcAttr
internal/engine/provider_claudecode.go:169:18: undefined: syscall.Kill
[…]
pkg/filelock/lock.go:58:18: undefined: syscall.Flock
pkg/filelock/lock.go:58:45: undefined: syscall.LOCK_EX
```

`provider_claudecode.go` was added in the v0.4.0 cycle and used `cmd.SysProcAttr.Setpgid` + `syscall.Kill(-pid, SIGTERM)` at three call sites. `pkg/filelock/lock.go` predates that but was never windows-clean. Neither had build tags.

## How

Followed the repo's existing platform-split convention (`research_unix.go`/`research_windows.go`, `service_supervisor_launchctl.go`/`service_supervisor_stub.go`). Two new platform pairs:

**Process-group helpers** (`internal/engine/process_group_{unix,windows}.go`):

- `setProcessGroup(cmd)` — Unix: sets `Setpgid: true` on `cmd.SysProcAttr` (preserving any existing fields). Windows: no-op.
- `killProcessGroup(cmd) error` — Unix: `syscall.Kill(-cmd.Process.Pid, SIGTERM)` to terminate the whole process tree. Windows: falls back to `cmd.Process.Kill()` on the direct child.

`provider_claudecode.go` now calls these helpers at the three sites (`Complete`, `Stream`, background runner around line 727) and drops its `syscall` import. The Windows fallback only terminates the direct child; subprocess-tree termination via Job Objects is a follow-up — out of scope here, but worth a tracking issue if Windows becomes a supported target.

**Advisory file lock helpers** (`pkg/filelock/lock_{unix,windows}.go`):

- `tryLock(fd) error` — Unix: `flock(LOCK_EX|LOCK_NB)`. Windows: `LockFileEx(LOCKFILE_EXCLUSIVE_LOCK|LOCKFILE_FAIL_IMMEDIATELY)` via `golang.org/x/sys/windows` (already in `go.sum` transitively via go-git).
- `unlock(fd) error` — Unix: `flock(LOCK_UN)`. Windows: `UnlockFileEx`.
- A small `errLockBusy` sentinel in `lock.go` signals "another process holds the lock" cross-platform; `Acquire` converts it to `ErrLockTimeout` after the deadline, same as before.

Public API (`Acquire`, `Release`, `FileLock`, `ErrLockTimeout`) is byte-identical. `pkg/alias/alias.go` and `lock_test.go` are unaffected.

`go.mod` is intentionally untouched. `golang.org/x/sys` is already an indirect dep — Go resolves it for the new direct import without needing the `// indirect` annotation removed; CI does not enforce `go mod tidy` state. Hygiene cleanup belongs in a separate commit if wanted.

## Acceptance

- [x] release.yml's bash build step compiles all 6 (GOOS, GOARCH) combinations
- [x] no behavior change on darwin / linux (existing tests still pass)
- [x] follows existing platform-split convention in the repo
- [ ] release.yml run on a v* tag attaches 7 assets (verify post-merge by cutting v0.4.2)

## Test evidence

```
$ go vet ./...
(silent)

$ go test -race -count=1 ./pkg/filelock/...
ok      github.com/cogos-dev/cogos/pkg/filelock 1.401s

$ go test -short -count=1 ./internal/engine/
ok      github.com/cogos-dev/cogos/internal/engine 7.615s

$ for goos in linux darwin windows; do for goarch in amd64 arm64; do
    CGO_ENABLED=0 GOOS=$goos GOARCH=$goarch go build -tags fts5 \
      -o /tmp/cogos-$goos-$goarch ./cmd/cogos/ && echo "  ok: $goos/$goarch"
  done; done
  ok: linux/amd64
  ok: linux/arm64
  ok: darwin/amd64
  ok: darwin/arm64
  ok: windows/amd64
  ok: windows/arm64
```

The cross-build matrix is the same one `release.yml` runs in CI; passing it locally is the e2e test of this fix.