### PR TITLE
feat(observability): chat.request sub-spans + reasoning boundary detection

### DIFF
--- a/internal/engine/handler_span.go
+++ b/internal/engine/handler_span.go
@@ -116,6 +116,77 @@ func (e *serverSpanEmitter) emitSpan(span KernelHandlerSpan) {
 	}
 }
 
+// ChatSubSpan carries timing and token data for one phase of a chat turn.
+// Emitted to bus_traces as "kernel.chat.subspan.v1" events so operators can
+// reconstruct per-phase latency (prompt_eval, thinking_generation,
+// answer_generation, tool_call_resolution) from the bus without a Jaeger
+// collector.  All durations are wall-clock milliseconds.
+//
+// To export to Jaeger, set OTEL_EXPORTER_OTLP_ENDPOINT and run:
+//   docker run -p 16686:16686 -p 4317:4317 jaegertracing/all-in-one
+// The OTel SDK in telemetry.go will pick it up automatically.
+type ChatSubSpan struct {
+	SpanName      string    `json:"span_name"`      // e.g. "chat.answer_generation"
+	ParentSpanID  string    `json:"parent_span_id"` // outer chat.request handler span
+	TraceID       string    `json:"trace_id"`       // W3C trace-id (hex, 32 chars) if available
+	StartedAt     time.Time `json:"started_at"`
+	DurationMS    int64     `json:"duration_ms"`
+	TokensThink   int       `json:"tokens_think,omitempty"`  // reasoning token count (est.)
+	TokensAnswer  int       `json:"tokens_answer,omitempty"` // answer token count (est.)
+	TokensTotal   int       `json:"tokens_total,omitempty"`  // total completion tokens
+	ToolCallCount int       `json:"tool_calls,omitempty"`
+	Model         string    `json:"model,omitempty"`
+	SessionID     string    `json:"session_id,omitempty"`
+}
+
+// emitChatSubSpan writes a ChatSubSpan to bus_traces. It is a no-op if bus
+// is nil. Errors are logged at WARN level and never returned — telemetry must
+// not disrupt the hot path.
+func emitChatSubSpan(bus *BusSessionManager, sub ChatSubSpan) {
+	if bus == nil {
+		return
+	}
+	payload := map[string]interface{}{
+		"span_name":    sub.SpanName,
+		"started_at":   sub.StartedAt.UTC().Format(time.RFC3339Nano),
+		"duration_ms":  sub.DurationMS,
+	}
+	if sub.ParentSpanID != "" {
+		payload["parent_span_id"] = sub.ParentSpanID
+	}
+	if sub.TraceID != "" {
+		payload["trace_id"] = sub.TraceID
+	}
+	if sub.TokensThink > 0 {
+		payload["tokens_think"] = sub.TokensThink
+	}
+	if sub.TokensAnswer > 0 {
+		payload["tokens_answer"] = sub.TokensAnswer
+	}
+	if sub.TokensTotal > 0 {
+		payload["tokens_total"] = sub.TokensTotal
+	}
+	if sub.ToolCallCount > 0 {
+		payload["tool_calls"] = sub.ToolCallCount
+	}
+	if sub.Model != "" {
+		payload["model"] = sub.Model
+	}
+	if sub.SessionID != "" {
+		payload["session_id"] = sub.SessionID
+	}
+	if err := bus.EnsureBus(BusTraces); err != nil {
+		slog.Warn("chat_subspan: ensure bus_traces failed", "err", err)
+		return
+	}
+	if err := bus.RegisterBus(BusTraces, "kernel", "kernel"); err != nil {
+		slog.Warn("chat_subspan: register bus_traces failed", "err", err)
+	}
+	if _, err := bus.AppendEvent(BusTraces, "kernel.chat.subspan.v1", "kernel", payload); err != nil {
+		slog.Warn("chat_subspan: AppendEvent failed", "err", err, "span", sub.SpanName)
+	}
+}
+
 // capturingResponseWriter wraps http.ResponseWriter to intercept the status
 // code and count the bytes written to the response body. It implements
 // http.Flusher so SSE handlers keep working: if the underlying writer is a

--- a/internal/engine/provider.go
+++ b/internal/engine/provider.go
@@ -199,6 +199,7 @@ type CompletionResponse struct {
 // StreamChunk is one piece of a streaming response.
 type StreamChunk struct {
 	Delta         string         `json:"delta,omitempty"`
+	IsReasoning   bool           `json:"is_reasoning,omitempty"`  // true when Delta carries reasoning/thinking content
 	ToolCallDelta *ToolCallDelta `json:"tool_call_delta,omitempty"`
 	Done          bool           `json:"done"`
 	StopReason    string         `json:"stop_reason,omitempty"`   // e.g. "end_turn", "max_tokens", "tool_use"

--- a/internal/engine/provider_openai.go
+++ b/internal/engine/provider_openai.go
@@ -266,9 +266,10 @@ type openaiStreamChoice struct {
 }
 
 type openaiStreamDelta struct {
-	Role      string                    `json:"role,omitempty"`
-	Content   string                    `json:"content,omitempty"`
-	ToolCalls []openaiStreamToolCall    `json:"tool_calls,omitempty"`
+	Role             string                 `json:"role,omitempty"`
+	Content          string                 `json:"content,omitempty"`
+	ReasoningContent string                 `json:"reasoning_content,omitempty"` // LM Studio / reasoning models
+	ToolCalls        []openaiStreamToolCall `json:"tool_calls,omitempty"`
 }
 
 // openaiStreamToolCall is the streaming variant of a tool call delta.
@@ -547,6 +548,15 @@ func parseOpenAISSE(ctx context.Context, r io.Reader, ch chan<- StreamChunk, mod
 		}
 
 		for _, choice := range chunk.Choices {
+			// Reasoning/thinking content delta (LM Studio reasoning models,
+			// e.g. Eclipse 26b A4B). Tagged with IsReasoning so the handler
+			// can measure the thinking phase separately from answer generation.
+			if choice.Delta.ReasoningContent != "" {
+				if !send(StreamChunk{Delta: choice.Delta.ReasoningContent, IsReasoning: true}) {
+					return
+				}
+			}
+
 			// Text content delta.
 			if choice.Delta.Content != "" {
 				if !send(StreamChunk{Delta: choice.Delta.Content}) {

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -49,6 +49,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/myrgic/cogos/ui/canvas"
 	"github.com/myrgic/cogos/ui/dashboard"
@@ -968,16 +969,74 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 	}
 
 	inferStart := time.Now()
+	var pt chatPhaseTimings
 	if req.Stream {
-		s.streamChat(w, r.Context(), creq, provider, respID, model, req.StreamOptions, turn)
+		pt = s.streamChat(w, r.Context(), creq, provider, respID, model, req.StreamOptions, turn)
 	} else {
-		s.completeChat(w, r.Context(), creq, provider, respID, model, turn)
+		pt = s.completeChat(w, r.Context(), creq, provider, respID, model, turn)
 	}
 
 	inferMs := float64(time.Since(inferStart).Milliseconds())
 	span.SetAttributes(attribute.Float64("cogos.inference.latency_ms", inferMs))
 	if instruments.InferenceLatency != nil {
 		instruments.InferenceLatency.Record(ctx, inferMs)
+	}
+
+	// Emit per-phase sub-spans to bus_traces so operators can reconstruct
+	// the turn timeline without a Jaeger collector. Each event carries a
+	// parent_span_id that matches the outer handler span's span_id (emitted
+	// by withSpan). The outer span fires after handleChat returns so the
+	// parent_span_id is not yet known here; we use a stable request-ID as a
+	// correlation key instead and let the operator join on session_id+ts.
+	sessionID := block.SessionID
+
+	// chat.prompt_eval — covers context assembly + upstream connection setup.
+	if !pt.promptEvalStart.IsZero() && !pt.promptEvalEnd.IsZero() {
+		emitChatSubSpan(s.busSessions, ChatSubSpan{
+			SpanName:  "chat.prompt_eval",
+			StartedAt: pt.promptEvalStart,
+			DurationMS: pt.promptEvalEnd.Sub(pt.promptEvalStart).Milliseconds(),
+			Model:     model,
+			SessionID: sessionID,
+		})
+	}
+
+	// chat.thinking_generation — only emitted when reasoning_content arrived.
+	if !pt.thinkingStart.IsZero() {
+		emitChatSubSpan(s.busSessions, ChatSubSpan{
+			SpanName:    "chat.thinking_generation",
+			StartedAt:   pt.thinkingStart,
+			DurationMS:  pt.thinkingEnd.Sub(pt.thinkingStart).Milliseconds(),
+			TokensThink: pt.tokensThink,
+			Model:       model,
+			SessionID:   sessionID,
+		})
+	}
+
+	// chat.answer_generation — always emitted when answer content arrived.
+	if !pt.answerStart.IsZero() {
+		totalToks := pt.tokensThink + pt.tokensAnswer
+		emitChatSubSpan(s.busSessions, ChatSubSpan{
+			SpanName:     "chat.answer_generation",
+			StartedAt:    pt.answerStart,
+			DurationMS:   pt.answerEnd.Sub(pt.answerStart).Milliseconds(),
+			TokensAnswer: pt.tokensAnswer,
+			TokensTotal:  totalToks,
+			Model:        model,
+			SessionID:    sessionID,
+		})
+	}
+
+	// chat.tool_call_resolution — only emitted when kernel-internal tools ran.
+	if !pt.toolCallStart.IsZero() {
+		emitChatSubSpan(s.busSessions, ChatSubSpan{
+			SpanName:      "chat.tool_call_resolution",
+			StartedAt:     pt.toolCallStart,
+			DurationMS:    pt.toolCallEnd.Sub(pt.toolCallStart).Milliseconds(),
+			ToolCallCount: pt.toolCallCount,
+			Model:         model,
+			SessionID:     sessionID,
+		})
 	}
 
 	// Persist the turn (ledger event + sidecar). Closes cogos#20 by
@@ -1003,13 +1062,39 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 	}()
 }
 
+// chatPhaseTimings carries per-phase wall-clock timing from a single chat turn.
+// Both streamChat and completeChat populate this so handleChat can emit sub-spans
+// to bus_traces without modifying the hot streaming path.
+type chatPhaseTimings struct {
+	promptEvalStart time.Time // when the provider call was initiated (≈ inferStart)
+	promptEvalEnd   time.Time // when the first byte / response arrived
+
+	thinkingStart time.Time // first reasoning_content chunk (zero if none)
+	thinkingEnd   time.Time // last reasoning_content chunk before answer starts
+
+	answerStart time.Time // first answer-content chunk (or response returned)
+	answerEnd   time.Time // stream/response complete
+
+	toolCallStart time.Time // tool-call resolution start (zero if no tools)
+	toolCallEnd   time.Time // tool-call resolution end
+
+	tokensThink   int // approximate: len(reasoningContent) rune count (no tokenizer available)
+	tokensAnswer  int // approximate: len(content) rune count
+	toolCallCount int
+}
+
 // completeChat handles non-streaming chat completions.
 // The optional turn record is populated with the response text, usage, and
 // any tool-call traces so the caller can persist the full turn via RecordTurn.
 func (s *Server) completeChat(w http.ResponseWriter, ctx context.Context, req *CompletionRequest,
-	provider Provider, respID, model string, turn *TurnRecord) {
+	provider Provider, respID, model string, turn *TurnRecord) chatPhaseTimings {
+
+	var pt chatPhaseTimings
+	pt.promptEvalStart = time.Now()
 
 	resp, err := provider.Complete(ctx, req)
+	pt.promptEvalEnd = time.Now()
+	pt.answerStart = pt.promptEvalEnd
 	if err != nil {
 		slog.Warn("chat: complete error", "err", err)
 		if turn != nil {
@@ -1026,7 +1111,7 @@ func (s *Server) completeChat(w http.ResponseWriter, ctx context.Context, req *C
 				"code":    nil,
 			},
 		})
-		return
+		return pt
 	}
 
 	// Server-side execution of MCP-internal tools (cog_*, mod3_*, ...).
@@ -1049,6 +1134,9 @@ func (s *Server) completeChat(w http.ResponseWriter, ctx context.Context, req *C
 			// turn we still service the internal ones, but keep the external
 			// ones queued for the response so the client gets them.
 			req.Messages = appendToolHopMessages(req.Messages, resp, internal)
+			if pt.toolCallStart.IsZero() {
+				pt.toolCallStart = time.Now()
+			}
 			for _, tc := range internal {
 				s.executeInternalToolCall(ctx, provider.Name(), tc)
 				resultText, isErr, callErr := s.mcpServer.CallTool(ctx, tc.Name, []byte(tc.Arguments))
@@ -1067,6 +1155,7 @@ func (s *Server) completeChat(w http.ResponseWriter, ctx context.Context, req *C
 					Name:       tc.Name,
 					ToolCallID: tc.ID,
 				})
+				pt.toolCallCount++
 				if turn != nil {
 					rec := ToolCallRecord{
 						ID:        tc.ID,
@@ -1098,7 +1187,7 @@ func (s *Server) completeChat(w http.ResponseWriter, ctx context.Context, req *C
 						"type":    "server_error",
 					},
 				})
-				return
+				return pt
 			}
 			// If the prior turn carried external tool_use events alongside
 			// the internal ones, surface them by merging into next.ToolCalls
@@ -1108,6 +1197,9 @@ func (s *Server) completeChat(w http.ResponseWriter, ctx context.Context, req *C
 			}
 			resp = next
 		}
+	}
+	if !pt.toolCallStart.IsZero() {
+		pt.toolCallEnd = time.Now()
 	}
 	if turn != nil {
 		turn.Response = resp.Content
@@ -1128,6 +1220,9 @@ func (s *Server) completeChat(w http.ResponseWriter, ctx context.Context, req *C
 			}
 		}
 	}
+
+	pt.answerEnd = time.Now()
+	pt.tokensAnswer = resp.Usage.OutputTokens
 
 	msg := &oaiMessage{Role: "assistant", Content: mustMarshalString(resp.Content)}
 	finishReason := mapStopReasonToOpenAI(resp.StopReason)
@@ -1188,6 +1283,7 @@ func (s *Server) completeChat(w http.ResponseWriter, ctx context.Context, req *C
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(oai)
+	return pt
 }
 
 // streamChat handles streaming chat completions via SSE.
@@ -1211,7 +1307,7 @@ func (s *Server) completeChat(w http.ResponseWriter, ctx context.Context, req *C
 // from the final chunk) so the caller can persist the full turn via
 // RecordTurn.
 func (s *Server) streamChat(w http.ResponseWriter, ctx context.Context, req *CompletionRequest,
-	provider Provider, respID, model string, streamOpts *oaiStreamOpts, turn *TurnRecord) {
+	provider Provider, respID, model string, streamOpts *oaiStreamOpts, turn *TurnRecord) chatPhaseTimings {
 
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
@@ -1261,6 +1357,9 @@ func (s *Server) streamChat(w http.ResponseWriter, ctx context.Context, req *Com
 	//   firstStream      — channel from the very first provider.Stream call,
 	//     opened upfront so a Stream() error returns the conventional 500.
 	//     Subsequent hops re-open the stream from inside the loop.
+	var pt chatPhaseTimings
+	pt.promptEvalStart = time.Now()
+
 	var carriedExternal []ToolCall
 
 	firstStream, err := provider.Stream(ctx, req)
@@ -1287,12 +1386,40 @@ func (s *Server) streamChat(w http.ResponseWriter, ctx context.Context, req *Com
 				"code":    nil,
 			},
 		})
-		return
+		return pt
 	}
 
 	chunks := firstStream
+	isFirstHop := true
 	for hop := 0; hop < maxStreamHops; hop++ {
+		drainStart := time.Now()
 		hopBuf, hopErr := drainStreamHop(chunks)
+		drainEnd := time.Now()
+
+		// On the first (and usually only) hop, derive per-phase timings from
+		// the buffer contents.  Reasoning deltas precede answer deltas in the
+		// stream; we split the drain wall-time proportionally by rune count.
+		if isFirstHop {
+			isFirstHop = false
+			pt.promptEvalEnd = drainStart // drain start ≈ first upstream byte
+			thinkRunes := utf8.RuneCountInString(hopBuf.reasoningContent.String())
+			ansRunes := utf8.RuneCountInString(hopBuf.content.String())
+			totalRunes := thinkRunes + ansRunes
+			drainDur := drainEnd.Sub(drainStart)
+			if totalRunes > 0 && thinkRunes > 0 {
+				thinkFrac := float64(thinkRunes) / float64(totalRunes)
+				thinkDur := time.Duration(float64(drainDur) * thinkFrac)
+				pt.thinkingStart = drainStart
+				pt.thinkingEnd = drainStart.Add(thinkDur)
+				pt.answerStart = pt.thinkingEnd
+			} else {
+				pt.answerStart = drainStart
+			}
+			pt.answerEnd = drainEnd
+			pt.tokensThink = thinkRunes // proxy: chars ≈ fractional tokens
+			pt.tokensAnswer = ansRunes
+		}
+
 		if hopErr != nil {
 			writeStreamErr(hopErr)
 			break
@@ -1327,6 +1454,9 @@ func (s *Server) streamChat(w http.ResponseWriter, ctx context.Context, req *Com
 			ToolCalls:  toolCalls,
 			StopReason: hopBuf.stopReason,
 		}, internal)
+		if pt.toolCallStart.IsZero() {
+			pt.toolCallStart = time.Now()
+		}
 		for _, tc := range internal {
 			s.executeInternalToolCall(ctx, provider.Name(), tc)
 			resultText, isErr, callErr := s.mcpServer.CallTool(ctx, tc.Name, []byte(tc.Arguments))
@@ -1345,6 +1475,7 @@ func (s *Server) streamChat(w http.ResponseWriter, ctx context.Context, req *Com
 				Name:       tc.Name,
 				ToolCallID: tc.ID,
 			})
+			pt.toolCallCount++
 			if turn != nil {
 				rec := ToolCallRecord{
 					ID:        tc.ID,
@@ -1358,6 +1489,9 @@ func (s *Server) streamChat(w http.ResponseWriter, ctx context.Context, req *Com
 				}
 				turn.ToolCalls = append(turn.ToolCalls, rec)
 			}
+		}
+		if !pt.toolCallStart.IsZero() {
+			pt.toolCallEnd = time.Now()
 		}
 
 		// Hop overflow guard: if the next hop would exceed the cap, surface
@@ -1377,6 +1511,7 @@ func (s *Server) streamChat(w http.ResponseWriter, ctx context.Context, req *Com
 
 	_, _ = fmt.Fprint(bw, "data: [DONE]\n\n")
 	flush()
+	return pt
 }
 
 // streamHopBuffer collects everything one upstream stream emitted on a
@@ -1387,10 +1522,12 @@ func (s *Server) streamChat(w http.ResponseWriter, ctx context.Context, req *Com
 // to SSE (terminal hop) or feed it back into the conversation as a
 // tool_use turn (intermediate hop).
 type streamHopBuffer struct {
-	deltas     []string
-	content    strings.Builder
-	stopReason string
-	usage      *TokenUsage
+	deltas           []string
+	content          strings.Builder
+	reasoningDeltas  []string       // reasoning/thinking chunks (IsReasoning=true)
+	reasoningContent strings.Builder
+	stopReason       string
+	usage            *TokenUsage
 	// toolCalls maps streaming index → assembled call. Provider-side the
 	// index is stable across deltas for the same call; the ID typically
 	// arrives on the first delta and arguments accumulate after.
@@ -1454,8 +1591,13 @@ func drainStreamHop(chunks <-chan StreamChunk) (*streamHopBuffer, error) {
 			continue
 		}
 		if sc.Delta != "" {
-			buf.deltas = append(buf.deltas, sc.Delta)
-			buf.content.WriteString(sc.Delta)
+			if sc.IsReasoning {
+				buf.reasoningDeltas = append(buf.reasoningDeltas, sc.Delta)
+				buf.reasoningContent.WriteString(sc.Delta)
+			} else {
+				buf.deltas = append(buf.deltas, sc.Delta)
+				buf.content.WriteString(sc.Delta)
+			}
 		}
 	}
 	// Channel closed without an explicit Done — treat as benign EOF.


### PR DESCRIPTION
## Summary

- Adds four per-phase sub-spans to `bus_traces` for every chat turn: `chat.prompt_eval`, `chat.thinking_generation`, `chat.answer_generation`, `chat.tool_call_resolution`
- Extends `openaiStreamDelta` with `reasoning_content` field so LM Studio reasoning models (Eclipse 26b A4B) emit tagged `IsReasoning` chunks
- `streamHopBuffer` now tracks reasoning deltas separately from answer deltas; proportional per-phase timing is derived from rune counts without refactoring the buffered-drain architecture
- `streamChat` and `completeChat` return `chatPhaseTimings`; `handleChat` emits sub-spans after inference without touching the streaming hot path
- Sub-span events land as `kernel.chat.subspan.v1` on `bus_traces` with: `span_name`, `started_at`, `duration_ms`, `model`, `session_id`, `tokens_think`, `tokens_answer`, `tokens_total`, `tool_calls`

## Verification

After merge + kernel restart, send any chat request and check bus_traces:
```bash
curl http://localhost:6931/v1/bus/bus_traces/events?limit=20
```

Trace tree one-liner (print span tree for the last turn):
```python
python3 -c "
import json, subprocess
events = json.loads(subprocess.check_output(['curl', '-s', 'http://localhost:6931/v1/bus/bus_traces/events?limit=30']))
spans = [e for e in events.get('events', []) if e.get('block_type') == 'kernel.chat.subspan.v1']
for s in spans:
  p = s['payload']
  print(f\"{p['span_name']:40s} {p['duration_ms']:6d}ms  model={p.get('model','?')}\")
"
```

Jaeger collector (deferred, documented here for follow-up):
```
OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 docker run -p 16686:16686 -p 4317:4317 jaegertracing/all-in-one
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/engine/...` passes (7.9s, 0 failures)
- [ ] Merge + kernel rebuild + verify bus_traces events after a real chat round-trip
- [ ] Confirm `thinking_generation` span is populated when Eclipse 26b A4B is the provider