### PR TITLE
feat(mod3): add mod3_tail_logs MCP tool — tail chat-flow events from mod3 ring buffer

### DIFF
--- a/internal/engine/mcp_modality_proxy.go
+++ b/internal/engine/mcp_modality_proxy.go
@@ -37,6 +37,7 @@
 //   - mod3_register_session     — kernel-minted session registration  (via kernel)
 //   - mod3_deregister_session   — session deregister                  (via kernel)
 //   - mod3_list_sessions        — merged kernel+mod3 session roster   (via kernel)
+//   - mod3_tail_logs            — tail chat-flow events from ring buffer (direct to mod3)
 package engine
 
 import (
@@ -194,6 +195,19 @@ func (m *MCPServer) registerMod3Tools() {
 			"block: kernel identity records + mod3's live per-channel state " +
 			"(voice_pool, voice_holders, serializer policy).",
 	}), withToolObserver(m, "mod3_list_sessions", m.toolMod3ListSessions))
+
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+		Name: "mod3_tail_logs",
+		Description: "Tail recent structured chat-flow events from mod3's " +
+			"in-memory ring buffer (up to 5000 events, DEBUG-level). " +
+			"Each event has: ts, event_type, session_id, message_id, " +
+			"from_seat, to_seats, content_hash, content_preview, direction. " +
+			"Optional: session_id (filter to one session), " +
+			"event_type (comma-separated, e.g. chat.message_received,chat.fan_out), " +
+			"since (ISO timestamp or relative like 5m), " +
+			"limit (default 50, max 500). " +
+			"Fallback: curl 'http://localhost:7860/v1/logs/chat-flow?limit=20'",
+	}), withToolObserver(m, "mod3_tail_logs", m.toolMod3TailLogs))
 }
 
 // ─── input / output types ────────────────────────────────────────────────────
@@ -224,6 +238,20 @@ type mod3VoicesInput struct {
 }
 
 type mod3StatusInput struct{}
+
+// mod3TailLogsInput controls the chat-flow log query parameters for mod3_tail_logs.
+type mod3TailLogsInput struct {
+	// SessionID filters to a single mod3 session (optional).
+	SessionID string `json:"session_id,omitempty"`
+	// EventType is a comma-separated list of event types to include, e.g.
+	// "chat.message_received,chat.fan_out". Empty means all types.
+	EventType string `json:"event_type,omitempty"`
+	// Since is an ISO 8601 timestamp or a relative duration like "5m" or "30s".
+	// Only events at or after this time are returned.
+	Since string `json:"since,omitempty"`
+	// Limit caps the number of events returned (default 50, max 500).
+	Limit int `json:"limit,omitempty"`
+}
 
 type mod3RegisterSessionInput struct {
 	SessionID             string `json:"session_id,omitempty"`
@@ -560,6 +588,57 @@ func (m *MCPServer) toolMod3Voices(ctx context.Context, req *mcp.CallToolRequest
 
 func (m *MCPServer) toolMod3Status(ctx context.Context, req *mcp.CallToolRequest, in mod3StatusInput) (*mcp.CallToolResult, any, error) {
 	return m.proxyMod3JSONAsMCP(ctx, http.MethodGet, "/health", nil)
+}
+
+// toolMod3TailLogs queries mod3's /v1/logs/chat-flow endpoint and returns
+// the structured event array. Supports the same filter params as the HTTP
+// endpoint: session_id, event_type, since, limit.
+//
+// Relative "since" values like "5m" or "30s" are resolved against the current
+// time before forwarding so mod3 receives a well-formed ISO timestamp.
+func (m *MCPServer) toolMod3TailLogs(ctx context.Context, req *mcp.CallToolRequest, in mod3TailLogsInput) (*mcp.CallToolResult, any, error) {
+	limit := in.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 500 {
+		limit = 500
+	}
+
+	q := url.Values{}
+	if in.SessionID != "" {
+		q.Set("session_id", in.SessionID)
+	}
+	if in.EventType != "" {
+		q.Set("event_type", in.EventType)
+	}
+	if in.Since != "" {
+		resolved := resolveSince(in.Since)
+		q.Set("since", resolved)
+	}
+	q.Set("limit", strconv.Itoa(limit))
+
+	path := "/v1/logs/chat-flow?" + q.Encode()
+	return m.proxyMod3JSONAsMCP(ctx, http.MethodGet, path, nil)
+}
+
+// resolveSince converts a relative duration string ("5m", "30s", "1h") to an
+// ISO 8601 UTC timestamp. If the input is already an ISO timestamp (contains
+// 'T' or '-') it is returned unchanged. Unrecognised formats pass through.
+func resolveSince(s string) string {
+	if s == "" {
+		return s
+	}
+	// If it looks like an ISO timestamp already, return as-is.
+	if strings.Contains(s, "T") || (len(s) > 4 && s[4] == '-') {
+		return s
+	}
+	// Try to parse as a Go duration (e.g. "5m", "30s", "1h").
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return s // pass through unmodified
+	}
+	return time.Now().UTC().Add(-d).Format(time.RFC3339)
 }
 
 // toolMod3RegisterSession routes through the kernel's shared

--- a/internal/engine/mcp_modality_proxy_test.go
+++ b/internal/engine/mcp_modality_proxy_test.go
@@ -15,6 +15,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,13 +35,14 @@ type fakeMod3Proxy struct {
 	captured []capturedProxyRequest
 
 	// Overrides for per-endpoint behavior.
-	synthesizeHandler  http.HandlerFunc
-	stopHandler        http.HandlerFunc
-	voicesHandler      http.HandlerFunc
-	healthHandler      http.HandlerFunc
-	regHandler         http.HandlerFunc
-	deregHandler       http.HandlerFunc
-	listSessionHandler http.HandlerFunc
+	synthesizeHandler   http.HandlerFunc
+	stopHandler         http.HandlerFunc
+	voicesHandler       http.HandlerFunc
+	healthHandler       http.HandlerFunc
+	regHandler          http.HandlerFunc
+	deregHandler        http.HandlerFunc
+	listSessionHandler  http.HandlerFunc
+	chatFlowLogHandler  http.HandlerFunc
 }
 
 type capturedProxyRequest struct {
@@ -159,6 +161,30 @@ func newFakeMod3Proxy(t *testing.T) *fakeMod3Proxy {
 		writeFakeJSON(w, http.StatusOK, map[string]any{
 			"sessions":   []any{},
 			"voice_pool": []string{"bm_lewis", "af_bella"},
+		})
+	})
+
+	mux.HandleFunc("GET /v1/logs/chat-flow", func(w http.ResponseWriter, r *http.Request) {
+		fm.capture(r)
+		if fm.chatFlowLogHandler != nil {
+			fm.chatFlowLogHandler(w, r)
+			return
+		}
+		writeFakeJSON(w, http.StatusOK, map[string]any{
+			"events": []map[string]any{
+				{
+					"ts":              "2026-05-15T00:00:00Z",
+					"event_type":      "chat.message_received",
+					"session_id":      r.URL.Query().Get("session_id"),
+					"message_id":      "test-msg",
+					"from_seat":       "http",
+					"to_seats":        []string{},
+					"content_hash":    "b94d27b9",
+					"content_preview": "hello world",
+					"direction":       "inbound",
+				},
+			},
+			"count": 1,
 		})
 	})
 
@@ -1319,6 +1345,148 @@ func TestCheckSessionSubscriber_Mod3UnreachableReturnsError(t *testing.T) {
 	}
 	if subscribed {
 		t.Fatal("expected subscribed=false on error")
+	}
+}
+
+// ─── mod3_tail_logs ──────────────────────────────────────────────────────────
+
+// TestMod3TailLogs_BasicQuery verifies that mod3_tail_logs forwards filter
+// params to /v1/logs/chat-flow and returns parseable event structs.
+func TestMod3TailLogs_BasicQuery(t *testing.T) {
+	fm := newFakeMod3Proxy(t)
+	m := &MCPServer{cfg: &Config{Mod3URL: fm.srv.URL}}
+
+	result, _, err := m.toolMod3TailLogs(context.Background(), nil, mod3TailLogsInput{
+		SessionID: "cs-abc123",
+		EventType: "chat.message_received",
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("toolMod3TailLogs: %v", err)
+	}
+	if result == nil {
+		t.Fatal("nil result")
+	}
+	if result.IsError {
+		t.Fatalf("tool returned IsError=true: %v", result.Content)
+	}
+
+	// Verify the HTTP layer received the expected query params.
+	last := fm.last()
+	if last.Path != "/v1/logs/chat-flow" {
+		t.Errorf("path = %q; want /v1/logs/chat-flow", last.Path)
+	}
+	if !strings.Contains(last.Query, "session_id=cs-abc123") {
+		t.Errorf("query %q missing session_id", last.Query)
+	}
+	if !strings.Contains(last.Query, "event_type=chat.message_received") {
+		t.Errorf("query %q missing event_type", last.Query)
+	}
+	if !strings.Contains(last.Query, "limit=10") {
+		t.Errorf("query %q missing limit", last.Query)
+	}
+
+	// Verify the result is parseable JSON with the expected "events" field.
+	if len(result.Content) == 0 {
+		t.Fatal("empty content")
+	}
+	tc, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("content[0] is %T, want *mcp.TextContent", result.Content[0])
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(tc.Text), &parsed); err != nil {
+		t.Fatalf("parse result JSON: %v (raw=%q)", err, tc.Text)
+	}
+	events, ok := parsed["events"].([]any)
+	if !ok {
+		t.Fatalf("events field missing or wrong type: %T", parsed["events"])
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	ev, ok := events[0].(map[string]any)
+	if !ok {
+		t.Fatalf("event is %T, want map", events[0])
+	}
+	if got := ev["event_type"]; got != "chat.message_received" {
+		t.Errorf("event_type = %q; want chat.message_received", got)
+	}
+}
+
+// TestMod3TailLogs_DefaultLimit verifies that the default limit (50) is sent
+// when the caller supplies 0.
+func TestMod3TailLogs_DefaultLimit(t *testing.T) {
+	fm := newFakeMod3Proxy(t)
+	m := &MCPServer{cfg: &Config{Mod3URL: fm.srv.URL}}
+
+	_, _, err := m.toolMod3TailLogs(context.Background(), nil, mod3TailLogsInput{})
+	if err != nil {
+		t.Fatalf("toolMod3TailLogs: %v", err)
+	}
+	last := fm.last()
+	if !strings.Contains(last.Query, "limit=50") {
+		t.Errorf("query %q: want default limit=50", last.Query)
+	}
+}
+
+// TestMod3TailLogs_LimitCap verifies that limit is capped at 500.
+func TestMod3TailLogs_LimitCap(t *testing.T) {
+	fm := newFakeMod3Proxy(t)
+	m := &MCPServer{cfg: &Config{Mod3URL: fm.srv.URL}}
+
+	_, _, err := m.toolMod3TailLogs(context.Background(), nil, mod3TailLogsInput{Limit: 9999})
+	if err != nil {
+		t.Fatalf("toolMod3TailLogs: %v", err)
+	}
+	last := fm.last()
+	if !strings.Contains(last.Query, "limit=500") {
+		t.Errorf("query %q: want capped limit=500", last.Query)
+	}
+}
+
+// TestMod3TailLogs_RelativeSince verifies that a relative "since" string like
+// "5m" is resolved to an ISO timestamp before forwarding to mod3.
+func TestMod3TailLogs_RelativeSince(t *testing.T) {
+	fm := newFakeMod3Proxy(t)
+	m := &MCPServer{cfg: &Config{Mod3URL: fm.srv.URL}}
+
+	before := time.Now().UTC().Add(-6 * time.Minute)
+	after := time.Now().UTC().Add(-4 * time.Minute)
+
+	_, _, err := m.toolMod3TailLogs(context.Background(), nil, mod3TailLogsInput{Since: "5m"})
+	if err != nil {
+		t.Fatalf("toolMod3TailLogs: %v", err)
+	}
+	last := fm.last()
+	// since= must be present and be a parseable ISO time in the expected window.
+	for _, kv := range strings.Split(last.Query, "&") {
+		if !strings.HasPrefix(kv, "since=") {
+			continue
+		}
+		raw, _ := url.QueryUnescape(strings.TrimPrefix(kv, "since="))
+		ts, parseErr := time.Parse(time.RFC3339, raw)
+		if parseErr != nil {
+			t.Fatalf("since= value %q is not valid RFC3339: %v", raw, parseErr)
+		}
+		if ts.Before(before) || ts.After(after) {
+			t.Errorf("since=%v not in expected window [%v, %v]", ts, before, after)
+		}
+		return
+	}
+	t.Errorf("since= not found in query: %q", last.Query)
+}
+
+// TestMod3TailLogs_Unreachable verifies that an unreachable mod3 returns an
+// IsError=true result (not a Go error) so the caller sees a tool-level error.
+func TestMod3TailLogs_Unreachable(t *testing.T) {
+	m := &MCPServer{cfg: &Config{Mod3URL: "http://127.0.0.1:1"}} // port 1: always ECONNREFUSED
+	result, _, err := m.toolMod3TailLogs(context.Background(), nil, mod3TailLogsInput{})
+	if err != nil {
+		t.Fatalf("unexpected Go error (want IsError result): %v", err)
+	}
+	if result == nil || !result.IsError {
+		t.Error("expected IsError=true when mod3 is unreachable")
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds `mod3_tail_logs` to the kernel's MCP tool surface. The tool wraps mod3's `GET /v1/logs/chat-flow` endpoint (added in myrgic/mod3#46) and exposes it as an MCP tool for Claude Code sessions and the operator.

- Input: `session_id` (optional), `event_type` (comma-separated, optional), `since` (ISO or relative like "5m"), `limit` (default 50, max 500).
- Relative `since` values ("5m", "30s") are resolved to RFC3339 timestamps before forwarding.
- Output: `{"events": [...], "count": N}` — each event has `ts`, `event_type`, `session_id`, `message_id`, `from_seat`, `to_seats`, `content_hash`, `content_preview`, `direction`.
- On mod3 unreachable: returns `IsError=true` tool result (no Go error propagation).

## Placement

Added to `internal/engine/mcp_modality_proxy.go` alongside existing `mod3_*` tools. Registration, input type, and handler follow the exact same pattern as `mod3_status` and `mod3_voices`.

## Tests

5 new tests in `mcp_modality_proxy_test.go`:
- `TestMod3TailLogs_BasicQuery` — verifies filter params forwarded, result parseable
- `TestMod3TailLogs_DefaultLimit` — limit defaults to 50
- `TestMod3TailLogs_LimitCap` — limit capped at 500
- `TestMod3TailLogs_RelativeSince` — "5m" resolved to ISO timestamp in window
- `TestMod3TailLogs_Unreachable` — unreachable mod3 → IsError=true (no panic)

## Depends on

myrgic/mod3#46 (merged) — the `/v1/logs/chat-flow` endpoint must be live.

## MCP tool invocation

```json
{
  "name": "mod3_tail_logs",
  "arguments": {
    "session_id": "cs-abc123",
    "event_type": "chat.message_received,chat.fan_out",
    "since": "5m",
    "limit": 20
  }
}
```

## Curl fallback

```bash
curl 'http://localhost:7860/v1/logs/chat-flow?session_id=cs-abc123&limit=20'
```