### PR TITLE
fix(rfc-0004): correct gomvpkg invocations to use package paths

### DIFF
--- a/docs/rfcs/0004-v0.5.0-refactor-architectural-calls.md
+++ b/docs/rfcs/0004-v0.5.0-refactor-architectural-calls.md
@@ -73,6 +73,14 @@ and provide the mapping table (generated from Stage A's appendix).
 **Stage D** (live code ports): use `gomvpkg` for each package move, then `goimports`
 for cleanup. The exact incantation per extraction PR:
 
+> **Package-path convention**: `gomvpkg` operates on Go import paths, not filesystem
+> paths. Both `-from` and `-to` must be the fully-qualified module-relative import paths
+> (e.g. `github.com/myrgic/cogos/internal/modality`), not directory paths like
+> `./internal/modality` or `internal/modality/`. Passing a filesystem path silently
+> produces the wrong import-rewrite behavior; the tool accepts it without error but
+> rewrites callers to a path that does not match the module's import graph. Always
+> verify with `go build ./...` immediately after the move.
+
 ```bash
 # 1. Ensure the destination package directory does not yet exist;
 #    gomvpkg creates it as part of the move.
@@ -80,7 +88,9 @@ for cleanup. The exact incantation per extraction PR:
 # 2. Move the package by import path — gomvpkg rewrites all inbound
 #    import references across the module automatically.
 #    Form: gomvpkg -from <old-import-path> -to <new-import-path>
-#    (operates on packages, not individual files)
+#    IMPORTANT: use the full module-qualified import path, not a filesystem path.
+#    Correct:   github.com/myrgic/cogos/internal/modality      (import path)
+#    Incorrect: ./internal/modality  OR  internal/modality/    (filesystem paths)
 gomvpkg -from github.com/myrgic/cogos/internal/<domain> \
         -to   github.com/myrgic/cogos/internal/providers/<domain>
 
@@ -89,6 +99,7 @@ gomvpkg -from github.com/myrgic/cogos/internal/<domain> \
 #         -to   github.com/myrgic/cogos/internal/providers/modality
 
 # 3. Run goimports to clean up any dangling or duplicate import lines.
+#    (goimports -w takes filesystem paths, unlike gomvpkg which takes import paths)
 goimports -w internal/providers/<domain>/
 
 # 4. Verify the module builds and tests pass.


### PR DESCRIPTION
## Summary

Addresses the REQUIRES-CHANGES-FIRST blocking item from PR #227 (council review 2026-05-12) on RFC-0004.

**Council verdict**: `gomvpkg` incantation passes file paths where package paths are required.

**Fix**: Added an explicit callout block before the `gomvpkg` bash example clarifying that both `-from` and `-to` must be fully-qualified module import paths (e.g. `github.com/myrgic/cogos/internal/modality`), not filesystem paths (`./internal/modality` or `internal/modality/`). Inline comments in the bash block also annotate the correct vs incorrect forms. Added a note explaining that `goimports -w` (immediately below) correctly takes filesystem paths — the distinction between the two tools is now explicit.

## Files touched

- `docs/rfcs/0004-v0.5.0-refactor-architectural-calls.md`

## Council reference

PR #227, seat verdict: REQUIRES-CHANGES-FIRST — "gomvpkg incantation passes file paths where package paths are required."