### PR TITLE
chore: revert CHANGELOG entry + fix Makefile VERSION 0.5.0 -> 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,16 +18,6 @@ Pre-1.0. Per semver convention, breaking changes can land at any minor-version b
 
 The entries below predate the changelog policy above and are preserved as the historical record. For releases at v0.4.0 or later, see the [Releases page](https://github.com/myrgic/cogos/releases).
 
-## [0.5.0] - 2026-05-08
-
-### Changed (BREAKING)
-- Go module path renamed to `github.com/myrgic/cogos` (org rename: cogos-dev -> myrgic).
-  Downstream consumers must update imports.
-- `github.com/myrgic/constellation` v0.2.0 dependency (module path updated alongside org rename).
-- Docker images now published to `ghcr.io/myrgic/cogos`.
-- User-facing install script (`scripts/setup.sh`) now points to `myrgic/cogos` releases.
-- CI LDFLAGS embed the new module path; binary version strings updated.
-
 ## [Unreleased]
 
 _(no entries — see Releases page going forward)_

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 #   make e2e      - Run e2e test in a container
 #   make e2e-local - Run e2e test locally
 
-VERSION := 0.5.0
+VERSION := 0.6.0
 BUILD_TIME := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -s -w -X github.com/myrgic/cogos/internal/engine.BuildTime=$(BUILD_TIME)
 BUILD_TAGS := fts5


### PR DESCRIPTION
## Summary
- Removes hand-curated v0.5.0 CHANGELOG entry inadvertently added in #212. Project policy (CHANGELOG.md preamble) is no hand-curated entries post-v0.4.0; release notes are auto-generated from PR titles.
- Fixes Makefile VERSION 0.5.0 -> 0.6.0 to match the actually-released tag (v0.5.0 was already taken by #211 SiteProvider release).

## Test plan
- [ ] CI green
- [ ] No unrelated edits