### PR TITLE
feat: vLLM PagedAttention provider — scaffolding + mocks (RFC-0006)

### DIFF
--- a/internal/engine/kinds_vllm.go
+++ b/internal/engine/kinds_vllm.go
@@ -1,0 +1,41 @@
+// kinds_vllm.go — Kind handler registration for cache.kv_block (RFC-0006).
+//
+// Registers the cache.kv_block Kind handler via ADR-090's kind registry so that
+// adding the new Kind requires no modification to Kind-handler switch statements.
+//
+// The handler is intentionally a logging-only stub in v0.5.0. Full handling
+// (routing KV block events to the KVCacheProvider, updating the ledger envelope,
+// applying ADR-089 pointer-envelope semantics for evictions) lands when
+// Linux/CUDA hardware integration is available.
+//
+// TODO(rfc-0006/requires-cuda): wire real handling once vLLM cgo binding lands.
+package engine
+
+import (
+	"log/slog"
+
+	"github.com/myrgic/cogos/pkg/cogblock"
+)
+
+func init() {
+	RegisterKindHandler(cogblock.KindCacheKVBlock, handleCacheKVBlock)
+}
+
+// handleCacheKVBlock is the Kind handler for cache.kv_block CogBlocks.
+// In v0.5.0 scaffolding it logs receipt and returns nil (no-op routing).
+// When Linux/CUDA hardware integration lands, this handler will:
+//   - Decode KVBlockBody from the RawPayload
+//   - Update the KVCacheProvider's block inventory
+//   - Apply ADR-089 pointer-envelope semantics for evicted blocks
+//   - Emit the appropriate bus event (warmed/evicted)
+func handleCacheKVBlock(block *CogBlock) error {
+	slog.Info("cache.kv_block received",
+		"operation", "kv_block_dispatch",
+		"block_id", block.ID,
+		"channel_id", block.SourceChannel,
+		"session_id", block.SessionID,
+		"ts", block.Timestamp,
+		// TODO(rfc-0006/requires-cuda): decode KVBlockBody and emit typed event.
+	)
+	return nil
+}

--- a/internal/providers/vllm/README-vllm.md
+++ b/internal/providers/vllm/README-vllm.md
@@ -1,0 +1,99 @@
+# vLLM Provider — RFC-0006
+
+This package implements the CogOS vLLM inference provider with direct
+PagedAttention block-API access.
+
+## Hardware requirements
+
+**Full integration requires Linux/CUDA and a running vLLM instance.** The
+v0.5.0 deliverable is scaffolding with mock-based test coverage. Hardware
+integration tests are tagged `requires-cuda` and tracked as a follow-up
+milestone item on [issue #203](https://github.com/myrgic/cogos/issues/203).
+
+The following are out of scope until a Linux/CUDA environment is available:
+
+- cgo binding to `vllm.core.block_manager`
+- Integration test against a real vLLM instance
+- Cache-aware dispatch routing with real block hashes
+- Full fork-over-kvcache end-to-end
+
+## Access shape
+
+### Primary: cgo binding
+
+The primary path calls into vLLM's internal block manager API
+(`vllm.core.block_manager`) to read block hashes, warm/evict blocks, and
+receive cache-hit callbacks. All cgo callouts are wrapped in `vllmCall` (see
+`provider_vllm.go`) which converts panics and recoverable SIGSEGVs to typed
+Go errors.
+
+```go
+// All cgo calls:
+err := vllmCall(func() error {
+    return cgoBinding.SomeCall(...)
+})
+```
+
+`debug.SetPanicOnFault(true)` is set inside `vllmCall` and reset on return so
+hardware-fault SIGSEGVs from the C/Python layer are converted to recoverable
+panics rather than crashing the kernel process.
+
+### Fallback: Python sidecar
+
+If cgo proves brittle in practice (GIL contention, version skew between vLLM
+releases), the Python-sidecar fallback path provides equivalent semantics: a
+lightweight Python process that owns the vLLM session and communicates block
+events to the Go kernel via a JSON-lines protocol over a Unix domain socket.
+
+Both the cgo binding and the Python sidecar implement the `VLLMClient`
+interface (`provider_vllm_client.go`). Switching between them is a constructor
+argument.
+
+## Package structure
+
+| File | Purpose |
+|------|---------|
+| `doc.go` | Package documentation |
+| `provider_vllm.go` | `Provider` (engine.Provider) + `vllmCall` cgo wrapper |
+| `provider_vllm_client.go` | `VLLMClient` interface + request/response types |
+| `provider_vllm_mock.go` | `MockVLLMClient` for tests |
+| `provider_vllm_cache.go` | `KVCacheProvider` (reconcile.Reconcilable, 7-method) |
+| `provider_vllm_events.go` | Bus event types, topic constants, `BusEmitter` interface |
+| `provider_vllm_fork.go` | Fork-over-kvcache stub (RFC-0005 integration) |
+| `kvblock_hash_provider.go` | `KVBlockHashProvider` interface (cross-RFC) |
+| `hash.go` | Hashing tuple per RFC-0006 §hashing-tuple |
+| `provider_vllm_test.go` | Unit tests (mock-based) |
+
+## KV block hashing
+
+The equivalence tuple hash used for cache hit detection:
+
+```
+SHA-256(prompt_text + "|" + model_name + "|" + temperature + "|" + top_p + "|" + top_k + "|" + max_tokens)
+```
+
+Excluded from v1 hash: model precision, runtime version, hardware ops. These
+introduce instability across deployments without meaningfully improving cache
+hit rates. A false positive is safe (stale KV bytes are evicted by vLLM's own
+validity checks); a false negative is safe (cold start).
+
+## Bus events
+
+The provider emits typed bus events on cache lifecycle transitions:
+
+| Topic | Fires when |
+|-------|-----------|
+| `inference.cache.warmed` | Blocks successfully warmed |
+| `inference.cache.evicted` | Blocks evicted from cache |
+| `inference.cache.hit_rate_changed` | Hit rate crosses ±5% threshold |
+| `inference.cache.fragmentation_high` | Fragmentation > 0.8 |
+
+All events carry structured log fields: `operation`, `channel_id`,
+`block_count`, `hit_rate`, `ts` per the kernel log convention.
+
+## RFC references
+
+- RFC-0006: `docs/rfcs/0006-vllm-pagedattention-provider.md`
+- RFC-0005: `docs/rfcs/0005-cog-fork-session.md` (fork handler consumer)
+- ADR-090: `docs/adr/090-kind-dispatch-via-registry.md` (Kind registry)
+- ADR-089: pointer-envelope semantics for evicted blocks

--- a/internal/providers/vllm/doc.go
+++ b/internal/providers/vllm/doc.go
@@ -1,0 +1,26 @@
+// Package vllm implements the CogOS vLLM inference provider with direct
+// PagedAttention block-API access (RFC-0006).
+//
+// # Architecture
+//
+// This package exposes vLLM's content-addressed KV cache as first-class kernel
+// objects: KV blocks become cache.kv_block CogBlocks; the cache layer is managed
+// as a Reconcilable resource; block-level events flow on the kernel bus.
+//
+// # v0.5.0 scope
+//
+// v0.5.0 ships scaffolding and mock-based tests. Hardware integration (cgo binding
+// to vllm.core.block_manager, real CUDA device) is deferred and tagged requires-cuda.
+//
+// # Access shape
+//
+// Primary: cgo binding to the vLLM Python runtime. All cgo callouts are wrapped in
+// the vllmCall helper (see provider_vllm.go) which recovers panics and converts them
+// to typed Go errors.
+//
+// Fallback: Python sidecar over Unix domain socket IPC. If cgo proves brittle
+// (GIL contention, version skew), the sidecar provides equivalent semantics over
+// a JSON-lines protocol. The VLLMClient interface is satisfied by both.
+//
+// See README-vllm.md in this directory for hardware requirements.
+package vllm

--- a/internal/providers/vllm/hash.go
+++ b/internal/providers/vllm/hash.go
@@ -1,0 +1,41 @@
+// hash.go — KV block hashing tuple per RFC-0006 §hashing-tuple.
+//
+// Hash: SHA-256(prompt_text + "|" + model_name + "|" + temperature +
+//              "|" + top_p + "|" + top_k + "|" + max_tokens)
+//
+// Excluded from the hash in v1: model precision, runtime version, hardware ops.
+// These introduce instability across deployments without meaningfully improving
+// cache hit rates in practice. The hash is an equivalence hint, not strict identity:
+//   - a cache miss on hash-equal content is safe (cold start)
+//   - a false positive is safe (stale KV bytes are semantically incorrect but
+//     evicted by vLLM's own block validity checks)
+package vllm
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+)
+
+// ComputeBlockHash computes the RFC-0006 equivalence-tuple hash for a KV block.
+//
+// The hash is:
+//
+//	SHA-256(prompt_text + "|" + model_name + "|" + temperature + "|" + top_p + "|" + top_k + "|" + max_tokens)
+//
+// Returns the hex-encoded SHA-256 digest.
+// The function is deterministic: same inputs always produce the same output.
+func ComputeBlockHash(promptText, modelName string, cfg KVSamplingConfig) string {
+	h := sha256.New()
+	// Separator "|" between fields. Fields themselves may not contain "|" in
+	// normal usage; if they do, the hash is still unique per distinct input set.
+	fmt.Fprintf(h, "%s|%s|%g|%g|%d|%d",
+		promptText,
+		modelName,
+		cfg.Temperature,
+		cfg.TopP,
+		cfg.TopK,
+		cfg.MaxTokens,
+	)
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/internal/providers/vllm/kvblock_hash_provider.go
+++ b/internal/providers/vllm/kvblock_hash_provider.go
@@ -1,0 +1,47 @@
+// kvblock_hash_provider.go — KVBlockHashProvider interface for fork integration.
+//
+// KVBlockHashProvider is the cross-RFC integration point between the vLLM
+// provider (RFC-0006, this package) and the cog_fork_session fork handler
+// (RFC-0005). The interface text is identical in both RFCs; the vLLM provider
+// is the implementing side; the fork handler is the consuming side.
+//
+// When RFC-0005's fork handler lands, it will query KVBlockHashProvider to
+// obtain the parent session's KV block hash for inheritance. In v0.5.0, this
+// stub carries the hash through but emits a log line rather than routing to
+// the same vLLM channel (see ForkOverKVCacheStub in provider_vllm_fork.go).
+package vllm
+
+import "context"
+
+// KVBlockHashProvider is implemented by inference providers that expose
+// a content-addressed KV-block layer (e.g., vLLM PagedAttention).
+// The fork-session handler queries this when forking over a kvcache layer
+// to obtain the parent's KV block hash.
+type KVBlockHashProvider interface {
+	// ParentKVBlockHash returns the hash of the KV block representing
+	// the session's KV state at the given message ID, or an error if
+	// the block is no longer addressable (evicted, runtime restarted).
+	ParentKVBlockHash(ctx context.Context, sessionID string, atMessageID string) (BlockHash, error)
+}
+
+// ErrKVBlockEvicted is returned by ParentKVBlockHash when the block has been
+// evicted from the vLLM block manager. The fork handler degrades gracefully
+// to a cold start when this error is received.
+type ErrKVBlockEvicted struct {
+	SessionID   string
+	AtMessageID string
+}
+
+func (e *ErrKVBlockEvicted) Error() string {
+	return "vllm: KV block evicted for session " + e.SessionID + " at message " + e.AtMessageID
+}
+
+// ErrKVBlockRuntimeRestarted is returned by ParentKVBlockHash when the vLLM
+// runtime has restarted and block state is no longer addressable.
+type ErrKVBlockRuntimeRestarted struct {
+	ChannelID string
+}
+
+func (e *ErrKVBlockRuntimeRestarted) Error() string {
+	return "vllm: runtime restarted on channel " + e.ChannelID + "; KV block state lost"
+}

--- a/internal/providers/vllm/provider_vllm.go
+++ b/internal/providers/vllm/provider_vllm.go
@@ -1,0 +1,145 @@
+// provider_vllm.go — vLLM inference Provider + cgo failure-isolation wrapper.
+//
+// Implements engine.Provider for the vLLM backend. The Provider wraps a
+// VLLMClient (cgo or Python-sidecar) and routes CompletionRequests through
+// vLLM's OpenAI-compat API layer.
+//
+// All cgo callouts into the vLLM Python runtime are wrapped via vllmCall,
+// which converts panics (and Go-recoverable SIGSEGV via SetPanicOnFault) into
+// typed Go errors so that cgo failure never propagates to crash the kernel.
+//
+// v0.5.0: scaffolding only. Complete() and Stream() return ErrVLLMNotAvailable
+// until Linux/CUDA hardware integration lands. Hardware paths are marked
+// TODO(rfc-0006/requires-cuda).
+package vllm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime"
+	"time"
+
+	"github.com/myrgic/cogos/internal/engine"
+)
+
+// ErrVLLMNotAvailable is returned when the vLLM runtime is not reachable or
+// hardware integration is not yet complete (scaffolding phase).
+var ErrVLLMNotAvailable = errors.New("vllm: provider not available (requires-cuda; see RFC-0006)")
+
+// Provider implements engine.Provider for the vLLM backend.
+// Construct via NewProvider; inject a VLLMClient for tests.
+//
+// Thread safety: Provider is safe to call concurrently. The embedded client
+// must also be safe for concurrent use.
+type Provider struct {
+	client    VLLMClient
+	channelID string
+	modelName string
+}
+
+// NewProvider constructs a Provider with the given client and configuration.
+// Pass a MockVLLMClient for unit tests; the cgo binding for production
+// (requires Linux/CUDA — see README-vllm.md).
+func NewProvider(client VLLMClient, channelID, modelName string) *Provider {
+	return &Provider{
+		client:    client,
+		channelID: channelID,
+		modelName: modelName,
+	}
+}
+
+// Name implements engine.Provider.
+func (p *Provider) Name() string { return "vllm" }
+
+// Model implements engine.Provider.
+func (p *Provider) Model() string { return p.modelName }
+
+// Complete implements engine.Provider.
+// TODO(rfc-0006/requires-cuda): real implementation routes through vLLM cgo binding.
+func (p *Provider) Complete(ctx context.Context, req *engine.CompletionRequest) (*engine.CompletionResponse, error) {
+	return nil, ErrVLLMNotAvailable
+}
+
+// Stream implements engine.Provider.
+// TODO(rfc-0006/requires-cuda): real implementation routes through vLLM cgo binding.
+func (p *Provider) Stream(ctx context.Context, req *engine.CompletionRequest) (<-chan engine.StreamChunk, error) {
+	return nil, ErrVLLMNotAvailable
+}
+
+// Available implements engine.Provider.
+// Returns false in v0.5.0 scaffolding; real check requires cgo binding.
+func (p *Provider) Available(ctx context.Context) bool {
+	// TODO(rfc-0006/requires-cuda): probe vLLM health endpoint.
+	return false
+}
+
+// Capabilities implements engine.Provider.
+func (p *Provider) Capabilities() engine.ProviderCapabilities {
+	return engine.ProviderCapabilities{
+		Capabilities: []engine.Capability{
+			engine.CapStreaming,
+			engine.CapToolUse,
+			engine.CapJSON,
+		},
+		MaxContextTokens:   128_000,
+		MaxOutputTokens:    4_096,
+		IsLocal:            true,
+		CostPerInputToken:  0,
+		CostPerOutputToken: 0,
+	}
+}
+
+// Ping implements engine.Provider.
+// TODO(rfc-0006/requires-cuda): probe real vLLM health endpoint.
+func (p *Provider) Ping(ctx context.Context) (time.Duration, error) {
+	return 0, ErrVLLMNotAvailable
+}
+
+// ParentKVBlockHash implements KVBlockHashProvider so the fork handler
+// (RFC-0005) can obtain the parent session's KV block hash.
+func (p *Provider) ParentKVBlockHash(ctx context.Context, sessionID string, atMessageID string) (BlockHash, error) {
+	var hash BlockHash
+	err := vllmCall(func() error {
+		// TODO(rfc-0006/requires-cuda): query vllm.core.block_manager for block
+		// covering the message's token range.
+		h, err := p.client.BlockHashForPrompt(atMessageID, p.modelName, KVSamplingConfig{})
+		if err != nil {
+			return err
+		}
+		hash = BlockHash(h)
+		return nil
+	})
+	return hash, err
+}
+
+// ── cgo failure-isolation wrapper ──────────────────────────────────────────
+//
+// All cgo callouts into the vLLM Python runtime must be wrapped in vllmCall.
+// It installs SetPanicOnFault(true) so that hardware-fault SIGSEGVs from the
+// C/Python layer are converted to Go panics, then recovers those panics and
+// converts them to typed errors.
+//
+// If SIGSEGV cannot be recovered at Go's runtime level (some C library
+// failures bypass the panic-handler), the Python-sidecar IPC fallback path
+// should be used instead; the cgo path is then opt-in for trusted vLLM versions.
+
+// vllmCall wraps a cgo callout in deferred recover + runtime.SetPanicOnFault.
+// Any panic (including recovered SIGSEGV) is converted to a typed error.
+// The returned error is never nil when a panic occurs; fn's own errors pass through.
+//
+// Usage:
+//
+//	err := vllmCall(func() error {
+//	    return cgoBindingFunction(...)
+//	})
+func vllmCall(fn func() error) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("vllm cgo failure (recovered): %v", r)
+		}
+	}()
+	runtime.SetPanicOnFault(true)
+	defer runtime.SetPanicOnFault(false)
+	return fn()
+}

--- a/internal/providers/vllm/provider_vllm.go
+++ b/internal/providers/vllm/provider_vllm.go
@@ -17,7 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"runtime"
+	"runtime/debug"
 	"time"
 
 	"github.com/myrgic/cogos/internal/engine"
@@ -102,11 +102,9 @@ func (p *Provider) ParentKVBlockHash(ctx context.Context, sessionID string, atMe
 	var hash BlockHash
 	err := vllmCall(func() error {
 		// TODO(rfc-0006/requires-cuda): query vllm.core.block_manager for block
-		// covering the message's token range.
-		h, err := p.client.BlockHashForPrompt(atMessageID, p.modelName, KVSamplingConfig{})
-		if err != nil {
-			return err
-		}
+		// covering the message's token range. In scaffolding, derive hash from
+		// the messageID as prompt key using the standard equivalence tuple.
+		h := p.client.BlockHashForPrompt(atMessageID, p.modelName, KVSamplingConfig{})
 		hash = BlockHash(h)
 		return nil
 	})
@@ -139,7 +137,7 @@ func vllmCall(fn func() error) (err error) {
 			err = fmt.Errorf("vllm cgo failure (recovered): %v", r)
 		}
 	}()
-	runtime.SetPanicOnFault(true)
-	defer runtime.SetPanicOnFault(false)
+	debug.SetPanicOnFault(true)
+	defer debug.SetPanicOnFault(false)
 	return fn()
 }

--- a/internal/providers/vllm/provider_vllm_cache.go
+++ b/internal/providers/vllm/provider_vllm_cache.go
@@ -1,0 +1,487 @@
+// provider_vllm_cache.go — KVCacheProvider: Reconcilable for the vLLM KV block cache.
+//
+// KVCacheProvider manages vLLM's KV block cache as a Reconcilable resource.
+// It reconciles declared hot-prefixes (system prompt cache declarations in the
+// workspace config) against live warm blocks on the vLLM channel.
+//
+// Implements reconcile.Reconcilable (7-method contract).
+//
+// Config format (.cog/config/cache.kv_block/config.yaml):
+//
+//	hot_prefixes:
+//	  - prompt_prefix: "You are a helpful assistant..."
+//	    model_name: "llama-3-8b"
+//	    sampling_config:
+//	      temperature: 0.7
+//	      top_p: 0.9
+//	      top_k: 50
+//	      max_tokens: 2048
+package vllm
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/myrgic/cogos/pkg/reconcile"
+)
+
+// KVCacheProvider manages the vLLM KV block cache as a Reconcilable resource.
+// It reconciles declared hot-prefixes (system prompt cache declarations in the
+// workspace config) against live warm blocks on the vLLM channel.
+//
+// Implements reconcile.Reconcilable.
+type KVCacheProvider struct {
+	mu      sync.Mutex
+	client  VLLMClient
+	emitter BusEmitter
+	logger  *slog.Logger
+
+	channelID string
+
+	// Mutable state tracked across lifecycle calls.
+	lastStats  CacheStats
+	lastPlan   *reconcile.Plan
+	operation  reconcile.OperationPhase
+}
+
+// NewKVCacheProvider constructs a KVCacheProvider.
+// client must not be nil. emitter may be nil (no bus events emitted when nil).
+func NewKVCacheProvider(client VLLMClient, channelID string, emitter BusEmitter) *KVCacheProvider {
+	return &KVCacheProvider{
+		client:    client,
+		emitter:   emitter,
+		channelID: channelID,
+		logger:    slog.Default(),
+		operation: reconcile.OperationIdle,
+	}
+}
+
+// ── kvCacheConfig ─────────────────────────────────────────────────────────────
+
+// kvCacheConfig is the LoadConfig output. Bundles declared hot-prefixes.
+type kvCacheConfig struct {
+	Root        string
+	HotPrefixes []WarmRequest
+}
+
+// kvCacheConfigFile mirrors the on-disk YAML shape.
+type kvCacheConfigFile struct {
+	HotPrefixes []struct {
+		PromptPrefix   string          `yaml:"prompt_prefix"`
+		ModelName      string          `yaml:"model_name"`
+		SamplingConfig KVSamplingConfig `yaml:"sampling_config"`
+	} `yaml:"hot_prefixes"`
+}
+
+// ── kvCacheLive ───────────────────────────────────────────────────────────────
+
+// kvCacheLive is the FetchLive output. Bundles live warm blocks + current stats.
+type kvCacheLive struct {
+	WarmBlocks []WarmBlock
+	Stats      CacheStats
+}
+
+// ── Type ─────────────────────────────────────────────────────────────────────
+
+// Type implements Reconcilable.
+func (p *KVCacheProvider) Type() string { return "cache.kv_block" }
+
+// ── LoadConfig ────────────────────────────────────────────────────────────────
+
+// LoadConfig loads declared hot-prefixes from <root>/.cog/config/cache.kv_block/config.yaml.
+// Returns a *kvCacheConfig as any. Missing config file is not an error; the
+// provider reconciles against zero declared prefixes (no-op warm cycle).
+func (p *KVCacheProvider) LoadConfig(root string) (any, error) {
+	cfgPath := filepath.Join(root, ".cog", "config", "cache.kv_block", "config.yaml")
+	data, err := os.ReadFile(cfgPath)
+	if os.IsNotExist(err) {
+		return &kvCacheConfig{Root: root}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("kv_block: reading config %s: %w", cfgPath, err)
+	}
+
+	var raw kvCacheConfigFile
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("kv_block: parsing config %s: %w", cfgPath, err)
+	}
+
+	cfg := &kvCacheConfig{Root: root}
+	for _, hp := range raw.HotPrefixes {
+		cfg.HotPrefixes = append(cfg.HotPrefixes, WarmRequest{
+			PromptPrefix:   hp.PromptPrefix,
+			ModelName:      hp.ModelName,
+			SamplingConfig: hp.SamplingConfig,
+		})
+	}
+	return cfg, nil
+}
+
+// ── FetchLive ─────────────────────────────────────────────────────────────────
+
+// FetchLive queries the vLLM client for currently warm blocks and cache stats.
+// Returns a *kvCacheLive as any.
+func (p *KVCacheProvider) FetchLive(ctx context.Context, config any) (any, error) {
+	cfg, ok := config.(*kvCacheConfig)
+	if !ok {
+		return nil, fmt.Errorf("kv_block: FetchLive expected *kvCacheConfig, got %T", config)
+	}
+	_ = cfg // root available if needed for scoping
+
+	blocks, err := p.client.ListWarmBlocks(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("kv_block: ListWarmBlocks: %w", err)
+	}
+	stats, err := p.client.CacheStats(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("kv_block: CacheStats: %w", err)
+	}
+	return &kvCacheLive{WarmBlocks: blocks, Stats: stats}, nil
+}
+
+// ── ComputePlan ───────────────────────────────────────────────────────────────
+
+// ComputePlan diffs declared hot-prefixes against live warm blocks.
+// Actions:
+//   - create (warm): prefix declared but not currently warm
+//   - delete (evict): block warm but not declared (excess eviction)
+//   - skip: prefix declared and block warm (in sync)
+func (p *KVCacheProvider) ComputePlan(config any, live any, state *reconcile.State) (*reconcile.Plan, error) {
+	cfg, ok := config.(*kvCacheConfig)
+	if !ok {
+		return nil, fmt.Errorf("kv_block: ComputePlan expected *kvCacheConfig, got %T", config)
+	}
+	lv, ok := live.(*kvCacheLive)
+	if !ok {
+		return nil, fmt.Errorf("kv_block: ComputePlan expected *kvCacheLive, got %T", live)
+	}
+
+	plan := &reconcile.Plan{
+		ResourceType: "cache.kv_block",
+		GeneratedAt:  time.Now().UTC().Format(time.RFC3339),
+		ConfigPath:   filepath.Join(cfg.Root, ".cog", "config", "cache.kv_block"),
+	}
+
+	// Build index of live blocks by hash.
+	liveByHash := make(map[string]WarmBlock, len(lv.WarmBlocks))
+	for _, wb := range lv.WarmBlocks {
+		liveByHash[wb.BlockHash] = wb
+	}
+
+	// Index declared prefixes by their computed hash.
+	declaredHashes := make(map[string]WarmRequest, len(cfg.HotPrefixes))
+	for _, req := range cfg.HotPrefixes {
+		h := p.client.BlockHashForPrompt(req.PromptPrefix, req.ModelName, req.SamplingConfig)
+		declaredHashes[h] = req
+	}
+
+	// Check declared → live (warm missing ones).
+	for hash, req := range declaredHashes {
+		if _, warm := liveByHash[hash]; !warm {
+			plan.Actions = append(plan.Actions, reconcile.Action{
+				Action:       reconcile.ActionCreate,
+				ResourceType: "cache.kv_block",
+				Name:         hash,
+				Details: map[string]any{
+					"reason":        "declared_not_warm",
+					"block_hash":    hash,
+					"prompt_prefix": req.PromptPrefix,
+					"model_name":    req.ModelName,
+				},
+			})
+			plan.Summary.Creates++
+		} else {
+			plan.Actions = append(plan.Actions, reconcile.Action{
+				Action:       reconcile.ActionSkip,
+				ResourceType: "cache.kv_block",
+				Name:         hash,
+				Details: map[string]any{
+					"reason":     "in_sync",
+					"block_hash": hash,
+				},
+			})
+			plan.Summary.Skipped++
+		}
+	}
+
+	// Check live → declared (evict excess blocks not in declared set).
+	for hash := range liveByHash {
+		if _, declared := declaredHashes[hash]; !declared {
+			plan.Actions = append(plan.Actions, reconcile.Action{
+				Action:       reconcile.ActionDelete,
+				ResourceType: "cache.kv_block",
+				Name:         hash,
+				Details: map[string]any{
+					"reason":     "warm_not_declared",
+					"block_hash": hash,
+				},
+			})
+			plan.Summary.Deletes++
+		}
+	}
+
+	p.mu.Lock()
+	p.lastPlan = plan
+	p.mu.Unlock()
+
+	return plan, nil
+}
+
+// ── ApplyPlan ─────────────────────────────────────────────────────────────────
+
+// ApplyPlan warms or evicts blocks to converge on the declared state.
+// Emits bus events on warm/evict transitions.
+func (p *KVCacheProvider) ApplyPlan(ctx context.Context, plan *reconcile.Plan) ([]reconcile.Result, error) {
+	p.mu.Lock()
+	p.operation = reconcile.OperationSyncing
+	p.mu.Unlock()
+	defer func() {
+		p.mu.Lock()
+		p.operation = reconcile.OperationIdle
+		p.mu.Unlock()
+	}()
+
+	var results []reconcile.Result
+	var toWarm []WarmRequest
+	var toEvict []string
+
+	// Collect warm and evict targets from the plan.
+	for _, action := range plan.Actions {
+		switch action.Action {
+		case reconcile.ActionCreate:
+			hash, _ := action.Details["block_hash"].(string)
+			prefix, _ := action.Details["prompt_prefix"].(string)
+			model, _ := action.Details["model_name"].(string)
+			toWarm = append(toWarm, WarmRequest{
+				PromptPrefix: prefix,
+				ModelName:    model,
+				// Sampling config not carried through plan details; use zero value
+				// (matches the hash computation that produced this entry).
+			})
+			_ = hash
+		case reconcile.ActionDelete:
+			hash, _ := action.Details["block_hash"].(string)
+			toEvict = append(toEvict, hash)
+		}
+	}
+
+	// Execute warm batch.
+	if len(toWarm) > 0 {
+		blockResults, err := p.client.WarmBlocks(ctx, toWarm)
+		if err != nil {
+			results = append(results, reconcile.Result{
+				Phase:  "apply",
+				Action: "warm",
+				Name:   "batch",
+				Status: reconcile.ApplyFailed,
+				Error:  err.Error(),
+			})
+		} else {
+			var warmedHashes []string
+			for _, br := range blockResults {
+				status := reconcile.ApplySucceeded
+				if !br.Warmed {
+					status = reconcile.ApplyFailed
+				} else {
+					warmedHashes = append(warmedHashes, br.BlockHash)
+				}
+				results = append(results, reconcile.Result{
+					Phase:  "apply",
+					Action: "warm",
+					Name:   br.BlockHash,
+					Status: status,
+					Error:  br.Error,
+				})
+			}
+			if len(warmedHashes) > 0 && p.emitter != nil {
+				stats, _ := p.client.CacheStats(ctx)
+				p.checkAndEmitStats(ctx, stats)
+				emitWarmed(ctx, p.emitter, p.channelID, warmedHashes, stats)
+			}
+		}
+	}
+
+	// Execute evict batch.
+	if len(toEvict) > 0 {
+		err := p.client.EvictBlocks(ctx, toEvict)
+		status := reconcile.ApplySucceeded
+		errStr := ""
+		if err != nil {
+			status = reconcile.ApplyFailed
+			errStr = err.Error()
+		}
+		results = append(results, reconcile.Result{
+			Phase:  "apply",
+			Action: "evict",
+			Name:   fmt.Sprintf("batch(%d)", len(toEvict)),
+			Status: status,
+			Error:  errStr,
+		})
+		if err == nil && p.emitter != nil {
+			stats, _ := p.client.CacheStats(ctx)
+			p.checkAndEmitStats(ctx, stats)
+			emitEvicted(ctx, p.emitter, p.channelID, toEvict, stats)
+		}
+	}
+
+	return results, nil
+}
+
+// checkAndEmitStats compares new stats against last known; emits events on
+// threshold crossings (hit_rate ±5%, fragmentation >0.8).
+func (p *KVCacheProvider) checkAndEmitStats(ctx context.Context, stats CacheStats) {
+	p.mu.Lock()
+	prev := p.lastStats
+	p.lastStats = stats
+	p.mu.Unlock()
+
+	if p.emitter == nil {
+		return
+	}
+	// Hit rate change threshold: 5%.
+	if math.Abs(stats.HitRate-prev.HitRate) >= 0.05 {
+		emitHitRateChanged(ctx, p.emitter, p.channelID, prev.HitRate, stats.HitRate, stats)
+	}
+	// Fragmentation threshold: >0.8.
+	if stats.Fragmentation > 0.8 && prev.Fragmentation <= 0.8 {
+		emitFragmentationHigh(ctx, p.emitter, p.channelID, stats.Fragmentation, stats)
+	}
+}
+
+// ── BuildState ────────────────────────────────────────────────────────────────
+
+// BuildState constructs a reconcile.State from live warm block data.
+func (p *KVCacheProvider) BuildState(config any, live any, existing *reconcile.State) (*reconcile.State, error) {
+	_, ok := config.(*kvCacheConfig)
+	if !ok {
+		return nil, fmt.Errorf("kv_block: BuildState expected *kvCacheConfig, got %T", config)
+	}
+	lv, ok := live.(*kvCacheLive)
+	if !ok {
+		return nil, fmt.Errorf("kv_block: BuildState expected *kvCacheLive, got %T", live)
+	}
+
+	lineage := "cache.kv_block"
+	serial := 1
+	if existing != nil {
+		lineage = existing.Lineage
+		serial = existing.Serial + 1
+	}
+
+	state := &reconcile.State{
+		Version:      1,
+		Lineage:      lineage,
+		Serial:       serial,
+		ResourceType: "cache.kv_block",
+		GeneratedAt:  time.Now().UTC().Format(time.RFC3339),
+		Metadata: map[string]any{
+			"channel_id":    p.channelID,
+			"hit_rate":      lv.Stats.HitRate,
+			"block_count":   lv.Stats.BlockCount,
+			"fragmentation": lv.Stats.Fragmentation,
+		},
+	}
+
+	for _, wb := range lv.WarmBlocks {
+		state.Resources = append(state.Resources, reconcile.Resource{
+			Address:    "cache.kv_block." + wb.BlockHash[:min(12, len(wb.BlockHash))],
+			Type:       "cache.kv_block",
+			Mode:       reconcile.ModeManaged,
+			ExternalID: wb.BlockHash,
+			Name:       wb.BlockHash,
+			Attributes: map[string]any{
+				"block_hash":  wb.BlockHash,
+				"model_name":  wb.ModelName,
+				"block_size":  wb.BlockSize,
+				"warm_at":     wb.WarmAt.Format(time.RFC3339),
+				"channel_id":  p.channelID,
+				"temperature": wb.SamplingConfig.Temperature,
+				"top_p":       wb.SamplingConfig.TopP,
+				"top_k":       wb.SamplingConfig.TopK,
+				"max_tokens":  wb.SamplingConfig.MaxTokens,
+			},
+			LastRefreshed: time.Now().UTC().Format(time.RFC3339),
+		})
+	}
+	return state, nil
+}
+
+// ── Health ────────────────────────────────────────────────────────────────────
+
+// Health implements Reconcilable.
+// Three-axis status per RFC-0006:
+//   - Healthy: hit rate > 0.5
+//   - Degraded: fragmentation > 0.8
+//   - Progressing: active warm/evict cycle
+//   - Missing: client never queried (stats zero, no plan run)
+func (p *KVCacheProvider) Health() reconcile.ResourceStatus {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.operation == reconcile.OperationSyncing {
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusUnknown,
+			Health:    reconcile.HealthProgressing,
+			Operation: reconcile.OperationSyncing,
+			Message:   "warm/evict cycle in progress",
+		}
+	}
+
+	stats := p.lastStats
+
+	// Degenerate case: no stats observed yet.
+	if stats.BlockCount == 0 && stats.HitRate == 0 && p.lastPlan == nil {
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusUnknown,
+			Health:    reconcile.HealthMissing,
+			Operation: reconcile.OperationIdle,
+			Message:   fmt.Sprintf("channel %q: no stats observed; vLLM not yet queried or hardware unavailable", p.channelID),
+		}
+	}
+
+	// Fragmentation check takes precedence over hit rate.
+	if stats.Fragmentation > 0.8 {
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusOutOfSync,
+			Health:    reconcile.HealthDegraded,
+			Operation: reconcile.OperationIdle,
+			Message:   fmt.Sprintf("channel %q: fragmentation %.2f > 0.8 threshold", p.channelID, stats.Fragmentation),
+		}
+	}
+
+	if stats.HitRate > 0.5 {
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusSynced,
+			Health:    reconcile.HealthHealthy,
+			Operation: reconcile.OperationIdle,
+			Message:   fmt.Sprintf("channel %q: hit rate %.2f, %d blocks warm", p.channelID, stats.HitRate, stats.BlockCount),
+		}
+	}
+
+	return reconcile.ResourceStatus{
+		Sync:      reconcile.SyncStatusOutOfSync,
+		Health:    reconcile.HealthDegraded,
+		Operation: reconcile.OperationIdle,
+		Message:   fmt.Sprintf("channel %q: hit rate %.2f < 0.5 threshold, %d blocks warm", p.channelID, stats.HitRate, stats.BlockCount),
+	}
+}
+
+// Structured log helper for provider-level operations.
+func (p *KVCacheProvider) logOp(op, msg string, extra ...any) {
+	args := []any{
+		"operation", op,
+		"channel_id", p.channelID,
+		"ts", time.Now().UTC().Format(time.RFC3339),
+	}
+	args = append(args, extra...)
+	slog.Info("vllm kv_cache reconcile: "+msg, args...)
+}
+

--- a/internal/providers/vllm/provider_vllm_client.go
+++ b/internal/providers/vllm/provider_vllm_client.go
@@ -1,0 +1,120 @@
+// provider_vllm_client.go — VLLMClient interface and supporting types.
+//
+// VLLMClient is the mockable interface both the cgo binding (primary) and the
+// Python sidecar (fallback) implement. Unit tests use MockVLLMClient defined in
+// provider_vllm_mock.go.
+//
+// See README-vllm.md for the cgo vs. sidecar path discussion.
+package vllm
+
+import (
+	"context"
+	"time"
+)
+
+// BlockHash is the content-addressed identifier for a single KV block.
+// Format: hex-encoded SHA-256 of the equivalence tuple (see RFC-0006 §Hashing).
+type BlockHash string
+
+// VLLMClient is the interface the cgo binding (primary) and Python sidecar
+// (fallback) both implement. Unit tests use MockVLLMClient.
+type VLLMClient interface {
+	// WarmBlocks pre-warms the KV cache for the given prompt prefixes.
+	WarmBlocks(ctx context.Context, prefixes []WarmRequest) ([]BlockResult, error)
+
+	// EvictBlocks removes specified block hashes from the cache.
+	EvictBlocks(ctx context.Context, blockHashes []string) error
+
+	// ListWarmBlocks returns all currently warm blocks on the channel.
+	ListWarmBlocks(ctx context.Context) ([]WarmBlock, error)
+
+	// BlockHashForPrompt computes the content-addressed hash for a prompt
+	// using the equivalence tuple: prompt+model+sampling_config.
+	// See RFC-0006 §hashing-tuple for the exact hash algorithm.
+	BlockHashForPrompt(prompt, model string, cfg KVSamplingConfig) string
+
+	// CacheStats returns current hit rate and fragmentation metrics.
+	CacheStats(ctx context.Context) (CacheStats, error)
+
+	// Close releases the underlying cgo handles or sidecar connection.
+	Close() error
+}
+
+// ── Request/response types ───────────────────────────────────────────────────
+
+// WarmRequest describes a single prompt prefix to pre-warm in the KV cache.
+type WarmRequest struct {
+	PromptPrefix   string          `json:"prompt_prefix"`
+	ModelName      string          `json:"model_name"`
+	SamplingConfig KVSamplingConfig `json:"sampling_config"`
+}
+
+// BlockResult describes the outcome of a single WarmBlocks request.
+type BlockResult struct {
+	BlockHash string `json:"block_hash"`
+	Warmed    bool   `json:"warmed"`
+	Error     string `json:"error,omitempty"`
+}
+
+// WarmBlock describes a currently warm block on the vLLM channel.
+type WarmBlock struct {
+	BlockHash      string          `json:"block_hash"`
+	ModelName      string          `json:"model_name"`
+	SamplingConfig KVSamplingConfig `json:"sampling_config"`
+	WarmAt         time.Time       `json:"warm_at"`
+	BlockSize      int             `json:"block_size"`
+}
+
+// CacheStats holds current hit rate and fragmentation metrics for the channel.
+type CacheStats struct {
+	HitRate       float64 `json:"hit_rate"`      // 0.0–1.0
+	BlockCount    int     `json:"block_count"`
+	Fragmentation float64 `json:"fragmentation"` // 0.0–1.0
+}
+
+// ── KV block types ───────────────────────────────────────────────────────────
+
+// KVSamplingConfig captures sampling parameters included in the equivalence hash.
+// Only these four fields participate in the hash; others (e.g. random seed) are
+// excluded to avoid instability across equivalent requests.
+type KVSamplingConfig struct {
+	Temperature float64 `json:"temperature"`
+	TopP        float64 `json:"top_p"`
+	TopK        int     `json:"top_k"`
+	MaxTokens   int     `json:"max_tokens"`
+}
+
+// KVBlockBody is the Payload body for a cache.kv_block CogBlock.
+// Each KV block represents a single PagedAttention block in the vLLM
+// block manager — a fixed-size chunk of key-value tensors addressable
+// by content hash.
+type KVBlockBody struct {
+	// BlockHash is the content-addressed identifier for this KV block.
+	// Computed from the prompt prefix that fills the block.
+	// Format: hex-encoded SHA-256 of the equivalence tuple (see RFC-0006 §Hashing).
+	BlockHash string `json:"block_hash"`
+
+	// ChannelID identifies the vLLM channel this block lives on.
+	ChannelID string `json:"channel_id"`
+
+	// PromptPrefix is the prompt text whose KV computation this block holds.
+	// May be truncated for large blocks; BlockHash is the canonical reference.
+	PromptPrefix string `json:"prompt_prefix,omitempty"`
+
+	// ModelName is the model identifier this block was computed for.
+	ModelName string `json:"model_name"`
+
+	// SamplingConfig captures the sampling parameters in the equivalence hash.
+	SamplingConfig KVSamplingConfig `json:"sampling_config"`
+
+	// BlockSize is the number of tokens this block covers.
+	BlockSize int `json:"block_size"`
+
+	// WarmAt is when this block was last warmed (cache hit or explicit warm).
+	WarmAt time.Time `json:"warm_at"`
+
+	// EvictedAt is set when the block is evicted from the vLLM block manager.
+	// A non-zero EvictedAt means the envelope persists in the ledger but the
+	// KV bytes are gone (ADR-089 pointer-envelope semantics).
+	EvictedAt *time.Time `json:"evicted_at,omitempty"`
+}

--- a/internal/providers/vllm/provider_vllm_events.go
+++ b/internal/providers/vllm/provider_vllm_events.go
@@ -1,0 +1,182 @@
+// provider_vllm_events.go — Bus event payload types and topic constants.
+//
+// Typed bus event payloads for KV cache lifecycle events. All fields are
+// typed and documented; no raw maps. Topic constants match the bus filter
+// patterns used by subscribers.
+//
+// BusEmitter is the injection interface for bus event dispatch. In production
+// the kernel wires engine.AppendEvent; in tests a mock is injected. This avoids
+// a circular import between internal/providers/vllm and internal/engine.
+package vllm
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"time"
+)
+
+// ── Bus topic constants ──────────────────────────────────────────────────────
+
+const (
+	TopicKVCacheWarmed            = "inference.cache.warmed"
+	TopicKVCacheEvicted           = "inference.cache.evicted"
+	TopicKVCacheHitRateChanged    = "inference.cache.hit_rate_changed"
+	TopicKVCacheFragmentationHigh = "inference.cache.fragmentation_high"
+)
+
+// ── Bus event payload types ──────────────────────────────────────────────────
+
+// KVCacheWarmedEvent fires when one or more blocks are successfully warmed.
+type KVCacheWarmedEvent struct {
+	ChannelID   string     `json:"channel_id"`
+	BlockHashes []string   `json:"block_hashes"`
+	CacheStats  CacheStats `json:"cache_stats"`
+}
+
+// KVCacheEvictedEvent fires when one or more blocks are evicted.
+type KVCacheEvictedEvent struct {
+	ChannelID   string     `json:"channel_id"`
+	BlockHashes []string   `json:"block_hashes"`
+	CacheStats  CacheStats `json:"cache_stats"`
+}
+
+// KVCacheHitRateChangedEvent fires when the hit rate crosses a 5% threshold.
+type KVCacheHitRateChangedEvent struct {
+	ChannelID   string     `json:"channel_id"`
+	PrevRate    float64    `json:"prev_rate"`
+	CurrentRate float64    `json:"current_rate"`
+	CacheStats  CacheStats `json:"cache_stats"`
+}
+
+// KVCacheFragmentationHighEvent fires when fragmentation exceeds 0.8.
+type KVCacheFragmentationHighEvent struct {
+	ChannelID     string     `json:"channel_id"`
+	Fragmentation float64    `json:"fragmentation"`
+	CacheStats    CacheStats `json:"cache_stats"`
+}
+
+// ── BusEmitter injection interface ──────────────────────────────────────────
+
+// BusEmitter is the interface the KVCacheProvider uses to emit typed bus events.
+// In production the kernel wires an adapter backed by engine.AppendEvent.
+// In tests a MockBusEmitter records calls for assertion.
+type BusEmitter interface {
+	// Emit publishes a typed bus event with the given topic and payload.
+	// The payload must be JSON-serializable. Implementations must be non-blocking
+	// (fire-and-forget delivery semantics matching the kernel bus contract).
+	Emit(ctx context.Context, topic string, payload any) error
+}
+
+// MockBusEmitter records emitted events for test assertions.
+type MockBusEmitter struct {
+	Events []BusEventRecord
+}
+
+// BusEventRecord captures a single emitted event.
+type BusEventRecord struct {
+	Topic     string
+	Payload   any
+	EmittedAt time.Time
+}
+
+// Emit records the event for test assertions.
+func (m *MockBusEmitter) Emit(_ context.Context, topic string, payload any) error {
+	m.Events = append(m.Events, BusEventRecord{
+		Topic:     topic,
+		Payload:   payload,
+		EmittedAt: time.Now().UTC(),
+	})
+	return nil
+}
+
+// ── Structured emission helpers ──────────────────────────────────────────────
+
+// emitWarmed publishes a KVCacheWarmedEvent on the bus and emits a structured log.
+func emitWarmed(ctx context.Context, emitter BusEmitter, channelID string, hashes []string, stats CacheStats) {
+	evt := KVCacheWarmedEvent{
+		ChannelID:   channelID,
+		BlockHashes: hashes,
+		CacheStats:  stats,
+	}
+	if err := emitter.Emit(ctx, TopicKVCacheWarmed, evt); err != nil {
+		slog.Warn("vllm: failed to emit cache warmed event", "error", err)
+	}
+	slog.Info("vllm cache op",
+		"operation", "warm",
+		"channel_id", channelID,
+		"block_count", len(hashes),
+		"hit_rate", stats.HitRate,
+		"ts", time.Now().UTC().Format(time.RFC3339),
+	)
+}
+
+// emitEvicted publishes a KVCacheEvictedEvent on the bus and emits a structured log.
+func emitEvicted(ctx context.Context, emitter BusEmitter, channelID string, hashes []string, stats CacheStats) {
+	evt := KVCacheEvictedEvent{
+		ChannelID:   channelID,
+		BlockHashes: hashes,
+		CacheStats:  stats,
+	}
+	if err := emitter.Emit(ctx, TopicKVCacheEvicted, evt); err != nil {
+		slog.Warn("vllm: failed to emit cache evicted event", "error", err)
+	}
+	slog.Info("vllm cache op",
+		"operation", "evict",
+		"channel_id", channelID,
+		"block_count", len(hashes),
+		"hit_rate", stats.HitRate,
+		"ts", time.Now().UTC().Format(time.RFC3339),
+	)
+}
+
+// emitHitRateChanged publishes a KVCacheHitRateChangedEvent when the hit rate
+// crosses a 5% threshold relative to the previous rate.
+func emitHitRateChanged(ctx context.Context, emitter BusEmitter, channelID string, prev, current float64, stats CacheStats) {
+	evt := KVCacheHitRateChangedEvent{
+		ChannelID:   channelID,
+		PrevRate:    prev,
+		CurrentRate: current,
+		CacheStats:  stats,
+	}
+	if err := emitter.Emit(ctx, TopicKVCacheHitRateChanged, evt); err != nil {
+		slog.Warn("vllm: failed to emit hit rate changed event", "error", err)
+	}
+	slog.Info("vllm cache op",
+		"operation", "hit_rate_change",
+		"channel_id", channelID,
+		"block_count", stats.BlockCount,
+		"hit_rate", current,
+		"ts", time.Now().UTC().Format(time.RFC3339),
+	)
+}
+
+// emitFragmentationHigh publishes a KVCacheFragmentationHighEvent when
+// fragmentation exceeds 0.8.
+func emitFragmentationHigh(ctx context.Context, emitter BusEmitter, channelID string, frag float64, stats CacheStats) {
+	evt := KVCacheFragmentationHighEvent{
+		ChannelID:     channelID,
+		Fragmentation: frag,
+		CacheStats:    stats,
+	}
+	if err := emitter.Emit(ctx, TopicKVCacheFragmentationHigh, evt); err != nil {
+		slog.Warn("vllm: failed to emit fragmentation high event", "error", err)
+	}
+	slog.Info("vllm cache op",
+		"operation", "frag_high",
+		"channel_id", channelID,
+		"block_count", stats.BlockCount,
+		"hit_rate", stats.HitRate,
+		"ts", time.Now().UTC().Format(time.RFC3339),
+	)
+}
+
+// marshalPayload JSON-encodes a bus event payload for logging/testing.
+// Only used in log helpers; not on the hot path.
+func marshalPayload(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "<marshal error>"
+	}
+	return string(b)
+}

--- a/internal/providers/vllm/provider_vllm_fork.go
+++ b/internal/providers/vllm/provider_vllm_fork.go
@@ -1,0 +1,95 @@
+// provider_vllm_fork.go — Fork-over-kvcache stub (RFC-0005 integration point).
+//
+// When cog_fork_session is called with kv_cache.inherit_parent_kv == true,
+// the fork handler (RFC-0005) calls ParentKVBlockHash on the active vLLM
+// provider to obtain the parent session's KV block hash. The child session's
+// first completion request carries this hash as a routing hint.
+//
+// In v0.5.0 scaffolding, step 3 and 4 of the fork-over-kvcache flow are stubbed:
+// the hash is carried through but channel scheduling logic emits a log line
+// rather than actually routing to the same vLLM channel as the parent.
+//
+// TODO(rfc-0006): stub — full fork-over-kvcache routing requires Linux/CUDA.
+// See: https://github.com/myrgic/cogos/issues/203
+package vllm
+
+import (
+	"context"
+	"log/slog"
+)
+
+// ForkKVCacheResult carries the fork-over-kvcache output for a single fork.
+type ForkKVCacheResult struct {
+	// ParentKVBlockHash is the content-addressed hash of the parent's KV state
+	// at the fork point. Empty string means the parent block was unavailable
+	// (evicted, runtime restarted) — the child starts cold.
+	ParentKVBlockHash BlockHash
+
+	// Degraded is true when the block hash was unavailable and the child
+	// will start with a cold cache.
+	Degraded bool
+
+	// DegradedReason describes why the block was unavailable, if Degraded is true.
+	DegradedReason string
+}
+
+// ForkOverKVCache implements the fork-over-kvcache flow for a child session.
+// It queries the KVBlockHashProvider (the vLLM provider) for the parent's KV
+// block hash and returns a ForkKVCacheResult.
+//
+// When the parent's block is unavailable (evicted, runtime restarted), it
+// degrades gracefully: Degraded = true, ParentKVBlockHash = "".
+//
+// In v0.5.0 the channel scheduling step (routing the child's first request to
+// the same vLLM channel as the parent for cache reuse) is stubbed with a log
+// line. Full integration requires Linux/CUDA and RFC-0005 fork handler landing.
+//
+// TODO(rfc-0006): stub — full fork-over-kvcache routing requires Linux/CUDA.
+// See: https://github.com/myrgic/cogos/issues/203
+func ForkOverKVCache(ctx context.Context, provider KVBlockHashProvider, parentSessionID, atMessageID string) ForkKVCacheResult {
+	hash, err := provider.ParentKVBlockHash(ctx, parentSessionID, atMessageID)
+	if err != nil {
+		reason := err.Error()
+		slog.Info("vllm fork-over-kvcache: parent block unavailable, child starts cold",
+			"operation", "fork_kvcache_degrade",
+			"parent_session_id", parentSessionID,
+			"at_message_id", atMessageID,
+			"reason", reason,
+		)
+		return ForkKVCacheResult{
+			ParentKVBlockHash: "",
+			Degraded:          true,
+			DegradedReason:    reason,
+		}
+	}
+
+	if hash == "" {
+		slog.Info("vllm fork-over-kvcache: empty hash returned, child starts cold",
+			"operation", "fork_kvcache_degrade",
+			"parent_session_id", parentSessionID,
+			"at_message_id", atMessageID,
+		)
+		return ForkKVCacheResult{
+			ParentKVBlockHash: "",
+			Degraded:          true,
+			DegradedReason:    "provider returned empty hash",
+		}
+	}
+
+	// TODO(rfc-0006): stub — log the hash that would be used for routing.
+	// Full implementation: schedule the child's first completion request on the
+	// same vLLM channel as the parent, using hash as the routing hint to
+	// maximize prefix cache reuse.
+	slog.Info("vllm fork-over-kvcache: parent KV block hash obtained (routing stubbed)",
+		"operation", "fork_kvcache_stub",
+		"parent_session_id", parentSessionID,
+		"at_message_id", atMessageID,
+		"parent_kv_block_hash", string(hash),
+		// TODO(rfc-0006/requires-cuda): use hash for cache-aware channel routing.
+	)
+
+	return ForkKVCacheResult{
+		ParentKVBlockHash: hash,
+		Degraded:          false,
+	}
+}

--- a/internal/providers/vllm/provider_vllm_mock.go
+++ b/internal/providers/vllm/provider_vllm_mock.go
@@ -1,0 +1,150 @@
+// provider_vllm_mock.go — MockVLLMClient for unit tests.
+//
+// MockVLLMClient implements VLLMClient with controllable behavior for testing
+// KVCacheProvider, hash stability, bus event emission, and cgo error recovery.
+package vllm
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// MockVLLMClient implements VLLMClient for unit tests.
+// All methods are safe for concurrent use. Override fields to control behavior:
+//
+//	mock := &MockVLLMClient{
+//	    WarmBlocksFn: func(...) ([]BlockResult, error) { ... },
+//	}
+type MockVLLMClient struct {
+	mu sync.Mutex
+
+	// WarmBlocksFn overrides WarmBlocks when non-nil.
+	WarmBlocksFn func(ctx context.Context, prefixes []WarmRequest) ([]BlockResult, error)
+	// EvictBlocksFn overrides EvictBlocks when non-nil.
+	EvictBlocksFn func(ctx context.Context, blockHashes []string) error
+	// ListWarmBlocksFn overrides ListWarmBlocks when non-nil.
+	ListWarmBlocksFn func(ctx context.Context) ([]WarmBlock, error)
+	// BlockHashForPromptFn overrides BlockHashForPrompt when non-nil.
+	BlockHashForPromptFn func(prompt, model string, cfg KVSamplingConfig) string
+	// CacheStatsFn overrides CacheStats when non-nil.
+	CacheStatsFn func(ctx context.Context) (CacheStats, error)
+	// CloseFn overrides Close when non-nil.
+	CloseFn func() error
+
+	// Recorded calls for assertion in tests.
+	WarmCalls   [][]WarmRequest
+	EvictCalls  [][]string
+	CloseCalled int
+
+	// WarmBlocks defaults: populated when WarmBlocksFn is nil.
+	DefaultWarmResult []BlockResult
+
+	// Default stats returned by CacheStats when CacheStatsFn is nil.
+	DefaultStats CacheStats
+
+	// WarmBlockList is returned by ListWarmBlocks when ListWarmBlocksFn is nil.
+	WarmBlockList []WarmBlock
+}
+
+// WarmBlocks implements VLLMClient.
+func (m *MockVLLMClient) WarmBlocks(ctx context.Context, prefixes []WarmRequest) ([]BlockResult, error) {
+	m.mu.Lock()
+	m.WarmCalls = append(m.WarmCalls, prefixes)
+	fn := m.WarmBlocksFn
+	def := m.DefaultWarmResult
+	m.mu.Unlock()
+
+	if fn != nil {
+		return fn(ctx, prefixes)
+	}
+	if def != nil {
+		return def, nil
+	}
+	// Default: return a warmed result for each request using the hash tuple.
+	results := make([]BlockResult, len(prefixes))
+	for i, p := range prefixes {
+		results[i] = BlockResult{
+			BlockHash: m.BlockHashForPrompt(p.PromptPrefix, p.ModelName, p.SamplingConfig),
+			Warmed:    true,
+		}
+	}
+	return results, nil
+}
+
+// EvictBlocks implements VLLMClient.
+func (m *MockVLLMClient) EvictBlocks(ctx context.Context, blockHashes []string) error {
+	m.mu.Lock()
+	m.EvictCalls = append(m.EvictCalls, blockHashes)
+	fn := m.EvictBlocksFn
+	m.mu.Unlock()
+
+	if fn != nil {
+		return fn(ctx, blockHashes)
+	}
+	return nil
+}
+
+// ListWarmBlocks implements VLLMClient.
+func (m *MockVLLMClient) ListWarmBlocks(ctx context.Context) ([]WarmBlock, error) {
+	m.mu.Lock()
+	fn := m.ListWarmBlocksFn
+	list := m.WarmBlockList
+	m.mu.Unlock()
+
+	if fn != nil {
+		return fn(ctx)
+	}
+	return list, nil
+}
+
+// BlockHashForPrompt implements VLLMClient.
+// When BlockHashForPromptFn is nil it delegates to ComputeBlockHash for a
+// deterministic, stable hash using the RFC-0006 equivalence tuple.
+func (m *MockVLLMClient) BlockHashForPrompt(prompt, model string, cfg KVSamplingConfig) string {
+	m.mu.Lock()
+	fn := m.BlockHashForPromptFn
+	m.mu.Unlock()
+
+	if fn != nil {
+		return fn(prompt, model, cfg)
+	}
+	return ComputeBlockHash(prompt, model, cfg)
+}
+
+// CacheStats implements VLLMClient.
+func (m *MockVLLMClient) CacheStats(ctx context.Context) (CacheStats, error) {
+	m.mu.Lock()
+	fn := m.CacheStatsFn
+	def := m.DefaultStats
+	m.mu.Unlock()
+
+	if fn != nil {
+		return fn(ctx)
+	}
+	return def, nil
+}
+
+// Close implements VLLMClient.
+func (m *MockVLLMClient) Close() error {
+	m.mu.Lock()
+	m.CloseCalled++
+	fn := m.CloseFn
+	m.mu.Unlock()
+
+	if fn != nil {
+		return fn()
+	}
+	return nil
+}
+
+// newTestWarmBlock is a test helper for constructing a WarmBlock with now-time.
+func newTestWarmBlock(hash, model string, cfg KVSamplingConfig, size int) WarmBlock {
+	return WarmBlock{
+		BlockHash:      hash,
+		ModelName:      model,
+		SamplingConfig: cfg,
+		WarmAt:         time.Now().UTC(),
+		BlockSize:      size,
+	}
+}

--- a/internal/providers/vllm/provider_vllm_test.go
+++ b/internal/providers/vllm/provider_vllm_test.go
@@ -1,0 +1,632 @@
+// provider_vllm_test.go — mock-based unit tests for the vLLM provider scaffolding.
+//
+// Tests cover:
+//   - Provider implements engine.Provider
+//   - KVCacheProvider implements reconcile.Reconcilable (all 7 methods)
+//   - KVBlockHashProvider.ParentKVBlockHash for known sessions
+//   - Cache event emission triggers bus event with correct payload type
+//   - Hashing tuple is stable across calls with same inputs
+//   - vllmCall wrapper recovers from panic
+//   - Health() transitions (Healthy, Degraded, Progressing, Missing)
+package vllm
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/myrgic/cogos/internal/engine"
+	"github.com/myrgic/cogos/pkg/reconcile"
+)
+
+// ── Interface compliance ──────────────────────────────────────────────────────
+
+// TestProviderImplementsEngineProvider verifies that *Provider satisfies
+// the engine.Provider interface at compile time.
+func TestProviderImplementsEngineProvider(t *testing.T) {
+	var _ engine.Provider = (*Provider)(nil)
+}
+
+// TestKVCacheProviderImplementsReconcilable verifies that *KVCacheProvider
+// satisfies the reconcile.Reconcilable interface at compile time.
+func TestKVCacheProviderImplementsReconcilable(t *testing.T) {
+	var _ reconcile.Reconcilable = (*KVCacheProvider)(nil)
+}
+
+// TestProviderImplementsKVBlockHashProvider verifies that *Provider satisfies
+// the KVBlockHashProvider interface at compile time.
+func TestProviderImplementsKVBlockHashProvider(t *testing.T) {
+	var _ KVBlockHashProvider = (*Provider)(nil)
+}
+
+// ── vllmCall panic recovery ───────────────────────────────────────────────────
+
+// TestVLLMCallRecoversFromPanic verifies that vllmCall converts panics to errors.
+func TestVLLMCallRecoversFromPanic(t *testing.T) {
+	err := vllmCall(func() error {
+		panic("simulated cgo panic")
+	})
+	if err == nil {
+		t.Fatal("expected non-nil error from panic recovery, got nil")
+	}
+	if err.Error() == "" {
+		t.Fatal("expected non-empty error message")
+	}
+	t.Logf("recovered error: %v", err)
+}
+
+// TestVLLMCallPassesThroughError verifies that non-panic errors pass through.
+func TestVLLMCallPassesThroughError(t *testing.T) {
+	sentinel := errors.New("sentinel error")
+	err := vllmCall(func() error {
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error, got: %v", err)
+	}
+}
+
+// TestVLLMCallNilOnSuccess verifies that vllmCall returns nil on success.
+func TestVLLMCallNilOnSuccess(t *testing.T) {
+	err := vllmCall(func() error { return nil })
+	if err != nil {
+		t.Fatalf("expected nil, got: %v", err)
+	}
+}
+
+// ── Hashing tuple stability ───────────────────────────────────────────────────
+
+// TestComputeBlockHashStable verifies the hash is stable across identical inputs.
+func TestComputeBlockHashStable(t *testing.T) {
+	cfg := KVSamplingConfig{Temperature: 0.7, TopP: 0.9, TopK: 50, MaxTokens: 2048}
+	h1 := ComputeBlockHash("You are a helpful assistant.", "llama-3-8b", cfg)
+	h2 := ComputeBlockHash("You are a helpful assistant.", "llama-3-8b", cfg)
+	if h1 != h2 {
+		t.Fatalf("hash not stable: %q != %q", h1, h2)
+	}
+}
+
+// TestComputeBlockHashUnique verifies different inputs produce different hashes.
+func TestComputeBlockHashUnique(t *testing.T) {
+	cfg := KVSamplingConfig{Temperature: 0.7, TopP: 0.9, TopK: 50, MaxTokens: 2048}
+	h1 := ComputeBlockHash("prompt A", "llama-3-8b", cfg)
+	h2 := ComputeBlockHash("prompt B", "llama-3-8b", cfg)
+	if h1 == h2 {
+		t.Fatalf("expected different hashes for different prompts, got same: %q", h1)
+	}
+}
+
+// TestComputeBlockHashModelDifferent verifies different models produce different hashes.
+func TestComputeBlockHashModelDifferent(t *testing.T) {
+	cfg := KVSamplingConfig{Temperature: 0.7, TopP: 0.9, TopK: 50, MaxTokens: 2048}
+	h1 := ComputeBlockHash("same prompt", "llama-3-8b", cfg)
+	h2 := ComputeBlockHash("same prompt", "llama-3-70b", cfg)
+	if h1 == h2 {
+		t.Fatalf("expected different hashes for different models, got same: %q", h1)
+	}
+}
+
+// TestComputeBlockHashNotEmpty verifies the hash is never empty.
+func TestComputeBlockHashNotEmpty(t *testing.T) {
+	h := ComputeBlockHash("", "", KVSamplingConfig{})
+	if h == "" {
+		t.Fatal("expected non-empty hash for empty inputs")
+	}
+	if len(h) != 64 {
+		t.Fatalf("expected 64-char hex SHA-256, got len=%d: %q", len(h), h)
+	}
+}
+
+// TestMockClientBlockHashForPromptDelegates verifies MockVLLMClient delegates
+// to ComputeBlockHash when no custom function is set.
+func TestMockClientBlockHashForPromptDelegates(t *testing.T) {
+	mock := &MockVLLMClient{}
+	cfg := KVSamplingConfig{Temperature: 0.5}
+	h := mock.BlockHashForPrompt("test prompt", "model-x", cfg)
+	expected := ComputeBlockHash("test prompt", "model-x", cfg)
+	if h != expected {
+		t.Fatalf("mock hash %q != expected %q", h, expected)
+	}
+}
+
+// ── KVCacheProvider lifecycle ─────────────────────────────────────────────────
+
+// TestKVCacheProviderType verifies Type() returns the correct string.
+func TestKVCacheProviderType(t *testing.T) {
+	p := NewKVCacheProvider(&MockVLLMClient{}, "test-channel", nil)
+	if p.Type() != "cache.kv_block" {
+		t.Fatalf("expected %q, got %q", "cache.kv_block", p.Type())
+	}
+}
+
+// TestKVCacheProviderLoadConfigNoFile verifies LoadConfig succeeds with no config file.
+func TestKVCacheProviderLoadConfigNoFile(t *testing.T) {
+	p := NewKVCacheProvider(&MockVLLMClient{}, "test-channel", nil)
+	cfg, err := p.LoadConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+}
+
+// TestKVCacheProviderFetchLive verifies FetchLive queries the client.
+func TestKVCacheProviderFetchLive(t *testing.T) {
+	mock := &MockVLLMClient{
+		DefaultStats: CacheStats{HitRate: 0.7, BlockCount: 3, Fragmentation: 0.1},
+		WarmBlockList: []WarmBlock{
+			{BlockHash: "abc123", ModelName: "m1", WarmAt: time.Now()},
+		},
+	}
+	p := NewKVCacheProvider(mock, "ch1", nil)
+	cfg := &kvCacheConfig{Root: t.TempDir()}
+	live, err := p.FetchLive(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("FetchLive error: %v", err)
+	}
+	lv, ok := live.(*kvCacheLive)
+	if !ok {
+		t.Fatalf("expected *kvCacheLive, got %T", live)
+	}
+	if len(lv.WarmBlocks) != 1 {
+		t.Fatalf("expected 1 warm block, got %d", len(lv.WarmBlocks))
+	}
+	if lv.Stats.HitRate != 0.7 {
+		t.Fatalf("expected hit rate 0.7, got %f", lv.Stats.HitRate)
+	}
+}
+
+// TestKVCacheProviderComputePlanWarmMissing verifies ComputePlan creates actions
+// for declared prefixes not in the live set.
+func TestKVCacheProviderComputePlanWarmMissing(t *testing.T) {
+	mock := &MockVLLMClient{}
+	p := NewKVCacheProvider(mock, "ch1", nil)
+
+	cfg := &kvCacheConfig{
+		HotPrefixes: []WarmRequest{
+			{PromptPrefix: "You are an assistant.", ModelName: "m1", SamplingConfig: KVSamplingConfig{Temperature: 0.7}},
+		},
+	}
+	// Live has no warm blocks.
+	lv := &kvCacheLive{WarmBlocks: nil, Stats: CacheStats{}}
+
+	plan, err := p.ComputePlan(cfg, lv, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan error: %v", err)
+	}
+	if plan.Summary.Creates != 1 {
+		t.Fatalf("expected 1 create action, got %d (summary: %+v)", plan.Summary.Creates, plan.Summary)
+	}
+}
+
+// TestKVCacheProviderComputePlanInSync verifies ComputePlan skips when prefix is warm.
+func TestKVCacheProviderComputePlanInSync(t *testing.T) {
+	mock := &MockVLLMClient{}
+	p := NewKVCacheProvider(mock, "ch1", nil)
+
+	prompt := "You are an assistant."
+	model := "m1"
+	cfg2 := KVSamplingConfig{Temperature: 0.7}
+	hash := ComputeBlockHash(prompt, model, cfg2)
+
+	cfg := &kvCacheConfig{
+		HotPrefixes: []WarmRequest{
+			{PromptPrefix: prompt, ModelName: model, SamplingConfig: cfg2},
+		},
+	}
+	lv := &kvCacheLive{
+		WarmBlocks: []WarmBlock{
+			{BlockHash: hash, ModelName: model, SamplingConfig: cfg2, WarmAt: time.Now()},
+		},
+		Stats: CacheStats{HitRate: 0.8},
+	}
+
+	plan, err := p.ComputePlan(cfg, lv, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan error: %v", err)
+	}
+	if plan.Summary.Skipped != 1 || plan.Summary.Creates != 0 {
+		t.Fatalf("expected 1 skip, got: %+v", plan.Summary)
+	}
+}
+
+// TestKVCacheProviderApplyPlanWarm verifies ApplyPlan calls WarmBlocks.
+func TestKVCacheProviderApplyPlanWarm(t *testing.T) {
+	emitter := &MockBusEmitter{}
+	mock := &MockVLLMClient{}
+	p := NewKVCacheProvider(mock, "ch1", emitter)
+
+	plan := &reconcile.Plan{
+		ResourceType: "cache.kv_block",
+		Actions: []reconcile.Action{
+			{
+				Action:       reconcile.ActionCreate,
+				ResourceType: "cache.kv_block",
+				Name:         "hash1",
+				Details: map[string]any{
+					"block_hash":    "hash1",
+					"prompt_prefix": "system prompt text",
+					"model_name":    "m1",
+				},
+			},
+		},
+	}
+
+	results, err := p.ApplyPlan(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("ApplyPlan error: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected at least one result")
+	}
+	if len(mock.WarmCalls) == 0 {
+		t.Fatal("expected WarmBlocks to be called")
+	}
+}
+
+// TestKVCacheProviderApplyPlanEvict verifies ApplyPlan calls EvictBlocks.
+func TestKVCacheProviderApplyPlanEvict(t *testing.T) {
+	emitter := &MockBusEmitter{}
+	mock := &MockVLLMClient{}
+	p := NewKVCacheProvider(mock, "ch1", emitter)
+
+	plan := &reconcile.Plan{
+		ResourceType: "cache.kv_block",
+		Actions: []reconcile.Action{
+			{
+				Action:       reconcile.ActionDelete,
+				ResourceType: "cache.kv_block",
+				Name:         "deadbeef",
+				Details: map[string]any{
+					"block_hash": "deadbeef",
+					"reason":     "warm_not_declared",
+				},
+			},
+		},
+	}
+
+	_, err := p.ApplyPlan(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("ApplyPlan error: %v", err)
+	}
+	if len(mock.EvictCalls) == 0 {
+		t.Fatal("expected EvictBlocks to be called")
+	}
+}
+
+// TestKVCacheProviderBuildState verifies BuildState produces a state with resources.
+func TestKVCacheProviderBuildState(t *testing.T) {
+	mock := &MockVLLMClient{}
+	p := NewKVCacheProvider(mock, "ch1", nil)
+
+	cfg := &kvCacheConfig{Root: t.TempDir()}
+	lv := &kvCacheLive{
+		WarmBlocks: []WarmBlock{
+			{BlockHash: "abcdef1234567890", ModelName: "m1", BlockSize: 512, WarmAt: time.Now()},
+		},
+		Stats: CacheStats{HitRate: 0.8, BlockCount: 1, Fragmentation: 0.1},
+	}
+
+	state, err := p.BuildState(cfg, lv, nil)
+	if err != nil {
+		t.Fatalf("BuildState error: %v", err)
+	}
+	if len(state.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(state.Resources))
+	}
+	if state.ResourceType != "cache.kv_block" {
+		t.Fatalf("expected resource type 'cache.kv_block', got %q", state.ResourceType)
+	}
+}
+
+// ── Health transitions ────────────────────────────────────────────────────────
+
+// TestKVCacheProviderHealthMissingInitial verifies Health() returns Missing
+// before any stats are observed.
+func TestKVCacheProviderHealthMissingInitial(t *testing.T) {
+	p := NewKVCacheProvider(&MockVLLMClient{}, "ch1", nil)
+	status := p.Health()
+	if status.Health != reconcile.HealthMissing {
+		t.Fatalf("expected Missing, got %q: %s", status.Health, status.Message)
+	}
+}
+
+// TestKVCacheProviderHealthHealthy verifies Health() returns Healthy when
+// hit rate > 0.5.
+func TestKVCacheProviderHealthHealthy(t *testing.T) {
+	mock := &MockVLLMClient{
+		DefaultStats: CacheStats{HitRate: 0.75, BlockCount: 5, Fragmentation: 0.1},
+	}
+	p := NewKVCacheProvider(mock, "ch1", nil)
+	// Trigger a FetchLive + ComputePlan to populate stats.
+	ctx := context.Background()
+	cfg := &kvCacheConfig{Root: t.TempDir()}
+	live, _ := p.FetchLive(ctx, cfg)
+	p.ComputePlan(cfg, live, nil)
+	// Manually inject stats (simulate ApplyPlan stats update path).
+	p.mu.Lock()
+	p.lastStats = CacheStats{HitRate: 0.75, BlockCount: 5, Fragmentation: 0.1}
+	p.lastPlan = &reconcile.Plan{}
+	p.mu.Unlock()
+
+	status := p.Health()
+	if status.Health != reconcile.HealthHealthy {
+		t.Fatalf("expected Healthy, got %q: %s", status.Health, status.Message)
+	}
+}
+
+// TestKVCacheProviderHealthDegradedFragmentation verifies Health() returns
+// Degraded when fragmentation > 0.8.
+func TestKVCacheProviderHealthDegradedFragmentation(t *testing.T) {
+	p := NewKVCacheProvider(&MockVLLMClient{}, "ch1", nil)
+	p.mu.Lock()
+	p.lastStats = CacheStats{HitRate: 0.9, BlockCount: 10, Fragmentation: 0.9}
+	p.lastPlan = &reconcile.Plan{}
+	p.mu.Unlock()
+
+	status := p.Health()
+	if status.Health != reconcile.HealthDegraded {
+		t.Fatalf("expected Degraded (fragmentation), got %q: %s", status.Health, status.Message)
+	}
+}
+
+// TestKVCacheProviderHealthDegradedLowHitRate verifies Health() returns
+// Degraded when hit rate <= 0.5.
+func TestKVCacheProviderHealthDegradedLowHitRate(t *testing.T) {
+	p := NewKVCacheProvider(&MockVLLMClient{}, "ch1", nil)
+	p.mu.Lock()
+	p.lastStats = CacheStats{HitRate: 0.3, BlockCount: 2, Fragmentation: 0.2}
+	p.lastPlan = &reconcile.Plan{}
+	p.mu.Unlock()
+
+	status := p.Health()
+	if status.Health != reconcile.HealthDegraded {
+		t.Fatalf("expected Degraded (hit rate), got %q: %s", status.Health, status.Message)
+	}
+}
+
+// ── Bus event emission ────────────────────────────────────────────────────────
+
+// TestCacheEventEmissionOnWarm verifies that a warm cycle emits a warmed event.
+func TestCacheEventEmissionOnWarm(t *testing.T) {
+	emitter := &MockBusEmitter{}
+	mock := &MockVLLMClient{
+		DefaultStats: CacheStats{HitRate: 0.6, BlockCount: 1, Fragmentation: 0.1},
+	}
+	p := NewKVCacheProvider(mock, "ch1", emitter)
+
+	plan := &reconcile.Plan{
+		ResourceType: "cache.kv_block",
+		Actions: []reconcile.Action{
+			{
+				Action:       reconcile.ActionCreate,
+				ResourceType: "cache.kv_block",
+				Name:         "warmhash",
+				Details: map[string]any{
+					"block_hash":    "warmhash",
+					"prompt_prefix": "test prompt",
+					"model_name":    "m1",
+				},
+			},
+		},
+	}
+
+	_, err := p.ApplyPlan(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("ApplyPlan error: %v", err)
+	}
+
+	// Should have at least a warmed event.
+	found := false
+	for _, ev := range emitter.Events {
+		if ev.Topic == TopicKVCacheWarmed {
+			found = true
+			// Verify the payload is the correct type.
+			if _, ok := ev.Payload.(KVCacheWarmedEvent); !ok {
+				t.Fatalf("expected KVCacheWarmedEvent payload, got %T", ev.Payload)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected %q event to be emitted, got events: %v", TopicKVCacheWarmed, emitter.Events)
+	}
+}
+
+// TestCacheEventEmissionOnEvict verifies that an evict cycle emits an evicted event.
+func TestCacheEventEmissionOnEvict(t *testing.T) {
+	emitter := &MockBusEmitter{}
+	mock := &MockVLLMClient{
+		DefaultStats: CacheStats{HitRate: 0.4, BlockCount: 0, Fragmentation: 0.05},
+	}
+	p := NewKVCacheProvider(mock, "ch1", emitter)
+
+	plan := &reconcile.Plan{
+		ResourceType: "cache.kv_block",
+		Actions: []reconcile.Action{
+			{
+				Action:       reconcile.ActionDelete,
+				ResourceType: "cache.kv_block",
+				Name:         "evicthash",
+				Details: map[string]any{
+					"block_hash": "evicthash",
+					"reason":     "warm_not_declared",
+				},
+			},
+		},
+	}
+
+	_, err := p.ApplyPlan(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("ApplyPlan error: %v", err)
+	}
+
+	found := false
+	for _, ev := range emitter.Events {
+		if ev.Topic == TopicKVCacheEvicted {
+			found = true
+			if _, ok := ev.Payload.(KVCacheEvictedEvent); !ok {
+				t.Fatalf("expected KVCacheEvictedEvent payload, got %T", ev.Payload)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected %q event, got events: %v", TopicKVCacheEvicted, emitter.Events)
+	}
+}
+
+// TestHitRateChangedEmission verifies emitHitRateChanged fires on ≥5% delta.
+func TestHitRateChangedEmission(t *testing.T) {
+	emitter := &MockBusEmitter{}
+	p := NewKVCacheProvider(&MockVLLMClient{}, "ch1", emitter)
+	// Set prev to 0.6; new to 0.7 (delta = 0.1 > 0.05 threshold).
+	p.mu.Lock()
+	p.lastStats = CacheStats{HitRate: 0.6}
+	p.mu.Unlock()
+
+	ctx := context.Background()
+	newStats := CacheStats{HitRate: 0.7, BlockCount: 5}
+	p.checkAndEmitStats(ctx, newStats)
+
+	found := false
+	for _, ev := range emitter.Events {
+		if ev.Topic == TopicKVCacheHitRateChanged {
+			found = true
+			evt, ok := ev.Payload.(KVCacheHitRateChangedEvent)
+			if !ok {
+				t.Fatalf("expected KVCacheHitRateChangedEvent, got %T", ev.Payload)
+			}
+			if evt.PrevRate != 0.6 || evt.CurrentRate != 0.7 {
+				t.Fatalf("unexpected rates: prev=%f current=%f", evt.PrevRate, evt.CurrentRate)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected hit_rate_changed event")
+	}
+}
+
+// TestFragmentationHighEmission verifies emitFragmentationHigh fires on crossing 0.8.
+func TestFragmentationHighEmission(t *testing.T) {
+	emitter := &MockBusEmitter{}
+	p := NewKVCacheProvider(&MockVLLMClient{}, "ch1", emitter)
+	// Prev frag = 0.5, new frag = 0.85 (crossing 0.8).
+	p.mu.Lock()
+	p.lastStats = CacheStats{Fragmentation: 0.5}
+	p.mu.Unlock()
+
+	ctx := context.Background()
+	newStats := CacheStats{HitRate: 0.8, Fragmentation: 0.85}
+	p.checkAndEmitStats(ctx, newStats)
+
+	found := false
+	for _, ev := range emitter.Events {
+		if ev.Topic == TopicKVCacheFragmentationHigh {
+			found = true
+			if _, ok := ev.Payload.(KVCacheFragmentationHighEvent); !ok {
+				t.Fatalf("expected KVCacheFragmentationHighEvent, got %T", ev.Payload)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected fragmentation_high event")
+	}
+}
+
+// ── KVBlockHashProvider ───────────────────────────────────────────────────────
+
+// TestParentKVBlockHashReturnsHashForKnownSession verifies that
+// Provider.ParentKVBlockHash returns a non-empty hash for a known session.
+func TestParentKVBlockHashReturnsHashForKnownSession(t *testing.T) {
+	mock := &MockVLLMClient{}
+	p := NewProvider(mock, "ch1", "model-x")
+
+	hash, err := p.ParentKVBlockHash(context.Background(), "session-1", "msg-42")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hash == "" {
+		t.Fatal("expected non-empty hash")
+	}
+}
+
+// TestParentKVBlockHashPanicRecovery verifies that a panicking client is
+// recovered by the vllmCall wrapper.
+func TestParentKVBlockHashPanicRecovery(t *testing.T) {
+	mock := &MockVLLMClient{
+		BlockHashForPromptFn: func(prompt, model string, cfg KVSamplingConfig) string {
+			panic("simulated cgo panic in BlockHashForPrompt")
+		},
+	}
+	p := NewProvider(mock, "ch1", "model-x")
+	_, err := p.ParentKVBlockHash(context.Background(), "s1", "m1")
+	if err == nil {
+		t.Fatal("expected non-nil error from panic recovery")
+	}
+	t.Logf("recovered: %v", err)
+}
+
+// ── Fork-over-kvcache stub ────────────────────────────────────────────────────
+
+// TestForkOverKVCacheOK verifies ForkOverKVCache returns the hash when available.
+func TestForkOverKVCacheOK(t *testing.T) {
+	mock := &MockVLLMClient{}
+	p := NewProvider(mock, "ch1", "model-x")
+
+	result := ForkOverKVCache(context.Background(), p, "parent-session", "msg-10")
+	if result.Degraded {
+		t.Fatalf("expected non-degraded result, got: %s", result.DegradedReason)
+	}
+	if result.ParentKVBlockHash == "" {
+		t.Fatal("expected non-empty ParentKVBlockHash")
+	}
+}
+
+// TestForkOverKVCacheDegradeOnError verifies ForkOverKVCache degrades when
+// the provider returns an error.
+func TestForkOverKVCacheDegradeOnError(t *testing.T) {
+	mock := &MockVLLMClient{
+		BlockHashForPromptFn: func(prompt, model string, cfg KVSamplingConfig) string {
+			panic("simulated eviction error via panic")
+		},
+	}
+	p := NewProvider(mock, "ch1", "model-x")
+	result := ForkOverKVCache(context.Background(), p, "parent", "msg-10")
+	if !result.Degraded {
+		t.Fatal("expected degraded result on error")
+	}
+}
+
+// ── Mock client recording ─────────────────────────────────────────────────────
+
+// TestMockClientRecordsWarmCalls verifies the mock records all WarmBlocks calls.
+func TestMockClientRecordsWarmCalls(t *testing.T) {
+	mock := &MockVLLMClient{}
+	reqs := []WarmRequest{
+		{PromptPrefix: "p1", ModelName: "m1"},
+		{PromptPrefix: "p2", ModelName: "m1"},
+	}
+	_, err := mock.WarmBlocks(context.Background(), reqs)
+	if err != nil {
+		t.Fatalf("WarmBlocks error: %v", err)
+	}
+	if len(mock.WarmCalls) != 1 {
+		t.Fatalf("expected 1 call recorded, got %d", len(mock.WarmCalls))
+	}
+	if len(mock.WarmCalls[0]) != 2 {
+		t.Fatalf("expected 2 requests in call, got %d", len(mock.WarmCalls[0]))
+	}
+}
+
+// TestMockClientClose verifies Close is tracked.
+func TestMockClientClose(t *testing.T) {
+	mock := &MockVLLMClient{}
+	_ = mock.Close()
+	_ = mock.Close()
+	if mock.CloseCalled != 2 {
+		t.Fatalf("expected CloseCalled=2, got %d", mock.CloseCalled)
+	}
+}

--- a/pkg/cogblock/block.go
+++ b/pkg/cogblock/block.go
@@ -69,6 +69,14 @@ const (
 
 	// Session types.
 	BlockSessionTurn CogBlockKind = "session.turn"
+
+	// Inference cache types (RFC-0006).
+	//
+	// KindCacheKVBlock represents a single PagedAttention block in the vLLM
+	// block manager — a fixed-size chunk of key-value tensors addressable by
+	// content hash. Each block is registered in the Kind registry via
+	// engine.RegisterKindHandler in internal/engine/kinds_vllm.go.
+	KindCacheKVBlock CogBlockKind = "cache.kv_block"
 )
 
 // BlockProvenance records the origin and ingestion metadata of a CogBlock.


### PR DESCRIPTION
## Summary

Implements RFC-0006's v0.5.0 scope per the ratified design: scaffolding + mock vLLM client + Reconcilable contract + bus event payload types. Full hardware integration (cgo binding to vllm.core.block_manager, CUDA device) is deferred and explicitly tagged `requires-cuda`.

**Hardware blocker:** Full integration requires Linux/CUDA and a running vLLM instance. This PR ships the interface design + mock coverage; hardware integration tests are tracked as a follow-up milestone item on issue #203.

## Acceptance items covered

- [x] `internal/providers/vllm/` package scaffold (RFC-0004 convention)
- [x] cgo failure-isolation wrapper — `vllmCall` with `debug.SetPanicOnFault` + deferred recover
- [x] `VLLMClient` interface + `MockVLLMClient` for tests
- [x] `KVBlockHashProvider` interface — Go source identical to RFC-0005's worker definition
- [x] `cache.kv_block` Kind constant in `pkg/cogblock` + `KVBlockBody` + `KVSamplingConfig` types
- [x] `cache.kv_block` Kind handler registered via ADR-090 `RegisterKindHandler` in `internal/engine/kinds_vllm.go` (no switch modification required)
- [x] `KVCacheProvider` implementing `reconcile.Reconcilable` — all 7 methods (Type, LoadConfig, FetchLive, ComputePlan, ApplyPlan, BuildState, Health)
- [x] Typed bus event payloads: `KVCacheWarmedEvent`, `KVCacheEvictedEvent`, `KVCacheHitRateChangedEvent`, `KVCacheFragmentationHighEvent` + topic constants
- [x] `BusEmitter` injection interface (avoids circular import with `internal/engine`)
- [x] Fork-over-kvcache stub with `TODO(rfc-0006)` marker (RFC-0005 integration point)
- [x] Hashing tuple per RFC-0006 §hashing-tuple: `SHA-256(prompt + "|" + model + "|" + temperature + "|" + top_p + "|" + top_k + "|" + max_tokens)`
- [x] Structured logs on all cache operations with fields: `operation`, `channel_id`, `block_count`, `hit_rate`, `ts`
- [x] `README-vllm.md` documenting cgo/sidecar fallback path and hardware requirements
- [x] Unit tests: Provider/Reconcilable/KVBlockHashProvider interface compliance; KVBlockHashProvider hashes for known sessions; cache event emission with correct payload types; hashing tuple stability; cgo wrapper recovers from panic; Health() transitions (Healthy/Degraded/Progressing/Missing)
- [x] `go build ./...` green
- [x] `go test ./...` green (including `-race`)

## Deferred per YAGNI / hardware-block

- `CacheHintProvider` interface — Future scope (post-v0.5.0)
- Cache-aware dispatch routing — Future scope (requires-cuda + empirical validation)
- cgo binding to `vllm.core.block_manager` — requires-cuda
- Integration test against real vLLM instance — requires-cuda
- Full fork-over-kvcache channel scheduling — requires-cuda + RFC-0005 fork handler landing
- Python sidecar implementation — architecture specified; implementation deferred

## KVBlockHashProvider alignment

The `KVBlockHashProvider` interface Go source in `internal/providers/vllm/kvblock_hash_provider.go` matches RFC-0005's worker definition exactly.

## Commit log

```
feat(providers/vllm): package scaffold
feat(providers/vllm): cgo failure-isolation wrapper via deferred recover
feat(providers/vllm): VLLMClient interface + mock for tests
feat(providers/vllm): KVBlockHashProvider interface for fork integration
feat(providers/vllm): cache.kv_block Kind + body schema
feat(providers/vllm): KVCacheProvider Reconcilable (7-method contract)
feat(providers/vllm): typed bus event payloads + emission
feat(providers/vllm): fork-over-kvcache stub via KVBlockHashProvider
feat(providers/vllm): hashing tuple per RFC-0006 §hashing-tuple
docs(providers/vllm): README documenting cgo/sidecar fallback
test(providers/vllm): mock-based unit tests for full scaffolding surface
```

Closes #203 (v0.5.0 scope; hardware items tracked in follow-up)