### PR TITLE
feat(engine): per-request keep_alive override for cold-start eval

### DIFF
--- a/internal/engine/provider.go
+++ b/internal/engine/provider.go
@@ -100,6 +100,15 @@ type CompletionRequest struct {
 
 	// Metadata carries routing/ledger information not sent to the model.
 	Metadata RequestMetadata `json:"metadata"`
+
+	// KeepAlive overrides the Ollama keep_alive value for this request only.
+	// Accepts a Go duration string ("5m", "1h"), an integer number of seconds,
+	// or -1 to keep the model loaded indefinitely. When nil, the provider's
+	// default is used (currently -1 to keep the model warm across cycles).
+	// Set to 0 to force model eviction after this request completes — useful
+	// for cold-start simulation in eval workloads.
+	// Non-Ollama providers ignore this field.
+	KeepAlive *any `json:"keep_alive,omitempty"`
 }
 
 // ProviderMessage is a single conversation turn.

--- a/internal/engine/provider_ollama.go
+++ b/internal/engine/provider_ollama.go
@@ -302,6 +302,15 @@ func buildOllamaRequest(model string, req *CompletionRequest, stream bool, conte
 		}
 	}
 
+	// Resolve keep_alive: per-request override takes precedence over the
+	// global default of -1. A nil KeepAlive on the request means "use the
+	// provider default." A non-nil value (including 0 for cold-start
+	// simulation) is forwarded verbatim to Ollama.
+	keepAlive := any(-1) // provider default: keep model in VRAM indefinitely
+	if req.KeepAlive != nil {
+		keepAlive = *req.KeepAlive
+	}
+
 	return &ollamaChatRequest{
 		Model:     model,
 		Messages:  msgs,
@@ -309,7 +318,7 @@ func buildOllamaRequest(model string, req *CompletionRequest, stream bool, conte
 		Stream:    stream,
 		Think:     false, // prevent silent token burn in qwen3 thinking mode
 		Options:   opts,
-		KeepAlive: -1, // pin model in VRAM; Ollama's 5m default evicts between cycles
+		KeepAlive: keepAlive,
 	}
 }
 

--- a/internal/engine/provider_ollama_test.go
+++ b/internal/engine/provider_ollama_test.go
@@ -114,6 +114,54 @@ func TestBuildOllamaRequestKeepAlivePinsModel(t *testing.T) {
 	}
 }
 
+func TestBuildOllamaRequestKeepAliveOverride(t *testing.T) {
+	t.Parallel()
+
+	// Zero override: forces model eviction after the request (cold-start simulation).
+	zeroVal := any(0)
+	reqZero := &CompletionRequest{
+		Messages:  []ProviderMessage{{Role: "user", Content: "hi"}},
+		KeepAlive: &zeroVal,
+	}
+	rZero := buildOllamaRequest("m", reqZero, false, 0)
+	bodyZero, err := json.Marshal(rZero)
+	if err != nil {
+		t.Fatalf("marshal zero: %v", err)
+	}
+	if !bytes.Contains(bodyZero, []byte(`"keep_alive":0`)) {
+		t.Errorf("zero override should produce keep_alive=0; got %s", bodyZero)
+	}
+
+	// Duration string override: "5m" passes through to Ollama as-is.
+	durVal := any("5m")
+	reqDur := &CompletionRequest{
+		Messages:  []ProviderMessage{{Role: "user", Content: "hi"}},
+		KeepAlive: &durVal,
+	}
+	rDur := buildOllamaRequest("m", reqDur, false, 0)
+	bodyDur, err := json.Marshal(rDur)
+	if err != nil {
+		t.Fatalf("marshal dur: %v", err)
+	}
+	if !bytes.Contains(bodyDur, []byte(`"keep_alive":"5m"`)) {
+		t.Errorf("duration string override should produce keep_alive=\"5m\"; got %s", bodyDur)
+	}
+
+	// Nil override: falls back to provider default (-1).
+	reqNil := &CompletionRequest{
+		Messages:  []ProviderMessage{{Role: "user", Content: "hi"}},
+		KeepAlive: nil,
+	}
+	rNil := buildOllamaRequest("m", reqNil, false, 0)
+	bodyNil, err := json.Marshal(rNil)
+	if err != nil {
+		t.Fatalf("marshal nil: %v", err)
+	}
+	if !bytes.Contains(bodyNil, []byte(`"keep_alive":-1`)) {
+		t.Errorf("nil override should fall back to keep_alive=-1; got %s", bodyNil)
+	}
+}
+
 func TestOllamaCapabilitiesContextWindow(t *testing.T) {
 	t.Parallel()
 	p := NewOllamaProvider("ollama", ProviderConfig{Model: "m", ContextWindow: 32768})


### PR DESCRIPTION
## Summary

Adds an optional `KeepAlive *any` field to `CompletionRequest` so callers can override the Ollama `keep_alive` value per-request without touching the global default.

- `provider.go`: add `KeepAlive *any` to `CompletionRequest` with doc comment
- `provider_ollama.go`: resolve nil to `-1` (existing pin-in-VRAM default); non-nil passes verbatim to Ollama
- `provider_ollama_test.go`: `TestBuildOllamaRequestKeepAliveOverride` — zero (evict), duration string ("5m"), nil (falls back to -1)

## Use cases

- **Cold-start simulation**: eval workloads set `KeepAlive = 0` to force model eviction after each trial, measuring true time-to-first-token across models
- **Bounded warm-up**: pass `"5m"` for requests that should hold the model warm for a finite window

## Non-Ollama providers

The field is silently ignored by all non-Ollama providers. The global `-1` default remains unchanged for normal production cycles.

## Test plan

- [ ] `go test ./internal/engine/ -run TestBuildOllamaRequest` passes (verified locally)
- [ ] CI green

Closes #115.