### PR TITLE
docs(rfc): align RFC-0005/0006 text with implementation reality

### DIFF
--- a/docs/rfcs/0005-cog-fork-session.md
+++ b/docs/rfcs/0005-cog-fork-session.md
@@ -226,7 +226,7 @@ type forkSessionOutput struct {
 
 ## HTTP endpoint
 
-`POST /api/sessions/{parent_session_id}/fork`
+`POST /v1/sessions/{parent_session_id}/fork`
 
 Request body: `forkSessionInput` JSON (with `parent_session_id` from the path param).
 Response: `forkSessionOutput` JSON, 201 Created on success.
@@ -329,7 +329,7 @@ the session-management surface without additional kernel changes.
       adding the `session.fork` Kind requires no modification to Kind-handler switch
       statements; the Kind infrastructure dispatches via registry, not switch.
 - [ ] `cog_fork_session` MCP tool registered and functional.
-- [ ] `POST /api/sessions/{id}/fork` HTTP endpoint wired.
+- [ ] `POST /v1/sessions/{id}/fork` HTTP endpoint wired.
 - [ ] `ForkChildren` and `ForkAncestors` projection functions implemented.
 - [ ] `/btw` consumer skill committed to the cog-workspace skills directory.
 - [ ] Unit tests cover: fork creation, overlay merge, GC eligibility calculation,
@@ -350,8 +350,8 @@ once usage patterns surface.
 When ready, the MCP tools are thin wrappers over the projection functions already
 implemented in v0.5.0, exposed via HTTP:
 
-- `GET /api/sessions/{session_id}/fork/children`
-- `GET /api/sessions/{session_id}/fork/ancestors`
+- `GET /v1/sessions/{session_id}/fork/children`
+- `GET /v1/sessions/{session_id}/fork/ancestors`
 
 ## Out of scope
 

--- a/docs/rfcs/0006-vllm-pagedattention-provider.md
+++ b/docs/rfcs/0006-vllm-pagedattention-provider.md
@@ -360,18 +360,21 @@ internal/providers/vllm/
 ## cgo failure isolation
 
 All cgo callouts into the vLLM Python runtime are wrapped in a deferred recover that
-converts panics (and Go-recoverable SIGSEGV via `runtime.SetPanicOnFault(true)`) into
-typed Go errors. cgo failure never propagates to crash the kernel process. The wrapper:
+converts panics (and Go-recoverable SIGSEGV via `debug.SetPanicOnFault(true)` from
+the `runtime/debug` package) into typed Go errors. cgo failure never propagates to
+crash the kernel process. The wrapper:
 
 ```go
+import "runtime/debug"
+
 func vllmCall(fn func() error) (err error) {
     defer func() {
         if r := recover(); r != nil {
             err = fmt.Errorf("vllm cgo failure (recovered): %v", r)
         }
     }()
-    runtime.SetPanicOnFault(true)
-    defer runtime.SetPanicOnFault(false)
+    debug.SetPanicOnFault(true)
+    defer debug.SetPanicOnFault(false)
     return fn()
 }
 ```


### PR DESCRIPTION
Two small post-merge text fixes surfaced during the wave-5 implementation:

**RFC-0005** — HTTP endpoint path was `/api/sessions/{id}/fork`; the kernel convention used by every other session endpoint is `/v1/...`. Implementation (PR #229) correctly used `/v1/`; this aligns the RFC text. 4 occurrences fixed (main endpoint + acceptance criterion + 2 future-scope lineage endpoints).

**RFC-0006** — Cited `runtime.SetPanicOnFault` which doesn't exist. The function lives in `runtime/debug` as `debug.SetPanicOnFault`. Implementation (PR #228) correctly used `debug.SetPanicOnFault`; this aligns the RFC text and adds the import statement to the example code block.

Docs-only; trivial.