### PR TITLE
fix(engine): trigger agent cycle immediately on dashboard user message

### DIFF
--- a/internal/engine/dashboard_inlet.go
+++ b/internal/engine/dashboard_inlet.go
@@ -131,11 +131,27 @@ func DrainEnginePendingUserMessages() []EnginePendingUserMsg {
 	return out
 }
 
-// --- Bus manager registry ---
+// --- Bus manager registry and controller reference ---
 
 // engineDashboardBusMgr holds the bus manager for publishing responses.
 // Atomic pointer for lock-free hot-path reads in the respond executor.
 var engineDashboardBusMgr atomic.Pointer[BusSessionManager]
+
+// engineDashboardController holds a reference to the harness controller so
+// that handleEngineDashboardChatEvent can trigger a cycle immediately when a
+// user message arrives, rather than waiting for the next autonomic tick.
+// Set via BindDashboardController when the agent controller is wired.
+var engineDashboardController atomic.Pointer[LocalHarnessController]
+
+// BindDashboardController registers the harness controller with the inlet so
+// that incoming user messages trigger an immediate cycle. Called by
+// SetAgentController when the controller is a *LocalHarnessController.
+func BindDashboardController(ctrl *LocalHarnessController) {
+	if ctrl == nil {
+		return
+	}
+	engineDashboardController.Store(ctrl)
+}
 
 // InstallEngineDashboardInlet wires bus_dashboard_chat → engine pending queue.
 //
@@ -214,6 +230,18 @@ func handleEngineDashboardChatEvent(busID string, block *BusBlock) {
 	})
 	slog.Info("dashboard-inlet: queued user message",
 		"text_len", len(text), "session", sessionID, "from", block.From)
+
+	// Trigger the harness cycle immediately so the response arrives promptly
+	// rather than waiting for the next autonomic tick (up to 60 seconds away).
+	// Non-blocking: if a cycle is already running, TriggerAgent returns
+	// already_running and the pending message will be drained on the next cycle.
+	if ctrl := engineDashboardController.Load(); ctrl != nil {
+		go func() {
+			if _, err := ctrl.TriggerAgent(context.Background(), DefaultAgentID, "dashboard-user-message", false); err != nil {
+				slog.Debug("dashboard-inlet: trigger agent failed", "err", err)
+			}
+		}()
+	}
 }
 
 // extractEngineDashboardText pulls message body from a BusBlock payload.

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -255,9 +255,12 @@ func (s *Server) SetAgentController(ctrl AgentController) {
 		s.mcpServer.SetAgentController(ctrl)
 	}
 	// Piece 2+3: wire dashboard bus into the harness so runCycle drains
-	// pending messages and the respond tool has a publish target.
+	// pending messages and the respond tool has a publish target. Also bind
+	// the controller to the inlet so incoming messages trigger an immediate
+	// cycle rather than waiting for the next autonomic tick.
 	if lhc, ok := ctrl.(*LocalHarnessController); ok && s.busSessions != nil {
 		lhc.SetDashboardBus(s.busSessions)
+		BindDashboardController(lhc)
 	}
 }
 


### PR DESCRIPTION
## Summary

Without this fix, pending user messages waited up to 60 seconds for the next autonomic tick before the harness would drain them. The ACP smoke test has a 60s timeout, causing frequent misses.

**Root cause**: `handleEngineDashboardChatEvent` enqueued messages to `enginePendingMsgs` but did not signal the harness to run immediately. The first smoke test confirmed the kernel correctly received and processed the message (logs show `tool_loop: executing kernel tool tool=respond`) but the cycle only fired because of an unrelated `degraded_health` escalation — not because a user message arrived.

**Fix**: Add `BindDashboardController(ctrl)` so `handleEngineDashboardChatEvent` can call `TriggerAgent(non-blocking)` immediately after enqueueing a user message. Non-blocking: if a cycle is already running the pending message is deferred to the next available cycle naturally.

`BindDashboardController` is called from `SetAgentController` alongside `SetDashboardBus` when the controller is a `*LocalHarnessController`.

## Test plan

- `go test ./internal/engine/... -run TestDashboardInlet` — all 4 tests pass
- `go test ./...` — all pass
- ACP smoke test: response arrives within the 60s window (the kernel logs confirm `respond` tool fires within seconds of message receipt)