### PR TITLE
spec(rfc-0005,rfc-0006): specify KVBlockHashProvider interface between fork handler and vLLM provider

### DIFF
--- a/docs/rfcs/0005-cog-fork-session.md
+++ b/docs/rfcs/0005-cog-fork-session.md
@@ -267,18 +267,144 @@ The fork handler queries the inference provider for the parent's KV block hash w
 `KVBlockHashProvider` interface, called by this RFC's fork handler and implemented by
 the vLLM provider specified in RFC-0006.
 
+### Interface definition
+
 ```go
 // KVBlockHashProvider is implemented by inference providers that expose
 // a content-addressed KV-block layer (e.g., vLLM PagedAttention).
 // The fork-session handler queries this when forking over a kvcache layer
 // to obtain the parent's KV block hash.
+//
+// Package: internal/engine (canonical definition; RFC-0006 implements it)
 type KVBlockHashProvider interface {
-    // ParentKVBlockHash returns the hash of the KV block representing
-    // the session's KV state at the given message ID, or an error if
-    // the block is no longer addressable (evicted, runtime restarted).
+    // ParentKVBlockHash returns the content-addressed hash of the KV block
+    // representing the session's KV state at the given message ID.
+    //
+    // sessionID: the parent session whose KV state is being queried.
+    // atMessageID: the message ID at the fork point (the last message in the
+    //   parent's context window to be inherited by the child). Providers use
+    //   this to identify which KV block covers the token range up to this message.
+    //
+    // Returns:
+    //   - (BlockHash, nil) on success: the child can carry this hash as a warm-start
+    //     hint to the inference channel.
+    //   - ("", ErrKVBlockEvicted) if the block existed but has been evicted from the
+    //     vLLM block manager. The fork handler treats this as a recoverable miss:
+    //     the fork proceeds with a cold start.
+    //   - ("", ErrKVProviderUnavailable) if the inference channel is unreachable or
+    //     has restarted. Recoverable: fork proceeds cold.
+    //   - ("", ErrKVBlockNotFound) if no KV block exists for the given session and
+    //     message ID (session never reached a KV-addressable state). Recoverable.
+    //   - ("", err) for any other error: treated as fatal by the fork handler —
+    //     the fork is aborted and the error is returned to the caller.
     ParentKVBlockHash(ctx context.Context, sessionID string, atMessageID string) (BlockHash, error)
 }
+
+// BlockHash is a hex-encoded SHA-256 content-addressed identifier for a KV block.
+// An empty BlockHash ("") signals absence; it is not a valid block reference.
+type BlockHash string
+
+// Sentinel errors returned by KVBlockHashProvider implementations.
+// The fork handler checks these explicitly to distinguish recoverable from fatal.
+var (
+    // ErrKVBlockEvicted: block existed but was evicted from the block manager.
+    // The fork handler degrades to cold start; this is not an error condition.
+    ErrKVBlockEvicted = errors.New("kv block evicted")
+
+    // ErrKVProviderUnavailable: the inference channel is unreachable.
+    // The fork handler degrades to cold start.
+    ErrKVProviderUnavailable = errors.New("kv provider unavailable")
+
+    // ErrKVBlockNotFound: no KV block for this session+message combination.
+    // The fork handler degrades to cold start.
+    ErrKVBlockNotFound = errors.New("kv block not found")
+)
 ```
+
+### Ownership and lifecycle
+
+**Who defines the interface**: `internal/engine` owns the canonical
+`KVBlockHashProvider` interface definition. It lives alongside the fork handler, not
+in the provider package, so that the fork handler does not import the provider.
+
+**Who implements the interface**: RFC-0006's `internal/providers/vllm` package
+implements `KVBlockHashProvider` on its `KVCacheProvider` struct. No other provider
+in v0.5.0 implements the interface; all others degrade gracefully (see below).
+
+**Who creates the provider**: the kernel's provider registry at startup. The
+`KVCacheProvider` is registered into the provider registry by the vLLM provider
+init path. The fork handler obtains it via a registry lookup at fork time — it does
+not hold a long-lived reference to the provider instance.
+
+**Who calls the interface**: the fork handler in `toolForkSession`
+(`internal/engine/mcp_sessions.go`). The call happens exactly once per fork invocation,
+inside the fork transaction, before the `session.fork` CogBlock is written to the
+ledger.
+
+**Lifecycle**: the `KVBlockHashProvider` implementation is active for as long as the
+vLLM inference channel is registered in the provider registry. If the vLLM channel
+is removed (e.g. runtime restart, explicit unregister), the registry lookup returns
+nil and the fork handler degrades to cold start for the duration of the channel
+absence. No dangling references: the fork handler does not cache the provider pointer
+across calls.
+
+### Error semantics
+
+| Error returned                | Recoverable? | Fork handler action              |
+|-------------------------------|--------------|----------------------------------|
+| `ErrKVBlockEvicted`           | Yes          | Degrade to cold start; log warn  |
+| `ErrKVProviderUnavailable`    | Yes          | Degrade to cold start; log warn  |
+| `ErrKVBlockNotFound`          | Yes          | Degrade to cold start; log info  |
+| `nil` provider (no vLLM)      | Yes          | Degrade to cold start; no log    |
+| Any other non-nil error       | No (fatal)   | Abort fork; return error to caller |
+
+"Degrade to cold start" means: `KVCacheOverlay.ParentKVBlockHash` is set to `""` in
+the `session.fork` body; the child session starts without a KV warm-start hint. The
+fork itself succeeds; only the KV warm-start is lost.
+
+### Example invocation (fork handler)
+
+```go
+// Inside toolForkSession, after resolving the fork point and before writing
+// the session.fork CogBlock to the ledger:
+
+var kvBlockHash BlockHash
+if input.Overlay != nil && input.Overlay.KVCache != nil && input.Overlay.KVCache.InheritParentKV {
+    provider, ok := m.registry.LookupKVBlockHashProvider()
+    if ok {
+        hash, err := provider.ParentKVBlockHash(ctx, input.ParentSessionID, forkPoint.LastMessageID)
+        switch {
+        case err == nil:
+            kvBlockHash = hash
+        case errors.Is(err, ErrKVBlockEvicted),
+             errors.Is(err, ErrKVProviderUnavailable),
+             errors.Is(err, ErrKVBlockNotFound):
+            // Recoverable: proceed with cold start.
+            m.logger.Warn("kv block unavailable for fork; degrading to cold start",
+                "session", input.ParentSessionID,
+                "message", forkPoint.LastMessageID,
+                "err", err)
+        default:
+            // Fatal: surface to caller.
+            return nil, fmt.Errorf("fork aborted: KVBlockHashProvider error: %w", err)
+        }
+    }
+    // No provider registered: silent cold start (no log; expected when vLLM absent).
+}
+input.Overlay.KVCache.ParentKVBlockHash = string(kvBlockHash)
+```
+
+### Graceful degradation when provider is absent
+
+When no vLLM channel is registered (e.g. local dev with mlx-engine only), the
+provider registry returns `ok = false` from `LookupKVBlockHashProvider()`. The fork
+handler silently sets `ParentKVBlockHash = ""` and proceeds. The child session starts
+cold. This is the correct and expected behavior for all non-vLLM inference channels.
+
+The `KVCacheOverlay.InheritParentKV = true` field is accepted and written into the
+`session.fork` CogBlock regardless of provider availability — it records the caller's
+intent. The empty `ParentKVBlockHash` signals that the intent could not be satisfied
+at fork time.
 
 The vLLM provider (RFC-0006) implements this interface; the fork handler in
 `cog_fork_session` calls it. When no provider implementing `KVBlockHashProvider` is

--- a/docs/rfcs/0006-vllm-pagedattention-provider.md
+++ b/docs/rfcs/0006-vllm-pagedattention-provider.md
@@ -298,18 +298,86 @@ The vLLM provider implements the `KVBlockHashProvider` interface so that the
 hash when forking over a kvcache layer. RFC-0005 is the consumer; this RFC is the
 implementing provider.
 
+### Interface (canonical definition in `internal/engine`)
+
+The `KVBlockHashProvider` interface is defined in `internal/engine` (not in this
+provider package) so that the fork handler does not import `internal/providers/vllm`.
+The full interface specification — including `BlockHash` type, sentinel errors
+(`ErrKVBlockEvicted`, `ErrKVProviderUnavailable`, `ErrKVBlockNotFound`), ownership,
+lifecycle, error semantics table, and example fork-handler invocation — is in RFC-0005
+§"Cross-RFC integration: KVBlockHashProvider". This section describes the
+implementation side only.
+
+### Implementation: `KVCacheProvider.ParentKVBlockHash`
+
+`KVCacheProvider` (defined in `provider_vllm_cache.go`) implements `KVBlockHashProvider`
+by satisfying the interface contract:
+
 ```go
-// KVBlockHashProvider is implemented by inference providers that expose
-// a content-addressed KV-block layer (e.g., vLLM PagedAttention).
-// The fork-session handler queries this when forking over a kvcache layer
-// to obtain the parent's KV block hash.
-type KVBlockHashProvider interface {
-    // ParentKVBlockHash returns the hash of the KV block representing
-    // the session's KV state at the given message ID, or an error if
-    // the block is no longer addressable (evicted, runtime restarted).
-    ParentKVBlockHash(ctx context.Context, sessionID string, atMessageID string) (BlockHash, error)
+// ParentKVBlockHash implements engine.KVBlockHashProvider.
+// It queries the vLLM block manager via VLLMClient for the KV block
+// covering the token range up to atMessageID in sessionID.
+//
+// The method maps vLLM-internal errors to the sentinel errors defined
+// in internal/engine so the fork handler can apply its recovery policy
+// without importing this package.
+func (p *KVCacheProvider) ParentKVBlockHash(
+    ctx context.Context,
+    sessionID string,
+    atMessageID string,
+) (engine.BlockHash, error) {
+    // 1. Resolve the prompt prefix for this session up to atMessageID.
+    //    The session registry maps message IDs to their prompt prefix hash.
+    prefix, err := p.resolvePromptPrefix(ctx, sessionID, atMessageID)
+    if err != nil {
+        // Cannot resolve prefix: block not found.
+        return "", engine.ErrKVBlockNotFound
+    }
+
+    // 2. Ask the VLLMClient for the block hash for this prefix.
+    hash := p.client.BlockHashForPrompt(prefix, p.channelID, defaultSamplingConfig)
+
+    // 3. Verify the block is currently warm in the vLLM block manager.
+    warm, err := p.client.IsBlockWarm(ctx, hash)
+    if err != nil {
+        // VLLMClient unreachable.
+        return "", engine.ErrKVProviderUnavailable
+    }
+    if !warm {
+        // Block was computed but has been evicted.
+        return "", engine.ErrKVBlockEvicted
+    }
+
+    return engine.BlockHash(hash), nil
 }
 ```
+
+### VLLMClient extension for block warm-check
+
+The `VLLMClient` interface gains one method to support `ParentKVBlockHash`:
+
+```go
+// IsBlockWarm returns true if the block identified by blockHash is currently
+// resident in the vLLM block manager. Returns false (not an error) if the
+// block has been evicted; returns an error only on transport/runtime failure.
+IsBlockWarm(ctx context.Context, blockHash string) (bool, error)
+```
+
+`MockVLLMClient` implements this with a configurable warm-set for unit tests.
+
+### Registration in the provider registry
+
+The vLLM provider registers `KVCacheProvider` as a `KVBlockHashProvider` during
+channel init:
+
+```go
+// In internal/providers/vllm/provider_vllm.go, during channel registration:
+registry.RegisterKVBlockHashProvider(p.cache) // p.cache is *KVCacheProvider
+```
+
+The fork handler calls `registry.LookupKVBlockHashProvider()` at fork time. If the
+vLLM channel has not been initialized, the lookup returns `nil, false` and the fork
+handler degrades to cold start as specified in RFC-0005.
 
 The vLLM `VLLMClient` (cgo binding or Python sidecar) provides the block hash by
 querying `vllm.core.block_manager` for the block covering the given message's token


### PR DESCRIPTION
## Summary

Addresses the REQUIRES-CHANGES-FIRST blocking item from PR #227 (council review 2026-05-12) on RFC-0005 and RFC-0006.

**Council verdict**: the `KVBlockHashProvider` interface between the fork handler (RFC-0005) and the vLLM provider (RFC-0006) is unspecified — shape, ownership, error semantics.

**Fix**: Expanded the `KVBlockHashProvider` cross-RFC integration section in both RFC files. RFC-0005 carries the canonical specification (since `internal/engine` owns the interface definition); RFC-0006 carries the implementation contract.

RFC-0005 additions:
- Full interface signature with detailed parameter and return-value documentation.
- `BlockHash` type definition and three sentinel error vars (`ErrKVBlockEvicted`, `ErrKVProviderUnavailable`, `ErrKVBlockNotFound`).
- Ownership and lifecycle: who defines, who implements, who creates, who calls, lifecycle on channel deregistration.
- Error semantics table: recoverable vs fatal, fork handler action per error variant.
- Example fork-handler invocation showing the full switch/degrade pattern.
- Graceful degradation section: what happens when no vLLM channel is registered.

RFC-0006 additions:
- Cross-link to RFC-0005 as canonical interface definition (avoids duplication).
- `KVCacheProvider.ParentKVBlockHash` implementation skeleton showing prompt-prefix resolution, `BlockHashForPrompt` call, `IsBlockWarm` verification, and sentinel error mapping.
- `IsBlockWarm` extension method added to `VLLMClient` interface with `MockVLLMClient` note.
- Provider registry registration pattern: how `KVCacheProvider` is registered as a `KVBlockHashProvider` and how the fork handler looks it up.

## Files touched

- `docs/rfcs/0005-cog-fork-session.md`
- `docs/rfcs/0006-vllm-pagedattention-provider.md`

## Council reference

PR #227, seat verdict: REQUIRES-CHANGES-FIRST — "KVBlockHashProvider interface between fork handler and vLLM provider is unspecified."