### PR TITLE
fix(context-blocks): use BaseFovea for chat-read view to drop inbox-raw boost

### DIFF
--- a/internal/engine/context_blocks.go
+++ b/internal/engine/context_blocks.go
@@ -76,7 +76,8 @@ func buildFieldBlock(process *Process, workspaceRoot string) *ContextBlock {
 	if field == nil {
 		return nil
 	}
-	fovea := field.Fovea(10)
+	// chat-read view: no inbox-raw boost (see field.go BaseFovea vs Fovea)
+	fovea := field.BaseFovea(10)
 	if len(fovea) == 0 {
 		return nil
 	}


### PR DESCRIPTION
The observer-view Fovea() applies an inbox-raw boost (+0.5) to cogdocs
under /inbox/ with status: raw. The chat-read view (buildFieldBlock)
should use BaseFovea() per the design comment at field.go:283-288.

Today's smoke test (2026-05-14) confirmed that 5-9 chatgpt-archive
cogdocs were surfacing at salience 0.916/0.792 in the Active Attention
surface for queries with no lexical overlap with their content.
Root cause: wrong method called at the call site.

The structural follow-up (sector relocation of inbox/conversations/chatgpt)
is deferred per the operator decision today.