### PR TITLE
feat(kernel): add GET /v1/hud/state endpoint for Claude Code HUD hook

### DIFF
--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -8,6 +8,7 @@
 //	POST /v1/chat/completions              — OpenAI-compatible chat (streaming + non-streaming)
 //	POST /v1/messages                      — Anthropic Messages-compatible chat
 //	POST /v1/context/foveated              — foveated context assembly for Claude Code hook
+//	GET  /v1/hud/state                     — compact kernel state snapshot for Claude Code HUD hook
 //	GET  /v1/proprioceptive                — last 50 proprioceptive log entries + light cone status
 //	GET  /v1/ledger                        — query the hash-chained event ledger
 //	GET  /v1/lightcone                     — light cone metadata (placeholder)
@@ -172,6 +173,7 @@ func NewServer(cfg *Config, nucleus *Nucleus, process *Process) *Server {
 	s.route(mux, "PATCH /v1/settings/context", s.handlePatchContextSettings)
 	s.route(mux, "POST /v1/chat/completions", s.handleChat)
 	s.route(mux, "POST /v1/messages", s.handleAnthropicMessages)
+	s.route(mux, "GET /v1/hud/state", s.handleHUDState)
 	s.route(mux, "GET /v1/proprioceptive", s.handleProprioceptive)
 	s.route(mux, "GET /v1/ledger", s.handleLedger)
 	s.route(mux, "GET /v1/traces", s.handleTraces)

--- a/internal/engine/serve_hud.go
+++ b/internal/engine/serve_hud.go
@@ -1,0 +1,154 @@
+// serve_hud.go — GET /v1/hud/state
+//
+// Returns a compact, structured snapshot of kernel state for the Claude Code
+// UserPromptSubmit HUD hook. Designed to be cheap (<50ms, no inference) and
+// consumed by the hook script in cog-workspace every prompt turn.
+//
+//	GET /v1/hud/state
+//	200 → HUDState JSON (see type below)
+//
+// Fields:
+//   - identity: node id, nucleus name, trust score
+//   - sessions: active foveated-context sessions (from SessionContextStore)
+//   - recent_uris: top-N fovea entries from the attentional field
+//   - node_health: per-service health from the last probe
+//   - kernel: state, version, workspace root, started_at
+//
+// All fields degrade gracefully to zero values when the underlying data is
+// unavailable (nil nucleus, no sessions, empty field). The hook caller must
+// not assume any field is non-nil.
+package engine
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+// HUDState is the response shape for GET /v1/hud/state.
+type HUDState struct {
+	// Identity reports which node this is and which seat (nucleus) is active.
+	Identity HUDIdentity `json:"identity"`
+
+	// Sessions lists all foveated-context sessions the kernel has seen.
+	Sessions []HUDSession `json:"sessions"`
+
+	// RecentURIs are the top attentional-field entries — the paths most
+	// recently in the kernel's fovea. Up to 10 entries, ordered by score.
+	RecentURIs []HUDURI `json:"recent_uris"`
+
+	// NodeHealth reports the last-probed status of sibling services.
+	// Map key is service name (e.g. "mod3", "cogos").
+	NodeHealth map[string]string `json:"node_health"`
+
+	// Kernel reports operational state of the running kernel.
+	Kernel HUDKernel `json:"kernel"`
+
+	// Timestamp is when this snapshot was taken.
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// HUDIdentity captures the node's identity at snapshot time.
+type HUDIdentity struct {
+	NodeID    string  `json:"node_id"`
+	Name      string  `json:"name,omitempty"`       // nucleus name (seat)
+	TrustScore float64 `json:"trust_score,omitempty"` // local trust score [0,1]
+}
+
+// HUDSession summarises one active foveated-context session.
+type HUDSession struct {
+	SessionID    string    `json:"session_id"`
+	Profile      string    `json:"profile"`
+	TurnNumber   int       `json:"turn_number"`
+	IrisPressure float64   `json:"iris_pressure"` // context-window fill [0,1]
+	TotalTokens  int       `json:"total_tokens"`
+	LastRequestAt time.Time `json:"last_request_at"`
+}
+
+// HUDUriEntry is one entry from the attentional field fovea.
+type HUDURI struct {
+	Path  string  `json:"path"`
+	Score float64 `json:"score"`
+}
+
+// HUDKernel reports kernel operational state.
+type HUDKernel struct {
+	State         string    `json:"state"`
+	Version       string    `json:"version"`
+	WorkspaceRoot string    `json:"workspace_root"`
+	StartedAt     time.Time `json:"started_at"`
+}
+
+// handleHUDState serves GET /v1/hud/state.
+//
+// All reads are lock-free where possible (Snapshot() methods return copies).
+// No inference, no disk I/O. Target: <50ms wall time.
+func (s *Server) handleHUDState(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	now := time.Now().UTC()
+
+	// Identity block.
+	identity := HUDIdentity{
+		NodeID: s.process.NodeID,
+	}
+	if s.nucleus != nil {
+		s.nucleus.mu.RLock()
+		identity.Name = s.nucleus.Name
+		s.nucleus.mu.RUnlock()
+	}
+	trust := s.process.TrustSnapshot()
+	identity.TrustScore = trust.LocalScore
+
+	// Active foveated-context sessions.
+	sessionSnap := s.sessions.Snapshot()
+	sessions := make([]HUDSession, 0, len(sessionSnap))
+	for _, st := range sessionSnap {
+		sessions = append(sessions, HUDSession{
+			SessionID:     st.SessionID,
+			Profile:       st.Profile,
+			TurnNumber:    st.TurnNumber,
+			IrisPressure:  st.IrisPressure,
+			TotalTokens:   st.TotalTokens,
+			LastRequestAt: st.LastRequestAt,
+		})
+	}
+
+	// Recent URIs from the attentional field fovea (top 10).
+	foveaEntries := s.process.Field().Fovea(10)
+	recentURIs := make([]HUDURI, 0, len(foveaEntries))
+	for _, fs := range foveaEntries {
+		recentURIs = append(recentURIs, HUDURI{
+			Path:  fs.Path,
+			Score: fs.Score,
+		})
+	}
+
+	// Node health summary.
+	var nodeHealth map[string]string
+	if nh := s.process.NodeHealth(); nh != nil {
+		nodeHealth = nh.Summary()
+	}
+	if nodeHealth == nil {
+		nodeHealth = map[string]string{}
+	}
+
+	// Kernel state.
+	kernel := HUDKernel{
+		State:         s.process.State().String(),
+		Version:       Version,
+		WorkspaceRoot: s.cfg.WorkspaceRoot,
+		StartedAt:     s.process.StartedAt(),
+	}
+
+	resp := HUDState{
+		Identity:   identity,
+		Sessions:   sessions,
+		RecentURIs: recentURIs,
+		NodeHealth: nodeHealth,
+		Kernel:     kernel,
+		Timestamp:  now,
+	}
+
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/internal/engine/serve_hud_test.go
+++ b/internal/engine/serve_hud_test.go
@@ -1,0 +1,101 @@
+package engine
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestHandleHUDState verifies that GET /v1/hud/state returns 200 with the
+// expected top-level fields and requires no inference calls.
+func TestHandleHUDState(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/hud/state", nil)
+	w := httptest.NewRecorder()
+
+	srv.handleHUDState(w, req)
+
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var hud HUDState
+	if err := json.NewDecoder(resp.Body).Decode(&hud); err != nil {
+		t.Fatalf("decode HUDState: %v", err)
+	}
+
+	// Identity must include a node_id.
+	if hud.Identity.NodeID == "" {
+		t.Error("expected non-empty identity.node_id")
+	}
+
+	// Sessions and RecentURIs should at least be non-nil slices.
+	if hud.Sessions == nil {
+		t.Error("expected non-nil sessions slice")
+	}
+	if hud.RecentURIs == nil {
+		t.Error("expected non-nil recent_uris slice")
+	}
+
+	// NodeHealth should be a non-nil map.
+	if hud.NodeHealth == nil {
+		t.Error("expected non-nil node_health map")
+	}
+
+	// Kernel state must be non-empty.
+	if hud.Kernel.State == "" {
+		t.Error("expected non-empty kernel.state")
+	}
+	if hud.Kernel.Version == "" {
+		t.Error("expected non-empty kernel.version")
+	}
+
+	// Timestamp must be set.
+	if hud.Timestamp.IsZero() {
+		t.Error("expected non-zero timestamp")
+	}
+
+	t.Logf("HUDState: node_id=%s state=%s sessions=%d uris=%d",
+		hud.Identity.NodeID, hud.Kernel.State, len(hud.Sessions), len(hud.RecentURIs))
+}
+
+// TestHandleHUDStateRegistered confirms the route appears in the httpRoutes manifest.
+func TestHandleHUDStateRegistered(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(t)
+
+	found := false
+	for _, r := range srv.httpRoutes {
+		if r.Path == "/v1/hud/state" && r.Method == "GET" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("GET /v1/hud/state not found in srv.httpRoutes — route not registered")
+	}
+}
+
+// TestHandleHUDStateContentType verifies the response sets Content-Type: application/json.
+func TestHandleHUDStateContentType(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/v1/hud/state", nil)
+	w := httptest.NewRecorder()
+
+	srv.handleHUDState(w, req)
+
+	ct := w.Header().Get("Content-Type")
+	if ct != "application/json" {
+		t.Errorf("Content-Type = %q; want application/json", ct)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `GET /v1/hud/state` in `internal/engine/serve_hud.go` — new handler on the existing kernel HTTP surface
- Returns a compact, structured kernel snapshot: identity (node_id, nucleus name, trust score), active foveated-context sessions, top-10 attentional field URIs, per-service node health, and kernel operational state
- Wired via `s.route(mux, "GET /v1/hud/state", s.handleHUDState)` in `serve.go`, registered in the `/v1/manifest` self-description
- Designed to be cheap: no inference, no disk I/O, all reads from in-memory state (Snapshot() copies). Target <50ms

Depends on: nothing — purely additive endpoint.

Companion PR: cog-workspace `feat/hud-hook` adds the UserPromptSubmit hook that calls this endpoint.

## Test plan

- [ ] `go test ./internal/engine/ -run TestHandleHUDState` — 3 unit tests pass (response shape, Content-Type, route registration)
- [ ] `curl http://localhost:6931/v1/hud/state | jq .` on a running kernel returns expected JSON fields
- [ ] Full engine test suite passes: `go test ./internal/engine/ -timeout 120s`