### PR TITLE
fix(engine): replace MCP streamable transport with direct REST in mod3_speak proxy

### DIFF
--- a/internal/engine/mcp_modality_proxy.go
+++ b/internal/engine/mcp_modality_proxy.go
@@ -5,18 +5,21 @@
 // The kernel becomes the MCP front door for mod3; the previous OpenClaw
 // gateway pattern in the installed binary read metrics but discarded audio
 // bytes. This proxy fixes that: it forwards speech requests to mod3's
-// queue-aware speak() MCP tool (via the /mcp streamable-HTTP endpoint), and
-// returns mod3's full queue metadata to the MCP caller.
+// /v1/synthesize REST endpoint and returns a queue-state-shaped response
+// derived from the response headers.
 //
 // Design locks:
 //
-//  1. MCP transport = mod3 MCP client. The mod3_speak tool handler calls
-//     mod3's speak() MCP tool via StreamableClientTransport at {Mod3URL}/mcp.
-//     This is the queue-aware path — mod3 owns serialization end-to-end.
-//     The local afplay/aplay path is retained as a fallback when mod3's MCP
-//     transport is unreachable (transport error), gated by error — not by
-//     default. Other synthesis/control tool handlers (/v1/stop, /v1/voices,
-//     /health) continue to POST/GET against cfg.Mod3URL + "/v1/*" as before.
+//  1. REST transport = direct POST to mod3's /v1/synthesize. Mod3 does not
+//     expose an /mcp endpoint; the prior StreamableClientTransport approach
+//     always failed with "unable to connect". The /v1/synthesize endpoint is
+//     blocking (waits for synthesis) and serializes concurrent calls
+//     server-side, so the kernel's local afplay/aplay handles playback.
+//     A synthesized queue-state response (status, job_id, metrics) is built
+//     from the X-Mod3-* response headers. The local player path and all
+//     fallback/subscriber-routing logic (Wave 4.3) are preserved unchanged.
+//     Other synthesis/control tool handlers (/v1/stop, /v1/voices, /health)
+//     continue to POST/GET against cfg.Mod3URL + "/v1/*" as before.
 //  2. Session authority = kernel-owned (Wave 3.5). The session-family tools
 //     (register/deregister/list) do NOT call mod3 directly — they call the
 //     kernel's RegisterChannelSession / DeregisterChannelSession /
@@ -95,11 +98,15 @@ type modalityProxy struct {
 	// (GET {Mod3URL}/v1/sessions/{id}/subscribers).
 	subscriberCheck func(ctx context.Context, sessionID string) (bool, error)
 
-	// mcpSpeakFn, when non-nil, replaces callMod3SpeakTool's default
-	// StreamableClientTransport dial + speak() call. Tests inject this to
-	// simulate mod3's MCP responses without spinning up a full MCP server.
+	// speakFn, when non-nil, replaces callMod3SpeakTool's default REST POST
+	// to /v1/synthesize. Tests inject this to simulate mod3's synthesize
+	// responses (queue-state map) without hitting a real HTTP server.
 	// Signature matches callMod3SpeakTool's return: (parsed map, error).
-	mcpSpeakFn func(ctx context.Context, in mod3SpeakInput) (map[string]any, error)
+	//
+	// Alias: the field was formerly named mcpSpeakFn; it is kept as speakFn
+	// after the MCP-transport removal. Test code that assigned mcpSpeakFn
+	// should be updated to speakFn; the old name is gone.
+	speakFn func(ctx context.Context, in mod3SpeakInput) (map[string]any, error)
 }
 
 // defaultMod3ProxyTimeout is the per-request timeout for mod3 forwards. 30s
@@ -280,29 +287,71 @@ func (m *MCPServer) toolMod3Speak(ctx context.Context, req *mcp.CallToolRequest,
 	}
 
 	// SkipPlayback: caller wants raw audio bytes (dashboard WS, file write,
-	// etc.). Fall through to /v1/synthesize — the queue-aware MCP path does
-	// not return bytes, so this path is intentionally separate.
+	// etc.). Fall through to /v1/synthesize directly so the caller gets bytes
+	// back in the response rather than triggering local playback.
 	if in.SkipPlayback {
 		return m.toolMod3SpeakRawBytes(ctx, in)
 	}
 
-	// Primary path: delegate to mod3's queue-aware speak() MCP tool via the
-	// streamable-HTTP transport at {Mod3URL}/mcp. Mod3 owns serialization,
-	// queue metadata, and playback end-to-end.
-	queueResult, mcpErr := m.callMod3SpeakTool(ctx, in)
-	if mcpErr == nil {
-		// Happy path — forward mod3's queue response verbatim, adding the
-		// session_id echo for observability consistency.
-		queueResult["session_id"] = in.SessionID
-		return marshalResult(queueResult)
+	// Primary path: POST to mod3's /v1/synthesize REST endpoint (blocking).
+	// callMod3SpeakTool handles the HTTP round-trip and synthesises a
+	// queue-state response map from the X-Mod3-* response headers.
+	// Playback is handled locally below (mod3 synthesizes audio and returns
+	// bytes; it does not play audio server-side).
+	synthesisResult, synthesisErr := m.callMod3SpeakTool(ctx, in)
+	if synthesisErr != nil {
+		// Synthesis failed — surface a clean error; no audio to play.
+		return mod3ErrorResult(fmt.Sprintf("mod3 unreachable: %v", synthesisErr))
 	}
 
-	// Transport failure — mod3's MCP endpoint is unreachable. Log, then fall
-	// back to the local afplay path so the caller isn't silently orphaned.
-	slog.Debug("mod3 proxy: MCP speak() unreachable, falling back to local afplay",
-		"err", mcpErr)
+	// Happy path — synthesis succeeded.  Add session_id echo for
+	// observability consistency, then handle local playback.
+	synthesisResult["session_id"] = in.SessionID
 
-	return m.toolMod3SpeakLocalFallback(ctx, in, mcpErr)
+	// Retrieve and strip the internal _audio_bytes transport field before
+	// any return path so the MCP response never exposes raw bytes here.
+	// (SkipPlayback callers use toolMod3SpeakRawBytes which returns base64.)
+	audioBytes, _ := synthesisResult["_audio_bytes"].([]byte)
+	delete(synthesisResult, "_audio_bytes")
+
+	p := m.getModalityProxy()
+	if p.disablePlayback {
+		synthesisResult["playback_status"] = "disabled"
+		return marshalResult(synthesisResult)
+	}
+
+	// Wave 4.3 subscriber-routing: when a session has a live dashboard
+	// WebSocket subscriber, mod3 routes WAV there independently; the kernel
+	// skips the local player.
+	if in.SessionID != "" {
+		subscribed, checkErr := m.checkSessionSubscriber(ctx, in.SessionID)
+		if checkErr != nil {
+			slog.Debug("mod3 proxy: subscriber check failed",
+				"session_id", in.SessionID, "err", checkErr)
+			synthesisResult["subscriber_check_error"] = checkErr.Error()
+		}
+		if subscribed {
+			synthesisResult["playback_status"] = "routed_ws"
+			return marshalResult(synthesisResult)
+		}
+	}
+
+	if len(audioBytes) == 0 {
+		synthesisResult["playback_status"] = "no_audio"
+		return marshalResult(synthesisResult)
+	}
+
+	playErr := p.playAudio(audioBytes, in.Blocking)
+	switch {
+	case playErr == nil && in.Blocking:
+		synthesisResult["playback_status"] = "played"
+	case playErr == nil:
+		synthesisResult["playback_status"] = "spawned"
+	default:
+		synthesisResult["playback_status"] = "error"
+		synthesisResult["playback_error"] = playErr.Error()
+	}
+	return marshalResult(synthesisResult)
 }
 
 // toolMod3SpeakRawBytes handles mod3_speak with skip_playback=true.
@@ -336,19 +385,24 @@ func (m *MCPServer) toolMod3SpeakRawBytes(ctx context.Context, in mod3SpeakInput
 	return marshalResult(result)
 }
 
-// toolMod3SpeakLocalFallback is the exceptional path: mod3's MCP transport
-// was unreachable (mcpErr != nil). We log the MCP failure, then attempt
-// /v1/synthesize + local afplay so the user still hears audio. This is an
-// error-gated path — it should never be the default route.
-func (m *MCPServer) toolMod3SpeakLocalFallback(ctx context.Context, in mod3SpeakInput, mcpErr error) (*mcp.CallToolResult, any, error) {
+// toolMod3SpeakLocalFallback is retained for backward compatibility with
+// tests that exercise the audio+playback path directly. Production code
+// routes through toolMod3Speak → callMod3SpeakTool (REST) → local player.
+// This function is no longer called from toolMod3Speak; its body is
+// preserved so existing test helpers can call it to validate the playback
+// plumbing independently.
+func (m *MCPServer) toolMod3SpeakLocalFallback(ctx context.Context, in mod3SpeakInput, fallbackReason error) (*mcp.CallToolResult, any, error) {
 	body := buildSynthesizeBody(in)
 	raw, _ := json.Marshal(body)
 
 	audio, headers, status, err := m.proxyMod3Bytes(ctx, http.MethodPost,
 		"/v1/synthesize", bytes.NewReader(raw), "application/json")
 	if err != nil {
-		// Both MCP and HTTP are down — surface composite error.
-		return mod3ErrorResult(fmt.Sprintf("mod3 unreachable (mcp: %v; http: %v)", mcpErr, err))
+		reasonStr := "http unreachable"
+		if fallbackReason != nil {
+			reasonStr = fmt.Sprintf("primary: %v; http: %v", fallbackReason, err)
+		}
+		return mod3ErrorResult(fmt.Sprintf("mod3 unreachable: %s", reasonStr))
 	}
 	if status < 200 || status >= 300 {
 		return mod3ErrorResult(fmt.Sprintf("mod3 returned %d: %s", status, truncate(string(audio), 400)))
@@ -356,11 +410,13 @@ func (m *MCPServer) toolMod3SpeakLocalFallback(ctx context.Context, in mod3Speak
 
 	metrics := extractMod3Metrics(headers)
 	result := map[string]any{
-		"ok":              true,
-		"bytes":           len(audio),
-		"metrics":         metrics,
-		"session_id":      in.SessionID,
-		"fallback_reason": mcpErr.Error(),
+		"ok":         true,
+		"bytes":      len(audio),
+		"metrics":    metrics,
+		"session_id": in.SessionID,
+	}
+	if fallbackReason != nil {
+		result["fallback_reason"] = fallbackReason.Error()
 	}
 
 	p := m.getModalityProxy()
@@ -369,9 +425,6 @@ func (m *MCPServer) toolMod3SpeakLocalFallback(ctx context.Context, in mod3Speak
 		return marshalResult(result)
 	}
 
-	// Wave 4.3 subscriber-routing: preserve this check in the fallback path
-	// so the dashboard still gets audio when mod3's MCP is down but the WS
-	// subscriber is connected.
 	if in.SessionID != "" {
 		subscribed, checkErr := m.checkSessionSubscriber(ctx, in.SessionID)
 		if checkErr != nil {
@@ -398,20 +451,22 @@ func (m *MCPServer) toolMod3SpeakLocalFallback(ctx context.Context, in mod3Speak
 	return marshalResult(result)
 }
 
-// callMod3SpeakTool dials mod3's streamable-HTTP MCP transport at
-// {Mod3URL}/mcp and calls the speak() tool. Returns the parsed queue-metadata
-// map on success, or a non-nil error when the transport is unreachable.
+// callMod3SpeakTool POSTs to mod3's /v1/synthesize REST endpoint (blocking)
+// and returns a queue-state-shaped response map synthesised from the
+// X-Mod3-* response headers. The audio bytes are stashed under the internal
+// key "_audio_bytes" so toolMod3Speak can hand them to the local player
+// without re-reading.
 //
-// The session is opened per-call and closed before returning. mod3's speak()
-// tool is non-blocking — it returns immediately with the job_id and queue
-// position — so the connection lifetime is short.
+// Mod3 does not expose an /mcp endpoint; the previous StreamableClientTransport
+// approach always failed. /v1/synthesize serialises concurrent calls server-side
+// so no additional queue-management is needed on the kernel side.
 //
-// Injectable via modalityProxy.mcpSpeakFn for tests that want to avoid
-// spinning up a full MCP server.
+// Injectable via modalityProxy.speakFn for tests that want deterministic
+// queue-state responses without hitting a real HTTP server.
 func (m *MCPServer) callMod3SpeakTool(ctx context.Context, in mod3SpeakInput) (map[string]any, error) {
 	p := m.getModalityProxy()
-	if p.mcpSpeakFn != nil {
-		return p.mcpSpeakFn(ctx, in)
+	if p.speakFn != nil {
+		return p.speakFn(ctx, in)
 	}
 
 	if m.cfg == nil {
@@ -422,88 +477,40 @@ func (m *MCPServer) callMod3SpeakTool(ctx context.Context, in mod3SpeakInput) (m
 		return nil, errors.New("Mod3URL not configured")
 	}
 
-	transport := &mcp.StreamableClientTransport{
-		Endpoint:             base + "/mcp",
-		HTTPClient:           m.getModalityProxy().client,
-		DisableStandaloneSSE: true, // request-response only; no persistent SSE needed
-	}
+	body := buildSynthesizeBody(in)
+	raw, _ := json.Marshal(body)
 
-	client := mcp.NewClient(&mcp.Implementation{
-		Name:    "cogos-kernel",
-		Version: "1.0",
-	}, nil)
-
-	connectCtx, connectCancel := context.WithTimeout(ctx, defaultMod3ProxyTimeout)
-	defer connectCancel()
-
-	session, err := client.Connect(connectCtx, transport, nil)
+	audio, headers, status, err := m.proxyMod3Bytes(ctx, http.MethodPost,
+		"/v1/synthesize", bytes.NewReader(raw), "application/json")
 	if err != nil {
-		return nil, fmt.Errorf("connect to mod3 MCP: %w", err)
+		return nil, fmt.Errorf("mod3 /v1/synthesize: %w", err)
 	}
-	defer func() {
-		if cerr := session.Close(); cerr != nil {
-			slog.Debug("mod3 proxy: MCP session close error", "err", cerr)
-		}
-	}()
-
-	args := map[string]any{"text": in.Text}
-	if in.Voice != "" {
-		args["voice"] = in.Voice
-	}
-	if in.Speed > 0 {
-		args["speed"] = in.Speed
-	}
-	if in.Emotion > 0 {
-		args["emotion"] = in.Emotion
-	}
-	if in.SessionID != "" {
-		args["session_id"] = in.SessionID
+	if status < 200 || status >= 300 {
+		return nil, fmt.Errorf("mod3 returned %d: %s", status, truncate(string(audio), 400))
 	}
 
-	callCtx, callCancel := context.WithTimeout(ctx, defaultMod3ProxyTimeout)
-	defer callCancel()
+	metrics := extractMod3Metrics(headers)
 
-	toolResult, err := session.CallTool(callCtx, &mcp.CallToolParams{
-		Name:      "speak",
-		Arguments: args,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("mod3 speak() MCP call: %w", err)
-	}
-	if toolResult.IsError {
-		// mod3 returned a tool-level error (e.g. empty text, session not found)
-		if len(toolResult.Content) > 0 {
-			if tc, ok := toolResult.Content[0].(*mcp.TextContent); ok {
-				return nil, fmt.Errorf("mod3 speak() tool error: %s", tc.Text)
-			}
-		}
-		return nil, errors.New("mod3 speak() returned IsError=true")
+	// Extract the job_id from the X-Mod3-Job-Id header so callers get a
+	// stable correlation handle even when the queue-position concept is N/A
+	// (synthesize is blocking; by the time we return, the job is done).
+	jobID := headers.Get("X-Mod3-Job-Id")
+	if jobID == "" {
+		jobID = "inline"
 	}
 
-	// mod3's speak() returns a JSON string as its result text.
-	if len(toolResult.Content) == 0 {
-		return nil, errors.New("mod3 speak() returned empty content")
+	result := map[string]any{
+		"status":              "completed",
+		"job_id":              jobID,
+		"queue_position":      float64(0),
+		"estimated_wait_sec":  float64(0),
+		"metrics":             metrics,
+		// _audio_bytes is an internal transport field stripped before the
+		// MCP response is sent; it lets toolMod3Speak hand raw bytes to the
+		// local player without a second HTTP round-trip.
+		"_audio_bytes": audio,
 	}
-	tc, ok := toolResult.Content[0].(*mcp.TextContent)
-	if !ok {
-		return nil, fmt.Errorf("mod3 speak() returned unexpected content type %T", toolResult.Content[0])
-	}
-	var parsed map[string]any
-	if err := json.Unmarshal([]byte(tc.Text), &parsed); err != nil {
-		return nil, fmt.Errorf("mod3 speak() parse response: %w (raw=%q)", err, tc.Text)
-	}
-
-	// Normalise mod3's status-only "speaking" response to include the standard
-	// queue fields at their zero values so callers get a consistent shape
-	// regardless of whether the item was queued or started immediately.
-	if _, hasQP := parsed["queue_position"]; !hasQP {
-		parsed["queue_position"] = float64(0)
-	}
-	if _, hasWait := parsed["estimated_wait_sec"]; !hasWait {
-		parsed["estimated_wait_sec"] = float64(0)
-	}
-
-	return parsed, nil
+	return result, nil
 }
 
 // buildSynthesizeBody constructs the JSON body for a /v1/synthesize request

--- a/internal/engine/mcp_modality_proxy_test.go
+++ b/internal/engine/mcp_modality_proxy_test.go
@@ -268,14 +268,14 @@ func decodeToolText(t *testing.T, res *mcp.CallToolResult) map[string]any {
 
 // ─── mod3_speak — MCP queue path ─────────────────────────────────────────────
 
-// newMCPSpeakFn builds a deterministic mcpSpeakFn stub. Each call returns a
+// newSpeakFn builds a deterministic speakFn stub. Each call returns a
 // "queued" response whose queue_position increments per call (starting at 1
 // for the first call that arrives while something is "playing"). The first
 // invocation returns a "speaking" response (queue_position 0); subsequent
 // ones simulate the queue growing.
 //
 // capturedArgs is populated with the args map each call receives, in order.
-func newMCPSpeakFn(capturedArgs *[]map[string]any) func(ctx context.Context, in mod3SpeakInput) (map[string]any, error) {
+func newSpeakFn(capturedArgs *[]map[string]any) func(ctx context.Context, in mod3SpeakInput) (map[string]any, error) {
 	var mu sync.Mutex
 	callCount := 0
 	return func(ctx context.Context, in mod3SpeakInput) (map[string]any, error) {
@@ -329,13 +329,15 @@ func newMCPSpeakFn(capturedArgs *[]map[string]any) func(ctx context.Context, in 
 	}
 }
 
-// TestMod3Speak_MCPSuccessPath — the primary happy path: mcpSpeakFn returns a
-// "speaking" response; the result must contain job_id + queue_position + no
-// playback_status field (mod3 owns playback, not the kernel).
+// TestMod3Speak_MCPSuccessPath — the primary happy path: speakFn returns a
+// "speaking" response; the result must contain job_id + queue_position.
+// With the REST transport replacing the old MCP transport, the kernel handles
+// playback locally. disablePlayback=true is set by newProxyMCP so the test
+// asserts playback_status="disabled" rather than "spawned"/"played".
 func TestMod3Speak_MCPSuccessPath(t *testing.T) {
 	fm := newFakeMod3Proxy(t)
 	m := newProxyMCP(t, fm)
-	m.mod3Proxy.mcpSpeakFn = newMCPSpeakFn(nil)
+	m.mod3Proxy.speakFn = newSpeakFn(nil)
 
 	res, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{
 		Text: "hello world",
@@ -364,13 +366,11 @@ func TestMod3Speak_MCPSuccessPath(t *testing.T) {
 	if _, ok := out["estimated_wait_sec"]; !ok {
 		t.Fatal("expected estimated_wait_sec in result")
 	}
-	// The kernel must NOT be spawning afplay — no playback_status field.
-	if _, present := out["playback_status"]; present {
-		t.Fatalf("expected no playback_status on MCP path, got %v", out["playback_status"])
-	}
-	// No bytes/metrics fields on the MCP path.
-	if _, present := out["bytes"]; present {
-		t.Fatalf("unexpected bytes field on MCP path")
+	// playback_status is present; "disabled" because disablePlayback=true in
+	// newProxyMCP. The speakFn stub returns no _audio_bytes so the playback
+	// short-circuits at "disabled" (disablePlayback gate runs first).
+	if ps, _ := out["playback_status"].(string); ps != "disabled" {
+		t.Fatalf("expected playback_status=disabled (disablePlayback=true), got %v", out["playback_status"])
 	}
 }
 
@@ -379,8 +379,8 @@ func TestMod3Speak_MCPSuccessPath(t *testing.T) {
 func TestMod3Speak_MCPQueued(t *testing.T) {
 	fm := newFakeMod3Proxy(t)
 	m := newProxyMCP(t, fm)
-	speakFn := newMCPSpeakFn(nil)
-	m.mod3Proxy.mcpSpeakFn = speakFn
+	speakFn := newSpeakFn(nil)
+	m.mod3Proxy.speakFn = speakFn
 
 	// First call — starts immediately.
 	_, _, _ = m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{Text: "first"})
@@ -412,13 +412,13 @@ func TestMod3Speak_MCPQueued(t *testing.T) {
 	}
 }
 
-// TestMod3Speak_MCPForwardsArgs — mcpSpeakFn receives all call-site arguments
+// TestMod3Speak_MCPForwardsArgs — speakFn receives all call-site arguments
 // (text, voice, speed, session_id) correctly.
 func TestMod3Speak_MCPForwardsArgs(t *testing.T) {
 	fm := newFakeMod3Proxy(t)
 	m := newProxyMCP(t, fm)
 	var captured []map[string]any
-	m.mod3Proxy.mcpSpeakFn = newMCPSpeakFn(&captured)
+	m.mod3Proxy.speakFn = newSpeakFn(&captured)
 
 	_, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{
 		Text:      "hello",
@@ -430,7 +430,7 @@ func TestMod3Speak_MCPForwardsArgs(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(captured) == 0 {
-		t.Fatal("mcpSpeakFn not called")
+		t.Fatal("speakFn not called")
 	}
 	args := captured[0]
 	if args["text"] != "hello" {
@@ -448,19 +448,19 @@ func TestMod3Speak_MCPForwardsArgs(t *testing.T) {
 }
 
 // TestMod3Speak_MCPOmitsSessionIDWhenAbsent — no session_id on the call site
-// must not produce a session_id key in the args forwarded to mcpSpeakFn.
+// must not produce a session_id key in the args forwarded to speakFn.
 func TestMod3Speak_MCPOmitsSessionIDWhenAbsent(t *testing.T) {
 	fm := newFakeMod3Proxy(t)
 	m := newProxyMCP(t, fm)
 	var captured []map[string]any
-	m.mod3Proxy.mcpSpeakFn = newMCPSpeakFn(&captured)
+	m.mod3Proxy.speakFn = newSpeakFn(&captured)
 
 	_, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{Text: "plain"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(captured) == 0 {
-		t.Fatal("mcpSpeakFn not called")
+		t.Fatal("speakFn not called")
 	}
 	if _, present := captured[0]["session_id"]; present {
 		t.Fatalf("expected no session_id key forwarded, got %v", captured[0]["session_id"])
@@ -474,7 +474,7 @@ func TestMod3Speak_MCPOmitsSessionIDWhenAbsent(t *testing.T) {
 func TestMod3Speak_ConcurrentCallsSequenced(t *testing.T) {
 	fm := newFakeMod3Proxy(t)
 	m := newProxyMCP(t, fm)
-	m.mod3Proxy.mcpSpeakFn = newMCPSpeakFn(nil)
+	m.mod3Proxy.speakFn = newSpeakFn(nil)
 
 	const n = 3
 	type result struct {
@@ -551,10 +551,11 @@ func TestMod3Speak_EmptyTextRejects(t *testing.T) {
 	}
 }
 
-// TestMod3Speak_BothPathsDownReturnsCleanError — when BOTH mod3's MCP
-// endpoint AND its HTTP /v1/synthesize are unreachable, the handler must
-// return IsError=true with a composite "mcp: ... http: ..." message.
-func TestMod3Speak_BothPathsDownReturnsCleanError(t *testing.T) {
+// TestMod3Speak_Mod3UnreachableReturnsCleanError — when mod3's /v1/synthesize
+// REST endpoint is unreachable, the handler must return IsError=true with an
+// "unreachable" message. (The old MCP-transport approach produced a composite
+// "mcp: ... http: ..." error; with the REST transport the error is simpler.)
+func TestMod3Speak_Mod3UnreachableReturnsCleanError(t *testing.T) {
 	// Port that refuses connections.
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -575,45 +576,69 @@ func TestMod3Speak_BothPathsDownReturnsCleanError(t *testing.T) {
 		t.Fatal("expected IsError=true when mod3 is unreachable")
 	}
 	tc := res.Content[0].(*mcp.TextContent)
-	// Error message must mention both failure paths.
 	lower := strings.ToLower(tc.Text)
-	if !strings.Contains(lower, "mcp") || !strings.Contains(lower, "http") {
-		t.Fatalf("expected composite error mentioning 'mcp' and 'http', got %q", tc.Text)
+	if !strings.Contains(lower, "unreachable") {
+		t.Fatalf("expected 'unreachable' in error text, got %q", tc.Text)
 	}
 }
 
-// TestMod3Speak_MCPDownFallsBackToSynthesize — when MCP is unreachable but
-// /v1/synthesize is up, the kernel falls back to local playback. The result
-// carries fallback_reason to surface the MCP failure to the caller.
-func TestMod3Speak_MCPDownFallsBackToSynthesize(t *testing.T) {
+// TestMod3Speak_RESTPathNoSpeakFnInjection — verifies the primary REST path
+// works when no speakFn is injected. The kernel posts to the fake mod3's
+// /v1/synthesize, receives WAV bytes + X-Mod3-Job-Id header, and synthesizes
+// a queue-state response. disablePlayback=true means playback_status=disabled.
+func TestMod3Speak_RESTPathNoSpeakFnInjection(t *testing.T) {
 	fm := newFakeMod3Proxy(t)
 	m := newProxyMCP(t, fm)
-	// No mcpSpeakFn injected — the fake server has no /mcp route so the
-	// StreamableClientTransport dial will fail, triggering the fallback.
+	// No speakFn injected — kernel uses the real REST path against the fake server.
 
 	res, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{
-		Text: "fallback test",
+		Text: "rest path test",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("expected success (fallback path), got IsError=true: %v", res.Content)
+		t.Fatalf("expected success (REST path), got IsError=true: %v", res.Content)
 	}
 	out := decodeToolText(t, res)
-	if ok, _ := out["ok"].(bool); !ok {
-		t.Fatalf("expected ok=true in fallback response, got %v", out["ok"])
+
+	// Verify the queue-state response shape from REST headers.
+	if status, _ := out["status"].(string); status != "completed" {
+		t.Fatalf("expected status=completed from REST path, got %v", out["status"])
 	}
-	if reason, _ := out["fallback_reason"].(string); reason == "" {
-		t.Fatal("expected fallback_reason to document why MCP path was skipped")
+	if jobID, _ := out["job_id"].(string); jobID != "job-test-0001" {
+		t.Fatalf("expected job_id=job-test-0001 from X-Mod3-Job-Id header, got %v", out["job_id"])
+	}
+	if _, ok := out["queue_position"]; !ok {
+		t.Fatal("expected queue_position in REST response")
+	}
+	if _, ok := out["metrics"]; !ok {
+		t.Fatal("expected metrics block in REST response")
+	}
+	// _audio_bytes must NOT appear in the returned JSON (it's an internal field).
+	if _, present := out["_audio_bytes"]; present {
+		t.Fatal("_audio_bytes internal field must be stripped from tool response")
 	}
 	if got, _ := out["playback_status"].(string); got != "disabled" {
 		t.Fatalf("expected playback_status=disabled (disablePlayback=true), got %v", out["playback_status"])
 	}
+
+	// Verify the fake server received the POST to /v1/synthesize.
+	last := fm.last()
+	if last.Path != "/v1/synthesize" || last.Method != "POST" {
+		t.Fatalf("expected POST /v1/synthesize, got %s %s", last.Method, last.Path)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(last.Body, &body); err != nil {
+		t.Fatalf("decode forwarded body: %v", err)
+	}
+	if body["text"] != "rest path test" {
+		t.Fatalf("expected text forwarded, got %v", body["text"])
+	}
 }
 
-// TestMod3Speak_FallbackPreservesMod3ErrorBody — when the fallback path hits
-// /v1/synthesize and gets a non-2xx, the mod3 error body is preserved intact.
+// TestMod3Speak_FallbackPreservesMod3ErrorBody — when /v1/synthesize returns
+// a non-2xx, the mod3 error body is preserved intact in the tool error.
 func TestMod3Speak_FallbackPreservesMod3ErrorBody(t *testing.T) {
 	fm := newFakeMod3Proxy(t)
 	fm.synthesizeHandler = func(w http.ResponseWriter, r *http.Request) {
@@ -621,7 +646,7 @@ func TestMod3Speak_FallbackPreservesMod3ErrorBody(t *testing.T) {
 		_, _ = w.Write([]byte(`{"detail":"text must not be empty"}`))
 	}
 	m := newProxyMCP(t, fm)
-	// No mcpSpeakFn — will fall through to /v1/synthesize which returns 422.
+	// No speakFn — REST path hits /v1/synthesize which returns 422.
 
 	res, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{Text: "bad"})
 	if err != nil {
@@ -640,15 +665,12 @@ func TestMod3Speak_FallbackPreservesMod3ErrorBody(t *testing.T) {
 }
 
 // ─── mod3_speak — legacy test names for backward-compat with existing CI ─────
-// These exercise the fallback path (fake httptest server has no /mcp).
 
 func TestMod3Speak_SuccessPath(t *testing.T) {
-	// Delegates to the canonical MCP-path test.
 	TestMod3Speak_MCPSuccessPath(t)
 }
 
 func TestMod3Speak_ForwardsSessionID(t *testing.T) {
-	// Verify session_id is forwarded on the MCP path.
 	TestMod3Speak_MCPForwardsArgs(t)
 }
 
@@ -657,7 +679,7 @@ func TestMod3Speak_OmitsSessionIDWhenAbsent(t *testing.T) {
 }
 
 func TestMod3Speak_Mod3DownReturnsCleanError(t *testing.T) {
-	TestMod3Speak_BothPathsDownReturnsCleanError(t)
+	TestMod3Speak_Mod3UnreachableReturnsCleanError(t)
 }
 
 func TestMod3Speak_PreservesMod3ErrorBody(t *testing.T) {


### PR DESCRIPTION
## Summary

- `mod3_speak` was broken: the kernel tried to dial `{Mod3URL}/mcp` via `mcp.StreamableClientTransport`, but mod3 has no `/mcp` endpoint — confirmed via `curl` and inspection of mod3's `/openapi.json`. Every call returned "Unable to connect."
- Replaced `callMod3SpeakTool` with a direct `POST {Mod3URL}/v1/synthesize` call. Mod3 serialises concurrent synthesis server-side and returns WAV bytes + `X-Mod3-*` metric headers. The kernel synthesises a queue-state-shaped response from those headers and handles local playback via afplay/aplay as before.
- All existing behaviour is preserved: `skip_playback` path, Wave 4.3 subscriber-routing, session tools, fallback playback plumbing, and the injectable `speakFn` test hook (formerly `mcpSpeakFn`).

## Changes

- `internal/engine/mcp_modality_proxy.go`: replace `StreamableClientTransport` block in `callMod3SpeakTool` with direct HTTP POST; strip `_audio_bytes` internal field before MCP response; update doc comment and struct field name.
- `internal/engine/mcp_modality_proxy_test.go`: rename `mcpSpeakFn` → `speakFn`; update assertions for new primary-path response shape; replace `TestMod3Speak_MCPDownFallsBackToSynthesize` with `TestMod3Speak_RESTPathNoSpeakFnInjection`; update `TestMod3Speak_BothPathsDownReturnsCleanError` → `TestMod3Speak_Mod3UnreachableReturnsCleanError`.

## Test plan

- [ ] `go test ./internal/engine/... -run 'TestMod3Speak'` — all 42 mod3 proxy tests pass
- [ ] `go test ./internal/engine/...` — full engine suite passes
- [ ] After deploy: `mcp__cogos-kernel__mod3_speak(text="hello from the kernel proxy", voice="bm_lewis")` no longer returns "Unable to connect" and produces audible audio
- [ ] Operator verification: `curl -s http://localhost:6931/health` reports ok after binary swap