### PR TITLE
feat(dispatch): named-provider override for cog_dispatch_to_harness (RFC-0007 Layer 1)

### DIFF
--- a/agent_dispatch.go
+++ b/agent_dispatch.go
@@ -61,12 +61,24 @@ type HarnessDispatcher struct {
 	// identifier prefix).
 	LMStudioModel string
 
-	// reachable cache for LM Studio. mu protects the two fields together.
-	// reachableUntil is the wall-clock instant after which we re-probe;
-	// reachableOK records the last probe result.
-	mu             sync.Mutex
-	reachableUntil time.Time
-	reachableOK    bool
+	// ProviderResolver, when non-nil, lets a caller pass an explicit
+	// provider name via DispatchRequest.Provider. The resolver materializes
+	// the backend URL, kind, model id, and API key from the providers
+	// registry. Empty (nil resolver, empty name) keeps the legacy
+	// Model-enum routing path. See RFC-0007.
+	ProviderResolver engine.ProviderResolver
+
+	// reachable cache. mu protects reachByURL together with the legacy
+	// single-URL fields below. Keyed by BackendURL so multiple providers
+	// with distinct endpoints don't collide on the cache.
+	mu        sync.Mutex
+	reachByURL map[string]reachabilityEntry
+}
+
+// reachabilityEntry records one probe outcome with a TTL.
+type reachabilityEntry struct {
+	ok    bool
+	until time.Time
 }
 
 // reachabilityCacheTTL is how long a successful or failed LM Studio probe
@@ -110,13 +122,43 @@ func (d *HarnessDispatcher) DispatchToHarness(ctx context.Context, req engine.Di
 		}
 	}
 
-	// Decide model routing once per batch. If the caller asked for 26B and
-	// LM Studio is unreachable, every slot degrades to e4b with the same
-	// warning attached.
+	// Resolve a named provider once per batch when the caller supplied one.
+	// Unknown names fail fast — the dispatcher will not silently fall through
+	// to the Model-enum path because that would mask a config typo.
+	var resolved engine.ResolvedProvider
+	if req.Provider != "" {
+		if d.ProviderResolver == nil {
+			return nil, &engine.AgentControllerError{
+				Code:    "invalid_input",
+				Message: "provider override requested but no provider resolver is wired into the dispatcher",
+			}
+		}
+		r, ok := d.ProviderResolver.ResolveDispatchProvider(req.Provider)
+		if !ok {
+			return nil, &engine.AgentControllerError{
+				Code:    "invalid_input",
+				Message: fmt.Sprintf("provider %q is not registered", req.Provider),
+			}
+		}
+		if r.BackendURL == "" {
+			return nil, &engine.AgentControllerError{
+				Code:    "invalid_input",
+				Message: fmt.Sprintf("provider %q resolved with empty BackendURL", req.Provider),
+			}
+		}
+		resolved = r
+	}
+
+	// Decide model routing once per batch. Precedence: explicit Provider
+	// override (already resolved above) > Model enum. If the caller asked
+	// for 26B and LM Studio is unreachable, every slot degrades to e4b with
+	// the same warning attached. Provider overrides do *not* degrade — an
+	// unreachable named provider surfaces as a slot error so the caller
+	// learns about the misconfiguration.
 	resolvedModel := req.Model
 	var degradeNote string
-	if resolvedModel == engine.DispatchModel26B {
-		if d.lmStudioReachable(ctx) {
+	if req.Provider == "" && resolvedModel == engine.DispatchModel26B {
+		if d.endpointReachable(ctx, d.LMStudioBaseURL) {
 			// stay on 26b
 		} else {
 			resolvedModel = engine.DispatchModelE4B
@@ -143,7 +185,7 @@ func (d *HarnessDispatcher) DispatchToHarness(ctx context.Context, req engine.Di
 		idx := i
 		go func() {
 			defer wg.Done()
-			batch.Results[idx] = d.runSlot(parentCtx, idx, req, resolvedModel)
+			batch.Results[idx] = d.runSlot(parentCtx, idx, req, resolvedModel, resolved)
 		}()
 	}
 	wg.Wait()
@@ -162,8 +204,10 @@ func (d *HarnessDispatcher) DispatchToHarness(ctx context.Context, req engine.Di
 }
 
 // runSlot runs one dispatch index to completion. Returns a populated
-// DispatchResult with Success, Content, Error, etc filled in.
-func (d *HarnessDispatcher) runSlot(parentCtx context.Context, idx int, req engine.DispatchRequest, resolvedModel engine.DispatchModel) engine.DispatchResult {
+// DispatchResult with Success, Content, Error, etc filled in. resolved is
+// the named-provider override pre-computed at batch entry (zero value when
+// the caller did not pass a Provider name).
+func (d *HarnessDispatcher) runSlot(parentCtx context.Context, idx int, req engine.DispatchRequest, resolvedModel engine.DispatchModel, resolved engine.ResolvedProvider) engine.DispatchResult {
 	res := engine.DispatchResult{
 		Index:     idx,
 		ModelUsed: resolvedModel,
@@ -177,7 +221,20 @@ func (d *HarnessDispatcher) runSlot(parentCtx context.Context, idx int, req engi
 		AllowedTools: req.Tools,
 		Thinking:     req.Thinking,
 	}
-	if resolvedModel == engine.DispatchModel26B {
+	switch {
+	case req.Provider != "":
+		// Named-provider override path (RFC-0007 Layer 1). The resolver
+		// already materialized URL/kind/model/api-key; we just hand them
+		// to the harness.
+		opts.BackendURL = resolved.BackendURL
+		opts.BackendKind = resolved.BackendKind
+		if opts.BackendKind == "" {
+			opts.BackendKind = backendKindOpenAI
+		}
+		opts.Model = resolved.Model
+		opts.APIKey = resolved.APIKey
+		res.ProviderUsed = req.Provider
+	case resolvedModel == engine.DispatchModel26B:
 		opts.BackendURL = d.LMStudioBaseURL
 		opts.BackendKind = backendKindOpenAI
 		opts.Model = d.LMStudioModel
@@ -219,17 +276,20 @@ func (d *HarnessDispatcher) runSlot(parentCtx context.Context, idx int, req engi
 	return res
 }
 
-// lmStudioReachable returns true when the LM Studio /v1/models endpoint
+// endpointReachable returns true when the /v1/models endpoint at url
 // responded OK within reachabilityProbeTimeout in the last
-// reachabilityCacheTTL. Empty LMStudioBaseURL always returns false (the
-// route is disabled).
-func (d *HarnessDispatcher) lmStudioReachable(ctx context.Context) bool {
-	if d.LMStudioBaseURL == "" {
+// reachabilityCacheTTL. Empty url always returns false (route disabled).
+// Per-URL cache so multiple providers don't share state.
+func (d *HarnessDispatcher) endpointReachable(ctx context.Context, url string) bool {
+	if url == "" {
 		return false
 	}
 	d.mu.Lock()
-	if time.Now().Before(d.reachableUntil) {
-		ok := d.reachableOK
+	if d.reachByURL == nil {
+		d.reachByURL = make(map[string]reachabilityEntry)
+	}
+	if ent, found := d.reachByURL[url]; found && time.Now().Before(ent.until) {
+		ok := ent.ok
 		d.mu.Unlock()
 		return ok
 	}
@@ -237,30 +297,38 @@ func (d *HarnessDispatcher) lmStudioReachable(ctx context.Context) bool {
 
 	probeCtx, cancel := context.WithTimeout(ctx, reachabilityProbeTimeout)
 	defer cancel()
-	httpReq, err := http.NewRequestWithContext(probeCtx, http.MethodGet, d.LMStudioBaseURL+"/v1/models", nil)
+	httpReq, err := http.NewRequestWithContext(probeCtx, http.MethodGet, url+"/v1/models", nil)
 	if err != nil {
-		d.cacheReachability(false)
+		d.cacheReachability(url, false)
 		return false
 	}
 	resp, err := http.DefaultClient.Do(httpReq)
 	if err != nil {
-		log.Printf("[dispatch] lm-studio probe failed: %v", err)
-		d.cacheReachability(false)
+		log.Printf("[dispatch] endpoint probe failed (%s): %v", url, err)
+		d.cacheReachability(url, false)
 		return false
 	}
 	defer resp.Body.Close()
 	_, _ = io.Copy(io.Discard, resp.Body)
-	ok := resp.StatusCode == http.StatusOK
-	d.cacheReachability(ok)
+	// LM Studio with auth required returns 401 for unauthenticated /v1/models.
+	// That still counts as "reachable" — the server is up; auth happens on the
+	// real chat request. Anything < 500 is treated as reachable.
+	ok := resp.StatusCode < 500
+	d.cacheReachability(url, ok)
 	return ok
 }
 
-// cacheReachability stores the probe result with a TTL.
-func (d *HarnessDispatcher) cacheReachability(ok bool) {
+// cacheReachability stores a per-URL probe result with a TTL.
+func (d *HarnessDispatcher) cacheReachability(url string, ok bool) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	d.reachableOK = ok
-	d.reachableUntil = time.Now().Add(reachabilityCacheTTL)
+	if d.reachByURL == nil {
+		d.reachByURL = make(map[string]reachabilityEntry)
+	}
+	d.reachByURL[url] = reachabilityEntry{
+		ok:    ok,
+		until: time.Now().Add(reachabilityCacheTTL),
+	}
 }
 
 // dispatchIdentityKey is the context key used to thread DispatchIdentity

--- a/agent_harness.go
+++ b/agent_harness.go
@@ -504,6 +504,12 @@ type ExecuteScopedOptions struct {
 	// Model overrides h.model for this call. Empty keeps the default.
 	Model string
 
+	// APIKey, when non-empty, is sent as `Authorization: Bearer <APIKey>`
+	// on OpenAI-compat backend calls. Required for LM Studio when API-token
+	// auth is enabled. Empty omits the header — correct for Ollama and for
+	// LM Studio servers with auth disabled. Per RFC-0007 Layer 1.
+	APIKey string
+
 	// Thinking, when non-nil, overrides the think flag for this call.
 	Thinking *bool
 
@@ -590,7 +596,7 @@ func (h *AgentHarness) ExecuteScoped(ctx context.Context, task string, opts Exec
 			KeepAlive: -1, // pin model in VRAM across dispatch turns
 		}
 
-		resp, err := h.chatCompletionTo(ctx, backendURL, backendKind, req)
+		resp, err := h.chatCompletionTo(ctx, backendURL, backendKind, opts.APIKey, req)
 		if err != nil {
 			return result, fmt.Errorf("execute-scoped turn %d: %w", turn, err)
 		}
@@ -782,8 +788,9 @@ const (
 // chatCompletionTo is the per-call variant of chatCompletion: takes an
 // explicit backend URL and kind so a dispatch can route to LM Studio without
 // mutating h.ollamaURL. Ollama path is the existing /api/chat shape; OpenAI
-// path translates to /v1/chat/completions and back.
-func (h *AgentHarness) chatCompletionTo(ctx context.Context, backendURL, kind string, req agentChatRequest) (*agentChatResponse, error) {
+// path translates to /v1/chat/completions and back. apiKey is forwarded to
+// the OpenAI branch as a Bearer token; the Ollama branch ignores it.
+func (h *AgentHarness) chatCompletionTo(ctx context.Context, backendURL, kind, apiKey string, req agentChatRequest) (*agentChatResponse, error) {
 	if backendURL == "" {
 		backendURL = h.ollamaURL
 	}
@@ -791,7 +798,7 @@ func (h *AgentHarness) chatCompletionTo(ctx context.Context, backendURL, kind st
 		kind = backendKindOllama
 	}
 	if kind == backendKindOpenAI {
-		return h.chatCompletionOpenAI(ctx, backendURL, req)
+		return h.chatCompletionOpenAI(ctx, backendURL, apiKey, req)
 	}
 	// Ollama native — same as chatCompletion but parameterized URL.
 	body, err := json.Marshal(req)
@@ -827,7 +834,7 @@ func (h *AgentHarness) chatCompletionTo(ctx context.Context, backendURL, kind st
 // OpenAI shape and translates the response back. Tool-call ID and arguments
 // shape match the Ollama native format already, so the rest of the loop
 // doesn't need to know which backend served a turn.
-func (h *AgentHarness) chatCompletionOpenAI(ctx context.Context, backendURL string, req agentChatRequest) (*agentChatResponse, error) {
+func (h *AgentHarness) chatCompletionOpenAI(ctx context.Context, backendURL, apiKey string, req agentChatRequest) (*agentChatResponse, error) {
 	type openaiToolCallFn struct {
 		Name      string `json:"name"`
 		Arguments string `json:"arguments"`
@@ -882,6 +889,9 @@ func (h *AgentHarness) chatCompletionOpenAI(ctx context.Context, backendURL stri
 		return nil, fmt.Errorf("create openai request: %w", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
+	if apiKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+	}
 	httpResp, err := h.httpClient.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("http openai request: %w", err)

--- a/agent_harness_test.go
+++ b/agent_harness_test.go
@@ -506,3 +506,48 @@ func makeContentResponse(content string) agentChatResponse {
 	resp.Message.Content = content
 	return resp
 }
+
+// RFC-0007 Layer 1: chatCompletionOpenAI sets `Authorization: Bearer ...`
+// when an API key is supplied, and omits the header otherwise. Validates
+// the bearer plumbing that lets a dispatch reach an auth-enabled LM Studio
+// (the desktop endpoint with token-required mode).
+func TestExecuteScoped_OpenAIBearerHeader(t *testing.T) {
+	cases := []struct {
+		name      string
+		apiKey    string
+		wantAuth  string // expected Authorization header value; empty means must be absent
+	}{
+		{name: "with-key", apiKey: "sk-lm-test-token", wantAuth: "Bearer sk-lm-test-token"},
+		{name: "no-key", apiKey: "", wantAuth: ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotAuth string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotAuth = r.Header.Get("Authorization")
+				// Minimal OpenAI-shaped response with one assistant message
+				// that has no tool calls — terminates the harness tool loop.
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"choices":[{"message":{"role":"assistant","content":"ok"}}]}`)
+			}))
+			defer srv.Close()
+
+			h := NewAgentHarness(AgentHarnessConfig{OllamaURL: "http://unused", Model: "gemma-test"})
+			opts := ExecuteScopedOptions{
+				BackendURL:  srv.URL,
+				BackendKind: backendKindOpenAI,
+				Model:       "gemma-test",
+				APIKey:      tc.apiKey,
+				MaxTurns:    1,
+			}
+			_, err := h.ExecuteScoped(context.Background(), "hi", opts)
+			if err != nil {
+				t.Fatalf("ExecuteScoped: %v", err)
+			}
+			if gotAuth != tc.wantAuth {
+				t.Errorf("Authorization header: got %q, want %q", gotAuth, tc.wantAuth)
+			}
+		})
+	}
+}

--- a/docs/rfcs/0007-dispatch-provider-override.md
+++ b/docs/rfcs/0007-dispatch-provider-override.md
@@ -1,0 +1,164 @@
+# RFC-0007: Named-Provider Override for Agent Dispatch
+
+| Field    | Value                                                                                          |
+|----------|------------------------------------------------------------------------------------------------|
+| Status   | Draft                                                                                          |
+| Author   | @chazmaniandinkle                                                                              |
+| Tracking | [#TBD](https://github.com/myrgic/cogos/issues/) (Layer 2 + 3 follow-ups)                       |
+| Target   | `v0.7.0` (Layer 1, this RFC) · later releases (Layers 2 + 3)                                   |
+| Relates  | [RFC-0006 vLLM provider](0006-vllm-pagedattention-provider.md), `cog://rfc/027` (bus peering)  |
+
+## Summary
+
+`cog_dispatch_to_harness` today exposes a binary `model: "e4b" | "26b"` enum that maps to two hardcoded backends. There is no way for a caller to dispatch against a *named* provider declared in `providers.yaml` / `providers.local.yaml`, even when the substrate has the provider fully wired (endpoint, auth, model). This RFC defines the wire shape and dispatcher contract that lets a caller say "run this on `desktop`" (or any other configured provider) and have the kernel honor it.
+
+It scopes three layers. **Layer 1** ships in this RFC's PR: thread an optional `provider` argument through the MCP tool, `DispatchRequest`, and the `HarnessDispatcher`, resolving against the existing providers registry. **Layer 2** (separate PR) lets agent identity cards declare `inference_provider:` in frontmatter so a dispatcher doesn't need to specify a provider per call. **Layer 3** (separate PR) makes the autonomic loop consult `routing.process_state_routing`, which it currently bypasses.
+
+## Background
+
+### Current routing path
+
+`cog_dispatch_to_harness` accepts `model: "e4b" | "26b"`. In `HarnessDispatcher.runSlot` these map to:
+
+- `e4b` → harness default (`h.ollamaURL` / `h.model`)
+- `26b` → `d.LMStudioBaseURL` + `d.LMStudioModel`, `BackendKind: backendKindOpenAI`
+
+`LMStudioBaseURL` is resolved once at kernel startup via `detectLocalLLMTarget(ctx, COGOS_LLM_ENDPOINT)`. There is exactly one OpenAI-compatible target per kernel process, and the caller cannot select a different one at dispatch time.
+
+The substrate already has richer routing: `SimpleRouter.Route()` respects `CompletionRequest.Metadata.PreferProvider` and consults `ProcessStateRouting`. But the dispatch path never constructs a `CompletionRequest` and never calls the router. Two parallel routing surfaces, one of them blind.
+
+### Why this matters now
+
+With desktop LM Studio (192.168.10.191:1234, `google/gemma-4-26b-a4b`) wired as the `desktop` provider in `providers.local.yaml`, the substrate has the quality ceiling available — but Claude Code / MCP callers can't reach it through `cog_dispatch_to_harness`. The dispatch path can hit `desktop` only by overloading `COGOS_LLM_ENDPOINT` to point there globally, which forces *every* "26b" dispatch through the desktop and breaks isolation from the laptop's local LM Studio.
+
+The same friction will recur for any future provider — vLLM (RFC-0006), Codex, peer-fleet members. Hardcoding two model names is the wrong primitive; a provider name is.
+
+## Layer 1 — `provider` parameter on dispatch (this PR)
+
+### Wire shape
+
+`dispatchToHarnessInput` (MCP) gains one field:
+
+```jsonc
+{
+  "provider": "desktop"   // optional. When set, overrides `model` routing.
+                          // Must name a provider in providers.{yaml,local.yaml}.
+                          // Unknown names error before the dispatch runs.
+}
+```
+
+`engine.DispatchRequest` gains the matching field:
+
+```go
+type DispatchRequest struct {
+    // ... existing fields ...
+    Provider string  // Named-provider override; resolved by HarnessDispatcher.
+}
+```
+
+### Resolution contract
+
+The dispatcher resolves a provider name into the same four values it already feeds into `ExecuteScopedOptions`: `BackendURL`, `BackendKind`, `Model`, and (new) `APIKey`. The resolver is an interface on `HarnessDispatcher`:
+
+```go
+// ProviderResolver translates a provider name into the backend config the
+// harness needs. ok=false signals an unknown name; the dispatcher surfaces
+// that as invalid_input.
+type ProviderResolver interface {
+    ResolveDispatchProvider(name string) (ResolvedProvider, bool)
+}
+
+type ResolvedProvider struct {
+    BackendURL  string  // e.g. http://192.168.10.191:1234
+    BackendKind string  // "openai" | "ollama"
+    Model       string  // e.g. google/gemma-4-26b-a4b
+    APIKey      string  // already materialized from api_key_env
+}
+```
+
+Wiring lives in `main.go`: the kernel passes a resolver backed by the live providers registry. Tests pass a stub.
+
+### Precedence
+
+In `runSlot`:
+
+1. If `req.Provider != ""` and the resolver returns ok → use the resolved values; ignore `req.Model`.
+2. Else fall through to the existing `Model`-based dispatch (e4b/26b).
+3. Unknown `req.Provider` → `AgentControllerError{Code: "invalid_input"}` at normalize time (`Normalize()` rejects).
+
+`DispatchResult.ModelUsed` carries the resolved model id when a provider override fired (currently a `DispatchModel` enum; we widen it to accept arbitrary model strings or add a `ProviderUsed` field — chosen below).
+
+### Auth plumbing
+
+`ExecuteScopedOptions` gains `APIKey string`. `chatCompletionOpenAI` sets `Authorization: Bearer <APIKey>` when non-empty. The existing "26b" path (no APIKey) keeps its current behavior, which means laptop LM Studio dispatches will continue to work as long as the laptop's server doesn't require auth; if it does, the legacy "26b" wire-up needs Layer 1 anyway to reach the laptop key (`LMS_API_KEY`). This RFC does not block on retrofitting the legacy "26b" path — that's an opportunistic follow-up.
+
+### Reachability cache
+
+The existing `lmStudioReachable` cache is keyed on the singleton URL. For per-request providers, the cache becomes a `map[string]reachabilityEntry` keyed by `BackendURL`. Same TTL (60s), same probe shape, just keyed.
+
+### Out of scope for Layer 1
+
+- Agent-card-declared provider preference (Layer 2).
+- Router integration / process-state routing in the autonomic loop (Layer 3).
+- Refactoring `Model` into a free-form string (deferred until Layer 2 surfaces a real need).
+- Multi-provider fallback chain at dispatch time (the router already does this for `CompletionRequest`; not exposed via dispatch here).
+
+## Layer 2 — agent-card provider preference (follow-up RFC or PR)
+
+Identity cards (`.cog/agents/identities/*.cog.md` in the workspace) gain optional frontmatter:
+
+```yaml
+inference:
+  provider: desktop          # optional; matches providers.yaml name
+  model: google/gemma-4-26b-a4b   # optional; overrides provider default
+```
+
+`DispatchRequest.Identity` already flows through dispatch (today as observability metadata). On Layer 2, the controller adapter reads the identity card via the kernel's identity registry, materializes `inference.provider`/`inference.model`, and populates `DispatchRequest.Provider` when the caller didn't explicitly override.
+
+Precedence becomes: explicit `provider` arg → agent-card declaration → `Model` enum → autodetect.
+
+This lets a Cog identity (Workspace Guardian) declare "I run on desktop" once in its card and have every dispatch into that agent honor it, no per-call argument needed.
+
+## Layer 3 — router-aware autonomic loop (follow-up RFC or PR)
+
+`LocalHarnessController` builds its provider once at startup via `buildLocalProvider(target, model, timeoutSec)` and never consults the router. To realize the existing `process_state_routing` config intent ("consolidating cycles should run on desktop"), the controller needs to:
+
+1. Read `process_state` from the running session.
+2. Consult `cfg.Routing.ProcessStateRouting[state]` → provider name.
+3. Resolve via the same `ProviderResolver` introduced in Layer 1.
+4. Fall back to the current local provider when the named provider is unreachable.
+
+This is a behavior change for the autonomic loop and warrants its own RFC plus a feature flag for at least one release cycle.
+
+## Migration & compatibility
+
+Layer 1 is additive. Existing callers that pass `model: "e4b"` or `model: "26b"` continue to work unchanged. Callers that pass neither also continue to work (default to e4b). The new `provider` field is opt-in.
+
+`DispatchResult.ModelUsed` is currently typed `DispatchModel` (a string alias). To carry arbitrary resolved model ids, we either:
+- (a) widen `ModelUsed`'s documented meaning to accept any string ("freeform when ProviderUsed is set");
+- (b) add a sibling `ProviderUsed string` field and keep `ModelUsed` strictly within the enum;
+- (c) emit "provider:NAME" as a synthetic `ModelUsed` value.
+
+This PR takes option (b) — additive, doesn't reinterpret existing field semantics. `ProviderUsed` is empty when the dispatch used the legacy enum path.
+
+## Tests (Layer 1)
+
+- `Normalize` rejects unknown provider names (invalid_input).
+- `runSlot` with a resolver hit overrides `Model` and reports `ProviderUsed`.
+- `runSlot` with no resolver hit and a non-empty `Provider` returns invalid_input.
+- `chatCompletionOpenAI` sets the Authorization header when APIKey is non-empty and omits it when empty.
+- The reachability cache is per-URL (two distinct providers with overlapping URLs don't collide; two providers with the same URL share the probe result).
+
+## Acceptance criteria (Layer 1)
+
+- `cog_dispatch_to_harness({provider: "desktop", task: "..."})` routes to the configured desktop endpoint with the desktop's `LMS_DESKTOP_API_TOKEN` and the resolved model.
+- Existing dispatch behavior (no `provider` field) is byte-for-byte unchanged.
+- Unknown provider names fail fast at normalize.
+- New unit tests pass; existing dispatch tests pass without modification.
+- One live test (gated on env, like `agent_dispatch_live_test.go`) confirms an end-to-end dispatch against the desktop endpoint.
+
+## Open questions
+
+1. Should `Provider` be exposed via a dedicated `provider` arg, or modeled as a richer `routing: { provider, model }` object in MCP input? Layer 1 takes the flat arg; if Layer 2 wants more structure, we add it then.
+2. Layer 3 may want to keep the autonomic loop's hot-path provider sticky (avoid re-resolving every cycle). Cache lifecycle is a Layer 3 design decision, not specified here.
+3. Whether `ProviderUsed` should also surface in the batch-level `Notes` for visibility. Probably yes; deferred to PR review.

--- a/internal/engine/agent_dispatch.go
+++ b/internal/engine/agent_dispatch.go
@@ -70,7 +70,16 @@ type DispatchRequest struct {
 	Tools []string
 
 	// Model selects the inference backend. Unknown values default to e4b.
+	// When Provider is set, Model is ignored — the resolved provider supplies
+	// its own model id.
 	Model DispatchModel
+
+	// Provider, when non-empty, names a provider declared in providers.yaml
+	// or providers.local.yaml. The dispatcher resolves the name to a
+	// concrete backend (URL, kind, model, api-key) via the wired
+	// ProviderResolver and uses those values instead of the Model-based
+	// fallback. Unknown names are rejected at Normalize time. See RFC-0007.
+	Provider string
 
 	// TimeoutSeconds is the per-dispatch wall-clock budget. Clamped to
 	// [1,120] by the controller. Default 30s.
@@ -122,6 +131,33 @@ type DispatchResult struct {
 	// differ from DispatchRequest.Model when "26b" degraded to e4b due to
 	// LM Studio being unreachable — Error then carries the warning.
 	ModelUsed DispatchModel `json:"model_used,omitempty"`
+	// ProviderUsed is the resolved provider name when DispatchRequest.Provider
+	// fired, otherwise empty. Surfaced for observability so a caller can tell
+	// the difference between "ran on the legacy e4b/26b path" and "ran on
+	// the named provider X." Per RFC-0007 Layer 1.
+	ProviderUsed string `json:"provider_used,omitempty"`
+}
+
+// ResolvedProvider is the materialized backend a ProviderResolver returns
+// for a named provider lookup. Mirrors the four fields the harness needs
+// at ExecuteScoped time. APIKey is pre-resolved from the provider's
+// api_key_env at lookup time so the dispatcher does not have to know
+// which env var any given provider uses.
+type ResolvedProvider struct {
+	BackendURL  string // e.g. http://192.168.10.191:1234 (no /v1 suffix; harness appends)
+	BackendKind string // "openai" | "ollama"
+	Model       string // e.g. google/gemma-4-26b-a4b
+	APIKey      string // already materialized; empty when the provider has no api_key_env
+}
+
+// ProviderResolver translates a dispatch-time provider name into the
+// concrete backend the harness needs. ok=false signals the name is not
+// in the providers registry; the dispatcher surfaces that as
+// invalid_input rather than silently falling through to the Model-based
+// path. Implementations are typically thin wrappers over the live router
+// config. See RFC-0007 Layer 1.
+type ProviderResolver interface {
+	ResolveDispatchProvider(name string) (ResolvedProvider, bool)
 }
 
 // DispatchBatchResult is the envelope returned to the caller. Results is

--- a/internal/engine/agent_dispatch_query.go
+++ b/internal/engine/agent_dispatch_query.go
@@ -45,6 +45,11 @@ func (r *DispatchRequest) Normalize() error {
 	if r.Task == "" {
 		return &AgentControllerError{Code: "invalid_input", Message: "task is required"}
 	}
+	r.Provider = strings.TrimSpace(r.Provider)
+	// Provider unknown-name validation happens in the dispatcher: only it
+	// holds the live ProviderResolver. Normalize merely trims and lets a
+	// non-empty value through; the dispatcher fails fast on unknown names
+	// before any slot starts.
 	switch r.Model {
 	case "", DispatchModelE4B:
 		r.Model = DispatchModelE4B

--- a/internal/engine/agent_dispatch_query_test.go
+++ b/internal/engine/agent_dispatch_query_test.go
@@ -111,6 +111,31 @@ func TestQueryDispatchToHarness_ControllerWithoutDispatcher(t *testing.T) {
 	}
 }
 
+// RFC-0007 Layer 1: Provider field flows through Normalize without
+// mutation. The Normalize step only trims; unknown-name validation is
+// deferred to the dispatcher, which holds the live ProviderResolver.
+func TestQueryDispatchToHarness_ProviderFieldFlowsThrough(t *testing.T) {
+	disp := &fakeAgentDispatcher{cannedOk: true}
+	req := DispatchRequest{Task: "do thing", Provider: "  desktop  "}
+	if _, err := QueryDispatchToHarness(context.Background(), disp, req); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if got := disp.lastReq.Provider; got != "desktop" {
+		t.Errorf("Provider not trimmed/preserved, got %q", got)
+	}
+}
+
+func TestQueryDispatchToHarness_EmptyProviderUnchanged(t *testing.T) {
+	disp := &fakeAgentDispatcher{cannedOk: true}
+	req := DispatchRequest{Task: "do thing"}
+	if _, err := QueryDispatchToHarness(context.Background(), disp, req); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if got := disp.lastReq.Provider; got != "" {
+		t.Errorf("Provider should default empty, got %q", got)
+	}
+}
+
 func TestDispatchRequest_NormalizeDedupesTools(t *testing.T) {
 	req := DispatchRequest{Task: "x", Tools: []string{"a", " ", "a", "b", "", "b"}}
 	if err := req.Normalize(); err != nil {

--- a/internal/engine/local_agent_harness.go
+++ b/internal/engine/local_agent_harness.go
@@ -810,13 +810,66 @@ func (c *LocalHarnessController) DispatchToHarness(ctx context.Context, req Disp
 		return nil, err
 	}
 
-	target, err := detectLocalLLMTarget(ctx, "")
-	if err != nil {
-		return nil, err
-	}
-	model, routeUsed, note := resolveDispatchLocalModel(target.Models, c.localModelHint(), req.Model)
-	if model == "" {
-		return nil, errors.New(note)
+	// Resolve the inference provider. Two paths:
+	//   1. Explicit named provider via req.Provider (RFC-0007 Layer 1):
+	//      look the name up in providers.yaml + providers.local.yaml, build
+	//      the matching Provider, and use its declared model.
+	//   2. Legacy Model-enum routing ("e4b" | "26b") via local-LLM probe.
+	//
+	// Unknown provider names error fast — never silently fall through to
+	// the legacy path because that would mask a config typo.
+	var provider Provider
+	var model string
+	var routeUsed DispatchModel
+	var note string
+	var err error
+	if req.Provider != "" {
+		pcfg, perr := loadProvidersConfig(c.cfg)
+		if perr != nil {
+			return nil, &AgentControllerError{
+				Code:    "internal_error",
+				Message: fmt.Sprintf("failed to load providers config: %v", perr),
+			}
+		}
+		pc, ok := pcfg.Providers[req.Provider]
+		if !ok {
+			known := make([]string, 0, len(pcfg.Providers))
+			for k := range pcfg.Providers {
+				known = append(known, k)
+			}
+			return nil, &AgentControllerError{
+				Code:    "invalid_input",
+				Message: fmt.Sprintf("provider %q is not configured (known: %v)", req.Provider, known),
+			}
+		}
+		if !pc.IsEnabled() {
+			return nil, &AgentControllerError{
+				Code:    "invalid_input",
+				Message: fmt.Sprintf("provider %q is disabled in config", req.Provider),
+			}
+		}
+		p, merr := makeProvider(req.Provider, pc, nil)
+		if merr != nil {
+			return nil, &AgentControllerError{
+				Code:    "internal_error",
+				Message: fmt.Sprintf("failed to construct provider %q: %v", req.Provider, merr),
+			}
+		}
+		provider = p
+		model = pc.Model
+		// routeUsed stays empty; ProviderUsed on each slot is the canonical
+		// signal that the named-provider path fired.
+	} else {
+		target, terr := detectLocalLLMTarget(ctx, "")
+		if terr != nil {
+			return nil, terr
+		}
+		m, ru, n := resolveDispatchLocalModel(target.Models, c.localModelHint(), req.Model)
+		if m == "" {
+			return nil, errors.New(n)
+		}
+		model, routeUsed, note = m, ru, n
+		provider = buildLocalProvider(target, model, c.localProviderTimeout)
 	}
 
 	// Resolve the named scope. Empty scope means the harness's own default
@@ -859,7 +912,6 @@ func (c *LocalHarnessController) DispatchToHarness(ctx context.Context, req Disp
 	c.ollamaMu.Lock()
 	defer c.ollamaMu.Unlock()
 
-	provider := buildLocalProvider(target, model, c.localProviderTimeout)
 	batch := &DispatchBatchResult{
 		Results: make([]DispatchResult, req.N),
 	}
@@ -883,8 +935,9 @@ func (c *LocalHarnessController) DispatchToHarness(ctx context.Context, req Disp
 
 func (c *LocalHarnessController) dispatchSlot(parent context.Context, provider Provider, registry *KernelToolRegistry, model string, routeUsed DispatchModel, req DispatchRequest, idx int, note string) DispatchResult {
 	res := DispatchResult{
-		Index:     idx,
-		ModelUsed: routeUsed,
+		Index:        idx,
+		ModelUsed:    routeUsed,
+		ProviderUsed: req.Provider,
 	}
 	slotCtx, cancel := context.WithTimeout(parent, time.Duration(req.TimeoutSeconds)*time.Second)
 	defer cancel()
@@ -907,9 +960,10 @@ func (c *LocalHarnessController) dispatchSlot(parent context.Context, provider P
 		Temperature:   &temp,
 		ModelOverride: model,
 		Metadata: RequestMetadata{
-			RequestID:   fmt.Sprintf("local-harness-dispatch-%d-%d", time.Now().UnixNano(), idx),
-			PreferLocal: true,
-			Source:      "local-harness-dispatch",
+			RequestID:      fmt.Sprintf("local-harness-dispatch-%d-%d", time.Now().UnixNano(), idx),
+			PreferLocal:    true,
+			PreferProvider: req.Provider,
+			Source:         "local-harness-dispatch",
 		},
 	}
 

--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -727,7 +727,8 @@ type dispatchToHarnessInput struct {
 	Task         string                 `json:"task" jsonschema:"Required. The user-role prompt the harness's Execute loop will receive."`
 	Scope        string                 `json:"scope,omitempty" jsonschema:"Named tool scope for this dispatch. \"consolidation\" (default, 11 substrate tools: memory/field/coherence/identity) or \"audit\" (consolidation + cog_read_file + cog_grep_files for read-only filesystem inspection). Unknown scope names error immediately. The tools parameter, if set, narrows further within the chosen scope."`
 	Tools        []string               `json:"tools,omitempty" jsonschema:"Optional tool allowlist (subset of the chosen scope's tools). nil/empty uses the full scope set. Unknown names error in the per-slot result rather than silently dropping."`
-	Model        string                 `json:"model,omitempty" jsonschema:"Inference backend. \"e4b\" (default, local Ollama) or \"26b\" (configured remote OpenAI-compatible endpoint). Unknown values fall back to e4b."`
+	Model        string                 `json:"model,omitempty" jsonschema:"Inference backend. \"e4b\" (default, local Ollama) or \"26b\" (configured remote OpenAI-compatible endpoint). Unknown values fall back to e4b. Ignored when provider is set."`
+	Provider     string                 `json:"provider,omitempty" jsonschema:"Optional named provider override (e.g. \"desktop\", \"lmstudio-mlx\"). Must match a provider declared in providers.yaml or providers.local.yaml; unknown names error before any slot runs. When set, takes precedence over model. Per RFC-0007."`
 	Timeout      int                    `json:"timeout_seconds,omitempty" jsonschema:"Per-slot wall-clock budget in seconds. Default 30, max 120. On exceed, that slot returns success=false error=\"timeout\"; sibling slots continue."`
 	N            int                    `json:"n,omitempty" jsonschema:"Parallel fan-out, [1,4]. Default 1. Each slot gets its own context, its own deadline, and its own result entry; failures don't abort siblings."`
 	SystemPrompt string                 `json:"system_prompt,omitempty" jsonschema:"Optional system-prompt override for this dispatch only. Empty keeps the harness default. Used by output-alignment roles (validator/rewriter/modality-matcher)."`
@@ -1758,6 +1759,7 @@ func (m *MCPServer) toolDispatchToHarness(ctx context.Context, req *mcp.CallTool
 		Scope:          input.Scope,
 		Tools:          input.Tools,
 		Model:          DispatchModel(input.Model),
+		Provider:       input.Provider,
 		TimeoutSeconds: input.Timeout,
 		N:              input.N,
 		SystemPrompt:   input.SystemPrompt,


### PR DESCRIPTION
## Summary

Adds a `provider` parameter to `cog_dispatch_to_harness` that names a provider declared in `providers.yaml` / `providers.local.yaml`. When set, the dispatch routes to the resolved provider's endpoint, model, and api-key — bypassing the legacy `model: \"e4b\" | \"26b\"` enum. Unknown names fail fast.

Concrete motivator: with the `desktop` provider (LM Studio at `192.168.10.191:1234`, `google/gemma-4-26b-a4b`) wired in `providers.local.yaml`, Claude Code and other MCP callers can now dispatch directly against the desktop quality ceiling without overloading `COGOS_LLM_ENDPOINT` globally.

Implements **RFC-0007 Layer 1**. Layers 2 (agent-card-declared providers) and 3 (router-aware autonomic loop) are scoped in the RFC and deferred to follow-up PRs.

## What changed

- `engine.DispatchRequest.Provider` field flows from MCP input through the dispatcher.
- `engine.ResolvedProvider` / `engine.ProviderResolver` define the resolution contract.
- `LocalHarnessController.DispatchToHarness` honors `req.Provider`: loads providers config, resolves via `makeProvider`, errors on unknown/disabled names. Also sets `RequestMetadata.PreferProvider` so any future router-aware codepath inherits the choice.
- `HarnessDispatcher` (legacy/test path): same override surface; its reachability cache becomes per-URL (`reachByURL`) so multiple providers don't share state.
- `ExecuteScopedOptions.APIKey` plumbs an `Authorization: Bearer <key>` onto OpenAI-compat backend calls. Required for LM Studio with token auth enabled; Ollama ignores it.
- `DispatchResult.ProviderUsed` (additive observability) — tells legacy-enum vs named-provider dispatches apart.

## Compatibility

Fully additive. Every existing caller continues to work unchanged: omit `provider`, get the prior behavior. The new field is opt-in.

## Test plan

- [x] `TestQueryDispatchToHarness_ProviderFieldFlowsThrough` — Provider trims & preserves through Normalize
- [x] `TestQueryDispatchToHarness_EmptyProviderUnchanged` — defaults remain empty
- [x] `TestExecuteScoped_OpenAIBearerHeader` — Bearer header set iff APIKey non-empty (with-key + no-key subtests)
- [x] Full `go test ./...` green
- [x] `go vet ./...` clean
- [ ] Live smoke test against the desktop endpoint after merge (`cog_dispatch_to_harness({provider: \"desktop\", task: \"...\"})`)

## Follow-ups (RFC-0007)

- Layer 2: agent identity cards declare `inference.provider:` in frontmatter; dispatcher reads it when no explicit override is passed.
- Layer 3: `LocalHarnessController` autonomic loop consults `routing.process_state_routing` (it currently bypasses the router entirely).
- Cache providers config across dispatches (each dispatch reloads today; fine for non-hot-path usage, worth optimizing later).