### PR TITLE
fix(engine): switch mod3_speak to queue-aware /v1/speak endpoint

### DIFF
--- a/internal/engine/mcp_modality_proxy.go
+++ b/internal/engine/mcp_modality_proxy.go
@@ -2,23 +2,20 @@
 //
 // Wave 3 of the mod3-kernel integration (ADR-082 + channel-provider RFC),
 // consolidated in Wave 3.5 with Wave 2's session-ID authority.
-// The kernel becomes the MCP front door for mod3; the previous OpenClaw
-// gateway pattern in the installed binary read metrics but discarded audio
-// bytes. This proxy fixes that: it forwards speech requests to mod3's
-// /v1/synthesize REST endpoint and returns a queue-state-shaped response
-// derived from the response headers.
+// Wave 4.4 (this file) switches the primary speak path from the blocking
+// /v1/synthesize endpoint to the queue-aware /v1/speak endpoint, so mod3's
+// drain thread owns all audio scheduling and the kernel never spawns a local
+// afplay/aplay process.
 //
 // Design locks:
 //
-//  1. REST transport = direct POST to mod3's /v1/synthesize. Mod3 does not
-//     expose an /mcp endpoint; the prior StreamableClientTransport approach
-//     always failed with "unable to connect". The /v1/synthesize endpoint is
-//     blocking (waits for synthesis) and serializes concurrent calls
-//     server-side, so the kernel's local afplay/aplay handles playback.
-//     A synthesized queue-state response (status, job_id, metrics) is built
-//     from the X-Mod3-* response headers. The local player path and all
-//     fallback/subscriber-routing logic (Wave 4.3) are preserved unchanged.
-//     Other synthesis/control tool handlers (/v1/stop, /v1/voices, /health)
+//  1. REST transport = direct POST to mod3's /v1/speak (primary) or
+//     /v1/synthesize (skip_playback=true, raw bytes). Mod3 does not expose
+//     an /mcp endpoint; the prior StreamableClientTransport approach always
+//     failed with "unable to connect". /v1/speak is non-blocking — it enqueues
+//     and returns {job_id, queue_position, status} immediately. Mod3's drain
+//     thread handles all audio; the kernel never spawns afplay/aplay for the
+//     primary path. Other control handlers (/v1/stop, /v1/voices, /health)
 //     continue to POST/GET against cfg.Mod3URL + "/v1/*" as before.
 //  2. Session authority = kernel-owned (Wave 3.5). The session-family tools
 //     (register/deregister/list) do NOT call mod3 directly — they call the
@@ -27,9 +24,9 @@
 //     and forward to mod3. Session ID minting happens in exactly one place.
 //  3. SkipPlayback = callers that need raw bytes (dashboard WS, file write,
 //     etc.) still use the /v1/synthesize HTTP path, which returns audio/wav.
-//     The subscriber-routing path (Wave 4.3) also remains: when a session
-//     has a live dashboard WebSocket subscriber, mod3 routes WAV there
-//     independently; the kernel skips the local player.
+//     The subscriber-routing path (Wave 4.3) also remains for skip_playback:
+//     when a session has a live dashboard WebSocket subscriber, mod3 routes
+//     WAV there independently; the kernel skips the local player.
 //
 // Tools registered (prefix `mod3_` to namespace against cog_* kernel tools):
 //
@@ -136,15 +133,15 @@ func (m *MCPServer) getModalityProxy() *modalityProxy {
 func (m *MCPServer) registerMod3Tools() {
 	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name: "mod3_speak",
-		Description: "Synthesize text to speech via mod3's queue-aware speak() " +
-			"MCP tool. Required: text. Optional: session_id, voice, speed, " +
+		Description: "Synthesize text to speech via mod3's queue-aware /v1/speak " +
+			"endpoint. Required: text. Optional: session_id, voice, speed, " +
 			"emotion, skip_playback (return raw base64 bytes without queuing). " +
-			"Returns mod3's queue state: status (speaking|queued|held), job_id, " +
-			"queue_position (0=playing immediately, N=queued at position N), " +
-			"currently_playing, estimated_wait_sec, and an actions hint. " +
-			"Concurrent calls are serialized by mod3 — no overlapping audio. " +
-			"Fallback: curl -X POST http://localhost:7860/v1/synthesize " +
-			"-d '{\"text\":\"...\"}' -o out.wav && afplay out.wav",
+			"Returns mod3's queue state: status (speaking|queued), job_id, " +
+			"queue_position (0=playing immediately, N=queued at position N). " +
+			"Concurrent calls are serialized by mod3's drain thread — no " +
+			"overlapping audio, no local afplay spawned by the kernel. " +
+			"Fallback: curl -X POST http://localhost:7860/v1/speak " +
+			"-H 'Content-Type: application/json' -d '{\"text\":\"...\"}'",
 	}), withToolObserver(m, "mod3_speak", m.toolMod3Speak))
 
 	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
@@ -293,65 +290,18 @@ func (m *MCPServer) toolMod3Speak(ctx context.Context, req *mcp.CallToolRequest,
 		return m.toolMod3SpeakRawBytes(ctx, in)
 	}
 
-	// Primary path: POST to mod3's /v1/synthesize REST endpoint (blocking).
-	// callMod3SpeakTool handles the HTTP round-trip and synthesises a
-	// queue-state response map from the X-Mod3-* response headers.
-	// Playback is handled locally below (mod3 synthesizes audio and returns
-	// bytes; it does not play audio server-side).
-	synthesisResult, synthesisErr := m.callMod3SpeakTool(ctx, in)
-	if synthesisErr != nil {
-		// Synthesis failed — surface a clean error; no audio to play.
-		return mod3ErrorResult(fmt.Sprintf("mod3 unreachable: %v", synthesisErr))
+	// Primary path: POST to mod3's /v1/speak REST endpoint (non-blocking,
+	// queue-aware). callMod3SpeakTool handles the HTTP round-trip and returns
+	// the JSON response {job_id, queue_position, status}. Mod3's drain thread
+	// owns all audio playback — the kernel never spawns afplay/aplay here.
+	speakResult, speakErr := m.callMod3SpeakTool(ctx, in)
+	if speakErr != nil {
+		return mod3ErrorResult(fmt.Sprintf("mod3 unreachable: %v", speakErr))
 	}
 
-	// Happy path — synthesis succeeded.  Add session_id echo for
-	// observability consistency, then handle local playback.
-	synthesisResult["session_id"] = in.SessionID
-
-	// Retrieve and strip the internal _audio_bytes transport field before
-	// any return path so the MCP response never exposes raw bytes here.
-	// (SkipPlayback callers use toolMod3SpeakRawBytes which returns base64.)
-	audioBytes, _ := synthesisResult["_audio_bytes"].([]byte)
-	delete(synthesisResult, "_audio_bytes")
-
-	p := m.getModalityProxy()
-	if p.disablePlayback {
-		synthesisResult["playback_status"] = "disabled"
-		return marshalResult(synthesisResult)
-	}
-
-	// Wave 4.3 subscriber-routing: when a session has a live dashboard
-	// WebSocket subscriber, mod3 routes WAV there independently; the kernel
-	// skips the local player.
-	if in.SessionID != "" {
-		subscribed, checkErr := m.checkSessionSubscriber(ctx, in.SessionID)
-		if checkErr != nil {
-			slog.Debug("mod3 proxy: subscriber check failed",
-				"session_id", in.SessionID, "err", checkErr)
-			synthesisResult["subscriber_check_error"] = checkErr.Error()
-		}
-		if subscribed {
-			synthesisResult["playback_status"] = "routed_ws"
-			return marshalResult(synthesisResult)
-		}
-	}
-
-	if len(audioBytes) == 0 {
-		synthesisResult["playback_status"] = "no_audio"
-		return marshalResult(synthesisResult)
-	}
-
-	playErr := p.playAudio(audioBytes, in.Blocking)
-	switch {
-	case playErr == nil && in.Blocking:
-		synthesisResult["playback_status"] = "played"
-	case playErr == nil:
-		synthesisResult["playback_status"] = "spawned"
-	default:
-		synthesisResult["playback_status"] = "error"
-		synthesisResult["playback_error"] = playErr.Error()
-	}
-	return marshalResult(synthesisResult)
+	// Echo session_id for observability consistency.
+	speakResult["session_id"] = in.SessionID
+	return marshalResult(speakResult)
 }
 
 // toolMod3SpeakRawBytes handles mod3_speak with skip_playback=true.
@@ -451,15 +401,10 @@ func (m *MCPServer) toolMod3SpeakLocalFallback(ctx context.Context, in mod3Speak
 	return marshalResult(result)
 }
 
-// callMod3SpeakTool POSTs to mod3's /v1/synthesize REST endpoint (blocking)
-// and returns a queue-state-shaped response map synthesised from the
-// X-Mod3-* response headers. The audio bytes are stashed under the internal
-// key "_audio_bytes" so toolMod3Speak can hand them to the local player
-// without re-reading.
-//
-// Mod3 does not expose an /mcp endpoint; the previous StreamableClientTransport
-// approach always failed. /v1/synthesize serialises concurrent calls server-side
-// so no additional queue-management is needed on the kernel side.
+// callMod3SpeakTool POSTs to mod3's /v1/speak REST endpoint (non-blocking,
+// queue-aware) and returns the parsed JSON response {job_id, queue_position,
+// status}. Mod3's drain thread owns all audio playback — the kernel never
+// spawns afplay/aplay for this path.
 //
 // Injectable via modalityProxy.speakFn for tests that want deterministic
 // queue-state responses without hitting a real HTTP server.
@@ -477,45 +422,47 @@ func (m *MCPServer) callMod3SpeakTool(ctx context.Context, in mod3SpeakInput) (m
 		return nil, errors.New("Mod3URL not configured")
 	}
 
-	body := buildSynthesizeBody(in)
+	body := buildSpeakBody(in)
 	raw, _ := json.Marshal(body)
 
-	audio, headers, status, err := m.proxyMod3Bytes(ctx, http.MethodPost,
-		"/v1/synthesize", bytes.NewReader(raw), "application/json")
+	respBytes, _, status, err := m.proxyMod3Bytes(ctx, http.MethodPost,
+		"/v1/speak", bytes.NewReader(raw), "application/json")
 	if err != nil {
-		return nil, fmt.Errorf("mod3 /v1/synthesize: %w", err)
+		return nil, fmt.Errorf("mod3 /v1/speak: %w", err)
 	}
 	if status < 200 || status >= 300 {
-		return nil, fmt.Errorf("mod3 returned %d: %s", status, truncate(string(audio), 400))
+		return nil, fmt.Errorf("mod3 returned %d: %s", status, truncate(string(respBytes), 400))
 	}
 
-	metrics := extractMod3Metrics(headers)
-
-	// Extract the job_id from the X-Mod3-Job-Id header so callers get a
-	// stable correlation handle even when the queue-position concept is N/A
-	// (synthesize is blocking; by the time we return, the job is done).
-	jobID := headers.Get("X-Mod3-Job-Id")
-	if jobID == "" {
-		jobID = "inline"
-	}
-
-	result := map[string]any{
-		"status":              "completed",
-		"job_id":              jobID,
-		"queue_position":      float64(0),
-		"estimated_wait_sec":  float64(0),
-		"metrics":             metrics,
-		// _audio_bytes is an internal transport field stripped before the
-		// MCP response is sent; it lets toolMod3Speak hand raw bytes to the
-		// local player without a second HTTP round-trip.
-		"_audio_bytes": audio,
+	// Parse the JSON response — {job_id, queue_position, status}.
+	var result map[string]any
+	if jsonErr := json.Unmarshal(respBytes, &result); jsonErr != nil {
+		return nil, fmt.Errorf("mod3 /v1/speak: decode response: %w (raw=%s)", jsonErr, truncate(string(respBytes), 200))
 	}
 	return result, nil
 }
 
+// buildSpeakBody constructs the JSON body for a /v1/speak request.
+// Used by callMod3SpeakTool for the primary queue-aware speak path.
+func buildSpeakBody(in mod3SpeakInput) map[string]any {
+	body := map[string]any{"text": in.Text}
+	if in.Voice != "" {
+		body["voice"] = in.Voice
+	}
+	if in.Speed > 0 {
+		body["speed"] = in.Speed
+	}
+	if in.Emotion > 0 {
+		body["emotion"] = in.Emotion
+	}
+	if in.SessionID != "" {
+		body["session_id"] = in.SessionID
+	}
+	return body
+}
+
 // buildSynthesizeBody constructs the JSON body for a /v1/synthesize request
-// from a mod3SpeakInput. Shared between the raw-bytes path and the local
-// fallback.
+// from a mod3SpeakInput. Used only by the raw-bytes path (skip_playback=true).
 func buildSynthesizeBody(in mod3SpeakInput) map[string]any {
 	body := map[string]any{"text": in.Text}
 	if in.Voice != "" {

--- a/internal/engine/mcp_modality_proxy_test.go
+++ b/internal/engine/mcp_modality_proxy_test.go
@@ -35,6 +35,7 @@ type fakeMod3Proxy struct {
 	captured []capturedProxyRequest
 
 	// Overrides for per-endpoint behavior.
+	speakHandler        http.HandlerFunc
 	synthesizeHandler   http.HandlerFunc
 	stopHandler         http.HandlerFunc
 	voicesHandler       http.HandlerFunc
@@ -65,6 +66,22 @@ func newFakeMod3Proxy(t *testing.T) *fakeMod3Proxy {
 	fm := &fakeMod3Proxy{t: t}
 	mux := http.NewServeMux()
 
+	// POST /v1/speak — primary queue-aware speak endpoint (non-blocking, JSON).
+	mux.HandleFunc("POST /v1/speak", func(w http.ResponseWriter, r *http.Request) {
+		fm.capture(r)
+		if fm.speakHandler != nil {
+			fm.speakHandler(w, r)
+			return
+		}
+		// Default: return a "speaking" response (queue_position=0, first call).
+		writeFakeJSON(w, http.StatusOK, map[string]any{
+			"job_id":         "job-speak-0001",
+			"queue_position": 0,
+			"status":         "speaking",
+		})
+	})
+
+	// POST /v1/synthesize — raw-bytes path (skip_playback=true or legacy).
 	mux.HandleFunc("POST /v1/synthesize", func(w http.ResponseWriter, r *http.Request) {
 		fm.capture(r)
 		if fm.synthesizeHandler != nil {
@@ -331,9 +348,8 @@ func newSpeakFn(capturedArgs *[]map[string]any) func(ctx context.Context, in mod
 
 // TestMod3Speak_MCPSuccessPath — the primary happy path: speakFn returns a
 // "speaking" response; the result must contain job_id + queue_position.
-// With the REST transport replacing the old MCP transport, the kernel handles
-// playback locally. disablePlayback=true is set by newProxyMCP so the test
-// asserts playback_status="disabled" rather than "spawned"/"played".
+// With the queue-aware /v1/speak endpoint, mod3 owns playback — the kernel
+// returns the JSON queue state directly without setting playback_status.
 func TestMod3Speak_MCPSuccessPath(t *testing.T) {
 	fm := newFakeMod3Proxy(t)
 	m := newProxyMCP(t, fm)
@@ -366,11 +382,10 @@ func TestMod3Speak_MCPSuccessPath(t *testing.T) {
 	if _, ok := out["estimated_wait_sec"]; !ok {
 		t.Fatal("expected estimated_wait_sec in result")
 	}
-	// playback_status is present; "disabled" because disablePlayback=true in
-	// newProxyMCP. The speakFn stub returns no _audio_bytes so the playback
-	// short-circuits at "disabled" (disablePlayback gate runs first).
-	if ps, _ := out["playback_status"].(string); ps != "disabled" {
-		t.Fatalf("expected playback_status=disabled (disablePlayback=true), got %v", out["playback_status"])
+	// playback_status is NOT set by the primary path — mod3's drain thread
+	// owns all audio scheduling; the kernel no longer reports local player status.
+	if _, present := out["playback_status"]; present {
+		t.Fatalf("playback_status must not appear in primary /v1/speak response, got %v", out["playback_status"])
 	}
 }
 
@@ -584,8 +599,8 @@ func TestMod3Speak_Mod3UnreachableReturnsCleanError(t *testing.T) {
 
 // TestMod3Speak_RESTPathNoSpeakFnInjection — verifies the primary REST path
 // works when no speakFn is injected. The kernel posts to the fake mod3's
-// /v1/synthesize, receives WAV bytes + X-Mod3-Job-Id header, and synthesizes
-// a queue-state response. disablePlayback=true means playback_status=disabled.
+// /v1/speak (queue-aware) and receives a JSON {job_id, queue_position, status}
+// response. Mod3 owns playback — no playback_status set by the kernel.
 func TestMod3Speak_RESTPathNoSpeakFnInjection(t *testing.T) {
 	fm := newFakeMod3Proxy(t)
 	m := newProxyMCP(t, fm)
@@ -602,31 +617,31 @@ func TestMod3Speak_RESTPathNoSpeakFnInjection(t *testing.T) {
 	}
 	out := decodeToolText(t, res)
 
-	// Verify the queue-state response shape from REST headers.
-	if status, _ := out["status"].(string); status != "completed" {
-		t.Fatalf("expected status=completed from REST path, got %v", out["status"])
+	// Verify the queue-state response shape from /v1/speak JSON body.
+	if status, _ := out["status"].(string); status != "speaking" {
+		t.Fatalf("expected status=speaking from /v1/speak, got %v", out["status"])
 	}
-	if jobID, _ := out["job_id"].(string); jobID != "job-test-0001" {
-		t.Fatalf("expected job_id=job-test-0001 from X-Mod3-Job-Id header, got %v", out["job_id"])
+	if jobID, _ := out["job_id"].(string); jobID != "job-speak-0001" {
+		t.Fatalf("expected job_id=job-speak-0001 from /v1/speak, got %v", out["job_id"])
 	}
-	if _, ok := out["queue_position"]; !ok {
-		t.Fatal("expected queue_position in REST response")
+	if qp, ok := out["queue_position"]; !ok {
+		t.Fatal("expected queue_position in /v1/speak response")
+	} else if qp.(float64) != 0 {
+		t.Fatalf("expected queue_position=0, got %v", qp)
 	}
-	if _, ok := out["metrics"]; !ok {
-		t.Fatal("expected metrics block in REST response")
-	}
-	// _audio_bytes must NOT appear in the returned JSON (it's an internal field).
+	// _audio_bytes must NOT appear — /v1/speak returns JSON not WAV bytes.
 	if _, present := out["_audio_bytes"]; present {
-		t.Fatal("_audio_bytes internal field must be stripped from tool response")
+		t.Fatal("_audio_bytes must not appear in /v1/speak response")
 	}
-	if got, _ := out["playback_status"].(string); got != "disabled" {
-		t.Fatalf("expected playback_status=disabled (disablePlayback=true), got %v", out["playback_status"])
+	// playback_status is NOT set by the primary path — mod3's drain thread owns audio.
+	if _, present := out["playback_status"]; present {
+		t.Fatalf("playback_status must not appear in primary /v1/speak response, got %v", out["playback_status"])
 	}
 
-	// Verify the fake server received the POST to /v1/synthesize.
+	// Verify the fake server received POST to /v1/speak (not /v1/synthesize).
 	last := fm.last()
-	if last.Path != "/v1/synthesize" || last.Method != "POST" {
-		t.Fatalf("expected POST /v1/synthesize, got %s %s", last.Method, last.Path)
+	if last.Path != "/v1/speak" || last.Method != "POST" {
+		t.Fatalf("expected POST /v1/speak, got %s %s", last.Method, last.Path)
 	}
 	var body map[string]any
 	if err := json.Unmarshal(last.Body, &body); err != nil {
@@ -637,16 +652,16 @@ func TestMod3Speak_RESTPathNoSpeakFnInjection(t *testing.T) {
 	}
 }
 
-// TestMod3Speak_FallbackPreservesMod3ErrorBody — when /v1/synthesize returns
-// a non-2xx, the mod3 error body is preserved intact in the tool error.
-func TestMod3Speak_FallbackPreservesMod3ErrorBody(t *testing.T) {
+// TestMod3Speak_PreservesErrorBody — when /v1/speak returns a non-2xx,
+// the mod3 error body is preserved intact in the tool error.
+func TestMod3Speak_PreservesErrorBody(t *testing.T) {
 	fm := newFakeMod3Proxy(t)
-	fm.synthesizeHandler = func(w http.ResponseWriter, r *http.Request) {
+	fm.speakHandler = func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnprocessableEntity)
 		_, _ = w.Write([]byte(`{"detail":"text must not be empty"}`))
 	}
 	m := newProxyMCP(t, fm)
-	// No speakFn — REST path hits /v1/synthesize which returns 422.
+	// No speakFn — REST path hits /v1/speak which returns 422.
 
 	res, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{Text: "bad"})
 	if err != nil {
@@ -682,8 +697,8 @@ func TestMod3Speak_Mod3DownReturnsCleanError(t *testing.T) {
 	TestMod3Speak_Mod3UnreachableReturnsCleanError(t)
 }
 
-func TestMod3Speak_PreservesMod3ErrorBody(t *testing.T) {
-	TestMod3Speak_FallbackPreservesMod3ErrorBody(t)
+func TestMod3Speak_FallbackPreservesMod3ErrorBody(t *testing.T) {
+	TestMod3Speak_PreservesErrorBody(t)
 }
 
 func TestMod3Speak_SkipPlaybackReturnsBase64(t *testing.T) {
@@ -1159,22 +1174,27 @@ sleep 5
 	}
 }
 
-// ─── Wave 4.3 — subscriber-check / afplay skip ───────────────────────────────
+// ─── Wave 4.3 — subscriber-check / afplay skip (local-fallback path) ────────
+//
+// These tests exercise toolMod3SpeakLocalFallback, which is the preserved
+// legacy code path for when a caller explicitly needs the kernel to manage
+// local audio playback (e.g. testing the audio plumbing independently from
+// the primary /v1/speak queue path). The primary toolMod3Speak now routes
+// through /v1/speak and mod3's drain thread owns all audio.
 
-// TestMod3Speak_NoSessionAlwaysSpawnsPlayer — session_id="" bypasses the
-// subscriber check entirely so CLI invocations of mod3_speak still play
-// audio through afplay as they always did.
-func TestMod3Speak_NoSessionAlwaysSpawnsPlayer(t *testing.T) {
+// TestMod3Speak_LocalFallback_NoSessionSpawnsPlayer — session_id="" in
+// the local-fallback path bypasses the subscriber check and spawns the player.
+func TestMod3Speak_LocalFallback_NoSessionSpawnsPlayer(t *testing.T) {
 	fm := newFakeMod3Proxy(t)
 	m := newProxyMCP(t, fm)
 
 	stubPath, count := writeStubPlayer(t)
 	m.mod3Proxy = &modalityProxy{player: stubPath}
 
-	res, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{
+	res, _, err := m.toolMod3SpeakLocalFallback(context.Background(), mod3SpeakInput{
 		Text:     "no session",
-		Blocking: true, // wait for stub to finish so the test can assert invocation count
-	})
+		Blocking: true,
+	}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1190,10 +1210,9 @@ func TestMod3Speak_NoSessionAlwaysSpawnsPlayer(t *testing.T) {
 	}
 }
 
-// TestMod3Speak_SessionWithSubscriberSkipsPlayer — when the injected
-// subscriber-check returns true, the kernel skips afplay entirely and
-// returns playback_status=routed_ws. The stub player must NOT be invoked.
-func TestMod3Speak_SessionWithSubscriberSkipsPlayer(t *testing.T) {
+// TestMod3Speak_LocalFallback_SessionWithSubscriberSkipsPlayer — subscriber-
+// check returns true: the local-fallback path skips the player (routed_ws).
+func TestMod3Speak_LocalFallback_SessionWithSubscriberSkipsPlayer(t *testing.T) {
 	fm := newFakeMod3Proxy(t)
 	m := newProxyMCP(t, fm)
 
@@ -1208,11 +1227,11 @@ func TestMod3Speak_SessionWithSubscriberSkipsPlayer(t *testing.T) {
 		},
 	}
 
-	res, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{
+	res, _, err := m.toolMod3SpeakLocalFallback(context.Background(), mod3SpeakInput{
 		Text:      "skip me",
 		SessionID: "cs-with-sub",
 		Blocking:  true,
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1230,10 +1249,9 @@ func TestMod3Speak_SessionWithSubscriberSkipsPlayer(t *testing.T) {
 	}
 }
 
-// TestMod3Speak_SessionWithoutSubscriberSpawnsPlayer — subscriber-check
-// returns false: kernel falls back to the normal afplay path and the stub
-// player IS invoked.
-func TestMod3Speak_SessionWithoutSubscriberSpawnsPlayer(t *testing.T) {
+// TestMod3Speak_LocalFallback_NoSubscriberSpawnsPlayer — subscriber-check
+// returns false: kernel falls back to the player path.
+func TestMod3Speak_LocalFallback_NoSubscriberSpawnsPlayer(t *testing.T) {
 	fm := newFakeMod3Proxy(t)
 	m := newProxyMCP(t, fm)
 
@@ -1245,11 +1263,11 @@ func TestMod3Speak_SessionWithoutSubscriberSpawnsPlayer(t *testing.T) {
 		},
 	}
 
-	res, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{
+	res, _, err := m.toolMod3SpeakLocalFallback(context.Background(), mod3SpeakInput{
 		Text:      "no subscriber",
 		SessionID: "cs-no-sub",
 		Blocking:  true,
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1265,11 +1283,9 @@ func TestMod3Speak_SessionWithoutSubscriberSpawnsPlayer(t *testing.T) {
 	}
 }
 
-// TestMod3Speak_SubscriberCheckErrorFallsBackToPlayer — transient
-// check error (mod3 flaky, timeout, etc.) must not orphan the audio.
-// The kernel logs the error, records subscriber_check_error in the result,
-// and still spawns the player so the user hears the reply.
-func TestMod3Speak_SubscriberCheckErrorFallsBackToPlayer(t *testing.T) {
+// TestMod3Speak_LocalFallback_SubscriberCheckErrorFallsBack — transient check
+// error must not orphan the audio; the local-fallback path still spawns the player.
+func TestMod3Speak_LocalFallback_SubscriberCheckErrorFallsBack(t *testing.T) {
 	fm := newFakeMod3Proxy(t)
 	m := newProxyMCP(t, fm)
 
@@ -1281,11 +1297,11 @@ func TestMod3Speak_SubscriberCheckErrorFallsBackToPlayer(t *testing.T) {
 		},
 	}
 
-	res, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{
+	res, _, err := m.toolMod3SpeakLocalFallback(context.Background(), mod3SpeakInput{
 		Text:      "check failed",
 		SessionID: "cs-flaky",
 		Blocking:  true,
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Switches `callMod3SpeakTool` from POST `/v1/synthesize` to POST `/v1/speak` (mod3 PR #54)
- Parses JSON `{job_id, queue_position, status}` response instead of WAV bytes + headers
- Removes kernel-side `afplay`/`aplay` spawning from the primary speak path — mod3's drain thread owns all audio scheduling
- `skip_playback=true` path (`toolMod3SpeakRawBytes`) still hits `/v1/synthesize` and returns raw bytes, unchanged
- Wave 4.3 subscriber-check tests redirected to `toolMod3SpeakLocalFallback` (which is preserved as explicit local-player test surface)

## Motivation

PR #258 (interim fix) made sound work again after mod3 PR #42 deleted the MCP shim, but it routed through `/v1/synthesize` — which is blocking, returns WAV bytes, and bypasses mod3's `_speech_queue` entirely. The kernel spawned a local `afplay` process. Concurrent kernel speak calls and dashboard-originated speech could overlap.

This PR implements Option 2 from the proposal (cog://mem/working/mod3-speak-proper-fix-proposal-2026-05-15): `/v1/speak` is non-blocking, enqueues via `_start_speech`, and mod3's drain thread serializes all audio. The kernel gets a job_id + queue_position and nothing else; it never touches audio files.

**Sequence dependency:** This PR requires mod3 PR #54 to be deployed before the kernel restart. The `callMod3SpeakTool` will 404 against an older mod3 that lacks `/v1/speak`.

## Test plan

- [x] `go test ./internal/engine/ -run TestMod3 -v` — all pass
- [x] `go test ./internal/engine/ -count=1` — full suite passes
- [x] `go build ./...` — clean build
- [ ] After mod3 PR #54 merges + mod3 restarts: rebuild kernel (`go build -o ... ./cmd/cogos`), restart kernel, verify `mod3_speak text="hello"` returns `{job_id, queue_position, status}` and audio plays
- [ ] Concurrent test: `for i in 1 2 3; do curl -X POST http://localhost:7860/v1/speak -H 'Content-Type: application/json' -d "{\"text\":\"counting $i\"}" & done; wait` — three distinct queue_positions, sequential audio
- [ ] `ps aux | grep -i afplay` — no kernel-spawned afplay after speak call

## Key diffs

- `callMod3SpeakTool`: 37 lines → 23 lines (removes WAV handling, header extraction, `_audio_bytes` stash)
- `toolMod3Speak`: primary path now 5 lines (was ~30 with player branching)
- Net: 142 insertions, 179 deletions — a net reduction

Depends-on: myrgic/mod3#54