### PR TITLE
fix(engine): gate respond tool on pending user message + enforce at-most-once per turn

### DIFF
--- a/internal/engine/dashboard_inlet.go
+++ b/internal/engine/dashboard_inlet.go
@@ -329,6 +329,13 @@ func (e errDashboardNotReady) Error() string { return string(e) }
 // the auto-fallback should fire.
 var engineRespondInvokeCount uint64
 
+// engineRespondPerTurnCount is the per-turn invocation counter for Gate B.
+// It is reset to 0 at the start of each user-turn execute phase (by
+// ResetEngineRespondPerTurnCount in runCycle) and incremented on each
+// successful respond dispatch. When > 0 at entry, engineRespondExecutor
+// rejects the call and returns a structured error to the model.
+var engineRespondPerTurnCount uint64
+
 // EngineRespondInvokeSnapshot returns the current respond-call counter.
 func EngineRespondInvokeSnapshot() uint64 {
 	return atomic.LoadUint64(&engineRespondInvokeCount)
@@ -339,6 +346,12 @@ func EngineRespondInvokedSince(snapshot uint64) bool {
 	return atomic.LoadUint64(&engineRespondInvokeCount) > snapshot
 }
 
+// ResetEngineRespondPerTurnCount zeroes the per-turn counter. Called by
+// runCycle at the start of each user-turn execute phase (Gate B reset).
+func ResetEngineRespondPerTurnCount() {
+	atomic.StoreUint64(&engineRespondPerTurnCount, 0)
+}
+
 // engineRespondPublish is the seam for the respond executor. Tests swap this
 // to capture output without a live bus manager.
 var engineRespondPublish = enginePublishDashboardResponse
@@ -346,7 +359,22 @@ var engineRespondPublish = enginePublishDashboardResponse
 // engineRespondExecutor is the toolExecutor for the `respond` tool.
 // It fans out across all session IDs in ctx (set by runCycle after draining
 // the pending queue) and publishes one reply per unique session.
+//
+// Gate B: at most one successful respond invocation is allowed per user turn.
+// If the per-turn counter is already > 0 this function returns a structured
+// error to the model and does NOT publish to bus_dashboard_response. The
+// counter is reset by ResetEngineRespondPerTurnCount at the start of each
+// user-turn execute phase.
 func engineRespondExecutor(ctx context.Context, arguments string) (string, error) {
+	// Gate B: reject 2nd+ invocations within the same user turn.
+	if atomic.LoadUint64(&engineRespondPerTurnCount) > 0 {
+		result, _ := json.Marshal(map[string]interface{}{
+			"ok":    false,
+			"error": "respond already invoked this turn (1 reply per turn)",
+		})
+		return string(result), nil
+	}
+
 	var p struct {
 		Text      string `json:"text"`
 		Reasoning string `json:"reasoning"`
@@ -397,8 +425,11 @@ func engineRespondExecutor(ctx context.Context, arguments string) (string, error
 		return string(errResult), nil
 	}
 
-	// Bump exactly once per tool invocation (N fan-out publishes = 1 call).
+	// Bump both counters exactly once per tool invocation (N fan-out publishes = 1 call).
+	// engineRespondInvokeCount: used by the auto-fallback dedupe (EngineRespondInvokedSince).
+	// engineRespondPerTurnCount: used by Gate B to reject 2nd+ invocations this turn.
 	atomic.AddUint64(&engineRespondInvokeCount, 1)
+	atomic.AddUint64(&engineRespondPerTurnCount, 1)
 
 	result, _ := json.Marshal(map[string]interface{}{
 		"ok":         true,

--- a/internal/engine/local_agent_harness.go
+++ b/internal/engine/local_agent_harness.go
@@ -48,6 +48,40 @@ var harnessToolScopes = map[string][]string{
 		"cog_emit_event",
 		engineRespondToolName, // Piece 3a: respond tool in consolidation scope
 	},
+	// consolidation_with_respond is identical to consolidation but named
+	// explicitly so callers can request it by scope name. The autonomic
+	// cycle uses this scope only when pending user messages are present;
+	// for purely autonomic ticks it uses consolidation_no_respond instead.
+	"consolidation_with_respond": {
+		"cog_resolve_uri",
+		"cog_search_memory",
+		"cog_read_cogdoc",
+		"cog_query_field",
+		"cog_check_coherence",
+		"cog_get_state",
+		"cog_get_trust",
+		"cog_get_nucleus",
+		"cog_get_index",
+		"cog_assemble_context",
+		"cog_emit_event",
+		engineRespondToolName,
+	},
+	// consolidation_no_respond is the autonomic-only scope: identical to
+	// consolidation except the respond tool is absent. The model cannot
+	// publish to bus_dashboard_response during a pure autonomic cycle.
+	"consolidation_no_respond": {
+		"cog_resolve_uri",
+		"cog_search_memory",
+		"cog_read_cogdoc",
+		"cog_query_field",
+		"cog_check_coherence",
+		"cog_get_state",
+		"cog_get_trust",
+		"cog_get_nucleus",
+		"cog_get_index",
+		"cog_assemble_context",
+		"cog_emit_event",
+	},
 	"audit": {
 		"cog_resolve_uri",
 		"cog_search_memory",
@@ -139,6 +173,10 @@ type LocalHarnessController struct {
 	toolRegistry    *KernelToolRegistry
 	dispatchTools   *KernelToolRegistry
 	backgroundTools *KernelToolRegistry
+	// backgroundToolsNoRespond is the tool set for purely autonomic cycles
+	// (no pending user messages). It is identical to backgroundTools but
+	// with the respond tool removed — Gate A enforcement.
+	backgroundToolsNoRespond *KernelToolRegistry
 
 	agentID  string
 	started  time.Time
@@ -217,7 +255,7 @@ func NewLocalHarnessControllerWithScope(cfg *Config, nucleus *Nucleus, process *
 	}
 	toolNames, ok := harnessToolScopes[scopeName]
 	if !ok {
-		return nil, fmt.Errorf("unknown harness scope %q (known: consolidation, audit)", scopeName)
+		return nil, fmt.Errorf("unknown harness scope %q (known: consolidation, consolidation_with_respond, consolidation_no_respond, audit)", scopeName)
 	}
 	registry := NewKernelToolRegistry(mcpSrv)
 	// Piece 3b: inject the respond native tool into the full registry before
@@ -229,22 +267,31 @@ func NewLocalHarnessControllerWithScope(cfg *Config, nucleus *Nucleus, process *
 		return nil, err
 	}
 
+	// Gate A: build a respond-free tool set for purely autonomic cycles.
+	// When runCycle drains an empty pending queue, it uses this registry so
+	// the model cannot see (and therefore cannot invoke) the respond tool.
+	noRespondTools, err := registry.Scoped(harnessToolScopes["consolidation_no_respond"])
+	if err != nil {
+		return nil, fmt.Errorf("build no-respond tool scope: %w", err)
+	}
+
 	interval := time.Minute
 	if cfg != nil && cfg.HeartbeatInterval > 0 {
 		interval = time.Duration(cfg.HeartbeatInterval) * time.Second
 	}
 
 	return &LocalHarnessController{
-		cfg:                  cfg,
-		nucleus:              nucleus,
-		process:              process,
-		toolRegistry:         registry,
-		dispatchTools:        dispatchTools,
-		backgroundTools:      dispatchTools,
-		agentID:              DefaultAgentID,
-		started:              time.Now().UTC(),
-		interval:             interval,
-		localProviderTimeout: resolveLocalProviderTimeout(cfg),
+		cfg:                      cfg,
+		nucleus:                  nucleus,
+		process:                  process,
+		toolRegistry:             registry,
+		dispatchTools:            dispatchTools,
+		backgroundTools:          dispatchTools,
+		backgroundToolsNoRespond: noRespondTools,
+		agentID:                  DefaultAgentID,
+		started:                  time.Now().UTC(),
+		interval:                 interval,
+		localProviderTimeout:     resolveLocalProviderTimeout(cfg),
 	}, nil
 }
 
@@ -438,6 +485,28 @@ func (c *LocalHarnessController) runCycle(parent context.Context, reason string,
 	if c.dashboardBus != nil {
 		pendingMsgs = DrainEnginePendingUserMessages()
 	}
+
+	// Gate A — select cycle-appropriate tool set.
+	//
+	// When there are no pending user messages this cycle is purely autonomic
+	// (health-check, memory consolidation, etc.). In that case, strip the
+	// respond tool from the model's visible tool set so it cannot publish to
+	// bus_dashboard_response. The model literally cannot see the tool; there
+	// is no text-based instruction that could override this.
+	//
+	// When pending messages are present, use the full background tool set
+	// (which includes respond) and reset the per-turn invocation counter so
+	// Gate B starts fresh for this turn.
+	cycleTools := c.backgroundTools
+	if len(pendingMsgs) == 0 {
+		if c.backgroundToolsNoRespond != nil {
+			cycleTools = c.backgroundToolsNoRespond
+		}
+	} else {
+		// Gate B: reset per-turn counter before each new user-turn execute phase.
+		ResetEngineRespondPerTurnCount()
+	}
+
 	// Snapshot the respond counter BEFORE the execute phase so we can detect
 	// whether the agent called it during this turn.
 	respondSnapshot := EngineRespondInvokeSnapshot()
@@ -525,7 +594,7 @@ func (c *LocalHarnessController) runCycle(parent context.Context, reason string,
 	}
 
 	if assessment.Action != "sleep" {
-		result, err := c.executeCycleTask(ctx, provider, assessment, outcome.record.Observation, c.backgroundTools)
+		result, err := c.executeCycleTask(ctx, provider, assessment, outcome.record.Observation, cycleTools)
 		if err != nil {
 			outcome.record.Action = "error"
 			outcome.record.Reason = err.Error()

--- a/internal/engine/respond_gate_test.go
+++ b/internal/engine/respond_gate_test.go
@@ -1,0 +1,312 @@
+// respond_gate_test.go — Unit tests for Gate A (cycle-level respond gating)
+// and Gate B (per-turn at-most-once enforcement).
+//
+// Gate A: the respond tool must NOT appear in the model's visible tool set
+// during a purely autonomic cycle (no pending user messages). The
+// consolidation_no_respond scope enforces this structurally.
+//
+// Gate B: if the model invokes respond more than once in a single user turn,
+// only the first invocation publishes; subsequent calls return a structured
+// error without touching bus_dashboard_response.
+//
+// Test C (per specification): mock the model invoking respond three times in
+// one turn; assert only the first published, 2nd and 3rd returned errors.
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+// TestGateA_RespondAbsentFromAutonomicScope verifies the scope table and
+// controller constructor both enforce the Gate A invariant structurally.
+func TestGateA_RespondAbsentFromAutonomicScope(t *testing.T) {
+	t.Parallel()
+
+	// 1. The consolidation_no_respond scope must NOT include respond.
+	noRespondScope, ok := harnessToolScopes["consolidation_no_respond"]
+	if !ok {
+		t.Fatal("consolidation_no_respond scope not registered in harnessToolScopes")
+	}
+	for _, name := range noRespondScope {
+		if name == engineRespondToolName {
+			t.Errorf("consolidation_no_respond scope unexpectedly contains %q", engineRespondToolName)
+		}
+	}
+
+	// 2. The consolidation_with_respond scope MUST include respond.
+	withRespondScope, ok := harnessToolScopes["consolidation_with_respond"]
+	if !ok {
+		t.Fatal("consolidation_with_respond scope not registered in harnessToolScopes")
+	}
+	found := false
+	for _, name := range withRespondScope {
+		if name == engineRespondToolName {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("consolidation_with_respond scope missing %q", engineRespondToolName)
+	}
+
+	// 3. The controller's backgroundToolsNoRespond registry must omit respond;
+	//    backgroundTools must include it.
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	proc := NewProcess(cfg, makeNucleus("Cog", "gate-a-scope"))
+	srv := NewServer(cfg, makeNucleus("Cog", "gate-a-scope"), proc)
+
+	ctrl, err := NewLocalHarnessController(cfg, makeNucleus("Cog", "gate-a-scope"), proc, srv.mcpServer)
+	if err != nil {
+		t.Fatalf("NewLocalHarnessController: %v", err)
+	}
+
+	fullDefs := ctrl.backgroundTools.Definitions()
+	foundInFull := false
+	for _, d := range fullDefs {
+		if d.Name == engineRespondToolName {
+			foundInFull = true
+			break
+		}
+	}
+	if !foundInFull {
+		t.Error("backgroundTools (full scope) missing respond — Gate A wiring broken")
+	}
+
+	if ctrl.backgroundToolsNoRespond == nil {
+		t.Fatal("backgroundToolsNoRespond is nil — Gate A not wired in constructor")
+	}
+	noDefs := ctrl.backgroundToolsNoRespond.Definitions()
+	for _, d := range noDefs {
+		if d.Name == engineRespondToolName {
+			t.Errorf("backgroundToolsNoRespond unexpectedly contains %q", engineRespondToolName)
+		}
+	}
+}
+
+// TestGateA_AutonomicCycleDoesNotPublish verifies that runCycle with NO pending
+// messages does not call engineRespondPublish, even when the mock LLM executes.
+// The respond tool is structurally absent from the tool set so the executor is
+// never called.
+func TestGateA_AutonomicCycleDoesNotPublish(t *testing.T) {
+	// Not parallel — modifies package-level seam.
+	clearEnginePendingQueue(t)
+	atomic.StoreUint64(&engineRespondPerTurnCount, 0)
+
+	var publishCount int64
+	origPublish := engineRespondPublish
+	engineRespondPublish = func(text, reasoning, sessionID string) (int, error) {
+		atomic.AddInt64(&publishCount, 1)
+		return len(text), nil
+	}
+	t.Cleanup(func() {
+		engineRespondPublish = origPublish
+		atomic.StoreUint64(&engineRespondPerTurnCount, 0)
+	})
+
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	cfg.LocalModel = "gemma4:e4b"
+
+	var callSeq atomic.Int64
+	model := "gemma4:e4b"
+	llm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/tags":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"models": []map[string]any{{"name": model}},
+			})
+		case "/api/chat":
+			seq := callSeq.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			switch seq {
+			case 1:
+				// assess: non-sleep action so executeCycleTask is called.
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"message": map[string]any{
+						"role":    "assistant",
+						"content": `{"action":"consolidate","reason":"housekeeping","urgency":0.2,"target":"memory","task":"scan recent events"}`,
+					},
+					"done": true, "prompt_eval_count": 10, "eval_count": 20,
+				})
+			default:
+				// execute: plain text, no tool calls.
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"message": map[string]any{
+						"role":    "assistant",
+						"content": "housekeeping complete",
+					},
+					"done": true, "prompt_eval_count": 5, "eval_count": 10,
+				})
+			}
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer llm.Close()
+	t.Setenv(localLLMEndpointEnv, llm.URL)
+
+	proc := NewProcess(cfg, makeNucleus("Cog", "gate-a-autonomic"))
+	srv := NewServer(cfg, makeNucleus("Cog", "gate-a-autonomic"), proc)
+
+	ctrl, err := NewLocalHarnessController(cfg, makeNucleus("Cog", "gate-a-autonomic"), proc, srv.mcpServer)
+	if err != nil {
+		t.Fatalf("NewLocalHarnessController: %v", err)
+	}
+	ctrl.SetDashboardBus(srv.busSessions)
+
+	// No pending messages enqueued — this is a pure autonomic cycle.
+	result, err := ctrl.TriggerAgent(context.Background(), DefaultAgentID, "test-autonomic-gate-a", true)
+	if err != nil {
+		t.Fatalf("TriggerAgent: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	if n := atomic.LoadInt64(&publishCount); n != 0 {
+		t.Errorf("Gate A failed: engineRespondPublish called %d time(s) on autonomic cycle (want 0)", n)
+	}
+}
+
+// TestGateB_MultipleRespondCallsInOneTurn is Test C from the verification spec.
+//
+// Invoke engineRespondExecutor three times within a single simulated user turn.
+// Expected behaviour:
+//   - 1st call: publishes, returns {"ok":true}.
+//   - 2nd call: does NOT publish, returns {"ok":false,"error":"respond already..."}
+//   - 3rd call: same as 2nd.
+//   - Global engineRespondInvokeCount increments by exactly 1.
+func TestGateB_MultipleRespondCallsInOneTurn(t *testing.T) {
+	// Not parallel — modifies package-level seams.
+	atomic.StoreUint64(&engineRespondInvokeCount, 0)
+	atomic.StoreUint64(&engineRespondPerTurnCount, 0)
+
+	var publishCount int64
+	origPublish := engineRespondPublish
+	engineRespondPublish = func(text, reasoning, sessionID string) (int, error) {
+		atomic.AddInt64(&publishCount, 1)
+		return len(text), nil
+	}
+	t.Cleanup(func() {
+		engineRespondPublish = origPublish
+		atomic.StoreUint64(&engineRespondPerTurnCount, 0)
+		atomic.StoreUint64(&engineRespondInvokeCount, 0)
+	})
+
+	ctx := WithSessionID(context.Background(), "sess-gate-b")
+
+	invoke := func(t *testing.T, text string) map[string]interface{} {
+		t.Helper()
+		args, err := json.Marshal(map[string]string{"text": text})
+		if err != nil {
+			t.Fatalf("marshal args: %v", err)
+		}
+		raw, err := engineRespondExecutor(ctx, string(args))
+		if err != nil {
+			t.Fatalf("executor returned Go error: %v", err)
+		}
+		var out map[string]interface{}
+		if err := json.Unmarshal([]byte(raw), &out); err != nil {
+			t.Fatalf("decode result %q: %v", raw, err)
+		}
+		return out
+	}
+
+	// First invocation must succeed and publish.
+	r1 := invoke(t, "first reply")
+	if ok, _ := r1["ok"].(bool); !ok {
+		t.Fatalf("1st invoke should succeed (Gate B not yet triggered): %v", r1)
+	}
+	if n := atomic.LoadInt64(&publishCount); n != 1 {
+		t.Errorf("after 1st invoke: publishCount = %d, want 1", n)
+	}
+
+	// Second invocation must be rejected by Gate B.
+	r2 := invoke(t, "second reply — must be blocked")
+	if ok, _ := r2["ok"].(bool); ok {
+		t.Errorf("2nd invoke should return ok=false (Gate B): %v", r2)
+	}
+	errMsg, _ := r2["error"].(string)
+	if errMsg == "" {
+		t.Errorf("2nd invoke: expected non-empty error field, got: %v", r2)
+	}
+	if n := atomic.LoadInt64(&publishCount); n != 1 {
+		t.Errorf("after 2nd invoke: publishCount = %d, want still 1", n)
+	}
+
+	// Third invocation must also be rejected.
+	r3 := invoke(t, "third reply — also blocked")
+	if ok, _ := r3["ok"].(bool); ok {
+		t.Errorf("3rd invoke should return ok=false (Gate B): %v", r3)
+	}
+	if n := atomic.LoadInt64(&publishCount); n != 1 {
+		t.Errorf("after 3rd invoke: publishCount = %d, want still 1", n)
+	}
+
+	// Global invoke counter must be exactly 1 (only the first counted).
+	if got := atomic.LoadUint64(&engineRespondInvokeCount); got != 1 {
+		t.Errorf("engineRespondInvokeCount = %d, want 1 (only 1st invocation counts)", got)
+	}
+}
+
+// TestGateB_PerTurnCounterResetBetweenTurns verifies that ResetEngineRespondPerTurnCount
+// restores the ability to respond on the next user turn.
+func TestGateB_PerTurnCounterResetBetweenTurns(t *testing.T) {
+	// Not parallel — modifies per-turn counter.
+	origPublish := engineRespondPublish
+	engineRespondPublish = func(text, reasoning, sessionID string) (int, error) {
+		return len(text), nil
+	}
+	t.Cleanup(func() {
+		engineRespondPublish = origPublish
+		atomic.StoreUint64(&engineRespondPerTurnCount, 0)
+		atomic.StoreUint64(&engineRespondInvokeCount, 0)
+	})
+
+	atomic.StoreUint64(&engineRespondPerTurnCount, 0)
+	atomic.StoreUint64(&engineRespondInvokeCount, 0)
+	ctx := WithSessionID(context.Background(), "sess-reset-test")
+
+	invoke := func(t *testing.T, text string) map[string]interface{} {
+		t.Helper()
+		args, _ := json.Marshal(map[string]string{"text": text})
+		raw, err := engineRespondExecutor(ctx, string(args))
+		if err != nil {
+			t.Fatalf("executor error: %v", err)
+		}
+		var out map[string]interface{}
+		_ = json.Unmarshal([]byte(raw), &out)
+		return out
+	}
+
+	// Turn 1: first call succeeds, second is rejected.
+	r1a := invoke(t, "turn-1 reply")
+	if ok, _ := r1a["ok"].(bool); !ok {
+		t.Fatalf("turn 1, 1st call should succeed: %v", r1a)
+	}
+	r1b := invoke(t, "turn-1 second (blocked)")
+	if ok, _ := r1b["ok"].(bool); ok {
+		t.Errorf("turn 1, 2nd call should be blocked: %v", r1b)
+	}
+
+	// Simulate runCycle resetting the counter for the next user turn.
+	ResetEngineRespondPerTurnCount()
+
+	// Turn 2: first call must succeed again after reset.
+	r2a := invoke(t, "turn-2 reply")
+	if ok, _ := r2a["ok"].(bool); !ok {
+		t.Errorf("turn 2, 1st call after reset should succeed: %v", r2a)
+	}
+
+	// Turn 2 second call must still be blocked.
+	r2b := invoke(t, "turn-2 second (blocked)")
+	if ok, _ := r2b["ok"].(bool); ok {
+		t.Errorf("turn 2, 2nd call should be blocked after reset: %v", r2b)
+	}
+}


### PR DESCRIPTION
## Problem

The dashboard shows the agent producing self-narrating messages on every autonomic cycle, e.g.:

- \"I have received your command. My highest priority is replying to the user...\"
- \"I have reviewed the previous session summary...\"

These arrive even when the user only sent one short message (e.g. \"hey\"), because:

1. The autonomic cycle fires every minute.
2. The respond tool was visible to the model on every cycle (including purely autonomic ones with no pending user message).
3. The model was also able to invoke respond multiple times in a single turn.

## Fix

Two kernel-side gates, each addressing one axis of the failure:

### Gate A — respond is only invocable when there is a pending user message

Added two new scope variants to harnessToolScopes:
- consolidation_no_respond: identical to consolidation but omits the respond tool. Used for purely autonomic cycles.
- consolidation_with_respond: explicit alias for the full scope. Used when pending messages are present.

LocalHarnessController gains a backgroundToolsNoRespond field built at construction time. runCycle selects cycleTools based on whether DrainEnginePendingUserMessages() returned a non-empty slice. The model structurally cannot see the respond tool during an autonomic cycle.

Implementation: internal/engine/local_agent_harness.go

### Gate B — at-most-one respond invocation per user turn

Added engineRespondPerTurnCount (package-level atomic uint64) and ResetEngineRespondPerTurnCount(). engineRespondExecutor checks the counter at entry: if already > 0, returns {"ok":false,"error":"respond already invoked this turn (1 reply per turn)"} without touching bus_dashboard_response. Counter incremented on successful publish, reset by runCycle at start of each user-turn execute phase.

Implementation: internal/engine/dashboard_inlet.go

## Tests added (respond_gate_test.go)

- TestGateA_RespondAbsentFromAutonomicScope: scope table + controller constructor invariant
- TestGateA_AutonomicCycleDoesNotPublish: full runCycle with fake Ollama, no pending messages
- TestGateB_MultipleRespondCallsInOneTurn (Test C per spec): 3 invocations in one turn — only first publishes, 2nd and 3rd return errors
- TestGateB_PerTurnCounterResetBetweenTurns: reset enables first-call on the next turn

go test ./... passes clean.