### PR TITLE
chore(gitignore): ignore .claude/ and agent-worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ run/
 
 # Moved to standalone autoresearch repo (2026-04-20)
 autoresearch-foveated/
+
+# Harness scratch + ephemeral parallel-agent worktrees
+.claude/
+agent-worktrees/


### PR DESCRIPTION
## Summary
- Add `.claude/` and `agent-worktrees/` to `.gitignore`
- Both are harness scratch produced by Claude Code parallel-agent workflows and should never enter source control
- Previously showed as untracked noise on `git status`

## Test plan
- [x] `git check-ignore -v .claude/ agent-worktrees/` matches the new patterns
- [x] `git status` no longer surfaces those directories on local checkout