### PR TITLE
ADRs 091+092: Substrate as named layer + substrate contracts

### DIFF
--- a/docs/adrs/091-substrate-as-named-architectural-layer.md
+++ b/docs/adrs/091-substrate-as-named-architectural-layer.md
@@ -1,0 +1,309 @@
+# ADR-091: Substrate as Named Architectural Layer
+
+| Field       | Value                                                                          |
+|-------------|--------------------------------------------------------------------------------|
+| Status      | Accepted                                                                       |
+| Author      | @chazmaniandinkle                                                              |
+| Created     | 2026-05-15                                                                     |
+| Companion   | [ADR-092 (Substrate contracts and concurrency)](092-substrate-contracts-and-concurrency.md) |
+| Refs        | ADR-090 (Kind dispatch via registry), RFC-0001 (root package refactor), RFC-0005 (cog_fork_session), RFC-0006 (vLLM PagedAttention), RFC-0008 (Inference Control Plane), `docs/SYSTEM-SPEC.md` (Membrane/Nucleus/Workspace three-zone model) |
+
+## Context
+
+CogOS has accumulated a set of concerns that share a common shape: they
+describe *the field within which observers, identities, reconciliations, and
+channels exist*, as distinct from concerns that describe *the agent loop's
+execution* or *a specific modality's projection*. Packages and types
+implementing these concerns are already present in the codebase, but the
+concerns themselves have not been named as a coherent layer:
+
+- `pkg/cogblock/` — hash-chained event ledger (append-only, content-addressable)
+- `pkg/reconcile/` — Reconcilable interface and reconcile-loop primitives
+- `pkg/modality/` — modality module registration (the extension mechanism)
+- `identity_provider.go` (repo root, `package main`) — OIDC-anchored observer identity (CRD)
+- `capability_resolver.go` (repo root, `package main`) — live capability advertisement and resolution
+- `session_manager.go` (repo root, `package main`) — session continuity, rotation, fork
+- `internal/engine/handler_span.go` — handler-level span emission for projection
+
+Each of these has been built and stabilized through independent forcing
+functions (RFC-0001 through RFC-0008, ADR-079, ADR-082, ADR-089, ADR-090).
+RFC-0001 is currently relocating the `package main` files into
+`internal/engine/`; the package paths listed above reflect their current
+locations on `main`, not their post-RFC-0001 destinations.
+
+### Relationship to the existing three-zone model
+
+`docs/SYSTEM-SPEC.md` §2 defines a canonical three-zone partition of a CogOS
+node, with **Workspace** literally named as *"the cognitive substrate."* This
+ADR does **not** replace, supersede, or modify that partition. The three-zone
+model partitions a node by **what's running where**:
+
+| Zone        | Contents                                          | Question it answers          |
+|-------------|---------------------------------------------------|------------------------------|
+| Membrane    | MCP Server, HTTP API, Router, Coherence           | "What mediates inside/outside?" |
+| Nucleus     | Identity Core, Process Loop                       | "What defines the node?"     |
+| Workspace   | Context Engine, Salience, Ledger, Memory, Blob Store | "What is the cognitive substrate?" |
+
+The trichotomy this ADR introduces (Substrate / Kernel / Module) partitions
+concerns by **what kind of operation each is**. The two partitions are
+**orthogonal**: a given package or type has both a SYSTEM-SPEC zone AND a
+trichotomy layer.
+
+## Decision
+
+Establish **Substrate / Kernel / Module** as a named architectural trichotomy
+in CogOS, orthogonal to the SYSTEM-SPEC three-zone model, with the following
+commitments:
+
+1. **Conceptual trichotomy is accepted**, *implementation extraction is
+   deferred*. The substrate-as-layer is a recognized category in the
+   architecture; it does not yet exist as a separately-deployed service or
+   process. Promotion to an explicit deployable boundary requires named
+   forcing functions (see *Forcing functions* below).
+
+2. **The trichotomy partitions concern-types orthogonally to the three-zone:**
+
+   | Layer         | Concern shape                              | Test                                                                      |
+   |---------------|--------------------------------------------|---------------------------------------------------------------------------|
+   | **Substrate** | Field-of-existence                         | Does this concern exist independent of any specific agent-loop running?   |
+   | **Kernel**    | Agent-loop execution                       | Does this concern require a planning/observing/acting loop to be present? |
+   | **Module**    | Modality / channel / surface               | Does this concern project the substrate through a specific medium?        |
+
+   A concrete package has both a SYSTEM-SPEC zone AND a trichotomy layer:
+
+   | Concrete concern                                            | SYSTEM-SPEC zone | Trichotomy layer |
+   |-------------------------------------------------------------|------------------|------------------|
+   | `pkg/cogblock/` (ledger)                                    | Workspace        | Substrate        |
+   | `pkg/reconcile/` (Reconcilable + reconcile loop)            | Workspace        | Substrate        |
+   | `pkg/modality/` (modality registration)                     | Membrane         | Substrate        |
+   | `identity_provider.go` (CRD)                                | Nucleus          | Substrate        |
+   | `capability_resolver.go` (live capability)                  | Nucleus          | Substrate        |
+   | `session_manager.go` (session continuity)                   | Workspace        | Substrate        |
+   | `internal/engine/handler_span.go` (projection)              | Membrane         | Substrate        |
+   | `internal/engine/agent_controller.go`, `internal/engine/autonomic_ticker.go` (agent loop) | Nucleus | Kernel           |
+   | `internal/engine/agent_dispatch.go`, `internal/engine/agent_dispatch_query.go` (dispatch executor) | Nucleus | Kernel           |
+   | `internal/engine/context_assembly.go` (context assembly)    | Workspace        | Kernel           |
+   | MCP Server, HTTP API, Router (`internal/engine/*`)          | Membrane         | Kernel           |
+   | `mod3` (separate repo, voice channel)                       | (external)       | Module           |
+   | `cog-sandbox-mcp` (separate repo, MCP bridge)               | (external)       | Module           |
+
+   Substrate concerns span multiple SYSTEM-SPEC zones (Workspace + Nucleus +
+   Membrane). Kernel concerns span multiple zones too. Module concerns are
+   external to the node-scoped three-zone partition. The orthogonality is
+   load-bearing: future ADRs should cite both axes when locating new code.
+
+3. **Substrate-shaped packages stay where they are** until a forcing function
+   triggers extraction. The classification in section 2's table is
+   documentation, not a refactor plan. (Note: `pkg/cogblock/`,
+   `pkg/reconcile/`, `pkg/modality/`, `pkg/bep/`, `pkg/coordination/`,
+   `pkg/uri/`, and `pkg/cogfield/` are already separately-versioned Go
+   modules with their own `go.mod` files. "Extraction" in this ADR refers
+   to *deployable boundaries* — separate processes, services, or repositories
+   — not to Go-module-as-versioning-unit, which already exists.)
+
+4. **Reconcile-loop vocabulary, honestly stated:**
+
+   *Today:* the substrate's reconcile loop is **Terraform-style** — edge-
+   triggered, CLI-invoked plan/apply, no watch/informer, no level-triggered
+   convergence guarantee. This is canonical per `pkg/reconcile/doc.go`:
+   *"the same Terraform-style loop used throughout the CogOS kernel."*
+
+   *External pitch:* the **Kubernetes operator pattern** (level-triggered,
+   watch-based, eventually consistent, single locus of authority) is the
+   structural analogy used in documentation and ecosystem positioning. The
+   conceptual primitive (reconcile against an observed-vs-desired state diff)
+   is the same in both Terraform and Kubernetes; the operational shape
+   differs significantly.
+
+   *Target:* evolution toward K8s-shape (level-triggered, watch-based) is an
+   *open question*, not a commitment. Forces that would drive that evolution
+   include federation-scale operation (multiple kernels reconciling against a
+   shared substrate) and the need for autonomic continuous reconciliation
+   rather than CLI-invoked one-shots. When and how to evolve is deferred to
+   a future RFC.
+
+   Documentation and contributor onboarding should describe the current shape
+   accurately (Terraform-style) while noting the K8s analogy as the
+   conceptual primitive. External pitches to cloud-native audiences may lead
+   with the K8s analogy provided they don't misrepresent the current code.
+
+5. **The ledger is the single write-ahead log for substrate state mutations.**
+   Where substrate primitives have both an authoritative record (the
+   hash-chained ledger via `pkg/cogblock`) and a derived view (an in-memory
+   cache, registry, or projection), the ledger MUST be written first; the
+   derived view is rebuilt or invalidated from ledger state. This rule pre-
+   empts the controller-bypasses-state-store failure mode documented in
+   early-Kubernetes operator history.
+
+   *Note:* this is a logical write-ordering rule, not a concurrency
+   guarantee. The ledger's current `AppendEvent` implementation is not
+   serialized across concurrent writers; ADR-092 specifies the concurrency
+   contract this rule depends on.
+
+## Forcing functions (when substrate is extracted)
+
+Extraction from the conceptual layer into a deployable boundary (separate
+process, service, or repository) waits for at least one of:
+
+1. **Dependency inversion trigger** — a change in one substrate-shaped package
+   requires coordinated changes across two or more others such that re-testing
+   the entire kernel is necessary for what should be a localized change.
+
+2. **Resource contention trigger** — a substrate concern (e.g., ledger replay,
+   reconcile-loop scheduling, projection fan-out) consumes resources that
+   interfere with the determinism of the primary kernel loop.
+
+3. **Deployment divergence trigger** — a substrate concern (e.g., ledger,
+   federation, identity service) needs to run physically separate from kernel
+   logic (sidecar pattern, separate process, or remote endpoint).
+
+Until one of these fires, the substrate layer remains implicit-but-named:
+code stays where it is, and the trichotomy governs new additions.
+
+## Rationale
+
+### Why a new layer when SYSTEM-SPEC already exists
+
+SYSTEM-SPEC's three-zone model partitions by *what's running where in a
+node*; it answers questions like "is this concern in the always-loaded
+nucleus or the workspace-scoped substrate?" The new trichotomy partitions by
+*what kind of operation each concern is*; it answers questions like "is this
+concern an agent-loop execution detail, or part of the field the loop runs
+in?"
+
+These are different questions, and contributors need both answers when
+locating new code. A reconcile primitive lives in Workspace (zone) AND
+Substrate (layer); the agent loop lives in Nucleus (zone) AND Kernel (layer);
+a Membrane component like the MCP Server lives in Membrane (zone) AND Kernel
+(layer). Without the trichotomy, the layer answer has to be reconstructed by
+reading code each time. The trichotomy makes the layer answer citable.
+
+### Why honest vocabulary on Terraform vs K8s
+
+The structural difference between Terraform-style and K8s-style reconcile
+loops is not aesthetic. Terraform is edge-triggered (run when invoked);
+Kubernetes is level-triggered (run continuously, converge to desired state).
+Idempotency means different things in each model. Watch-based observation is
+core to K8s-style operation and absent in Terraform-style. Misrepresenting
+the current shape as K8s-style would mislead contributors writing new
+reconcilers about what guarantees the substrate provides.
+
+The K8s analogy remains useful as the conceptual primitive (reconcile against
+state-diff is the operator pattern's primitive) and as external pitch
+positioning (K8s's accretion of an ecosystem from a reconciliation primitive
+is the empirical precedent for the substrate's bet). Both can be true: the
+primitive is K8s-shaped, the current implementation is Terraform-shaped, the
+evolution toward K8s-shape is an open question.
+
+### Why deferred extraction
+
+A multi-seat architecture review (six perspectives across two orthogonal
+review angles, plus three cross-family local-model perspectives) converged on
+"premature abstraction" as the primary risk of extraction without forcing
+functions present. Specific findings that survived cross-model verification:
+
+- A proposed ten-directory carving (identity / ledger / reconcile / capability
+  / metabolism / boundary / continuity / observatory / extension / federation)
+  was over-specified; no reviewer defended it intact.
+- Several proposed concerns ("metabolism", "boundary") failed the
+  field-of-existence test and belong elsewhere (operator tooling and identity
+  respectively).
+- The cleanest extraction with non-zero value at near-zero cost is moving
+  `pkg/reconcile` and `pkg/cogblock` to a `substrate/` package path, but this
+  can be deferred to coincide with the first forcing-function trigger.
+- The cognitive-state vs infrastructure-state analogy has real structural
+  limits (no decidable convergence predicate for some cognitive operations;
+  no single locus of authority equivalent to etcd for cross-substrate truth)
+  that should be acknowledged in any reconciler implementation rather than
+  hidden behind extraction-as-credibility.
+
+### What this ADR is not
+
+This ADR does not:
+
+- Authorize a refactor of any existing package.
+- Define a new public API surface.
+- Commit to a target module structure for future extraction.
+- Replace or supersede `docs/SYSTEM-SPEC.md` or any existing RFC or ADR.
+- Commit to evolving the reconcile loop toward K8s-shape (open question).
+
+It establishes naming, an orthogonal partition, and an honest vocabulary
+record. Implementation decisions are deferred to subsequent ADRs that will
+reference this one when forcing functions arrive.
+
+## Consequences
+
+### Positive
+
+- New ADRs and RFCs can reference *Substrate*, *Kernel*, and *Module* as
+  defined layers without restating the trichotomy each time.
+- Contributors locating new code can use both the SYSTEM-SPEC zone test and
+  the trichotomy test orthogonally, narrowing placement decisions on both
+  axes.
+- The honest vocabulary record (Terraform-style today, K8s-shape as analogy
+  and open evolution target) prevents future contributors from being
+  misled by external-pitch vocabulary that doesn't match the code.
+- The ledger-first rule in section 5 of the *Decision* pre-empts a known
+  failure mode without requiring any code change today (concurrency contract
+  is specified separately in ADR-092).
+
+### Negative
+
+- The substrate-shaped packages remain physically distributed across `pkg/`,
+  the repo root, and `internal/engine/`. Readers will need to consult this
+  ADR or future onboarding documentation to recognize them as part of the
+  same layer.
+- The trichotomy boundary will be contested at the margins for some
+  additions. The field-of-existence test is the canonical adjudication
+  criterion; ambiguous cases should produce a follow-up ADR.
+- Two architectural vocabularies (SYSTEM-SPEC three-zone, trichotomy layer)
+  now coexist. Contributor onboarding documentation must explain both and
+  their orthogonality.
+
+### Neutral
+
+- The Kubernetes-as-conceptual-primitive analogy is structurally apt for
+  single-substrate operation and strains at federation boundaries (no single
+  locus of authority for cross-substrate truth). The current implementation
+  being Terraform-style is a separate matter from the long-run target. Both
+  are flagged here; both are addressed when the relevant forcing functions
+  arrive.
+
+## Implementation
+
+No implementation work is authorized by this ADR. The following are
+documentation-only follow-ups that may be performed at any time:
+
+1. Update `docs/SYSTEM-SPEC.md` to reference the trichotomy as an orthogonal
+   partition (a footnote or a new section, not a replacement).
+2. Add a section to `docs/architecture-diagram-source.md` showing the layers
+   alongside the zones.
+3. Add a "Layer" field (Substrate / Kernel / Module) and a "Zone" field
+   (Membrane / Nucleus / Workspace / external) to subsequent ADRs and RFCs.
+
+When a forcing function fires, the implementing ADR will reference this one
+and supply the extraction shape.
+
+## Open questions
+
+- **Federation truth.** Cross-substrate consistency (when more than one
+  substrate instance exists) has no defined ground-truth authority. Flagged
+  as a known open problem; future ADR when a second substrate instance is on
+  the roadmap.
+- **Reconcile-loop evolution.** Whether and how to evolve from Terraform-
+  style (edge-triggered, CLI-invoked) to K8s-style (level-triggered, watch-
+  based) for federation-scale operation. Future RFC when federation pressure
+  arrives or when autonomic continuous reconciliation becomes a forcing
+  function.
+- **Schema versioning on the ledger.** The ledger is append-only and
+  hash-chained; on-disk event-body schema cannot be rewritten. What semantics
+  govern old readers on new events, and new readers on old events. Specified
+  in ADR-092.
+- **Concurrency contract for substrate primitives.** Specified in ADR-092.
+- **Substrate-to-Module boundary.** How Modules (e.g., `mod3`, written in
+  Python; `cog-sandbox-mcp`, also Python) actually consume substrate
+  primitives written in Go. Specified in ADR-092.
+- **Where dispatch lives in the trichotomy.** The dispatch tool spans
+  substrate-shaped concerns (capability routing as a substrate primitive),
+  kernel-shaped concerns (execution within the agent loop), and module-shaped
+  concerns (MCP exposure to external clients). Specified in ADR-092.

--- a/docs/adrs/092-substrate-contracts-and-concurrency.md
+++ b/docs/adrs/092-substrate-contracts-and-concurrency.md
@@ -1,0 +1,343 @@
+# ADR-092: Substrate Contracts and Concurrency
+
+| Field       | Value                                                                          |
+|-------------|--------------------------------------------------------------------------------|
+| Status      | Accepted                                                                       |
+| Author      | @chazmaniandinkle                                                              |
+| Created     | 2026-05-15                                                                     |
+| Parent      | [ADR-091 (Substrate as Named Architectural Layer)](091-substrate-as-named-architectural-layer.md) |
+| Refs        | ADR-090 (Kind dispatch via registry), RFC-0005 (cog_fork_session), `pkg/cogblock/`, `pkg/reconcile/` |
+
+## Context
+
+[ADR-091](091-substrate-as-named-architectural-layer.md) names the Substrate as
+an architectural layer with a ledger-first rule (§5) and a Reconcilable
+primitive (§3), but defers the operational contracts those primitives depend
+on. This ADR specifies those contracts and the concurrency model they imply.
+
+The concerns addressed here surfaced during an independent architecture
+review of ADR-091. Each concern names something the substrate currently
+relies on implicitly that needs to be made explicit so future contributors
+can reason about it and so future implementations can satisfy it.
+
+The contracts fall into eight numbered sub-decisions. Each is marked
+**Accepted**, **Documented status quo** (recording what is, not committing
+to a change), or **Open question** (acknowledging an unresolved decision).
+
+## Decision
+
+### §1 — Ledger writer concurrency contract
+
+**Status:** Accepted (going-forward contract; current implementation gap noted).
+
+The ledger has a **single-writer-per-session** contract. For any given
+session ID (the partition key under `.cog/ledger/<sessionID>/events.jsonl`),
+at most one goroutine appends events at a time. The contract is enforced by
+a per-session mutex held across the read-current-head → compute-chain-hash →
+append window.
+
+`pkg/cogblock.AppendEvent` does not currently serialize concurrent writers
+to the same session ledger. Two concurrent callers will both `GetLastEvent`,
+both compute the same `prior_hash`, both `O_APPEND`, and break the chain.
+This is a known gap that consumers must work around today by routing all
+appends through a single owning goroutine per session. A follow-up issue
+tracks adding the mutex to `pkg/cogblock` itself; until that lands, callers
+MUST NOT invoke `AppendEvent` from multiple goroutines for the same session
+without external serialization.
+
+Cross-session concurrency is unconstrained: different session ledgers may be
+written by different goroutines without coordination.
+
+### §2 — Boot order and replay semantics
+
+**Status:** Accepted (going-forward contract; current implementation gap noted).
+
+The substrate boot sequence is:
+
+1. **Genesis check** — read `.cog/ledger/<sessionID>/genesis.json` (or
+   equivalent) to confirm the substrate is initialized.
+2. **Ledger replay** — read `events.jsonl` in order; for each event, apply
+   to the appropriate in-memory derived view (identity registry, capability
+   cache, session state, etc.). Replay completes before any service accepts
+   external requests.
+3. **Service registration** — the kernel's HTTP API, MCP server, and bus
+   broker start. Modules may now consume substrate primitives.
+4. **Reconcile loop start** — periodic / on-demand reconciliation begins.
+
+Today, several derived views start empty rather than from ledger replay:
+`LifecycleManager`, `SessionManager`, and the capability cache. Identity is
+read from YAML files, not the ledger. This is **divergent from the
+contract** — the in-memory state at boot reflects on-disk caches and
+configuration, not authoritative ledger replay. The substrate currently
+relies on these caches being kept in sync with the ledger by the writing
+code paths.
+
+A future RFC will move boot-time state reconstruction to ledger replay as
+the authoritative source. Until then, the contract is documented but not
+yet enforced.
+
+### §3 — Crash recovery during reconcile
+
+**Status:** Accepted (idempotency requirement).
+
+`Reconcilable.ApplyPlan` MUST be idempotent against its own plan: running
+the same plan twice on the same `liveState` MUST produce the same final
+state and the same observable side effects. Consumers of the substrate
+should assume `ApplyPlan` may be invoked after a crash on partially-applied
+state, and write their implementations accordingly.
+
+The substrate provides at-least-once semantics for `ApplyPlan` invocation,
+not at-most-once. If the kernel dies between `ApplyPlan` succeeding and the
+meta-reconciler's subsequent call to the package-level `reconcile.WriteState`
+function persisting the post-apply state, the next reconcile cycle will
+re-invoke `ApplyPlan` against the unchanged stored state. Reconcilables that
+cannot tolerate replay (e.g., that send network requests with non-idempotent
+semantics or that mutate external systems by side effect) MUST guard their
+own apply path with operation IDs or other deduplication mechanisms.
+
+The substrate itself does not provide such deduplication. Adding it is a
+candidate future RFC.
+
+### §4 — Reconcilable contract guarantees
+
+**Status:** Accepted (formalizes the existing seven-method interface).
+
+`pkg/reconcile/types.go::Reconcilable` requires seven methods. Each method's
+contract:
+
+| Method        | Determinism                | Side effects | Blocking          | Idempotency required |
+|---------------|----------------------------|--------------|-------------------|----------------------|
+| `Type()`      | Deterministic, pure        | None         | Non-blocking      | N/A                  |
+| `LoadConfig()` | Deterministic given input config | Read from disk OK | Bounded by ctx | Yes (re-callable)    |
+| `FetchLive()` | May depend on external state | Read-only observation of world | Bounded by ctx, MUST honor cancellation | Yes (multiple reads OK) |
+| `ComputePlan()` | Deterministic given (live, config) | None — pure function | Non-blocking      | N/A                  |
+| `ApplyPlan()` | Need not be deterministic; results may depend on world state | Mutates external systems | Bounded by ctx, MUST honor cancellation | **Required** — see §3 |
+| `BuildState()` | Deterministic given (live, applied) | None — pure function | Non-blocking      | N/A                  |
+| `Health()`    | May reflect transient state | None         | Fast (sub-second) | N/A                  |
+
+Reconcilables that violate these contracts (e.g., `ComputePlan` reading from
+disk, `BuildState` mutating state) are non-conforming and should be flagged
+in code review.
+
+`pkg/reconcile.RegisterProvider` panics on duplicate registration; this is
+intentional. Reconcilables register at process init; duplicate registration
+indicates a programming error and is not recoverable at runtime. Hot reload
+of providers (re-registering at runtime) is not supported in the current
+contract.
+
+### §5 — Schema versioning and on-disk format evolution
+
+**Status:** Accepted (going-forward contract).
+
+The ledger is append-only and hash-chained. Once written, event payloads
+cannot be rewritten or migrated in place. Schema evolution therefore happens
+forward-only, and readers must tolerate cross-version mismatches in both
+directions.
+
+**Forward-compatibility (old reader, new event):**
+
+- Each `EventPayload` carries a `schema_version` field (currently absent;
+  follow-up issue will add it). Readers encountering a `schema_version`
+  newer than they understand MUST log a structured warning and either skip
+  the event or report it as opaque, depending on context. Readers MUST NOT
+  panic, crash, or corrupt downstream state on an unrecognized version.
+
+- Required-field additions in a new schema version are forbidden if old
+  readers must still consume the event. New schema versions may add
+  optional fields; required fields require a major version bump and a
+  documented migration plan.
+
+**Backward-compatibility (new reader, old event):**
+
+- Readers MUST tolerate missing optional fields in old events, supplying
+  defaults that match the original schema's semantics.
+- If a field's semantics change across versions, the new reader MUST
+  branch on `schema_version` rather than silently reinterpreting old data.
+
+**CogBlockKind evolution** (per ADR-090): adding a new Kind is an additive
+change; old readers without a registered handler for the new Kind invoke
+the registry's `ErrNoKindHandler` path. Removing or renaming a Kind requires
+a separate deprecation ADR and a compatibility shim period.
+
+### §6 — Multi-kernel-on-one-substrate (today's status)
+
+**Status:** Documented status quo.
+
+The substrate today supports **exactly one kernel per substrate instance**.
+The ledger is partitioned by session ID, the reconcile registry is a
+process-local map, and capability advertisement is per-process. Two kernels
+attempting to consume the same `.cog/` directory will:
+
+- Race on ledger appends (per §1's gap).
+- Diverge on in-memory derived views.
+- Both attempt to register modality providers, causing duplicate-registration
+  panics on overlapping provider names.
+
+Multi-kernel-on-one-substrate is **not supported** today and not blocked
+explicitly — operators who try it will get undefined behavior, not a clean
+error. Future work to support it requires (at minimum): a cross-process
+ledger writer protocol, distributed reconcile-registry coordination, and
+identity registration with conflict-resolution semantics. None of this is
+on the immediate roadmap.
+
+This entry exists to make the today-status statement citable rather than
+ambient. Future ADRs proposing multi-kernel work should reference this
+section as the baseline.
+
+### §7 — Substrate-to-Module boundary
+
+**Status:** Accepted (documents the current contract).
+
+Modules (e.g., `mod3`, `cog-sandbox-mcp`, future channel implementations)
+consume substrate primitives via three surfaces:
+
+| Surface              | Direction          | Protocol     | Allowed operations                           |
+|----------------------|--------------------|--------------|----------------------------------------------|
+| MCP server (`/mcp`)  | Module → Kernel    | JSON-RPC over Streamable HTTP | Tool calls into substrate-fronted MCP tools |
+| HTTP API             | Module → Kernel    | REST/JSON    | Substrate-fronted endpoints (`/v1/sessions`, `/v1/ledger`, `/v1/agents`, etc.) |
+| SSE bus              | Kernel → Module    | Server-Sent Events | Subscriptions to bus topics; one-way push (future surface — `internal/engine/bus_stream.go` implements the broker but no HTTP route is wired today; callers wire their own SSE) |
+
+**Modules MAY NOT mutate substrate state directly.** All mutations route
+through kernel-mediated calls — typically the kernel's MCP server or HTTP
+API. The kernel applies authorization (per `capability_resolver.go`),
+serializes writes (per §1), and ensures the ledger-first rule (per ADR-091
+§5) holds.
+
+In-process Go modules (same-binary consumers; currently none beyond the
+kernel itself) MAY import substrate packages directly. The same contracts
+apply in-process; the only difference is the absence of network overhead.
+
+Module authors writing in languages other than Go (Python, TypeScript,
+Rust) MUST use the network surfaces above and MUST NOT attempt to read or
+write the on-disk ledger directly. The hash-chain integrity guarantees
+require the writer to compute the chain hash from the current head; bypass
+breaks the chain.
+
+### §8 — Where dispatch lives in the trichotomy
+
+**Status:** Accepted (resolves an ambiguity in ADR-091).
+
+The dispatch system (`internal/engine/agent_dispatch.go`,
+`internal/engine/agent_dispatch_query.go`, the `cog_dispatch_to_harness`
+MCP tool) is a layer-crossing concern. Resolving where it "lives" by
+component:
+
+| Component                                        | SYSTEM-SPEC zone | Trichotomy layer |
+|--------------------------------------------------|------------------|------------------|
+| Capability routing primitive (which agent gets a task, given capability advertisements) | Workspace        | Substrate        |
+| Dispatch executor (the goroutine that actually runs a dispatched task within the agent loop) | Nucleus          | Kernel           |
+| MCP exposure (`cog_dispatch_to_harness` tool)    | Membrane         | Kernel           |
+| Out-of-process dispatcher clients (e.g., Claude Code calling MCP) | (external)       | Module           |
+
+Dispatch is therefore not "a module" or "a kernel concern" wholesale. It is
+a substrate primitive (capability routing) consumed by the kernel
+(execution) and exposed via the membrane (MCP) to modules (external
+callers). Future ADRs touching dispatch should cite which component they
+mean.
+
+## Rationale
+
+### Why one ADR covering eight concerns
+
+These contracts are interdependent. §1 (concurrency) is what makes §3
+(crash recovery) and §4 (Reconcilable guarantees) safe to rely on. §2 (boot
+replay) is what makes §5 (schema versioning) work cross-restart. §6
+(multi-kernel status) follows from §1's single-writer-per-session contract.
+§7 (Module boundary) and §8 (dispatch placement) operationalize ADR-091's
+trichotomy.
+
+Splitting these across multiple ADRs would create cross-referencing
+overhead and obscure the consistency of the model. Each concern is small
+enough to fit in a sub-decision and large enough to matter; the ADR as a
+whole is the right granularity.
+
+### Why "Accepted" with implementation gaps
+
+Several sub-decisions (§1, §2) document a *contract* that the current
+implementation does not yet enforce. This is intentional: the contract
+defines the going-forward invariant, and follow-up issues track the work to
+bring the implementation into compliance. ADRs are architectural decisions,
+not implementation status. The alternative — leaving these as "Open
+question" — would mean future contributors have no canonical reference for
+what the substrate is supposed to do, only what it currently does.
+
+The implementation gaps are flagged explicitly in each sub-decision and
+should be tracked as follow-up issues.
+
+### Why not put the dispatch placement (§8) in ADR-091
+
+ADR-091's trichotomy section would have been substantially longer with §8
+inline, and dispatch is one of several layer-crossing concerns that may
+need similar resolution in the future. Treating §8 as a worked example in
+ADR-092 (alongside Module boundary in §7) keeps ADR-091 focused on the
+layer definitions themselves.
+
+## Consequences
+
+### Positive
+
+- Substrate primitives have citable contracts. New consumers can reference
+  ADR-092 §1–§8 instead of reading code to discover implicit semantics.
+- Implementation gaps are made explicit. Follow-up issues tracking work to
+  close the gaps have clear acceptance criteria.
+- Module authors in non-Go languages (mod3 in Python) have a canonical
+  reference for what they can and cannot do.
+- Dispatch's layer-crossing nature is acknowledged rather than hand-waved.
+- Schema-versioning rules pre-empt the "what does an old reader do on a new
+  event" question that will inevitably surface.
+
+### Negative
+
+- Several sub-decisions document contracts the current implementation does
+  not yet meet. Until follow-up issues land, the contract and the code are
+  out of sync. This is honest but requires discipline to track.
+- Eight sub-decisions in one ADR is at the upper end of granularity. Future
+  authors looking for "the ledger concurrency rule" will need to find §1
+  inside this ADR rather than a dedicated document. The table of contents
+  at the top of the Decision section helps.
+
+### Neutral
+
+- Some sub-decisions (especially §5 schema versioning, §6 multi-kernel)
+  describe future scenarios that may never materialize. The cost of having
+  them documented but never invoked is low; the cost of needing them and
+  not having them is high. They stay.
+
+## Implementation
+
+The following follow-up issues are implied by this ADR. None are authorized
+by this ADR; each requires its own implementation plan:
+
+1. **Add per-session mutex to `pkg/cogblock.AppendEvent`** (closes §1
+   implementation gap).
+2. **Add `schema_version` field to `EventPayload`** with default-handling
+   logic in readers (closes §5 implementation gap).
+3. **Move boot-time state reconstruction to ledger replay** (closes §2
+   implementation gap). Likely a multi-PR effort spanning identity,
+   capability, session, and lifecycle managers.
+4. **Document the Reconcilable contracts in `pkg/reconcile/doc.go`** so
+   the contracts are visible to implementers without reading this ADR.
+5. **Add static analysis or linting** for Reconcilable contract violations
+   (e.g., a `go vet`-style check that `ComputePlan` doesn't import
+   `os` or `net/http`).
+
+## Open questions
+
+- **At-most-once dispatch / apply.** §3 establishes at-least-once semantics
+  for `ApplyPlan`. Some prospective Reconcilables (e.g., one that initiates
+  outbound HTTP calls with non-idempotent side effects) would benefit from
+  at-most-once. Whether the substrate provides operation-ID-based
+  deduplication is deferred to a future RFC.
+- **Watch-based observation.** §4's `FetchLive` is poll-based today. A
+  watch-based variant (subscribe to changes rather than poll) is implicit
+  in the K8s-style target referenced in ADR-091 §4 and is deferred to a
+  future RFC alongside the level-triggered evolution.
+- **Cross-process Reconcilable registration.** §4's registry is process-
+  local. Federation (multiple kernels coordinating) will require cross-
+  process registration semantics; deferred until federation is on the
+  roadmap.
+- **Module identity and capability advertisement.** §7 says Modules consume
+  substrate via kernel-mediated surfaces, but Modules themselves have
+  identities (per `mod3`'s session model) that the substrate doesn't
+  currently anchor. Whether Modules register as substrate-visible observer
+  identities, and what authorization that would imply, is a future ADR.


### PR DESCRIPTION
## Summary

Two paired architecture decision records establishing **Substrate** as a named layer in CogOS and specifying the operational contracts it implies.

- **ADR-091** names a **Substrate / Kernel / Module** trichotomy that partitions concerns by *operation type*, explicitly orthogonal to the existing SYSTEM-SPEC **Membrane / Nucleus / Workspace** three-zone partition (which partitions by *node location*). Maps every cited package onto both axes. Adopts honest vocabulary: Terraform-style today per `pkg/reconcile/doc.go`; K8s operator pattern as the conceptual analogy and external pitch; K8s-shape evolution open. Establishes the **ledger-first rule** for substrate state mutations.

- **ADR-092** is a companion specifying contracts ADR-091 defers — eight sub-decisions:
  1. Ledger writer concurrency (single-writer-per-session; implementation gap noted)
  2. Boot order and replay semantics (contract; current divergence noted)
  3. Crash recovery during reconcile (at-least-once `ApplyPlan`; idempotency required)
  4. Reconcilable contract guarantees (per-method determinism/side-effects/blocking/idempotency table)
  5. Schema versioning (append-only, forward-only, `schema_version` field convention)
  6. Multi-kernel-on-one-substrate (documented as not supported today)
  7. Substrate-to-Module boundary (MCP + HTTP today; SSE future; modules MAY NOT mutate substrate state directly)
  8. Dispatch placement in the trichotomy (cross-cutting concern)

## What this changes

**Nothing in code.** Neither ADR authorizes a refactor. Both establish naming, partitions, and contract documentation. Extraction from the conceptual layer to a deployable boundary is deferred until one of three named forcing functions fires:

1. **Dependency inversion** — coordinated changes across substrate-shaped packages forcing kernel-wide retest
2. **Resource contention** — substrate concern eating cycles from the primary kernel loop
3. **Deployment divergence** — substrate concern needs to run physically separate

## Why now

The substrate-shaped packages stabilized through their individual RFCs/ADRs (RFC-0001 through RFC-0008, ADR-079, ADR-082, ADR-089, ADR-090). Naming the layer makes future ADRs/RFCs able to reference it without restating the trichotomy each time, and the K8s analogy is the cleanest external pitch idiom for the substrate's primitive. Deferring extraction until forcing functions fire avoids the premature-abstraction trap.

## Follow-up issues implied by ADR-092 (not authorized by this PR)

1. Add per-session mutex to `pkg/cogblock.AppendEvent` (closes §1 gap)
2. Add `schema_version` field to `EventPayload` with default-handling reader logic (closes §5 gap)
3. Move boot-time state reconstruction to ledger replay (closes §2 gap)
4. Document the Reconcilable contracts in `pkg/reconcile/doc.go` (visibility for implementers)
5. Add static analysis or linting for Reconcilable contract violations

## Open questions deferred to future ADRs

- Federation truth (no etcd-equivalent for cross-substrate consistency)
- Reconcile-loop evolution toward K8s-shape (level-triggered, watch-based)
- At-most-once dispatch / apply semantics
- Watch-based observation primitives
- Cross-process Reconcilable registration
- Module identity and capability advertisement
- Identity-on-disk vs identity-in-ledger normativity
- `.cog/` directory schema as a substrate-API surface

## Review trail

- Independent Opus review (no foveal injection) caught factual errors + SYSTEM-SPEC collision + 8 missing contracts → addressed in revision
- Opus second-pass review caught 3 new line-level factual errors after the revision → all applied
- Cross-family local-model council (Gemma 4, LM Studio Eclipse Qwen3-coder-A4B, MLX-LM Qwen) converged on the same skeptical findings as the Sonnet council, validating cross-model independence per the existing `cross-model-verification-for-research-councils` discipline.
- Codex 5.4/5.5 high-reasoning runs hung silently on prompt-as-argument invocation; skipped after defensive review saturation reached.

## Test plan

- [ ] Renderable markdown — ADRs follow ADR-090's format
- [ ] References resolve — RFC/ADR cross-references point to existing files
- [ ] No code changes — strictly docs/adrs/ additions