### PR TITLE
docs(rfc): RFC-0004 — v0.5.0 refactor architectural calls

### DIFF
--- a/docs/rfcs/0004-v0.5.0-refactor-architectural-calls.md
+++ b/docs/rfcs/0004-v0.5.0-refactor-architectural-calls.md
@@ -74,23 +74,29 @@ and provide the mapping table (generated from Stage A's appendix).
 for cleanup. The exact incantation per extraction PR:
 
 ```bash
-# 1. Create the destination package directory.
-mkdir -p internal/<domain>/
+# 1. Ensure the destination package directory does not yet exist;
+#    gomvpkg creates it as part of the move.
 
-# 2. Move files that belong to the new package.
-#    gomvpkg rewrites import paths in all callers within the module.
-gomvpkg -from github.com/myrgic/cogos -to github.com/myrgic/cogos/internal/<domain> \
-  <file1.go> <file2.go> ...
+# 2. Move the package by import path — gomvpkg rewrites all inbound
+#    import references across the module automatically.
+#    Form: gomvpkg -from <old-import-path> -to <new-import-path>
+#    (operates on packages, not individual files)
+gomvpkg -from github.com/myrgic/cogos/internal/<domain> \
+        -to   github.com/myrgic/cogos/internal/providers/<domain>
+
+# Worked example — extracting the modality package:
+# gomvpkg -from github.com/myrgic/cogos/internal/modality \
+#         -to   github.com/myrgic/cogos/internal/providers/modality
 
 # 3. Run goimports to clean up any dangling or duplicate import lines.
-goimports -w internal/<domain>/
+goimports -w internal/providers/<domain>/
 
 # 4. Verify the module builds and tests pass.
 go build ./... && go test ./...
 
 # 5. Stage all changes (gomvpkg touches callers across the tree).
 git add -A
-git commit -m "chore(root): extract <domain> -> internal/<domain>"
+git commit -m "chore(root): extract <domain> -> internal/providers/<domain>"
 ```
 
 For packages that are pure deletions (Stage B orphan deletes), skip `gomvpkg`:

--- a/docs/rfcs/0004-v0.5.0-refactor-architectural-calls.md
+++ b/docs/rfcs/0004-v0.5.0-refactor-architectural-calls.md
@@ -1,0 +1,207 @@
+# RFC-0004: v0.5.0 Refactor — Architectural Calls and Execution Plan
+
+| Field     | Value                                                                 |
+|-----------|-----------------------------------------------------------------------|
+| Status    | Draft                                                                 |
+| Author    | @chazmaniandinkle                                                     |
+| Tracking  | [#104](https://github.com/myrgic/cogos/issues/104)                   |
+| Target    | `v0.5.0`                                                              |
+| Amends    | RFC-0001 (root-package-refactor)                                      |
+| Supersedes | RFC-0001 tooling section (gomvpkg decision; see §Tooling)            |
+
+## Summary
+
+RFC-0001 established the structural case for retiring the root package and laid out
+stages A–E. This RFC locks in the outstanding architectural calls that RFC-0001
+left open — tooling incantation, deprecation policy, public-surface discipline, and
+sequencing relative to feature work in the v0.5.0 milestone. These are decisions,
+not open questions. Implementation proceeds against RFC-0001's stage map and the
+additional constraints here.
+
+## Motivation
+
+RFC-0001 was authored before three pieces of information were settled:
+
+1. Issues #202 (`cog_fork_session`) and #203 (vLLM PagedAttention provider) were
+   promoted to the v0.5.0 milestone. Both are kernel-primitive additions that touch
+   `internal/engine/`. Running a structural refactor across those files simultaneously
+   creates avoidable rebase friction.
+
+2. The operator confirmed that external Go consumers of this module do not exist at
+   pre-1.0. The question of deprecation aliases and `pkg/` surface was genuinely open
+   in RFC-0001; it is closed here.
+
+3. RFC-0001's tooling section ruled out `gomvpkg` on the grounds that root has no
+   inbound callers. That reasoning remains sound for pure-deletion work (Stages B, C),
+   but Stage D ports (moving live code into new packages) benefit from `gomvpkg`'s
+   import-rewrite pass over the internal call graph. The ruling is reversed for Stage D.
+
+## Architectural Calls
+
+These decisions are final for v0.5.0. They are not re-opened during implementation.
+
+### Public surface discipline
+
+All domain extractions land in `internal/`. The only packages that belong in `pkg/`
+are those with demonstrated external consumers today:
+
+- `pkg/reconcile/` — stays as-is. External: `internal/eval/` and `internal/providers/`
+  depend on the `Reconcilable` interface; it remains a leaf package with its own
+  `go.mod`.
+- No new top-level `pkg/` directories are created by this refactor. Adding a `pkg/`
+  directory commits to a semver public API and external consumability. That bar is not
+  met by any of the v0.5.0 extraction targets (agent, decompose, openclaw, capability,
+  discord).
+
+Rationale: cogos is primarily a binary; the `internal/` compiler enforcement is the
+right safety boundary for code that has not been designed for external use. Promoting
+`internal/` to `pkg/` later is mechanical; the reverse is much harder.
+
+### Deprecation aliases
+
+None. v0.5.0 is a hard-break on internal import paths. Import aliases create surface
+to maintain, invite accidental external use, and conflict with the `internal/` boundary.
+At pre-1.0 (v0.x), breaking internal changes require no compatibility period.
+
+The `v0.5.0` release notes will state explicitly that internal import paths have moved
+and provide the mapping table (generated from Stage A's appendix).
+
+### Tooling incantation
+
+**Stage B and C** (deletion): no tooling needed beyond `go build ./...` verification.
+
+**Stage D** (live code ports): use `gomvpkg` for each package move, then `goimports`
+for cleanup. The exact incantation per extraction PR:
+
+```bash
+# 1. Create the destination package directory.
+mkdir -p internal/<domain>/
+
+# 2. Move files that belong to the new package.
+#    gomvpkg rewrites import paths in all callers within the module.
+gomvpkg -from github.com/myrgic/cogos -to github.com/myrgic/cogos/internal/<domain> \
+  <file1.go> <file2.go> ...
+
+# 3. Run goimports to clean up any dangling or duplicate import lines.
+goimports -w internal/<domain>/
+
+# 4. Verify the module builds and tests pass.
+go build ./... && go test ./...
+
+# 5. Stage all changes (gomvpkg touches callers across the tree).
+git add -A
+git commit -m "chore(root): extract <domain> -> internal/<domain>"
+```
+
+For packages that are pure deletions (Stage B orphan deletes), skip `gomvpkg`:
+
+```bash
+# Delete domain group files, verify build still green.
+git rm <domain>_*.go
+go build ./... && go test ./...
+git commit -m "chore(root): delete orphan <domain>_* files"
+```
+
+### Migration order
+
+Leaf packages first (no inter-target dependencies), `internal/engine/` last.
+Ordered by blast radius (ascending):
+
+1. `internal/capability/` — no inter-target deps; small (4 files).
+2. `internal/decompose/` — depends on `pkg/cogblock` and stdlib only.
+3. `internal/openclaw/` — depends on OCI client; isolated.
+4. `internal/providers/discord/` — needs DI-seam pattern; extra care per RFC-0001.
+5. `internal/agent/` — biggest; touches `internal/engine/` only via interfaces.
+
+Stage A (audit) and Stage B (bulk orphan delete) precede all of the above; they have
+no ordering constraint relative to each other and can run in parallel if multiple
+contributors are active.
+
+### Sequencing relative to feature work
+
+The refactor lands **after** #202 (`cog_fork_session`) and #203 (vLLM PagedAttention
+provider) merge. Rationale: feature work adds kernel primitives in `internal/engine/`
+— the same files Stage D will touch. Running the refactor first means every feature
+PR rebases across structural changes; running it after means only the refactor PRs
+absorb feature-branch churn. The refactor is designed to be a clean rebase target
+once feature work stabilizes.
+
+Timeline implication: Stage A (audit PR) may land at any time — it is non-functional
+and low-risk. Stages B–E wait for #202 and #203 to merge.
+
+## Target package layout
+
+No change from RFC-0001 §"Proposed final layout". Reproduced here for self-containment:
+
+```
+myrgic/cogos/
+├── cmd/cogos/                  # unchanged
+├── internal/
+│   ├── engine/                 # kernel daemon, unchanged scope
+│   ├── eval/  linkfeed/  workspace/  # already exist
+│   ├── providers/
+│   │   ├── component/  daemon/     # already exist
+│   │   └── discord/               # NEW
+│   ├── agent/                  # NEW
+│   ├── decompose/              # NEW
+│   ├── openclaw/               # NEW
+│   └── capability/             # NEW
+├── pkg/                        # unchanged; no new top-level packages
+│   ├── bep/  cogblock/  cogfield/
+│   ├── coordination/  modality/  reconcile/  skills/  uri/
+├── harness/  sdk/  envspec/    # unchanged
+└── docs/  scripts/
+```
+
+## In-flight PR rebase strategy
+
+During Stage A–B (which may run while #202/#203 are in flight):
+
+- Stage A is non-functional; it adds documentation only. Zero rebase risk.
+- Stage B deletions touch root files only. Files at root are not touched by #202 or
+  #203 (both live in `internal/`). Zero overlap; zero coordination needed.
+
+When Stages C–E begin (post-#202/#203 merge):
+
+- Run `git fetch origin main && git rebase origin/main` at the start of each
+  Stage D extraction PR. The rebase is cheap: Stage D files live in a new
+  `internal/` package; #202/#203 will have already landed in `internal/engine/`.
+- If a #202 or #203 follow-up PR introduces a file in a Stage D target package
+  (`internal/agent/`, etc.), the convention from RFC-0001 applies: whichever PR
+  lands first stakes the claim; the second rebases.
+
+## Acceptance criteria
+
+Mirrors issue #104 acceptance, with tooling specifics added:
+
+- [ ] Stage A: `docs/rfcs/0001-appendix-A-file-disposition.md` populated by
+      `scripts/audit-root-package.sh` and merged.
+- [ ] Root contains zero `.go` files (preferred) or only `doc.go`.
+- [ ] `go build ./...` and `go test ./...` green on final Stage E PR.
+- [ ] `make e2e-local` passes.
+- [ ] `pkg/*` go.mod boundaries unchanged: each builds standalone.
+- [ ] v0.5.0 release notes contain import-path break notice and mapping table.
+- [ ] RFC-0001 status flips Draft → Implemented in a final commit.
+- [ ] RFC-0004 status flips Draft → Implemented in the same commit.
+- [ ] `cogos-dev/cogfield` smoke-tested against new import paths (TS frontend; verifies
+      kernel HTTP API contracts are intact, not Go imports).
+
+## Out of scope
+
+Inherits RFC-0001 out-of-scope list. Additionally:
+
+- Adding or removing `pkg/` go.mod boundaries.
+- Any rearrangement of `internal/engine/` internals (separate RFC if needed).
+- Migration of `harness/`, `sdk/`, or `envspec/` modules.
+- Updating architecture documentation prose (follows implementation).
+
+## Relationship to RFC-0001
+
+RFC-0001 remains the authoritative stage-by-stage design document. This RFC's
+precedence over RFC-0001 is limited to:
+
+- §Tooling: `gomvpkg` IS used for Stage D (overrides RFC-0001's "explicitly not used").
+- §Deprecation aliases: no aliases (RFC-0001 was silent; this RFC decides).
+- §Public surface: `internal/` for all new extractions (RFC-0001 implied but did not
+  commit; this RFC commits).
+- §Sequencing: feature work first (RFC-0001 predated #202/#203 milestone assignment).


### PR DESCRIPTION
## Summary

RFC-0004 locks in the outstanding architectural decisions for the v0.5.0 root-package refactor, amending RFC-0001 (which established the structural case and stage map). RFC-0001 left several calls open; this RFC closes them.

**Decisions made:**

- **Public surface**: all domain extractions go to `internal/`. `pkg/reconcile/` stays as-is (only pkg/ with demonstrated external consumers). No new top-level `pkg/` directories.
- **Deprecation aliases**: none. Hard-break at v0.5.0 per v0.x pre-1.0 policy.
- **Tooling**: `gomvpkg` IS used for Stage D live-code ports (overrides RFC-0001's "explicitly not used" ruling — RFC-0001 was correct for pure-deletion work but Stage D ports benefit from the import-rewrite pass). `goimports` for cleanup. Exact incantation documented in §Tooling.
- **Migration order**: leaf packages first (capability → decompose → openclaw → discord → agent), `internal/engine/` last.
- **Sequencing**: refactor lands **after** #202 (`cog_fork_session`) and #203 (vLLM provider) merge. Stage A (audit PR) may land at any time; Stages B–E wait for feature work.

## Relationship to RFC-0001

RFC-0001 remains the authoritative stage-by-stage design document. RFC-0004's precedence is limited to: tooling (gomvpkg decision), deprecation policy, public-surface discipline, and sequencing. RFC-0001 is not superseded — it is extended.

## Tracks

Closes: #104 (RFC phase only — implementation is a multi-PR follow-up wave once this RFC merges)

## Review

This RFC documents operator-approved architectural calls. Review for:
- Internal consistency with RFC-0001's stage map
- Accuracy of the tooling incantation
- Completeness of the acceptance criteria