### PR TITLE
fix(kernel): wire SetSessionsBackend in subprocess MCP serve startup

### DIFF
--- a/internal/engine/cli_mcp.go
+++ b/internal/engine/cli_mcp.go
@@ -126,6 +126,16 @@ func runMCPServeEngine(args []string, defaultWorkspace string, stderr io.Writer)
 	process := NewProcess(cfg, nucleus)
 	server := NewMCPServer(cfg, nucleus, process)
 
+	// Wire session-management backends so cog_register_session /
+	// cog_list_sessions / cog_offer_handoff / cog_list_handoffs / etc. work
+	// over stdio (same registries the HTTP path uses, just no live Server).
+	busSessions := NewBusSessionManager(cfg.WorkspaceRoot)
+	sessionRegistry := NewSessionRegistry()
+	handoffRegistry := NewHandoffRegistry()
+	_ = ReplaySessionRegistry(busSessions, sessionRegistry)
+	_ = ReplayHandoffRegistry(busSessions, handoffRegistry)
+	server.SetSessionsBackend(busSessions, sessionRegistry, handoffRegistry)
+
 	// Wire a signal-aware context so shells (or hosts like Claude Desktop)
 	// that send SIGINT/SIGTERM on shutdown get a clean exit.
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)


### PR DESCRIPTION
## Summary

- The `cogos mcp serve` (stdio transport) path constructed `MCPServer` via `NewMCPServer` but never called `SetSessionsBackend`, leaving all session/handoff MCP tools returning "sessions backend not configured"
- The HTTP path in `registerMCPRoutes` (`serve_mcp.go:19`) already wired these correctly — this PR mirrors that pattern for the subprocess path
- Fix: construct `BusSessionManager` + `SessionRegistry` + `HandoffRegistry`, replay from bus, and wire via `SetSessionsBackend` before `RunStdio` in `cli_mcp.go`

## Root cause

`mcp__cogos__cog_list_handoffs` (stdio) errored while `mcp__cogos-kernel__cog_list_handoffs` (HTTP) worked — diagnosed in the 2026-05-14 orchestrator session.

## Test plan

- [ ] `go build ./...` passes (verified locally)
- [ ] `cogos mcp serve` over stdio: `cog_list_handoffs` returns the handoff roster instead of "sessions backend not configured"
- [ ] Existing session/handoff unit tests pass: `go test ./internal/engine/...`