### PR TITLE
chore: drop legacy 'cogn8' name; accept only 'cog:' for nested frontmatter blocks

### DIFF
--- a/frontmatter.go
+++ b/frontmatter.go
@@ -339,11 +339,11 @@ func IsCogdoc(filePath string) (bool, error) {
 		return false, nil
 	}
 
-	// Must have either memory_sector or cogn8 block
+	// Must have either memory_sector or a cog: nested block
 	if _, hasSector := data["memory_sector"]; hasSector {
 		return true, nil
 	}
-	if _, hasCogn8 := data["cogn8"]; hasCogn8 {
+	if _, hasCog := data["cog"]; hasCog {
 		return true, nil
 	}
 

--- a/frontmatter_test.go
+++ b/frontmatter_test.go
@@ -327,9 +327,9 @@ func TestIsCogdoc(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "valid cogdoc with cogn8",
-			content:  "---\ntitle: Test\ncogn8:\n  version: 1.0\n---\nBody",
-			filename: "cogn8.md",
+			name:     "valid cogdoc with nested cog block",
+			content:  "---\ntitle: Test\ncog:\n  version: 1.0\n---\nBody",
+			filename: "cog-block.md",
 			expected: true,
 		},
 		{

--- a/handlers.go
+++ b/handlers.go
@@ -175,8 +175,8 @@ func validateCogdocContent(content, filePath string) string {
 
 	frontmatter := strings.Join(lines[1:closingIndex], "\n")
 	if !strings.Contains(frontmatter, "type:") && !strings.Contains(frontmatter, "type :") {
-		// Check for nested type (cogn8 format)
-		if !regexp.MustCompile(`(?m)(cogn8|cog):\s*\n\s+.*type:`).MatchString(frontmatter) {
+		// Accept type: nested under a top-level cog: block
+		if !regexp.MustCompile(`(?m)cog:\s*\n\s+.*type:`).MatchString(frontmatter) {
 			return "Missing 'type' field in frontmatter."
 		}
 	}

--- a/rbac.go
+++ b/rbac.go
@@ -149,7 +149,7 @@ func (rl *RoleLoader) parseFrontmatter(data []byte) (*Role, error) {
 	// Parse YAML safely (no eval, no code execution)
 	var role Role
 	decoder := yaml.NewDecoder(strings.NewReader(frontmatterYAML))
-	decoder.KnownFields(false) // Allow extra fields (cogn8 metadata)
+	decoder.KnownFields(false) // Allow extra fields (cog block + other metadata)
 
 	if err := decoder.Decode(&role); err != nil {
 		return nil, fmt.Errorf("YAML parse error: %w", err)

--- a/scripts/vectors.sh
+++ b/scripts/vectors.sh
@@ -140,13 +140,13 @@ cog_embed_update() {
 }
 
 # =============================================================================
-# INTEGRATION WITH COGN8
+# INTEGRATION WITH cog CLI
 # =============================================================================
 
-# These functions can be called via the unified cogn8 interface
-# Example: cogn8 embed index
-#          cogn8 embed search "query"
-#          cogn8 embed status
+# These functions can be called via the unified cog interface
+# Example: cog embed index
+#          cog embed search "query"
+#          cog embed status
 
 # Export functions for subshells (bash only)
 if [ -n "${BASH_VERSION:-}" ]; then


### PR DESCRIPTION
## Summary

Five files in HEAD reference a legacy `cogn8` name — as a YAML frontmatter key (\`data[\"cogn8\"]\`), as part of a regex alternation (`(cogn8|cog):`), in test fixtures, and in CLI-integration comments. handlers.go's regex already accepted both `cogn8:` and `cog:` as the nested type-block prefix, so `cog:` is the alternate form that was already wired in.

This removes the legacy name from the public source. Capability is preserved (frontmatter blocks still work; just the prefix is now uniformly `cog:`).

## Files changed

| file | change |
|---|---|
| `frontmatter.go` | `IsCogdoc()` now checks `memory_sector` OR top-level `cog:` (was `cogn8:`). Aligns with handlers.go regex preference. |
| `frontmatter_test.go` | Test fixture renamed: \`name: \"valid cogdoc with nested cog block\"\`, content uses `cog:`, filename `cog-block.md`. |
| `handlers.go` | `validateCogdocContent` regex simplified `(cogn8\|cog):` → `cog:`. |
| `rbac.go` | Comment updated: `(cogn8 metadata)` → `(cog block + other metadata)`. |
| `scripts/vectors.sh` | Integration-section comments use `cog embed search` etc. instead of `cogn8 embed search`. |

## Migration note

Substrate cogdocs in private workspaces that have used `cogn8:` as a top-level frontmatter key will need a one-line rename to `cog:` to keep passing `IsCogdoc` validation. That's a follow-up substrate-side migration. The audit of the canonical workspace found ~10 files in `.cog/mem/episodic/` and ~5 under `.cog/bin/tools/coordination/` using the legacy key.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -short` on package main + `internal/engine/...` passes
- [x] No remaining `cogn8` strings in tracked source (only matches are in gitignored agent-worktree mirrors)

## History note

This is a current-HEAD removal. Past commits in repo history still contain the term. The repo is public, so the term is in publicly-readable history — this PR stops the bleeding for current/future state. A full history scrub via \`git filter-repo\` is heavier and not in scope.