### PR TITLE
fix(engine): unwrap mod3 bus/send payload to recover session_id for ACP routing

### DIFF
--- a/internal/engine/dashboard_inlet.go
+++ b/internal/engine/dashboard_inlet.go
@@ -191,11 +191,16 @@ func ensureEngineDashboardBuses(mgr *BusSessionManager) {
 
 // handleEngineDashboardChatEvent is the bus handler registered on the engine's
 // BusSessionManager. It filters non-target buses, extracts the user message
-// text, and enqueues it onto the pending FIFO.
+// text and session_id, and enqueues them onto the pending FIFO.
 //
-// Expected Mod³ payload shape:
+// Two payload shapes are accepted:
 //
-//	{"type": "user_message", "text": "hello agent", "session_id": "...", "ts": "..."}
+//  1. Direct shape (e.g. from tests or direct bus appends):
+//     {"type":"user_message","text":"hello","session_id":"...","ts":"..."}
+//
+//  2. Wrapped shape from Mod³ /v1/bus/send (handleBusSend wraps the event JSON
+//     into the "content" field of the stored payload):
+//     {"content":"{\"type\":\"user_message\",\"text\":\"hello\",\"session_id\":\"...\"}"}
 func handleEngineDashboardChatEvent(busID string, block *BusBlock) {
 	if busID != engineDashboardChatBusID || block == nil {
 		return
@@ -205,7 +210,17 @@ func handleEngineDashboardChatEvent(busID string, block *BusBlock) {
 		return
 	}
 
-	text := extractEngineDashboardText(block)
+	// Unwrap: if the payload has a "content" field containing JSON (the
+	// handleBusSend shape), parse it to recover the inner event fields.
+	payload := block.Payload
+	if content, ok := payload["content"].(string); ok && len(content) > 0 && content[0] == '{' {
+		var inner map[string]interface{}
+		if err := json.Unmarshal([]byte(content), &inner); err == nil {
+			payload = inner
+		}
+	}
+
+	text := extractPayloadText(payload)
 	if text == "" {
 		slog.Debug("dashboard-inlet: drop: no text in block",
 			"seq", block.Seq, "from", block.From, "type", block.Type)
@@ -219,7 +234,7 @@ func handleEngineDashboardChatEvent(busID string, block *BusBlock) {
 		}
 	}
 	sessionID := ""
-	if v, ok := block.Payload["session_id"].(string); ok {
+	if v, ok := payload["session_id"].(string); ok {
 		sessionID = v
 	}
 
@@ -244,16 +259,18 @@ func handleEngineDashboardChatEvent(busID string, block *BusBlock) {
 	}
 }
 
-// extractEngineDashboardText pulls message body from a BusBlock payload.
-// Accepts either "text" or "content" keys.
-func extractEngineDashboardText(block *BusBlock) string {
-	if block == nil || block.Payload == nil {
+// extractPayloadText pulls message body from a payload map.
+// Accepts either "text" or "content" keys. When content looks like a JSON
+// object (starts with "{"), it is NOT used as the message text — that case is
+// handled by the caller's unwrap logic.
+func extractPayloadText(payload map[string]interface{}) string {
+	if payload == nil {
 		return ""
 	}
-	if v, ok := block.Payload["text"].(string); ok && v != "" {
+	if v, ok := payload["text"].(string); ok && v != "" {
 		return v
 	}
-	if v, ok := block.Payload["content"].(string); ok && v != "" {
+	if v, ok := payload["content"].(string); ok && v != "" && (len(v) == 0 || v[0] != '{') {
 		return v
 	}
 	return ""


### PR DESCRIPTION
## Summary

The ACP end-to-end smoke test was timing out (60s) even though the kernel was correctly running the `respond` tool and publishing to `bus_dashboard_response`. Root cause: session_id was empty ("") on every event from mod3's `/v1/bus/send` path, so `run_response_bridge` in mod3 couldn't find the registered ACP listener and fell through to the broadcast path.

**Root cause trace**:

1. mod3's `post_user_message` encodes the event as `{"bus_id": ..., "message": JSON.stringify({type, text, session_id, ts})}`
2. `handleBusSend` in `serve_bus.go` stores the payload as `{"content": <message-string>}` -- the inner JSON becomes a string value under "content"
3. `handleEngineDashboardChatEvent` was reading `block.Payload["session_id"]` directly, which is absent at the top level -- always got `""`
4. `enginePublishDashboardResponse` published with `session_id=""` (broadcast)
5. `run_response_bridge` in mod3: `_has_acp_listener("")` = false, so the response went to `BrowserChannel` broadcast instead of the ACP queue

**Fix**: detect the JSON-wrapped "content" shape and unmarshal the inner object before extracting `text` and `session_id`. The `extractPayloadText` helper skips "content" fields that look like JSON objects (starts with `{`) to avoid treating the raw JSON string as the reply text.

## Test plan
- `go test ./internal/engine/... -run TestDashboardInlet` -- 4/4 pass
- `go test ./...` -- all pass
- ACP smoke test: `session/prompt` now receives `session/update agent_message_chunk` + `session/prompt result` within the 60s window