### PR TITLE
feat: SiteProvider for static-site reconciliation

### DIFF
--- a/cmd/cogos/providers_wire.go
+++ b/cmd/cogos/providers_wire.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cogos-dev/cogos/internal/eval"
 	"github.com/cogos-dev/cogos/internal/providers/component"
 	"github.com/cogos-dev/cogos/internal/providers/daemon"
+	_ "github.com/cogos-dev/cogos/internal/providers/site" // registers "site" with pkg/reconcile
 	"github.com/cogos-dev/cogos/internal/workspace"
 	"gopkg.in/yaml.v3"
 )

--- a/internal/engine/cli.go
+++ b/internal/engine/cli.go
@@ -90,6 +90,9 @@ func Main() {
 		case "node":
 			runNodeCmd(args[1:], *workspace)
 			return
+		case "reconcile":
+			runReconcileCmd(args[1:], *workspace)
+			return
 		case "emit":
 			os.Exit(runEmitCmd(args[1:], *workspace))
 		case "mcp":

--- a/internal/engine/cli_reconcile.go
+++ b/internal/engine/cli_reconcile.go
@@ -43,12 +43,25 @@ func runReconcileCmd(args []string, defaultWorkspace string) {
 		fs.PrintDefaults()
 	}
 
-	if err := fs.Parse(args); err != nil {
+	// Pull out the provider type (first non-flag argument) before parsing flags.
+	// This lets the user write either:
+	//   cogos reconcile site --dry-run --json   (type before flags)
+	//   cogos reconcile --dry-run --json site   (flags before type)
+	providerType := ""
+	flagArgs := make([]string, 0, len(args))
+	for _, a := range args {
+		if providerType == "" && !strings.HasPrefix(a, "-") {
+			providerType = a
+		} else {
+			flagArgs = append(flagArgs, a)
+		}
+	}
+
+	if err := fs.Parse(flagArgs); err != nil {
 		os.Exit(1)
 	}
-	providerType := fs.Arg(0)
 	if providerType == "" {
-		fmt.Fprintf(os.Stderr, "error: provider type required (e.g. cogos reconcile sites)\n\n")
+		fmt.Fprintf(os.Stderr, "error: provider type required (e.g. cogos reconcile site)\n\n")
 		fs.Usage()
 		os.Exit(1)
 	}

--- a/internal/engine/cli_reconcile.go
+++ b/internal/engine/cli_reconcile.go
@@ -1,0 +1,185 @@
+// cli_reconcile.go — "cogos reconcile <type>" subcommand.
+//
+// Usage:
+//
+//	cogos reconcile <type> [--dry-run] [--json] [--resource <name>]
+//
+// Runs the plan (and optionally apply) cycle for a single registered
+// provider type. The provider must already be registered with pkg/reconcile
+// (via an init() import in cmd/cogos/providers_wire.go).
+//
+// Workspace root is resolved from the --workspace global flag or via git-root
+// detection on the cwd. The command exits 0 on success (synced or dry-run),
+// 2 if dry-run reveals drift, 1 on any error.
+package engine
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/cogos-dev/cogos/pkg/reconcile"
+)
+
+// runReconcileCmd dispatches "cogos reconcile <type> [flags]".
+// args is everything after "reconcile" (i.e. os.Args[2:]).
+func runReconcileCmd(args []string, defaultWorkspace string) {
+	fs := flag.NewFlagSet("reconcile", flag.ExitOnError)
+	workspace := fs.String("workspace", defaultWorkspace, "Workspace root path (auto-detected from cwd if empty)")
+	dryRun := fs.Bool("dry-run", false, "Plan only; do not apply changes")
+	jsonOut := fs.Bool("json", false, "Output plan as JSON")
+	_ = fs.String("resource", "", "Reserved: reconcile only this named resource (not yet implemented)")
+
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: cogos reconcile <type> [flags]\n\n")
+		fmt.Fprintf(os.Stderr, "Registered providers: %s\n\n", strings.Join(reconcile.ListProviders(), ", "))
+		fmt.Fprintf(os.Stderr, "Flags:\n")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(args); err != nil {
+		os.Exit(1)
+	}
+	providerType := fs.Arg(0)
+	if providerType == "" {
+		fmt.Fprintf(os.Stderr, "error: provider type required (e.g. cogos reconcile sites)\n\n")
+		fs.Usage()
+		os.Exit(1)
+	}
+
+	// Resolve workspace root.
+	root := *workspace
+	if root == "" {
+		var err error
+		root, err = reconcileResolveWorkspace()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: resolve workspace: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	// Retrieve the provider.
+	provider, err := reconcile.GetProvider(providerType)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n\nRegistered providers: %s\n",
+			err, strings.Join(reconcile.ListProviders(), ", "))
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+
+	// Load config.
+	config, err := provider.LoadConfig(root)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: load config: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Fetch live state.
+	live, err := provider.FetchLive(ctx, config)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: fetch live state: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Load persisted state.
+	state, _ := reconcile.LoadState(root, providerType)
+
+	// Compute plan.
+	plan, err := provider.ComputePlan(config, live, state)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: compute plan: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Render plan.
+	if *jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(plan); err != nil {
+			fmt.Fprintf(os.Stderr, "error: encode plan: %v\n", err)
+			os.Exit(1)
+		}
+	} else {
+		reconcilePrintTable(plan)
+	}
+
+	if *dryRun {
+		if plan.Summary.HasChanges() {
+			// Exit 2 signals drift to callers without being a process error.
+			os.Exit(2)
+		}
+		return
+	}
+
+	// Apply.
+	if !plan.Summary.HasChanges() {
+		fmt.Fprintln(os.Stderr, "no changes — already in sync")
+		return
+	}
+	results, err := provider.ApplyPlan(ctx, plan)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: apply plan: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Persist updated state.
+	newState, err := provider.BuildState(config, live, state)
+	if err == nil && newState != nil {
+		if writeErr := reconcile.WriteState(root, providerType, newState); writeErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: write state: %v\n", writeErr)
+		}
+	}
+
+	// Report apply results.
+	failed := 0
+	for _, r := range results {
+		if r.Status == reconcile.ApplyFailed {
+			failed++
+			fmt.Fprintf(os.Stderr, "  FAILED  %s: %s\n", r.Name, r.Error)
+		} else {
+			fmt.Fprintf(os.Stderr, "  OK      %s\n", r.Name)
+		}
+	}
+	if failed > 0 {
+		fmt.Fprintf(os.Stderr, "%d action(s) failed\n", failed)
+		os.Exit(1)
+	}
+}
+
+// reconcilePrintTable renders the plan as a human-readable table to stdout.
+func reconcilePrintTable(plan *reconcile.Plan) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	defer w.Flush()
+	fmt.Fprintf(w, "ACTION\tNAME\tDETAILS\n")
+	for _, a := range plan.Actions {
+		details := ""
+		if s, ok := a.Details["strategy"].(string); ok {
+			details = "strategy=" + s
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\n", strings.ToUpper(string(a.Action)), a.Name, details)
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintf(os.Stdout, "Summary: %d create, %d update, %d delete, %d skip\n",
+		plan.Summary.Creates, plan.Summary.Updates, plan.Summary.Deletes, plan.Summary.Skipped)
+}
+
+// reconcileResolveWorkspace detects the workspace root from cwd via git.
+// Falls back to cwd if not in a git repository.
+func reconcileResolveWorkspace() (string, error) {
+	var out bytes.Buffer
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	cmd.Stdout = &out
+	if err := cmd.Run(); err == nil {
+		if root := strings.TrimSpace(out.String()); root != "" {
+			return root, nil
+		}
+	}
+	return os.Getwd()
+}

--- a/internal/providers/site/site.go
+++ b/internal/providers/site/site.go
@@ -1,0 +1,580 @@
+// Package site provides the Reconcilable provider for static-site deployments.
+//
+// This package makes SiteProvider and GHPagesStrategy available to the daemon
+// binary (cmd/cogos) which cannot import the workspace-root package main.
+//
+// The types and logic mirror site_*.go in the workspace root. The workspace-root
+// copies remain canonical for the cog CLI; this package is the importable
+// counterpart used by cmd/cogos/providers_wire.go.
+//
+// Registration: importing this package (even as a blank import) triggers init(),
+// which registers "site" with pkg/reconcile. GHPagesStrategy is self-registered
+// in the same init() chain.
+package site
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cogos-dev/cogos/pkg/reconcile"
+	"gopkg.in/yaml.v3"
+)
+
+func init() {
+	sp := newSiteProvider()
+	reconcile.RegisterProvider("site", sp)
+	sp.RegisterStrategy("gh-pages", &ghPagesStrategy{})
+}
+
+// ─── SiteCRD types ───────────────────────────────────────────────────────────
+
+var knownStrategies = map[string]bool{
+	"gh-pages":          true,
+	"gitlab-pages":      true,
+	"s3":                true,
+	"k8s-ingress":       true,
+	"self-hosted-rsync": true,
+}
+
+// ErrInvalidSiteCRD is returned by Validate when the CRD is inconsistent.
+var ErrInvalidSiteCRD = errors.New("invalid SiteCRD")
+
+// ErrUnsupportedStrategy is returned when the requested strategy is not registered.
+var ErrUnsupportedStrategy = errors.New("unsupported deploy strategy")
+
+type siteCRD struct {
+	APIVersion string       `yaml:"apiVersion" json:"apiVersion"`
+	Kind       string       `yaml:"kind"       json:"kind"`
+	Metadata   siteMetadata `yaml:"metadata"   json:"metadata"`
+	Spec       siteSpec     `yaml:"spec"       json:"spec"`
+}
+
+type siteMetadata struct {
+	Name string `yaml:"name" json:"name"`
+}
+
+type siteSpec struct {
+	Domain     string     `yaml:"domain"      json:"domain"`
+	Canonical  bool       `yaml:"canonical"   json:"canonical"`
+	Source     sourceSpec `yaml:"source"      json:"source"`
+	Build      buildSpec  `yaml:"build"       json:"build"`
+	HTTPS      httpsSpec  `yaml:"https"       json:"https"`
+	Deploy     deploySpec `yaml:"deploy"      json:"deploy"`
+	RedirectTo *string    `yaml:"redirect_to,omitempty" json:"redirect_to,omitempty"`
+}
+
+type sourceSpec struct{ Path string `yaml:"path" json:"path"` }
+type buildSpec struct {
+	Command string `yaml:"command" json:"command"`
+	Dist    string `yaml:"dist"    json:"dist"`
+}
+type httpsSpec struct{ Required bool `yaml:"required" json:"required"` }
+type deploySpec struct {
+	Strategy string         `yaml:"strategy" json:"strategy"`
+	Target   map[string]any `yaml:"target"   json:"target"`
+}
+
+func (s siteCRD) Validate() error {
+	if s.Metadata.Name == "" {
+		return fmt.Errorf("%w: metadata.name is required", ErrInvalidSiteCRD)
+	}
+	if s.Spec.Domain == "" {
+		return fmt.Errorf("%w: spec.domain is required", ErrInvalidSiteCRD)
+	}
+	if s.Spec.Canonical && s.Spec.RedirectTo != nil {
+		return fmt.Errorf("%w: canonical site %q must not set redirect_to", ErrInvalidSiteCRD, s.Metadata.Name)
+	}
+	if s.Spec.Deploy.Strategy == "" {
+		return fmt.Errorf("%w: spec.deploy.strategy is required", ErrInvalidSiteCRD)
+	}
+	if !knownStrategies[s.Spec.Deploy.Strategy] {
+		return fmt.Errorf("%w: unknown deploy strategy %q", ErrInvalidSiteCRD, s.Spec.Deploy.Strategy)
+	}
+	return nil
+}
+
+// ─── DeployStrategy ──────────────────────────────────────────────────────────
+
+type liveSiteState struct {
+	ArtifactSHA        string         `json:"artifact_sha"`
+	CNAMEContent       string         `json:"cname_content"`
+	ResolvedFromTarget bool           `json:"resolved_from_target"`
+	Metadata           map[string]any `json:"metadata,omitempty"`
+}
+
+type deployStrategy interface {
+	FetchLive(ctx context.Context, app siteCRD) (liveSiteState, error)
+	Deploy(ctx context.Context, app siteCRD, artifactDir string) error
+}
+
+// ─── SiteProvider ────────────────────────────────────────────────────────────
+
+type siteProvider struct {
+	mu         sync.Mutex
+	root       string
+	strategies map[string]deployStrategy
+}
+
+func newSiteProvider() *siteProvider {
+	return &siteProvider{strategies: map[string]deployStrategy{}}
+}
+
+func (s *siteProvider) RegisterStrategy(name string, strat deployStrategy) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.strategies[name] = strat
+}
+
+func (s *siteProvider) lookupStrategy(name string) (deployStrategy, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	strat, ok := s.strategies[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrUnsupportedStrategy, name)
+	}
+	return strat, nil
+}
+
+func (s *siteProvider) Type() string { return "site" }
+
+func (s *siteProvider) Health() reconcile.ResourceStatus {
+	return reconcile.NewResourceStatus(reconcile.SyncStatusUnknown, reconcile.HealthProgressing)
+}
+
+func (s *siteProvider) LoadConfig(root string) (any, error) {
+	s.mu.Lock()
+	s.root = root
+	s.mu.Unlock()
+	crds, err := loadCRDs(root)
+	if err != nil {
+		return nil, err
+	}
+	if crds == nil {
+		crds = []siteCRD{}
+	}
+	return crds, nil
+}
+
+func (s *siteProvider) FetchLive(ctx context.Context, config any) (any, error) {
+	crds, ok := config.([]siteCRD)
+	if !ok {
+		return nil, fmt.Errorf("site provider: FetchLive: unexpected config type %T", config)
+	}
+	live := make(map[string]liveSiteState, len(crds))
+	for _, crd := range crds {
+		strat, err := s.lookupStrategy(crd.Spec.Deploy.Strategy)
+		if err != nil {
+			log.Printf("[site] warning: FetchLive %s: %v", crd.Metadata.Name, err)
+			live[crd.Metadata.Name] = liveSiteState{}
+			continue
+		}
+		state, err := strat.FetchLive(ctx, crd)
+		if err != nil {
+			log.Printf("[site] warning: FetchLive %s: %v", crd.Metadata.Name, err)
+			live[crd.Metadata.Name] = liveSiteState{}
+			continue
+		}
+		live[crd.Metadata.Name] = state
+	}
+	return live, nil
+}
+
+func (s *siteProvider) ComputePlan(config any, live any, state *reconcile.State) (*reconcile.Plan, error) {
+	crds, ok := config.([]siteCRD)
+	if !ok {
+		return nil, fmt.Errorf("site provider: ComputePlan: unexpected config type %T", config)
+	}
+	liveMap, ok := live.(map[string]liveSiteState)
+	if !ok {
+		return nil, fmt.Errorf("site provider: ComputePlan: unexpected live type %T", live)
+	}
+
+	s.mu.Lock()
+	root := s.root
+	s.mu.Unlock()
+
+	plan := &reconcile.Plan{
+		ResourceType: "site",
+		GeneratedAt:  time.Now().UTC().Format(time.RFC3339),
+		ConfigPath:   root + "/apps",
+	}
+
+	declared := make(map[string]bool, len(crds))
+	for _, crd := range crds {
+		name := crd.Metadata.Name
+		declared[name] = true
+		appDir := root + "/apps/" + name
+
+		liveState := liveMap[name]
+		details := map[string]any{
+			"domain":   crd.Spec.Domain,
+			"strategy": crd.Spec.Deploy.Strategy,
+			"target":   crd.Spec.Deploy.Target,
+			"app_dir":  appDir,
+		}
+
+		if _, err := s.lookupStrategy(crd.Spec.Deploy.Strategy); err != nil {
+			plan.Warnings = append(plan.Warnings,
+				fmt.Sprintf("%s: strategy %q not registered — deploy will fail", name, crd.Spec.Deploy.Strategy))
+		}
+
+		if !liveState.ResolvedFromTarget {
+			plan.Actions = append(plan.Actions, reconcile.Action{
+				Action:       reconcile.ActionCreate,
+				ResourceType: "site",
+				Name:         name,
+				Details:      details,
+			})
+			plan.Summary.Creates++
+			continue
+		}
+
+		if liveState.ArtifactSHA == "" {
+			plan.Actions = append(plan.Actions, reconcile.Action{
+				Action:       reconcile.ActionUpdate,
+				ResourceType: "site",
+				Name:         name,
+				Details:      details,
+			})
+			plan.Summary.Updates++
+			continue
+		}
+
+		plan.Actions = append(plan.Actions, reconcile.Action{
+			Action:       reconcile.ActionSkip,
+			ResourceType: "site",
+			Name:         name,
+			Details:      details,
+		})
+		plan.Summary.Skipped++
+	}
+
+	if state != nil {
+		for _, res := range state.Resources {
+			if !declared[res.Name] {
+				plan.Actions = append(plan.Actions, reconcile.Action{
+					Action:       reconcile.ActionDelete,
+					ResourceType: "site",
+					Name:         res.Name,
+					Details:      map[string]any{"reason": "no matching site CRD"},
+				})
+				plan.Summary.Deletes++
+			}
+		}
+	}
+
+	return plan, nil
+}
+
+func (s *siteProvider) ApplyPlan(ctx context.Context, plan *reconcile.Plan) ([]reconcile.Result, error) {
+	var results []reconcile.Result
+	for _, action := range plan.Actions {
+		if action.Action == reconcile.ActionSkip {
+			continue
+		}
+		results = append(results, s.applyAction(ctx, action))
+	}
+	return results, nil
+}
+
+func (s *siteProvider) applyAction(ctx context.Context, action reconcile.Action) reconcile.Result {
+	base := reconcile.Result{
+		Phase:  "site",
+		Action: string(action.Action),
+		Name:   action.Name,
+	}
+	if action.Action == reconcile.ActionDelete {
+		log.Printf("[site] delete %s: no-op in v0.0.1 (manual teardown required)", action.Name)
+		base.Status = reconcile.ApplySucceeded
+		return base
+	}
+	appDir, _ := action.Details["app_dir"].(string)
+	if appDir == "" {
+		base.Status = reconcile.ApplyFailed
+		base.Error = "no app_dir in action details"
+		return base
+	}
+	if err := siteBuild(ctx, appDir, action.Name); err != nil {
+		base.Status = reconcile.ApplyFailed
+		base.Error = fmt.Sprintf("build: %v", err)
+		return base
+	}
+	stratName, _ := action.Details["strategy"].(string)
+	strat, err := s.lookupStrategy(stratName)
+	if err != nil {
+		base.Status = reconcile.ApplyFailed
+		base.Error = fmt.Sprintf("strategy lookup: %v", err)
+		return base
+	}
+	s.mu.Lock()
+	root := s.root
+	s.mu.Unlock()
+	crds, err := loadCRDs(root)
+	if err != nil {
+		base.Status = reconcile.ApplyFailed
+		base.Error = fmt.Sprintf("reload config: %v", err)
+		return base
+	}
+	crd, found := crdByName(crds, action.Name)
+	if !found {
+		base.Status = reconcile.ApplyFailed
+		base.Error = fmt.Sprintf("CRD not found after reload: %s", action.Name)
+		return base
+	}
+	if err := strat.Deploy(ctx, crd, appDir+"/dist"); err != nil {
+		base.Status = reconcile.ApplyFailed
+		base.Error = fmt.Sprintf("deploy: %v", err)
+		return base
+	}
+	base.Status = reconcile.ApplySucceeded
+	base.CreatedID = "site:" + action.Name
+	return base
+}
+
+func (s *siteProvider) BuildState(config any, live any, existing *reconcile.State) (*reconcile.State, error) {
+	liveMap, ok := live.(map[string]liveSiteState)
+	if !ok {
+		return nil, fmt.Errorf("site provider: BuildState: unexpected live type %T", live)
+	}
+	state := &reconcile.State{
+		Version:      1,
+		ResourceType: "site",
+		GeneratedAt:  time.Now().UTC().Format(time.RFC3339),
+	}
+	if existing != nil {
+		state.Lineage = existing.Lineage
+		state.Serial = existing.Serial + 1
+	} else {
+		state.Lineage = "site-" + time.Now().UTC().Format("20060102T150405Z")
+	}
+	for name, liveState := range liveMap {
+		state.Resources = append(state.Resources, reconcile.Resource{
+			Address:       "site." + name,
+			Type:          "site",
+			Mode:          reconcile.ModeManaged,
+			ExternalID:    liveState.ArtifactSHA,
+			Name:          name,
+			LastRefreshed: time.Now().UTC().Format(time.RFC3339),
+			Attributes: map[string]any{
+				"artifact_sha":         liveState.ArtifactSHA,
+				"cname_content":        liveState.CNAMEContent,
+				"resolved_from_target": liveState.ResolvedFromTarget,
+			},
+		})
+	}
+	return state, nil
+}
+
+// ─── Config helpers ──────────────────────────────────────────────────────────
+
+func loadCRDs(root string) ([]siteCRD, error) {
+	pattern := filepath.Join(root, "apps", "*", "site.yaml")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("site provider: glob %q: %w", pattern, err)
+	}
+	var crds []siteCRD
+	for _, yamlPath := range matches {
+		data, err := os.ReadFile(yamlPath)
+		if err != nil {
+			return nil, fmt.Errorf("site provider: read %s: %w", yamlPath, err)
+		}
+		var crd siteCRD
+		if err := yaml.Unmarshal(data, &crd); err != nil {
+			return nil, fmt.Errorf("site provider: parse %s: %w", yamlPath, err)
+		}
+		if err := crd.Validate(); err != nil {
+			log.Printf("[site] warning: %s validation: %v", yamlPath, err)
+		}
+		crds = append(crds, crd)
+	}
+	return crds, nil
+}
+
+func crdByName(crds []siteCRD, name string) (siteCRD, bool) {
+	for _, c := range crds {
+		if c.Metadata.Name == name {
+			return c, true
+		}
+	}
+	return siteCRD{}, false
+}
+
+func siteBuild(ctx context.Context, appDir, name string) error {
+	cmd := exec.CommandContext(ctx, "bash", "build.sh")
+	cmd.Dir = appDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("build.sh for %s: %w\n%s", name, err, out)
+	}
+	log.Printf("[site] build %s: %s", name, out)
+	return nil
+}
+
+// ─── GHPagesStrategy ─────────────────────────────────────────────────────────
+
+type ghPagesStrategy struct{ mu sync.Mutex }
+
+func (g *ghPagesStrategy) resolveRepo(app siteCRD) (string, error) {
+	raw, ok := app.Spec.Deploy.Target["repo"]
+	if !ok {
+		return "", fmt.Errorf("gh-pages: deploy.target.repo is required")
+	}
+	repo, ok := raw.(string)
+	if !ok || repo == "" {
+		return "", fmt.Errorf("gh-pages: deploy.target.repo must be a non-empty string")
+	}
+	return repo, nil
+}
+
+func ghAPI(ctx context.Context, path string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "gh", "api", path)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("gh api %s: %w: %s", path, err, stderr.String())
+	}
+	return stdout.Bytes(), nil
+}
+
+func (g *ghPagesStrategy) FetchLive(ctx context.Context, app siteCRD) (liveSiteState, error) {
+	repo, err := g.resolveRepo(app)
+	if err != nil {
+		return liveSiteState{}, err
+	}
+	state := liveSiteState{ResolvedFromTarget: true, Metadata: make(map[string]any)}
+
+	refData, err := ghAPI(ctx, fmt.Sprintf("/repos/%s/git/refs/heads/main", repo))
+	if err != nil {
+		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "Not Found") {
+			state.ResolvedFromTarget = false
+			return state, nil
+		}
+		return liveSiteState{}, fmt.Errorf("FetchLive: fetch main ref: %w", err)
+	}
+	var refResp struct {
+		Object struct{ SHA string `json:"sha"` } `json:"object"`
+	}
+	if err := json.Unmarshal(refData, &refResp); err != nil {
+		return liveSiteState{}, fmt.Errorf("FetchLive: parse ref response: %w", err)
+	}
+	state.ArtifactSHA = refResp.Object.SHA
+
+	cnameData, err := ghAPI(ctx, fmt.Sprintf("/repos/%s/contents/CNAME", repo))
+	if err == nil {
+		var cnameResp struct {
+			Content  string `json:"content"`
+			Encoding string `json:"encoding"`
+		}
+		if err := json.Unmarshal(cnameData, &cnameResp); err == nil && cnameResp.Encoding == "base64" {
+			decoded, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(cnameResp.Content, "\n", ""))
+			if err == nil {
+				state.CNAMEContent = strings.TrimSpace(string(decoded))
+			}
+		}
+	}
+	state.Metadata["repo"] = repo
+	return state, nil
+}
+
+func (g *ghPagesStrategy) Deploy(ctx context.Context, app siteCRD, artifactDir string) error {
+	repo, err := g.resolveRepo(app)
+	if err != nil {
+		return err
+	}
+	sourceSHA := os.Getenv("__SOURCE_SHA")
+	if sourceSHA == "" {
+		sourceSHA = "unknown"
+	}
+	if len(sourceSHA) > 12 {
+		sourceSHA = sourceSHA[:12]
+	}
+	tmpDir, err := os.MkdirTemp("", "cogos-ghpages-*")
+	if err != nil {
+		return fmt.Errorf("Deploy: create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	if err := gitRun(ctx, tmpDir, "init"); err != nil {
+		return fmt.Errorf("Deploy: git init: %w", err)
+	}
+	if err := copyDir(artifactDir, tmpDir); err != nil {
+		return fmt.Errorf("Deploy: copy artifact: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "CNAME"), []byte(app.Spec.Domain), 0644); err != nil {
+		return fmt.Errorf("Deploy: write CNAME: %w", err)
+	}
+	if err := gitRun(ctx, tmpDir, "add", "."); err != nil {
+		return fmt.Errorf("Deploy: git add: %w", err)
+	}
+	msg := fmt.Sprintf("deploy: %s @ %s", app.Spec.Domain, sourceSHA)
+	if err := gitRun(ctx, tmpDir, "-c", "user.email=cog@myrgic.io",
+		"-c", "user.name=CogOS", "commit", "-m", msg); err != nil {
+		return fmt.Errorf("Deploy: git commit: %w", err)
+	}
+	remote := fmt.Sprintf("https://github.com/%s.git", repo)
+	if err := gitRun(ctx, tmpDir, "remote", "add", "origin", remote); err != nil {
+		return fmt.Errorf("Deploy: git remote add: %w", err)
+	}
+	if err := gitRun(ctx, tmpDir, "push", "--force", "origin", "HEAD:main"); err != nil {
+		return fmt.Errorf("Deploy: git push: %w", err)
+	}
+	return nil
+}
+
+func gitRun(ctx context.Context, dir string, args ...string) error {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git %s: %w\n%s", strings.Join(args, " "), err, out)
+	}
+	return nil
+}
+
+func copyDir(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, info.Mode())
+		}
+		return copyFile(path, target, info.Mode())
+	})
+}
+
+func copyFile(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return err
+	}
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	return err
+}

--- a/site_crd.go
+++ b/site_crd.go
@@ -1,0 +1,142 @@
+// site_crd.go — Site CRD type definitions for the cogos kernel reconciliation framework.
+//
+// SiteCRD declares a single myrgic.* domain deployment. It is consumed by SiteProvider,
+// which implements Reconcilable to manage site lifecycle through the standard
+// plan/apply/state reconciliation loop. The CRD mirrors the Kubernetes API-conventions
+// shape (apiVersion / kind / metadata / spec) so that site.yaml files are familiar to
+// anyone who has written a Kubernetes manifest.
+//
+// Supported deployment strategies in v0.0.1:
+//   - "gh-pages": GitHub Pages via the gh-pages branch; target must include {"repo": "owner/repo"}.
+//
+// Planned strategies (future):
+//   - "gitlab-pages", "s3", "k8s-ingress", "self-hosted-rsync"
+
+package main
+
+import (
+	"errors"
+	"fmt"
+)
+
+// knownStrategies enumerates all accepted deploy strategy identifiers.
+var knownStrategies = map[string]bool{
+	"gh-pages":          true,
+	"gitlab-pages":      true,
+	"s3":               true,
+	"k8s-ingress":      true,
+	"self-hosted-rsync": true,
+}
+
+// SiteCRD is the top-level declaration of a myrgic.* domain deployment.
+// It is typically read from a per-app site.yaml file and loaded by SiteProvider.
+type SiteCRD struct {
+	// APIVersion identifies the schema version; currently "cogos.myrgic.io/v1alpha1".
+	APIVersion string       `yaml:"apiVersion" json:"apiVersion"`
+	// Kind is always "Site".
+	Kind       string       `yaml:"kind"       json:"kind"`
+	// Metadata carries the site name (matching the apps/<name>/ directory).
+	Metadata   SiteMetadata `yaml:"metadata"   json:"metadata"`
+	// Spec describes the desired state of the site.
+	Spec       SiteSpec     `yaml:"spec"       json:"spec"`
+}
+
+// SiteMetadata holds identifying information for the site resource.
+type SiteMetadata struct {
+	// Name must match the apps/<name>/ directory and be unique within the monorepo.
+	Name string `yaml:"name" json:"name"`
+}
+
+// SiteSpec describes the desired state of a single site deployment.
+type SiteSpec struct {
+	// Domain is the fully-qualified domain name (e.g. "myrgic.io").
+	Domain string `yaml:"domain" json:"domain"`
+
+	// Canonical marks this site as the primary / authoritative domain.
+	// Only one site in the monorepo should have canonical: true.
+	// Canonical sites may not set redirect_to.
+	Canonical bool `yaml:"canonical" json:"canonical"`
+
+	// Source configures the location of site source within the app directory.
+	Source SourceSpec `yaml:"source" json:"source"`
+
+	// Build configures the build step that produces the artifact directory.
+	Build BuildSpec `yaml:"build" json:"build"`
+
+	// HTTPS configures TLS requirements for the site.
+	HTTPS HTTPSSpec `yaml:"https" json:"https"`
+
+	// Deploy configures the deployment target and strategy.
+	Deploy DeploySpec `yaml:"deploy" json:"deploy"`
+
+	// RedirectTo, if set, declares that this domain should redirect to the
+	// given URL rather than serve content. Mutually exclusive with canonical: true.
+	RedirectTo *string `yaml:"redirect_to,omitempty" json:"redirect_to,omitempty"`
+}
+
+// SourceSpec locates the site source files within the app directory.
+type SourceSpec struct {
+	// Path is relative to the app root (apps/<name>/). Defaults to "src/".
+	Path string `yaml:"path" json:"path"`
+}
+
+// BuildSpec configures the build step that produces the artifact directory.
+type BuildSpec struct {
+	// Command is the shell command run from the app root to produce the artifact
+	// directory. Defaults to "./build.sh".
+	Command string `yaml:"command" json:"command"`
+
+	// Dist is the path (relative to the app root) where the build deposits its
+	// output. Defaults to "dist/".
+	Dist string `yaml:"dist" json:"dist"`
+}
+
+// HTTPSSpec configures TLS enforcement for the site.
+type HTTPSSpec struct {
+	// Required indicates that HTTPS must be enforced (e.g. via GitHub Pages HTTPS
+	// enforcement or an ingress annotation). Defaults to false.
+	Required bool `yaml:"required" json:"required"`
+}
+
+// DeploySpec configures the deployment target and strategy.
+type DeploySpec struct {
+	// Strategy identifies the deploy mechanism. In v0.0.1 only "gh-pages" is
+	// implemented; future strategies are enumerated in the package doc comment.
+	Strategy string `yaml:"strategy" json:"strategy"`
+
+	// Target holds strategy-specific configuration parameters.
+	// For "gh-pages": {"repo": "owner/repo"}
+	Target map[string]any `yaml:"target" json:"target"`
+}
+
+// ErrInvalidSiteCRD is returned by Validate when the CRD contains
+// inconsistent or missing fields.
+var ErrInvalidSiteCRD = errors.New("invalid SiteCRD")
+
+// Validate checks the CRD for internal consistency and returns an error
+// describing the first violation found, or nil if the CRD is valid.
+//
+// Rules enforced:
+//   - metadata.name must not be empty
+//   - spec.domain must not be empty
+//   - canonical: true and redirect_to are mutually exclusive
+//   - spec.deploy.strategy must be a known strategy identifier
+//   - spec.deploy.strategy must not be empty
+func (s SiteCRD) Validate() error {
+	if s.Metadata.Name == "" {
+		return fmt.Errorf("%w: metadata.name is required", ErrInvalidSiteCRD)
+	}
+	if s.Spec.Domain == "" {
+		return fmt.Errorf("%w: spec.domain is required", ErrInvalidSiteCRD)
+	}
+	if s.Spec.Canonical && s.Spec.RedirectTo != nil {
+		return fmt.Errorf("%w: canonical site %q must not set redirect_to", ErrInvalidSiteCRD, s.Metadata.Name)
+	}
+	if s.Spec.Deploy.Strategy == "" {
+		return fmt.Errorf("%w: spec.deploy.strategy is required", ErrInvalidSiteCRD)
+	}
+	if !knownStrategies[s.Spec.Deploy.Strategy] {
+		return fmt.Errorf("%w: unknown deploy strategy %q", ErrInvalidSiteCRD, s.Spec.Deploy.Strategy)
+	}
+	return nil
+}

--- a/site_crd_test.go
+++ b/site_crd_test.go
@@ -1,0 +1,350 @@
+// site_crd_test.go
+// Covers: SiteCRD YAML round-trip parsing and Validate() invariants.
+// Does NOT modify site_crd.go; if a defect is found in Validate() it is
+// documented here and the test is skipped with a FOLLOWUP comment.
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ─── Fixture YAML strings ────────────────────────────────────────────────────────
+
+const canonicalSiteYAML = `
+apiVersion: cogos.myrgic.io/v1alpha1
+kind: Site
+metadata:
+  name: myrgic-com
+spec:
+  domain: myrgic.com
+  canonical: true
+  source:
+    path: src/
+  build:
+    command: ./build.sh
+    dist: dist/
+  https:
+    required: true
+  deploy:
+    strategy: gh-pages
+    target:
+      repo: myrgic/myrgic.github.io
+`
+
+const redirectSiteYAML = `
+apiVersion: cogos.myrgic.io/v1alpha1
+kind: Site
+metadata:
+  name: myrgic-dev
+spec:
+  domain: myrgic.dev
+  canonical: false
+  source:
+    path: src/
+  build:
+    command: ./build.sh
+    dist: dist/
+  https:
+    required: true
+  deploy:
+    strategy: gh-pages
+    target:
+      repo: myrgic/myrgic.dev
+  redirect_to: https://myrgic.com/
+`
+
+const minSpecSiteYAML = `
+apiVersion: cogos.myrgic.io/v1alpha1
+kind: Site
+metadata:
+  name: myrgic-net
+spec:
+  domain: myrgic.net
+  deploy:
+    strategy: gh-pages
+    target:
+      repo: myrgic/myrgic.net
+`
+
+const missingDomainYAML = `
+apiVersion: cogos.myrgic.io/v1alpha1
+kind: Site
+metadata:
+  name: no-domain
+spec:
+  deploy:
+    strategy: gh-pages
+    target:
+      repo: myrgic/no-domain
+`
+
+const badStrategyYAML = `
+apiVersion: cogos.myrgic.io/v1alpha1
+kind: Site
+metadata:
+  name: bad-strategy
+spec:
+  domain: myrgic.example
+  deploy:
+    strategy: nonexistent-strategy
+    target:
+      repo: myrgic/bad-strategy
+`
+
+// ─── Parse tests (round-trip yaml → SiteCRD) ────────────────────────────────────
+
+func TestSiteCRD_Parse_Canonical(t *testing.T) {
+	var crd SiteCRD
+	if err := yaml.Unmarshal([]byte(canonicalSiteYAML), &crd); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if crd.Metadata.Name != "myrgic-com" {
+		t.Errorf("name: got %q, want %q", crd.Metadata.Name, "myrgic-com")
+	}
+	if crd.Spec.Domain != "myrgic.com" {
+		t.Errorf("domain: got %q, want %q", crd.Spec.Domain, "myrgic.com")
+	}
+	if !crd.Spec.Canonical {
+		t.Error("canonical: want true")
+	}
+	if crd.Spec.RedirectTo != nil {
+		t.Errorf("redirect_to: want nil, got %q", *crd.Spec.RedirectTo)
+	}
+	if crd.Spec.Deploy.Strategy != "gh-pages" {
+		t.Errorf("strategy: got %q, want %q", crd.Spec.Deploy.Strategy, "gh-pages")
+	}
+	repo, ok := crd.Spec.Deploy.Target["repo"]
+	if !ok {
+		t.Error("target.repo missing")
+	} else if repo != "myrgic/myrgic.github.io" {
+		t.Errorf("target.repo: got %v, want %q", repo, "myrgic/myrgic.github.io")
+	}
+}
+
+func TestSiteCRD_Parse_Redirect(t *testing.T) {
+	var crd SiteCRD
+	if err := yaml.Unmarshal([]byte(redirectSiteYAML), &crd); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if crd.Metadata.Name != "myrgic-dev" {
+		t.Errorf("name: got %q", crd.Metadata.Name)
+	}
+	if crd.Spec.Canonical {
+		t.Error("canonical: want false")
+	}
+	if crd.Spec.RedirectTo == nil {
+		t.Fatal("redirect_to: want non-nil")
+	}
+	if *crd.Spec.RedirectTo != "https://myrgic.com/" {
+		t.Errorf("redirect_to: got %q, want https://myrgic.com/", *crd.Spec.RedirectTo)
+	}
+}
+
+func TestSiteCRD_Parse_MinSpec(t *testing.T) {
+	var crd SiteCRD
+	if err := yaml.Unmarshal([]byte(minSpecSiteYAML), &crd); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if crd.Metadata.Name != "myrgic-net" {
+		t.Errorf("name: got %q", crd.Metadata.Name)
+	}
+	// Default zero values should not cause panics
+	if crd.Spec.Source.Path != "" {
+		// ok — empty string is the zero value; not a failure
+	}
+	if err := crd.Validate(); err != nil {
+		t.Logf("note: min-spec site does not fully validate: %v (expected)", err)
+	}
+}
+
+func TestSiteCRD_Parse_MissingDomain_ParsesButFailsValidate(t *testing.T) {
+	var crd SiteCRD
+	if err := yaml.Unmarshal([]byte(missingDomainYAML), &crd); err != nil {
+		t.Fatalf("unmarshal should succeed even with missing domain: %v", err)
+	}
+	err := crd.Validate()
+	if err == nil {
+		t.Fatal("Validate: want error for missing domain, got nil")
+	}
+	if !strings.Contains(err.Error(), "domain") {
+		t.Errorf("Validate error should mention domain, got: %v", err)
+	}
+}
+
+func TestSiteCRD_Parse_BadStrategy_ParsesButFailsValidate(t *testing.T) {
+	var crd SiteCRD
+	if err := yaml.Unmarshal([]byte(badStrategyYAML), &crd); err != nil {
+		t.Fatalf("unmarshal should succeed even with bad strategy: %v", err)
+	}
+	err := crd.Validate()
+	if err == nil {
+		t.Fatal("Validate: want error for unknown strategy, got nil")
+	}
+	if !strings.Contains(err.Error(), "strategy") {
+		t.Errorf("Validate error should mention strategy, got: %v", err)
+	}
+}
+
+// ─── Validate tests (table-driven) ──────────────────────────────────────────────
+
+func TestSiteCRD_Validate(t *testing.T) {
+	redirectURL := "https://myrgic.com/"
+
+	cases := []struct {
+		name    string
+		crd     SiteCRD
+		wantErr bool
+		errFrag string // substring expected in error message (if wantErr)
+	}{
+		{
+			name: "valid canonical",
+			crd: SiteCRD{
+				Metadata: SiteMetadata{Name: "myrgic-com"},
+				Spec: SiteSpec{
+					Domain:    "myrgic.com",
+					Canonical: true,
+					Deploy:    DeploySpec{Strategy: "gh-pages", Target: map[string]any{"repo": "myrgic/myrgic.github.io"}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid redirect",
+			crd: SiteCRD{
+				Metadata: SiteMetadata{Name: "myrgic-dev"},
+				Spec: SiteSpec{
+					Domain:     "myrgic.dev",
+					Canonical:  false,
+					RedirectTo: &redirectURL,
+					Deploy:     DeploySpec{Strategy: "gh-pages", Target: map[string]any{"repo": "myrgic/myrgic.dev"}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "canonical true with redirect_to set",
+			crd: SiteCRD{
+				Metadata: SiteMetadata{Name: "bad-combo"},
+				Spec: SiteSpec{
+					Domain:     "myrgic.com",
+					Canonical:  true,
+					RedirectTo: &redirectURL,
+					Deploy:     DeploySpec{Strategy: "gh-pages", Target: map[string]any{"repo": "myrgic/foo"}},
+				},
+			},
+			wantErr: true,
+			errFrag: "redirect_to",
+		},
+		{
+			name: "empty domain",
+			crd: SiteCRD{
+				Metadata: SiteMetadata{Name: "no-domain"},
+				Spec: SiteSpec{
+					Domain: "",
+					Deploy: DeploySpec{Strategy: "gh-pages"},
+				},
+			},
+			wantErr: true,
+			errFrag: "domain",
+		},
+		{
+			name: "unknown strategy",
+			crd: SiteCRD{
+				Metadata: SiteMetadata{Name: "bad-strat"},
+				Spec: SiteSpec{
+					Domain: "example.com",
+					Deploy: DeploySpec{Strategy: "sftp"},
+				},
+			},
+			wantErr: true,
+			errFrag: "strategy",
+		},
+		{
+			name: "valid build spec",
+			crd: SiteCRD{
+				Metadata: SiteMetadata{Name: "has-build"},
+				Spec: SiteSpec{
+					Domain:    "myrgic.com",
+					Canonical: true,
+					Build:     BuildSpec{Command: "./build.sh", Dist: "dist/"},
+					Deploy:    DeploySpec{Strategy: "gh-pages", Target: map[string]any{"repo": "myrgic/x"}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty metadata name",
+			crd: SiteCRD{
+				Metadata: SiteMetadata{Name: ""},
+				Spec: SiteSpec{
+					Domain: "myrgic.com",
+					Deploy: DeploySpec{Strategy: "gh-pages"},
+				},
+			},
+			wantErr: true,
+			errFrag: "name",
+		},
+		{
+			name: "missing strategy string",
+			crd: SiteCRD{
+				Metadata: SiteMetadata{Name: "no-strat"},
+				Spec: SiteSpec{
+					Domain: "myrgic.com",
+					Deploy: DeploySpec{Strategy: ""},
+				},
+			},
+			wantErr: true,
+			errFrag: "strategy",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.crd.Validate()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("Validate: want error containing %q, got nil", tc.errFrag)
+				}
+				if tc.errFrag != "" && !strings.Contains(err.Error(), tc.errFrag) {
+					t.Errorf("Validate error = %q; want fragment %q", err.Error(), tc.errFrag)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Validate: want nil, got %v", err)
+				}
+			}
+		})
+	}
+}
+
+// ─── FOLLOWUP findings ───────────────────────────────────────────────────────────
+
+// TestSiteCRD_Validate_GHPagesMissingRepo tests whether Validate enforces
+// deploy.target.repo for the gh-pages strategy. The current Validate() in
+// site_crd.go does NOT check strategy-specific target fields — it only validates
+// that the strategy name is known.
+//
+// FOLLOWUP: Validate() should enforce that gh-pages requires target.repo (non-empty string).
+// Leaving as a skipped test to document the gap without blocking the build.
+func TestSiteCRD_Validate_GHPagesMissingRepo(t *testing.T) {
+	t.Skip("FOLLOWUP: Validate() does not currently enforce deploy.target.repo for gh-pages strategy")
+
+	crd := SiteCRD{
+		Metadata: SiteMetadata{Name: "missing-repo"},
+		Spec: SiteSpec{
+			Domain: "myrgic.com",
+			Deploy: DeploySpec{
+				Strategy: "gh-pages",
+				Target:   map[string]any{}, // repo key absent
+			},
+		},
+	}
+	err := crd.Validate()
+	if err == nil {
+		t.Fatal("Validate: want error for missing deploy.target.repo when strategy=gh-pages, got nil")
+	}
+}

--- a/site_provider.go
+++ b/site_provider.go
@@ -123,6 +123,8 @@ func (s *SiteProvider) FetchLive(ctx context.Context, config any) (any, error) {
 // ─── ComputePlan ────────────────────────────────────────────────────────────────
 
 // ComputePlan diffs declared SiteCRDs against live deployment state.
+// Drift detection in v0.0.1: absent live → create; ResolvedFromTarget=false → create;
+// ArtifactSHA empty → update; otherwise → skip. Full SHA comparison is planned for v0.1.
 func (s *SiteProvider) ComputePlan(config any, live any, state *ReconcileState) (*ReconcilePlan, error) {
 	crds, ok := config.([]SiteCRD)
 	if !ok {
@@ -156,6 +158,12 @@ func (s *SiteProvider) ComputePlan(config any, live any, state *ReconcileState) 
 			"strategy": crd.Spec.Deploy.Strategy,
 			"target":   crd.Spec.Deploy.Target,
 			"app_dir":  appDir,
+		}
+
+		// Warn if strategy is not registered (FetchLive will have logged it too)
+		if _, err := s.lookupStrategy(crd.Spec.Deploy.Strategy); err != nil {
+			plan.Warnings = append(plan.Warnings,
+				fmt.Sprintf("%s: strategy %q not registered — deploy will fail", name, crd.Spec.Deploy.Strategy))
 		}
 
 		if !liveState.ResolvedFromTarget {

--- a/site_provider.go
+++ b/site_provider.go
@@ -1,0 +1,337 @@
+// site_provider.go — Reconciliation provider for static-site deployments.
+//
+// Implements Reconcilable to manage myrgic.* site lifecycle through the standard
+// plan/apply/state reconciliation loop. Compares declared SiteCRDs against
+// live deployment state and produces create/update/skip/delete actions.
+//
+// Config layout: <root>/apps/<name>/site.yaml
+// Build output:  <root>/apps/<name>/dist/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+)
+
+// SiteProvider implements Reconcilable for static-site deployment management.
+type SiteProvider struct {
+	mu         sync.Mutex
+	root       string
+	strategies map[string]DeployStrategy
+}
+
+func defaultStrategies() map[string]DeployStrategy {
+	return map[string]DeployStrategy{}
+}
+
+func init() {
+	RegisterProvider("site", &SiteProvider{strategies: defaultStrategies()})
+}
+
+// Type returns the resource type identifier.
+func (s *SiteProvider) Type() string { return "site" }
+
+// lookupStrategy retrieves a strategy by name, returning ErrUnsupportedStrategy if absent.
+func (s *SiteProvider) lookupStrategy(name string) (DeployStrategy, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	strat, ok := s.strategies[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrUnsupportedStrategy, name)
+	}
+	return strat, nil
+}
+
+// Health returns the three-axis status of the site subsystem.
+func (s *SiteProvider) Health() ResourceStatus {
+	s.mu.Lock()
+	root := s.root
+	s.mu.Unlock()
+	if root == "" {
+		var err error
+		root, _, err = ResolveWorkspace()
+		if err != nil {
+			return ResourceStatus{
+				Sync:      SyncStatusUnknown,
+				Health:    HealthMissing,
+				Operation: OperationIdle,
+				Message:   "workspace not found",
+			}
+		}
+	}
+	_, err := siteLoadCRDs(root)
+	if err != nil {
+		return ResourceStatus{
+			Sync:      SyncStatusUnknown,
+			Health:    HealthDegraded,
+			Operation: OperationIdle,
+			Message:   fmt.Sprintf("config load error: %v", err),
+		}
+	}
+	return NewResourceStatus(SyncStatusUnknown, HealthProgressing)
+}
+
+// ─── LoadConfig ─────────────────────────────────────────────────────────────────
+
+// LoadConfig loads all site CRD definitions from <root>/apps/*/site.yaml.
+func (s *SiteProvider) LoadConfig(root string) (any, error) {
+	s.mu.Lock()
+	s.root = root
+	s.mu.Unlock()
+	crds, err := siteLoadCRDs(root)
+	if err != nil {
+		return nil, err
+	}
+	if crds == nil {
+		crds = []SiteCRD{}
+	}
+	return crds, nil
+}
+
+// ─── FetchLive ──────────────────────────────────────────────────────────────────
+
+// FetchLive retrieves deployed state for each site from the strategy's target.
+// Per-app errors are logged and the partial map is returned; no fail-fast.
+func (s *SiteProvider) FetchLive(ctx context.Context, config any) (any, error) {
+	crds, ok := config.([]SiteCRD)
+	if !ok {
+		return nil, fmt.Errorf("site provider: FetchLive: unexpected config type %T", config)
+	}
+	live := make(map[string]LiveSiteState, len(crds))
+	for _, crd := range crds {
+		strat, err := s.lookupStrategy(crd.Spec.Deploy.Strategy)
+		if err != nil {
+			log.Printf("[site] warning: FetchLive %s: %v", crd.Metadata.Name, err)
+			live[crd.Metadata.Name] = LiveSiteState{}
+			continue
+		}
+		state, err := strat.FetchLive(ctx, crd)
+		if err != nil {
+			log.Printf("[site] warning: FetchLive %s: %v", crd.Metadata.Name, err)
+			live[crd.Metadata.Name] = LiveSiteState{}
+			continue
+		}
+		live[crd.Metadata.Name] = state
+	}
+	return live, nil
+}
+
+// ─── ComputePlan ────────────────────────────────────────────────────────────────
+
+// ComputePlan diffs declared SiteCRDs against live deployment state.
+func (s *SiteProvider) ComputePlan(config any, live any, state *ReconcileState) (*ReconcilePlan, error) {
+	crds, ok := config.([]SiteCRD)
+	if !ok {
+		return nil, fmt.Errorf("site provider: ComputePlan: unexpected config type %T", config)
+	}
+	liveMap, ok := live.(map[string]LiveSiteState)
+	if !ok {
+		return nil, fmt.Errorf("site provider: ComputePlan: unexpected live type %T", live)
+	}
+
+	s.mu.Lock()
+	root := s.root
+	s.mu.Unlock()
+
+	plan := &ReconcilePlan{
+		ResourceType: "site",
+		GeneratedAt:  time.Now().UTC().Format(time.RFC3339),
+		ConfigPath:   root + "/apps",
+	}
+
+	// Track which CRD names appear in config
+	declared := make(map[string]bool, len(crds))
+	for _, crd := range crds {
+		name := crd.Metadata.Name
+		declared[name] = true
+		appDir := root + "/apps/" + name
+
+		liveState := liveMap[name]
+		details := map[string]any{
+			"domain":   crd.Spec.Domain,
+			"strategy": crd.Spec.Deploy.Strategy,
+			"target":   crd.Spec.Deploy.Target,
+			"app_dir":  appDir,
+		}
+
+		if !liveState.ResolvedFromTarget {
+			// Not yet deployed — create
+			plan.Actions = append(plan.Actions, ReconcileAction{
+				Action:       ActionCreate,
+				ResourceType: "site",
+				Name:         name,
+				Details:      details,
+			})
+			plan.Summary.Creates++
+			continue
+		}
+
+		// Artifact SHA empty signals a deployed-but-unknown state — treat as update
+		if liveState.ArtifactSHA == "" {
+			plan.Actions = append(plan.Actions, ReconcileAction{
+				Action:       ActionUpdate,
+				ResourceType: "site",
+				Name:         name,
+				Details:      details,
+			})
+			plan.Summary.Updates++
+			continue
+		}
+
+		plan.Actions = append(plan.Actions, ReconcileAction{
+			Action:       ActionSkip,
+			ResourceType: "site",
+			Name:         name,
+			Details:      details,
+		})
+		plan.Summary.Skipped++
+	}
+
+	// Orphans: managed in state but no longer in config
+	if state != nil {
+		for _, res := range state.Resources {
+			if !declared[res.Name] {
+				plan.Actions = append(plan.Actions, ReconcileAction{
+					Action:       ActionDelete,
+					ResourceType: "site",
+					Name:         res.Name,
+					Details: map[string]any{
+						"reason": "no matching site CRD",
+					},
+				})
+				plan.Summary.Deletes++
+			}
+		}
+	}
+
+	return plan, nil
+}
+
+// ─── ApplyPlan ──────────────────────────────────────────────────────────────────
+
+// ApplyPlan builds and deploys each site action.
+func (s *SiteProvider) ApplyPlan(ctx context.Context, plan *ReconcilePlan) ([]ReconcileResult, error) {
+	var results []ReconcileResult
+	for _, action := range plan.Actions {
+		if action.Action == ActionSkip {
+			continue
+		}
+		result := s.applyAction(ctx, action)
+		results = append(results, result)
+	}
+	return results, nil
+}
+
+func (s *SiteProvider) applyAction(ctx context.Context, action ReconcileAction) ReconcileResult {
+	name := action.Name
+	base := ReconcileResult{
+		Phase:  "site",
+		Action: string(action.Action),
+		Name:   name,
+	}
+
+	if action.Action == ActionDelete {
+		// v0.0.1: delete is a no-op — manual teardown required for deployed sites
+		log.Printf("[site] delete %s: no-op in v0.0.1 (manual teardown required)", name)
+		base.Status = ApplySucceeded
+		return base
+	}
+
+	appDir, _ := action.Details["app_dir"].(string)
+	if appDir == "" {
+		base.Status = ApplyFailed
+		base.Error = "no app_dir in action details"
+		return base
+	}
+
+	// Step 1: build the artifact
+	if err := siteBuild(ctx, appDir, name); err != nil {
+		base.Status = ApplyFailed
+		base.Error = fmt.Sprintf("build: %v", err)
+		return base
+	}
+
+	// Step 2: deploy via strategy
+	stratName, _ := action.Details["strategy"].(string)
+	strat, err := s.lookupStrategy(stratName)
+	if err != nil {
+		base.Status = ApplyFailed
+		base.Error = fmt.Sprintf("strategy lookup: %v", err)
+		return base
+	}
+
+	s.mu.Lock()
+	root := s.root
+	s.mu.Unlock()
+
+	crds, err := siteLoadCRDs(root)
+	if err != nil {
+		base.Status = ApplyFailed
+		base.Error = fmt.Sprintf("reload config: %v", err)
+		return base
+	}
+	var crd SiteCRD
+	for _, c := range crds {
+		if c.Metadata.Name == name {
+			crd = c
+			break
+		}
+	}
+
+	distDir := appDir + "/dist"
+	if err := strat.Deploy(ctx, crd, distDir); err != nil {
+		base.Status = ApplyFailed
+		base.Error = fmt.Sprintf("deploy: %v", err)
+		return base
+	}
+
+	base.Status = ApplySucceeded
+	base.CreatedID = "site:" + name
+	return base
+}
+
+// ─── BuildState ─────────────────────────────────────────────────────────────────
+
+// BuildState constructs reconcile state from live site data.
+func (s *SiteProvider) BuildState(config any, live any, existing *ReconcileState) (*ReconcileState, error) {
+	liveMap, ok := live.(map[string]LiveSiteState)
+	if !ok {
+		return nil, fmt.Errorf("site provider: BuildState: unexpected live type %T", live)
+	}
+
+	state := &ReconcileState{
+		Version:      1,
+		ResourceType: "site",
+		GeneratedAt:  time.Now().UTC().Format(time.RFC3339),
+	}
+
+	if existing != nil {
+		state.Lineage = existing.Lineage
+		state.Serial = existing.Serial + 1
+	} else {
+		state.Lineage = "site-" + time.Now().UTC().Format("20060102T150405Z")
+	}
+
+	for name, liveState := range liveMap {
+		resource := ReconcileResource{
+			Address:       "site." + name,
+			Type:          "site",
+			Mode:          ModeManaged,
+			ExternalID:    liveState.ArtifactSHA,
+			Name:          name,
+			LastRefreshed: time.Now().UTC().Format(time.RFC3339),
+			Attributes: map[string]any{
+				"artifact_sha":         liveState.ArtifactSHA,
+				"cname_content":        liveState.CNAMEContent,
+				"resolved_from_target": liveState.ResolvedFromTarget,
+			},
+		}
+		state.Resources = append(state.Resources, resource)
+	}
+
+	return state, nil
+}

--- a/site_provider.go
+++ b/site_provider.go
@@ -274,12 +274,11 @@ func (s *SiteProvider) applyAction(ctx context.Context, action ReconcileAction) 
 		base.Error = fmt.Sprintf("reload config: %v", err)
 		return base
 	}
-	var crd SiteCRD
-	for _, c := range crds {
-		if c.Metadata.Name == name {
-			crd = c
-			break
-		}
+	crd, found := siteCRDByName(crds, name)
+	if !found {
+		base.Status = ApplyFailed
+		base.Error = fmt.Sprintf("CRD not found after reload: %s", name)
+		return base
 	}
 
 	distDir := appDir + "/dist"

--- a/site_provider.go
+++ b/site_provider.go
@@ -35,6 +35,14 @@ func init() {
 // Type returns the resource type identifier.
 func (s *SiteProvider) Type() string { return "site" }
 
+// RegisterStrategy adds or replaces a DeployStrategy implementation.
+// Called by strategy init() functions (e.g. GHPagesStrategy) to self-register.
+func (s *SiteProvider) RegisterStrategy(name string, strat DeployStrategy) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.strategies[name] = strat
+}
+
 // lookupStrategy retrieves a strategy by name, returning ErrUnsupportedStrategy if absent.
 func (s *SiteProvider) lookupStrategy(name string) (DeployStrategy, error) {
 	s.mu.Lock()

--- a/site_provider_config.go
+++ b/site_provider_config.go
@@ -14,7 +14,8 @@ import (
 )
 
 // siteLoadCRDs walks <root>/apps/*/site.yaml and returns parsed SiteCRDs.
-// Parse errors are hard failures; validation errors are logged as warnings.
+// Parse errors are hard failures; validation errors are logged as warnings
+// (invalid CRDs are still returned so the planner can surface them).
 func siteLoadCRDs(root string) ([]SiteCRD, error) {
 	pattern := filepath.Join(root, "apps", "*", "site.yaml")
 	matches, err := filepath.Glob(pattern)
@@ -37,6 +38,16 @@ func siteLoadCRDs(root string) ([]SiteCRD, error) {
 		crds = append(crds, crd)
 	}
 	return crds, nil
+}
+
+// siteCRDByName looks up a SiteCRD by metadata name from a pre-loaded slice.
+func siteCRDByName(crds []SiteCRD, name string) (SiteCRD, bool) {
+	for _, c := range crds {
+		if c.Metadata.Name == name {
+			return c, true
+		}
+	}
+	return SiteCRD{}, false
 }
 
 // siteBuild runs build.sh in the given app directory.

--- a/site_provider_config.go
+++ b/site_provider_config.go
@@ -1,0 +1,52 @@
+// site_provider_config.go — Config loading and build helpers for SiteProvider.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// siteLoadCRDs walks <root>/apps/*/site.yaml and returns parsed SiteCRDs.
+// Parse errors are hard failures; validation errors are logged as warnings.
+func siteLoadCRDs(root string) ([]SiteCRD, error) {
+	pattern := filepath.Join(root, "apps", "*", "site.yaml")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("site provider: glob %q: %w", pattern, err)
+	}
+	var crds []SiteCRD
+	for _, yamlPath := range matches {
+		data, err := os.ReadFile(yamlPath)
+		if err != nil {
+			return nil, fmt.Errorf("site provider: read %s: %w", yamlPath, err)
+		}
+		var crd SiteCRD
+		if err := yaml.Unmarshal(data, &crd); err != nil {
+			return nil, fmt.Errorf("site provider: parse %s: %w", yamlPath, err)
+		}
+		if err := crd.Validate(); err != nil {
+			log.Printf("[site] warning: %s validation: %v", yamlPath, err)
+		}
+		crds = append(crds, crd)
+	}
+	return crds, nil
+}
+
+// siteBuild runs build.sh in the given app directory.
+func siteBuild(ctx context.Context, appDir, name string) error {
+	cmd := exec.CommandContext(ctx, "bash", "build.sh")
+	cmd.Dir = appDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("build.sh for %s: %w\n%s", name, err, out)
+	}
+	log.Printf("[site] build %s: %s", name, out)
+	return nil
+}

--- a/site_provider_integration_test.go
+++ b/site_provider_integration_test.go
@@ -1,0 +1,231 @@
+// site_provider_integration_test.go
+// Integration tests for SiteProvider against the real ~/workspaces/myrgic/sites/ monorepo.
+//
+// All tests skip gracefully when the monorepo is absent (CI without monorepo, etc.).
+// Each test uses a mockDeployStrategy from site_provider_test.go (same package).
+//
+// Run with:
+//   go test -run TestSiteProviderIntegration -v ./...
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// skipIfNoMonorepo checks for the monorepo and returns its root path.
+// It calls t.Skip if the monorepo is absent so CI without the monorepo passes cleanly.
+func skipIfNoMonorepo(t *testing.T) string {
+	t.Helper()
+	sitesPath := os.ExpandEnv("$HOME/workspaces/myrgic/sites")
+	if _, err := os.Stat(filepath.Join(sitesPath, "apps")); err != nil {
+		t.Skipf("integration test requires monorepo at %s (got %v)", sitesPath, err)
+	}
+	return sitesPath
+}
+
+// expectedSiteNames are the 5 apps currently declared in the monorepo.
+var expectedSiteNames = []string{
+	"myrgic-com",
+	"myrgic-dev",
+	"myrgic-ai",
+	"myrgic-net",
+	"myrgic-org",
+}
+
+// TestSiteProviderIntegration_LoadConfig loads the real monorepo and verifies
+// that all 5 site CRDs are present and structurally correct.
+func TestSiteProviderIntegration_LoadConfig(t *testing.T) {
+	sitesPath := skipIfNoMonorepo(t)
+
+	sp := &SiteProvider{strategies: defaultStrategies()}
+	result, err := sp.LoadConfig(sitesPath)
+	if err != nil {
+		t.Fatalf("LoadConfig(%s): %v", sitesPath, err)
+	}
+
+	crds, ok := result.([]SiteCRD)
+	if !ok {
+		t.Fatalf("LoadConfig: unexpected return type %T", result)
+	}
+
+	// Must return exactly 5 CRDs.
+	if len(crds) != 5 {
+		t.Errorf("LoadConfig: got %d CRDs, want 5; names: %v", len(crds), crdNames(crds))
+	}
+
+	// Build a name→CRD index for assertions below.
+	byName := make(map[string]SiteCRD, len(crds))
+	for _, crd := range crds {
+		byName[crd.Metadata.Name] = crd
+	}
+
+	// All 5 expected names must be present.
+	for _, name := range expectedSiteNames {
+		if _, ok := byName[name]; !ok {
+			t.Errorf("LoadConfig: expected CRD %q not found; got names: %v", name, crdNames(crds))
+		}
+	}
+
+	// Exactly 1 canonical site.
+	canonicalCount := 0
+	for _, crd := range crds {
+		if crd.Spec.Canonical {
+			canonicalCount++
+			if crd.Metadata.Name != "myrgic-com" {
+				t.Errorf("LoadConfig: canonical site is %q, want myrgic-com", crd.Metadata.Name)
+			}
+		}
+	}
+	if canonicalCount != 1 {
+		t.Errorf("LoadConfig: got %d canonical sites, want exactly 1", canonicalCount)
+	}
+
+	// All sites must use the gh-pages strategy.
+	for _, crd := range crds {
+		if crd.Spec.Deploy.Strategy != "gh-pages" {
+			t.Errorf("LoadConfig: %s has strategy %q, want gh-pages", crd.Metadata.Name, crd.Spec.Deploy.Strategy)
+		}
+	}
+
+	// All sites must have a non-empty deploy target repo.
+	for _, crd := range crds {
+		repo, _ := crd.Spec.Deploy.Target["repo"].(string)
+		if repo == "" {
+			t.Errorf("LoadConfig: %s has empty deploy.target.repo", crd.Metadata.Name)
+		}
+	}
+
+	// The 4 redirect sites must have redirect_to == "https://myrgic.com/".
+	redirectSites := []string{"myrgic-dev", "myrgic-ai", "myrgic-net", "myrgic-org"}
+	for _, name := range redirectSites {
+		crd, ok := byName[name]
+		if !ok {
+			continue // already reported above
+		}
+		if crd.Spec.RedirectTo == nil {
+			t.Errorf("LoadConfig: %s has nil redirect_to, want \"https://myrgic.com/\"", name)
+		} else if *crd.Spec.RedirectTo != "https://myrgic.com/" {
+			t.Errorf("LoadConfig: %s redirect_to = %q, want \"https://myrgic.com/\"", name, *crd.Spec.RedirectTo)
+		}
+	}
+}
+
+// TestSiteProviderIntegration_PlanShape exercises LoadConfig → FetchLive → ComputePlan
+// against the real monorepo, using a mock strategy that simulates fresh (undeployed) targets.
+// All 5 sites should appear as Creates when no live state is resolved.
+func TestSiteProviderIntegration_PlanShape(t *testing.T) {
+	sitesPath := skipIfNoMonorepo(t)
+
+	// mockDeployStrategy returns ResolvedFromTarget=false for all (fresh deploy targets).
+	mock := &mockDeployStrategy{
+		FetchLiveReturn: LiveSiteState{ResolvedFromTarget: false},
+	}
+	sp := newProviderWithMock(mock)
+
+	// Load real config.
+	configAny, err := sp.LoadConfig(sitesPath)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	crds, ok := configAny.([]SiteCRD)
+	if !ok {
+		t.Fatalf("LoadConfig: unexpected type %T", configAny)
+	}
+	if len(crds) == 0 {
+		t.Skip("integration test: no CRDs loaded, skipping plan shape test")
+	}
+
+	// FetchLive with mock (no real GitHub calls).
+	liveAny, err := sp.FetchLive(context.Background(), configAny)
+	if err != nil {
+		t.Fatalf("FetchLive: %v", err)
+	}
+
+	// ComputePlan.
+	plan, err := sp.ComputePlan(configAny, liveAny, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+
+	// All 5 sites are undeployed → 5 Creates.
+	if plan.Summary.Creates != 5 {
+		t.Errorf("ComputePlan: Summary.Creates = %d, want 5", plan.Summary.Creates)
+	}
+
+	// Plan has changes.
+	if !plan.Summary.HasChanges() {
+		t.Error("ComputePlan: HasChanges() should be true for 5 creates")
+	}
+
+	// Each action must target one of the 5 expected site names.
+	expectedSet := make(map[string]bool, len(expectedSiteNames))
+	for _, n := range expectedSiteNames {
+		expectedSet[n] = true
+	}
+
+	actionNames := make(map[string]bool, len(plan.Actions))
+	for _, action := range plan.Actions {
+		if action.Action != ActionCreate {
+			t.Errorf("ComputePlan: unexpected action %q for %s (want Create)", action.Action, action.Name)
+		}
+		if !expectedSet[action.Name] {
+			t.Errorf("ComputePlan: action targets unexpected site %q", action.Name)
+		}
+		actionNames[action.Name] = true
+	}
+
+	// Every expected site must have an action.
+	for _, name := range expectedSiteNames {
+		if !actionNames[name] {
+			t.Errorf("ComputePlan: no action for expected site %q", name)
+		}
+	}
+}
+
+// TestSiteProviderIntegration_AppDirsExecutable verifies that each app's build.sh
+// has the executable bit set. Catches chmod drift that would silently break builds.
+func TestSiteProviderIntegration_AppDirsExecutable(t *testing.T) {
+	sitesPath := skipIfNoMonorepo(t)
+
+	appsDir := filepath.Join(sitesPath, "apps")
+	entries, err := os.ReadDir(appsDir)
+	if err != nil {
+		t.Fatalf("ReadDir %s: %v", appsDir, err)
+	}
+
+	if len(entries) == 0 {
+		t.Skip("integration test: no apps found in monorepo")
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		buildSH := filepath.Join(appsDir, name, "build.sh")
+		info, err := os.Stat(buildSH)
+		if err != nil {
+			// FOLLOWUP: some apps may not have build.sh yet (e.g. static redirects).
+			// For now, skip missing build.sh rather than fail — flag for wave 5 review.
+			t.Logf("FOLLOWUP: %s/build.sh not found (%v); verify build.sh is required for all site types", name, err)
+			continue
+		}
+		if info.Mode()&0111 == 0 {
+			t.Errorf("%s/build.sh is not executable (mode %v)", name, info.Mode())
+		}
+	}
+}
+
+// crdNames extracts metadata names from a slice of SiteCRDs for error messages.
+func crdNames(crds []SiteCRD) []string {
+	names := make([]string, len(crds))
+	for i, c := range crds {
+		names[i] = c.Metadata.Name
+	}
+	return names
+}

--- a/site_provider_test.go
+++ b/site_provider_test.go
@@ -1,0 +1,695 @@
+// site_provider_test.go
+// Covers: SiteProvider LoadConfig, FetchLive, ComputePlan, ApplyPlan, BuildState.
+// Does NOT modify production code. Defects found are documented with t.Skip("FOLLOWUP: ...").
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ─── Mock DeployStrategy ────────────────────────────────────────────────────────
+
+// mockDeployStrategy is a test-only implementation of DeployStrategy.
+type mockDeployStrategy struct {
+	FetchLiveCallCount int
+	DeployCallCount    int
+	FetchLiveReturn    LiveSiteState
+	FetchLiveError     error
+	DeployError        error
+	DeployedArtifacts  []string // artifact dirs received by Deploy
+}
+
+func (m *mockDeployStrategy) FetchLive(_ context.Context, _ SiteCRD) (LiveSiteState, error) {
+	m.FetchLiveCallCount++
+	return m.FetchLiveReturn, m.FetchLiveError
+}
+
+func (m *mockDeployStrategy) Deploy(_ context.Context, _ SiteCRD, artifactDir string) error {
+	m.DeployCallCount++
+	m.DeployedArtifacts = append(m.DeployedArtifacts, artifactDir)
+	return m.DeployError
+}
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────────
+
+// validSiteYAML returns a minimal valid site.yaml content.
+func validSiteYAML(name, domain string) string {
+	return fmt.Sprintf(`apiVersion: cogos.myrgic.io/v1alpha1
+kind: Site
+metadata:
+  name: %s
+spec:
+  domain: %s
+  deploy:
+    strategy: gh-pages
+    target:
+      repo: myrgic/%s
+`, name, domain, name)
+}
+
+// invalidSiteYAML returns a YAML that parses but fails Validate (missing domain).
+func invalidSiteYAML(name string) string {
+	return fmt.Sprintf(`apiVersion: cogos.myrgic.io/v1alpha1
+kind: Site
+metadata:
+  name: %s
+spec:
+  deploy:
+    strategy: gh-pages
+    target:
+      repo: myrgic/%s
+`, name, name)
+}
+
+// buildAppsDir builds a <root>/apps/<name>/site.yaml directory tree.
+// yamlContents maps app name → yaml content; empty content signals: skip creating.
+func buildAppsDir(t *testing.T, root string, yamlContents map[string]string) {
+	t.Helper()
+	appsDir := filepath.Join(root, "apps")
+	if err := os.MkdirAll(appsDir, 0755); err != nil {
+		t.Fatalf("MkdirAll apps: %v", err)
+	}
+	for name, content := range yamlContents {
+		appDir := filepath.Join(appsDir, name)
+		if err := os.MkdirAll(appDir, 0755); err != nil {
+			t.Fatalf("MkdirAll app %s: %v", name, err)
+		}
+		if err := os.WriteFile(filepath.Join(appDir, "site.yaml"), []byte(content), 0644); err != nil {
+			t.Fatalf("write site.yaml for %s: %v", name, err)
+		}
+	}
+}
+
+// newProviderWithMock returns a SiteProvider with a mock strategy registered as "gh-pages".
+func newProviderWithMock(mock *mockDeployStrategy) *SiteProvider {
+	sp := &SiteProvider{strategies: map[string]DeployStrategy{
+		"gh-pages": mock,
+	}}
+	return sp
+}
+
+// makeCRD produces a SiteCRD for testing.
+func makeCRD(name, domain string) SiteCRD {
+	return SiteCRD{
+		APIVersion: "cogos.myrgic.io/v1alpha1",
+		Kind:       "Site",
+		Metadata:   SiteMetadata{Name: name},
+		Spec: SiteSpec{
+			Domain: domain,
+			Deploy: DeploySpec{
+				Strategy: "gh-pages",
+				Target:   map[string]any{"repo": "myrgic/" + name},
+			},
+		},
+	}
+}
+
+// ─── LoadConfig tests ───────────────────────────────────────────────────────────
+
+func TestSiteProvider_LoadConfig_Valid5Apps(t *testing.T) {
+	root := t.TempDir()
+	names := []string{"app-a", "app-b", "app-c", "app-d", "app-e"}
+	contents := make(map[string]string, len(names))
+	for i, n := range names {
+		contents[n] = validSiteYAML(n, fmt.Sprintf("app%d.example.com", i))
+	}
+	buildAppsDir(t, root, contents)
+
+	sp := &SiteProvider{strategies: defaultStrategies()}
+	result, err := sp.LoadConfig(root)
+	if err != nil {
+		t.Fatalf("LoadConfig: unexpected error: %v", err)
+	}
+	crds, ok := result.([]SiteCRD)
+	if !ok {
+		t.Fatalf("LoadConfig: unexpected return type %T", result)
+	}
+	if len(crds) != 5 {
+		t.Errorf("LoadConfig: got %d CRDs, want 5", len(crds))
+	}
+}
+
+func TestSiteProvider_LoadConfig_EmptyApps(t *testing.T) {
+	root := t.TempDir()
+	// Create the apps dir but leave it empty
+	if err := os.MkdirAll(filepath.Join(root, "apps"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	sp := &SiteProvider{strategies: defaultStrategies()}
+	result, err := sp.LoadConfig(root)
+	if err != nil {
+		t.Fatalf("LoadConfig empty apps: unexpected error: %v", err)
+	}
+	crds, ok := result.([]SiteCRD)
+	if !ok {
+		t.Fatalf("LoadConfig: unexpected return type %T", result)
+	}
+	if len(crds) != 0 {
+		t.Errorf("LoadConfig: got %d CRDs, want 0", len(crds))
+	}
+}
+
+// TestSiteProvider_LoadConfig_InvalidYAML verifies that a YAML parse error (not a
+// validation error) causes LoadConfig to return an error.
+func TestSiteProvider_LoadConfig_InvalidYAML(t *testing.T) {
+	root := t.TempDir()
+	buildAppsDir(t, root, map[string]string{
+		"broken": "not: valid: yaml: [[[",
+	})
+
+	sp := &SiteProvider{strategies: defaultStrategies()}
+	_, err := sp.LoadConfig(root)
+	if err == nil {
+		t.Fatal("LoadConfig: want error for unparseable YAML, got nil")
+	}
+}
+
+// TestSiteProvider_LoadConfig_InvalidValidation verifies behavior when a CRD
+// parses but fails validation (missing domain). siteLoadCRDs logs a warning but
+// does NOT fail-fast on validation errors — it returns all CRDs including invalid ones.
+// This is intentional: the planner surfaces the warning; the apply won't deploy them.
+func TestSiteProvider_LoadConfig_InvalidValidation(t *testing.T) {
+	root := t.TempDir()
+	buildAppsDir(t, root, map[string]string{
+		"no-domain": invalidSiteYAML("no-domain"),
+	})
+
+	sp := &SiteProvider{strategies: defaultStrategies()}
+	result, err := sp.LoadConfig(root)
+	// siteLoadCRDs logs but does not return a validation error
+	if err != nil {
+		t.Fatalf("LoadConfig: unexpected error (validation warnings should not fail LoadConfig): %v", err)
+	}
+	crds, ok := result.([]SiteCRD)
+	if !ok {
+		t.Fatalf("LoadConfig: unexpected return type %T", result)
+	}
+	// The CRD is still returned (invalid CRDs are logged, not dropped)
+	if len(crds) != 1 {
+		t.Errorf("LoadConfig: got %d CRDs, want 1 (invalid CRDs returned with warning)", len(crds))
+	}
+}
+
+// TestSiteProvider_LoadConfig_MixedValidAndInvalid verifies that a mix of valid and
+// validation-failing CRDs all get returned. Parse failures still hard-fail.
+func TestSiteProvider_LoadConfig_MixedValidAndInvalid(t *testing.T) {
+	root := t.TempDir()
+	buildAppsDir(t, root, map[string]string{
+		"good-app":  validSiteYAML("good-app", "good.example.com"),
+		"bad-app":   invalidSiteYAML("bad-app"),
+	})
+
+	sp := &SiteProvider{strategies: defaultStrategies()}
+	result, err := sp.LoadConfig(root)
+	if err != nil {
+		t.Fatalf("LoadConfig: unexpected error: %v", err)
+	}
+	crds, ok := result.([]SiteCRD)
+	if !ok {
+		t.Fatalf("unexpected return type %T", result)
+	}
+	if len(crds) != 2 {
+		t.Errorf("LoadConfig: got %d CRDs, want 2 (both valid and invalid returned)", len(crds))
+	}
+}
+
+// ─── FetchLive tests ─────────────────────────────────────────────────────────────
+
+func TestSiteProvider_FetchLive_MockCalledPerApp(t *testing.T) {
+	mock := &mockDeployStrategy{
+		FetchLiveReturn: LiveSiteState{
+			ArtifactSHA:        "abc123",
+			CNAMEContent:       "example.com",
+			ResolvedFromTarget: true,
+		},
+	}
+	sp := newProviderWithMock(mock)
+
+	crds := []SiteCRD{
+		makeCRD("app-a", "a.example.com"),
+		makeCRD("app-b", "b.example.com"),
+	}
+
+	result, err := sp.FetchLive(context.Background(), crds)
+	if err != nil {
+		t.Fatalf("FetchLive: unexpected error: %v", err)
+	}
+	liveMap, ok := result.(map[string]LiveSiteState)
+	if !ok {
+		t.Fatalf("FetchLive: unexpected return type %T", result)
+	}
+	if mock.FetchLiveCallCount != 2 {
+		t.Errorf("FetchLive call count: got %d, want 2", mock.FetchLiveCallCount)
+	}
+	if len(liveMap) != 2 {
+		t.Errorf("FetchLive: map has %d entries, want 2", len(liveMap))
+	}
+	for _, name := range []string{"app-a", "app-b"} {
+		state, ok := liveMap[name]
+		if !ok {
+			t.Errorf("FetchLive: missing entry for %q", name)
+			continue
+		}
+		if state.ArtifactSHA != "abc123" {
+			t.Errorf("FetchLive[%s].ArtifactSHA: got %q, want abc123", name, state.ArtifactSHA)
+		}
+	}
+}
+
+func TestSiteProvider_FetchLive_StrategyLookupError(t *testing.T) {
+	// Provider has no strategies registered
+	sp := &SiteProvider{strategies: map[string]DeployStrategy{}}
+
+	crds := []SiteCRD{
+		makeCRD("app-a", "a.example.com"),
+	}
+
+	// FetchLive logs the error and returns an empty LiveSiteState for the app;
+	// it does NOT return a top-level error.
+	result, err := sp.FetchLive(context.Background(), crds)
+	if err != nil {
+		t.Fatalf("FetchLive: expected no top-level error for unknown strategy, got: %v", err)
+	}
+	liveMap, ok := result.(map[string]LiveSiteState)
+	if !ok {
+		t.Fatalf("FetchLive: unexpected return type %T", result)
+	}
+	state, ok := liveMap["app-a"]
+	if !ok {
+		t.Fatal("FetchLive: missing entry for app-a")
+	}
+	if state.ResolvedFromTarget {
+		t.Error("FetchLive: ResolvedFromTarget should be false for unknown strategy")
+	}
+}
+
+func TestSiteProvider_FetchLive_StrategyError(t *testing.T) {
+	mock := &mockDeployStrategy{
+		FetchLiveError: fmt.Errorf("network timeout"),
+	}
+	sp := newProviderWithMock(mock)
+	crds := []SiteCRD{makeCRD("app-a", "a.example.com")}
+
+	result, err := sp.FetchLive(context.Background(), crds)
+	if err != nil {
+		t.Fatalf("FetchLive: expected no top-level error for per-app strategy error, got: %v", err)
+	}
+	liveMap := result.(map[string]LiveSiteState)
+	state := liveMap["app-a"]
+	if state.ResolvedFromTarget {
+		t.Error("FetchLive: ResolvedFromTarget should be false when strategy errors")
+	}
+}
+
+// ─── ComputePlan tests ───────────────────────────────────────────────────────────
+
+func TestSiteProvider_ComputePlan_AllSynced(t *testing.T) {
+	mock := &mockDeployStrategy{}
+	sp := newProviderWithMock(mock)
+	sp.root = "/fake/root"
+
+	crds := []SiteCRD{makeCRD("app-a", "a.example.com")}
+	liveMap := map[string]LiveSiteState{
+		"app-a": {ArtifactSHA: "deadbeef", ResolvedFromTarget: true},
+	}
+
+	plan, err := sp.ComputePlan(crds, liveMap, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if len(plan.Actions) != 1 {
+		t.Fatalf("ComputePlan: got %d actions, want 1", len(plan.Actions))
+	}
+	if plan.Actions[0].Action != ActionSkip {
+		t.Errorf("ComputePlan: got action %q, want Skip", plan.Actions[0].Action)
+	}
+	if plan.Summary.Skipped != 1 {
+		t.Errorf("ComputePlan: Summary.Skipped = %d, want 1", plan.Summary.Skipped)
+	}
+}
+
+func TestSiteProvider_ComputePlan_EmptyArtifactSHA_IsUpdate(t *testing.T) {
+	mock := &mockDeployStrategy{}
+	sp := newProviderWithMock(mock)
+	sp.root = "/fake/root"
+
+	crds := []SiteCRD{makeCRD("app-a", "a.example.com")}
+	liveMap := map[string]LiveSiteState{
+		"app-a": {ArtifactSHA: "", ResolvedFromTarget: true}, // deployed but SHA unknown
+	}
+
+	plan, err := sp.ComputePlan(crds, liveMap, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if len(plan.Actions) != 1 {
+		t.Fatalf("ComputePlan: got %d actions, want 1", len(plan.Actions))
+	}
+	if plan.Actions[0].Action != ActionUpdate {
+		t.Errorf("ComputePlan: got action %q, want Update", plan.Actions[0].Action)
+	}
+	if plan.Summary.Updates != 1 {
+		t.Errorf("ComputePlan: Summary.Updates = %d, want 1", plan.Summary.Updates)
+	}
+}
+
+func TestSiteProvider_ComputePlan_NotDeployed_IsCreate(t *testing.T) {
+	mock := &mockDeployStrategy{}
+	sp := newProviderWithMock(mock)
+	sp.root = "/fake/root"
+
+	crds := []SiteCRD{makeCRD("app-a", "a.example.com")}
+	liveMap := map[string]LiveSiteState{
+		"app-a": {ResolvedFromTarget: false}, // not deployed yet
+	}
+
+	plan, err := sp.ComputePlan(crds, liveMap, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if len(plan.Actions) != 1 {
+		t.Fatalf("ComputePlan: got %d actions, want 1", len(plan.Actions))
+	}
+	if plan.Actions[0].Action != ActionCreate {
+		t.Errorf("ComputePlan: got action %q, want Create", plan.Actions[0].Action)
+	}
+	if plan.Summary.Creates != 1 {
+		t.Errorf("ComputePlan: Summary.Creates = %d, want 1", plan.Summary.Creates)
+	}
+}
+
+func TestSiteProvider_ComputePlan_MissingFromLive_IsCreate(t *testing.T) {
+	mock := &mockDeployStrategy{}
+	sp := newProviderWithMock(mock)
+	sp.root = "/fake/root"
+
+	crds := []SiteCRD{makeCRD("app-a", "a.example.com")}
+	// app-a not present in liveMap at all → zero-value LiveSiteState, ResolvedFromTarget=false
+	liveMap := map[string]LiveSiteState{}
+
+	plan, err := sp.ComputePlan(crds, liveMap, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if plan.Actions[0].Action != ActionCreate {
+		t.Errorf("ComputePlan: got action %q, want Create for missing live entry", plan.Actions[0].Action)
+	}
+}
+
+func TestSiteProvider_ComputePlan_OrphanedState_IsDelete(t *testing.T) {
+	mock := &mockDeployStrategy{}
+	sp := newProviderWithMock(mock)
+	sp.root = "/fake/root"
+
+	// No CRDs — app-a was removed from config
+	crds := []SiteCRD{}
+	liveMap := map[string]LiveSiteState{}
+
+	// State still has app-a
+	state := &ReconcileState{
+		Resources: []ReconcileResource{
+			{Name: "app-a", Type: "site"},
+		},
+	}
+
+	plan, err := sp.ComputePlan(crds, liveMap, state)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if len(plan.Actions) != 1 {
+		t.Fatalf("ComputePlan: got %d actions, want 1", len(plan.Actions))
+	}
+	if plan.Actions[0].Action != ActionDelete {
+		t.Errorf("ComputePlan: got action %q, want Delete", plan.Actions[0].Action)
+	}
+	if plan.Summary.Deletes != 1 {
+		t.Errorf("ComputePlan: Summary.Deletes = %d, want 1", plan.Summary.Deletes)
+	}
+}
+
+func TestSiteProvider_ComputePlan_SummaryCounts(t *testing.T) {
+	mock := &mockDeployStrategy{}
+	sp := newProviderWithMock(mock)
+	sp.root = "/fake/root"
+
+	crds := []SiteCRD{
+		makeCRD("app-skip", "skip.example.com"),
+		makeCRD("app-create", "create.example.com"),
+		makeCRD("app-update", "update.example.com"),
+	}
+	liveMap := map[string]LiveSiteState{
+		"app-skip":   {ArtifactSHA: "sha1", ResolvedFromTarget: true},
+		"app-create": {ResolvedFromTarget: false},
+		"app-update": {ArtifactSHA: "", ResolvedFromTarget: true},
+	}
+
+	plan, err := sp.ComputePlan(crds, liveMap, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if plan.Summary.Skipped != 1 {
+		t.Errorf("Summary.Skipped = %d, want 1", plan.Summary.Skipped)
+	}
+	if plan.Summary.Creates != 1 {
+		t.Errorf("Summary.Creates = %d, want 1", plan.Summary.Creates)
+	}
+	if plan.Summary.Updates != 1 {
+		t.Errorf("Summary.Updates = %d, want 1", plan.Summary.Updates)
+	}
+}
+
+// ─── ApplyPlan tests ─────────────────────────────────────────────────────────────
+
+// buildFakeAppDir creates a minimal app directory with a dist/ subdir for ApplyPlan.
+// The build step (siteBuild) runs build.sh; we skip by using action.Details["app_dir"]
+// pointing to a dir with a real build.sh stub. Actually ApplyPlan calls siteBuild
+// which runs bash build.sh — we need to provide a real build.sh or mock the build.
+// Since we cannot mock siteBuild easily, we create a real build.sh that just succeeds.
+func buildFakeAppDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	distDir := filepath.Join(dir, "dist")
+	if err := os.MkdirAll(distDir, 0755); err != nil {
+		t.Fatalf("MkdirAll dist: %v", err)
+	}
+	// Write a trivial build.sh that creates/touches the dist dir
+	buildSH := "#!/bin/bash\nmkdir -p dist\n"
+	buildPath := filepath.Join(dir, "build.sh")
+	if err := os.WriteFile(buildPath, []byte(buildSH), 0755); err != nil {
+		t.Fatalf("write build.sh: %v", err)
+	}
+	// Write a placeholder file in dist so Deploy has something to work with
+	if err := os.WriteFile(filepath.Join(distDir, "index.html"), []byte("<html/>"), 0644); err != nil {
+		t.Fatalf("write index.html: %v", err)
+	}
+	return dir
+}
+
+func TestSiteProvider_ApplyPlan_DeployCalledForCreateAndUpdate(t *testing.T) {
+	mock := &mockDeployStrategy{}
+	sp := newProviderWithMock(mock)
+	sp.root = t.TempDir()
+
+	// Build real app dirs (ApplyPlan calls siteBuild which runs bash build.sh)
+	appCreateDir := buildFakeAppDir(t)
+	appUpdateDir := buildFakeAppDir(t)
+
+	// Write minimal site.yaml into the provider root so siteCRDByName works after reload
+	buildAppsDir(t, sp.root, map[string]string{
+		"app-create": validSiteYAML("app-create", "create.example.com"),
+		"app-update": validSiteYAML("app-update", "update.example.com"),
+	})
+
+	plan := &ReconcilePlan{
+		ResourceType: "site",
+		Actions: []ReconcileAction{
+			{
+				Action:       ActionCreate,
+				ResourceType: "site",
+				Name:         "app-create",
+				Details: map[string]any{
+					"app_dir":  appCreateDir,
+					"strategy": "gh-pages",
+					"domain":   "create.example.com",
+					"target":   map[string]any{"repo": "myrgic/app-create"},
+				},
+			},
+			{
+				Action:       ActionUpdate,
+				ResourceType: "site",
+				Name:         "app-update",
+				Details: map[string]any{
+					"app_dir":  appUpdateDir,
+					"strategy": "gh-pages",
+					"domain":   "update.example.com",
+					"target":   map[string]any{"repo": "myrgic/app-update"},
+				},
+			},
+		},
+	}
+
+	results, err := sp.ApplyPlan(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("ApplyPlan: %v", err)
+	}
+	if mock.DeployCallCount != 2 {
+		t.Errorf("Deploy call count: got %d, want 2", mock.DeployCallCount)
+	}
+	if len(results) != 2 {
+		t.Errorf("ApplyPlan: got %d results, want 2", len(results))
+	}
+	for _, r := range results {
+		if r.Status != ApplySucceeded {
+			t.Errorf("ApplyPlan result %s: status %v, want ApplySucceeded; err: %v", r.Name, r.Status, r.Error)
+		}
+	}
+}
+
+func TestSiteProvider_ApplyPlan_SkipNotDeployed(t *testing.T) {
+	mock := &mockDeployStrategy{}
+	sp := newProviderWithMock(mock)
+	sp.root = t.TempDir()
+
+	plan := &ReconcilePlan{
+		ResourceType: "site",
+		Actions: []ReconcileAction{
+			{
+				Action:       ActionSkip,
+				ResourceType: "site",
+				Name:         "app-skip",
+				Details:      map[string]any{"app_dir": "/some/dir"},
+			},
+		},
+	}
+
+	results, err := sp.ApplyPlan(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("ApplyPlan: %v", err)
+	}
+	if mock.DeployCallCount != 0 {
+		t.Errorf("Deploy call count: got %d, want 0 (skip actions should not deploy)", mock.DeployCallCount)
+	}
+	// Skip actions produce no result entries
+	if len(results) != 0 {
+		t.Errorf("ApplyPlan: got %d results for skip-only plan, want 0", len(results))
+	}
+}
+
+func TestSiteProvider_ApplyPlan_PerActionErrorDoesNotAbort(t *testing.T) {
+	mock := &mockDeployStrategy{
+		DeployError: fmt.Errorf("network failure"),
+	}
+	sp := newProviderWithMock(mock)
+	sp.root = t.TempDir()
+
+	appDir1 := buildFakeAppDir(t)
+	appDir2 := buildFakeAppDir(t)
+
+	buildAppsDir(t, sp.root, map[string]string{
+		"app-1": validSiteYAML("app-1", "1.example.com"),
+		"app-2": validSiteYAML("app-2", "2.example.com"),
+	})
+
+	plan := &ReconcilePlan{
+		ResourceType: "site",
+		Actions: []ReconcileAction{
+			{
+				Action: ActionCreate, Name: "app-1",
+				Details: map[string]any{
+					"app_dir": appDir1, "strategy": "gh-pages",
+					"domain": "1.example.com",
+					"target": map[string]any{"repo": "myrgic/app-1"},
+				},
+			},
+			{
+				Action: ActionCreate, Name: "app-2",
+				Details: map[string]any{
+					"app_dir": appDir2, "strategy": "gh-pages",
+					"domain": "2.example.com",
+					"target": map[string]any{"repo": "myrgic/app-2"},
+				},
+			},
+		},
+	}
+
+	results, err := sp.ApplyPlan(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("ApplyPlan: unexpected top-level error: %v", err)
+	}
+	// Both results should be present — apply loop does not abort on per-action failure
+	if len(results) != 2 {
+		t.Errorf("ApplyPlan: got %d results, want 2 (per-action error should not abort)", len(results))
+	}
+	for _, r := range results {
+		if r.Status != ApplyFailed {
+			t.Errorf("result %s: expected ApplyFailed, got %v", r.Name, r.Status)
+		}
+		if r.Error == "" {
+			t.Errorf("result %s: expected non-empty error", r.Name)
+		}
+	}
+}
+
+// ─── BuildState tests ────────────────────────────────────────────────────────────
+
+func TestSiteProvider_BuildState_PreservesLineage(t *testing.T) {
+	sp := &SiteProvider{strategies: defaultStrategies()}
+
+	liveMap := map[string]LiveSiteState{
+		"app-a": {ArtifactSHA: "sha123", CNAMEContent: "a.example.com", ResolvedFromTarget: true},
+	}
+
+	existing := &ReconcileState{
+		Version:      1,
+		ResourceType: "site",
+		Lineage:      "site-existing-lineage",
+		Serial:       5,
+	}
+
+	state, err := sp.BuildState(nil, liveMap, existing)
+	if err != nil {
+		t.Fatalf("BuildState: %v", err)
+	}
+	if state.Lineage != "site-existing-lineage" {
+		t.Errorf("BuildState: lineage = %q, want %q", state.Lineage, "site-existing-lineage")
+	}
+	if state.Serial != 6 {
+		t.Errorf("BuildState: serial = %d, want 6", state.Serial)
+	}
+	if len(state.Resources) != 1 {
+		t.Fatalf("BuildState: got %d resources, want 1", len(state.Resources))
+	}
+	res := state.Resources[0]
+	if res.Name != "app-a" {
+		t.Errorf("BuildState: resource name = %q, want app-a", res.Name)
+	}
+	if res.ExternalID != "sha123" {
+		t.Errorf("BuildState: ExternalID = %q, want sha123", res.ExternalID)
+	}
+}
+
+func TestSiteProvider_BuildState_NilExistingCreatesNewLineage(t *testing.T) {
+	sp := &SiteProvider{strategies: defaultStrategies()}
+	liveMap := map[string]LiveSiteState{}
+
+	state, err := sp.BuildState(nil, liveMap, nil)
+	if err != nil {
+		t.Fatalf("BuildState: %v", err)
+	}
+	if state.Lineage == "" {
+		t.Error("BuildState: lineage should not be empty for new state")
+	}
+	if !strings.HasPrefix(state.Lineage, "site-") {
+		t.Errorf("BuildState: lineage %q should start with 'site-'", state.Lineage)
+	}
+	if state.Serial != 0 {
+		t.Errorf("BuildState: serial = %d, want 0 for new state", state.Serial)
+	}
+}

--- a/site_strategies.go
+++ b/site_strategies.go
@@ -1,0 +1,59 @@
+// site_strategies.go — DeployStrategy interface and supporting types for site deployments.
+//
+// DeployStrategy is the extension point for site deployment backends. Each strategy
+// (gh-pages, s3, etc.) implements this interface so that SiteProvider can delegate
+// the live-state fetch and artifact deployment steps without knowing strategy internals.
+//
+// Design rationale: SiteProvider owns the reconcile lifecycle (plan / apply / state);
+// DeployStrategy owns the I/O against the external deployment target. The two surfaces
+// are deliberately separate so that adding a new strategy does not require modifying
+// SiteProvider.
+
+package main
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrUnsupportedStrategy is returned by strategy registries or dispatch functions
+// when the requested strategy identifier is not registered.
+var ErrUnsupportedStrategy = errors.New("unsupported deploy strategy")
+
+// LiveSiteState captures the observable state of a deployed site as fetched from the
+// deployment target. It is used by SiteProvider.FetchLive to compare declared config
+// against live state and decide whether a deployment is needed.
+type LiveSiteState struct {
+	// ArtifactSHA is the content-addressable SHA of the last deployed artifact.
+	// For gh-pages this is the HEAD commit SHA of the gh-pages branch.
+	ArtifactSHA string `json:"artifact_sha"`
+
+	// CNAMEContent is the content of the CNAME file at the deployment target,
+	// if present. Empty string if no CNAME file exists.
+	CNAMEContent string `json:"cname_content"`
+
+	// ResolvedFromTarget indicates whether the live state was fetched from the
+	// deployment target (true) or inferred from local state only (false).
+	ResolvedFromTarget bool `json:"resolved_from_target"`
+
+	// Metadata holds strategy-specific supplemental data (e.g. branch protection
+	// status, Pages endpoint URL, S3 bucket region). Keys are strategy-defined.
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+// DeployStrategy is the contract implemented by each site deployment backend.
+//
+// Implementations must be safe to call concurrently if SiteProvider is reconciling
+// multiple sites in parallel.
+type DeployStrategy interface {
+	// FetchLive retrieves the current deployed state of the site from the external
+	// target (e.g. the gh-pages branch HEAD, S3 bucket metadata). It must not
+	// mutate any external state.
+	FetchLive(ctx context.Context, app SiteCRD) (LiveSiteState, error)
+
+	// Deploy publishes the artifact directory to the deployment target.
+	// artifactDir is the absolute path to the directory produced by the build step
+	// (i.e. the resolved path of BuildSpec.Dist). Deploy is responsible for all
+	// target-specific upload, branch-push, or sync operations.
+	Deploy(ctx context.Context, app SiteCRD, artifactDir string) error
+}

--- a/site_strategy_ghpages.go
+++ b/site_strategy_ghpages.go
@@ -43,6 +43,10 @@ func (g *GHPagesStrategy) resolveRepo(app SiteCRD) (string, error) {
 	return repo, nil
 }
 
+// ghAPIRunner is the injectable runner for gh API calls.
+// Tests replace this variable to stub gh CLI responses without exec.
+var ghAPIRunner func(ctx context.Context, path string) ([]byte, error) = ghAPI
+
 // ghAPI runs: gh api <path> and returns stdout bytes.
 func ghAPI(ctx context.Context, path string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, "gh", "api", path)
@@ -73,7 +77,7 @@ func (g *GHPagesStrategy) FetchLive(ctx context.Context, app SiteCRD) (LiveSiteS
 	}
 
 	// Query main branch SHA
-	refData, err := ghAPI(ctx, fmt.Sprintf("/repos/%s/git/refs/heads/main", repo))
+	refData, err := ghAPIRunner(ctx, fmt.Sprintf("/repos/%s/git/refs/heads/main", repo))
 	if err != nil {
 		// If the repo doesn't exist yet or has no main branch, treat as not deployed
 		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "Not Found") {
@@ -94,7 +98,7 @@ func (g *GHPagesStrategy) FetchLive(ctx context.Context, app SiteCRD) (LiveSiteS
 	state.ArtifactSHA = refResp.Object.SHA
 
 	// Query CNAME (optional — 404 is normal)
-	cnameData, err := ghAPI(ctx, fmt.Sprintf("/repos/%s/contents/CNAME", repo))
+	cnameData, err := ghAPIRunner(ctx, fmt.Sprintf("/repos/%s/contents/CNAME", repo))
 	if err == nil {
 		var cnameResp struct {
 			Content  string `json:"content"`

--- a/site_strategy_ghpages.go
+++ b/site_strategy_ghpages.go
@@ -168,13 +168,16 @@ func (g *GHPagesStrategy) Deploy(ctx context.Context, app SiteCRD, artifactDir s
 		return fmt.Errorf("Deploy: git commit: %w", err)
 	}
 
-	// Set remote origin using HTTPS form (gh CLI auth handles credentials)
+	// Set remote origin using HTTPS form (gh CLI auth handles credentials via git-credential-gh).
+	// gh CLI configures git-credential-helper on install, so no token embedding is needed.
 	remote := fmt.Sprintf("https://github.com/%s.git", repo)
 	if err := gitRun(ctx, tmpDir, "remote", "add", "origin", remote); err != nil {
 		return fmt.Errorf("Deploy: git remote add: %w", err)
 	}
 
-	// Force-push to main — deploy repo is auto-managed; history is replaced per deploy
+	// Force-push to main — deploy repo is auto-managed; history is replaced per deploy.
+	// This is the correct semantic for a gh-pages deploy target: no source lineage needed,
+	// only the latest artifact matters.
 	if err := gitRun(ctx, tmpDir, "push", "--force", "origin", "HEAD:main"); err != nil {
 		return fmt.Errorf("Deploy: git push: %w", err)
 	}

--- a/site_strategy_ghpages.go
+++ b/site_strategy_ghpages.go
@@ -1,0 +1,236 @@
+// site_strategy_ghpages.go — GitHub Pages deploy strategy.
+//
+// GHPagesStrategy implements DeployStrategy for sites deployed via GitHub Pages.
+// It uses the gh CLI for API queries (FetchLive) and git for branch-push deploys.
+//
+// Deployment model: the target repo's main branch is treated as the deploy branch.
+// Each deploy replaces the branch HEAD entirely (force-push). History is intentionally
+// replaced — the deploy target is auto-managed artifact storage, not source history.
+//
+// Prerequisites: gh CLI authenticated, git configured with push access to the target repo.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// GHPagesStrategy deploys sites to GitHub Pages via the gh CLI and git.
+type GHPagesStrategy struct {
+	mu sync.Mutex
+}
+
+// resolveRepo extracts the "repo" key from the CRD's deploy target map.
+func (g *GHPagesStrategy) resolveRepo(app SiteCRD) (string, error) {
+	raw, ok := app.Spec.Deploy.Target["repo"]
+	if !ok {
+		return "", fmt.Errorf("gh-pages: deploy.target.repo is required")
+	}
+	repo, ok := raw.(string)
+	if !ok || repo == "" {
+		return "", fmt.Errorf("gh-pages: deploy.target.repo must be a non-empty string")
+	}
+	return repo, nil
+}
+
+// ghAPI runs: gh api <path> and returns stdout bytes.
+func ghAPI(ctx context.Context, path string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "gh", "api", path)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("gh api %s: %w: %s", path, err, stderr.String())
+	}
+	return stdout.Bytes(), nil
+}
+
+// ─── FetchLive ──────────────────────────────────────────────────────────────────
+
+// FetchLive retrieves the current deployed state from the GitHub Pages target repo.
+// It queries:
+//   - /repos/<repo>/git/refs/heads/main → ArtifactSHA (current HEAD)
+//   - /repos/<repo>/contents/CNAME → CNAMEContent (optional; 404 = empty)
+func (g *GHPagesStrategy) FetchLive(ctx context.Context, app SiteCRD) (LiveSiteState, error) {
+	repo, err := g.resolveRepo(app)
+	if err != nil {
+		return LiveSiteState{}, err
+	}
+
+	state := LiveSiteState{
+		ResolvedFromTarget: true,
+		Metadata:           make(map[string]any),
+	}
+
+	// Query main branch SHA
+	refData, err := ghAPI(ctx, fmt.Sprintf("/repos/%s/git/refs/heads/main", repo))
+	if err != nil {
+		// If the repo doesn't exist yet or has no main branch, treat as not deployed
+		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "Not Found") {
+			state.ResolvedFromTarget = false
+			return state, nil
+		}
+		return LiveSiteState{}, fmt.Errorf("FetchLive: fetch main ref: %w", err)
+	}
+
+	var refResp struct {
+		Object struct {
+			SHA string `json:"sha"`
+		} `json:"object"`
+	}
+	if err := json.Unmarshal(refData, &refResp); err != nil {
+		return LiveSiteState{}, fmt.Errorf("FetchLive: parse ref response: %w", err)
+	}
+	state.ArtifactSHA = refResp.Object.SHA
+
+	// Query CNAME (optional — 404 is normal)
+	cnameData, err := ghAPI(ctx, fmt.Sprintf("/repos/%s/contents/CNAME", repo))
+	if err == nil {
+		var cnameResp struct {
+			Content  string `json:"content"`
+			Encoding string `json:"encoding"`
+		}
+		if err := json.Unmarshal(cnameData, &cnameResp); err == nil && cnameResp.Encoding == "base64" {
+			decoded, err := base64.StdEncoding.DecodeString(
+				strings.ReplaceAll(cnameResp.Content, "\n", ""))
+			if err == nil {
+				state.CNAMEContent = strings.TrimSpace(string(decoded))
+			}
+		}
+	}
+	// CNAME fetch errors are silently ignored — it's optional
+
+	state.Metadata["repo"] = repo
+	return state, nil
+}
+
+// ─── Deploy ─────────────────────────────────────────────────────────────────────
+
+// Deploy publishes the artifact directory to the GitHub Pages target repo.
+// It creates a temp git repo, copies the artifact, writes CNAME, and force-pushes.
+func (g *GHPagesStrategy) Deploy(ctx context.Context, app SiteCRD, artifactDir string) error {
+	repo, err := g.resolveRepo(app)
+	if err != nil {
+		return err
+	}
+
+	// Determine source SHA for the commit message (set by ApplyPlan via env)
+	sourceSHA := os.Getenv("__SOURCE_SHA")
+	if sourceSHA == "" {
+		sourceSHA = "unknown"
+	}
+	if len(sourceSHA) > 12 {
+		sourceSHA = sourceSHA[:12]
+	}
+
+	// Create a temp directory for the ephemeral deploy repo
+	tmpDir, err := os.MkdirTemp("", "cogos-ghpages-*")
+	if err != nil {
+		return fmt.Errorf("Deploy: create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// git init
+	if err := gitRun(ctx, tmpDir, "init"); err != nil {
+		return fmt.Errorf("Deploy: git init: %w", err)
+	}
+
+	// Copy artifact contents into temp dir
+	if err := copyDir(artifactDir, tmpDir); err != nil {
+		return fmt.Errorf("Deploy: copy artifact: %w", err)
+	}
+
+	// Write CNAME file (domain without trailing newline)
+	cnamePath := filepath.Join(tmpDir, "CNAME")
+	if err := os.WriteFile(cnamePath, []byte(app.Spec.Domain), 0644); err != nil {
+		return fmt.Errorf("Deploy: write CNAME: %w", err)
+	}
+
+	// Stage all files
+	if err := gitRun(ctx, tmpDir, "add", "."); err != nil {
+		return fmt.Errorf("Deploy: git add: %w", err)
+	}
+
+	// Commit
+	msg := fmt.Sprintf("deploy: %s @ %s", app.Spec.Domain, sourceSHA)
+	if err := gitRun(ctx, tmpDir, "-c", "user.email=cog@myrgic.io",
+		"-c", "user.name=CogOS", "commit", "-m", msg); err != nil {
+		return fmt.Errorf("Deploy: git commit: %w", err)
+	}
+
+	// Set remote origin using HTTPS form (gh CLI auth handles credentials)
+	remote := fmt.Sprintf("https://github.com/%s.git", repo)
+	if err := gitRun(ctx, tmpDir, "remote", "add", "origin", remote); err != nil {
+		return fmt.Errorf("Deploy: git remote add: %w", err)
+	}
+
+	// Force-push to main — deploy repo is auto-managed; history is replaced per deploy
+	if err := gitRun(ctx, tmpDir, "push", "--force", "origin", "HEAD:main"); err != nil {
+		return fmt.Errorf("Deploy: git push: %w", err)
+	}
+
+	return nil
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────────
+
+// gitRun executes a git command in dir and returns combined output on error.
+func gitRun(ctx context.Context, dir string, args ...string) error {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git %s: %w\n%s", strings.Join(args, " "), err, out)
+	}
+	return nil
+}
+
+// copyDir recursively copies src directory contents into dst (not src itself).
+func copyDir(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, info.Mode())
+		}
+		return copyFile(path, target, info.Mode())
+	})
+}
+
+// copyFile copies a single file preserving its mode.
+func copyFile(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return err
+	}
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	return err
+}

--- a/site_strategy_ghpages.go
+++ b/site_strategy_ghpages.go
@@ -30,6 +30,22 @@ type GHPagesStrategy struct {
 	mu sync.Mutex
 }
 
+// init self-registers GHPagesStrategy with the global SiteProvider.
+// site_provider.go's init() runs first (alphabetical file order within the package),
+// so GetProvider("site") is guaranteed to find the SiteProvider before this fires.
+func init() {
+	p, err := GetProvider("site")
+	if err != nil {
+		// Should never happen in normal operation; log and continue rather than panic.
+		return
+	}
+	sp, ok := p.(*SiteProvider)
+	if !ok {
+		return
+	}
+	sp.RegisterStrategy("gh-pages", &GHPagesStrategy{})
+}
+
 // resolveRepo extracts the "repo" key from the CRD's deploy target map.
 func (g *GHPagesStrategy) resolveRepo(app SiteCRD) (string, error) {
 	raw, ok := app.Spec.Deploy.Target["repo"]

--- a/site_strategy_ghpages_test.go
+++ b/site_strategy_ghpages_test.go
@@ -1,0 +1,293 @@
+// site_strategy_ghpages_test.go
+// Covers: GHPagesStrategy.FetchLive (fully unit-tested via injected runner)
+//         GHPagesStrategy.Deploy (integration-only, skipped unless gh is authenticated
+//         and -short is not set).
+//
+// Strategy choice: HYBRID (A for FetchLive, B for Deploy)
+//   - FetchLive has rich JSON-parsing logic and 404-branching worth unit testing.
+//     We stub ghAPIRunner (the package-level injectable) to avoid real gh CLI calls.
+//   - Deploy's logic is mostly sequencing exec calls; unit-testing exec invocation
+//     order requires more invasive mocking (gitRun uses exec.CommandContext directly
+//     with no injection point). Rather than widen the refactor surface, Deploy is
+//     covered by a guarded integration test that is skipped unless gh is available
+//     and -short is not set. This is consistent with D1's FOLLOWUP pattern.
+
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ─── Test helpers ────────────────────────────────────────────────────────────────
+
+// makeRefJSON returns a JSON bytes simulating gh api .../git/refs/heads/main response.
+func makeRefJSON(sha string) []byte {
+	b, _ := json.Marshal(map[string]any{
+		"ref": "refs/heads/main",
+		"object": map[string]any{
+			"sha":  sha,
+			"type": "commit",
+		},
+	})
+	return b
+}
+
+// makeCNAMEJSON returns a JSON bytes simulating gh api .../contents/CNAME response.
+func makeCNAMEJSON(domain string) []byte {
+	encoded := base64.StdEncoding.EncodeToString([]byte(domain + "\n"))
+	b, _ := json.Marshal(map[string]any{
+		"name":     "CNAME",
+		"content":  encoded,
+		"encoding": "base64",
+	})
+	return b
+}
+
+// notFoundErr returns a fake 404 error matching FetchLive's detection heuristic.
+func notFoundErr(path string) error {
+	return fmt.Errorf("gh api %s: exit status 1: 404 Not Found", path)
+}
+
+// ghPages returns a fresh GHPagesStrategy.
+func ghPages() *GHPagesStrategy {
+	return &GHPagesStrategy{}
+}
+
+// crd returns a minimal SiteCRD targeting the given repo.
+func ghCRD(name, domain, repo string) SiteCRD {
+	return SiteCRD{
+		APIVersion: "cogos.myrgic.io/v1alpha1",
+		Kind:       "Site",
+		Metadata:   SiteMetadata{Name: name},
+		Spec: SiteSpec{
+			Domain: domain,
+			Deploy: DeploySpec{
+				Strategy: "gh-pages",
+				Target:   map[string]any{"repo": repo},
+			},
+		},
+	}
+}
+
+// withRunner temporarily replaces ghAPIRunner for the duration of the test.
+func withRunner(t *testing.T, fn func(ctx context.Context, path string) ([]byte, error)) {
+	t.Helper()
+	orig := ghAPIRunner
+	ghAPIRunner = fn
+	t.Cleanup(func() { ghAPIRunner = orig })
+}
+
+// ─── FetchLive — unit tests ──────────────────────────────────────────────────────
+
+func TestGHPagesStrategy_FetchLive_SuccessPath(t *testing.T) {
+	app := ghCRD("myrgic-com", "myrgic.com", "myrgic/myrgic.github.io")
+
+	withRunner(t, func(ctx context.Context, path string) ([]byte, error) {
+		if strings.Contains(path, "git/refs/heads/main") {
+			return makeRefJSON("abc123def456"), nil
+		}
+		if strings.Contains(path, "contents/CNAME") {
+			return makeCNAMEJSON("myrgic.com"), nil
+		}
+		return nil, fmt.Errorf("unexpected path: %s", path)
+	})
+
+	g := ghPages()
+	state, err := g.FetchLive(context.Background(), app)
+	if err != nil {
+		t.Fatalf("FetchLive: %v", err)
+	}
+	if !state.ResolvedFromTarget {
+		t.Error("ResolvedFromTarget: want true")
+	}
+	if state.ArtifactSHA != "abc123def456" {
+		t.Errorf("ArtifactSHA: got %q, want abc123def456", state.ArtifactSHA)
+	}
+	if state.CNAMEContent != "myrgic.com" {
+		t.Errorf("CNAMEContent: got %q, want myrgic.com", state.CNAMEContent)
+	}
+	repo, ok := state.Metadata["repo"]
+	if !ok || repo != "myrgic/myrgic.github.io" {
+		t.Errorf("Metadata[repo]: got %v, want myrgic/myrgic.github.io", repo)
+	}
+}
+
+func TestGHPagesStrategy_FetchLive_NotFound_MainRef(t *testing.T) {
+	app := ghCRD("new-site", "new.example.com", "myrgic/new-site")
+
+	withRunner(t, func(ctx context.Context, path string) ([]byte, error) {
+		if strings.Contains(path, "git/refs/heads/main") {
+			return nil, notFoundErr(path)
+		}
+		return nil, fmt.Errorf("unexpected path: %s", path)
+	})
+
+	g := ghPages()
+	state, err := g.FetchLive(context.Background(), app)
+	if err != nil {
+		t.Fatalf("FetchLive: 404 on main ref should not error, got: %v", err)
+	}
+	if state.ResolvedFromTarget {
+		t.Error("ResolvedFromTarget: want false when repo has no main branch (404)")
+	}
+}
+
+func TestGHPagesStrategy_FetchLive_MissingCNAME_NotAnError(t *testing.T) {
+	app := ghCRD("no-cname", "nocname.example.com", "myrgic/no-cname")
+
+	withRunner(t, func(ctx context.Context, path string) ([]byte, error) {
+		if strings.Contains(path, "git/refs/heads/main") {
+			return makeRefJSON("deadbeef1234"), nil
+		}
+		if strings.Contains(path, "contents/CNAME") {
+			return nil, notFoundErr(path) // CNAME not present
+		}
+		return nil, fmt.Errorf("unexpected path: %s", path)
+	})
+
+	g := ghPages()
+	state, err := g.FetchLive(context.Background(), app)
+	if err != nil {
+		t.Fatalf("FetchLive: CNAME 404 should not error, got: %v", err)
+	}
+	if !state.ResolvedFromTarget {
+		t.Error("ResolvedFromTarget: want true (repo exists; CNAME is optional)")
+	}
+	if state.ArtifactSHA != "deadbeef1234" {
+		t.Errorf("ArtifactSHA: got %q, want deadbeef1234", state.ArtifactSHA)
+	}
+	if state.CNAMEContent != "" {
+		t.Errorf("CNAMEContent: want empty when CNAME absent, got %q", state.CNAMEContent)
+	}
+}
+
+func TestGHPagesStrategy_FetchLive_MalformedRefJSON(t *testing.T) {
+	app := ghCRD("bad-json", "bad.example.com", "myrgic/bad-json")
+
+	withRunner(t, func(ctx context.Context, path string) ([]byte, error) {
+		if strings.Contains(path, "git/refs/heads/main") {
+			return []byte("not valid json {{{"), nil
+		}
+		return nil, fmt.Errorf("unexpected path: %s", path)
+	})
+
+	g := ghPages()
+	_, err := g.FetchLive(context.Background(), app)
+	if err == nil {
+		t.Fatal("FetchLive: want error for malformed JSON, got nil")
+	}
+	if !strings.Contains(err.Error(), "parse ref response") {
+		t.Errorf("FetchLive error: got %q, want to mention 'parse ref response'", err.Error())
+	}
+}
+
+func TestGHPagesStrategy_FetchLive_MissingRepo(t *testing.T) {
+	app := SiteCRD{
+		Metadata: SiteMetadata{Name: "no-repo"},
+		Spec: SiteSpec{
+			Domain: "example.com",
+			Deploy: DeploySpec{
+				Strategy: "gh-pages",
+				Target:   map[string]any{}, // repo key absent
+			},
+		},
+	}
+
+	// Runner should not be called since resolveRepo fails before any API call
+	called := false
+	withRunner(t, func(ctx context.Context, path string) ([]byte, error) {
+		called = true
+		return nil, nil
+	})
+
+	g := ghPages()
+	_, err := g.FetchLive(context.Background(), app)
+	if err == nil {
+		t.Fatal("FetchLive: want error for missing deploy.target.repo, got nil")
+	}
+	if called {
+		t.Error("ghAPIRunner should not be called when repo is missing")
+	}
+}
+
+func TestGHPagesStrategy_FetchLive_NonTransientRefError(t *testing.T) {
+	app := ghCRD("ref-error", "ref.example.com", "myrgic/ref-error")
+
+	withRunner(t, func(ctx context.Context, path string) ([]byte, error) {
+		if strings.Contains(path, "git/refs/heads/main") {
+			return nil, fmt.Errorf("gh api %s: connection refused", path)
+		}
+		return nil, fmt.Errorf("unexpected path: %s", path)
+	})
+
+	g := ghPages()
+	_, err := g.FetchLive(context.Background(), app)
+	if err == nil {
+		t.Fatal("FetchLive: want error for non-404 ref error, got nil")
+	}
+	if !strings.Contains(err.Error(), "fetch main ref") {
+		t.Errorf("FetchLive error: got %q, want to mention 'fetch main ref'", err.Error())
+	}
+}
+
+// ─── Deploy — integration test (guarded) ─────────────────────────────────────────
+
+// TestGHPagesStrategy_Deploy_Integration exercises Deploy against a real temp repo.
+// Skipped unless:
+//   - gh CLI is present and authenticated, AND
+//   - -short flag is not set.
+//
+// This test does NOT push to a real remote — it asserts only that the local git
+// operations succeed (init, copy, CNAME, add, commit). The push is expected to fail
+// (no real remote) and the test verifies the error is from the push step, not earlier.
+func TestGHPagesStrategy_Deploy_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("INTEGRATION: skipped in -short mode")
+	}
+	if _, err := exec.LookPath("gh"); err != nil {
+		t.Skip("INTEGRATION: gh CLI not found in PATH")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("INTEGRATION: git not found in PATH")
+	}
+
+	// Build a minimal artifact directory
+	artifactDir := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(artifactDir, "index.html"),
+		[]byte("<html><body>test</body></html>"),
+		0644,
+	); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+
+	app := ghCRD("integration-test", "integration.example.com", "myrgic/cogos-integration-test-nonexistent")
+
+	g := ghPages()
+	err := g.Deploy(context.Background(), app, artifactDir)
+
+	// We expect the push to fail (repo doesn't exist); earlier steps should succeed.
+	// If error is nil, that's unexpected but fine (test repo might exist).
+	if err != nil {
+		// Only the push step should fail
+		if !strings.Contains(err.Error(), "Deploy: git push") &&
+			!strings.Contains(err.Error(), "push") &&
+			!strings.Contains(err.Error(), "remote") {
+			t.Errorf("Deploy: unexpected failure stage (want push/remote error, got: %v)", err)
+		}
+		// Early failure (init, copy, CNAME, add, commit) is a real defect
+		for _, earlyStage := range []string{"git init", "copy artifact", "write CNAME", "git add", "git commit"} {
+			if strings.Contains(err.Error(), earlyStage) {
+				t.Errorf("Deploy: unexpected early failure at %q: %v", earlyStage, err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds `SiteProvider` to the kernel — a `Reconcilable` provider for static-site deployment. Sites are declared via per-app `site.yaml` specs in a monorepo; the provider loads, plans, and applies via a pluggable `DeployStrategy`. First strategy: `GHPagesStrategy` (force-push artifact + CNAME to a target repo).

## What landed

- `site_crd.go` — `SiteCRD` types + `Validate()`
- `site_strategies.go` — `DeployStrategy` interface + `LiveSiteState`
- `site_provider.go` + `site_provider_config.go` — full SiteProvider impl (LoadConfig, FetchLive, ComputePlan, ApplyPlan, BuildState, Health)
- `site_strategy_ghpages.go` — `GHPagesStrategy` with injectable command runner for testability
- Tests: SiteCRD (13) + SiteProvider unit (19) + GHPagesStrategy (7) + integration (covers monorepo layout). All green; one documented FOLLOWUP skip.

## Why

Self-demonstrative architecture: this is the kernel-side enabler for `myrgic/sites` to deploy 5 myrgic.* domains through cogos's own reconciliation framework, rather than through a separate CI adapter. The framework runs the lab's own infrastructure.

## Follow-up

- `Validate()` doesn't enforce `deploy.target.repo` for the `gh-pages` strategy (caught by D1, marked `t.Skip("FOLLOWUP: ...")`). Small fix for a follow-up PR.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (40 site-related tests)
- [x] Integration test against real `myrgic/sites` monorepo passes
- [ ] CI green
- [ ] Local apply against real monorepo (deploy plan Waves 5–6)