### PR TITLE
docs: refresh install path, releasing flow, and Go version after v0.4.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ make build
 ./scripts/setup-dev.sh
 ```
 
-Requirements: Go 1.24+, macOS or Linux.
+Requirements: Go 1.25+, macOS or Linux.
 
 ## Running tests
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ make build && ./cogos serve --workspace ~/my-project
 # http://localhost:6931/health
 ```
 
+Or install a pre-built binary:
+
+```sh
+# macOS Apple Silicon (latest release)
+curl -L https://github.com/cogos-dev/cogos/releases/latest/download/cogos-darwin-arm64 -o cogos
+chmod +x cogos && mv cogos ~/.cog/bin/cogos
+```
+
+For Linux, Windows, and other architectures, see [docs/RELEASING.md](docs/RELEASING.md).
+
 ---
 
 ## What this is
@@ -323,7 +333,7 @@ cog claude
 ### Developer setup
 
 ```sh
-./scripts/setup-dev.sh    # Build, install to ~/.cogos/bin, configure PATH
+./scripts/setup-dev.sh    # Build, install to ~/.cog/bin, configure PATH
 ```
 
 ### Docker

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -2,11 +2,10 @@
 
 ## Prerequisites
 - All CI checks passing on main
-- CHANGELOG.md updated with changes since last release
 
 ## Steps
 
-1. Update CHANGELOG.md — move "Unreleased" items under a new version header
+1. Verify recent PR titles follow conventional-commit format — they become the auto-generated release notes (via `gh release create --generate-notes`; see CONTRIBUTING.md). Optionally amend the historical-entries section of CHANGELOG.md only if there is a specific note that does not fit a PR title.
 2. Commit: `git commit -am "release: prepare v0.x.y"`
 3. Tag: `git tag v0.x.y`
 4. Push: `git push origin main --tags`

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -9,15 +9,15 @@
 # What it does:
 #   1. Checks prerequisites (Go, Docker/Colima, git)
 #   2. Builds cogos from source
-#   3. Installs cogos binary to ~/.cogos/bin/
-#   4. Installs cog CLI wrapper to ~/.cogos/bin/
-#   5. Adds ~/.cogos/bin to PATH (shell profile)
+#   3. Installs cogos binary to ~/.cog/bin/cogos
+#   4. Installs cog CLI wrapper to ~/.cog/bin/cog
+#   5. Adds ~/.cog/bin to PATH (shell profile)
 #   6. Verifies the install
 
 set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-INSTALL_DIR="$HOME/.cogos/bin"
+INSTALL_DIR="$HOME/.cog/bin"
 SHELL_NAME="$(basename "$SHELL")"
 
 # ── Colors ────────────────────────────────────────────────────────────────────
@@ -130,9 +130,9 @@ else
         *)    PROFILE="$HOME/.profile" ;;
     esac
 
-    PATH_LINE='export PATH="$HOME/.cogos/bin:$PATH"'
+    PATH_LINE='export PATH="$HOME/.cog/bin:$PATH"'
 
-    if [ -n "$PROFILE" ] && ! grep -qF '.cogos/bin' "$PROFILE" 2>/dev/null; then
+    if [ -n "$PROFILE" ] && ! grep -qF '.cog/bin' "$PROFILE" 2>/dev/null; then
         echo "" >> "$PROFILE"
         echo "# CogOS" >> "$PROFILE"
         echo "$PATH_LINE" >> "$PROFILE"


### PR DESCRIPTION
## Summary

Four targeted doc fixes left over from the v0.4.2 release and the 2026-05-05 org workflow change (direct branches to upstream, squash-merge):

- **`scripts/setup-dev.sh`**: install path updated from `~/.cogos/bin` to `~/.cog/bin` throughout (INSTALL_DIR variable, PATH_LINE export, grep guard, and comment block). Now matches `make install`'s INSTALL_DIR/INSTALL_TARGET.
- **`README.md`**: (1) Developer setup comment updated from `~/.cogos/bin` to `~/.cog/bin` to match the fixed script. (2) Pre-built binary install pointer added after the opening `make build` quickstart — shows the macOS Apple Silicon curl one-liner and links `docs/RELEASING.md` for other platforms.
- **`docs/RELEASING.md`**: Step 1 replaced. The old "Update CHANGELOG.md — move Unreleased items" instruction contradicts CHANGELOG.md's own policy (no hand-curation from v0.4.0 onward; release notes are auto-generated from PR titles via `gh release create --generate-notes`). New step 1 reflects the actual process and points to CONTRIBUTING.md for PR title conventions.
- **`CONTRIBUTING.md`**: Go version requirement updated from `1.24+` to `1.25+`, matching `go.mod`'s `go 1.25.0` directive.

## Test plan

- [ ] Diff confirms only the four intended hunks changed — no unrelated edits
- [ ] `scripts/setup-dev.sh` installs to `~/.cog/bin` on a clean checkout
- [ ] README pre-built binary curl one-liner matches the release artifact name in `cogos-dev/cogos/releases/latest`
- [ ] RELEASING.md step 1 no longer contradicts CHANGELOG.md policy header
- [ ] CONTRIBUTING.md Go version matches `go.mod`

Intent: squash-merge per org workflow established 2026-05-05.