### PR TITLE
fix(embed): parameterize Ollama embed model + conditional prefix application

### DIFF
--- a/decompose_integration_test.go
+++ b/decompose_integration_test.go
@@ -178,7 +178,9 @@ The pipeline uses a local LLM (Gemma E4B) via Ollama for tiers 0-2.
 
 	// 7. Verify embeddings were attempted (best-effort — check if non-nil)
 	t.Run("embeddings_attempted", func(t *testing.T) {
-		embedResults(runCtx, ollamaURL, result)
+		// "" -> defaultEmbedModel (bge-m3:latest); set EMBED_MODEL env to override.
+		embedModel := os.Getenv("EMBED_MODEL")
+		embedResults(runCtx, ollamaURL, embedModel, result)
 		if result.Embeddings == nil {
 			t.Log("Embeddings are nil — embed model may not be available (acceptable)")
 		} else {

--- a/decompose_store.go
+++ b/decompose_store.go
@@ -26,6 +26,22 @@ import (
 	"github.com/myrgic/cogos/sdk/constellation"
 )
 
+// defaultEmbedModel is used when callers don't specify one. Kept in sync with
+// the kernel's OllamaEmbedModel default in internal/engine/trm_context.go.
+const defaultEmbedModel = "bge-m3:latest"
+
+// nomic-class encoders are trained with task-specific prefixes; other dense
+// encoders (bge-m3, e5, etc.) are not, and prepending a prefix corrupts them.
+// documentPrefix returns the prefix to prepend at indexing time, or "" if
+// the model doesn't use prefixes.
+func documentPrefix(model string) string {
+	base, _, _ := strings.Cut(model, ":")
+	if base == "nomic-embed-text" {
+		return "search_document: "
+	}
+	return ""
+}
+
 // === C1+C2: Embedding Generation ===
 
 // ollamaEmbedRequest is the request body for Ollama's /api/embed endpoint.
@@ -40,10 +56,15 @@ type ollamaEmbedResponse struct {
 }
 
 // embedFromOllama calls Ollama's native embed endpoint for a single text.
-// Returns the full embedding vector (768-dim for nomic-embed-text) or error.
-func embedFromOllama(ctx context.Context, ollamaURL, text string) ([]float32, error) {
+// `model` is the Ollama model tag (e.g. "bge-m3:latest", "nomic-embed-text");
+// pass "" to use defaultEmbedModel. Returns the full embedding vector — native
+// dimensionality depends on the model (768 for nomic, 1024 for bge-m3).
+func embedFromOllama(ctx context.Context, ollamaURL, model, text string) ([]float32, error) {
+	if model == "" {
+		model = defaultEmbedModel
+	}
 	reqBody := ollamaEmbedRequest{
-		Model: "nomic-embed-text",
+		Model: model,
 		Input: text,
 	}
 	bodyBytes, err := json.Marshal(reqBody)
@@ -93,18 +114,25 @@ func truncateVec(v []float32, n int) []float32 {
 }
 
 // embedResults generates embeddings for each tier in the decomposition result.
+// `model` selects the Ollama embedding model; pass "" to use defaultEmbedModel.
+// The task-specific document prefix is applied conditionally — nomic-class
+// encoders get "search_document: ", others get nothing.
 // Best-effort: logs warnings on failure, never returns an error.
-func embedResults(ctx context.Context, ollamaURL string, result *DecompositionResult) {
+func embedResults(ctx context.Context, ollamaURL, model string, result *DecompositionResult) {
 	if result == nil {
 		return
 	}
+	if model == "" {
+		model = defaultEmbedModel
+	}
+	pfx := documentPrefix(model)
 
 	emb := &DecompEmbeddings{}
 	var generated bool
 
 	// Tier 0: embed the one-sentence summary
 	if result.Tier0 != nil && result.Tier0.Summary != "" {
-		vec, err := embedFromOllama(ctx, ollamaURL, "search_document: "+result.Tier0.Summary)
+		vec, err := embedFromOllama(ctx, ollamaURL, model, pfx+result.Tier0.Summary)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: tier 0 embedding failed: %v\n", err)
 		} else {
@@ -115,7 +143,7 @@ func embedResults(ctx context.Context, ollamaURL string, result *DecompositionRe
 
 	// Tier 1: embed the paragraph summary
 	if result.Tier1 != nil && result.Tier1.Summary != "" {
-		vec, err := embedFromOllama(ctx, ollamaURL, "search_document: "+result.Tier1.Summary)
+		vec, err := embedFromOllama(ctx, ollamaURL, model, pfx+result.Tier1.Summary)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: tier 1 embedding failed: %v\n", err)
 		} else {
@@ -138,7 +166,7 @@ func embedResults(ctx context.Context, ollamaURL string, result *DecompositionRe
 		}
 		if len(parts) > 0 {
 			fullText := strings.Join(parts, "\n")
-			vec, err := embedFromOllama(ctx, ollamaURL, "search_document: "+fullText)
+			vec, err := embedFromOllama(ctx, ollamaURL, model, pfx+fullText)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: tier 2 embedding failed: %v\n", err)
 			} else {

--- a/internal/engine/config.go
+++ b/internal/engine/config.go
@@ -111,7 +111,9 @@ type Config struct {
 	OllamaEmbedEndpoint string
 
 	// OllamaEmbedModel is the embedding model name for Ollama.
-	// Default: nomic-embed-text
+	// Default (when empty): bge-m3:latest — see trm_context.go defaultEmbedModel.
+	// Prefix-aware encoders (nomic-embed-text) automatically receive
+	// "search_query: " / "search_document: " prefixes; others receive raw text.
 	OllamaEmbedModel string
 
 	// ToolCallValidationEnabled gates runtime validation for model-emitted tool calls.

--- a/internal/engine/trm_context.go
+++ b/internal/engine/trm_context.go
@@ -21,8 +21,25 @@ import (
 	"net/http"
 	"sort"
 	"os"
+	"strings"
 	"time"
 )
+
+// defaultEmbedModel is used when cfg.OllamaEmbedModel is empty. Aligned with
+// the canonical workspace pin (bge-m3 — wider embedding geometry than nomic,
+// see workspace research notes on encoder ceiling).
+const defaultEmbedModel = "bge-m3:latest"
+
+// queryPrefix returns the task-specific prefix to prepend to retrieval queries
+// for this model, or "" if the model wasn't trained on prefixed input. Only
+// nomic-class encoders use prefixes; bge-m3, e5, and others receive raw text.
+func queryPrefix(model string) string {
+	base, _, _ := strings.Cut(model, ":")
+	if base == "nomic-embed-text" {
+		return "search_query: "
+	}
+	return ""
+}
 
 // ollamaEmbedRequest is the request body for POST /api/embeddings.
 type ollamaEmbedRequest struct {
@@ -35,8 +52,12 @@ type ollamaEmbedResponse struct {
 	Embedding []float64 `json:"embedding"`
 }
 
-// OllamaEmbed calls Ollama to embed a query string. Returns a 384-dim float32 vector.
-// The endpoint and model are taken from config; defaults are localhost:11434 and nomic-embed-text.
+// OllamaEmbed calls Ollama to embed a query string. Native dimensionality
+// depends on the model (768 for nomic-embed-text, 1024 for bge-m3, etc.).
+//
+// The endpoint and model come from cfg; defaults are localhost:11434 and
+// defaultEmbedModel (bge-m3:latest). The task-specific query prefix is
+// applied only for prefix-aware models — see queryPrefix.
 func OllamaEmbed(ctx context.Context, cfg *Config, query string) ([]float32, error) {
 	endpoint := cfg.OllamaEmbedEndpoint
 	if endpoint == "" {
@@ -44,12 +65,12 @@ func OllamaEmbed(ctx context.Context, cfg *Config, query string) ([]float32, err
 	}
 	model := cfg.OllamaEmbedModel
 	if model == "" {
-		model = "nomic-embed-text"
+		model = defaultEmbedModel
 	}
 
 	reqBody, err := json.Marshal(ollamaEmbedRequest{
 		Model:  model,
-		Prompt: "search_query: " + query,
+		Prompt: queryPrefix(model) + query,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("marshal embed request: %w", err)


### PR DESCRIPTION
## Summary

Two production code paths into Ollama hardcoded `nomic-embed-text` as the model and the nomic-specific task prefixes (`search_document:`, `search_query:`):

- `decompose_store.go::embedFromOllama` (decompose pipeline, all three tier-N call sites)
- `internal/engine/trm_context.go::OllamaEmbed` (kernel-side query embedding)

Two failure modes:
1. With nomic unpinned in Ollama, every decompose cycle paid the cold-start (~30s on first call after eviction). On a workspace running decompose regularly, that's hot path latency.
2. Swapping to any non-nomic encoder (bge-m3, e5, etc.) silently corrupts embeddings — the hardcoded prefix would still get prepended, poisoning encoders that weren't trained on prefixed input. There was no clean swap path.

## What changed

- `decompose_store.go`: thread `model` parameter through `embedFromOllama` and `embedResults`; new `documentPrefix(model)` helper applies nomic prefix only for nomic-class encoders. Default model (when caller passes `""`) is now `bge-m3:latest`.
- `internal/engine/trm_context.go`: same shape on the query side. `queryPrefix(model)` helper, fallback default flipped from `nomic-embed-text` → `bge-m3:latest`, prefix applied conditionally. Doc-string corrected (was claiming 384-dim, never actually was).
- `internal/engine/config.go`: doc-comment on `OllamaEmbedModel` describes the new default and the conditional-prefix behavior.
- `decompose_integration_test.go`: updated call site to match the new `embedResults` signature; reads `EMBED_MODEL` env var for override.

Both `defaultEmbedModel` constants live in their respective packages and are commented as paired — if one is changed the other should follow.

## Why bge-m3 as default

Substrate research established the encoder is the retrieval ceiling, not the SSM (see `trm-pipeline-upgrade-synthesis`). bge-m3 has wider geometry (mean_sim 0.56 vs nomic's 0.71), lifting cosine baseline from 0.40 to 0.78 NDCG. Recent geometric analysis confirmed nomic produces a narrow embedding cone on real cogdoc content. Pairs with the substrate-side `.cog/bin/embed-server.py` and `.cog/config/kernel.yaml` updates that swap nomic → bge-m3 across the substrate workspace.

Encoder-naive call sites that already pass intent strings (`search_query`, `search_document`) through the Python embed-server's HTTP API don't need changes — the embed-server materializes the prefix conditionally per model.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -short ./internal/engine/...` passes (7.7s)
- [x] `go test -short .` passes (package main)
- [x] Smoke-tested `documentPrefix`/`queryPrefix` across bge-m3 / nomic / empty / unknown model tags
- [ ] Integration test against pinned bge-m3 in Ollama — would actually exercise the new path end-to-end if Ollama + Gemma E4B are available in CI

## Migration notes (for downstream consumers)

If anything stores embeddings produced under the old (nomic, 768-dim) regime and reads them back at query time, the existing index is now incompatible with the new default (bge-m3, 1024-dim). The kernel's TRM scoring is currently disabled (no weights in canonical workspace), so this isn't a live issue today. When TRM ships, build the EMB1 index against bge-m3 from the start.