### PR TITLE
fix(engine): wire BusSessionManager to SSE broker for live event delivery

### DIFF
--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -124,6 +124,22 @@ func NewServer(cfg *Config, nucleus *Nucleus, process *Process) *Server {
 	// arrives, and the bus dirs are created idempotently.
 	InstallEngineDashboardInlet(s.busSessions)
 	s.busBroker = NewBusEventBroker()
+
+	// Wire BusSessionManager → BusEventBroker so that any direct AppendEvent
+	// call (e.g. enginePublishDashboardResponse from the respond tool) notifies
+	// live SSE subscribers on /v1/bus/{id}/stream.  Without this hook, events
+	// written via AppendEvent bypass the broker and never reach mod3's response
+	// bridge subscriber.  handleBusSend already calls busBroker.Publish after
+	// the AppendEvent write, so the handler below is intentionally idempotent
+	// (the broker uses non-blocking channel sends and tolerates double-notify).
+	// Capture the broker pointer so the closure doesn't race on s.busBroker.
+	{
+		broker := s.busBroker
+		s.busSessions.AddEventHandler("sse-broker-notify", func(busID string, block *BusBlock) {
+			broker.Publish(busID, block)
+		})
+	}
+
 	s.busConsumers = NewConsumerRegistry(
 		// Match root's persistence path: .cog/run/bus/{bus_id}.cursors.jsonl
 		filepath.Join(cfg.WorkspaceRoot, ".cog", "run", "bus"),


### PR DESCRIPTION
## Summary

- Direct `AppendEvent` calls (e.g. `enginePublishDashboardResponse` from the `respond` tool) were bypassing the `BusEventBroker`, so SSE subscribers on `/v1/bus/{id}/stream` never received live agent responses
- `handleBusSend` already calls `busBroker.Publish` directly, but internal engine writes do not go through that HTTP handler
- Add an event handler on `BusSessionManager` that calls `busBroker.Publish` after every successful `AppendEvent` write
- The handler is idempotent: broker uses non-blocking channel sends that tolerate double-notify from `handleBusSend` + handler

## Root cause

`enginePublishDashboardResponse` writes directly to `BusSessionManager.AppendEvent`. The kernel's bus SSE broker (`BusEventBroker`) is only notified via `handleBusSend`. Since the respond tool bypasses `handleBusSend`, live SSE subscribers never received agent response events, causing mod3's response bridge to time out on every ACP prompt.

## Test plan

- [ ] All 4 `TestDashboardInlet*` tests pass
- [ ] Full test suite passes (no regressions)
- [ ] CI green
- [ ] ACP end-to-end smoke test: `session/prompt` receives `session/update` chunk + `result` with `stopReason=end_turn`