### PR TITLE
feat(engine): speculative-output block in turn-record and context assembly

### DIFF
--- a/internal/engine/context_assembly.go
+++ b/internal/engine/context_assembly.go
@@ -73,6 +73,13 @@ type ContextPackage struct {
 	// + conversation history) after eviction. Equal to the original flex
 	// budget minus whatever remained unspent.
 	FlexBudgetUsed int
+
+	// PreviousTurnSpeculative is the barge-in-truncated suffix from the
+	// previous turn — text the model generated but that was never played to
+	// the user. Non-empty only when the previous turn was interrupted.
+	// Injected into the system prompt as an agent-private block so the model
+	// knows what it "almost said" without the user having heard it.
+	PreviousTurnSpeculative string
 }
 
 // FovealDoc is a single CogDoc selected for context injection.
@@ -183,17 +190,18 @@ func (p *Process) AssembleContext(query string, messages []ProviderMessage, budg
 	for _, o := range opts {
 		o(&ao)
 	}
-	return p.assembleContextInnerWithOpts(ao.ctx, ao.convID, query, messages, budget, ao.manifestMode, ao.iris)
+	return p.assembleContextInnerWithOpts(ao.ctx, ao.convID, query, messages, budget, ao.manifestMode, ao.iris, ao.previousTurnSpeculative)
 }
 
 // AssembleOption configures optional AssembleContext parameters.
 type AssembleOption func(*assembleOpts)
 
 type assembleOpts struct {
-	ctx          context.Context
-	convID       string
-	iris         irisSignal
-	manifestMode bool
+	ctx                     context.Context
+	convID                  string
+	iris                    irisSignal
+	manifestMode            bool
+	previousTurnSpeculative string
 }
 
 func assembleDefaults() assembleOpts {
@@ -222,7 +230,14 @@ func WithManifestMode(enabled bool) AssembleOption {
 	return func(o *assembleOpts) { o.manifestMode = enabled }
 }
 
-func (p *Process) assembleContextInnerWithOpts(ctx context.Context, convID string, query string, messages []ProviderMessage, budget int, manifestMode bool, iris irisSignal) (*ContextPackage, error) {
+// WithPreviousTurnSpeculative injects the barge-in-truncated suffix from the
+// previous turn as an agent-private block in the assembled system prompt.
+// Pass "" to omit the block (no barge-in on the previous turn).
+func WithPreviousTurnSpeculative(text string) AssembleOption {
+	return func(o *assembleOpts) { o.previousTurnSpeculative = text }
+}
+
+func (p *Process) assembleContextInnerWithOpts(ctx context.Context, convID string, query string, messages []ProviderMessage, budget int, manifestMode bool, iris irisSignal, previousTurnSpeculative string) (*ContextPackage, error) {
 	if budget <= 0 {
 		budget = p.cfg.EffectiveBudget()
 	}
@@ -241,7 +256,11 @@ func (p *Process) assembleContextInnerWithOpts(ctx context.Context, convID strin
 		outputReserve = 4096
 	}
 
-	pkg := &ContextPackage{OutputReserve: outputReserve, Budget: budget}
+	pkg := &ContextPackage{
+		OutputReserve:           outputReserve,
+		Budget:                  budget,
+		PreviousTurnSpeculative: previousTurnSpeculative,
+	}
 
 	// === Decompose client messages ===
 
@@ -281,9 +300,14 @@ func (p *Process) assembleContextInnerWithOpts(ctx context.Context, convID strin
 	if pkg.CurrentMessage != nil {
 		currentMsgTokens = estimateTokens(pkg.CurrentMessage.Content)
 	}
+	speculativeTokens := 0
+	if previousTurnSpeculative != "" {
+		// Approximate tokens for the injected speculative block (header + content).
+		speculativeTokens = estimateTokens("<previous-turn-speculative>\n" + previousTurnSpeculative + "\n</previous-turn-speculative>")
+	}
 
 	// Budget available for CogDocs + conversation history.
-	flexBudget := budget - outputReserve - nucleusTokens - clientSysTokens - currentMsgTokens
+	flexBudget := budget - outputReserve - nucleusTokens - clientSysTokens - currentMsgTokens - speculativeTokens
 	if flexBudget < 0 {
 		flexBudget = 0
 	}
@@ -476,6 +500,21 @@ func (pkg *ContextPackage) FormatForProvider() (string, []ProviderMessage) {
 				sb.WriteString("\n\n")
 			}
 		}
+	}
+
+	// Inject speculative-output block as agent-private context (Slice 4).
+	// This block is visible only to the model — it is NOT shown to the user.
+	// It carries the suffix of the previous response that was generated but
+	// never delivered because the user barged in. The model can use it to
+	// decide whether to repeat, continue, or drop the unsaid content.
+	if pkg.PreviousTurnSpeculative != "" {
+		if sb.Len() > 0 {
+			sb.WriteString("\n\n---\n")
+		}
+		sb.WriteString("<previous-turn-speculative>\n")
+		sb.WriteString("The following text was generated in your previous response but was NOT delivered to the user (they interrupted before it could be spoken). You may choose to naturally resume, re-state, or drop this content based on their new message.\n\n")
+		sb.WriteString(pkg.PreviousTurnSpeculative)
+		sb.WriteString("\n</previous-turn-speculative>")
 	}
 
 	systemPrompt := sb.String()

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -859,6 +859,29 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Fetch the most-recent barge-in event from mod3 for this session.
+	// Used two ways: (a) inject previous-turn speculative text into context,
+	// (b) backfill the previous turn's sidecar row after RecordTurn.
+	// Best-effort: a nil event means no barge-in occurred or mod3 is down.
+	var bargeinEv *mod3BargeinEvent
+	if s.cfg != nil && s.cfg.Mod3URL != "" {
+		bargeinEv = fetchRecentBargeinEvent(r.Context(), s.cfg.Mod3URL, block.SessionID)
+	}
+	previousSpeculative := ""
+	if bargeinEv != nil {
+		previousSpeculative = bargeinEv.TextSpeculative
+	}
+
+	// Read the previous turn's TurnID now (before RecordTurn writes the new
+	// row) so we can backfill speculative fields after inference completes.
+	// best-effort: nil means first turn or sidecar unreadable.
+	var previousTurnID string
+	if bargeinEv != nil {
+		if prev, err := ReadLastTurn(s.cfg.WorkspaceRoot, block.SessionID); err == nil && prev != nil {
+			previousTurnID = prev.TurnID
+		}
+	}
+
 	// Allow per-request budget override via the X-Cogos-Context-Budget header.
 	// A value of 0 (absent or unparseable) defers to the kernel's configured
 	// default_budget (or the package-level DefaultBudget fallback).
@@ -873,6 +896,7 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 		WithContext(r.Context()),
 		WithConversationID(creq.Metadata.RequestID),
 		WithManifestMode(true),
+		WithPreviousTurnSpeculative(previousSpeculative),
 	); err != nil {
 		slog.Warn("chat: context assembly failed", "err", err)
 		// Fallback: preserve any client-supplied role=system messages as the
@@ -1044,6 +1068,28 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 	turn.DurationMs = time.Since(inferStart).Milliseconds()
 	if err := s.process.RecordTurn(turn); err != nil {
 		slog.Warn("chat: RecordTurn failed", "err", err, "session", turn.SessionID)
+	}
+
+	// Backfill the previous turn's sidecar row with barge-in position data.
+	// This is the speculative-output bookkeeping (Slice 4): the previous turn
+	// was interrupted, so we patch its ResponseSpeculative/BargeinPositionMs/
+	// BargeinPositionTextOffset fields now that we know them. Done after the
+	// current turn is persisted to avoid ordering hazards.
+	if bargeinEv != nil && previousTurnID != "" {
+		if err := PatchTurnSpeculative(
+			s.cfg.WorkspaceRoot,
+			block.SessionID,
+			previousTurnID,
+			bargeinEv.TextSpeculative,
+			bargeinEv.BargeinPositionMs,
+			bargeinEv.BargeinPositionTextOffset,
+		); err != nil {
+			slog.Debug("chat: PatchTurnSpeculative failed (best-effort)",
+				"err", err,
+				"prev_turn_id", previousTurnID,
+				"session", block.SessionID,
+			)
+		}
 	}
 
 	// Capture debug snapshot (best-effort, non-blocking).

--- a/internal/engine/speculative_output.go
+++ b/internal/engine/speculative_output.go
@@ -1,0 +1,142 @@
+// speculative_output.go — bargein-driven speculative-output helpers (Slice 4).
+//
+// When mod3 detects a barge-in (user speaks while TTS is playing), it emits a
+// "bargein.event" to its chat_flow_log ring buffer. That event carries:
+//   - text_actually_played   — what the user heard
+//   - text_speculative       — what was generated but NOT played
+//   - bargein_position_ms    — wall-time ms into the utterance
+//   - bargein_position_text_offset — character offset marking the boundary
+//
+// The kernel fetches this event at the START of each new turn (via
+// fetchRecentBargeinEvent) and uses it two ways:
+//
+//  1. Context injection: the speculative text is passed to AssembleContext via
+//     WithPreviousTurnSpeculative so FormatForProvider can inject a
+//     <previous-turn-speculative> block into the model's system prompt.
+//
+//  2. Turn-record backfill: after RecordTurn writes the previous turn, the
+//     bargein data is written back via PatchTurnSpeculative so the sidecar
+//     records what actually happened.
+//
+// Bargein events are matched to the previous turn by session_id and recency
+// (event must be within BargeinMatchWindowS of the current request). This
+// is a best-effort heuristic — if mod3 is down or the event is stale, the
+// speculative block is silently omitted rather than blocking inference.
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// BargeinMatchWindowS is the maximum age (seconds) of a bargein.event for it
+// to be considered relevant to the current turn. Events older than this are
+// assumed to belong to a prior conversation segment and are ignored.
+const BargeinMatchWindowS = 30.0
+
+// mod3BargeinEvent is the JSON shape of a bargein.event from
+// GET /v1/logs/chat-flow?event_type=bargein.event&session_id=X&limit=1.
+// Only fields needed for speculative-output backfill are decoded.
+type mod3BargeinEvent struct {
+	EventType               string  `json:"event_type"`
+	Timestamp               string  `json:"ts"`
+	SessionID               string  `json:"session_id"`
+	TextActuallyPlayed      string  `json:"text_actually_played"`
+	TextSpeculative         string  `json:"text_speculative"`
+	BargeinPositionMs       float64 `json:"bargein_position_ms"`
+	BargeinPositionTextOffset int   `json:"bargein_position_text_offset"`
+}
+
+// fetchRecentBargeinEvent queries mod3's chat-flow log for the most recent
+// bargein.event for the given session. Returns nil if mod3 is unreachable,
+// the event is older than BargeinMatchWindowS, or no bargein occurred.
+// Errors are logged at debug level and suppressed — this path must never
+// block or panic the inference path.
+func fetchRecentBargeinEvent(ctx context.Context, mod3URL, sessionID string) *mod3BargeinEvent {
+	if mod3URL == "" || sessionID == "" {
+		return nil
+	}
+
+	reqURL, err := url.Parse(mod3URL + "/v1/logs/chat-flow")
+	if err != nil {
+		slog.Debug("speculative_output: bad mod3URL", "err", err)
+		return nil
+	}
+	q := reqURL.Query()
+	q.Set("session_id", sessionID)
+	q.Set("event_type", "bargein.event")
+	q.Set("limit", "1")
+	reqURL.RawQuery = q.Encode()
+
+	fetchCtx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(fetchCtx, http.MethodGet, reqURL.String(), nil)
+	if err != nil {
+		slog.Debug("speculative_output: build request failed", "err", err)
+		return nil
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		slog.Debug("speculative_output: mod3 fetch failed", "err", err)
+		return nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		slog.Debug("speculative_output: mod3 returned non-200", "status", resp.StatusCode)
+		return nil
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		slog.Debug("speculative_output: read body failed", "err", err)
+		return nil
+	}
+
+	var result struct {
+		Events []mod3BargeinEvent `json:"events"`
+		Count  int                `json:"count"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		slog.Debug("speculative_output: unmarshal failed", "err", err)
+		return nil
+	}
+	if len(result.Events) == 0 {
+		return nil
+	}
+
+	ev := &result.Events[0]
+
+	// Recency check: parse the event timestamp and reject if too old.
+	if ev.Timestamp != "" {
+		// mod3 emits ISO 8601 timestamps; try RFC3339 first then RFC3339Nano.
+		var ts time.Time
+		for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+			if t, err := time.Parse(layout, ev.Timestamp); err == nil {
+				ts = t
+				break
+			}
+		}
+		if !ts.IsZero() && time.Since(ts).Seconds() > BargeinMatchWindowS {
+			slog.Debug("speculative_output: bargein event too old",
+				"age_s", fmt.Sprintf("%.1f", time.Since(ts).Seconds()),
+				"session", sessionID,
+			)
+			return nil
+		}
+	}
+
+	if ev.TextSpeculative == "" {
+		return nil
+	}
+
+	return ev
+}

--- a/internal/engine/turn_storage.go
+++ b/internal/engine/turn_storage.go
@@ -55,6 +55,16 @@ type TurnRecord struct {
 	Status     string           `json:"status,omitempty"`       // "ok" | "error"
 	Error      string           `json:"error,omitempty"`        // on status="error"
 	LedgerHash string           `json:"ledger_hash,omitempty"`  // turn.completed hash, filled after append
+
+	// Speculative-output fields — populated when barge-in interrupted playback
+	// mid-utterance (Slice 4). Response contains what was actually delivered to
+	// the user; ResponseSpeculative is the suffix that was generated but never
+	// played. BargeinPositionMs is the wall-time position into the utterance
+	// where playback stopped; BargeinPositionTextOffset is the character offset
+	// in Response (full text) marking the solidified/speculative boundary.
+	ResponseSpeculative         string  `json:"response_speculative,omitempty"`
+	BargeinPositionMs           float64 `json:"bargein_position_ms,omitempty"`
+	BargeinPositionTextOffset   int     `json:"bargein_position_text_offset,omitempty"`
 }
 
 // TurnUsage is a minimal (provider-neutral) token tally for a turn.
@@ -145,6 +155,93 @@ func readSidecarMaxTurnIndex(workspaceRoot, sessionID string) int {
 // turnSidecarPath returns the sidecar path for a session's turn JSONL.
 func turnSidecarPath(workspaceRoot, sessionID string) string {
 	return filepath.Join(workspaceRoot, ".cog", "run", "turns", sessionID+".jsonl")
+}
+
+// ReadLastTurn reads the most-recent TurnRecord from the session sidecar.
+// Returns nil, nil when the sidecar does not exist or is empty. Errors only
+// for genuine I/O failures (permissions, truncated JSON on last line).
+func ReadLastTurn(workspaceRoot, sessionID string) (*TurnRecord, error) {
+	path := turnSidecarPath(workspaceRoot, sessionID)
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("open sidecar: %w", err)
+	}
+	defer f.Close()
+
+	dec := json.NewDecoder(f)
+	var last *TurnRecord
+	for dec.More() {
+		var row TurnRecord
+		if err := dec.Decode(&row); err != nil {
+			break // ignore trailing partial line
+		}
+		copy := row
+		last = &copy
+	}
+	return last, nil
+}
+
+// PatchTurnSpeculative rewrites the most-recent TurnRecord in the session
+// sidecar to include speculative-output fields. It reads all rows, updates
+// the last one, and atomically replaces the file. This is intentionally
+// O(N) in sidecar size — sidecars are bounded (one session) and patching
+// is a rare post-turn path, not the hot inference path.
+func PatchTurnSpeculative(workspaceRoot, sessionID string, turnID string, specText string, bargeinMs float64, textOffset int) error {
+	path := turnSidecarPath(workspaceRoot, sessionID)
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open sidecar: %w", err)
+	}
+
+	dec := json.NewDecoder(f)
+	var rows []TurnRecord
+	for dec.More() {
+		var row TurnRecord
+		if err := dec.Decode(&row); err != nil {
+			break
+		}
+		rows = append(rows, row)
+	}
+	f.Close()
+
+	// Find and patch the target turn.
+	patched := false
+	for i := range rows {
+		if rows[i].TurnID == turnID {
+			rows[i].ResponseSpeculative = specText
+			rows[i].BargeinPositionMs = bargeinMs
+			rows[i].BargeinPositionTextOffset = textOffset
+			patched = true
+			break
+		}
+	}
+	if !patched {
+		return fmt.Errorf("turn %s not found in sidecar", turnID)
+	}
+
+	// Atomic rewrite: write to .tmp then rename.
+	tmp := path + ".tmp"
+	out, err := os.Create(tmp)
+	if err != nil {
+		return fmt.Errorf("create tmp sidecar: %w", err)
+	}
+	enc := json.NewEncoder(out)
+	for _, row := range rows {
+		if err := enc.Encode(row); err != nil {
+			out.Close()
+			os.Remove(tmp)
+			return fmt.Errorf("encode sidecar row: %w", err)
+		}
+	}
+	out.Close()
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("rename sidecar: %w", err)
+	}
+	return nil
 }
 
 // turnSidecarRelPath returns the workspace-relative sidecar path used in


### PR DESCRIPTION
## Summary

- Extends `TurnRecord` with `response_speculative`, `bargein_position_ms`, and `bargein_position_text_offset` fields, populated when mod3 barge-in interrupts TTS mid-utterance
- Adds `WithPreviousTurnSpeculative` option to `AssembleContext`; `FormatForProvider` injects a `<previous-turn-speculative>` block into the system prompt so the model knows what it generated but never delivered
- New `speculative_output.go` fetches the most-recent `bargein.event` from mod3's chat-flow log at turn start; matching events drive both context injection and post-`RecordTurn` sidecar backfill via `PatchTurnSpeculative`
- `PatchTurnSpeculative` rewrites the previous turn's sidecar row atomically (tmp+rename) so the audit trail records the solidified/speculative boundary
- All paths are best-effort: mod3 unavailability (200ms timeout) never blocks inference

## Dependencies

Depends on mod3 Slice 3 (PR #57, merged) for the `bargein.event` emission that this code consumes.

## Test plan

- [ ] `go build ./...` passes (verified locally)
- [ ] `go test ./internal/engine/...` passes (verified locally, 8s)
- [ ] CI passes
- [ ] After merge: rebuild kernel binary and restart via launchctl
- [ ] Manual: speak a long sentence, barge in, confirm next turn's system prompt contains `<previous-turn-speculative>` block (visible in `/v1/context` debug endpoint)
- [ ] Manual: check sidecar at `~/.cog/run/turns/<session_id>.jsonl` — interrupted turn has `response_speculative` field populated