### PR TITLE
feat(harness): honour process_state_routing in DispatchToHarness

### DIFF
--- a/internal/engine/local_agent_harness.go
+++ b/internal/engine/local_agent_harness.go
@@ -640,6 +640,34 @@ func (c *LocalHarnessController) localModelHint() string {
 	return defaultOllamaModel
 }
 
+// resolveProviderByProcessState consults process_state_routing in the merged
+// providers config and returns the configured provider name for the current
+// process state. Returns ("", false) when no process is attached, no state
+// routing applies, or the config cannot be loaded.
+//
+// This implements Path 2 in DispatchToHarness: harness dispatches without an
+// explicit req.Provider consult the same routing table as the SimpleRouter,
+// so the autonomic loop honours the operator's per-state provider preferences
+// (e.g., receptive -> mlx-lm, active -> claude-code).
+func (c *LocalHarnessController) resolveProviderByProcessState() (string, bool) {
+	if c.process == nil {
+		return "", false
+	}
+	state := c.process.State().String()
+	if state == "" {
+		return "", false
+	}
+	pcfg, err := loadProvidersConfig(c.cfg)
+	if err != nil {
+		return "", false
+	}
+	name, ok := pcfg.Routing.ProcessStateRouting[state]
+	if !ok || name == "" {
+		return "", false
+	}
+	return name, true
+}
+
 func (c *LocalHarnessController) summary() AgentSummary {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -810,11 +838,17 @@ func (c *LocalHarnessController) DispatchToHarness(ctx context.Context, req Disp
 		return nil, err
 	}
 
-	// Resolve the inference provider. Two paths:
+	// Resolve the inference provider. Three paths, evaluated in order:
 	//   1. Explicit named provider via req.Provider (RFC-0007 Layer 1):
 	//      look the name up in providers.yaml + providers.local.yaml, build
 	//      the matching Provider, and use its declared model.
-	//   2. Legacy Model-enum routing ("e4b" | "26b") via local-LLM probe.
+	//   2. Process-state routing (new): when req.Provider is empty and the
+	//      controller has an associated process, consult process_state_routing
+	//      in providers config. If the current state maps to a configured
+	//      provider, dispatch there. This wires the autonomic loop and harness
+	//      dispatches through the same routing table as the main router.
+	//   3. Legacy Model-enum routing ("e4b" | "26b") via local-LLM probe.
+	//      Backward-compatible fallback when no process-state route applies.
 	//
 	// Unknown provider names error fast — never silently fall through to
 	// the legacy path because that would mask a config typo.
@@ -860,16 +894,44 @@ func (c *LocalHarnessController) DispatchToHarness(ctx context.Context, req Disp
 		// routeUsed stays empty; ProviderUsed on each slot is the canonical
 		// signal that the named-provider path fired.
 	} else {
-		target, terr := detectLocalLLMTarget(ctx, "")
-		if terr != nil {
-			return nil, terr
+		// Path 2: process-state routing — try before falling back to legacy.
+		// When the controller has a process with a known state, consult
+		// process_state_routing in providers config. If the state maps to a
+		// valid, enabled provider, dispatch there. Otherwise fall through to
+		// the legacy local-LLM probe (Path 3).
+		usedStateRoute := false
+		if stateProvider, stateOK := c.resolveProviderByProcessState(); stateOK {
+			pcfg, perr := loadProvidersConfig(c.cfg)
+			if perr == nil {
+				if pc, pok := pcfg.Providers[stateProvider]; pok && pc.IsEnabled() {
+					p, merr := makeProvider(stateProvider, pc, nil)
+					if merr != nil {
+						return nil, &AgentControllerError{
+							Code:    "internal_error",
+							Message: fmt.Sprintf("state-routing: failed to construct provider %q: %v", stateProvider, merr),
+						}
+					}
+					provider = p
+					model = pc.Model
+					note = fmt.Sprintf("state-routing: state=%s -> provider=%s", c.process.State().String(), stateProvider)
+					usedStateRoute = true
+				}
+				// If provider not found or disabled: fall through to legacy path silently.
+			}
 		}
-		m, ru, n := resolveDispatchLocalModel(target.Models, c.localModelHint(), req.Model)
-		if m == "" {
-			return nil, errors.New(n)
+		if !usedStateRoute {
+			// Path 3: legacy model-enum routing via local-LLM probe.
+			target, terr := detectLocalLLMTarget(ctx, "")
+			if terr != nil {
+				return nil, terr
+			}
+			m, ru, n := resolveDispatchLocalModel(target.Models, c.localModelHint(), req.Model)
+			if m == "" {
+				return nil, errors.New(n)
+			}
+			model, routeUsed, note = m, ru, n
+			provider = buildLocalProvider(target, model, c.localProviderTimeout)
 		}
-		model, routeUsed, note = m, ru, n
-		provider = buildLocalProvider(target, model, c.localProviderTimeout)
 	}
 
 	// Resolve the named scope. Empty scope means the harness's own default

--- a/internal/engine/local_agent_harness.go
+++ b/internal/engine/local_agent_harness.go
@@ -654,7 +654,10 @@ func (c *LocalHarnessController) resolveProviderByProcessState() (string, bool) 
 		return "", false
 	}
 	state := c.process.State().String()
-	if state == "" {
+	// "unknown" is the default-case sentinel from ProcessState.String(); treat
+	// it the same as empty string so an unrecognised state falls back to the
+	// legacy local-LLM path rather than routing to process_state_routing["unknown"].
+	if state == "" || state == "unknown" {
 		return "", false
 	}
 	pcfg, err := loadProvidersConfig(c.cfg)
@@ -857,6 +860,12 @@ func (c *LocalHarnessController) DispatchToHarness(ctx context.Context, req Disp
 	var routeUsed DispatchModel
 	var note string
 	var err error
+	// needsOllamaMu is true when the selected path goes through Ollama
+	// (either legacy Path 3 or an explicit/state-routed provider of type
+	// "ollama"). Non-Ollama state-routed dispatches (openai, mlx-lm, …)
+	// must NOT acquire the lock — they have no VRAM-sharing risk with the
+	// metabolic cycle and would needlessly block behind it.
+	needsOllamaMu := false
 	if req.Provider != "" {
 		pcfg, perr := loadProvidersConfig(c.cfg)
 		if perr != nil {
@@ -891,6 +900,7 @@ func (c *LocalHarnessController) DispatchToHarness(ctx context.Context, req Disp
 		}
 		provider = p
 		model = pc.Model
+		needsOllamaMu = pc.Type == "ollama"
 		// routeUsed stays empty; ProviderUsed on each slot is the canonical
 		// signal that the named-provider path fired.
 	} else {
@@ -913,6 +923,12 @@ func (c *LocalHarnessController) DispatchToHarness(ctx context.Context, req Disp
 					}
 					provider = p
 					model = pc.Model
+					// Populate req.Provider so dispatchSlot records the
+					// resolved provider name in ProviderUsed — otherwise it
+					// stays empty and the caller can't distinguish this path
+					// from the legacy Ollama path.
+					req.Provider = stateProvider
+					needsOllamaMu = pc.Type == "ollama"
 					note = fmt.Sprintf("state-routing: state=%s -> provider=%s", c.process.State().String(), stateProvider)
 					usedStateRoute = true
 				}
@@ -921,6 +937,8 @@ func (c *LocalHarnessController) DispatchToHarness(ctx context.Context, req Disp
 		}
 		if !usedStateRoute {
 			// Path 3: legacy model-enum routing via local-LLM probe.
+			// Always Ollama — always needs the serialisation lock.
+			needsOllamaMu = true
 			target, terr := detectLocalLLMTarget(ctx, "")
 			if terr != nil {
 				return nil, terr
@@ -971,8 +989,14 @@ func (c *LocalHarnessController) DispatchToHarness(ctx context.Context, req Disp
 	// req.N slots also serialize against the cycle (they already share the same
 	// provider object, so they are already serialized at the Ollama layer, but
 	// holding the lock makes the exclusion explicit and testable).
-	c.ollamaMu.Lock()
-	defer c.ollamaMu.Unlock()
+	//
+	// Non-Ollama state-routed dispatches (openai, mlx-lm, …) skip the lock:
+	// they have no shared VRAM risk with the metabolic cycle and must not
+	// block behind Ollama-bound cycles.
+	if needsOllamaMu {
+		c.ollamaMu.Lock()
+		defer c.ollamaMu.Unlock()
+	}
 
 	batch := &DispatchBatchResult{
 		Results: make([]DispatchResult, req.N),
@@ -1060,9 +1084,10 @@ func (c *LocalHarnessController) dispatchSlot(parent context.Context, provider P
 	if res.Content == "" && len(transcript) > 0 {
 		res.Content = summarizeToolTranscript(transcript)
 	}
-	if note != "" && res.Error == "" {
-		res.Error = note
-	}
+	// Routing notes (e.g. "state-routing: state=receptive -> provider=mlx-lm")
+	// are batch-level diagnostics already captured in batch.Notes by the
+	// caller; do NOT copy them into res.Error on successful slots — that
+	// produces misleading success=true + non-empty error results.
 	return res
 }
 

--- a/internal/engine/local_agent_harness.go
+++ b/internal/engine/local_agent_harness.go
@@ -671,6 +671,20 @@ func (c *LocalHarnessController) resolveProviderByProcessState() (string, bool) 
 	return name, true
 }
 
+// isOllamaProvider reports whether a named ProviderConfig resolves to the
+// Ollama backend. It mirrors makeProvider's type inference: when pc.Type is
+// empty the provider name itself is the effective type (see router.go
+// makeProvider). This means a provider named "ollama" without an explicit
+// type: field is correctly identified as Ollama — required so ollamaMu is
+// acquired even when the config omits the redundant type: ollama annotation.
+func isOllamaProvider(name string, pc ProviderConfig) bool {
+	t := pc.Type
+	if t == "" {
+		t = name
+	}
+	return t == "ollama"
+}
+
 func (c *LocalHarnessController) summary() AgentSummary {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -900,7 +914,7 @@ func (c *LocalHarnessController) DispatchToHarness(ctx context.Context, req Disp
 		}
 		provider = p
 		model = pc.Model
-		needsOllamaMu = pc.Type == "ollama"
+		needsOllamaMu = isOllamaProvider(req.Provider, pc)
 		// routeUsed stays empty; ProviderUsed on each slot is the canonical
 		// signal that the named-provider path fired.
 	} else {
@@ -928,7 +942,7 @@ func (c *LocalHarnessController) DispatchToHarness(ctx context.Context, req Disp
 					// stays empty and the caller can't distinguish this path
 					// from the legacy Ollama path.
 					req.Provider = stateProvider
-					needsOllamaMu = pc.Type == "ollama"
+					needsOllamaMu = isOllamaProvider(stateProvider, pc)
 					note = fmt.Sprintf("state-routing: state=%s -> provider=%s", c.process.State().String(), stateProvider)
 					usedStateRoute = true
 				}

--- a/internal/engine/local_agent_harness.go
+++ b/internal/engine/local_agent_harness.go
@@ -872,7 +872,12 @@ func (c *LocalHarnessController) DispatchToHarness(ctx context.Context, req Disp
 	var provider Provider
 	var model string
 	var routeUsed DispatchModel
+	// note is a batch-level diagnostic string (e.g. state-routing path taken).
+	// slotNote carries per-slot warnings that must appear on each DispatchResult
+	// (e.g. "26b route unavailable, degraded to e4b") — distinct from note so
+	// state-routing diagnostics are not incorrectly surfaced in slot Error fields.
 	var note string
+	var slotNote string
 	var err error
 	// needsOllamaMu is true when the selected path goes through Ollama
 	// (either legacy Path 3 or an explicit/state-routed provider of type
@@ -961,7 +966,13 @@ func (c *LocalHarnessController) DispatchToHarness(ctx context.Context, req Disp
 			if m == "" {
 				return nil, errors.New(n)
 			}
-			model, routeUsed, note = m, ru, n
+			model, routeUsed = m, ru
+			// Downgrade warnings (e.g. "26b route unavailable, degraded to e4b")
+			// are per-slot: each slot's result must carry the warning so callers
+			// that inspect individual slots know the requested model wasn't honored.
+			// These are distinct from batch-level diagnostics (state-routing note)
+			// which go into batch.Notes via the outer `note` variable.
+			slotNote = n
 			provider = buildLocalProvider(target, model, c.localProviderTimeout)
 		}
 	}
@@ -1025,7 +1036,7 @@ func (c *LocalHarnessController) DispatchToHarness(ctx context.Context, req Disp
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			batch.Results[idx] = c.dispatchSlot(ctx, provider, registry, model, routeUsed, req, idx, note)
+			batch.Results[idx] = c.dispatchSlot(ctx, provider, registry, model, routeUsed, req, idx, slotNote)
 		}(i)
 	}
 	wg.Wait()
@@ -1033,7 +1044,7 @@ func (c *LocalHarnessController) DispatchToHarness(ctx context.Context, req Disp
 	return batch, nil
 }
 
-func (c *LocalHarnessController) dispatchSlot(parent context.Context, provider Provider, registry *KernelToolRegistry, model string, routeUsed DispatchModel, req DispatchRequest, idx int, note string) DispatchResult {
+func (c *LocalHarnessController) dispatchSlot(parent context.Context, provider Provider, registry *KernelToolRegistry, model string, routeUsed DispatchModel, req DispatchRequest, idx int, slotNote string) DispatchResult {
 	res := DispatchResult{
 		Index:        idx,
 		ModelUsed:    routeUsed,
@@ -1098,10 +1109,13 @@ func (c *LocalHarnessController) dispatchSlot(parent context.Context, provider P
 	if res.Content == "" && len(transcript) > 0 {
 		res.Content = summarizeToolTranscript(transcript)
 	}
-	// Routing notes (e.g. "state-routing: state=receptive -> provider=mlx-lm")
-	// are batch-level diagnostics already captured in batch.Notes by the
-	// caller; do NOT copy them into res.Error on successful slots — that
-	// produces misleading success=true + non-empty error results.
+	// slotNote carries per-slot warnings (e.g. legacy "26b route unavailable,
+	// degraded to e4b") that the caller may need to surface per-result. These
+	// are distinct from batch-level state-routing diagnostics, which live in
+	// batch.Notes and must not be set here.
+	if slotNote != "" {
+		res.Error = slotNote
+	}
 	return res
 }
 

--- a/internal/engine/local_agent_harness.go
+++ b/internal/engine/local_agent_harness.go
@@ -671,20 +671,6 @@ func (c *LocalHarnessController) resolveProviderByProcessState() (string, bool) 
 	return name, true
 }
 
-// isOllamaProvider reports whether a named ProviderConfig resolves to the
-// Ollama backend. It mirrors makeProvider's type inference: when pc.Type is
-// empty the provider name itself is the effective type (see router.go
-// makeProvider). This means a provider named "ollama" without an explicit
-// type: field is correctly identified as Ollama — required so ollamaMu is
-// acquired even when the config omits the redundant type: ollama annotation.
-func isOllamaProvider(name string, pc ProviderConfig) bool {
-	t := pc.Type
-	if t == "" {
-		t = name
-	}
-	return t == "ollama"
-}
-
 func (c *LocalHarnessController) summary() AgentSummary {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -879,12 +865,6 @@ func (c *LocalHarnessController) DispatchToHarness(ctx context.Context, req Disp
 	var note string
 	var slotNote string
 	var err error
-	// needsOllamaMu is true when the selected path goes through Ollama
-	// (either legacy Path 3 or an explicit/state-routed provider of type
-	// "ollama"). Non-Ollama state-routed dispatches (openai, mlx-lm, …)
-	// must NOT acquire the lock — they have no VRAM-sharing risk with the
-	// metabolic cycle and would needlessly block behind it.
-	needsOllamaMu := false
 	if req.Provider != "" {
 		pcfg, perr := loadProvidersConfig(c.cfg)
 		if perr != nil {
@@ -919,7 +899,6 @@ func (c *LocalHarnessController) DispatchToHarness(ctx context.Context, req Disp
 		}
 		provider = p
 		model = pc.Model
-		needsOllamaMu = isOllamaProvider(req.Provider, pc)
 		// routeUsed stays empty; ProviderUsed on each slot is the canonical
 		// signal that the named-provider path fired.
 	} else {
@@ -947,7 +926,6 @@ func (c *LocalHarnessController) DispatchToHarness(ctx context.Context, req Disp
 					// stays empty and the caller can't distinguish this path
 					// from the legacy Ollama path.
 					req.Provider = stateProvider
-					needsOllamaMu = isOllamaProvider(stateProvider, pc)
 					note = fmt.Sprintf("state-routing: state=%s -> provider=%s", c.process.State().String(), stateProvider)
 					usedStateRoute = true
 				}
@@ -956,8 +934,6 @@ func (c *LocalHarnessController) DispatchToHarness(ctx context.Context, req Disp
 		}
 		if !usedStateRoute {
 			// Path 3: legacy model-enum routing via local-LLM probe.
-			// Always Ollama — always needs the serialisation lock.
-			needsOllamaMu = true
 			target, terr := detectLocalLLMTarget(ctx, "")
 			if terr != nil {
 				return nil, terr
@@ -1008,17 +984,17 @@ func (c *LocalHarnessController) DispatchToHarness(ctx context.Context, req Disp
 	}
 
 	// ollamaMu serializes dispatch inference calls against concurrent metabolic
-	// cycles. Ollama is single-threaded by default; a dispatch arriving while
-	// runCycle is mid-stream would issue a concurrent /api/chat that loads a
-	// second model copy into VRAM. The lock is held for the full batch so that
-	// req.N slots also serialize against the cycle (they already share the same
-	// provider object, so they are already serialized at the Ollama layer, but
-	// holding the lock makes the exclusion explicit and testable).
+	// cycles for all local-inference backends. "Local" backends (Ollama,
+	// OpenAI-compat mlx-lm/vllm/lmstudio, mlx-supervised, pi) compete for the
+	// same on-device accelerator/VRAM; a dispatch arriving while runCycle is
+	// mid-stream would issue a concurrent inference call that may load a second
+	// model copy into VRAM or cause memory pressure.
 	//
-	// Non-Ollama state-routed dispatches (openai, mlx-lm, …) skip the lock:
-	// they have no shared VRAM risk with the metabolic cycle and must not
-	// block behind Ollama-bound cycles.
-	if needsOllamaMu {
+	// The gate is keyed on provider.Capabilities().IsLocal so it covers all
+	// local backends uniformly, not just the "ollama" type name. Remote
+	// providers (anthropic, etc.) are excluded — they have no shared hardware
+	// resource with the local metabolic cycle.
+	if provider.Capabilities().IsLocal {
 		c.ollamaMu.Lock()
 		defer c.ollamaMu.Unlock()
 	}
@@ -1113,8 +1089,14 @@ func (c *LocalHarnessController) dispatchSlot(parent context.Context, provider P
 	// degraded to e4b") that the caller may need to surface per-result. These
 	// are distinct from batch-level state-routing diagnostics, which live in
 	// batch.Notes and must not be set here.
+	// Preserve any existing res.Error (e.g. unsupported client tool calls)
+	// rather than clobbering it; append the downgrade note instead.
 	if slotNote != "" {
-		res.Error = slotNote
+		if res.Error == "" {
+			res.Error = slotNote
+		} else {
+			res.Error += "; " + slotNote
+		}
 	}
 	return res
 }

--- a/internal/engine/local_agent_harness_test.go
+++ b/internal/engine/local_agent_harness_test.go
@@ -307,3 +307,422 @@ routing:
 		t.Errorf("mlx-lm endpoint was NOT called; expected state-routing (receptive -> mlx-lm) to route there instead of Ollama legacy path")
 	}
 }
+
+// TestDispatchToHarness_StateRouting_UnknownStateFallsBackToLegacy verifies
+// that a process in an unrecognised state (ProcessState outside the defined
+// iota range) falls back to the legacy Ollama probe path instead of routing
+// to process_state_routing["unknown"].
+func TestDispatchToHarness_StateRouting_UnknownStateFallsBackToLegacy(t *testing.T) {
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+
+	var ollamaCalled atomic.Bool
+	ollamaSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/tags":
+			ollamaCalled.Store(true)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"models": []map[string]any{{"name": "gemma4:e4b"}},
+			})
+		case "/api/chat":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"message": map[string]any{"role": "assistant", "content": "ollama fallback"},
+				"done":    true, "prompt_eval_count": 1, "eval_count": 1,
+			})
+		}
+	}))
+	defer ollamaSrv.Close()
+
+	// providers.yaml maps "unknown" state to a provider; this MUST NOT fire.
+	writeTestFile(t, filepath.Join(root, ".cog", "config", "providers.yaml"), `providers:
+  ollama:
+    type: ollama
+    endpoint: `+ollamaSrv.URL+`
+    model: gemma4:e4b
+routing:
+  default: ollama
+  process_state_routing:
+    unknown: ollama
+`)
+	t.Setenv(localLLMEndpointEnv, ollamaSrv.URL)
+
+	proc := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	// Force the process into an out-of-range state so State().String() returns "unknown".
+	proc.transitionWithReason(ProcessState(99), "test: force unknown state")
+
+	if got := proc.State().String(); got != "unknown" {
+		t.Fatalf("proc.State().String() = %q; want \"unknown\"", got)
+	}
+
+	srv := NewServer(cfg, makeNucleus("Cog", "tester"), proc)
+	ctrl, err := NewLocalHarnessController(cfg, makeNucleus("Cog", "tester"), proc, srv.mcpServer)
+	if err != nil {
+		t.Fatalf("NewLocalHarnessController: %v", err)
+	}
+
+	_, _ = ctrl.DispatchToHarness(context.Background(), DispatchRequest{
+		Task:           "unknown-state fallback test",
+		N:              1,
+		TimeoutSeconds: 10,
+	})
+
+	// The legacy Ollama probe should have been hit (via /api/tags), not state-routed.
+	if !ollamaCalled.Load() {
+		t.Errorf("Ollama /api/tags was NOT called; unknown state should fall back to legacy path, not route via process_state_routing[\"unknown\"]")
+	}
+}
+
+// TestDispatchToHarness_StateRouting_NoMappingFallsBackToLegacy verifies that
+// when a process state has no entry in process_state_routing, dispatch falls
+// through to the legacy local-LLM probe.
+func TestDispatchToHarness_StateRouting_NoMappingFallsBackToLegacy(t *testing.T) {
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+
+	var ollamaCalled atomic.Bool
+	ollamaSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/tags":
+			ollamaCalled.Store(true)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"models": []map[string]any{{"name": "gemma4:e4b"}},
+			})
+		case "/api/chat":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"message": map[string]any{"role": "assistant", "content": "ok"},
+				"done":    true, "prompt_eval_count": 1, "eval_count": 1,
+			})
+		}
+	}))
+	defer ollamaSrv.Close()
+
+	// process_state_routing has no "receptive" entry — state has no mapping.
+	writeTestFile(t, filepath.Join(root, ".cog", "config", "providers.yaml"), `providers:
+  ollama:
+    type: ollama
+    endpoint: `+ollamaSrv.URL+`
+    model: gemma4:e4b
+routing:
+  default: ollama
+  process_state_routing:
+    active: ollama
+`)
+	t.Setenv(localLLMEndpointEnv, ollamaSrv.URL)
+
+	// NewProcess starts in StateReceptive — no mapping for "receptive" above.
+	proc := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	srv := NewServer(cfg, makeNucleus("Cog", "tester"), proc)
+	ctrl, err := NewLocalHarnessController(cfg, makeNucleus("Cog", "tester"), proc, srv.mcpServer)
+	if err != nil {
+		t.Fatalf("NewLocalHarnessController: %v", err)
+	}
+
+	_, _ = ctrl.DispatchToHarness(context.Background(), DispatchRequest{
+		Task:           "no-mapping fallback test",
+		N:              1,
+		TimeoutSeconds: 10,
+	})
+
+	if !ollamaCalled.Load() {
+		t.Errorf("Ollama /api/tags was NOT called; receptive state with no mapping should fall back to legacy path")
+	}
+}
+
+// TestDispatchToHarness_StateRouting_DisabledProviderFallsBackToLegacy verifies
+// that when state_routing resolves to a provider that is disabled (enabled: false),
+// dispatch falls through to the legacy local-LLM probe.
+func TestDispatchToHarness_StateRouting_DisabledProviderFallsBackToLegacy(t *testing.T) {
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+
+	var ollamaCalled atomic.Bool
+	ollamaSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/tags":
+			ollamaCalled.Store(true)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"models": []map[string]any{{"name": "gemma4:e4b"}},
+			})
+		case "/api/chat":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"message": map[string]any{"role": "assistant", "content": "ok"},
+				"done":    true, "prompt_eval_count": 1, "eval_count": 1,
+			})
+		}
+	}))
+	defer ollamaSrv.Close()
+
+	// mlx-lm is mapped for receptive but marked enabled: false.
+	writeTestFile(t, filepath.Join(root, ".cog", "config", "providers.yaml"), `providers:
+  ollama:
+    type: ollama
+    endpoint: `+ollamaSrv.URL+`
+    model: gemma4:e4b
+  mlx-lm:
+    type: openai
+    endpoint: http://127.0.0.1:1
+    model: gemma-4-e4b
+    enabled: false
+routing:
+  default: ollama
+  process_state_routing:
+    receptive: mlx-lm
+`)
+	t.Setenv(localLLMEndpointEnv, ollamaSrv.URL)
+
+	proc := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	srv := NewServer(cfg, makeNucleus("Cog", "tester"), proc)
+	ctrl, err := NewLocalHarnessController(cfg, makeNucleus("Cog", "tester"), proc, srv.mcpServer)
+	if err != nil {
+		t.Fatalf("NewLocalHarnessController: %v", err)
+	}
+
+	_, _ = ctrl.DispatchToHarness(context.Background(), DispatchRequest{
+		Task:           "disabled-provider fallback test",
+		N:              1,
+		TimeoutSeconds: 10,
+	})
+
+	if !ollamaCalled.Load() {
+		t.Errorf("Ollama /api/tags was NOT called; disabled state-routed provider should fall back to legacy path")
+	}
+}
+
+// TestDispatchToHarness_StateRouting_MissingProviderFallsBackToLegacy verifies
+// that when state_routing names a provider that doesn't exist in the providers
+// map, dispatch falls through to the legacy local-LLM probe.
+func TestDispatchToHarness_StateRouting_MissingProviderFallsBackToLegacy(t *testing.T) {
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+
+	var ollamaCalled atomic.Bool
+	ollamaSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/tags":
+			ollamaCalled.Store(true)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"models": []map[string]any{{"name": "gemma4:e4b"}},
+			})
+		case "/api/chat":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"message": map[string]any{"role": "assistant", "content": "ok"},
+				"done":    true, "prompt_eval_count": 1, "eval_count": 1,
+			})
+		}
+	}))
+	defer ollamaSrv.Close()
+
+	// process_state_routing points "receptive" at "nonexistent" which is not
+	// in the providers map.
+	writeTestFile(t, filepath.Join(root, ".cog", "config", "providers.yaml"), `providers:
+  ollama:
+    type: ollama
+    endpoint: `+ollamaSrv.URL+`
+    model: gemma4:e4b
+routing:
+  default: ollama
+  process_state_routing:
+    receptive: nonexistent
+`)
+	t.Setenv(localLLMEndpointEnv, ollamaSrv.URL)
+
+	proc := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	srv := NewServer(cfg, makeNucleus("Cog", "tester"), proc)
+	ctrl, err := NewLocalHarnessController(cfg, makeNucleus("Cog", "tester"), proc, srv.mcpServer)
+	if err != nil {
+		t.Fatalf("NewLocalHarnessController: %v", err)
+	}
+
+	_, _ = ctrl.DispatchToHarness(context.Background(), DispatchRequest{
+		Task:           "missing-provider fallback test",
+		N:              1,
+		TimeoutSeconds: 10,
+	})
+
+	if !ollamaCalled.Load() {
+		t.Errorf("Ollama /api/tags was NOT called; missing provider in state_routing should fall back to legacy path")
+	}
+}
+
+// TestDispatchToHarness_StateRouting_HappyPath_ProviderUsedAndNoError verifies
+// the result shape on a successful state-routed dispatch:
+// - provider_used is populated with the resolved provider name
+// - error is empty on success
+// - success is true
+func TestDispatchToHarness_StateRouting_HappyPath_ProviderUsedAndNoError(t *testing.T) {
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+
+	mlxSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/models":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"gemma-4-e4b","object":"model"}]}`))
+		case "/v1/chat/completions":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":      "chatcmpl-test",
+				"object":  "chat.completion",
+				"model":   "gemma-4-e4b",
+				"choices": []map[string]any{{"index": 0, "message": map[string]any{"role": "assistant", "content": "done"}, "finish_reason": "stop"}},
+				"usage":   map[string]any{"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
+			})
+		}
+	}))
+	defer mlxSrv.Close()
+
+	writeTestFile(t, filepath.Join(root, ".cog", "config", "providers.yaml"), `providers:
+  mlx-lm:
+    type: openai
+    endpoint: `+mlxSrv.URL+`
+    model: gemma-4-e4b
+routing:
+  process_state_routing:
+    receptive: mlx-lm
+`)
+
+	proc := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	srv := NewServer(cfg, makeNucleus("Cog", "tester"), proc)
+	ctrl, err := NewLocalHarnessController(cfg, makeNucleus("Cog", "tester"), proc, srv.mcpServer)
+	if err != nil {
+		t.Fatalf("NewLocalHarnessController: %v", err)
+	}
+
+	batch, dispErr := ctrl.DispatchToHarness(context.Background(), DispatchRequest{
+		Task:           "happy path provider_used test",
+		N:              1,
+		TimeoutSeconds: 10,
+	})
+	if dispErr != nil {
+		t.Fatalf("DispatchToHarness: %v", dispErr)
+	}
+	if len(batch.Results) != 1 {
+		t.Fatalf("batch.Results len = %d; want 1", len(batch.Results))
+	}
+	res := batch.Results[0]
+
+	// provider_used must be populated so callers can distinguish state-routed from legacy.
+	if res.ProviderUsed == "" {
+		t.Errorf("ProviderUsed is empty; want \"mlx-lm\" on state-routed path")
+	}
+	if res.ProviderUsed != "mlx-lm" {
+		t.Errorf("ProviderUsed = %q; want \"mlx-lm\"", res.ProviderUsed)
+	}
+
+	// error must be empty on a successful dispatch — routing notes must NOT
+	// bleed into error.
+	if res.Error != "" {
+		t.Errorf("Error = %q; want empty on successful state-routed dispatch", res.Error)
+	}
+
+	if !res.Success {
+		t.Errorf("Success = false; want true")
+	}
+}
+
+// TestDispatchToHarness_StateRouting_NonOllamaDoesNotBlockOnOllamaMu verifies
+// that a state-routed dispatch to a non-Ollama provider does not hold ollamaMu,
+// allowing concurrent Ollama metabolic cycles to proceed without serialisation.
+func TestDispatchToHarness_StateRouting_NonOllamaDoesNotBlockOnOllamaMu(t *testing.T) {
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+
+	// mlx-lm stub with a deliberate delay to hold the dispatch open.
+	mlxReady := make(chan struct{})
+	mlxSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/models":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"gemma-4-e4b","object":"model"}]}`))
+		case "/v1/chat/completions":
+			close(mlxReady) // signal that mlx dispatch is in-flight
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":      "chatcmpl-test",
+				"object":  "chat.completion",
+				"model":   "gemma-4-e4b",
+				"choices": []map[string]any{{"index": 0, "message": map[string]any{"role": "assistant", "content": "done"}, "finish_reason": "stop"}},
+				"usage":   map[string]any{"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+			})
+		}
+	}))
+	defer mlxSrv.Close()
+
+	// Ollama stub to verify the cycle can acquire the lock independently.
+	var ollamaCycles atomic.Int32
+	ollamaSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/tags":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"models": []map[string]any{{"name": "gemma4:e4b"}},
+			})
+		case "/api/chat":
+			ollamaCycles.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"message": map[string]any{"role": "assistant", "content": `{"action":"sleep","reason":"idle","urgency":0.0,"target":"","task":""}`},
+				"done": true, "prompt_eval_count": 1, "eval_count": 1,
+			})
+		}
+	}))
+	defer ollamaSrv.Close()
+
+	writeTestFile(t, filepath.Join(root, ".cog", "config", "providers.yaml"), `providers:
+  mlx-lm:
+    type: openai
+    endpoint: `+mlxSrv.URL+`
+    model: gemma-4-e4b
+routing:
+  process_state_routing:
+    receptive: mlx-lm
+`)
+	t.Setenv(localLLMEndpointEnv, ollamaSrv.URL)
+
+	proc := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	srv := NewServer(cfg, makeNucleus("Cog", "tester"), proc)
+	ctrl, err := NewLocalHarnessController(cfg, makeNucleus("Cog", "tester"), proc, srv.mcpServer)
+	if err != nil {
+		t.Fatalf("NewLocalHarnessController: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Launch a state-routed (non-Ollama) dispatch in the background.
+	dispDone := make(chan error, 1)
+	go func() {
+		_, e := ctrl.DispatchToHarness(ctx, DispatchRequest{
+			Task:           "non-ollama dispatch",
+			N:              1,
+			TimeoutSeconds: 10,
+		})
+		dispDone <- e
+	}()
+
+	// Wait until the mlx dispatch is in-flight, then run a metabolic cycle.
+	// If ollamaMu were held by the mlx dispatch, this TriggerAgent call would
+	// deadlock for the dispatch's duration.
+	select {
+	case <-mlxReady:
+	case err := <-dispDone:
+		t.Fatalf("dispatch completed before mlxReady signal: %v", err)
+	}
+
+	_, cycleErr := ctrl.TriggerAgent(ctx, DefaultAgentID, "concurrent-cycle", true)
+	if cycleErr != nil {
+		t.Fatalf("TriggerAgent while mlx dispatch in-flight: %v", cycleErr)
+	}
+
+	// Wait for dispatch to finish.
+	if err := <-dispDone; err != nil {
+		t.Fatalf("DispatchToHarness: %v", err)
+	}
+
+	// The metabolic cycle hit Ollama (proving it wasn't blocked on ollamaMu).
+	if got := ollamaCycles.Load(); got == 0 {
+		t.Errorf("ollamaCycles = 0; want >= 1 (metabolic cycle should have run concurrently with mlx dispatch)")
+	}
+}

--- a/internal/engine/local_agent_harness_test.go
+++ b/internal/engine/local_agent_harness_test.go
@@ -624,27 +624,44 @@ routing:
 	}
 }
 
-// TestDispatchToHarness_StateRouting_NonOllamaDoesNotBlockOnOllamaMu verifies
-// that a state-routed dispatch to a non-Ollama provider does not hold ollamaMu,
-// allowing concurrent Ollama metabolic cycles to proceed without serialisation.
-func TestDispatchToHarness_StateRouting_NonOllamaDoesNotBlockOnOllamaMu(t *testing.T) {
+// TestDispatchToHarness_StateRouting_LocalProviderSerializesWithCycle verifies
+// that a state-routed dispatch to a local OpenAI-compatible provider (mlx-lm,
+// vllm, lmstudio, etc.) still acquires ollamaMu and serialises against the
+// metabolic cycle. Local providers compete for the same on-device
+// accelerator/VRAM as the Ollama metabolic path; concurrent access can cause
+// memory pressure. This test pins the contract that provider.Capabilities().IsLocal
+// governs the lock, not the provider type name "ollama".
+func TestDispatchToHarness_StateRouting_LocalProviderSerializesWithCycle(t *testing.T) {
 	root := makeWorkspace(t)
 	cfg := makeConfig(t, root)
 
-	// mlx-lm stub: signals mlxReady when the completions call arrives, then
-	// waits on mlxUnblock before sending the response. This ensures the mlx
-	// dispatch is genuinely in-flight (holding any lock it might hold) while
-	// the Ollama metabolic cycle runs, proving the two don't serialize.
-	mlxReady := make(chan struct{})
-	mlxUnblock := make(chan struct{})
+	var inFlight atomic.Int32
+	var maxInFlight atomic.Int32
+
+	// Track calls across both the mlx-lm dispatch stub and the Ollama cycle
+	// stub using a shared in-flight counter.
+	recordInFlight := func() func() {
+		cur := inFlight.Add(1)
+		for {
+			old := maxInFlight.Load()
+			if cur <= old {
+				break
+			}
+			if maxInFlight.CompareAndSwap(old, cur) {
+				break
+			}
+		}
+		return func() { inFlight.Add(-1) }
+	}
+
 	mlxSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/v1/models":
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"gemma-4-e4b","object":"model"}]}`))
 		case "/v1/chat/completions":
-			close(mlxReady)  // signal: mlx dispatch is now in-flight
-			<-mlxUnblock     // hold open until the Ollama cycle has started
+			done := recordInFlight()
+			defer done()
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"id":      "chatcmpl-test",
@@ -657,10 +674,6 @@ func TestDispatchToHarness_StateRouting_NonOllamaDoesNotBlockOnOllamaMu(t *testi
 	}))
 	defer mlxSrv.Close()
 
-	// Ollama stub: signals ollamaStarted on the first /api/chat, proving the
-	// metabolic cycle ran while the mlx dispatch was still blocked.
-	ollamaStarted := make(chan struct{})
-	var ollamaCycles atomic.Int32
 	ollamaSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/tags":
@@ -668,9 +681,8 @@ func TestDispatchToHarness_StateRouting_NonOllamaDoesNotBlockOnOllamaMu(t *testi
 				"models": []map[string]any{{"name": "gemma4:e4b"}},
 			})
 		case "/api/chat":
-			if ollamaCycles.Add(1) == 1 {
-				close(ollamaStarted) // first Ollama call started while mlx is in-flight
-			}
+			done := recordInFlight()
+			defer done()
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"message": map[string]any{"role": "assistant", "content": `{"action":"sleep","reason":"idle","urgency":0.0,"target":"","task":""}`},
@@ -700,50 +712,31 @@ routing:
 
 	ctx := context.Background()
 
-	// Launch a state-routed (non-Ollama) dispatch in the background. The mlx
-	// handler will block until we unblock it below.
-	dispDone := make(chan error, 1)
+	// Fire a state-routed dispatch (mlx-lm, IsLocal=true) and a metabolic
+	// cycle concurrently. Both should acquire ollamaMu and therefore serialize;
+	// max concurrent in-flight should be <= 1.
+	errs := make(chan error, 2)
+	go func() {
+		_, e := ctrl.TriggerAgent(ctx, DefaultAgentID, "cycle", true)
+		errs <- e
+	}()
 	go func() {
 		_, e := ctrl.DispatchToHarness(ctx, DispatchRequest{
-			Task:           "non-ollama dispatch",
+			Task:           "local non-Ollama serialization test",
 			N:              1,
-			TimeoutSeconds: 30,
+			TimeoutSeconds: 10,
 		})
-		dispDone <- e
+		errs <- e
 	}()
 
-	// Wait until the mlx dispatch is genuinely in-flight (blocked in the handler).
-	select {
-	case <-mlxReady:
-	case err := <-dispDone:
-		t.Fatalf("dispatch completed before mlxReady signal: %v", err)
+	for i := 0; i < 2; i++ {
+		if err := <-errs; err != nil {
+			t.Errorf("goroutine %d error: %v", i, err)
+		}
 	}
 
-	// With mlx dispatch in-flight, run a metabolic cycle via Ollama. If
-	// ollamaMu were held by the mlx dispatch this would deadlock until the
-	// dispatch timed out (30s). The test would fail with TriggerAgent error.
-	_, cycleErr := ctrl.TriggerAgent(ctx, DefaultAgentID, "concurrent-cycle", true)
-	if cycleErr != nil {
-		t.Fatalf("TriggerAgent while mlx dispatch in-flight: %v (may indicate ollamaMu contention)", cycleErr)
-	}
-
-	// Wait for Ollama to have started so we know overlap happened, then
-	// unblock the mlx handler.
-	select {
-	case <-ollamaStarted:
-	case err := <-dispDone:
-		t.Fatalf("dispatch finished before ollamaStarted signal: %v", err)
-	}
-	close(mlxUnblock)
-
-	// Wait for dispatch to finish.
-	if err := <-dispDone; err != nil {
-		t.Fatalf("DispatchToHarness: %v", err)
-	}
-
-	// Confirm the metabolic cycle ran Ollama while mlx was in-flight.
-	if got := ollamaCycles.Load(); got == 0 {
-		t.Errorf("ollamaCycles = 0; want >= 1 (metabolic cycle should have run concurrently with mlx dispatch)")
+	if got := maxInFlight.Load(); got > 1 {
+		t.Errorf("max concurrent local inference calls = %d; want <= 1 (mlx-lm IsLocal=true should still serialize via ollamaMu)", got)
 	}
 }
 

--- a/internal/engine/local_agent_harness_test.go
+++ b/internal/engine/local_agent_harness_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 )
@@ -224,5 +225,85 @@ func TestLocalHarnessOllamaConcurrencySerialized(t *testing.T) {
 
 	if got := maxInFlight.Load(); got > 1 {
 		t.Errorf("max concurrent Ollama /api/chat calls = %d; want <= 1 (ollamaMu not working)", got)
+	}
+}
+
+// TestDispatchToHarness_StateRouting_ReceptiveGoesToMLX verifies that when the
+// process state is "receptive" and process_state_routing maps "receptive" to a
+// configured openai-compat provider (simulating mlx-lm), DispatchToHarness
+// without an explicit req.Provider routes to that provider rather than the
+// legacy Ollama local-LLM path.
+//
+// This is the core behavioural requirement for Wave C W2: the autonomic loop's
+// harness dispatches must honour process_state_routing, not hardcode Ollama.
+func TestDispatchToHarness_StateRouting_ReceptiveGoesToMLX(t *testing.T) {
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+
+	// Stand up a lightweight openai-compat stub (simulates mlx-lm endpoint).
+	var mlxCalled atomic.Bool
+	mlxSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/models":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"gemma-4-e4b","object":"model"}]}`))
+		case "/v1/chat/completions":
+			mlxCalled.Store(true)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":      "chatcmpl-test",
+				"object":  "chat.completion",
+				"model":   "gemma-4-e4b",
+				"choices": []map[string]any{{"index": 0, "message": map[string]any{"role": "assistant", "content": "mlx response"}, "finish_reason": "stop"}},
+				"usage":   map[string]any{"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
+			})
+		default:
+			t.Errorf("mlxSrv: unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer mlxSrv.Close()
+
+	// Write providers.yaml with process_state_routing: receptive -> mlx-lm.
+	// The mlx-lm endpoint points at our httptest server.
+	writeTestFile(t, filepath.Join(root, ".cog", "config", "providers.yaml"), `providers:
+  ollama:
+    type: ollama
+    endpoint: http://localhost:11434
+    model: gemma4:e4b
+  mlx-lm:
+    type: openai
+    endpoint: `+mlxSrv.URL+`
+    model: gemma-4-e4b
+routing:
+  default: ollama
+  fallback_chain: [mlx-lm, ollama]
+  process_state_routing:
+    receptive: mlx-lm
+`)
+
+	// NewProcess starts in StateReceptive — no transition needed.
+	proc := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	if got := proc.State().String(); got != "receptive" {
+		t.Fatalf("process initial state = %q; want receptive", got)
+	}
+
+	srv := NewServer(cfg, makeNucleus("Cog", "tester"), proc)
+	ctrl, err := NewLocalHarnessController(cfg, makeNucleus("Cog", "tester"), proc, srv.mcpServer)
+	if err != nil {
+		t.Fatalf("NewLocalHarnessController: %v", err)
+	}
+
+	ctx := context.Background()
+	_, dispErr := ctrl.DispatchToHarness(ctx, DispatchRequest{
+		Task:           "state-routing test",
+		N:              1,
+		TimeoutSeconds: 10,
+	})
+	// Dispatch may fail (mlx stub returns no tool results, etc.) but what
+	// matters is whether the mlx-lm endpoint was called.
+	_ = dispErr
+
+	if !mlxCalled.Load() {
+		t.Errorf("mlx-lm endpoint was NOT called; expected state-routing (receptive -> mlx-lm) to route there instead of Ollama legacy path")
 	}
 }

--- a/internal/engine/local_agent_harness_test.go
+++ b/internal/engine/local_agent_harness_test.go
@@ -631,15 +631,20 @@ func TestDispatchToHarness_StateRouting_NonOllamaDoesNotBlockOnOllamaMu(t *testi
 	root := makeWorkspace(t)
 	cfg := makeConfig(t, root)
 
-	// mlx-lm stub with a deliberate delay to hold the dispatch open.
+	// mlx-lm stub: signals mlxReady when the completions call arrives, then
+	// waits on mlxUnblock before sending the response. This ensures the mlx
+	// dispatch is genuinely in-flight (holding any lock it might hold) while
+	// the Ollama metabolic cycle runs, proving the two don't serialize.
 	mlxReady := make(chan struct{})
+	mlxUnblock := make(chan struct{})
 	mlxSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/v1/models":
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"gemma-4-e4b","object":"model"}]}`))
 		case "/v1/chat/completions":
-			close(mlxReady) // signal that mlx dispatch is in-flight
+			close(mlxReady)  // signal: mlx dispatch is now in-flight
+			<-mlxUnblock     // hold open until the Ollama cycle has started
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"id":      "chatcmpl-test",
@@ -652,7 +657,9 @@ func TestDispatchToHarness_StateRouting_NonOllamaDoesNotBlockOnOllamaMu(t *testi
 	}))
 	defer mlxSrv.Close()
 
-	// Ollama stub to verify the cycle can acquire the lock independently.
+	// Ollama stub: signals ollamaStarted on the first /api/chat, proving the
+	// metabolic cycle ran while the mlx dispatch was still blocked.
+	ollamaStarted := make(chan struct{})
 	var ollamaCycles atomic.Int32
 	ollamaSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -661,7 +668,9 @@ func TestDispatchToHarness_StateRouting_NonOllamaDoesNotBlockOnOllamaMu(t *testi
 				"models": []map[string]any{{"name": "gemma4:e4b"}},
 			})
 		case "/api/chat":
-			ollamaCycles.Add(1)
+			if ollamaCycles.Add(1) == 1 {
+				close(ollamaStarted) // first Ollama call started while mlx is in-flight
+			}
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"message": map[string]any{"role": "assistant", "content": `{"action":"sleep","reason":"idle","urgency":0.0,"target":"","task":""}`},
@@ -691,38 +700,134 @@ routing:
 
 	ctx := context.Background()
 
-	// Launch a state-routed (non-Ollama) dispatch in the background.
+	// Launch a state-routed (non-Ollama) dispatch in the background. The mlx
+	// handler will block until we unblock it below.
 	dispDone := make(chan error, 1)
 	go func() {
 		_, e := ctrl.DispatchToHarness(ctx, DispatchRequest{
 			Task:           "non-ollama dispatch",
 			N:              1,
-			TimeoutSeconds: 10,
+			TimeoutSeconds: 30,
 		})
 		dispDone <- e
 	}()
 
-	// Wait until the mlx dispatch is in-flight, then run a metabolic cycle.
-	// If ollamaMu were held by the mlx dispatch, this TriggerAgent call would
-	// deadlock for the dispatch's duration.
+	// Wait until the mlx dispatch is genuinely in-flight (blocked in the handler).
 	select {
 	case <-mlxReady:
 	case err := <-dispDone:
 		t.Fatalf("dispatch completed before mlxReady signal: %v", err)
 	}
 
+	// With mlx dispatch in-flight, run a metabolic cycle via Ollama. If
+	// ollamaMu were held by the mlx dispatch this would deadlock until the
+	// dispatch timed out (30s). The test would fail with TriggerAgent error.
 	_, cycleErr := ctrl.TriggerAgent(ctx, DefaultAgentID, "concurrent-cycle", true)
 	if cycleErr != nil {
-		t.Fatalf("TriggerAgent while mlx dispatch in-flight: %v", cycleErr)
+		t.Fatalf("TriggerAgent while mlx dispatch in-flight: %v (may indicate ollamaMu contention)", cycleErr)
 	}
+
+	// Wait for Ollama to have started so we know overlap happened, then
+	// unblock the mlx handler.
+	select {
+	case <-ollamaStarted:
+	case err := <-dispDone:
+		t.Fatalf("dispatch finished before ollamaStarted signal: %v", err)
+	}
+	close(mlxUnblock)
 
 	// Wait for dispatch to finish.
 	if err := <-dispDone; err != nil {
 		t.Fatalf("DispatchToHarness: %v", err)
 	}
 
-	// The metabolic cycle hit Ollama (proving it wasn't blocked on ollamaMu).
+	// Confirm the metabolic cycle ran Ollama while mlx was in-flight.
 	if got := ollamaCycles.Load(); got == 0 {
 		t.Errorf("ollamaCycles = 0; want >= 1 (metabolic cycle should have run concurrently with mlx dispatch)")
+	}
+}
+
+// TestDispatchToHarness_TypelessOllamaStillAcquiresOllamaMu verifies that a
+// provider named "ollama" WITHOUT an explicit type: field is still treated as
+// Ollama for lock-acquisition purposes. The isOllamaProvider helper must mirror
+// makeProvider's inference rule (empty type == provider name) so that the
+// documented short-form config shape is not silently misclassified as non-Ollama.
+func TestDispatchToHarness_TypelessOllamaStillAcquiresOllamaMu(t *testing.T) {
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+
+	var inFlight atomic.Int32
+	var maxInFlight atomic.Int32
+
+	ollamaSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/tags":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"models": []map[string]any{{"name": "gemma4:e4b"}},
+			})
+		case "/api/chat":
+			cur := inFlight.Add(1)
+			for {
+				old := maxInFlight.Load()
+				if cur <= old {
+					break
+				}
+				if maxInFlight.CompareAndSwap(old, cur) {
+					break
+				}
+			}
+			defer inFlight.Add(-1)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"message": map[string]any{"role": "assistant", "content": `{"action":"sleep","reason":"idle","urgency":0.0,"target":"","task":""}`},
+				"done": true, "prompt_eval_count": 1, "eval_count": 1,
+			})
+		}
+	}))
+	defer ollamaSrv.Close()
+
+	// Provider named "ollama" with NO explicit type: field — the documented
+	// short-form config shape. isOllamaProvider must still return true.
+	writeTestFile(t, filepath.Join(root, ".cog", "config", "providers.yaml"), `providers:
+  ollama:
+    endpoint: `+ollamaSrv.URL+`
+    model: gemma4:e4b
+routing:
+  process_state_routing:
+    receptive: ollama
+`)
+	t.Setenv(localLLMEndpointEnv, ollamaSrv.URL)
+
+	proc := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	srv := NewServer(cfg, makeNucleus("Cog", "tester"), proc)
+	ctrl, err := NewLocalHarnessController(cfg, makeNucleus("Cog", "tester"), proc, srv.mcpServer)
+	if err != nil {
+		t.Fatalf("NewLocalHarnessController: %v", err)
+	}
+
+	ctx := context.Background()
+
+	errs := make(chan error, 2)
+	go func() {
+		_, err := ctrl.TriggerAgent(ctx, DefaultAgentID, "cycle", true)
+		errs <- err
+	}()
+	go func() {
+		_, err := ctrl.DispatchToHarness(ctx, DispatchRequest{
+			Task:           "typeless-ollama lock test",
+			N:              1,
+			TimeoutSeconds: 10,
+		})
+		errs <- err
+	}()
+
+	for i := 0; i < 2; i++ {
+		if err := <-errs; err != nil {
+			t.Errorf("goroutine %d error: %v", i, err)
+		}
+	}
+
+	if got := maxInFlight.Load(); got > 1 {
+		t.Errorf("max concurrent Ollama /api/chat = %d; want <= 1 (typeless ollama provider should still hold ollamaMu)", got)
 	}
 }

--- a/internal/engine/local_agent_harness_test.go
+++ b/internal/engine/local_agent_harness_test.go
@@ -747,6 +747,69 @@ routing:
 	}
 }
 
+// TestDispatchToHarness_Legacy26bDowngradeWarningPerSlot is a regression test
+// ensuring that the "26b route unavailable, degraded to e4b" per-slot warning
+// from the legacy path still appears in each DispatchResult.Error even when
+// Success=true. This was silently dropped in an earlier iteration of the
+// state-routing patch; this test pins the contract.
+func TestDispatchToHarness_Legacy26bDowngradeWarningPerSlot(t *testing.T) {
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	cfg.LocalModel = "gemma4:e4b"
+
+	// Ollama stub that only lists gemma4:e4b — no 26b-class model available.
+	ollamaSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/tags":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"models": []map[string]any{{"name": "gemma4:e4b"}},
+			})
+		case "/api/chat":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"message": map[string]any{"role": "assistant", "content": "ok"},
+				"done":    true, "prompt_eval_count": 1, "eval_count": 1,
+			})
+		}
+	}))
+	defer ollamaSrv.Close()
+	t.Setenv(localLLMEndpointEnv, ollamaSrv.URL)
+
+	proc := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	srv := NewServer(cfg, makeNucleus("Cog", "tester"), proc)
+	ctrl, err := NewLocalHarnessController(cfg, makeNucleus("Cog", "tester"), proc, srv.mcpServer)
+	if err != nil {
+		t.Fatalf("NewLocalHarnessController: %v", err)
+	}
+
+	batch, dispErr := ctrl.DispatchToHarness(context.Background(), DispatchRequest{
+		Task:           "26b downgrade test",
+		Model:          DispatchModel26B,
+		N:              1,
+		TimeoutSeconds: 10,
+	})
+	if dispErr != nil {
+		t.Fatalf("DispatchToHarness: %v", dispErr)
+	}
+	if len(batch.Results) != 1 {
+		t.Fatalf("batch.Results len = %d; want 1", len(batch.Results))
+	}
+	res := batch.Results[0]
+
+	// Dispatch must succeed — it fell back to e4b.
+	if !res.Success {
+		t.Errorf("Success = false; want true (26b fallback to e4b should still succeed)")
+	}
+	// Per-slot Error must carry the downgrade warning so callers that inspect
+	// individual slot results can see that the requested model was not honored.
+	if res.Error == "" {
+		t.Errorf("Error is empty; want downgrade warning (e.g. %q)", "26b route unavailable, degraded to e4b")
+	}
+	if res.ModelUsed != DispatchModelE4B {
+		t.Errorf("ModelUsed = %q; want DispatchModelE4B", res.ModelUsed)
+	}
+}
+
 // TestDispatchToHarness_TypelessOllamaStillAcquiresOllamaMu verifies that a
 // provider named "ollama" WITHOUT an explicit type: field is still treated as
 // Ollama for lock-acquisition purposes. The isOllamaProvider helper must mirror


### PR DESCRIPTION
## Summary

- DispatchToHarness previously bypassed process_state_routing for all dispatches without an explicit req.Provider, always falling through to the legacy Ollama local-LLM probe
- Adds Path 2 to the three-path resolver: when req.Provider is empty and a process is attached, consult process_state_routing for the current state; if mapped provider is configured and enabled, dispatch there
- Falls through to legacy Ollama probe if state has no routing entry or the provider is unavailable (backward-compatible)
- New helper resolveProviderByProcessState() encapsulates the state lookup

## Test plan

- [x] TestDispatchToHarness_StateRouting_ReceptiveGoesToMLX: receptive state with process_state_routing.receptive=mlx-lm routes to mlx-lm openai-compat endpoint, not Ollama
- [x] All existing harness tests pass
- [ ] DO NOT auto-merge: kernel concurrency-adjacent code; needs human review

## Context

Wave C W2 — B3 routing gap. The autonomic loop dispatched with model=e4b hardcoded to Ollama regardless of process_state_routing. This PR wires the harness dispatch path through the same routing table already used by SimpleRouter.