### PR TITLE
feat(inference): core inference model contract — N-tier resolver with default Haiku-via-Max

### DIFF
--- a/internal/engine/config.go
+++ b/internal/engine/config.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/myrgic/cogos/internal/engine/inference"
 )
 
 // Default context-gating knobs for the foveated assembler.
@@ -154,6 +156,11 @@ type Config struct {
 	LocalModel string
 
 	localModelConfigured bool
+
+	// CoreInference is the node's declared N-tier inference contract.
+	// Loaded from .cog/config/core-inference.yaml; falls back to
+	// inference.DefaultCoreInferenceConfig() if the file is absent.
+	CoreInference inference.CoreInferenceConfig
 }
 
 // kernelConfigSection holds settings that can appear at the top level or inside v3:.
@@ -180,6 +187,10 @@ type kernelConfigSection struct {
 	DigestPaths           map[string]string `yaml:"digest_paths"`
 	KernelLogPath         string            `yaml:"kernel_log_path"`
 	Mod3URL               string            `yaml:"mod3_url"`
+	// CoreInferencePath is an optional override for the core-inference.yaml file path.
+	// When empty, LoadConfig uses workspaceRoot/.cog/config/core-inference.yaml.
+	// Reserved for future use — not yet wired into the loader.
+	CoreInferencePath string `yaml:"core_inference_path,omitempty"`
 }
 
 // kernelConfig is the on-disk YAML shape of .cog/config/kernel.yaml.
@@ -239,6 +250,14 @@ func LoadConfig(workspaceRoot string, port int) (*Config, error) {
 	if v := os.Getenv("COGOS_MOD3_URL"); v != "" {
 		cfg.Mod3URL = v
 	}
+
+	// Load core inference contract. Non-fatal: falls back to default if absent.
+	ci, ciErr := inference.LoadCoreInferenceConfig(workspaceRoot)
+	if ciErr != nil {
+		// File exists but is unreadable or unparseable — use default and continue.
+		ci = inference.DefaultCoreInferenceConfig()
+	}
+	cfg.CoreInference = ci
 
 	// Flag override.
 	if port != 0 {

--- a/internal/engine/inference/contract.go
+++ b/internal/engine/inference/contract.go
@@ -1,0 +1,133 @@
+// Package inference implements the core inference model contract for CogOS kernel
+// autonomic operations.
+//
+// The contract declares an ordered N-tier ladder of inference resources. Each tier
+// specifies a kind (local/external/claude-code), a model, and the autonomic operation
+// roles it serves. The Resolver walks the ladder in order and returns the first
+// available provider that satisfies a requested role.
+//
+// Default configuration (lowest friction):
+//
+//	Tier 0: Haiku via claude-code provider (Max subscription) — zero infrastructure,
+//	        works immediately on any authenticated Claude Code install.
+//	Tier 1: local Ollama gemma4:e4b (kept-warm) — VRAM-committed, zero cold-start
+//	        when kept warm, but subject to the 90s kernel cycle budget vs 110s cold-start gap.
+//
+// The contract abstracts tier shape from the autonomic logic: the kernel declares
+// what role it needs; the resolver decides which tier satisfies it.
+//
+// Substrate refs:
+//   - feedback_node_core_inference_model_contract.md — N-tier ladder spec
+//   - feedback_claude_max_subscription_only.md — claude-code provider is canonical external path
+//   - feedback_substrate_eval_constraints.md — 90s cycle budget, 110s cold-start
+//   - feedback_models_always_swappable.md — model is parameter, not hardcoded
+package inference
+
+// TierKind identifies the shape of an inference tier.
+type TierKind string
+
+const (
+	// TierKeptWarmLocal is a local model (e.g. Ollama gemma4:e4b) kept resident in VRAM.
+	// Cost: persistent VRAM + Ollama process. Benefit: zero cold-start, deterministic latency.
+	TierKeptWarmLocal TierKind = "kept-warm-local"
+
+	// TierWarmWithColdStart is a local model that may be evicted under memory pressure,
+	// but with a documented cold-start ceiling so callers can budget appropriately.
+	// Note: the current 90s localHarnessCycleTimeout is shorter than gemma4's ~110s cold-start
+	// on M4 Pro — operators must pre-warm or use TierClaudeCodeProvider as fallback.
+	TierWarmWithColdStart TierKind = "warm-with-cold-start"
+
+	// TierExternalSelfHosted is a self-hosted inference endpoint (vLLM, mlx-lm, LM Studio).
+	// Cost: separate infrastructure. Benefit: no local VRAM cost on the kernel node.
+	TierExternalSelfHosted TierKind = "external-self-hosted"
+
+	// TierClaudeCodeProvider routes through the claude-code provider (claude -p subprocess)
+	// using the operator's Claude Max subscription. Zero incremental cost for Max subscribers.
+	// Zero infrastructure burden — works the moment Claude Code is installed and authenticated.
+	TierClaudeCodeProvider TierKind = "claude-code"
+)
+
+// TierProfile declares one rung of the N-tier inference ladder.
+type TierProfile struct {
+	// Kind identifies the provider shape.
+	Kind TierKind `yaml:"kind"`
+
+	// Name is a human-readable label, e.g. "local-gemma4", "haiku-via-max".
+	// Used in resolver logs and diagnostics.
+	Name string `yaml:"name"`
+
+	// Model is the model identifier passed to the provider (e.g. "gemma4:e4b", "haiku").
+	// For claude-code tiers: "haiku", "sonnet", "opus".
+	Model string `yaml:"model"`
+
+	// Endpoint is the inference endpoint URL for local or self-hosted tiers.
+	// Empty for TierClaudeCodeProvider (the claude binary handles routing).
+	Endpoint string `yaml:"endpoint,omitempty"`
+
+	// ColdStartCeilingSeconds documents the maximum cold-start latency for TierWarmWithColdStart.
+	// 0 means not applicable (tier is always warm or network-latency-bound).
+	ColdStartCeilingSeconds int `yaml:"cold_start_ceiling_seconds,omitempty"`
+
+	// MaxTimeoutSeconds overrides the kernel dispatch timeout for calls routed through this tier.
+	// 0 means use the kernel default (localHarnessCycleTimeout = 90s).
+	// Set this to ≥ ColdStartCeilingSeconds for TierWarmWithColdStart tiers.
+	MaxTimeoutSeconds int `yaml:"max_timeout_seconds,omitempty"`
+
+	// Roles is the list of autonomic operation roles this tier serves.
+	// When empty, the tier matches any role (universal fallback).
+	// Example role names: "autonomic", "metabolic", "abstract-generation",
+	// "foveal-scoring", "reconcilable-observer".
+	Roles []string `yaml:"roles,omitempty"`
+}
+
+// CoreInferenceConfig is the node's declared inference contract.
+//
+// It is loaded from .cog/config/core-inference.yaml. If that file is absent,
+// DefaultCoreInferenceConfig() is used.
+type CoreInferenceConfig struct {
+	// Tiers is the ordered N-tier ladder. Index 0 is the preferred tier (lowest cost,
+	// highest availability for the operator profile). The Resolver walks this in order,
+	// selecting the first available tier that matches the requested role.
+	Tiers []TierProfile `yaml:"tiers"`
+
+	// DefaultRole is the role assumed when Resolve is called with an empty role string.
+	DefaultRole string `yaml:"default_role,omitempty"`
+}
+
+// DefaultCoreInferenceConfig returns the recommended default configuration.
+//
+// Default stack for a Max-subscriber node:
+//   - Tier 0: Haiku via claude-code (lowest friction — works immediately)
+//   - Tier 1: local Ollama gemma4:e4b (for operators who have it running)
+//
+// This is the "stupid easy" path: the operator only needs Claude Code installed
+// and authenticated. No Ollama setup, no model downloads, no VRAM management required
+// for the default to work. Tier 1 is additive for operators who prefer local inference.
+func DefaultCoreInferenceConfig() CoreInferenceConfig {
+	return CoreInferenceConfig{
+		DefaultRole: "autonomic",
+		Tiers: []TierProfile{
+			{
+				Kind:  TierClaudeCodeProvider,
+				Name:  "haiku-via-max",
+				Model: "haiku",
+				// 90s matches the kernel's localHarnessCycleTimeout ceiling.
+				// Network RTT is well under 90s; this budget is for the full
+				// round-trip including model generation.
+				MaxTimeoutSeconds: 90,
+				Roles:             []string{"autonomic", "abstract-generation", "metabolic", "reconcilable-observer"},
+			},
+			{
+				Kind:     TierKeptWarmLocal,
+				Name:     "local-gemma4",
+				Model:    "gemma4:e4b",
+				Endpoint: "http://localhost:11434",
+				// 90s matches localHarnessCycleTimeout. Cold-start on M4 Pro is ~110s
+				// (exceeds this budget) — operators using this tier must pre-warm gemma4
+				// or accept cold-start failures. See feedback_substrate_eval_constraints.md.
+				MaxTimeoutSeconds: 90,
+				Roles:             []string{"autonomic", "foveal-scoring"},
+			},
+		},
+	}
+}

--- a/internal/engine/inference/contract_test.go
+++ b/internal/engine/inference/contract_test.go
@@ -1,0 +1,200 @@
+package inference
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// testProvider is a minimal stub satisfying ProviderLike for resolver tests.
+type testProvider struct {
+	name      string
+	model     string
+	available bool
+}
+
+func (p *testProvider) Name() string                        { return p.name }
+func (p *testProvider) Model() string                       { return p.model }
+func (p *testProvider) Available(_ context.Context) bool    { return p.available }
+
+// --- DefaultCoreInferenceConfig tests ---
+
+func TestDefaultCoreInferenceConfig(t *testing.T) {
+	cfg := DefaultCoreInferenceConfig()
+
+	if len(cfg.Tiers) < 1 {
+		t.Fatalf("expected at least 1 tier, got 0")
+	}
+	if cfg.Tiers[0].Kind != TierClaudeCodeProvider {
+		t.Errorf("tier 0 kind: want %q, got %q", TierClaudeCodeProvider, cfg.Tiers[0].Kind)
+	}
+	if cfg.DefaultRole == "" {
+		t.Error("DefaultRole must not be empty")
+	}
+	if cfg.Tiers[0].Model == "" {
+		t.Error("tier 0 Model must not be empty")
+	}
+}
+
+// --- Resolver tests ---
+
+func TestResolveClaudeCodeAvailable(t *testing.T) {
+	claude := &testProvider{name: "claude", model: "haiku", available: true}
+	providers := map[string]ProviderLike{"claude": claude}
+
+	r := NewResolver(DefaultCoreInferenceConfig(), providers)
+	p, tierName, err := r.Resolve(context.Background(), "autonomic")
+	if err != nil {
+		t.Fatalf("Resolve: unexpected error: %v", err)
+	}
+	if p == nil {
+		t.Fatal("Resolve: expected non-nil provider")
+	}
+	if p.Name() != "claude" {
+		t.Errorf("expected provider name 'claude', got %q", p.Name())
+	}
+	if tierName != "haiku-via-max" {
+		t.Errorf("expected tier name 'haiku-via-max', got %q", tierName)
+	}
+}
+
+func TestResolveFallsThrough(t *testing.T) {
+	// claude unavailable, ollama available — should fall through to tier 1
+	claude := &testProvider{name: "claude", model: "haiku", available: false}
+	ollama := &testProvider{name: "ollama", model: "gemma4:e4b", available: true}
+	providers := map[string]ProviderLike{"claude": claude, "ollama": ollama}
+
+	r := NewResolver(DefaultCoreInferenceConfig(), providers)
+	p, tierName, err := r.Resolve(context.Background(), "autonomic")
+	if err != nil {
+		t.Fatalf("Resolve: unexpected error: %v", err)
+	}
+	if p.Name() != "ollama" {
+		t.Errorf("expected fallback to 'ollama', got %q", p.Name())
+	}
+	if tierName != "local-gemma4" {
+		t.Errorf("expected tier name 'local-gemma4', got %q", tierName)
+	}
+}
+
+func TestResolveNoTiersAvailable(t *testing.T) {
+	claude := &testProvider{name: "claude", model: "haiku", available: false}
+	ollama := &testProvider{name: "ollama", model: "gemma4:e4b", available: false}
+	providers := map[string]ProviderLike{"claude": claude, "ollama": ollama}
+
+	r := NewResolver(DefaultCoreInferenceConfig(), providers)
+	_, _, err := r.Resolve(context.Background(), "autonomic")
+	if err == nil {
+		t.Fatal("expected error when no tiers available, got nil")
+	}
+}
+
+func TestResolveEmptyRoleUsesDefault(t *testing.T) {
+	claude := &testProvider{name: "claude", model: "haiku", available: true}
+	providers := map[string]ProviderLike{"claude": claude}
+
+	r := NewResolver(DefaultCoreInferenceConfig(), providers)
+	// empty role → should use DefaultRole = "autonomic"
+	p, _, err := r.Resolve(context.Background(), "")
+	if err != nil {
+		t.Fatalf("Resolve with empty role: unexpected error: %v", err)
+	}
+	if p == nil {
+		t.Fatal("expected non-nil provider for empty role")
+	}
+}
+
+func TestResolveRoleNotServedByTier(t *testing.T) {
+	// "foveal-scoring" is only in tier 1 (local-gemma4); tier 0 (claude) doesn't serve it.
+	// With only claude available (and ollama unavailable), resolve should fail.
+	claude := &testProvider{name: "claude", model: "haiku", available: true}
+	ollama := &testProvider{name: "ollama", model: "gemma4:e4b", available: false}
+	providers := map[string]ProviderLike{"claude": claude, "ollama": ollama}
+
+	r := NewResolver(DefaultCoreInferenceConfig(), providers)
+	_, _, err := r.Resolve(context.Background(), "foveal-scoring")
+	if err == nil {
+		t.Fatal("expected error: claude tier does not serve foveal-scoring and ollama is unavailable")
+	}
+}
+
+// --- LoadCoreInferenceConfig tests ---
+
+func TestLoadCoreInferenceConfigMissing(t *testing.T) {
+	// A directory that definitely has no .cog/config/core-inference.yaml
+	cfg, err := LoadCoreInferenceConfig("/tmp/no-such-dir-cogos-test-xyz")
+	if err != nil {
+		t.Fatalf("expected no error for missing config, got: %v", err)
+	}
+	// Should return the default
+	if len(cfg.Tiers) == 0 {
+		t.Error("expected default tiers from missing config")
+	}
+	if cfg.Tiers[0].Kind != TierClaudeCodeProvider {
+		t.Errorf("expected default tier 0 to be claude-code, got %q", cfg.Tiers[0].Kind)
+	}
+}
+
+func TestLoadCoreInferenceConfigValid(t *testing.T) {
+	dir := t.TempDir()
+	cogDir := filepath.Join(dir, ".cog", "config")
+	if err := os.MkdirAll(cogDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	yaml := `tiers:
+  - kind: claude-code
+    name: haiku-custom
+    model: haiku
+    max_timeout_seconds: 60
+    roles:
+      - autonomic
+      - abstract-generation
+default_role: autonomic
+`
+	if err := os.WriteFile(filepath.Join(cogDir, "core-inference.yaml"), []byte(yaml), 0644); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	cfg, err := LoadCoreInferenceConfig(dir)
+	if err != nil {
+		t.Fatalf("LoadCoreInferenceConfig: unexpected error: %v", err)
+	}
+	if len(cfg.Tiers) != 1 {
+		t.Fatalf("expected 1 tier, got %d", len(cfg.Tiers))
+	}
+	if cfg.Tiers[0].Kind != TierClaudeCodeProvider {
+		t.Errorf("tier kind: want %q, got %q", TierClaudeCodeProvider, cfg.Tiers[0].Kind)
+	}
+	if cfg.Tiers[0].Name != "haiku-custom" {
+		t.Errorf("tier name: want 'haiku-custom', got %q", cfg.Tiers[0].Name)
+	}
+	if cfg.DefaultRole != "autonomic" {
+		t.Errorf("default role: want 'autonomic', got %q", cfg.DefaultRole)
+	}
+}
+
+func TestLoadCoreInferenceConfigEmptyTiers(t *testing.T) {
+	// A file with valid YAML but no tiers should fall back to default.
+	dir := t.TempDir()
+	cogDir := filepath.Join(dir, ".cog", "config")
+	if err := os.MkdirAll(cogDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	yaml := `default_role: autonomic
+tiers: []
+`
+	if err := os.WriteFile(filepath.Join(cogDir, "core-inference.yaml"), []byte(yaml), 0644); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	cfg, err := LoadCoreInferenceConfig(dir)
+	if err != nil {
+		t.Fatalf("LoadCoreInferenceConfig: unexpected error: %v", err)
+	}
+	// Empty tiers → default
+	if cfg.Tiers[0].Kind != TierClaudeCodeProvider {
+		t.Errorf("expected default tier 0 to be claude-code, got %q", cfg.Tiers[0].Kind)
+	}
+}

--- a/internal/engine/inference/loader.go
+++ b/internal/engine/inference/loader.go
@@ -1,0 +1,53 @@
+package inference
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// coreInferenceConfigFile is the canonical path relative to workspaceRoot.
+const coreInferenceConfigFile = ".cog/config/core-inference.yaml"
+
+// coreInferenceYAML is the on-disk YAML shape. It wraps CoreInferenceConfig
+// directly, since the file contains the contract fields at the top level.
+type coreInferenceYAML struct {
+	Tiers       []TierProfile `yaml:"tiers"`
+	DefaultRole string        `yaml:"default_role,omitempty"`
+}
+
+// LoadCoreInferenceConfig reads the core inference contract from
+// workspaceRoot/.cog/config/core-inference.yaml.
+//
+// If the file is absent, DefaultCoreInferenceConfig() is returned with no error.
+// If the file is present but Tiers is empty after parsing, DefaultCoreInferenceConfig()
+// is returned (guards against an empty/stub config file).
+// Any other read or parse error is returned as-is.
+func LoadCoreInferenceConfig(workspaceRoot string) (CoreInferenceConfig, error) {
+	path := filepath.Join(workspaceRoot, coreInferenceConfigFile)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return DefaultCoreInferenceConfig(), nil
+		}
+		return CoreInferenceConfig{}, fmt.Errorf("load core-inference.yaml: %w", err)
+	}
+
+	var raw coreInferenceYAML
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return CoreInferenceConfig{}, fmt.Errorf("parse core-inference.yaml: %w", err)
+	}
+
+	if len(raw.Tiers) == 0 {
+		// File exists but contains no tiers — treat as absent.
+		return DefaultCoreInferenceConfig(), nil
+	}
+
+	return CoreInferenceConfig{
+		Tiers:       raw.Tiers,
+		DefaultRole: raw.DefaultRole,
+	}, nil
+}

--- a/internal/engine/inference/resolver.go
+++ b/internal/engine/inference/resolver.go
@@ -1,0 +1,150 @@
+package inference
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+// ProviderLike is the subset of the engine.Provider interface that the Resolver
+// requires. It is defined here (rather than importing internal/engine) to avoid
+// a circular import — the inference package lives under internal/engine/ but
+// must not import its parent package.
+//
+// engine.Provider is a superset of ProviderLike; all engine.Provider values
+// satisfy this interface and can be passed directly to NewResolver.
+type ProviderLike interface {
+	// Name returns the provider identifier (e.g. "ollama", "claude-code").
+	Name() string
+	// Model returns the configured model identifier (e.g. "gemma4:e4b", "haiku").
+	Model() string
+	// Available reports whether the provider is ready to serve requests.
+	Available(ctx context.Context) bool
+}
+
+// Resolver resolves autonomic inference targets from the N-tier contract.
+//
+// It is constructed once by the kernel (after providers are registered) and
+// shared across all autonomic operations. The Resolver does NOT own provider
+// lifecycle — it only selects from the map of already-registered providers.
+type Resolver struct {
+	cfg       CoreInferenceConfig
+	providers map[string]ProviderLike
+}
+
+// NewResolver creates a Resolver from a CoreInferenceConfig and a provider map.
+// The provider map is keyed by provider name (matching Provider.Name()).
+// Typically this is the same map the engine router uses.
+func NewResolver(cfg CoreInferenceConfig, providers map[string]ProviderLike) *Resolver {
+	return &Resolver{cfg: cfg, providers: providers}
+}
+
+// Resolve returns the first available provider that satisfies the given role.
+//
+// Algorithm:
+//  1. If role is empty, use cfg.DefaultRole.
+//  2. Walk cfg.Tiers in order (tier 0 is preferred).
+//  3. For each tier: check roleMatches, then find a registered provider for that tier.
+//  4. If a provider is found and reports Available, return it.
+//  5. If no tier satisfies the role with an available provider, return an error.
+//
+// Returns: (provider, selectedTierName, error).
+func (r *Resolver) Resolve(ctx context.Context, role string) (ProviderLike, string, error) {
+	if role == "" {
+		role = r.cfg.DefaultRole
+	}
+	if role == "" {
+		role = "autonomic" // ultimate fallback
+	}
+
+	var tried []string
+	for _, tier := range r.cfg.Tiers {
+		if !roleMatches(tier, role) {
+			continue
+		}
+		p := findProvider(r.providers, tier)
+		if p == nil {
+			tried = append(tried, fmt.Sprintf("%s(no-registered-provider)", tier.Name))
+			continue
+		}
+		if !p.Available(ctx) {
+			tried = append(tried, fmt.Sprintf("%s(unavailable)", tier.Name))
+			continue
+		}
+		return p, tier.Name, nil
+	}
+
+	if len(tried) == 0 {
+		return nil, "", fmt.Errorf("inference resolver: no tier configured for role %q", role)
+	}
+	return nil, "", fmt.Errorf("inference resolver: no available provider for role %q (tried: %s)",
+		role, strings.Join(tried, ", "))
+}
+
+// ResolveForOperation is a convenience wrapper that logs the selection decision.
+// operationName is a human-readable label for the autonomic operation (used in logs).
+func (r *Resolver) ResolveForOperation(ctx context.Context, operationName, role string) (ProviderLike, string, error) {
+	p, tierName, err := r.Resolve(ctx, role)
+	if err != nil {
+		slog.Warn("inference resolver: no provider selected",
+			"operation", operationName,
+			"role", role,
+			"error", err,
+		)
+		return nil, "", err
+	}
+	slog.Info("inference resolver: tier selected",
+		"operation", operationName,
+		"role", role,
+		"tier", tierName,
+		"provider", p.Name(),
+		"model", p.Model(),
+	)
+	return p, tierName, nil
+}
+
+// roleMatches reports whether tier serves the requested role.
+// An empty Roles list means the tier matches any role.
+func roleMatches(tier TierProfile, role string) bool {
+	if len(tier.Roles) == 0 {
+		return true // universal tier
+	}
+	for _, r := range tier.Roles {
+		if r == role {
+			return true
+		}
+	}
+	return false
+}
+
+// findProvider searches the providers map for a provider that matches the tier's
+// kind and model. Returns nil if no match is found.
+//
+// Matching heuristics (by TierKind):
+//   - TierClaudeCodeProvider: Name contains "claude" OR Model matches tier.Model
+//   - TierKeptWarmLocal / TierWarmWithColdStart: Name contains "ollama"
+//   - TierExternalSelfHosted: Name contains "vllm" or "mlx"
+func findProvider(providers map[string]ProviderLike, tier TierProfile) ProviderLike {
+	for _, p := range providers {
+		if matchesTier(p, tier) {
+			return p
+		}
+	}
+	return nil
+}
+
+// matchesTier reports whether provider p is a candidate for the given tier.
+func matchesTier(p ProviderLike, tier TierProfile) bool {
+	name := strings.ToLower(p.Name())
+	switch tier.Kind {
+	case TierClaudeCodeProvider:
+		return strings.Contains(name, "claude") || p.Model() == tier.Model
+	case TierKeptWarmLocal, TierWarmWithColdStart:
+		return strings.Contains(name, "ollama")
+	case TierExternalSelfHosted:
+		return strings.Contains(name, "vllm") || strings.Contains(name, "mlx")
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `internal/engine/inference/` package with the core inference contract: `TierKind`, `TierProfile`, `CoreInferenceConfig`, `Resolver`, and `LoadCoreInferenceConfig`.
- The N-tier ladder declares inference resources in priority order; the `Resolver` walks it and returns the first available provider for a given autonomic operation role.
- Default config selects **Haiku via claude-code** as tier 0 (zero infrastructure — works immediately on any authenticated Claude Code install) and **local Ollama gemma4:e4b** as tier 1 for operators who have it.
- Wires `CoreInference` field into the kernel `Config` struct; loaded from `.cog/config/core-inference.yaml`, falling back to the default if absent.
- 9 unit tests, all passing. Full `go build ./...` clean.

## Design notes

- `ProviderLike` is a local interface in the `inference` package (not importing `internal/engine`) to avoid a circular import. `engine.Provider` is a superset and satisfies it transparently.
- The `Resolver` is not instantiated by `LoadConfig` — it is constructed by callers that have a live provider map (e.g., the autonomic ticker, the cogdoc review reconciler). PR2 wires it into the conversations-observatory abstract generation step.
- The 90s `MaxTimeoutSeconds` on both default tiers matches `localHarnessCycleTimeout`. The cold-start hazard for gemma4 (110s cold-start vs 90s budget) is documented inline per `feedback_substrate_eval_constraints.md`.

## Test plan

- [x] `go test ./internal/engine/inference/...` — 9 tests, all PASS
- [x] `go build ./...` — clean
- [ ] Integration: PR2 will exercise the resolver end-to-end through the observatory ingest path