### PR TITLE
feat(engine): adopt "vllm" as a first-class provider config citizen (Phase 0)

### DIFF
--- a/docs/inference/vllm.md
+++ b/docs/inference/vllm.md
@@ -1,0 +1,135 @@
+# vLLM as a CogOS Inference Provider
+
+vLLM is a first-class provider type in the CogOS kernel. The `"vllm"`
+type label routes through the shared OpenAI-compatible dispatch path
+(`internal/engine/provider_openai.go`); no dedicated provider
+implementation is required for the unsupervised case (the operator runs
+`vllm serve` themselves).
+
+This page covers the unsupervised setup. A future `"vllm-supervised"`
+provider type will add launchd / systemd lifecycle management, mirroring
+how `mlx-supervised` works today.
+
+## When to use vLLM
+
+- **Linux / CUDA nodes**: vLLM is the recommended local-tier provider.
+  PagedAttention, native prefix caching, and chunked prefill give better
+  throughput than Ollama under continuous-running autonomic workloads.
+- **LAN-attached inference box**: a remote vLLM endpoint is just an
+  OpenAI-compatible HTTP target. Set `endpoint` to the box's address.
+- **Apple Silicon laptop**: vLLM's Metal backend is not production-ready
+  for continuous-running autonomic work. Prefer `mlx-supervised`
+  locally and route to a remote vLLM endpoint for heavier inference.
+
+## Prerequisites
+
+Install vLLM and confirm it can serve a model. The minimum setup is:
+
+```bash
+pip install vllm
+vllm serve google/gemma-2-9b-it \
+    --host 127.0.0.1 \
+    --port 8000 \
+    --enable-prefix-caching
+```
+
+vLLM speaks the OpenAI `/v1/chat/completions` and `/v1/models` API on
+the configured port. The kernel reaches it through the standard
+`OpenAICompatProvider`.
+
+Recommended startup flags for substrate use:
+
+| Flag | Purpose |
+|------|---------|
+| `--host 127.0.0.1` | Loopback-only listener for laptop / single-node nodes. |
+| `--port 8000` | Default port; align with `providers.local.yaml`. |
+| `--enable-prefix-caching` | Reuse KV cache across dispatches with shared identity / role prefixes. The substrate is designed to benefit from this — see Phase 2 of the migration plan. |
+| `--enable-chunked-prefill` | Smooths long-prompt latency under concurrent load. |
+| `--max-model-len <N>` | Cap context window if you need to bound VRAM. |
+
+## Configuration
+
+Add a `vllm` block to `.cog/config/providers.local.yaml`. Example:
+
+```yaml
+providers:
+  vllm-local:
+    type: vllm
+    enabled: true
+    endpoint: "http://localhost:8000"
+    model: "google/gemma-2-9b-it"
+    timeout: 300
+    context_window: 32768
+
+routing:
+  prefer_local: true
+  fallback_chain:
+    - vllm-local
+    - ollama
+    - anthropic
+```
+
+Key fields:
+
+- **`type: vllm`** — registers under the OpenAI-compat dispatch path.
+  The kernel uses this label in logs and metrics so vLLM is
+  distinguishable from LM Studio / llama.cpp servers.
+- **`endpoint`** — the vLLM server's HTTP base URL. Strip the trailing
+  `/v1` if present; the kernel normalizes it.
+- **`model`** — the model identifier vLLM advertises in `/v1/models`.
+  Must exactly match the `--model` argument vLLM was started with.
+- **`timeout`** — request timeout in seconds; bump to 300+ if you serve
+  large prompts on a busy box.
+- **`context_window`** — informational ceiling used by context
+  assembly. Must be ≤ vLLM's `--max-model-len`.
+
+## Remote vLLM (LAN)
+
+Same shape, just point `endpoint` at the remote box:
+
+```yaml
+providers:
+  vllm-remote:
+    type: vllm
+    enabled: true
+    endpoint: "http://10.0.0.42:8000"
+    model: "google/gemma-2-9b-it"
+    timeout: 300
+```
+
+The kernel makes no distinction between a local and remote OpenAI-
+compatible endpoint at dispatch time. Authentication is via the standard
+`api_key_env` field if the remote endpoint requires a bearer token.
+
+## Verifying
+
+```bash
+# Server health
+curl -sf http://localhost:8000/v1/models | jq .
+
+# Roundtrip a request through the kernel router
+./scripts/cog infer --model vllm-local "hello"
+```
+
+If the model is listed at `/v1/models` and `infer` completes, vLLM is
+correctly registered.
+
+## Caveats
+
+- **GPU / VRAM**: vLLM allocates per-model VRAM up front. Coexisting
+  multiple model servers on one GPU requires manual fraction allocation
+  (`--gpu-memory-utilization 0.5`).
+- **No kernel lifecycle**: the unsupervised type does not start or
+  restart vLLM. If the server crashes, the router marks it unavailable;
+  fallback chains continue dispatching to whatever remains.
+- **Default model fallback**: removing Ollama from the fallback chain is
+  a Phase 4 migration step. Until then, leave Ollama in the fallback so
+  the kernel stays responsive when vLLM is loading or restarting.
+
+## See also
+
+- `docs/PROVIDER-SPEC.md` — full Provider interface spec.
+- `docs/writing-a-provider.md` — guide for adding new provider types.
+- `internal/engine/router.go` — `makeProvider` registration switch.
+- `internal/engine/provider_openai.go` — the dispatch path vLLM uses.
+- `internal/engine/provider_vllm_test.go` — dispatch parity tests.

--- a/internal/engine/defaults/providers.yaml
+++ b/internal/engine/defaults/providers.yaml
@@ -1,6 +1,23 @@
 # Inference provider configuration
 # The router loads enabled providers at startup and routes requests
 # based on capability, availability, and the sovereignty gradient.
+#
+# Additional provider types are first-class but disabled by default:
+#   - vllm           : OpenAI-compatible local server (Linux/CUDA). See
+#                      docs/inference/vllm.md for setup. The kernel
+#                      assumes the operator runs `vllm serve` themselves;
+#                      a future "vllm-supervised" type will add launchd /
+#                      systemd lifecycle management.
+#   - lmstudio       : LM Studio's local OpenAI-compatible server.
+#   - mlx-supervised : kernel-managed mlx_lm.server (Apple Silicon).
+# Add them to providers.local.yaml to opt in. Example for vLLM:
+#   vllm-local:
+#     type: vllm
+#     enabled: true
+#     endpoint: "http://localhost:8000"
+#     model: "google/gemma-2-9b-it"
+#     timeout: 300
+#     context_window: 32768
 
 providers:
   ollama:

--- a/internal/engine/provider_vllm_test.go
+++ b/internal/engine/provider_vllm_test.go
@@ -1,0 +1,244 @@
+// provider_vllm_test.go — vLLM provider dispatch parity tests.
+//
+// vLLM is registered as a first-class provider type in router.go's
+// makeProvider switch (case "vllm"). It resolves to OpenAICompatProvider
+// because vLLM speaks the OpenAI /v1/chat/completions and /v1/models
+// contract.
+//
+// These tests do not require a live vLLM server. They use httptest.Server
+// to emit vLLM-shaped responses and verify the OpenAICompatProvider parses
+// them correctly. vLLM's distinguishing wire-level features — the standard
+// "usage" block with prompt_tokens / completion_tokens / total_tokens, and
+// the /v1/models listing — are confirmed to round-trip through the
+// existing OpenAICompatProvider without any vLLM-specific code path.
+//
+// Phase 0 of the Ollama → vLLM migration plan; see docs/inference/vllm.md
+// and the migration cogdoc for the broader phased approach.
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newVLLMTestServer returns an httptest server that emits vLLM-shaped
+// /v1/models and /v1/chat/completions responses for the configured model.
+func newVLLMTestServer(t *testing.T, modelID string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/models":
+			// vLLM's /v1/models response shape matches OpenAI's: a "data"
+			// array of objects with an "id" field plus implementation-
+			// specific extras the OpenAI client ignores.
+			_ = json.NewEncoder(w).Encode(openaiModelsResponseJSON(modelID))
+		case "/v1/chat/completions":
+			if r.Method != http.MethodPost {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			var payload openaiChatRequest
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			if payload.Stream {
+				// Minimal SSE response with one delta and a usage chunk.
+				w.Header().Set("Content-Type", "text/event-stream")
+				stop := "stop"
+				chunks := []openaiStreamChunk{
+					{
+						ID:      "vllm-chatcmpl-1",
+						Choices: []openaiStreamChoice{{Index: 0, Delta: openaiStreamDelta{Role: "assistant"}}},
+					},
+					{
+						ID:      "vllm-chatcmpl-1",
+						Choices: []openaiStreamChoice{{Index: 0, Delta: openaiStreamDelta{Content: "pong"}}},
+					},
+					{
+						ID:      "vllm-chatcmpl-1",
+						Choices: []openaiStreamChoice{{Index: 0, Delta: openaiStreamDelta{}, FinishReason: &stop}},
+						Usage:   &openaiUsageResponse{PromptTokens: 8, CompletionTokens: 1, TotalTokens: 9},
+					},
+				}
+				for _, c := range chunks {
+					b, _ := json.Marshal(c)
+					fmt.Fprintf(w, "data: %s\n\n", b)
+				}
+				fmt.Fprint(w, "data: [DONE]\n\n")
+				return
+			}
+			// Non-streaming: emit a vLLM-shaped chat completion with a
+			// canonical usage block (vLLM always populates usage).
+			_ = json.NewEncoder(w).Encode(openaiChatResponse{
+				ID: "vllm-chatcmpl-1",
+				Choices: []openaiChoice{
+					{
+						Index:        0,
+						Message:      openaiMessage{Role: "assistant", Content: "pong"},
+						FinishReason: "stop",
+					},
+				},
+				Usage: &openaiUsageResponse{
+					PromptTokens:     8,
+					CompletionTokens: 1,
+					TotalTokens:      9,
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+// TestVLLMProviderTypeResolvesToOpenAICompat asserts that the "vllm"
+// provider type label produces an OpenAICompatProvider — i.e., vLLM
+// reuses the shared dispatch path. This is the load-bearing claim for
+// Phase 0: no new provider implementation is required.
+func TestVLLMProviderTypeResolvesToOpenAICompat(t *testing.T) {
+	t.Parallel()
+
+	p, err := makeProvider("vllm", ProviderConfig{
+		Type:     "vllm",
+		Endpoint: "http://localhost:8000",
+		Model:    "gemma4:e4b",
+		Timeout:  30,
+	}, nil)
+	if err != nil {
+		t.Fatalf("makeProvider(vllm): %v", err)
+	}
+	oa, ok := p.(*OpenAICompatProvider)
+	if !ok {
+		t.Fatalf("vllm should resolve to *OpenAICompatProvider, got %T", p)
+	}
+	if oa.Name() != "vllm" {
+		t.Errorf("Name() = %q; want vllm", oa.Name())
+	}
+	if oa.Model() != "gemma4:e4b" {
+		t.Errorf("Model() = %q; want gemma4:e4b", oa.Model())
+	}
+	caps := oa.Capabilities()
+	if !caps.IsLocal {
+		t.Error("IsLocal should be true for vllm (local-tier provider)")
+	}
+}
+
+// TestVLLMAvailableHitsModelsEndpoint verifies the /v1/models probe used
+// by the router's availability check works against a vLLM-shaped server.
+func TestVLLMAvailableHitsModelsEndpoint(t *testing.T) {
+	t.Parallel()
+
+	srv := newVLLMTestServer(t, "gemma4:e4b")
+	defer srv.Close()
+
+	p, err := makeProvider("vllm-local", ProviderConfig{
+		Type:     "vllm",
+		Endpoint: srv.URL,
+		Model:    "gemma4:e4b",
+		Timeout:  5,
+	}, nil)
+	if err != nil {
+		t.Fatalf("makeProvider: %v", err)
+	}
+	if !p.Available(context.Background()) {
+		t.Error("Available() = false; want true when model is listed at /v1/models")
+	}
+}
+
+// TestVLLMCompleteParsesUsageBlock confirms that vLLM's standard usage
+// block round-trips through the shared OpenAI-compat parsing logic. This
+// is the dispatch-parity assertion against Ollama / lmstudio.
+func TestVLLMCompleteParsesUsageBlock(t *testing.T) {
+	t.Parallel()
+
+	srv := newVLLMTestServer(t, "gemma4:e4b")
+	defer srv.Close()
+
+	p, err := makeProvider("vllm-local", ProviderConfig{
+		Type:     "vllm",
+		Endpoint: srv.URL,
+		Model:    "gemma4:e4b",
+		Timeout:  5,
+	}, nil)
+	if err != nil {
+		t.Fatalf("makeProvider: %v", err)
+	}
+	resp, err := p.Complete(context.Background(), &CompletionRequest{
+		Messages: []ProviderMessage{
+			{Role: "user", Content: "reply with: pong"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if resp.Content != "pong" {
+		t.Errorf("Content = %q; want pong", resp.Content)
+	}
+	if resp.StopReason != "end_turn" {
+		t.Errorf("StopReason = %q; want end_turn", resp.StopReason)
+	}
+	if resp.Usage.InputTokens != 8 || resp.Usage.OutputTokens != 1 {
+		t.Errorf("Usage = %+v; want {InputTokens:8 OutputTokens:1}", resp.Usage)
+	}
+	if resp.ProviderMeta.Provider != "vllm-local" {
+		t.Errorf("ProviderMeta.Provider = %q; want vllm-local", resp.ProviderMeta.Provider)
+	}
+}
+
+// TestVLLMStreamEmitsSSEDeltas confirms SSE streaming through the shared
+// parseOpenAISSE path against a vLLM-shaped event stream.
+func TestVLLMStreamEmitsSSEDeltas(t *testing.T) {
+	t.Parallel()
+
+	srv := newVLLMTestServer(t, "gemma4:e4b")
+	defer srv.Close()
+
+	p, err := makeProvider("vllm-local", ProviderConfig{
+		Type:     "vllm",
+		Endpoint: srv.URL,
+		Model:    "gemma4:e4b",
+		Timeout:  5,
+	}, nil)
+	if err != nil {
+		t.Fatalf("makeProvider: %v", err)
+	}
+	ch, err := p.Stream(context.Background(), &CompletionRequest{
+		Messages: []ProviderMessage{{Role: "user", Content: "reply pong"}},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+
+	var content strings.Builder
+	var done bool
+	var usage *TokenUsage
+	for sc := range ch {
+		if sc.Error != nil {
+			t.Fatalf("stream error: %v", sc.Error)
+		}
+		if sc.Delta != "" {
+			content.WriteString(sc.Delta)
+		}
+		if sc.Done {
+			done = true
+			usage = sc.Usage
+		}
+	}
+	if content.String() != "pong" {
+		t.Errorf("streamed content = %q; want pong", content.String())
+	}
+	if !done {
+		t.Error("expected a Done chunk at end of vllm SSE stream")
+	}
+	if usage == nil {
+		t.Fatal("expected usage on final stream chunk")
+	}
+	if usage.InputTokens != 8 || usage.OutputTokens != 1 {
+		t.Errorf("Usage = %+v; want {8, 1}", usage)
+	}
+}

--- a/internal/engine/router.go
+++ b/internal/engine/router.go
@@ -521,6 +521,14 @@ func makeProvider(name string, pc ProviderConfig, procMgr *ProcessManager) (Prov
 		return NewOllamaProvider(name, pc), nil
 	case "anthropic":
 		return NewAnthropicProvider(name, pc), nil
+	// "vllm" is a first-class config citizen: it routes through the same
+	// OpenAI-compatible HTTP dispatch path as lmstudio and llama.cpp servers.
+	// vLLM's /v1/chat/completions and /v1/models endpoints satisfy the
+	// OpenAICompatProvider contract; no separate provider implementation is
+	// required for the unsupervised case (operator runs vllm serve themselves).
+	// A future "vllm-supervised" type will add launchd/systemd lifecycle
+	// management, mirroring mlx-supervised. See docs/inference/vllm.md and
+	// the ollama-to-vllm-migration-plan cogdoc.
 	case "openai-compat", "openai", "lmstudio", "vllm", "llamacpp":
 		return NewOpenAICompatProvider(name, pc), nil
 	case "claude-code":

--- a/internal/engine/router_test.go
+++ b/internal/engine/router_test.go
@@ -234,6 +234,28 @@ func TestMakeProviderInfersTypeFromName(t *testing.T) {
 	}
 }
 
+// TestMakeProviderVLLM verifies that type "vllm" is registered and routes to
+// the OpenAI-compatible provider implementation. vLLM exposes the OpenAI
+// /v1/chat/completions and /v1/models contract; no dedicated provider type
+// is required for the unsupervised case.
+func TestMakeProviderVLLM(t *testing.T) {
+	t.Parallel()
+	p, err := makeProvider("vllm-local", ProviderConfig{
+		Type:     "vllm",
+		Endpoint: "http://localhost:8000",
+		Model:    "gemma4:e4b",
+	}, nil)
+	if err != nil {
+		t.Fatalf("makeProvider(vllm): %v", err)
+	}
+	if _, ok := p.(*OpenAICompatProvider); !ok {
+		t.Errorf("vllm should resolve to *OpenAICompatProvider, got %T", p)
+	}
+	if p.Name() != "vllm-local" {
+		t.Errorf("Name() = %q; want vllm-local", p.Name())
+	}
+}
+
 // ── defaultProvidersConfig ────────────────────────────────────────────────────
 
 func TestDefaultProvidersConfig(t *testing.T) {


### PR DESCRIPTION
## Summary

**Phase 0 of the Ollama→vLLM migration plan** (full plan: `cog://mem/semantic/projects/ollama-to-vllm-migration-plan.cog.md`). Smallest viable PR — adds vLLM as a first-class config citizen without changing any dispatch logic.

The router already mapped `"vllm"` to `NewOpenAICompatProvider` alongside `"openai-compat"`, `"lmstudio"`, `"llamacpp"`; vLLM was *nominally* a registered provider type. This PR adds the missing pieces: comment explaining the mapping, example config block, integration tests, operator-facing docs page.

## Changes

| File | Lines | Purpose |
|------|-------|---------|
| `internal/engine/router.go` | +8 | Comment block above the `"vllm"` case explaining the OpenAI-compat reuse |
| `internal/engine/defaults/providers.yaml` | +17 | Header comment + commented vLLM example config |
| `internal/engine/router_test.go` | +22 | `TestMakeProviderVLLM` — unit test for `makeProvider("vllm", ...)` |
| `internal/engine/provider_vllm_test.go` | +244 (new) | Four httptest stub-server tests: type resolution, `/v1/models`, `/v1/chat/completions` parsing with vLLM-shaped usage block, SSE streaming |
| `docs/inference/vllm.md` | +135 (new) | Operator brief: when to use vLLM, prerequisites, `vllm serve` flags, config example, remote-vLLM pattern, verification, caveats |

Total: +426 / -0.

## Strictly NOT in scope

- No dispatch logic changes
- No new provider implementation (NewOpenAICompatProvider reused)
- No harness consolidation (Phase 1)
- No prefix-caching changes (Phase 2)
- No vLLM-supervised provider (Phase 3)
- No default changes (Phase 4)

## Test plan

- [x] `go test ./internal/engine/` — ok 7.7s; new tests pass, no regressions
- [x] `go test ./...` — all packages green (`internal/engine`, `internal/eval`, `internal/providers/daemon`, `internal/providers/pin`, `pkg/alias`, `pkg/filelock`, `pkg/skills`, root `myrgic/cogos`)
- [x] Stub-server tests run in normal `go test` flow (no live vLLM required; no `//go:build integration` tag)
- [ ] Operator manually verifies the config example works against a real vLLM server (out-of-band; example is documentation-grade)

## Follow-ups (Phase 1+)

- `local_agent_harness.go:787` / `local_llm.go` still call `detectLocalLLMTarget` + `buildLocalProvider`, bypassing the router. Phase 1 consolidates this.
- Operators may prefer the vLLM example in a separate `*.example` file at repo root rather than the embedded defaults YAML; trivially movable if so.