### PR TITLE
fix(engine): serialize concurrent Ollama calls via ollamaMu (closes #107)

### DIFF
--- a/internal/engine/local_agent_harness.go
+++ b/internal/engine/local_agent_harness.go
@@ -185,6 +185,14 @@ type LocalHarnessController struct {
 	// Cleared whenever the snapshot returns to AllGreen.
 	lastEscalatedFingerprint string
 	history                  []localHarnessCycleRecord
+
+	// ollamaMu serializes all Ollama inference calls across both the metabolic
+	// cycle (runCycle) and user-initiated dispatches (DispatchToHarness).
+	// Ollama defaults to OLLAMA_NUM_PARALLEL=1; concurrent requests from the
+	// same controller cause duplicate model copies in VRAM and queued waits
+	// that look like hangs. One lock per controller, held for the duration of
+	// the inference call, makes the serialization explicit and debuggable.
+	ollamaMu sync.Mutex
 }
 
 func NewLocalHarnessController(cfg *Config, nucleus *Nucleus, process *Process, mcpSrv *MCPServer) (*LocalHarnessController, error) {
@@ -427,9 +435,15 @@ func (c *LocalHarnessController) runCycle(parent context.Context, reason string,
 	}
 	outcome.record.Model = model
 
+	// ollamaMu serializes this cycle's inference calls against concurrent
+	// DispatchToHarness calls. Ollama is single-threaded by default; holding
+	// the lock for the full assess+execute block prevents two concurrent
+	// /api/chat requests from loading duplicate model copies into VRAM.
+	c.ollamaMu.Lock()
 	provider := buildLocalProvider(target, model, c.localProviderTimeout)
 	assessment, err := c.assessCycle(ctx, provider, outcome.record.Observation)
 	if err != nil {
+		c.ollamaMu.Unlock()
 		outcome.record.Action = "error"
 		outcome.record.Reason = err.Error()
 		c.finishCycle(outcome.record)
@@ -460,6 +474,7 @@ func (c *LocalHarnessController) runCycle(parent context.Context, reason string,
 			outcome.record.Result = result
 		}
 	}
+	c.ollamaMu.Unlock()
 
 	if ctx.Err() == context.DeadlineExceeded {
 		outcome.timedOut = true
@@ -833,6 +848,16 @@ func (c *LocalHarnessController) DispatchToHarness(ctx context.Context, req Disp
 			return nil, err
 		}
 	}
+
+	// ollamaMu serializes dispatch inference calls against concurrent metabolic
+	// cycles. Ollama is single-threaded by default; a dispatch arriving while
+	// runCycle is mid-stream would issue a concurrent /api/chat that loads a
+	// second model copy into VRAM. The lock is held for the full batch so that
+	// req.N slots also serialize against the cycle (they already share the same
+	// provider object, so they are already serialized at the Ollama layer, but
+	// holding the lock makes the exclusion explicit and testable).
+	c.ollamaMu.Lock()
+	defer c.ollamaMu.Unlock()
 
 	provider := buildLocalProvider(target, model, c.localProviderTimeout)
 	batch := &DispatchBatchResult{

--- a/internal/engine/local_agent_harness_test.go
+++ b/internal/engine/local_agent_harness_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 )
 
@@ -132,5 +133,96 @@ func TestServerLegacyAgentStatusRoute(t *testing.T) {
 	}
 	if body["uptime"].(string) != "1m0s" {
 		t.Fatalf("uptime = %v; want 1m0s", body["uptime"])
+	}
+}
+
+// TestLocalHarnessOllamaConcurrencySerialized verifies that ollamaMu prevents
+// runCycle and DispatchToHarness from issuing concurrent /api/chat requests.
+// It spins up a fake Ollama server that increments an in-flight counter on
+// entry and decrements on exit; any counter value > 1 means concurrent calls
+// leaked through and would load duplicate model copies on a real Ollama node.
+func TestLocalHarnessOllamaConcurrencySerialized(t *testing.T) {
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	cfg.LocalModel = "gemma4:e4b"
+	proc := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	srv := NewServer(cfg, makeNucleus("Cog", "tester"), proc)
+
+	model := "gemma4:e4b"
+
+	var (
+		inFlight    atomic.Int32
+		maxInFlight atomic.Int32
+	)
+
+	llm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/tags":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"models": []map[string]any{{"name": model}},
+			})
+		case "/api/chat":
+			cur := inFlight.Add(1)
+			// Record the peak concurrency seen.
+			for {
+				old := maxInFlight.Load()
+				if cur <= old {
+					break
+				}
+				if maxInFlight.CompareAndSwap(old, cur) {
+					break
+				}
+			}
+			defer inFlight.Add(-1)
+
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"message": map[string]any{
+					"role":    "assistant",
+					"content": `{"action":"sleep","reason":"idle","urgency":0.0,"target":"","task":""}`,
+				},
+				"done":              true,
+				"prompt_eval_count": 1,
+				"eval_count":        1,
+			})
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer llm.Close()
+	t.Setenv(localLLMEndpointEnv, llm.URL)
+
+	ctrl, err := NewLocalHarnessController(cfg, makeNucleus("Cog", "tester"), proc, srv.mcpServer)
+	if err != nil {
+		t.Fatalf("NewLocalHarnessController: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Fire a metabolic cycle and a dispatch concurrently. Without ollamaMu
+	// both would immediately call buildLocalProvider and hit /api/chat at
+	// the same time.
+	errs := make(chan error, 2)
+	go func() {
+		_, err := ctrl.TriggerAgent(ctx, DefaultAgentID, "concurrency-test", true)
+		errs <- err
+	}()
+	go func() {
+		_, err := ctrl.DispatchToHarness(ctx, DispatchRequest{
+			Task:           "concurrency-check",
+			N:              1,
+			TimeoutSeconds: 10,
+		})
+		errs <- err
+	}()
+
+	for i := 0; i < 2; i++ {
+		if err := <-errs; err != nil {
+			t.Errorf("goroutine %d error: %v", i, err)
+		}
+	}
+
+	if got := maxInFlight.Load(); got > 1 {
+		t.Errorf("max concurrent Ollama /api/chat calls = %d; want <= 1 (ollamaMu not working)", got)
 	}
 }


### PR DESCRIPTION
## Summary

- `runCycle` and `DispatchToHarness` both call `buildLocalProvider` independently, allowing a user dispatch to arrive while a metabolic cycle is in-flight and issue a concurrent `/api/chat` to Ollama.
- Ollama defaults to `OLLAMA_NUM_PARALLEL=1`; concurrent requests load duplicate model copies into VRAM (user-visible: multiple instances of the same model resident simultaneously).
- Fix: `ollamaMu sync.Mutex` on `LocalHarnessController`, acquired before `buildLocalProvider`, held for the full inference block in both `runCycle` and `DispatchToHarness`.

## Test plan

- `TestLocalHarnessOllamaConcurrencySerialized`: fires a cycle and a dispatch concurrently against a fake Ollama server that tracks concurrent `/api/chat` calls; asserts `maxInFlight <= 1`.
- All existing `TestLocalHarness*` and `TestServer*` tests pass without changes.

## Notes

- `req.N > 1` (fan-out) still launches N goroutines sharing one provider, but the whole batch is serialized against concurrent cycles.
- Not a breaking change.

Closes #107.