### PR TITLE
fix(engine): extract tool-call text args into turn.Response for audit fidelity

### DIFF
--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -1221,6 +1221,12 @@ func (s *Server) completeChat(w http.ResponseWriter, ctx context.Context, req *C
 				})
 			}
 		}
+		// Audit-fidelity fix: when the model replies via speak/send_text/output
+		// tool calls, resp.Content is empty. Extract the text payload from the
+		// tool-call arguments so turn.Response captures what was actually said.
+		if turn.Response == "" {
+			turn.Response = extractTextFromToolCalls(turn.ToolCalls)
+		}
 	}
 
 	// Derive per-phase timings from the response payload.
@@ -1717,6 +1723,13 @@ func (s *Server) flushStreamHop(buf *streamHopBuffer, externalCalls []ToolCall,
 				OutputTokens: buf.usage.OutputTokens,
 				TotalTokens:  buf.usage.InputTokens + buf.usage.OutputTokens,
 			}
+		}
+		// Audit-fidelity fix: when the model replies via speak/send_text/output
+		// tool calls, the streaming buffer text content is empty. Extract the
+		// text payload from tool-call arguments so the turn record captures what
+		// was actually said.
+		if turn.Response == "" {
+			turn.Response = extractTextFromToolCalls(turn.ToolCalls)
 		}
 	}
 

--- a/internal/engine/turn_storage.go
+++ b/internal/engine/turn_storage.go
@@ -23,6 +23,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 	"unicode/utf8"
@@ -151,6 +152,53 @@ func turnSidecarPath(workspaceRoot, sessionID string) string {
 // rewrites by downstream consumers).
 func turnSidecarRelPath(sessionID string) string {
 	return filepath.Join(".cog", "run", "turns", sessionID+".jsonl")
+}
+
+// extractTextFromToolCalls scans a slice of ToolCallRecords for text-bearing
+// tool calls (speak, send_text, output) and concatenates their text payloads
+// with a double-newline separator. Returns "" when no text-bearing calls exist.
+//
+// This is the fix for the audit-fidelity gap: when the model replies purely
+// via tool calls (e.g. speak({text:"..."})), resp.Content is empty and
+// turn.Response would otherwise persist as "". Callers apply this after
+// setting turn.Response = resp.Content:
+//
+//	if turn.Response == "" {
+//	    turn.Response = extractTextFromToolCalls(turn.ToolCalls)
+//	}
+func extractTextFromToolCalls(calls []ToolCallRecord) string {
+	var parts []string
+	for _, tc := range calls {
+		if tc.Arguments == "" {
+			continue
+		}
+		var args map[string]any
+		if err := json.Unmarshal([]byte(tc.Arguments), &args); err != nil {
+			continue
+		}
+		var text string
+		switch tc.Name {
+		case "speak", "output":
+			if v, ok := args["text"]; ok {
+				text, _ = v.(string)
+			}
+		case "send_text":
+			// send_text uses "content" as its text field.
+			if v, ok := args["content"]; ok {
+				text, _ = v.(string)
+			}
+			// Fallback: some callers pass "text" even on send_text.
+			if text == "" {
+				if v, ok := args["text"]; ok {
+					text, _ = v.(string)
+				}
+			}
+		}
+		if text != "" {
+			parts = append(parts, text)
+		}
+	}
+	return strings.Join(parts, "\n\n")
 }
 
 // truncateUTF8Bytes returns a prefix of s containing at most capBytes bytes,


### PR DESCRIPTION
## Summary

- When the model replies via `speak()`, `send_text()`, or `output()` tool calls, `resp.Content` is empty. Turn records have been persisting with blank `response_text` in the sidecar JSONL and empty `content_preview` in ledger events.
- Adds `extractTextFromToolCalls(calls []ToolCallRecord) string` helper in `turn_storage.go` that scans tool call records for text-bearing tools and extracts their payload.
- Applied in both `completeChat` and `streamChat` as a fallback when `turn.Response` is empty after the standard content assignment.

## Tool coverage

- `speak` — extracts `arguments.text`
- `output` — extracts `arguments.text` (future unified tool)
- `send_text` — extracts `arguments.content` (with `arguments.text` fallback)
- Multiple text-bearing calls in one turn joined with `\n\n`

## Verification

Build passes. End-to-end: after a voice turn via `speak()`, the sidecar at `.cog/run/turns/<session_id>.jsonl` will have a non-empty `response` field matching the spoken text.

This is slice 1 of the speculative-output observability stack.