### PR TITLE
chore(release): bump VERSION to 0.4.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 #   make e2e      - Run e2e test in a container
 #   make e2e-local - Run e2e test locally
 
-VERSION := 0.4.1
+VERSION := 0.4.2
 BUILD_TIME := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -s -w -X github.com/cogos-dev/cogos/internal/engine.BuildTime=$(BUILD_TIME)
 BUILD_TAGS := fts5


### PR DESCRIPTION
## What and why

Tags v0.4.2. Picks up the windows-portability fix from #200, which restores release.yml's ability to ship binaries (v0.4.0 and v0.4.1 both shipped 0 assets due to windows build failures; #200 now lets all 6 platforms build).

## How

One-line bump in `Makefile`. Same pattern as #140 (v0.4.1 bump).

## Acceptance

- [x] VERSION matches the next semver tag
- [ ] release.yml run on the v0.4.2 tag attaches 7 assets (verify post-tag)

## Test evidence

The validation lives in #200 (cross-build matrix for all 6 release targets). This PR is a metadata bump — CI re-runs to confirm no regression.