### PR TITLE
fix(engine): populate node_health + sessions in HUD, use BaseFovea, propagate traceparent to sub-spans

### DIFF
--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -1014,14 +1014,27 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 	// correlation key instead and let the operator join on session_id+ts.
 	sessionID := block.SessionID
 
+	// Extract the W3C trace-id from the incoming traceparent header so the
+	// sub-span events can share the same trace_id as the mod3 phase events that
+	// injected it (CogOSProvider._make_traceparent). This lets the trace panel
+	// join mod3 phase events with kernel sub-spans by trace_id.
+	// Format: "00-<trace_id_32hex>-<parent_id_16hex>-<flags>"
+	var subSpanTraceID string
+	if tp := r.Header.Get("traceparent"); tp != "" {
+		if parts := strings.SplitN(tp, "-", 4); len(parts) == 4 && len(parts[1]) == 32 {
+			subSpanTraceID = parts[1]
+		}
+	}
+
 	// chat.prompt_eval — covers context assembly + upstream connection setup.
 	if !pt.promptEvalStart.IsZero() && !pt.promptEvalEnd.IsZero() {
 		emitChatSubSpan(s.busSessions, ChatSubSpan{
-			SpanName:  "chat.prompt_eval",
-			StartedAt: pt.promptEvalStart,
+			SpanName:   "chat.prompt_eval",
+			TraceID:    subSpanTraceID,
+			StartedAt:  pt.promptEvalStart,
 			DurationMS: pt.promptEvalEnd.Sub(pt.promptEvalStart).Milliseconds(),
-			Model:     model,
-			SessionID: sessionID,
+			Model:      model,
+			SessionID:  sessionID,
 		})
 	}
 
@@ -1029,6 +1042,7 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 	if !pt.thinkingStart.IsZero() {
 		emitChatSubSpan(s.busSessions, ChatSubSpan{
 			SpanName:    "chat.thinking_generation",
+			TraceID:     subSpanTraceID,
 			StartedAt:   pt.thinkingStart,
 			DurationMS:  pt.thinkingEnd.Sub(pt.thinkingStart).Milliseconds(),
 			TokensThink: pt.tokensThink,
@@ -1042,6 +1056,7 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 		totalToks := pt.tokensThink + pt.tokensAnswer
 		emitChatSubSpan(s.busSessions, ChatSubSpan{
 			SpanName:     "chat.answer_generation",
+			TraceID:      subSpanTraceID,
 			StartedAt:    pt.answerStart,
 			DurationMS:   pt.answerEnd.Sub(pt.answerStart).Milliseconds(),
 			TokensAnswer: pt.tokensAnswer,
@@ -1055,6 +1070,7 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 	if !pt.toolCallStart.IsZero() {
 		emitChatSubSpan(s.busSessions, ChatSubSpan{
 			SpanName:      "chat.tool_call_resolution",
+			TraceID:       subSpanTraceID,
 			StartedAt:     pt.toolCallStart,
 			DurationMS:    pt.toolCallEnd.Sub(pt.toolCallStart).Milliseconds(),
 			ToolCallCount: pt.toolCallCount,

--- a/internal/engine/serve_hud.go
+++ b/internal/engine/serve_hud.go
@@ -100,22 +100,42 @@ func (s *Server) handleHUDState(w http.ResponseWriter, r *http.Request) {
 	trust := s.process.TrustSnapshot()
 	identity.TrustScore = trust.LocalScore
 
-	// Active foveated-context sessions.
-	sessionSnap := s.sessions.Snapshot()
-	sessions := make([]HUDSession, 0, len(sessionSnap))
-	for _, st := range sessionSnap {
-		sessions = append(sessions, HUDSession{
+	// Active sessions: merge SessionContextStore (foveated chat sessions) with
+	// ChannelSessionRegistry (mod3 channel sessions). The channel registry
+	// contains live mod3 dashboard sessions; the context store contains sessions
+	// that have made /v1/chat/completions requests to the kernel. Both are
+	// populated from separate code paths — include both so the HUD shows all
+	// active sessions regardless of which path each session took.
+	sessionSet := make(map[string]HUDSession)
+	for _, st := range s.sessions.Snapshot() {
+		sessionSet[st.SessionID] = HUDSession{
 			SessionID:     st.SessionID,
 			Profile:       st.Profile,
 			TurnNumber:    st.TurnNumber,
 			IrisPressure:  st.IrisPressure,
 			TotalTokens:   st.TotalTokens,
 			LastRequestAt: st.LastRequestAt,
-		})
+		}
+	}
+	// Layer channel-session records on top (or as additions).
+	for _, rec := range s.channelSessionRegistry.Snapshot() {
+		if _, exists := sessionSet[rec.SessionID]; !exists {
+			sessionSet[rec.SessionID] = HUDSession{
+				SessionID:     rec.SessionID,
+				Profile:       rec.ParticipantType,
+				LastRequestAt: rec.LastSeen,
+			}
+		}
+	}
+	sessions := make([]HUDSession, 0, len(sessionSet))
+	for _, s := range sessionSet {
+		sessions = append(sessions, s)
 	}
 
 	// Recent URIs from the attentional field fovea (top 10).
-	foveaEntries := s.process.Field().Fovea(10)
+	// Use BaseFovea (no inbox-raw boost) so chatgpt-archive inbox entries
+	// don't dominate the list — same as the chat-read view in context_blocks.go.
+	foveaEntries := s.process.Field().BaseFovea(10)
 	recentURIs := make([]HUDURI, 0, len(foveaEntries))
 	for _, fs := range foveaEntries {
 		recentURIs = append(recentURIs, HUDURI{
@@ -125,8 +145,14 @@ func (s *Server) handleHUDState(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Node health summary.
+	// If no probe has fired yet (empty map), trigger one on-demand so the HUD
+	// reports the same data as /health. This is safe: Probe() is designed for
+	// concurrent goroutine use and the 2s per-probe timeout is bounded.
 	var nodeHealth map[string]string
 	if nh := s.process.NodeHealth(); nh != nil {
+		if nm := s.process.NodeManifest(); nm != nil && len(nh.Summary()) == 0 {
+			nh.Probe(nm, s.cfg.Port)
+		}
 		nodeHealth = nh.Summary()
 	}
 	if nodeHealth == nil {


### PR DESCRIPTION
## Summary

Fixes 4 observability bugs blocking HUD hook activation:

- **Bug 1 — node_health empty:** HUD handler now triggers an on-demand node probe when the health map is empty and the manifest is loaded (probes normally fire on heartbeat ticks so the first HUD request after a restart returned `{}`).
- **Bug 2 — sessions empty:** `SessionContextStore` is only populated by `/v1/chat/completions` paths; mod3 dashboard sessions live in `ChannelSessionRegistry`. HUD now merges both sources.
- **Bug 3 — fovea inbox-dominated:** `Field.Fovea()` applies inbox-raw score boost. Switch to `BaseFovea()` (same as `context_blocks.go` chat-read view) so chatgpt-archive inbox cogdocs stop dominating `recent_uris`.
- **Bug 5 — kernel sub-spans missing trace_id:** Parse the W3C `traceparent` header from the incoming chat request and attach the trace_id to all four `ChatSubSpan` events (`prompt_eval`, `thinking_generation`, `answer_generation`, `tool_call_resolution`). This lets the trace panel correlate mod3 phase events with kernel sub-spans by shared trace_id.

## Test plan

- [ ] `go test ./internal/engine/` passes
- [ ] `curl http://localhost:6931/v1/hud/state | jq '.node_health, .sessions, .recent_uris'` — node_health populated, sessions non-empty when dashboard is open, recent_uris no longer chatgpt-dominated
- [ ] After rebuild+restart: `echo '{"hook_event_name":"UserPromptSubmit"}' | python3 ~/.claude/hooks/hud-state.py` shows services + sessions lines
- [ ] After a dashboard chat turn: kernel bus_traces sub-spans include `trace_id` matching mod3 provider_call phase event