### PR TITLE
spec(rfc-0005,rfc-0006): A4 council follow-up amendments

### DIFF
--- a/docs/rfcs/0005-cog-fork-session.md
+++ b/docs/rfcs/0005-cog-fork-session.md
@@ -541,17 +541,26 @@ the session-management surface without additional kernel changes.
       adding the `session.fork` Kind requires no modification to Kind-handler switch
       statements; the Kind infrastructure dispatches via registry, not switch.
 - [ ] `cog_fork_session` MCP tool registered and functional.
+- [ ] `cog_fork_disown` MCP tool registered and functional: accepts `child_session_id`,
+      removes the child's GC root on the parent in `ForkRegistry`, returns
+      `{"status": "disowned", "child_session_id": "<id>"}`. Must be nil-safe when
+      `ForkRegistry` is not wired (returns a clean "not configured" error).
 - [ ] `POST /v1/sessions/{id}/fork` HTTP endpoint wired.
 - [ ] `ForkChildren` and `ForkAncestors` projection functions implemented.
 - [ ] `/btw` consumer skill committed to the cog-workspace skills directory.
 - [ ] Unit tests cover: fork creation, overlay merge, GC eligibility calculation,
       lineage projection (parent→children, child→ancestors).
+- [ ] Unit test for `cog_fork_disown`: disown removes GC root; parent becomes
+      GC-eligible immediately when no other child holds a reference and no
+      `PinnedUntil` is active; child's `session.fork` CogBlock remains readable.
 - [ ] Cross-workspace fork returns `501 Not Implemented`.
 - [ ] Integration test: fork a session, resume child, verify lineage projection.
-- [ ] All `cog_fork_session` operations emit structured logs per the kernel log
-      convention with fields: `operation` (=`fork`), `parent_session_id`,
-      `child_session_id`, `overlay_layers` (comma-separated), `ts`. Ledger-walk
-      projection tools follow the same convention.
+- [ ] Integration test: fork a session, call `cog_fork_disown`, verify parent GC
+      eligibility without requiring retention window expiry.
+- [ ] All `cog_fork_session` and `cog_fork_disown` operations emit structured logs
+      per the kernel log convention with fields: `operation` (=`fork` or `disown`),
+      `parent_session_id`, `child_session_id`, `overlay_layers` (comma-separated,
+      fork only), `ts`. Ledger-walk projection tools follow the same convention.
 
 ## Future scope (post-v0.5.0)
 

--- a/docs/rfcs/0006-vllm-pagedattention-provider.md
+++ b/docs/rfcs/0006-vllm-pagedattention-provider.md
@@ -367,17 +367,25 @@ IsBlockWarm(ctx context.Context, blockHash string) (bool, error)
 
 ### Registration in the provider registry
 
-The vLLM provider registers `KVCacheProvider` as a `KVBlockHashProvider` during
-channel init:
+The vLLM provider wires `KVCacheProvider` into `MCPServer` as a `KVBlockHashProvider`
+during channel init. The binding is a direct field assignment on `MCPServer`, not a
+separate registry object — `MCPServer.kvBlockHashProvider` is the single provider slot:
 
 ```go
-// In internal/providers/vllm/provider_vllm.go, during channel registration:
-registry.RegisterKVBlockHashProvider(p.cache) // p.cache is *KVCacheProvider
+// In the kernel startup path (e.g. cmd/cogos or serve_kernel.go), after
+// the vLLM provider channel is initialized:
+mcpServer.kvBlockHashProvider = vllmProvider.cache // *KVCacheProvider implements KVBlockHashProvider
 ```
 
-The fork handler calls `registry.LookupKVBlockHashProvider()` at fork time. If the
-vLLM channel has not been initialized, the lookup returns `nil, false` and the fork
-handler degrades to cold start as specified in RFC-0005.
+The fork handler reads `m.kvBlockHashProvider` directly at fork time. If the field is
+`nil` (vLLM channel not initialized), the fork handler degrades to cold start as
+specified in RFC-0005. There is no `RegisterKVBlockHashProvider` /
+`LookupKVBlockHashProvider` registry method pair; the field is the registry.
+
+> **Implementation note:** the field is unexported (`kvBlockHashProvider`) and
+> typed to the `engine.KVBlockHashProvider` interface defined in
+> `internal/engine/session_fork_types.go`. The vLLM package satisfies it via
+> `KVCacheProvider.ParentKVBlockHash`.
 
 The vLLM `VLLMClient` (cgo binding or Python sidecar) provides the block hash by
 querying `vllm.core.block_manager` for the block covering the given message's token


### PR DESCRIPTION
## Summary

- **RFC-0005**: Add `cog_fork_disown` to acceptance criteria — tool registration, nil-safe `ForkRegistry` guard, unit test for GC root release on disown, integration test verifying parent GC eligibility without waiting for retention window expiry. Logging criterion updated to include `operation=disown`.
- **RFC-0006**: Correct registry method signatures. Replace the fictional `registry.RegisterKVBlockHashProvider()` / `registry.LookupKVBlockHashProvider()` method pair with the actual implementation: a direct `kvBlockHashProvider` field on `MCPServer` (typed to `engine.KVBlockHashProvider`, defined in `internal/engine/session_fork_types.go`). The field is the registry; there is no separate registry object.

Both amendments follow A4 council notes. RFC-0005 tracks fork-GC work from commits 6fd1b0d and d89f6d6. RFC-0006 aligns spec text with the implementation that landed in #229.

## Test plan

- [ ] `grep -n "cog_fork_disown" docs/rfcs/0005-cog-fork-session.md` — should appear in acceptance criteria section
- [ ] `grep -n "RegisterKVBlockHashProvider\|LookupKVBlockHashProvider" docs/rfcs/0006-vllm-pagedattention-provider.md` — should return no results
- [ ] `grep -n "kvBlockHashProvider\|MCPServer" docs/rfcs/0006-vllm-pagedattention-provider.md` — should show the corrected field-based wiring in the registration section
- [ ] RFC YAML frontmatter (if any) parses cleanly — these files are Markdown with no YAML block, so no YAML validation needed