### PR TITLE
refactor(engine): rename internal 'cogos-v3' strings to 'cogos'

### DIFF
--- a/internal/engine/benchmark.go
+++ b/internal/engine/benchmark.go
@@ -9,7 +9,7 @@
 //   - Total token count of assembled context
 //   - Model response (for manual quality review)
 //
-// Run with: cogos-v3 bench [--prompts path] [--model name] [--budget n]
+// Run with: cogos bench [--prompts path] [--model name] [--budget n]
 package engine
 
 import (
@@ -255,7 +255,7 @@ func SaveResults(workspaceRoot string, results []BenchmarkResult, model, method 
 
 // runBenchCmd is the entry point for the "bench" subcommand.
 //
-//	cogos-v3 bench [--workspace path] [--prompts path] [--model name] [--budget n] [--no-inference]
+//	cogos bench [--workspace path] [--prompts path] [--model name] [--budget n] [--no-inference]
 func runBenchCmd(args []string, workspaceRoot string, defaultPort int) {
 	fs := flag.NewFlagSet("bench", flag.ExitOnError)
 	workspace := fs.String("workspace", workspaceRoot, "Workspace root path (auto-detected if empty)")
@@ -311,7 +311,7 @@ func runBenchCmd(args []string, workspaceRoot string, defaultPort int) {
 		exe, _ := os.Executable()
 		candidates := []string{
 			filepath.Join(filepath.Dir(exe), "testdata", "benchmark_prompts.json"),
-			filepath.Join(cfg.WorkspaceRoot, "apps", "cogos-v3", "testdata", "benchmark_prompts.json"),
+			filepath.Join(cfg.WorkspaceRoot, "apps", "cogos", "testdata", "benchmark_prompts.json"),
 		}
 		for _, c := range candidates {
 			if _, serr := os.Stat(c); serr == nil {

--- a/internal/engine/blobs_cmd.go
+++ b/internal/engine/blobs_cmd.go
@@ -2,12 +2,12 @@
 //
 // Usage:
 //
-//	cogos-v3 blobs list              — list all stored blobs
-//	cogos-v3 blobs store <file>      — manually store a file
-//	cogos-v3 blobs get <hash> <out>  — retrieve blob to file
-//	cogos-v3 blobs verify            — check all pointers have matching blobs
-//	cogos-v3 blobs gc [--dry-run]    — garbage collect unreferenced blobs
-//	cogos-v3 blobs init              — initialize the blob store
+//	cogos blobs list              — list all stored blobs
+//	cogos blobs store <file>      — manually store a file
+//	cogos blobs get <hash> <out>  — retrieve blob to file
+//	cogos blobs verify            — check all pointers have matching blobs
+//	cogos blobs gc [--dry-run]    — garbage collect unreferenced blobs
+//	cogos blobs init              — initialize the blob store
 package engine
 
 import (
@@ -50,7 +50,7 @@ func runBlobsCmd(args []string, workspace string) {
 
 	case "store":
 		if len(args) < 2 {
-			fmt.Fprintln(os.Stderr, "usage: cogos-v3 blobs store <file>")
+			fmt.Fprintln(os.Stderr, "usage: cogos blobs store <file>")
 			os.Exit(1)
 		}
 		filePath := args[1]
@@ -80,7 +80,7 @@ func runBlobsCmd(args []string, workspace string) {
 
 	case "get":
 		if len(args) < 3 {
-			fmt.Fprintln(os.Stderr, "usage: cogos-v3 blobs get <hash> <output-file>")
+			fmt.Fprintln(os.Stderr, "usage: cogos blobs get <hash> <output-file>")
 			os.Exit(1)
 		}
 		hash := args[1]
@@ -191,7 +191,7 @@ func runBlobsCmd(args []string, workspace string) {
 	case "dehydrate":
 		// Replace files with blob pointers (store content, write pointer).
 		if len(args) < 2 {
-			fmt.Fprintln(os.Stderr, "usage: cogos-v3 blobs dehydrate <file-or-dir>")
+			fmt.Fprintln(os.Stderr, "usage: cogos blobs dehydrate <file-or-dir>")
 			os.Exit(1)
 		}
 		target := args[1]
@@ -244,7 +244,7 @@ func runBlobsCmd(args []string, workspace string) {
 }
 
 func printBlobsUsage() {
-	fmt.Println(`Usage: cogos-v3 blobs <command>
+	fmt.Println(`Usage: cogos blobs <command>
 
 Commands:
   init              Initialize the blob store

--- a/internal/engine/chat.go
+++ b/internal/engine/chat.go
@@ -9,10 +9,10 @@
 //
 // Usage:
 //
-//	cogos-v3 chat              # connect to daemon on default port 6931
-//	cogos-v3 chat --port 6931  # explicit port
-//	cogos-v3 --port 6931 chat  # flags must precede subcommand name
-//	cogos-v3 chat --direct     # bypass daemon, talk directly to Ollama
+//	cogos chat              # connect to daemon on default port 6931
+//	cogos chat --port 6931  # explicit port
+//	cogos --port 6931 chat  # flags must precede subcommand name
+//	cogos chat --direct     # bypass daemon, talk directly to Ollama
 package engine
 
 import (
@@ -65,7 +65,7 @@ func runDirectChat(workspace, model string) {
 		os.Exit(1)
 	}
 
-	fmt.Fprintln(os.Stderr, "cogos-v3 chat (direct mode — Ctrl+C or Ctrl+D to exit)")
+	fmt.Fprintln(os.Stderr, "cogos chat (direct mode — Ctrl+C or Ctrl+D to exit)")
 
 	var messages []ProviderMessage
 	scanner := bufio.NewScanner(os.Stdin)
@@ -141,7 +141,7 @@ func runServerChat(workspace string, port int, model string) {
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/health", nil)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: daemon not reachable at %s — start it with: cogos-v3 serve or cogos-v3 start\n", baseURL)
+		fmt.Fprintf(os.Stderr, "error: daemon not reachable at %s — start it with: cogos serve or cogos start\n", baseURL)
 		os.Exit(1)
 	}
 	_ = resp.Body.Close()
@@ -149,7 +149,7 @@ func runServerChat(workspace string, port int, model string) {
 		fmt.Fprintf(os.Stderr, "warning: daemon health check returned %d\n", resp.StatusCode)
 	}
 
-	fmt.Fprintf(os.Stderr, "cogos-v3 chat (daemon at %s — Ctrl+C or Ctrl+D to exit)\n", baseURL)
+	fmt.Fprintf(os.Stderr, "cogos chat (daemon at %s — Ctrl+C or Ctrl+D to exit)\n", baseURL)
 
 	var messages []oaiMessage
 	scanner := bufio.NewScanner(os.Stdin)

--- a/internal/engine/cli.go
+++ b/internal/engine/cli.go
@@ -97,7 +97,7 @@ func Main() {
 		}
 	}
 
-	// Compatibility path: plain `cogos-v3` still serves in the foreground.
+	// Compatibility path: plain `cogos` still serves in the foreground.
 	runServe(*workspace, *port, "")
 }
 
@@ -144,7 +144,7 @@ func runServe(workspace string, port int, bindAddr string) {
 	}
 
 	setupLogger()
-	slog.Info("cogos-v3: starting", "build", BuildTime)
+	slog.Info("cogos: starting", "build", BuildTime)
 
 	// Load configuration.
 	cfg, err := LoadConfig(workspace, port)
@@ -275,7 +275,7 @@ func runServe(workspace string, port int, bindAddr string) {
 	// Wait for shutdown signal or fatal error.
 	select {
 	case <-ctx.Done():
-		slog.Info("cogos-v3: shutdown signal received")
+		slog.Info("cogos: shutdown signal received")
 	case err := <-serverDone:
 		if err != nil {
 			slog.Error("server error", "err", err)
@@ -303,7 +303,7 @@ func runServe(workspace string, port int, bindAddr string) {
 		slog.Warn("process did not stop in time")
 	}
 
-	slog.Info("cogos-v3: stopped")
+	slog.Info("cogos: stopped")
 }
 
 // runHealthCheck performs a quick health check and exits 0 (healthy) or 1 (unhealthy).

--- a/internal/engine/daemon_lifecycle.go
+++ b/internal/engine/daemon_lifecycle.go
@@ -159,7 +159,7 @@ func workspaceSlug(workspaceRoot string) string {
 }
 
 func containerNameForWorkspace(workspaceRoot string) string {
-	return "cogos-v3-" + workspaceSlug(workspaceRoot)
+	return "cogos-" + workspaceSlug(workspaceRoot)
 }
 
 func checkDaemonHealth(endpoint string, timeout time.Duration) (*DaemonHealth, error) {

--- a/internal/engine/docs_generate.go
+++ b/internal/engine/docs_generate.go
@@ -11,7 +11,7 @@
 // This is the efferent pathway: knowledge flows OUT of the CogDoc substrate
 // as human-readable documentation. No LLM calls — purely deterministic.
 //
-// Usage: cogos-v3 docs [--workspace PATH]
+// Usage: cogos docs [--workspace PATH]
 package engine
 
 import (
@@ -34,7 +34,7 @@ func runDocsCmd(args []string, workspace string) {
 		workspace = ws
 	}
 
-	fmt.Printf("cogos-v3 docs: generating from %s\n", workspace)
+	fmt.Printf("cogos docs: generating from %s\n", workspace)
 
 	memDir := filepath.Join(workspace, ".cog", "mem")
 	if _, err := os.Stat(memDir); os.IsNotExist(err) {

--- a/internal/engine/experiment.go
+++ b/internal/engine/experiment.go
@@ -7,7 +7,7 @@
 //
 // Usage:
 //
-//	cogos-v3 experiment run <path-to-experiment.md>
+//	cogos experiment run <path-to-experiment.md>
 //
 // The runner:
 //  1. Loads the experiment config from YAML frontmatter
@@ -96,7 +96,7 @@ func RunExperiment(ctx context.Context, experimentPath, workspaceRoot string, pr
 
 	if cfg.Run.PromptsFile == "" {
 		cfg.Run.PromptsFile = filepath.Join(workspaceRoot,
-			"apps", "cogos-v3", "testdata", "benchmark_prompts.json")
+			"apps", "cogos", "testdata", "benchmark_prompts.json")
 	} else if !filepath.IsAbs(cfg.Run.PromptsFile) {
 		cfg.Run.PromptsFile = filepath.Join(workspaceRoot, cfg.Run.PromptsFile)
 	}
@@ -215,7 +215,7 @@ type: experiment
 title: "Foveated Context Experiment"
 created: "%s"
 run:
-  prompts_file: ""  # default: apps/cogos-v3/testdata/benchmark_prompts.json
+  prompts_file: ""  # default: apps/cogos/testdata/benchmark_prompts.json
   model: "qwen3.5:9b"
   budget: 4096
   method: "keyword-match"
@@ -243,14 +243,14 @@ func runExperimentCmd(args []string, workspaceRoot string, defaultPort int) {
 
 	subArgs := fs.Args()
 	if len(subArgs) == 0 {
-		fmt.Fprintln(os.Stderr, "usage: cogos-v3 experiment <run|new> [args...]")
+		fmt.Fprintln(os.Stderr, "usage: cogos experiment <run|new> [args...]")
 		os.Exit(1)
 	}
 
 	switch subArgs[0] {
 	case "run":
 		if len(subArgs) < 2 {
-			fmt.Fprintln(os.Stderr, "usage: cogos-v3 experiment run <path-to-experiment.md>")
+			fmt.Fprintln(os.Stderr, "usage: cogos experiment run <path-to-experiment.md>")
 			os.Exit(1)
 		}
 		runExperimentRun(subArgs[1], *workspace)

--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -106,7 +106,7 @@ func NewMCPServer(cfg *Config, nucleus *Nucleus, process *Process) *MCPServer {
 // that case so clients get a consistent error shape.
 func NewMCPServerWithAgentController(cfg *Config, nucleus *Nucleus, process *Process, ctrl AgentController) *MCPServer {
 	server := mcp.NewServer(&mcp.Implementation{
-		Name:    "cogos-v3",
+		Name:    "cogos",
 		Version: BuildTime,
 	}, nil)
 

--- a/internal/engine/salience_test.go
+++ b/internal/engine/salience_test.go
@@ -108,7 +108,7 @@ func TestComputeFileSalienceRealRepo(t *testing.T) {
 
 	sig := &object.Signature{
 		Name:  "Test Author",
-		Email: "test@cogos-v3.test",
+		Email: "test@cogos.test",
 		When:  time.Now(),
 	}
 	if _, err := wt.Commit("feat: initial test commit", &git.CommitOptions{

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -611,7 +611,7 @@ type oaiChatResponse struct {
 // handleChat is the OpenAI-compatible /v1/chat/completions endpoint.
 // Routes through the inference Router when set; returns 501 otherwise.
 func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
-	ctx, span := otel.Tracer("cogos-v3").Start(r.Context(), "chat.request")
+	ctx, span := otel.Tracer("cogos").Start(r.Context(), "chat.request")
 	defer span.End()
 	r = r.WithContext(ctx)
 

--- a/internal/engine/telemetry.go
+++ b/internal/engine/telemetry.go
@@ -5,12 +5,12 @@
 //
 // Environment variables:
 //   OTEL_EXPORTER_OTLP_ENDPOINT — collector endpoint (default: http://localhost:4318)
-//   OTEL_SERVICE_NAME           — service name (default: cogos-v3)
+//   OTEL_SERVICE_NAME           — service name (default: cogos)
 //
 // Usage:
 //   shutdown := initTelemetry(ctx)
 //   defer shutdown(ctx)
-//   // Use otel.Tracer("cogos-v3") and otel.Meter("cogos-v3") anywhere.
+//   // Use otel.Tracer("cogos") and otel.Meter("cogos") anywhere.
 package engine
 
 import (
@@ -47,7 +47,7 @@ var instruments struct {
 func initTelemetry(ctx context.Context) func(context.Context) {
 	serviceName := os.Getenv("OTEL_SERVICE_NAME")
 	if serviceName == "" {
-		serviceName = "cogos-v3"
+		serviceName = "cogos"
 	}
 
 	res, _ := resource.New(ctx,
@@ -94,7 +94,7 @@ func initTelemetry(ctx context.Context) func(context.Context) {
 	}
 
 	// Register instruments.
-	meter := otel.Meter("cogos-v3")
+	meter := otel.Meter("cogos")
 	instruments.ChatRequests, _ = meter.Int64Counter("cogos.chat.requests",
 		metric.WithDescription("Total chat completion requests"))
 	instruments.ContextTokens, _ = meter.Int64Histogram("cogos.context.tokens",

--- a/internal/engine/testhelper_test.go
+++ b/internal/engine/testhelper_test.go
@@ -1,4 +1,4 @@
-// testhelper_test.go — shared test utilities for cogos-v3
+// testhelper_test.go — shared test utilities for cogos
 //
 // All helpers follow these conventions:
 //   - Accept *testing.T as first argument


### PR DESCRIPTION
## Summary

v0.4.2 retired the `-v3` suffix. The binary and release artifacts are now distributed as `cogos`, but internal strings still emitted the old name. This PR completes the cleanup.

**Strings renamed:**
- MCP `serverInfo.name`: `"cogos-v3"` → `"cogos"` (`mcp_server.go`)
- Daemon slog messages: `"cogos-v3: starting"`, `"cogos-v3: shutdown signal received"`, `"cogos-v3: stopped"` (`cli.go`)
- OTel default service name: `OTEL_SERVICE_NAME` default `"cogos-v3"` → `"cogos"` (`telemetry.go`)
- OTel tracer/meter instrument names: `otel.Tracer("cogos-v3")` / `otel.Meter("cogos-v3")` → `"cogos"` (`telemetry.go`, `serve.go`)
- Container name prefix: `"cogos-v3-<slug>"` → `"cogos-<slug>"` (`daemon_lifecycle.go`)
- CLI usage strings in comments and user-facing stderr across `chat.go`, `blobs_cmd.go`, `benchmark.go`, `experiment.go`, `docs_generate.go`
- Default `prompts_file` fallback path: `apps/cogos-v3/` → `apps/cogos/` (`benchmark.go`, `experiment.go`)
- Test file header comment and git author email domain (`testhelper_test.go`, `salience_test.go`)

**Not renamed (intentional):**
- `bus_session_test.go:198`, `serve_bus_test.go:4` — fixture capture provenance comments ("captured from the live cogos-v3 daemon") — historical context for byte-compat regression tests; renaming would lose the audit trail.
- `config_test.go:295` — `filepath.Join(root, "apps", "cogos-v3")` — test fixture directory path for `findWorkspaceRoot` traversal logic; the string value is a test-only temp directory label, not a product name.

## Test plan

- [x] `go build -tags fts5 -o /tmp/cogos-rename-test ./cmd/cogos/` — clean build
- [x] `go test -tags fts5 -short -count=1 -timeout=120s ./internal/engine/` — passes (7.8s)
- [x] `/tmp/cogos-rename-test version` — outputs `cogos version=dev build=unknown`
- [x] Grep confirms no remaining `cogos-v3` in non-excluded Go source files

Per org convention: please squash-merge.