### PR TITLE
refactor: full myrgic rebrand + module path rename (v0.5.0)

### DIFF
--- a/.cogpublic
+++ b/.cogpublic
@@ -1,9 +1,9 @@
-# .cogpublic — Public release gate for cogos-dev/cogos
+# .cogpublic — Public release gate for myrgic/cogos
 # Defines what crosses the constellation boundary outward.
 # Used by `cog plan upstream` / `cog apply upstream` to sanitize pushes.
 #
-# Gate 1: private dev → personal public fork (chazmaniandinkle/cogos)
-# Gate 2: personal fork → org upstream (cogos-dev/cogos)
+# Gate 1: private dev → org upstream (myrgic/cogos, direct branch workflow)
+# Gate 2: squash-merge to main
 
 version: 1
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -60,7 +60,7 @@ body:
         project's supported config. Don't include paths or PIDs from your
         machine here — those go in the Environment section below.
       placeholder: |
-        1. Start the kernel: `cogos-v3 serve --port 6931`
+        1. Start the kernel: `cogos serve --port 6931`
         2. Send: `curl -s http://localhost:6931/v1/models`
         3. Observe: response includes `claude-opus-4-6` (stale).
     validations:
@@ -160,8 +160,8 @@ body:
   - type: input
     id: env_build
     attributes:
-      label: cogos-v3 build / commit
-      description: Output of `cogos-v3 --version` or the build timestamp from `kernel.log.jsonl`.
+      label: cogos build / commit
+      description: Output of `cogos --version` or the build timestamp from `kernel.log.jsonl`.
       placeholder: 2026-04-27T23:09:52Z (build timestamp) or commit 72f2161
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Question or discussion
-    url: https://github.com/cogos-dev/cogos/discussions
+    url: https://github.com/myrgic/cogos/discussions
     about: For open-ended questions, design discussions, or proposals not yet ready for an RFC.
   - name: Constellation (multi-node) issue
-    url: https://github.com/cogos-dev/constellation/issues
+    url: https://github.com/myrgic/constellation/issues
     about: For node-orchestration, sync, or multi-machine bugs unrelated to the kernel itself.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           mkdir -p dist
           VERSION="${GITHUB_REF_NAME}"
           BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          LDFLAGS="-s -w -X github.com/cogos-dev/cogos/internal/engine.Version=${VERSION} -X github.com/cogos-dev/cogos/internal/engine.BuildTime=${BUILD_TIME}"
+          LDFLAGS="-s -w -X github.com/myrgic/cogos/internal/engine.Version=${VERSION} -X github.com/myrgic/cogos/internal/engine.BuildTime=${BUILD_TIME}"
           for GOOS in linux darwin windows; do
             for GOARCH in amd64 arm64; do
               ext=""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ Pre-1.0. Per semver convention, breaking changes can land at any minor-version b
 
 The entries below predate the changelog policy above and are preserved as the historical record. For releases at v0.4.0 or later, see the [Releases page](https://github.com/myrgic/cogos/releases).
 
+## [0.5.0] - 2026-05-08
+
+### Changed (BREAKING)
+- Go module path renamed to `github.com/myrgic/cogos` (org rename: cogos-dev -> myrgic).
+  Downstream consumers must update imports.
+- `github.com/myrgic/constellation` v0.2.0 dependency (module path updated alongside org rename).
+- Docker images now published to `ghcr.io/myrgic/cogos`.
+- User-facing install script (`scripts/setup.sh`) now points to `myrgic/cogos` releases.
+- CI LDFLAGS embed the new module path; binary version strings updated.
+
 ## [Unreleased]
 
 _(no entries — see Releases page going forward)_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 > **Going forward (v0.4.0 onward):** this project does not maintain hand-curated changelog entries. PR titles and bodies are the canonical record; auto-generated GitHub release notes are the per-release projection.
 >
-> - **Per-release summaries:** [Releases page](https://github.com/cogos-dev/cogos/releases)
+> - **Per-release summaries:** [Releases page](https://github.com/myrgic/cogos/releases)
 > - **Detailed PR list per release:** auto-generated from PR titles since the previous tag (via `gh release create --generate-notes`)
 > - **Per-PR rationale:** the linked PR's description and discussion
 >
@@ -16,7 +16,7 @@ Pre-1.0. Per semver convention, breaking changes can land at any minor-version b
 
 # Historical entries
 
-The entries below predate the changelog policy above and are preserved as the historical record. For releases at v0.4.0 or later, see the [Releases page](https://github.com/cogos-dev/cogos/releases).
+The entries below predate the changelog policy above and are preserved as the historical record. For releases at v0.4.0 or later, see the [Releases page](https://github.com/myrgic/cogos/releases).
 
 ## [Unreleased]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for your interest in CogOS. This document covers how to set up a developm
 ## Development setup
 
 ```sh
-git clone https://github.com/cogos-dev/cogos.git
+git clone https://github.com/myrgic/cogos.git
 cd cogos
 make build
 ./scripts/setup-dev.sh
@@ -49,9 +49,9 @@ If your reproduction depends on a specific local arrangement (a particular provi
 
 ### Examples that meet this standard
 
-- [#75](https://github.com/cogos-dev/cogos/issues/75) -- model advertisement staleness + routing semantics. Three sub-bugs in one issue with shared fix surface, each cited at file:line.
-- [#79](https://github.com/cogos-dev/cogos/issues/79) -- kernel hang RCA. Filed with hypotheses honestly marked as hypotheses, then updated with a follow-up RCA that named the actual root cause.
-- [#80](https://github.com/cogos-dev/cogos/issues/80), [#81](https://github.com/cogos-dev/cogos/issues/81) -- companion issues cross-linked so a reader entering through any one can find the others.
+- [#75](https://github.com/myrgic/cogos/issues/75) -- model advertisement staleness + routing semantics. Three sub-bugs in one issue with shared fix surface, each cited at file:line.
+- [#79](https://github.com/myrgic/cogos/issues/79) -- kernel hang RCA. Filed with hypotheses honestly marked as hypotheses, then updated with a follow-up RCA that named the actual root cause.
+- [#80](https://github.com/myrgic/cogos/issues/80), [#81](https://github.com/myrgic/cogos/issues/81) -- companion issues cross-linked so a reader entering through any one can find the others.
 
 ## Submitting changes
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 # CogOS Kernel — Multi-stage OCI build
 #
 # Build:
-#   docker build -t cogos-dev/cogos:dev .
+#   docker build -t ghcr.io/myrgic/cogos:dev .
 #
 # Run:
 #   docker run -v /path/to/workspace:/workspace \
-#              -p 6931:6931 cogos-dev/cogos:dev \
+#              -p 6931:6931 ghcr.io/myrgic/cogos:dev \
 #              serve --workspace /workspace --port 6931
 #
 # Multi-platform:
-#   docker buildx build --platform linux/amd64,linux/arm64 -t cogos-dev/cogos:dev .
+#   docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/myrgic/cogos:dev .
 
 # ── Stage 1: Build ────────────────────────────────────────────────────────────
 FROM golang:1.24-alpine AS builder
@@ -35,7 +35,7 @@ COPY . .
 # Build with CGO for SQLite FTS5 support
 RUN CGO_ENABLED=1 go build \
     -tags "fts5" \
-    -ldflags="-s -w -X github.com/cogos-dev/cogos/internal/engine.BuildTime=${BUILD_TIME}" \
+    -ldflags="-s -w -X github.com/myrgic/cogos/internal/engine.BuildTime=${BUILD_TIME}" \
     -o /cog ./cmd/cogos
 
 # ── Stage 2: Runtime ──────────────────────────────────────────────────────────

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -17,7 +17,7 @@ RUN go mod download
 COPY . .
 
 RUN CGO_ENABLED=0 go build \
-    -ldflags="-s -w -X github.com/cogos-dev/cogos/internal/engine.BuildTime=${BUILD_TIME}" \
+    -ldflags="-s -w -X github.com/myrgic/cogos/internal/engine.BuildTime=${BUILD_TIME}" \
     -o /cogos ./cmd/cogos
 
 # ── Stage 2: Test ─────────────────────────────────────────────────────────────

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # CogOS Kernel Build System
-# github.com/cogos-dev/cogos
+# github.com/myrgic/cogos
 #
 # Multi-platform binaries can be built for distribution.
 #
@@ -16,12 +16,12 @@
 
 VERSION := 0.4.2
 BUILD_TIME := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
-LDFLAGS := -s -w -X github.com/cogos-dev/cogos/internal/engine.BuildTime=$(BUILD_TIME)
+LDFLAGS := -s -w -X github.com/myrgic/cogos/internal/engine.BuildTime=$(BUILD_TIME)
 BUILD_TAGS := fts5
 BINARY := cog
 GO := go
 
-IMAGE      := cogos-dev/cogos
+IMAGE      := ghcr.io/myrgic/cogos
 TAG        := dev
 PORT       := 6931
 WORKSPACE  ?= $(shell git rev-parse --show-toplevel 2>/dev/null || echo $$HOME/cog-workspace)

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 #   make e2e      - Run e2e test in a container
 #   make e2e-local - Run e2e test locally
 
-VERSION := 0.4.2
+VERSION := 0.5.0
 BUILD_TIME := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -s -w -X github.com/myrgic/cogos/internal/engine.BuildTime=$(BUILD_TIME)
 BUILD_TAGS := fts5

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Or install a pre-built binary:
 
 ```sh
 # macOS Apple Silicon (latest release)
-curl -L https://github.com/cogos-dev/cogos/releases/latest/download/cogos-darwin-arm64 -o cogos
+curl -L https://github.com/myrgic/cogos/releases/latest/download/cogos-darwin-arm64 -o cogos
 chmod +x cogos && mv cogos ~/.cog/bin/cogos
 ```
 
@@ -300,7 +300,7 @@ cog bus send ...        # Write to the bus. Direct JSONL by default; --http for 
 ### Build and run
 
 ```sh
-git clone https://github.com/cogos-dev/cogos.git
+git clone https://github.com/myrgic/cogos.git
 cd cogos
 make build
 
@@ -418,7 +418,7 @@ scripts/                Setup, CLI wrapper, e2e tests, experiment harnesses
 
 ### Next
 
-- Direct import of the `cogos-dev/constellation` L1 trust-node protocol via the `ConstellationBridge` seam (the kernel already embeds `sdk/constellation/` for the Constellation memory graph of cogdocs; the external L1 peer protocol is the piece not yet wired)
+- Direct import of the `myrgic/constellation` L1 trust-node protocol via the `ConstellationBridge` seam (the kernel already embeds `sdk/constellation/` for the Constellation memory graph of cogdocs; the external L1 peer protocol is the piece not yet wired)
 - Multi-agent process management (the agent controller API is forward-compatible; only the `primary` instance is registered today)
 - Further agent state surface (beyond the v1 trigger/state/list)
 
@@ -430,17 +430,17 @@ CogOS is one piece of a larger system. Each component is its own repo with indep
 
 | Repo | Purpose | Status |
 |------|---------|--------|
-| **[cogos](https://github.com/cogos-dev/cogos)** | The daemon (this repo) | Active |
-| [constellation](https://github.com/cogos-dev/constellation) | L1 trust-node protocol for the Constellation substrate. Git-backed hash-chained ledger, ECDSA P-256 identity, EMA-weighted peer trust. Consumed via the kernel's `ConstellationBridge` seam. | Active |
-| [mod3](https://github.com/cogos-dev/mod3) | Modality bus: voice I/O, TTS, channel multiplexing | Active |
-| [skills](https://github.com/cogos-dev/skills) | Agent skill library (Claude Code compatible) | Active |
-| [charts](https://github.com/cogos-dev/charts) | Helm charts and Docker Compose for deployment | Active |
+| **[cogos](https://github.com/myrgic/cogos)** | The daemon (this repo) | Active |
+| [constellation](https://github.com/myrgic/constellation) | L1 trust-node protocol for the Constellation substrate. Git-backed hash-chained ledger, ECDSA P-256 identity, EMA-weighted peer trust. Consumed via the kernel's `ConstellationBridge` seam. | Active |
+| [mod3](https://github.com/myrgic/mod3) | Modality bus: voice I/O, TTS, channel multiplexing | Active |
+| [skills](https://github.com/myrgic/skills) | Agent skill library (Claude Code compatible) | Active |
+| [charts](https://github.com/myrgic/charts) | Helm charts and Docker Compose for deployment | Active |
 
 ---
 
 ## Releases & Changelog
 
-Per-release summaries: the [Releases page](https://github.com/cogos-dev/cogos/releases) (auto-generated from PR titles since the previous tag). See [CHANGELOG.md](CHANGELOG.md) for the policy and the historical entries (pre-v0.4.0).
+Per-release summaries: the [Releases page](https://github.com/myrgic/cogos/releases) (auto-generated from PR titles since the previous tag). See [CHANGELOG.md](CHANGELOG.md) for the policy and the historical entries (pre-v0.4.0).
 
 ---
 

--- a/agent_bus_inlet.go
+++ b/agent_bus_inlet.go
@@ -25,7 +25,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/cogos-dev/cogos/internal/engine"
+	"github.com/myrgic/cogos/internal/engine"
 )
 
 // --- Pending user-message queue ---

--- a/agent_dispatch.go
+++ b/agent_dispatch.go
@@ -31,7 +31,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cogos-dev/cogos/internal/engine"
+	"github.com/myrgic/cogos/internal/engine"
 )
 
 // HarnessDispatcher is the AgentDispatcher implementation backed by the

--- a/agent_dispatch_live_test.go
+++ b/agent_dispatch_live_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cogos-dev/cogos/internal/engine"
+	"github.com/myrgic/cogos/internal/engine"
 )
 
 func TestDispatchLive_HelloFromGemma(t *testing.T) {

--- a/agent_dispatch_test.go
+++ b/agent_dispatch_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cogos-dev/cogos/internal/engine"
+	"github.com/myrgic/cogos/internal/engine"
 )
 
 // ollamaServer returns a stand-in /api/chat endpoint that responds with the

--- a/agent_harness.go
+++ b/agent_harness.go
@@ -19,8 +19,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/cogos-dev/cogos/internal/engine"
-	"github.com/cogos-dev/cogos/trace"
+	"github.com/myrgic/cogos/internal/engine"
+	"github.com/myrgic/cogos/trace"
 )
 
 // cycleIDFromContext extracts a cycle-trace correlation ID from ctx, or

--- a/agent_tools.go
+++ b/agent_tools.go
@@ -14,7 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/cogos-dev/cogos/internal/linkfeed"
+	"github.com/myrgic/cogos/internal/linkfeed"
 )
 
 // linkfeedHarnessAdapter adapts *AgentHarness to linkfeed.Harness.

--- a/channel_types.go
+++ b/channel_types.go
@@ -5,7 +5,7 @@
 
 package main
 
-import "github.com/cogos-dev/cogos/pkg/modality"
+import "github.com/myrgic/cogos/pkg/modality"
 
 // Type aliases — channel types.
 type ChannelDescriptor = modality.ChannelDescriptor

--- a/cmd/cogos/main.go
+++ b/cmd/cogos/main.go
@@ -10,7 +10,7 @@
 //	cogos version
 package main
 
-import "github.com/cogos-dev/cogos/internal/engine"
+import "github.com/myrgic/cogos/internal/engine"
 
 func main() {
 	engine.Main()

--- a/cmd/cogos/providers_wire.go
+++ b/cmd/cogos/providers_wire.go
@@ -37,12 +37,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/cogos-dev/cogos/internal/engine"
-	"github.com/cogos-dev/cogos/internal/eval"
-	"github.com/cogos-dev/cogos/internal/providers/component"
-	"github.com/cogos-dev/cogos/internal/providers/daemon"
-	_ "github.com/cogos-dev/cogos/internal/providers/site" // registers "site" with pkg/reconcile
-	"github.com/cogos-dev/cogos/internal/workspace"
+	"github.com/myrgic/cogos/internal/engine"
+	"github.com/myrgic/cogos/internal/eval"
+	"github.com/myrgic/cogos/internal/providers/component"
+	"github.com/myrgic/cogos/internal/providers/daemon"
+	_ "github.com/myrgic/cogos/internal/providers/site" // registers "site" with pkg/reconcile
+	"github.com/myrgic/cogos/internal/workspace"
 	"gopkg.in/yaml.v3"
 )
 

--- a/cmd_alias.go
+++ b/cmd_alias.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/cogos-dev/cogos/pkg/alias"
+	"github.com/myrgic/cogos/pkg/alias"
 )
 
 // ── Dispatcher ────────────────────────────────────────────────────────────────

--- a/cmd_alias.go
+++ b/cmd_alias.go
@@ -238,7 +238,7 @@ Schema (~/.cog/node/aliases.yaml):
   aliases:
     cog: cog-workspace            # short form
     m3:                           # long form with metadata
-      workspace: cogos-dev/mod3
+      workspace: myrgic/mod3
       description: "mod3 voice server"
       node: darkstar
 

--- a/cmd_alias_test.go
+++ b/cmd_alias_test.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cogos-dev/cogos/pkg/alias"
+	"github.com/myrgic/cogos/pkg/alias"
 )
 
 // ── helpers ───────────────────────────────────────────────────────────────────

--- a/cmd_constellation.go
+++ b/cmd_constellation.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/cogos-dev/cogos/sdk/constellation"
+	"github.com/myrgic/cogos/sdk/constellation"
 )
 
 // cmdConstellation handles constellation subcommands

--- a/cmd_node.go
+++ b/cmd_node.go
@@ -25,7 +25,7 @@ import (
 
 	"os/exec"
 
-	"github.com/cogos-dev/cogos/envspec"
+	"github.com/myrgic/cogos/envspec"
 	"gopkg.in/yaml.v3"
 )
 

--- a/cmd_pin.go
+++ b/cmd_pin.go
@@ -65,11 +65,11 @@ Flags for add / bump:
   --sync <policy>                 read-only | read-write | mirror (default: read-only)
 
 Examples:
-  cog pin add cogos-dev/cogos v0.5.0 --digest sha256:abc123 --branch main
-  cog pin verify cogos-dev/cogos
-  cog pin bump cogos-dev/cogos v0.6.0
+  cog pin add myrgic/cogos v0.5.0 --digest sha256:abc123 --branch main
+  cog pin verify myrgic/cogos
+  cog pin bump myrgic/cogos v0.6.0
   cog pin list
-  cog pin remove cogos-dev/cogos
+  cog pin remove myrgic/cogos
 `)
 	return nil
 }

--- a/cmd_pin.go
+++ b/cmd_pin.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cogos-dev/cogos/internal/providers/pin"
+	"github.com/myrgic/cogos/internal/providers/pin"
 	"gopkg.in/yaml.v3"
 )
 

--- a/cmd_skill.go
+++ b/cmd_skill.go
@@ -15,7 +15,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/cogos-dev/cogos/pkg/skills"
+	"github.com/myrgic/cogos/pkg/skills"
 )
 
 // ─── Re-exported types ───────────────────────────────────────────────────────

--- a/cmd_skill_test.go
+++ b/cmd_skill_test.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cogos-dev/cogos/pkg/skills"
+	"github.com/myrgic/cogos/pkg/skills"
 )
 
 // ─── Fixtures ───────────────────────────────────────────────────────────────────

--- a/cog.go
+++ b/cog.go
@@ -895,7 +895,7 @@ func globalConfigPath() string {
 }
 
 // globalConfigLegacyPath returns the old path (~/.cog/config) used before
-// the migration introduced in cogos-dev/cogos#161. Used only by the one-time
+// the migration introduced in myrgic/cogos#161. Used only by the one-time
 // migration helper; callers must not persist to this path.
 func globalConfigLegacyPath() string {
 	home, err := os.UserHomeDir()

--- a/cog.go
+++ b/cog.go
@@ -30,8 +30,8 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/cogos-dev/cogos/internal/workspace"
-	"github.com/cogos-dev/cogos/pkg/coordination"
+	"github.com/myrgic/cogos/internal/workspace"
+	"github.com/myrgic/cogos/pkg/coordination"
 )
 
 // === VERSION & BUILD INFO ===

--- a/component_wiring.go
+++ b/component_wiring.go
@@ -14,7 +14,7 @@
 package main
 
 import (
-	"github.com/cogos-dev/cogos/internal/providers/component"
+	"github.com/myrgic/cogos/internal/providers/component"
 )
 
 func init() {

--- a/constellation_bus.go
+++ b/constellation_bus.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/cogos-dev/cogos/sdk/constellation"
+	"github.com/myrgic/cogos/sdk/constellation"
 )
 
 // constellationBusIndexer indexes chat bus events into constellation FTS5.

--- a/constellation_sessions.go
+++ b/constellation_sessions.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cogos-dev/cogos/sdk/constellation"
+	"github.com/myrgic/cogos/sdk/constellation"
 )
 
 // sessionTranscriptEntry represents one line of a Claude Code JSONL transcript.

--- a/constellation_singleton.go
+++ b/constellation_singleton.go
@@ -8,7 +8,7 @@ package main
 import (
 	"sync"
 
-	"github.com/cogos-dev/cogos/sdk/constellation"
+	"github.com/myrgic/cogos/sdk/constellation"
 )
 
 var constellationCache sync.Map // map[string]*constellation.Constellation

--- a/decompose_store.go
+++ b/decompose_store.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cogos-dev/cogos/sdk/constellation"
+	"github.com/myrgic/cogos/sdk/constellation"
 )
 
 // === C1+C2: Embedding Generation ===

--- a/docker-compose.node.yml
+++ b/docker-compose.node.yml
@@ -21,7 +21,7 @@
 # Prerequisites:
 #   - Build kernel image:  docker build -t cogos/kernel:latest .
 #   - Build gateway image: docker build -t cogos/gateway:latest ../moltbot-gateway/
-#   - Bridge image:        once ghcr.io/cogos-dev/cog-sandbox-mcp is published,
+#   - Bridge image:        once ghcr.io/myrgic/cog-sandbox-mcp is published,
 #                          no build step needed. Until then, the bridge service
 #                          builds from ../cog-sandbox-mcp (expects sibling-dir
 #                          layout — i.e. cog-sandbox-mcp checked out alongside
@@ -108,8 +108,8 @@ services:
   # session substrate coordination — each client is an independent MCP peer on
   # this central server, emitting to and reading from the same bus.
   #
-  # Image source: once ghcr.io/cogos-dev/cog-sandbox-mcp is published, swap the
-  # `build:` block for `image: ghcr.io/cogos-dev/cog-sandbox-mcp:latest`. Until
+  # Image source: once ghcr.io/myrgic/cog-sandbox-mcp is published, swap the
+  # `build:` block for `image: ghcr.io/myrgic/cog-sandbox-mcp:latest`. Until
   # then, builds from ../cog-sandbox-mcp (sibling-dir layout).
   bridge-primary:
     build:

--- a/docs/MCP-SPEC.md
+++ b/docs/MCP-SPEC.md
@@ -9,11 +9,11 @@
 
 ## Overview
 
-CogOS v3 exposes its cognitive infrastructure through a native MCP (Model Context Protocol) server written in Go, embedded directly in the `cogos-v3` daemon on port 6931. This replaces the v2 Python-based cogos-api (45 tools across 5 profiles) with a focused, stage-1 tool set that maps directly to v3's first-principles architecture.
+CogOS v3 exposes its cognitive infrastructure through a native MCP (Model Context Protocol) server written in Go, embedded directly in the `cogos` daemon on port 6931. This replaces the v2 Python-based cogos-api (45 tools across 5 profiles) with a focused, stage-1 tool set that maps directly to v3's first-principles architecture.
 
 ### Design Principles
 
-1. **One server, one process.** The MCP server is embedded in the cogos-v3 daemon, not a separate sidecar. Tools call internal Go functions directly — no HTTP round-trips to self.
+1. **One server, one process.** The MCP server is embedded in the cogos daemon, not a separate sidecar. Tools call internal Go functions directly — no HTTP round-trips to self.
 2. **Fewer tools, deeper integration.** v2 had 45 tools because it wrapped external systems (K8s, Docker, git). v3 stage-1 exposes 11 tools that map 1:1 to the six core components of the cognitive architecture.
 3. **Continuous process model.** The server is always running. Tools query a live attentional field, not a cold database. State is real-time.
 4. **cog:// URIs as first-class identifiers.** Every CogDoc, every resource, every reference uses the URI projection system. The MCP server speaks the same URI language as the rest of the organism.
@@ -35,7 +35,7 @@ CogOS v3 exposes its cognitive infrastructure through a native MCP (Model Contex
 
 ### SSE Transport (Primary)
 
-The MCP server runs as an HTTP handler on the existing cogos-v3 HTTP server at `http://localhost:6931/mcp`.
+The MCP server runs as an HTTP handler on the existing cogos HTTP server at `http://localhost:6931/mcp`.
 
 This uses the MCP SSE transport, which is the standard transport that Claude Code, Claude Desktop, Cursor, and other MCP clients expect for remote/networked servers.
 
@@ -51,7 +51,7 @@ This uses the MCP SSE transport, which is the standard transport that Claude Cod
 For local development and CLI integration, the daemon also supports stdio transport when invoked with `--mcp-stdio`:
 
 ```bash
-cogos-v3 serve --mcp-stdio
+cogos serve --mcp-stdio
 ```
 
 This is useful for `.mcp.json` configurations that launch the server as a subprocess.
@@ -65,7 +65,7 @@ This is useful for `.mcp.json` configurations that launch the server as a subpro
 ```json
 {
   "mcpServers": {
-    "cogos-v3": {
+    "cogos": {
       "url": "http://localhost:6931/mcp"
     }
   }
@@ -77,8 +77,8 @@ This is useful for `.mcp.json` configurations that launch the server as a subpro
 ```json
 {
   "mcpServers": {
-    "cogos-v3": {
-      "command": "cogos-v3",
+    "cogos": {
+      "command": "cogos",
       "args": ["serve", "--mcp-stdio"],
       "env": {
         "COG_WORKSPACE": "/path/to/cog-workspace"
@@ -414,7 +414,7 @@ Input: { "layers": ["ledger", "memory"], "verbose": true }
 
 ### Tool 5: `cog_get_state`
 
-**Description:** Get the current process state of the cogos-v3 daemon. Returns the four-state continuous process status, session metadata, uptime, and field statistics. This is a lightweight status query.
+**Description:** Get the current process state of the cogos daemon. Returns the four-state continuous process status, session metadata, uptime, and field statistics. This is a lightweight status query.
 
 **Internal component:** Continuous Process (process state machine)
 
@@ -971,7 +971,7 @@ Rationale:
 
 ### Wiring into serve.go
 
-The MCP server should be mounted as an HTTP handler on the existing cogos-v3 HTTP server. The daemon's `serve.go` already manages the HTTP listener on port 6931.
+The MCP server should be mounted as an HTTP handler on the existing cogos HTTP server. The daemon's `serve.go` already manages the HTTP listener on port 6931.
 
 ```go
 package main
@@ -988,7 +988,7 @@ import (
 func newMCPServer(kernel *Kernel) *mcp.Server {
     server := mcp.NewServer(
         &mcp.Implementation{
-            Name:    "cogos-v3",
+            Name:    "cogos",
             Version: "3.0.0-alpha",
         },
         nil, // default options
@@ -1155,9 +1155,9 @@ func setupHTTP(kernel *Kernel) *http.ServeMux {
 ### File Organization
 
 ```
-apps/cogos-v3/
+apps/cogos/
 ├── cmd/
-│   └── cogos-v3/
+│   └── cogos/
 │       └── main.go          # Entrypoint, flag parsing
 ├── internal/
 │   ├── kernel/

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -23,12 +23,12 @@
 ## Installing from a release
 ```sh
 # macOS (Apple Silicon)
-curl -L https://github.com/cogos-dev/cogos/releases/latest/download/cogos-darwin-arm64 -o cogos
+curl -L https://github.com/myrgic/cogos/releases/latest/download/cogos-darwin-arm64 -o cogos
 chmod +x cogos
 ./cogos serve
 
 # Linux
-curl -L https://github.com/cogos-dev/cogos/releases/latest/download/cogos-linux-amd64 -o cogos
+curl -L https://github.com/myrgic/cogos/releases/latest/download/cogos-linux-amd64 -o cogos
 chmod +x cogos
 ./cogos serve
 
@@ -48,13 +48,13 @@ Pick the right architecture for your machine (most users want `amd64`; `arm64` i
 Using PowerShell:
 ```powershell
 # amd64 (x86-64)
-Invoke-WebRequest -Uri https://github.com/cogos-dev/cogos/releases/latest/download/cogos-windows-amd64.exe -OutFile cogos.exe
+Invoke-WebRequest -Uri https://github.com/myrgic/cogos/releases/latest/download/cogos-windows-amd64.exe -OutFile cogos.exe
 
 # arm64
-Invoke-WebRequest -Uri https://github.com/cogos-dev/cogos/releases/latest/download/cogos-windows-arm64.exe -OutFile cogos.exe
+Invoke-WebRequest -Uri https://github.com/myrgic/cogos/releases/latest/download/cogos-windows-arm64.exe -OutFile cogos.exe
 ```
 
-Or download manually from the [latest release](https://github.com/cogos-dev/cogos/releases/latest) and rename to `cogos.exe`.
+Or download manually from the [latest release](https://github.com/myrgic/cogos/releases/latest) and rename to `cogos.exe`.
 
 Verify the SHA-256 against `checksums.txt` from the same release:
 ```powershell

--- a/docs/SYSTEM-SPEC.md
+++ b/docs/SYSTEM-SPEC.md
@@ -102,7 +102,7 @@ Afferent pipeline that accepts raw external material and converts it into substr
 
 ### Embodiment / modality
 
-The embodiment layer transduces between raw physical/channel signals and normalized cognitive events. [Mod³](https://github.com/cogos-dev/mod3) handles TTS with adaptive playback and speech queuing. The afferent path (STT, VAD) feeds the same attentional field.
+The embodiment layer transduces between raw physical/channel signals and normalized cognitive events. [Mod³](https://github.com/myrgic/mod3) handles TTS with adaptive playback and speech queuing. The afferent path (STT, VAD) feeds the same attentional field.
 
 ---
 
@@ -110,7 +110,7 @@ The embodiment layer transduces between raw physical/channel signals and normali
 
 ### Identity as dynamical property
 
-Identity is coherence with history — not a static credential. The [Constellation Protocol](https://github.com/cogos-dev/constellation) implements this:
+Identity is coherence with history — not a static credential. The [Constellation Protocol](https://github.com/myrgic/constellation) implements this:
 
 - **Publicly verifiable**: any peer can check a node's state in O(1)
 - **Privately irreproducible**: cannot be forged without the full hash chain
@@ -158,9 +158,9 @@ Each subsystem is its own repo, its own release cycle, its own organelle:
 
 | Repo | Role |
 |------|------|
-| [cogos-dev/cogos](https://github.com/cogos-dev/cogos) | Kernel — continuous process daemon |
-| [cogos-dev/constellation](https://github.com/cogos-dev/constellation) | Identity & trust protocol |
-| [cogos-dev/mod3](https://github.com/cogos-dev/mod3) | Modality server (TTS, VAD, speech queuing) |
+| [myrgic/cogos](https://github.com/myrgic/cogos) | Kernel — continuous process daemon |
+| [myrgic/constellation](https://github.com/myrgic/constellation) | Identity & trust protocol |
+| [myrgic/mod3](https://github.com/myrgic/mod3) | Modality server (TTS, VAD, speech queuing) |
 
 Organelles coordinate through the substrate, not through imports. Discovery happens at runtime through capability scanning.
 

--- a/docs/architecture-diagram-source.md
+++ b/docs/architecture-diagram-source.md
@@ -258,7 +258,7 @@ Same three operations at every level: fork, merge, die.
 
 ```
     ┌────────────────────────────────────────────────────────────┐
-    │                    cogos-dev (org)                          │
+    │                    myrgic (org)                          │
     │                    Canonical upstream                       │
     │                                                            │
     │   ┌──────────────┐  ┌──────────────┐  ┌──────────────┐   │

--- a/docs/architecture/cognitive-gitops.md
+++ b/docs/architecture/cognitive-gitops.md
@@ -52,9 +52,9 @@ Each platform (Jenkins, GitHub Actions, GitLab, AWS) is a node in the cognitive 
 ## Current Ecosystem
 
 ```
-cogos-dev/cogos          → kernel (Go, public)
-cogos-dev/constellation  → identity & trust (Go, public)
-cogos-dev/mod3           → modality server (Python, public)
+myrgic/cogos          → kernel (Go, public)
+myrgic/constellation  → identity & trust (Go, public)
+myrgic/mod3           → modality server (Python, public)
 ```
 
 Each repo stands alone. They don't import each other. The workspace discovers them at runtime through capability scanning — like Kubernetes service discovery, but through content-addressed artifacts and attentional salience instead of DNS and labels.

--- a/docs/architecture/the-constellation.md
+++ b/docs/architecture/the-constellation.md
@@ -1,6 +1,6 @@
 # The Constellation
 
-The Constellation is one substrate. What the codebase calls `constellation.db` and what the public `cogos-dev/constellation` repo calls "the identity protocol" are two node populations over the same architecture, not two systems. This doc formalizes that framing and names what Constellation means as a term of art inside CogOS.
+The Constellation is one substrate. What the codebase calls `constellation.db` and what the public `myrgic/constellation` repo calls "the identity protocol" are two node populations over the same architecture, not two systems. This doc formalizes that framing and names what Constellation means as a term of art inside CogOS.
 
 The framing landed on 2026-04-22, in the same arc that produced `channels-and-buses.md` and `identity-cycle.md`. It resolves what looked like a naming collision (kernel memory-graph vs. identity-protocol repo, both called "constellation") into a single architectural claim: the primitives converged because the primitives are what the substrate actually needs. The repos stay where they are. The term stops being ambiguous.
 
@@ -8,7 +8,7 @@ The framing landed on 2026-04-22, in the same arc that produced `channels-and-bu
 
 The Constellation is a hash-chained, git-backed event ledger plus a peer/reference graph indexed out of it plus EMA-weighted signals over the relationships. Everything that lives in CogOS's coordination layer — cogdocs, identities, channels, sessions, agents, peer nodes — is a node population in that one substrate. Edges between populations (references, trust attestations, attendance, mentions, derivations) compose freely because they share primitives. Signals over edges (attention, trust, salience) are all exponential moving averages over the same ledger.
 
-One substrate, many projections. The kernel's memory-graph is the cogdoc-and-reference projection. The `cogos-dev/constellation` reference implementation is the trust-node projection. Neither is the whole Constellation; both are views of it.
+One substrate, many projections. The kernel's memory-graph is the cogdoc-and-reference projection. The `myrgic/constellation` reference implementation is the trust-node projection. Neither is the whole Constellation; both are views of it.
 
 **Confidence: consensus (within this codebase and session).** The unification is verified at the primitive level (see § Shared Primitives below); the application to new populations (channels, sessions as nodes) is still a design target, not yet in code.
 
@@ -35,10 +35,10 @@ A node in the Constellation is anything the ledger can refer to by a stable iden
 
 - **Cogdocs** — `.cog.md` files under `.cog/mem/`, indexed in `constellation.db`. The oldest and most numerous population. Already production.
 - **Identities** — keyed by NodeID (SHA-256 of pubkey DER in the trust-node projection). Today's kernel tracks a subset via session records; the trust-node projection specifies the full node lifecycle.
-- **Channels** — first-class node type proposed by the channel-provider-interface RFC (`/Users/slowbro/workspaces/cog/.cog/mem/semantic/designs/channel-provider-interface.cog.md`). Storage: cogdocs under `.cog/mem/procedural/channels/`. Not yet implemented.
+- **Channels** — first-class node type proposed by the channel-provider-interface RFC (`${COGOS_WORKSPACE:-$HOME/workspaces/cog}/.cog/mem/semantic/designs/channel-provider-interface.cog.md`). Storage: cogdocs under `.cog/mem/procedural/channels/`. Not yet implemented.
 - **Sessions** — currently tracked by kernel session records; not yet canonicalized as Constellation nodes. Candidate for promotion.
 - **Agents** — partially represented (identity cards in `cog://agents/`, session records). No canonical node form yet; would compose from identity + session populations.
-- **Peer nodes** — remote CogOS instances federated via the trust-node projection. Today only present in the `cogos-dev/constellation` reference implementation; not yet integrated into the kernel's memory-graph.
+- **Peer nodes** — remote CogOS instances federated via the trust-node projection. Today only present in the `myrgic/constellation` reference implementation; not yet integrated into the kernel's memory-graph.
 
 The list is extensible by design. Adding a population does not require a substrate change — only a node type, a storage convention, and edge schemas. The Constellation's invariants (hash-chain integrity, EMA decay, tree-hash fingerprinting) apply automatically.
 
@@ -76,7 +76,7 @@ Trace a single event through the substrate to see populations interact.
 
 1. **Session registers.** The agent calls `cogos_session_register`. A session node enters the constellation (today via the kernel's session records; under the channel-provider RFC, also as a `type: channel` cogdoc's `attendance` field). A canonical-JSON event lands on the ledger; `prior_hash` chains to the previous event; the tree hash of `events/` advances.
 
-2. **User message arrives on the channel.** A `chat.request` block hits the gateway. `constellation_bus.go` (see `/Users/slowbro/workspaces/cogos-dev/cogos/constellation_bus.go`) indexes the content into the FTS-backed constellation database. Node population: event (bus block). Edges: event → session, event → user identity (by `user_id`/`user_name` payload fields). Signal update: the session's attention-EMA ticks.
+2. **User message arrives on the channel.** A `chat.request` block hits the gateway. `constellation_bus.go` (see `${MYRGIC_REPOS_ROOT:-$HOME/workspaces/myrgic}/cogos/constellation_bus.go`) indexes the content into the FTS-backed constellation database. Node population: event (bus block). Edges: event → session, event → user identity (by `user_id`/`user_name` payload fields). Signal update: the session's attention-EMA ticks.
 
 3. **Agent reads a cogdoc.** The agent queries `cogos_memory_search` and reads `cog://mem/semantic/.../some-insight.cog.md`. Population: cogdoc. Edge: event → cogdoc (a "read" relation, implicit today, explicit under the attention-EMA design). Signal update: the cogdoc's attention decay bumps upward.
 
@@ -130,9 +130,9 @@ From `identity-cycle.md`:
 
 Both neighboring docs assume a substrate. This doc names it.
 
-## The cogos-dev/constellation Repo's Role
+## The myrgic/constellation Repo's Role
 
-The public repo `cogos-dev/constellation` (at `/Users/slowbro/workspaces/cogos-dev/constellation/`) is the **canonical specification and reference implementation for the trust-node projection**. It stays published. It is not renamed. It is not deprecated. It is not a competitor to the kernel's memory-graph — it is specifying the trust semantics the kernel will eventually run natively over the same Constellation substrate.
+The public repo `myrgic/constellation` (at `${MYRGIC_REPOS_ROOT:-$HOME/workspaces/myrgic}/constellation/`) is the **canonical specification and reference implementation for the trust-node projection**. It stays published. It is not renamed. It is not deprecated. It is not a competitor to the kernel's memory-graph — it is specifying the trust semantics the kernel will eventually run natively over the same Constellation substrate.
 
 Why keep it separate as a repo even though the architecture is unified:
 
@@ -148,7 +148,7 @@ The convergence — running the trust-node semantics natively inside the kernel 
 
 To avoid overclaiming: this doc unifies the **architecture**, not the **code**.
 
-- **The code paths are still separate.** The memory-graph's indexing (`sdk/constellation/`, writes from `cog memory write`) and the trust-node projection's heartbeat loop (in the `cogos-dev/constellation` repo) run in different parts of the kernel process, or entirely different processes. They share the bridge but not the event loop.
+- **The code paths are still separate.** The memory-graph's indexing (`sdk/constellation/`, writes from `cog memory write`) and the trust-node projection's heartbeat loop (in the `myrgic/constellation` repo) run in different parts of the kernel process, or entirely different processes. They share the bridge but not the event loop.
 - **The 5-second heartbeat and the memory-graph's event ingestion are on different clocks today.** The trust-node projection emits a fresh heartbeat every 5 seconds by design (frequent, cheap, consistency-checking). The memory-graph writes when a cogdoc changes (on edit). Both feed the same ledger shape conceptually; operationally, they feed different ledgers today.
 - **No migration is specified here.** This doc does not say "delete constellation.db and replace it with the protocol repo's ledger." It says the primitives are the same. Convergence is a design target; the migration is its own RFC.
 - **Not every subsystem that touches the ledger is "in" the Constellation.** The bus layer writes ledger events; the kernel's scheduler reads them; the bridge emits fingerprints. Whether each of those is *part of* the Constellation or *adjacent to* it is an open boundary question. The substrate-vs-service distinction (see `channels-and-buses.md` § Providers per Kind — "Bus is not a reconciled resource. It is a service.") applies: the Constellation is the substrate; everything else is service.
@@ -174,8 +174,8 @@ To avoid overclaiming: this doc unifies the **architecture**, not the **code**.
 
 Two concrete tracks follow from this framing.
 
-**Near-term (design landed, code pending).** The channel-provider RFC at `/Users/slowbro/workspaces/cog/.cog/mem/semantic/designs/channel-provider-interface.cog.md` is the first adoption of this framing at the code level. It treats channels as a new node population in the Constellation, with attendance as the edge type and an attention-EMA as the signal — exactly the shape this doc makes generic. Adopting the RFC and prototyping the first `audio`-kind provider (mod3) validates whether the unified framing holds under implementation pressure.
+**Near-term (design landed, code pending).** The channel-provider RFC at `${COGOS_WORKSPACE:-$HOME/workspaces/cog}/.cog/mem/semantic/designs/channel-provider-interface.cog.md` is the first adoption of this framing at the code level. It treats channels as a new node population in the Constellation, with attendance as the edge type and an attention-EMA as the signal — exactly the shape this doc makes generic. Adopting the RFC and prototyping the first `audio`-kind provider (mod3) validates whether the unified framing holds under implementation pressure.
 
-**Medium-term (convergence).** The larger work is running the trust-node projection's semantics natively in the kernel over the same `constellation.db` the memory-graph uses. Concretely: promote the kernel's session-record surface into a first-class identity-node table (with the columns the trust-node projection specifies); wire the 5-second heartbeat loop into the kernel's process state; teach the memory-graph indexer to emit events into the same `events/{seq:08d}.json` ledger shape the trust-node projection already uses; keep the public `cogos-dev/constellation` repo as the specification the kernel implements. When that lands, "the Constellation" stops being an architectural claim layered over two implementations and becomes one running system. The bridge interface at `internal/engine/constellation_bridge.go` is the seam where that convergence will happen.
+**Medium-term (convergence).** The larger work is running the trust-node projection's semantics natively in the kernel over the same `constellation.db` the memory-graph uses. Concretely: promote the kernel's session-record surface into a first-class identity-node table (with the columns the trust-node projection specifies); wire the 5-second heartbeat loop into the kernel's process state; teach the memory-graph indexer to emit events into the same `events/{seq:08d}.json` ledger shape the trust-node projection already uses; keep the public `myrgic/constellation` repo as the specification the kernel implements. When that lands, "the Constellation" stops being an architectural claim layered over two implementations and becomes one running system. The bridge interface at `internal/engine/constellation_bridge.go` is the seam where that convergence will happen.
 
 Neither of those tracks is this doc's scope to execute. This doc is scope-setting: naming the substrate, making the populations explicit, making the shared primitives visible, so that future design work inherits the framing rather than re-deriving it each time.

--- a/docs/rfc-drafts/mod3-bus-sessions-subscription.md
+++ b/docs/rfc-drafts/mod3-bus-sessions-subscription.md
@@ -1,8 +1,8 @@
 # RFC Draft: mod3 subscribes to bus_sessions for cross-session voice presence
 
 **Status:** Draft — awaiting review and RFC number assignment  
-**Closes:** cogos-dev/cogos#156  
-**Depends on:** cogos-dev/cogos#154 (bus_sessions read path must be live before this data path is useful)  
+**Closes:** myrgic/cogos#156  
+**Depends on:** myrgic/cogos#154 (bus_sessions read path must be live before this data path is useful)  
 **Scope:** Design only — no implementation in this document
 
 ---
@@ -189,7 +189,7 @@ Mod3 maintains a new in-memory map `_bus_session_state`:
 {
     "slowbro-laptop-cogos-gap-closure": {
         "session_id": "slowbro-laptop-cogos-gap-closure",
-        "workspace": "/Users/slowbro/workspaces/cog",
+        "workspace": "${COGOS_WORKSPACE:-$HOME/workspaces/cog}",
         "role": "claude-code",
         "status": "active",
         "last_seen": <unix epoch float>,
@@ -265,7 +265,7 @@ returns current channel membership with joined agent-session state:
       "agent_session_id": "slowbro-laptop-cogos-gap-closure",
       "assigned_voice": "bm_lewis",
       "state": "speaking",
-      "workspace": "/Users/slowbro/workspaces/cog",
+      "workspace": "${COGOS_WORKSPACE:-$HOME/workspaces/cog}",
       "role": "claude-code",
       "agent_active": true,
       "last_seen": 1746212345.678
@@ -276,7 +276,7 @@ returns current channel membership with joined agent-session state:
       "agent_session_id": "slowbro-laptop-eval-runner",
       "assigned_voice": "af_heart",
       "state": "idle",
-      "workspace": "/Users/slowbro/workspaces/cogos-dev",
+      "workspace": "${MYRGIC_REPOS_ROOT:-$HOME/workspaces/myrgic}",
       "role": "claude-code",
       "agent_active": true,
       "last_seen": 1746212300.123
@@ -310,7 +310,7 @@ The section renders as:
 ```
 VOICE-CHANNEL CO-PRESENCE:
   channel general — 2 agents
-    af_heart (eval-runner, idle)  workspace: /Users/slowbro/workspaces/cogos-dev
+    af_heart (eval-runner, idle)  workspace: ${MYRGIC_REPOS_ROOT:-$HOME/workspaces/myrgic}
 ```
 
 The kernel calls mod3's `/v1/channels/{id}/peers` with a configurable timeout

--- a/docs/rfc-drafts/workspace-node-relationship.md
+++ b/docs/rfc-drafts/workspace-node-relationship.md
@@ -1,8 +1,8 @@
 # RFC Draft: workspace ⟷ node relationship (N:M)
 
 **Status:** Draft — awaiting review and RFC number assignment
-**Closes:** cogos-dev/cogos#160
-**Companion:** cogos-dev/cogos#161 (mechanical on-disk demonstration)
+**Closes:** myrgic/cogos#160
+**Companion:** myrgic/cogos#161 (mechanical on-disk demonstration)
 **Scope:** Design only — no implementation in this document
 
 ---
@@ -204,7 +204,7 @@ in the workspace, not in the node-only subtree.
 ### 5.2 Project workspace
 
 ```
-~/workspaces/cogos-dev/cogos/
+~/workspaces/myrgic/cogos/
 └── .cog/
     ├── config/
     │   └── node/
@@ -230,7 +230,7 @@ Node 1 (~/.cog/node/global.yaml):
   workspaces:
     - path: /Users/alice
       workspace_id: ws-abc123
-    - path: /Users/alice/workspaces/cogos-dev
+    - path: /Users/alice/workspaces/myrgic
       workspace_id: ws-def456
 
 Node 2 (~/.cog/node/global.yaml):

--- a/envspec/go.mod
+++ b/envspec/go.mod
@@ -1,3 +1,3 @@
-module github.com/cogos-dev/cogos/envspec
+module github.com/myrgic/cogos/envspec
 
 go 1.24

--- a/eval_wiring.go
+++ b/eval_wiring.go
@@ -19,9 +19,9 @@ package main
 import (
 	"time"
 
-	"github.com/cogos-dev/cogos/internal/engine"
-	"github.com/cogos-dev/cogos/internal/eval"
-	"github.com/cogos-dev/cogos/pkg/reconcile"
+	"github.com/myrgic/cogos/internal/engine"
+	"github.com/myrgic/cogos/internal/eval"
+	"github.com/myrgic/cogos/pkg/reconcile"
 )
 
 // evalProviderInstance is the singleton EvalProvider registered with the

--- a/go.mod
+++ b/go.mod
@@ -7,20 +7,23 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/coder/websocket v1.8.14
-	github.com/myrgic/cogos/envspec v0.0.0
-	github.com/myrgic/cogos/harness v0.0.0
-	github.com/myrgic/cogos/pkg/cogfield v0.0.0
-	github.com/myrgic/cogos/sdk v0.0.0
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-git/go-git/v5 v5.16.4
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/mattn/go-sqlite3 v1.14.24
 	github.com/modelcontextprotocol/go-sdk v1.5.0
+	github.com/myrgic/cogos/envspec v0.0.0
+	github.com/myrgic/cogos/harness v0.0.0
+	github.com/myrgic/cogos/pkg/cogblock v0.0.0-00010101000000-000000000000
+	github.com/myrgic/cogos/pkg/cogfield v0.0.0
+	github.com/myrgic/cogos/pkg/coordination v0.0.0-00010101000000-000000000000
+	github.com/myrgic/cogos/pkg/modality v0.0.0-00010101000000-000000000000
+	github.com/myrgic/cogos/pkg/reconcile v0.0.0-00010101000000-000000000000
+	github.com/myrgic/cogos/sdk v0.0.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
-	github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82
 	github.com/zclconf/go-cty v1.17.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0
@@ -31,6 +34,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/net v0.52.0
+	golang.org/x/sys v0.42.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
 	oras.land/oras-go/v2 v2.6.0
@@ -88,7 +92,6 @@ require (
 	golang.org/x/mod v0.33.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	golang.org/x/tools v0.42.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
@@ -104,3 +107,15 @@ replace github.com/myrgic/cogos/harness => ./harness
 replace github.com/myrgic/cogos/envspec => ./envspec
 
 replace github.com/myrgic/cogos/pkg/cogfield => ./pkg/cogfield
+
+replace github.com/myrgic/cogos/pkg/cogblock => ./pkg/cogblock
+
+replace github.com/myrgic/cogos/pkg/coordination => ./pkg/coordination
+
+replace github.com/myrgic/cogos/pkg/modality => ./pkg/modality
+
+replace github.com/myrgic/cogos/pkg/reconcile => ./pkg/reconcile
+
+replace github.com/myrgic/cogos/pkg/uri => ./pkg/uri
+
+replace github.com/myrgic/cogos/pkg/bep => ./pkg/bep

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cogos-dev/cogos
+module github.com/myrgic/cogos
 
 go 1.25.0
 
@@ -7,10 +7,10 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/coder/websocket v1.8.14
-	github.com/cogos-dev/cogos/envspec v0.0.0
-	github.com/cogos-dev/cogos/harness v0.0.0
-	github.com/cogos-dev/cogos/pkg/cogfield v0.0.0
-	github.com/cogos-dev/cogos/sdk v0.0.0
+	github.com/myrgic/cogos/envspec v0.0.0
+	github.com/myrgic/cogos/harness v0.0.0
+	github.com/myrgic/cogos/pkg/cogfield v0.0.0
+	github.com/myrgic/cogos/sdk v0.0.0
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-git/go-git/v5 v5.16.4
 	github.com/google/uuid v1.6.0
@@ -97,10 +97,10 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )
 
-replace github.com/cogos-dev/cogos/sdk => ./sdk
+replace github.com/myrgic/cogos/sdk => ./sdk
 
-replace github.com/cogos-dev/cogos/harness => ./harness
+replace github.com/myrgic/cogos/harness => ./harness
 
-replace github.com/cogos-dev/cogos/envspec => ./envspec
+replace github.com/myrgic/cogos/envspec => ./envspec
 
-replace github.com/cogos-dev/cogos/pkg/cogfield => ./pkg/cogfield
+replace github.com/myrgic/cogos/pkg/cogfield => ./pkg/cogfield

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,6 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
-github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82 h1:6C8qej6f1bStuePVkLSFxoU22XBS165D3klxlzRg8F4=
-github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82/go.mod h1:xe4pgH49k4SsmkQq5OT8abwhWmnzkhpgnXeekbx2efw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/go.work
+++ b/go.work
@@ -2,6 +2,8 @@ go 1.25.0
 
 use (
 	.
+	./envspec
+	./harness
 	./pkg/bep
 	./pkg/cogblock
 	./pkg/cogfield

--- a/harness/go.mod
+++ b/harness/go.mod
@@ -1,4 +1,4 @@
-module github.com/cogos-dev/cogos/harness
+module github.com/myrgic/cogos/harness
 
 go 1.24.0
 

--- a/identity_crd.go
+++ b/identity_crd.go
@@ -44,7 +44,7 @@ type IdentityCRDMeta struct {
 
 // IdentityCRDSpec holds the OIDC-shaped identity body.
 //
-//	Issuer     — OIDC `iss`; who minted this identity (e.g., "cogos-dev",
+//	Issuer     — OIDC `iss`; who minted this identity (e.g., "myrgic",
 //	             "https://accounts.google.com", "node:<hostname>", or a
 //	             federation URL). Required.
 //	Subject    — OIDC `sub`; globally stable identifier for the principal.

--- a/inference.go
+++ b/inference.go
@@ -27,7 +27,7 @@ import (
 	"sync"
 	"time"
 
-	sdk "github.com/cogos-dev/cogos/sdk"
+	sdk "github.com/myrgic/cogos/sdk"
 )
 
 // === INFERENCE REQUEST/RESPONSE TYPES ===

--- a/internal/engine/autonomic_ticker.go
+++ b/internal/engine/autonomic_ticker.go
@@ -26,7 +26,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/cogos-dev/cogos/pkg/reconcile"
+	"github.com/myrgic/cogos/pkg/reconcile"
 )
 
 // --- Constants ---------------------------------------------------------------

--- a/internal/engine/autonomic_ticker_test.go
+++ b/internal/engine/autonomic_ticker_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cogos-dev/cogos/pkg/reconcile"
+	"github.com/myrgic/cogos/pkg/reconcile"
 )
 
 // Ensure json and http/httptest are used (used in test helper functions below).

--- a/internal/engine/bus_session.go
+++ b/internal/engine/bus_session.go
@@ -30,7 +30,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cogos-dev/cogos/pkg/cogfield"
+	"github.com/myrgic/cogos/pkg/cogfield"
 )
 
 // eventsFileMaxBytes is the size threshold that triggers a size-based rotation

--- a/internal/engine/cli_reconcile.go
+++ b/internal/engine/cli_reconcile.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/cogos-dev/cogos/pkg/reconcile"
+	"github.com/myrgic/cogos/pkg/reconcile"
 )
 
 // runReconcileCmd dispatches "cogos reconcile <type> [flags]".

--- a/internal/engine/cogblock.go
+++ b/internal/engine/cogblock.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/cogos-dev/cogos/pkg/cogblock"
+	"github.com/myrgic/cogos/pkg/cogblock"
 )
 
 // CogBlock is the engine-local CogBlock that includes typed Messages.

--- a/internal/engine/context_blocks_health.go
+++ b/internal/engine/context_blocks_health.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cogos-dev/cogos/pkg/reconcile"
+	"github.com/myrgic/cogos/pkg/reconcile"
 )
 
 // healthProbeTimeout is the per-provider Health() timeout. Health() is

--- a/internal/engine/context_blocks_health_test.go
+++ b/internal/engine/context_blocks_health_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cogos-dev/cogos/pkg/reconcile"
+	"github.com/myrgic/cogos/pkg/reconcile"
 )
 
 // stubProvider is a minimal Reconcilable used for unit-testing the health

--- a/internal/engine/daemon_lifecycle.go
+++ b/internal/engine/daemon_lifecycle.go
@@ -23,7 +23,7 @@ const (
 	daemonModeBareMetal = "bare-metal"
 	daemonModeContainer = "container"
 
-	defaultDaemonImage = "cogos/kernel-v3:dev"
+	defaultDaemonImage = "ghcr.io/myrgic/cogos:dev"
 	stateHealthTimeout = 1500 * time.Millisecond
 )
 

--- a/internal/engine/defaults/kernel.yaml
+++ b/internal/engine/defaults/kernel.yaml
@@ -1,5 +1,5 @@
 # CogOS kernel configuration
-# See docs for all options: https://github.com/cogos-dev/cogos
+# See docs for all options: https://github.com/myrgic/cogos
 
 port: 6931
 consolidation_interval: 3600  # seconds between consolidation sweeps

--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -79,7 +79,7 @@ type MCPServer struct {
 	// snapshotToolDefinitions (which does an in-process ListTools); read
 	// by handleChat when the kernel-agent path needs to advertise its own
 	// tools. Frozen after construction returns — read-only afterwards.
-	// See mcp_tool_defs.go and cogos-dev/cogos#89.
+	// See mcp_tool_defs.go and myrgic/cogos#89.
 	toolDefs []ToolDefinition
 }
 
@@ -125,7 +125,7 @@ func NewMCPServerWithAgentController(cfg *Config, nucleus *Nucleus, process *Pro
 	// Snapshot the registered tool list as kernel-side ToolDefinitions so the
 	// chat path can auto-advertise the kernel's MCP tool surface to the
 	// inference provider when the request targets the kernel-agent route
-	// without supplying its own tools (cogos-dev/cogos#89). Best-effort: a
+	// without supplying its own tools (myrgic/cogos#89). Best-effort: a
 	// snapshot failure logs a warning and leaves m.toolDefs nil — chat falls
 	// back to the previous behavior (no tools advertised) without breaking.
 	m.toolDefs = snapshotToolDefinitions(server)

--- a/internal/engine/mcp_tool_defs.go
+++ b/internal/engine/mcp_tool_defs.go
@@ -12,7 +12,7 @@
 // the snapshot is read-only and lock-free — registerTools has already
 // returned, so nothing mutates the set after this point.
 //
-// See cogos-dev/cogos#89 (auto-inject kernel tool registry on
+// See myrgic/cogos#89 (auto-inject kernel tool registry on
 // `model: kernel-agent`) for the user-visible motivation.
 package engine
 

--- a/internal/engine/pin_adapter_test.go
+++ b/internal/engine/pin_adapter_test.go
@@ -9,7 +9,7 @@
 // They are the tests that would have caught the bug reported in the Codex
 // review of PR #180 (#175 fixup): ResolveWorkspacePath was building
 // "cog://"+name and calling URIRegistry.Resolve, which splits the authority
-// at the first slash, so "cogos-dev/cogos" was looked up as "cogos-dev"
+// at the first slash, so "myrgic/cogos" was looked up as "myrgic"
 // instead of the full slash-bearing key.
 //
 // These tests must fail on the pre-fix code (Resolve round-trip) and pass
@@ -40,7 +40,7 @@ func (a *realAdapterLocator) LocateWorkspace(ctx context.Context, name string) (
 	return path, nil
 }
 
-// setupSlashNameRegistry writes a global.yaml with "cogos-dev/cogos" as a
+// setupSlashNameRegistry writes a global.yaml with "myrgic/cogos" as a
 // workspace, swaps URIRegistry for the duration of the test, creates the
 // workspace directory, and returns its path.
 func setupSlashNameRegistry(t *testing.T) (targetDir string) {
@@ -51,13 +51,13 @@ func setupSlashNameRegistry(t *testing.T) (targetDir string) {
 		t.Fatal(err)
 	}
 
-	targetDir = filepath.Join(base, "cogos-dev", "cogos")
+	targetDir = filepath.Join(base, "myrgic", "cogos")
 	if err := os.MkdirAll(targetDir, 0755); err != nil {
 		t.Fatal(err)
 	}
 
 	global := "version: \"1.0\"\nworkspaces:\n" +
-		"  cogos-dev/cogos:\n    path: " + targetDir + "\n"
+		"  myrgic/cogos:\n    path: " + targetDir + "\n"
 	if err := os.WriteFile(filepath.Join(nd, "global.yaml"), []byte(global), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -74,16 +74,16 @@ func setupSlashNameRegistry(t *testing.T) (targetDir string) {
 // for the Codex finding on PR #180.
 //
 // It wires the real engine.ResolveWorkspacePath adapter (not a stub) against a
-// registry containing "cogos-dev/cogos" (slash-bearing), creates a minimal git
+// registry containing "myrgic/cogos" (slash-bearing), creates a minimal git
 // repo at that path, and asserts that pin FetchLive resolves HEAD without
 // error.
 //
-// Without the fix, ResolveWorkspacePath calls URIRegistry.Resolve("cog://cogos-dev/cogos"),
-// which splits authority at "/" → looks up "cogos-dev" → workspace not found →
+// Without the fix, ResolveWorkspacePath calls URIRegistry.Resolve("cog://myrgic/cogos"),
+// which splits authority at "/" → looks up "myrgic" → workspace not found →
 // returns ErrUnknownAuthority → pin.LocateWorkspace returns ErrWorkspaceNotFound
 // → FetchLive falls back to sibling scan → no sibling found → error.
 //
-// With the fix, ResolveWorkspacePath calls resolveAuthority("cogos-dev/cogos")
+// With the fix, ResolveWorkspacePath calls resolveAuthority("myrgic/cogos")
 // directly → global.yaml lookup succeeds → returns targetDir → FetchLive resolves HEAD.
 func TestPinAdapter_SlashBearingWorkspaceName(t *testing.T) {
 	targetDir := setupSlashNameRegistry(t)
@@ -101,13 +101,13 @@ func TestPinAdapter_SlashBearingWorkspaceName(t *testing.T) {
 		}
 	}
 
-	// Set up source workspace with a pin targeting "cogos-dev/cogos".
+	// Set up source workspace with a pin targeting "myrgic/cogos".
 	source := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(source, ".cog", "pins"), 0755); err != nil {
 		t.Fatal(err)
 	}
-	pinYAML := "target: cogos-dev/cogos\npin:\n  ref: abc1234567890abcdef1234567890abcdef123456\nsync: read-only\n"
-	if err := os.WriteFile(filepath.Join(source, ".cog", "pins", "cogos-dev_cogos.yaml"), []byte(pinYAML), 0644); err != nil {
+	pinYAML := "target: myrgic/cogos\npin:\n  ref: abc1234567890abcdef1234567890abcdef123456\nsync: read-only\n"
+	if err := os.WriteFile(filepath.Join(source, ".cog", "pins", "myrgic_cogos.yaml"), []byte(pinYAML), 0644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/engine/pin_adapter_test.go
+++ b/internal/engine/pin_adapter_test.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/cogos-dev/cogos/internal/providers/pin"
+	"github.com/myrgic/cogos/internal/providers/pin"
 )
 
 // realAdapterLocator adapts engine.ResolveWorkspacePath to pin.WorkspaceLocator.

--- a/internal/engine/process.go
+++ b/internal/engine/process.go
@@ -28,7 +28,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cogos-dev/cogos/trace"
+	"github.com/myrgic/cogos/trace"
 	"github.com/google/uuid"
 )
 

--- a/internal/engine/provider_claudecode_test.go
+++ b/internal/engine/provider_claudecode_test.go
@@ -340,7 +340,7 @@ func TestParseStreamLine_ErrorResult(t *testing.T) {
 
 // TestComplete_ContextCancel_KillsSubprocess verifies that cancelling the
 // context actually kills the subprocess instead of leaving cmd.Wait() stuck in
-// waitpid(2). This is the regression test for cogos-dev/cogos#79.
+// waitpid(2). This is the regression test for myrgic/cogos#79.
 //
 // Strategy: point cliBinary at a tiny shell wrapper that ignores all its
 // arguments and just sleeps for 30 s. Cancel the context after 50 ms and

--- a/internal/engine/provider_mlx_supervised.go
+++ b/internal/engine/provider_mlx_supervised.go
@@ -60,7 +60,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cogos-dev/cogos/pkg/reconcile"
+	"github.com/myrgic/cogos/pkg/reconcile"
 )
 
 // mlxSupervisedType is the value of ProviderConfig.Type that activates this driver.

--- a/internal/engine/provider_mlx_supervised_test.go
+++ b/internal/engine/provider_mlx_supervised_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cogos-dev/cogos/pkg/reconcile"
+	"github.com/myrgic/cogos/pkg/reconcile"
 )
 
 // ── helpers ────────────────────────────────────────────────────────────────────

--- a/internal/engine/router.go
+++ b/internal/engine/router.go
@@ -23,7 +23,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/cogos-dev/cogos/pkg/reconcile"
+	"github.com/myrgic/cogos/pkg/reconcile"
 	"gopkg.in/yaml.v3"
 )
 

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -753,7 +753,7 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 		// baseline), then any other provider with IsLocal=true. If no local
 		// provider is registered, fall through to default routing and warn so
 		// operators notice (silent cloud routing under a "local" alias is the
-		// bug this fixes; see cogos-dev/cogos#75).
+		// bug this fixes; see myrgic/cogos#75).
 		if name, ok := s.router.ProviderForName("ollama"); ok {
 			creq.Metadata.PreferProvider = name
 		} else if name, ok := s.router.FirstLocalProvider(); ok {
@@ -774,7 +774,7 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 		// see .cog/scratch/audit-inference-paths/REPORT.md.
 		creq.Metadata.PreferProvider = "ollama"
 		// Auto-inject the kernel's MCP tool registry when the client did not
-		// supply tools of its own. Closes cogos-dev/cogos#89: the dashboard's
+		// supply tools of its own. Closes myrgic/cogos#89: the dashboard's
 		// chat path constructs `{model, messages, stream}` with no `tools`
 		// array, so the model receives zero tool definitions and promises
 		// tool calls that never fire. Advertising the kernel surface lets

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -49,8 +49,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cogos-dev/cogos/ui/canvas"
-	"github.com/cogos-dev/cogos/ui/dashboard"
+	"github.com/myrgic/cogos/ui/canvas"
+	"github.com/myrgic/cogos/ui/dashboard"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"

--- a/internal/engine/serve_bus.go
+++ b/internal/engine/serve_bus.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cogos-dev/cogos/pkg/cogfield"
+	"github.com/myrgic/cogos/pkg/cogfield"
 )
 
 // registerBusRoutes attaches the nine /v1/bus/* routes + the two

--- a/internal/engine/serve_internal_tools.go
+++ b/internal/engine/serve_internal_tools.go
@@ -1,7 +1,7 @@
 // serve_internal_tools.go — chat-handler glue for executing MCP-internal
 // tools (cog_*, mod3_*, ...) in-process.
 //
-// Closes cogos-dev/cogos#94. Background: #89 made the kernel auto-inject
+// Closes myrgic/cogos#94. Background: #89 made the kernel auto-inject
 // its MCP tool registry into kernel-agent chat requests so the inference
 // provider sees real tool definitions. But the chat handler still routed
 // every tool_use event to the client via OpenAI tool_calls, so the

--- a/internal/engine/serve_internal_tools_test.go
+++ b/internal/engine/serve_internal_tools_test.go
@@ -1,4 +1,4 @@
-// serve_internal_tools_test.go — coverage for cogos-dev/cogos#94 and #95:
+// serve_internal_tools_test.go — coverage for myrgic/cogos#94 and #95:
 // when a kernel-agent chat request lands and the provider emits a
 // tool_use event for an MCP-internal tool (cog_*, mod3_*, ...), the
 // kernel must execute the tool in-process, append a tool_result message,

--- a/internal/engine/serve_kernel_agent_tools.go
+++ b/internal/engine/serve_kernel_agent_tools.go
@@ -1,7 +1,7 @@
 // serve_kernel_agent_tools.go — auto-injection of the kernel's MCP tool
 // registry on the kernel-agent chat route.
 //
-// Closes cogos-dev/cogos#89 (auto-injection) and #94 (server-side execution
+// Closes myrgic/cogos#89 (auto-injection) and #94 (server-side execution
 // of injected cog_* tools instead of client forwarding).
 //
 // Background: when a chat request lands on the kernel-agent route, the

--- a/internal/engine/serve_kernel_agent_tools_test.go
+++ b/internal/engine/serve_kernel_agent_tools_test.go
@@ -1,5 +1,5 @@
 // serve_kernel_agent_tools_test.go — coverage for the kernel-agent
-// tool-registry auto-injection added in cogos-dev/cogos#89.
+// tool-registry auto-injection added in myrgic/cogos#89.
 //
 // The dashboard chat path forwards `{model, messages, stream}` with no
 // `tools` array. Before #89 the kernel-agent route would advertise zero

--- a/internal/engine/serve_local_routing_test.go
+++ b/internal/engine/serve_local_routing_test.go
@@ -1,7 +1,7 @@
 // serve_local_routing_test.go — tests for model="local" routing semantics
 // and /v1/models advertisement.
 //
-// Covers cogos-dev/cogos#75:
+// Covers myrgic/cogos#75:
 //   - model="local" pins to the "ollama" provider when one is registered.
 //   - model="local" with no local provider falls through to default routing
 //     and emits a structured warning.

--- a/internal/engine/serve_skills.go
+++ b/internal/engine/serve_skills.go
@@ -14,7 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/cogos-dev/cogos/pkg/skills"
+	"github.com/myrgic/cogos/pkg/skills"
 )
 
 // ─── Re-exported types ────────────────────────────────────────────────────────

--- a/internal/engine/uri_registry.go
+++ b/internal/engine/uri_registry.go
@@ -380,17 +380,17 @@ func verifyDigest(path, expectedHex string) error {
 // All other errors are I/O or parse failures in the global.yaml registry file.
 //
 // name must be the raw workspace name as registered in global.yaml (e.g.
-// "cogos-dev/cogos"). It must NOT be constructed as a URI authority component:
+// "myrgic/cogos"). It must NOT be constructed as a URI authority component:
 // synthesising "cog://"+name and re-parsing would split the authority at the
-// first slash, looking up "cogos-dev" instead of "cogos-dev/cogos".
+// first slash, looking up "myrgic" instead of "myrgic/cogos".
 func ResolveWorkspacePath(ctx context.Context, name string) (string, error) {
 	if URIRegistry == nil {
 		return "", fmt.Errorf("%w: URIRegistry not initialised", ErrUnknownAuthority)
 	}
 	// Type-assert to *uriRegistryImpl so we can call resolveAuthority directly
 	// with the raw name.  This avoids the "cog://"+name round-trip through
-	// Resolve → strings.Cut(rest, "/") which splits "cogos-dev/cogos" into
-	// authority="cogos-dev" and path="cogos", losing the slash-bearing key.
+	// Resolve → strings.Cut(rest, "/") which splits "myrgic/cogos" into
+	// authority="myrgic" and path="cogos", losing the slash-bearing key.
 	impl, ok := URIRegistry.(*uriRegistryImpl)
 	if !ok {
 		// Fallback for test doubles that only implement uriResolver.

--- a/internal/engine/uri_registry.go
+++ b/internal/engine/uri_registry.go
@@ -25,8 +25,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/cogos-dev/cogos/internal/workspace"
-	"github.com/cogos-dev/cogos/pkg/alias"
+	"github.com/myrgic/cogos/internal/workspace"
+	"github.com/myrgic/cogos/pkg/alias"
 )
 
 // ── uriContent and resolver interface ────────────────────────────────────────

--- a/internal/engine/uri_registry_integration_test.go
+++ b/internal/engine/uri_registry_integration_test.go
@@ -15,7 +15,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/cogos-dev/cogos/pkg/alias"
+	"github.com/myrgic/cogos/pkg/alias"
 )
 
 // ── Fixture ───────────────────────────────────────────────────────────────────

--- a/internal/engine/uri_registry_test.go
+++ b/internal/engine/uri_registry_test.go
@@ -64,7 +64,7 @@ func TestParseGlobalYAML(t *testing.T) {
 workspaces:
   cog-workspace:
     path: /home/user/workspaces/cog
-  cogos-dev/cogos:
+  myrgic/cogos:
     path: /home/user/workspaces/cogos
 `
 	got, err := parseGlobalYAML([]byte(yaml))
@@ -74,8 +74,8 @@ workspaces:
 	if got["cog-workspace"] != "/home/user/workspaces/cog" {
 		t.Errorf("cog-workspace: got %q", got["cog-workspace"])
 	}
-	if got["cogos-dev/cogos"] != "/home/user/workspaces/cogos" {
-		t.Errorf("cogos-dev/cogos: got %q", got["cogos-dev/cogos"])
+	if got["myrgic/cogos"] != "/home/user/workspaces/cogos" {
+		t.Errorf("myrgic/cogos: got %q", got["myrgic/cogos"])
 	}
 }
 
@@ -296,7 +296,7 @@ func TestResolveFragmentBeforeQuery_Rejected(t *testing.T) {
 // ── ResolveWorkspacePath: slash-bearing name regression (#175 fixup) ─────────
 
 // testNodeSetupWithSlashName creates a node dir whose global.yaml has a
-// slash-bearing workspace name ("cogos-dev/cogos"), swaps URIRegistry for the
+// slash-bearing workspace name ("myrgic/cogos"), swaps URIRegistry for the
 // duration of the test, and returns the node dir and workspace root.
 func testNodeSetupWithSlashName(t *testing.T) (nd, wsSlash string) {
 	t.Helper()
@@ -306,13 +306,13 @@ func testNodeSetupWithSlashName(t *testing.T) (nd, wsSlash string) {
 		t.Fatal(err)
 	}
 
-	wsSlash = filepath.Join(base, "cogos-dev", "cogos")
+	wsSlash = filepath.Join(base, "myrgic", "cogos")
 	if err := os.MkdirAll(wsSlash, 0755); err != nil {
 		t.Fatal(err)
 	}
 
 	global := "version: \"1.0\"\nworkspaces:\n" +
-		"  cogos-dev/cogos:\n    path: " + wsSlash + "\n"
+		"  myrgic/cogos:\n    path: " + wsSlash + "\n"
 	if err := os.WriteFile(filepath.Join(nd, "global.yaml"), []byte(global), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -328,9 +328,9 @@ func testNodeSetupWithSlashName(t *testing.T) (nd, wsSlash string) {
 // TestResolveWorkspacePathSlashBearing is the regression test for the bug found
 // by Codex review of PR #180.
 //
-// Before the fix, ResolveWorkspacePath built "cog://cogos-dev/cogos" and called
+// Before the fix, ResolveWorkspacePath built "cog://myrgic/cogos" and called
 // URIRegistry.Resolve, which split the authority at the first slash and looked
-// up workspace "cogos-dev" instead of "cogos-dev/cogos". The test would have
+// up workspace "cogos-dev" instead of "myrgic/cogos". The test would have
 // returned ErrUnknownAuthority.
 //
 // After the fix, ResolveWorkspacePath resolves the raw name directly via
@@ -338,9 +338,9 @@ func testNodeSetupWithSlashName(t *testing.T) (nd, wsSlash string) {
 func TestResolveWorkspacePathSlashBearing(t *testing.T) {
 	_, wsSlash := testNodeSetupWithSlashName(t)
 
-	got, err := ResolveWorkspacePath(context.Background(), "cogos-dev/cogos")
+	got, err := ResolveWorkspacePath(context.Background(), "myrgic/cogos")
 	if err != nil {
-		t.Fatalf("ResolveWorkspacePath(cogos-dev/cogos): %v", err)
+		t.Fatalf("ResolveWorkspacePath(myrgic/cogos): %v", err)
 	}
 	if got != wsSlash {
 		t.Errorf("path: got %q, want %q", got, wsSlash)
@@ -351,9 +351,9 @@ func TestResolveWorkspacePathSlashBearing(t *testing.T) {
 // name not in the registry returns ErrUnknownAuthority (not a panic or empty
 // string).
 func TestResolveWorkspacePathSlashBearing_NotFound(t *testing.T) {
-	testNodeSetupWithSlashName(t) // sets up URIRegistry with cogos-dev/cogos only
+	testNodeSetupWithSlashName(t) // sets up URIRegistry with myrgic/cogos only
 
-	_, err := ResolveWorkspacePath(context.Background(), "cogos-dev/other-repo")
+	_, err := ResolveWorkspacePath(context.Background(), "myrgic/other-repo")
 	if err == nil {
 		t.Fatal("expected ErrUnknownAuthority for unknown slash-bearing name, got nil")
 	}

--- a/internal/eval/provider.go
+++ b/internal/eval/provider.go
@@ -26,7 +26,7 @@ package eval
 import (
 	"context"
 
-	"github.com/cogos-dev/cogos/pkg/reconcile"
+	"github.com/myrgic/cogos/pkg/reconcile"
 )
 
 // ---------------------------------------------------------------------------

--- a/internal/eval/provider_impl.go
+++ b/internal/eval/provider_impl.go
@@ -30,7 +30,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cogos-dev/cogos/pkg/reconcile"
+	"github.com/myrgic/cogos/pkg/reconcile"
 	"gopkg.in/yaml.v3"
 )
 

--- a/internal/eval/provider_test.go
+++ b/internal/eval/provider_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cogos-dev/cogos/pkg/reconcile"
+	"github.com/myrgic/cogos/pkg/reconcile"
 )
 
 // ---------------------------------------------------------------------------

--- a/internal/providers/component/component_provider.go
+++ b/internal/providers/component/component_provider.go
@@ -23,8 +23,8 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/cogos-dev/cogos/internal/workspace"
-	"github.com/cogos-dev/cogos/pkg/reconcile"
+	"github.com/myrgic/cogos/internal/workspace"
+	"github.com/myrgic/cogos/pkg/reconcile"
 )
 
 // --- Dependency-injection seams ----------------------------------------------

--- a/internal/providers/daemon/daemon.go
+++ b/internal/providers/daemon/daemon.go
@@ -41,11 +41,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cogos-dev/cogos/internal/providers/pin"
-	"github.com/cogos-dev/cogos/pkg/reconcile"
+	"github.com/myrgic/cogos/internal/providers/pin"
+	"github.com/myrgic/cogos/pkg/reconcile"
 
 	// Trigger internal/providers/component's init() which registers "component".
-	_ "github.com/cogos-dev/cogos/internal/providers/component"
+	_ "github.com/myrgic/cogos/internal/providers/component"
 )
 
 // workspaceRoot is set at daemon boot by SetWorkspaceRoot (called from

--- a/internal/providers/daemon/daemon_test.go
+++ b/internal/providers/daemon/daemon_test.go
@@ -115,13 +115,13 @@ func TestPinProvider_DaemonHealth_SurfacesDrift(t *testing.T) {
 	if err := os.MkdirAll(pinsDir, 0o755); err != nil {
 		t.Fatalf("mkdir pins: %v", err)
 	}
-	pinYAML := `target: cogos-dev/nonexistent-target
+	pinYAML := `target: myrgic/nonexistent-target
 pin:
   ref: abc000000000
 branch: main
 sync: read-only
 `
-	if err := os.WriteFile(filepath.Join(pinsDir, "cogos-dev_nonexistent-target.yaml"), []byte(pinYAML), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(pinsDir, "myrgic_nonexistent-target.yaml"), []byte(pinYAML), 0o644); err != nil {
 		t.Fatalf("write pin yaml: %v", err)
 	}
 
@@ -144,7 +144,7 @@ sync: read-only
 	}
 
 	h := p.Health()
-	// The target "cogos-dev/nonexistent-target" cannot be found locally,
+	// The target "myrgic/nonexistent-target" cannot be found locally,
 	// so FetchLive marks it unreachable and ComputePlan emits a missing action.
 	// Health() must NOT be Healthy — it must be Degraded.
 	if h.Health == reconcile.HealthHealthy {
@@ -228,13 +228,13 @@ func TestPinProvider_ConcurrentHealth_NoParallelRefresh(t *testing.T) {
 	if err := os.MkdirAll(pinsDir, 0o755); err != nil {
 		t.Fatalf("mkdir pins: %v", err)
 	}
-	pinYAML := `target: cogos-dev/nonexistent-target
+	pinYAML := `target: myrgic/nonexistent-target
 pin:
   ref: abc000000000
 branch: main
 sync: read-only
 `
-	if err := os.WriteFile(filepath.Join(pinsDir, "cogos-dev_nonexistent-target.yaml"), []byte(pinYAML), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(pinsDir, "myrgic_nonexistent-target.yaml"), []byte(pinYAML), 0o644); err != nil {
 		t.Fatalf("write pin yaml: %v", err)
 	}
 

--- a/internal/providers/daemon/daemon_test.go
+++ b/internal/providers/daemon/daemon_test.go
@@ -18,12 +18,12 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/cogos-dev/cogos/internal/providers/daemon"
-	"github.com/cogos-dev/cogos/pkg/reconcile"
+	"github.com/myrgic/cogos/internal/providers/daemon"
+	"github.com/myrgic/cogos/pkg/reconcile"
 
 	// Blank import fires daemon.init(), registering all 10 providers; the named
 	// import above is for the new SetWorkspaceRoot regression test.
-	_ "github.com/cogos-dev/cogos/internal/providers/daemon"
+	_ "github.com/myrgic/cogos/internal/providers/daemon"
 )
 
 var expectedProviders = []string{

--- a/internal/providers/daemon/mlx_inference.go
+++ b/internal/providers/daemon/mlx_inference.go
@@ -32,7 +32,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/cogos-dev/cogos/pkg/reconcile"
+	"github.com/myrgic/cogos/pkg/reconcile"
 )
 
 const mlxSupervisedTypeKey = "mlx-supervised"

--- a/internal/providers/pin/pin.go
+++ b/internal/providers/pin/pin.go
@@ -37,7 +37,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/cogos-dev/cogos/pkg/reconcile"
+	"github.com/myrgic/cogos/pkg/reconcile"
 )
 
 // ─── WorkspaceLocator ────────────────────────────────────────────────────────

--- a/internal/providers/pin/pin.go
+++ b/internal/providers/pin/pin.go
@@ -42,7 +42,7 @@ import (
 
 // ─── WorkspaceLocator ────────────────────────────────────────────────────────
 
-// WorkspaceLocator resolves a workspace name (e.g. "cogos-dev/cogos") to its
+// WorkspaceLocator resolves a workspace name (e.g. "myrgic/cogos") to its
 // absolute filesystem root path. In production it is backed by engine.URIRegistry
 // via an adapter wired at daemon startup. Tests inject a stub.
 type WorkspaceLocator interface {
@@ -84,7 +84,7 @@ type PinRef struct {
 // PinRecord is the on-disk schema for a single pin relationship.
 // Lives at <workspace>/.cog/pins/<sanitized-target-name>.yaml.
 type PinRecord struct {
-	// Target is the workspace name as registered in global.yaml (e.g. "cogos-dev/cogos").
+	// Target is the workspace name as registered in global.yaml (e.g. "myrgic/cogos").
 	// Must resolve via global workspace registry (URIRegistry in #167).
 	Target string `yaml:"target"`
 	// Pin holds the pinned position.
@@ -283,7 +283,7 @@ func (r *localGitHeadResolver) locateTarget(ctx context.Context, target, workspa
 	parent := filepath.Dir(workspaceRoot)
 	grandParent := filepath.Dir(parent)
 
-	// "cogos-dev/cogos" → last two components in sibling tree.
+	// "myrgic/cogos" → last two components in sibling tree.
 	parts := strings.SplitN(target, "/", 2)
 	switch len(parts) {
 	case 1:
@@ -293,7 +293,7 @@ func (r *localGitHeadResolver) locateTarget(ctx context.Context, target, workspa
 			return candidate, nil
 		}
 	case 2:
-		// two-component target (e.g., "cogos-dev/cogos") — look one level up.
+		// two-component target (e.g., "myrgic/cogos") — look one level up.
 		candidate := filepath.Join(grandParent, parts[0], parts[1])
 		if isGitRepo(candidate) {
 			return candidate, nil
@@ -780,7 +780,7 @@ func (p *Provider) BuildState(config any, live any, existing *reconcile.State) (
 	return state, nil
 }
 
-// sanitiseName converts "cogos-dev/cogos" → "cogos-dev_cogos" for use as a
+// sanitiseName converts "myrgic/cogos" → "myrgic_cogos" for use as a
 // Reconcile State address component.
 func sanitiseName(name string) string {
 	return strings.ReplaceAll(name, "/", "_")
@@ -1076,7 +1076,7 @@ func RemovePinRecord(root, target string) error {
 }
 
 // sanitiseFilename converts a target workspace name to a safe filename stem.
-// "cogos-dev/cogos" → "cogos-dev_cogos"
+// "myrgic/cogos" → "myrgic_cogos"
 func sanitiseFilename(target string) string {
 	return strings.NewReplacer("/", "_", ":", "_", " ", "_").Replace(target)
 }

--- a/internal/providers/pin/pin_test.go
+++ b/internal/providers/pin/pin_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cogos-dev/cogos/internal/providers/pin"
-	"github.com/cogos-dev/cogos/pkg/reconcile"
+	"github.com/myrgic/cogos/internal/providers/pin"
+	"github.com/myrgic/cogos/pkg/reconcile"
 )
 
 // ─── Test helpers ────────────────────────────────────────────────────────────

--- a/internal/providers/pin/pin_test.go
+++ b/internal/providers/pin/pin_test.go
@@ -119,8 +119,8 @@ func TestLoadConfig_EmptyPinsDir(t *testing.T) {
 
 func TestLoadConfig_SingleRecord(t *testing.T) {
 	root := setupWorkspace(t)
-	writePinYAML(t, root, "cogos-dev_cogos", `
-target: cogos-dev/cogos
+	writePinYAML(t, root, "myrgic_cogos", `
+target: myrgic/cogos
 pin:
   ref: v0.4.1
 branch: main
@@ -140,16 +140,16 @@ func TestLoadConfig_TwoSourcesIndependent(t *testing.T) {
 	root1 := setupWorkspace(t)
 	root2 := setupWorkspace(t)
 
-	const target = "cogos-dev/cogos"
+	const target = "myrgic/cogos"
 
-	writePinYAML(t, root1, "cogos-dev_cogos", `
-target: cogos-dev/cogos
+	writePinYAML(t, root1, "myrgic_cogos", `
+target: myrgic/cogos
 pin:
   ref: v0.4.0
 sync: read-only
 `)
-	writePinYAML(t, root2, "cogos-dev_cogos", `
-target: cogos-dev/cogos
+	writePinYAML(t, root2, "myrgic_cogos", `
+target: myrgic/cogos
 pin:
   ref: v0.5.0
 sync: read-only
@@ -212,10 +212,10 @@ sync: read-only
 
 func TestReconcile_InSync_Green(t *testing.T) {
 	root := setupWorkspace(t)
-	const target = "cogos-dev/cogos"
+	const target = "myrgic/cogos"
 	const ref = "abc1234567890"
-	writePinYAML(t, root, "cogos-dev_cogos", `
-target: cogos-dev/cogos
+	writePinYAML(t, root, "myrgic_cogos", `
+target: myrgic/cogos
 pin:
   ref: abc1234567890
 sync: read-only
@@ -236,9 +236,9 @@ sync: read-only
 
 func TestReconcile_Drift_Yellow(t *testing.T) {
 	root := setupWorkspace(t)
-	const target = "cogos-dev/cogos"
-	writePinYAML(t, root, "cogos-dev_cogos", `
-target: cogos-dev/cogos
+	const target = "myrgic/cogos"
+	writePinYAML(t, root, "myrgic_cogos", `
+target: myrgic/cogos
 pin:
   ref: abc000000000
 sync: read-only
@@ -259,9 +259,9 @@ sync: read-only
 
 func TestReconcile_TargetUnreachable_Red(t *testing.T) {
 	root := setupWorkspace(t)
-	const target = "cogos-dev/cogos"
-	writePinYAML(t, root, "cogos-dev_cogos", `
-target: cogos-dev/cogos
+	const target = "myrgic/cogos"
+	writePinYAML(t, root, "myrgic_cogos", `
+target: myrgic/cogos
 pin:
   ref: abc000000000
 sync: read-only
@@ -282,9 +282,9 @@ sync: read-only
 
 func TestReconcile_DigestMismatch_Red(t *testing.T) {
 	root := setupWorkspace(t)
-	const target = "cogos-dev/cogos"
-	writePinYAML(t, root, "cogos-dev_cogos", `
-target: cogos-dev/cogos
+	const target = "myrgic/cogos"
+	writePinYAML(t, root, "myrgic_cogos", `
+target: myrgic/cogos
 pin:
   ref: abc1234567890
   digest: sha256:aaaa
@@ -315,9 +315,9 @@ sync: read-only
 
 func TestApplyPlan_ReadOnly_Rejects(t *testing.T) {
 	root := setupWorkspace(t)
-	const target = "cogos-dev/cogos"
-	writePinYAML(t, root, "cogos-dev_cogos", `
-target: cogos-dev/cogos
+	const target = "myrgic/cogos"
+	writePinYAML(t, root, "myrgic_cogos", `
+target: myrgic/cogos
 pin:
   ref: old000000000
 sync: read-only
@@ -355,7 +355,7 @@ func TestHealth_BeforeLoadConfig_Missing(t *testing.T) {
 func TestWriteAndRemovePinRecord(t *testing.T) {
 	root := t.TempDir() // no pins dir yet
 	rec := &pin.PinRecord{
-		Target: "cogos-dev/cogos",
+		Target: "myrgic/cogos",
 		Pin:    pin.PinRef{Ref: "v0.5.0"},
 		Branch: "main",
 		Sync:   pin.SyncReadOnly,
@@ -378,12 +378,12 @@ func TestWriteAndRemovePinRecord(t *testing.T) {
 	}
 
 	// Remove it.
-	if err := pin.RemovePinRecord(root, "cogos-dev/cogos"); err != nil {
+	if err := pin.RemovePinRecord(root, "myrgic/cogos"); err != nil {
 		t.Fatalf("RemovePinRecord: %v", err)
 	}
 
 	// Verify gone.
-	pinPath := filepath.Join(root, ".cog", "pins", "cogos-dev_cogos.yaml")
+	pinPath := filepath.Join(root, ".cog", "pins", "myrgic_cogos.yaml")
 	if _, err := os.Stat(pinPath); !os.IsNotExist(err) {
 		t.Errorf("expected pin file to be removed, got: %v", err)
 	}
@@ -393,9 +393,9 @@ func TestWriteAndRemovePinRecord(t *testing.T) {
 
 func TestBuildState_PopulatesResources(t *testing.T) {
 	root := setupWorkspace(t)
-	const target = "cogos-dev/cogos"
-	writePinYAML(t, root, "cogos-dev_cogos", `
-target: cogos-dev/cogos
+	const target = "myrgic/cogos"
+	writePinYAML(t, root, "myrgic_cogos", `
+target: myrgic/cogos
 pin:
   ref: v0.4.1
 sync: read-only
@@ -437,9 +437,9 @@ sync: read-only
 // live digest, the result must be RED, not GREEN."
 func TestComputePlan_DeclaredDigest_EmptyLive_Red(t *testing.T) {
 	root := setupWorkspace(t)
-	const target = "cogos-dev/cogos"
-	writePinYAML(t, root, "cogos-dev_cogos", `
-target: cogos-dev/cogos
+	const target = "myrgic/cogos"
+	writePinYAML(t, root, "myrgic_cogos", `
+target: myrgic/cogos
 pin:
   ref: abc1234567890
   digest: sha256:deadbeef
@@ -506,9 +506,9 @@ sync: read-only
 // are the necessary precondition for correct verify output.
 func TestComputePlan_VerifyDigestMismatch_PlanHasReason(t *testing.T) {
 	root := setupWorkspace(t)
-	const target = "cogos-dev/cogos"
-	writePinYAML(t, root, "cogos-dev_cogos", `
-target: cogos-dev/cogos
+	const target = "myrgic/cogos"
+	writePinYAML(t, root, "myrgic_cogos", `
+target: myrgic/cogos
 pin:
   ref: abc1234567890
   digest: sha256:aaaa
@@ -565,9 +565,9 @@ sync: read-only
 // cmdPinVerify surfaces it correctly.
 func TestComputePlan_VerifyUnreachable_PlanHasReason(t *testing.T) {
 	root := setupWorkspace(t)
-	const target = "cogos-dev/cogos"
-	writePinYAML(t, root, "cogos-dev_cogos", `
-target: cogos-dev/cogos
+	const target = "myrgic/cogos"
+	writePinYAML(t, root, "myrgic_cogos", `
+target: myrgic/cogos
 pin:
   ref: abc1234567890
 sync: read-only
@@ -629,9 +629,9 @@ func runAndCheck(t *testing.T, p *pin.Provider, root string, check func(reconcil
 // non-nil error.
 func TestRunVerify_DigestUnverifiable(t *testing.T) {
 	root := setupWorkspace(t)
-	const target = "cogos-dev/cogos"
-	writePinYAML(t, root, "cogos-dev_cogos", `
-target: cogos-dev/cogos
+	const target = "myrgic/cogos"
+	writePinYAML(t, root, "myrgic_cogos", `
+target: myrgic/cogos
 pin:
   ref: abc1234567890
   digest: sha256:aabbcc
@@ -675,9 +675,9 @@ sync: read-only
 // Expects [DRIFT] output containing "digest mismatch".
 func TestRunVerify_DigestMismatch(t *testing.T) {
 	root := setupWorkspace(t)
-	const target = "cogos-dev/cogos"
-	writePinYAML(t, root, "cogos-dev_cogos", `
-target: cogos-dev/cogos
+	const target = "myrgic/cogos"
+	writePinYAML(t, root, "myrgic_cogos", `
+target: myrgic/cogos
 pin:
   ref: abc1234567890
   digest: sha256:aaaa
@@ -716,9 +716,9 @@ sync: read-only
 // output containing "unreachable".
 func TestRunVerify_TargetUnreachable(t *testing.T) {
 	root := setupWorkspace(t)
-	const target = "cogos-dev/cogos"
-	writePinYAML(t, root, "cogos-dev_cogos", `
-target: cogos-dev/cogos
+	const target = "myrgic/cogos"
+	writePinYAML(t, root, "myrgic_cogos", `
+target: myrgic/cogos
 pin:
   ref: abc1234567890
 sync: read-only
@@ -774,10 +774,10 @@ func (l *stubLocator) LocateWorkspace(_ context.Context, name string) (string, e
 func TestSetWorkspaceLocator_ConsultedBeforeFallback(t *testing.T) {
 	t.Parallel()
 	root := setupWorkspace(t)
-	const target = "cogos-dev/cogos"
+	const target = "myrgic/cogos"
 
-	writePinYAML(t, root, "cogos-dev_cogos", `
-target: cogos-dev/cogos
+	writePinYAML(t, root, "myrgic_cogos", `
+target: myrgic/cogos
 pin:
   ref: abc1234567890
 sync: read-only
@@ -895,10 +895,10 @@ func (l *errLocator) LocateWorkspace(_ context.Context, _ string) (string, error
 func TestLocatorNonNotFoundError_Propagated(t *testing.T) {
 	t.Parallel()
 	source := setupWorkspace(t)
-	const target = "cogos-dev/cogos"
+	const target = "myrgic/cogos"
 
-	writePinYAML(t, source, "cogos-dev_cogos", `
-target: cogos-dev/cogos
+	writePinYAML(t, source, "myrgic_cogos", `
+target: myrgic/cogos
 pin:
   ref: abc1234567890abcdef1234567890abcdef123456
 sync: read-only

--- a/internal/providers/site/site.go
+++ b/internal/providers/site/site.go
@@ -28,7 +28,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cogos-dev/cogos/pkg/reconcile"
+	"github.com/myrgic/cogos/pkg/reconcile"
 	"gopkg.in/yaml.v3"
 )
 

--- a/kernel_guarantees_test.go
+++ b/kernel_guarantees_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/cogos-dev/cogos/sdk/types"
+	"github.com/myrgic/cogos/sdk/types"
 )
 
 // === INVARIANT TESTS ===

--- a/kernel_harness.go
+++ b/kernel_harness.go
@@ -28,7 +28,7 @@ import (
 	"encoding/json"
 	"os"
 
-	"github.com/cogos-dev/cogos/harness"
+	"github.com/myrgic/cogos/harness"
 )
 
 // kernelServicesAdapter implements harness.KernelServices by wrapping the

--- a/ledger_core.go
+++ b/ledger_core.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/cogos-dev/cogos/pkg/cogblock"
+	"github.com/myrgic/cogos/pkg/cogblock"
 )
 
 // Re-export ledger types and functions from pkg/cogblock so existing kernel

--- a/memory.go
+++ b/memory.go
@@ -25,7 +25,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cogos-dev/cogos/sdk/constellation"
+	"github.com/myrgic/cogos/sdk/constellation"
 	"gopkg.in/yaml.v3"
 )
 

--- a/modality_bus.go
+++ b/modality_bus.go
@@ -5,7 +5,7 @@
 
 package main
 
-import "github.com/cogos-dev/cogos/pkg/modality"
+import "github.com/myrgic/cogos/pkg/modality"
 
 // Type aliases — bus types.
 type ChannelConnection = modality.ChannelConnection

--- a/modality_events.go
+++ b/modality_events.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/cogos-dev/cogos/pkg/modality"
+	"github.com/myrgic/cogos/pkg/modality"
 )
 
 // Re-export event type constants.

--- a/modality_salience.go
+++ b/modality_salience.go
@@ -5,7 +5,7 @@
 
 package main
 
-import "github.com/cogos-dev/cogos/pkg/modality"
+import "github.com/myrgic/cogos/pkg/modality"
 
 // Type aliases — salience types.
 type SalienceEntry = modality.SalienceEntry

--- a/modality_supervisor.go
+++ b/modality_supervisor.go
@@ -5,7 +5,7 @@
 
 package main
 
-import "github.com/cogos-dev/cogos/pkg/modality"
+import "github.com/myrgic/cogos/pkg/modality"
 
 // Type aliases — supervisor types.
 type SupervisorConfig = modality.SupervisorConfig

--- a/modality_text.go
+++ b/modality_text.go
@@ -5,7 +5,7 @@
 
 package main
 
-import "github.com/cogos-dev/cogos/pkg/modality"
+import "github.com/myrgic/cogos/pkg/modality"
 
 // Type alias — text module.
 type TextModule = modality.TextModule

--- a/modality_types.go
+++ b/modality_types.go
@@ -6,7 +6,7 @@
 
 package main
 
-import "github.com/cogos-dev/cogos/pkg/modality"
+import "github.com/myrgic/cogos/pkg/modality"
 
 // Type aliases — modality types.
 type ModalityType = modality.ModalityType

--- a/modality_wire.go
+++ b/modality_wire.go
@@ -5,7 +5,7 @@
 
 package main
 
-import "github.com/cogos-dev/cogos/pkg/modality"
+import "github.com/myrgic/cogos/pkg/modality"
 
 // Type aliases — wire protocol types.
 type WireMessage = modality.WireMessage

--- a/performance_test.go
+++ b/performance_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/cogos-dev/cogos/sdk/types"
+	"github.com/myrgic/cogos/sdk/types"
 )
 
 // === PERFORMANCE BENCHMARKS ===

--- a/pkg/alias/alias.go
+++ b/pkg/alias/alias.go
@@ -6,7 +6,7 @@
 // cog://authority/path URI:
 //
 //	cog://cog/mem/semantic/x    — "cog" resolves via alias to "cog-workspace"
-//	cog://kernel/adr/067         — "kernel" resolves to "cogos-dev/cogos"
+//	cog://kernel/adr/067         — "kernel" resolves to "myrgic/cogos"
 //
 // Aliases are a display/input convenience.  The kernel always stores and logs
 // the canonical workspace name; aliases are expanded at parse time.
@@ -17,7 +17,7 @@
 //	aliases:
 //	  cog: cog-workspace                         # short form
 //	  m3:                                        # long form with metadata
-//	    workspace: cogos-dev/mod3
+//	    workspace: myrgic/mod3
 //	    description: "mod3 voice server"
 //	    node: darkstar                           # optional node pin
 //

--- a/pkg/alias/alias.go
+++ b/pkg/alias/alias.go
@@ -39,7 +39,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cogos-dev/cogos/pkg/filelock"
+	"github.com/myrgic/cogos/pkg/filelock"
 	"gopkg.in/yaml.v3"
 )
 

--- a/pkg/alias/alias_test.go
+++ b/pkg/alias/alias_test.go
@@ -91,11 +91,11 @@ aliases:
 }
 
 func TestLoadLongForm(t *testing.T) {
-	dir := nodeDir(t, "cogos-dev/mod3")
+	dir := nodeDir(t, "myrgic/mod3")
 	writeAliases(t, dir, `version: "1.0"
 aliases:
   m3:
-    workspace: cogos-dev/mod3
+    workspace: myrgic/mod3
     description: "mod3 voice server"
     node: darkstar
 `)
@@ -107,17 +107,17 @@ aliases:
 	if !ok {
 		t.Fatal("Expand: alias not found")
 	}
-	if ws != "cogos-dev/mod3" || node != "darkstar" {
+	if ws != "myrgic/mod3" || node != "darkstar" {
 		t.Fatalf("Expand: got ws=%q node=%q", ws, node)
 	}
 }
 
 func TestLoadMultiple(t *testing.T) {
-	dir := nodeDir(t, "cog-workspace", "cogos-dev/cogos")
+	dir := nodeDir(t, "cog-workspace", "myrgic/cogos")
 	writeAliases(t, dir, `version: "1.0"
 aliases:
   cog: cog-workspace
-  kernel: cogos-dev/cogos
+  kernel: myrgic/cogos
 `)
 	m, err := alias.Load(dir)
 	if err != nil {
@@ -393,9 +393,9 @@ func TestAddValidNames(t *testing.T) {
 // ── Round-trip long form ──────────────────────────────────────────────────────
 
 func TestAddLongFormRoundTrip(t *testing.T) {
-	dir := nodeDir(t, "cogos-dev/mod3")
+	dir := nodeDir(t, "myrgic/mod3")
 	m, _ := alias.Load(dir)
-	if err := m.Add("m3", "cogos-dev/mod3", alias.AliasOpts{
+	if err := m.Add("m3", "myrgic/mod3", alias.AliasOpts{
 		Description: "voice server",
 		Node:        "darkstar",
 	}); err != nil {

--- a/pkg/alias/alias_test.go
+++ b/pkg/alias/alias_test.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/cogos-dev/cogos/pkg/alias"
+	"github.com/myrgic/cogos/pkg/alias"
 )
 
 // ── helpers ───────────────────────────────────────────────────────────────────

--- a/pkg/bep/go.mod
+++ b/pkg/bep/go.mod
@@ -1,4 +1,4 @@
-module github.com/cogos-dev/cogos/pkg/bep
+module github.com/myrgic/cogos/pkg/bep
 
 go 1.24.0
 

--- a/pkg/cogblock/go.mod
+++ b/pkg/cogblock/go.mod
@@ -1,3 +1,3 @@
-module github.com/cogos-dev/cogos/pkg/cogblock
+module github.com/myrgic/cogos/pkg/cogblock
 
 go 1.25.0

--- a/pkg/cogfield/go.mod
+++ b/pkg/cogfield/go.mod
@@ -1,3 +1,3 @@
-module github.com/cogos-dev/cogos/pkg/cogfield
+module github.com/myrgic/cogos/pkg/cogfield
 
 go 1.24.0

--- a/pkg/coordination/go.mod
+++ b/pkg/coordination/go.mod
@@ -1,3 +1,3 @@
-module github.com/cogos-dev/cogos/pkg/coordination
+module github.com/myrgic/cogos/pkg/coordination
 
 go 1.25.0

--- a/pkg/filelock/lock_test.go
+++ b/pkg/filelock/lock_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cogos-dev/cogos/pkg/filelock"
+	"github.com/myrgic/cogos/pkg/filelock"
 )
 
 // TestAcquireRelease verifies basic lock/unlock lifecycle.

--- a/pkg/modality/bus_test.go
+++ b/pkg/modality/bus_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/cogos-dev/cogos/pkg/modality"
+	"github.com/myrgic/cogos/pkg/modality"
 )
 
 func TestBus_RegisterAndPerceive(t *testing.T) {

--- a/pkg/modality/channel_test.go
+++ b/pkg/modality/channel_test.go
@@ -3,7 +3,7 @@ package modality_test
 import (
 	"testing"
 
-	"github.com/cogos-dev/cogos/pkg/modality"
+	"github.com/myrgic/cogos/pkg/modality"
 )
 
 func TestChannelRegistry_RegisterAndGet(t *testing.T) {

--- a/pkg/modality/events_test.go
+++ b/pkg/modality/events_test.go
@@ -3,7 +3,7 @@ package modality_test
 import (
 	"testing"
 
-	"github.com/cogos-dev/cogos/pkg/modality"
+	"github.com/myrgic/cogos/pkg/modality"
 )
 
 func TestRequireFields_AllPresent(t *testing.T) {

--- a/pkg/modality/go.mod
+++ b/pkg/modality/go.mod
@@ -1,3 +1,3 @@
-module github.com/cogos-dev/cogos/pkg/modality
+module github.com/myrgic/cogos/pkg/modality
 
 go 1.24

--- a/pkg/modality/salience_test.go
+++ b/pkg/modality/salience_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cogos-dev/cogos/pkg/modality"
+	"github.com/myrgic/cogos/pkg/modality"
 )
 
 func TestSalience_OnEvent(t *testing.T) {

--- a/pkg/modality/text_test.go
+++ b/pkg/modality/text_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/cogos-dev/cogos/pkg/modality"
+	"github.com/myrgic/cogos/pkg/modality"
 )
 
 func TestTextModule_Type(t *testing.T) {

--- a/pkg/modality/wire_test.go
+++ b/pkg/modality/wire_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/cogos-dev/cogos/pkg/modality"
+	"github.com/myrgic/cogos/pkg/modality"
 )
 
 func TestWireMessage_RoundTrip(t *testing.T) {

--- a/pkg/reconcile/go.mod
+++ b/pkg/reconcile/go.mod
@@ -1,3 +1,3 @@
-module github.com/cogos-dev/cogos/pkg/reconcile
+module github.com/myrgic/cogos/pkg/reconcile
 
 go 1.24

--- a/pkg/skills/skills_test.go
+++ b/pkg/skills/skills_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cogos-dev/cogos/pkg/skills"
+	"github.com/myrgic/cogos/pkg/skills"
 )
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────

--- a/pkg/uri/go.mod
+++ b/pkg/uri/go.mod
@@ -1,3 +1,3 @@
-module github.com/cogos-dev/cogos/pkg/uri
+module github.com/myrgic/cogos/pkg/uri
 
 go 1.25.0

--- a/reconcile_events.go
+++ b/reconcile_events.go
@@ -5,7 +5,7 @@
 
 package main
 
-import "github.com/cogos-dev/cogos/pkg/reconcile"
+import "github.com/myrgic/cogos/pkg/reconcile"
 
 // --- Re-exported event type aliases ---
 

--- a/reconcile_meta.go
+++ b/reconcile_meta.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/cogos-dev/cogos/pkg/reconcile"
+	"github.com/myrgic/cogos/pkg/reconcile"
 	"gopkg.in/yaml.v3"
 )
 

--- a/reconcile_registry.go
+++ b/reconcile_registry.go
@@ -3,7 +3,7 @@
 
 package main
 
-import "github.com/cogos-dev/cogos/pkg/reconcile"
+import "github.com/myrgic/cogos/pkg/reconcile"
 
 // RegisterProvider adds a reconciliation provider to the global registry.
 func RegisterProvider(name string, provider Reconcilable) {

--- a/reconcile_state.go
+++ b/reconcile_state.go
@@ -3,7 +3,7 @@
 
 package main
 
-import "github.com/cogos-dev/cogos/pkg/reconcile"
+import "github.com/myrgic/cogos/pkg/reconcile"
 
 // reconcileStatePath returns the path to a provider's state file.
 func reconcileStatePath(root, resourceType string) string {

--- a/reconcile_types.go
+++ b/reconcile_types.go
@@ -4,7 +4,7 @@
 
 package main
 
-import "github.com/cogos-dev/cogos/pkg/reconcile"
+import "github.com/myrgic/cogos/pkg/reconcile"
 
 // --- Type aliases for backward compatibility ---
 

--- a/registry_indexer.go
+++ b/registry_indexer.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cogos-dev/cogos/sdk/constellation"
+	"github.com/myrgic/cogos/sdk/constellation"
 )
 
 // ---------------------------------------------------------------------------

--- a/scripts/e2e-integration.sh
+++ b/scripts/e2e-integration.sh
@@ -187,7 +187,7 @@ by default. Use the charts repo for Kubernetes deployments.
 Supported deployment modes:
 - Tier 1: Developer (cogos serve in terminal)
 - Tier 2: Desktop (CogOS.app via Wails)
-- Tier 3: Production (helm install via cogos-dev/charts)
+- Tier 3: Production (helm install via myrgic/charts)
 SEED
 
 check "seed doc: architecture"   test -f "$WORKSPACE/.cog/mem/semantic/insights/test-architecture.md"

--- a/scripts/nightly-consolidation.py
+++ b/scripts/nightly-consolidation.py
@@ -34,7 +34,7 @@ from pathlib import Path
 # ── Paths ────────────────────────────────────────────────────────────────────
 
 WORKSPACE = Path(os.environ.get("WORKSPACE", os.path.expanduser("~/workspaces/cog")))
-COGOS_DEV = Path(os.environ.get("COGOS_DEV", os.path.expanduser("~/workspaces/cogos-dev/cogos")))
+COGOS_DEV = Path(os.environ.get("COGOS_DEV", os.path.join(os.environ.get("MYRGIC_REPOS_ROOT", os.path.expanduser("~/workspaces/myrgic")), "cogos")))
 AUTORESEARCH = Path(os.environ.get("AUTORESEARCH", os.path.expanduser("~/cog-workspace/apps/cogos-v3/autoresearch")))
 CLAUDE_DIR = Path.home() / ".claude" / "projects"
 KERNEL_PORT = int(os.environ.get("KERNEL_PORT", "6931"))

--- a/scripts/overnight-ablation.py
+++ b/scripts/overnight-ablation.py
@@ -128,7 +128,7 @@ WORKSPACE_QA = [
     },
     {
         "id": "ws-15",
-        "question": "How many skills are in the cogos-dev/skills marketplace?",
+        "question": "How many skills are in the myrgic/skills marketplace?",
         "answer_contains": ["17", "18"],
         "source": "skills/README.md",
     },

--- a/scripts/overnight-cascade.sh
+++ b/scripts/overnight-cascade.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 
 SUPERVISOR="${SUPERVISOR:-local}"  # "local" (gemma4:26b) or "codex"
 WORKSPACE="${CASCADE_WORKSPACE:-$HOME/workspaces/cog}"
-COGOS_WORKSPACE="${CASCADE_COGOS:-$HOME/workspaces/cogos-dev/cogos}"
+COGOS_WORKSPACE="${CASCADE_COGOS:-${MYRGIC_REPOS_ROOT:-$HOME/workspaces/myrgic}/cogos}"
 OLLAMA="${OLLAMA_HOST:-http://localhost:11434}"
 MAX_CYCLES="${MAX_CYCLES:-999}"
 CYCLE_PAUSE="${CYCLE_PAUSE:-60}"  # seconds between cycles

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -2,7 +2,7 @@
 # setup-dev.sh — Developer setup for CogOS
 #
 # Run this after cloning the repo to set up your local dev environment:
-#   git clone https://github.com/cogos-dev/cogos.git
+#   git clone https://github.com/myrgic/cogos.git
 #   cd cogos
 #   ./scripts/setup-dev.sh
 #
@@ -82,7 +82,7 @@ cd "$REPO_DIR"
 
 VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
 BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-LDFLAGS="-s -w -X github.com/cogos-dev/cogos/internal/engine.Version=${VERSION} -X github.com/cogos-dev/cogos/internal/engine.BuildTime=${BUILD_TIME}"
+LDFLAGS="-s -w -X github.com/myrgic/cogos/internal/engine.Version=${VERSION} -X github.com/myrgic/cogos/internal/engine.BuildTime=${BUILD_TIME}"
 
 go build -ldflags="$LDFLAGS" -o cogos ./cmd/cogos
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,14 +4,14 @@
 # Downloads the latest release binary and installs cogos + cog.
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/cogos-dev/cogos/main/scripts/setup.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/myrgic/cogos/main/scripts/setup.sh | sh
 #
 # Or clone and run locally:
 #   ./scripts/setup.sh
 
 set -euo pipefail
 
-REPO="cogos-dev/cogos"
+REPO="myrgic/cogos"
 INSTALL_DIR="$HOME/.cogos/bin"
 
 # ── Colors ────────────────────────────────────────────────────────────────────

--- a/sdk/clients/clients.go
+++ b/sdk/clients/clients.go
@@ -22,7 +22,7 @@
 package clients
 
 import (
-	"github.com/cogos-dev/cogos/sdk"
+	"github.com/myrgic/cogos/sdk"
 )
 
 // Clients provides access to all convenience clients.

--- a/sdk/clients/clients_test.go
+++ b/sdk/clients/clients_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cogos-dev/cogos/sdk/types"
+	"github.com/myrgic/cogos/sdk/types"
 )
 
 // TestMemoryClientSearchOptions tests the functional options pattern for search.

--- a/sdk/clients/context.go
+++ b/sdk/clients/context.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/cogos-dev/cogos/sdk"
-	"github.com/cogos-dev/cogos/sdk/types"
+	"github.com/myrgic/cogos/sdk"
+	"github.com/myrgic/cogos/sdk/types"
 )
 
 // ContextClient builds context for inference.

--- a/sdk/clients/event.go
+++ b/sdk/clients/event.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 	"strings"
 
-	sdk "github.com/cogos-dev/cogos/sdk"
+	sdk "github.com/myrgic/cogos/sdk"
 )
 
 // EventClient emits events to the CogOS event system

--- a/sdk/clients/inference.go
+++ b/sdk/clients/inference.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/cogos-dev/cogos/sdk"
-	"github.com/cogos-dev/cogos/sdk/types"
+	"github.com/myrgic/cogos/sdk"
+	"github.com/myrgic/cogos/sdk/types"
 )
 
 // InferenceClient provides ergonomic access to cog:inference

--- a/sdk/clients/memory.go
+++ b/sdk/clients/memory.go
@@ -7,8 +7,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/cogos-dev/cogos/sdk"
-	"github.com/cogos-dev/cogos/sdk/types"
+	"github.com/myrgic/cogos/sdk"
+	"github.com/myrgic/cogos/sdk/types"
 )
 
 // MemoryClient provides ergonomic access to cog:mem/*

--- a/sdk/clients/signal.go
+++ b/sdk/clients/signal.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/cogos-dev/cogos/sdk"
-	"github.com/cogos-dev/cogos/sdk/types"
+	"github.com/myrgic/cogos/sdk"
+	"github.com/myrgic/cogos/sdk/types"
 )
 
 // SignalClient provides ergonomic access to cog:signals/*

--- a/sdk/clients/thread.go
+++ b/sdk/clients/thread.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/cogos-dev/cogos/sdk"
-	"github.com/cogos-dev/cogos/sdk/types"
+	"github.com/myrgic/cogos/sdk"
+	"github.com/myrgic/cogos/sdk/types"
 )
 
 // ThreadClient provides ergonomic access to cog:thread/*

--- a/sdk/cogos.go
+++ b/sdk/cogos.go
@@ -59,8 +59,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cogos-dev/cogos/sdk/internal/fs"
-	"github.com/cogos-dev/cogos/sdk/types"
+	"github.com/myrgic/cogos/sdk/internal/fs"
+	"github.com/myrgic/cogos/sdk/types"
 )
 
 // Version is the SDK version.

--- a/sdk/context.go
+++ b/sdk/context.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cogos-dev/cogos/sdk/types"
+	"github.com/myrgic/cogos/sdk/types"
 )
 
 // contextProjector handles cog:context namespace.

--- a/sdk/context_test.go
+++ b/sdk/context_test.go
@@ -4,7 +4,7 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/cogos-dev/cogos/sdk/types"
+	"github.com/myrgic/cogos/sdk/types"
 )
 
 func TestEstimateTokens(t *testing.T) {

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,4 +1,4 @@
-module github.com/cogos-dev/cogos/sdk
+module github.com/myrgic/cogos/sdk
 
 go 1.24
 

--- a/sdk/httputil/client.go
+++ b/sdk/httputil/client.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	sdk "github.com/cogos-dev/cogos/sdk"
+	sdk "github.com/myrgic/cogos/sdk"
 	"github.com/coder/websocket"
 	"github.com/coder/websocket/wsjson"
 )

--- a/sdk/httputil/httputil_test.go
+++ b/sdk/httputil/httputil_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	sdk "github.com/cogos-dev/cogos/sdk"
+	sdk "github.com/myrgic/cogos/sdk"
 )
 
 // testKernel creates a kernel connected to a temporary workspace.

--- a/sdk/httputil/openai.go
+++ b/sdk/httputil/openai.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	sdk "github.com/cogos-dev/cogos/sdk"
-	"github.com/cogos-dev/cogos/sdk/types"
+	sdk "github.com/myrgic/cogos/sdk"
+	"github.com/myrgic/cogos/sdk/types"
 )
 
 // OpenAIHandler provides an OpenAI-compatible /v1/chat/completions endpoint.

--- a/sdk/httputil/server.go
+++ b/sdk/httputil/server.go
@@ -30,7 +30,7 @@ import (
 	"sync"
 	"time"
 
-	sdk "github.com/cogos-dev/cogos/sdk"
+	sdk "github.com/myrgic/cogos/sdk"
 	"github.com/coder/websocket"
 	"github.com/coder/websocket/wsjson"
 )

--- a/sdk/index.go
+++ b/sdk/index.go
@@ -11,7 +11,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/cogos-dev/cogos/sdk/types"
+	"github.com/myrgic/cogos/sdk/types"
 	"gopkg.in/yaml.v3"
 )
 

--- a/sdk/inference.go
+++ b/sdk/inference.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cogos-dev/cogos/sdk/types"
+	"github.com/myrgic/cogos/sdk/types"
 )
 
 // inferenceProjector handles cog:inference namespace.

--- a/sdk/inference_test.go
+++ b/sdk/inference_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cogos-dev/cogos/sdk/types"
+	"github.com/myrgic/cogos/sdk/types"
 )
 
 func TestModelAlias(t *testing.T) {

--- a/sdk/mutation_test.go
+++ b/sdk/mutation_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cogos-dev/cogos/sdk/types"
+	"github.com/myrgic/cogos/sdk/types"
 )
 
 // --- Phase 2 Mutation Tests ---

--- a/sdk/signals.go
+++ b/sdk/signals.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/cogos-dev/cogos/sdk/internal/fs"
-	"github.com/cogos-dev/cogos/sdk/types"
+	"github.com/myrgic/cogos/sdk/internal/fs"
+	"github.com/myrgic/cogos/sdk/types"
 )
 
 // signalFieldState represents the persisted signal field structure.

--- a/sdk/thread.go
+++ b/sdk/thread.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cogos-dev/cogos/sdk/internal/fs"
-	"github.com/cogos-dev/cogos/sdk/types"
+	"github.com/myrgic/cogos/sdk/internal/fs"
+	"github.com/myrgic/cogos/sdk/types"
 )
 
 // threadProjector handles cog:thread/* namespace.

--- a/sdk/validate.go
+++ b/sdk/validate.go
@@ -11,7 +11,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/cogos-dev/cogos/sdk/types"
+	"github.com/myrgic/cogos/sdk/types"
 	"gopkg.in/yaml.v3"
 )
 

--- a/shadow_log.go
+++ b/shadow_log.go
@@ -14,7 +14,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cogos-dev/cogos/sdk/constellation"
+	"github.com/myrgic/cogos/sdk/constellation"
 )
 
 // ShadowLogEntry represents one Tier 4 query with dual scores for all candidates.

--- a/tier4_semantic.go
+++ b/tier4_semantic.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/cogos-dev/cogos/sdk/constellation"
+	"github.com/myrgic/cogos/sdk/constellation"
 )
 
 // embedClientCache holds per-workspace embed clients.

--- a/tier4_semantic_test.go
+++ b/tier4_semantic_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cogos-dev/cogos/sdk/constellation"
+	"github.com/myrgic/cogos/sdk/constellation"
 )
 
 func TestQueryConstellationNoAnchor(t *testing.T) {

--- a/trace_emit.go
+++ b/trace_emit.go
@@ -42,8 +42,8 @@ import (
 	"strings"
 	"sync/atomic"
 
-	"github.com/cogos-dev/cogos/internal/engine"
-	"github.com/cogos-dev/cogos/trace"
+	"github.com/myrgic/cogos/internal/engine"
+	"github.com/myrgic/cogos/trace"
 )
 
 // traceBusID is the dedicated bus that carries cycle-trace events (B5 /

--- a/trace_emit_test.go
+++ b/trace_emit_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cogos-dev/cogos/internal/engine"
-	"github.com/cogos-dev/cogos/trace"
+	"github.com/myrgic/cogos/internal/engine"
+	"github.com/myrgic/cogos/trace"
 )
 
 // resetTraceEmitterForTest clears the package-level atomics that

--- a/types_shared.go
+++ b/types_shared.go
@@ -12,7 +12,7 @@
 package main
 
 import (
-	"github.com/cogos-dev/cogos/pkg/cogfield"
+	"github.com/myrgic/cogos/pkg/cogfield"
 )
 
 // CogBlock is the Messages API content block — the canonical wire format

--- a/ui/README.md
+++ b/ui/README.md
@@ -32,5 +32,5 @@ from anywhere in the module.
 ## Out of scope
 
 - Build pipelines (Vite, npm, etc.) — these are single-file static surfaces.
-- The `cogfield` panel: consumed via HTTP from `cogos-dev/cogfield`, not embedded here.
+- The `cogfield` panel: consumed via HTTP from `myrgic/cogfield`, not embedded here.
 - API-explorer / manifest-driven panel discovery: tracked in issue #98.


### PR DESCRIPTION
## Summary

Largest mechanical wave of the cogos-dev -> myrgic rebrand. Renames the Go module path, cascades all imports across root + sub-modules, updates go.work, CI LDFLAGS, Docker image refs, install scripts, and the full doc surface. Bumps to v0.5.0 (BREAKING for downstream consumers).

## Changes

- `module github.com/cogos-dev/cogos` -> `github.com/myrgic/cogos` (root + 10 sub-modules: harness, sdk, envspec, pkg/bep, pkg/cogblock, pkg/cogfield, pkg/coordination, pkg/modality, pkg/reconcile, pkg/uri)
- All Go imports cascaded across 107 source files
- Replace directives added to root go.mod for all locally-replaced sub-modules (cogblock, coordination, modality, reconcile, uri, bep were missing them)
- harness and envspec added to go.work use list (they were missing, causing incorrect workspace resolution)
- constellation: no external go.mod dependency found; `sdk/constellation/` is an embedded local package already under the new module path
- CI release.yml LDFLAGS: `github.com/myrgic/cogos/internal/engine.Version` and `BuildTime`
- Docker images: `ghcr.io/myrgic/cogos`; `defaultDaemonImage` in daemon_lifecycle.go updated
- `scripts/setup.sh` REPO -> `myrgic/cogos`
- Scripts variabilized: `MYRGIC_REPOS_ROOT` env var for overnight-cascade.sh and nightly-consolidation.py
- Doc URL sweep: README, CONTRIBUTING, CHANGELOG, docs/RELEASING, SYSTEM-SPEC, MCP-SPEC, architecture docs, rfc-drafts, .github/ templates
- `docs/MCP-SPEC.md`: binary name `cogos-v3` -> `cogos` (7 occurrences); cogdoc path `cogos-v3-design-spec` left unchanged per spec
- Absolute paths in docs variabilized to `${MYRGIC_REPOS_ROOT}/...` or `${COGOS_WORKSPACE}/...` env-var form
- Issue comment refs (#75, #79, #89, #94, #95 etc.) updated to `myrgic/cogos#NNN`
- Test fixtures for slash-bearing workspace name tests updated from `cogos-dev/cogos` to `myrgic/cogos`
- `.cogpublic` gate descriptions updated for direct-upstream workflow
- v0.5.0 CHANGELOG entry added; Makefile VERSION bumped

## Judgment calls

- `identity_crd_test.go` and `identity_provider_test.go`: `iss: cogos-dev` issuer strings left unchanged. These are OIDC issuer values, not org slugs. Changing them would break tests that validate the issuer field by name.
- `go.work` was not including `harness` and `envspec` in its `use` list. Added them. This is a correctness fix independent of the rename -- without them, builds from within those subdirectories fail because the workspace's root module claims the path.
- Replace directives for pkg/cogblock, pkg/coordination, pkg/modality, pkg/reconcile, pkg/uri, pkg/bep were missing from root go.mod. Added them. Without these, `go mod tidy` tries to fetch from the remote (old commit) and fails with module path mismatch.
- `defaultDaemonImage` changed from `cogos/kernel-v3:dev` to `ghcr.io/myrgic/cogos:dev`. The `kernel-v3` suffix is internal versioning; updated to match the GHCR image naming convention.

## Verification

- [x] `go build ./...` passes (root module)
- [x] All 10 sub-modules build clean (`go build ./...`)
- [x] `go test ./...` passes (root module): 9 packages pass, 0 failures
- [x] `sdk` module: 3 of 4 packages pass; `TestCogdocTypeValidation` fails -- this is a pre-existing failure on `main` before this branch, unrelated to the rename
- [ ] CI green (pending push)
- [ ] v0.5.0 tag will be created post-merge