### PR TITLE
feat(engine): gen_ai.* OTel attribute aliasing layer + span kind constants (H1)

### DIFF
--- a/docs/adrs/095-daemon-reconcile-loop-driver.md
+++ b/docs/adrs/095-daemon-reconcile-loop-driver.md
@@ -1,0 +1,221 @@
+# ADR-095: Daemon Reconcile Loop Driver
+
+| Field       | Value                                                                          |
+|-------------|--------------------------------------------------------------------------------|
+| Status      | Accepted                                                                       |
+| Author      | @chazmaniandinkle                                                              |
+| Created     | 2026-05-16                                                                     |
+| Parent      | [ADR-091 §2 trichotomy — Layer = Kernel](091-substrate-as-named-architectural-layer.md) |
+| Refs        | ADR-092 §1 (single-writer-per-session), §3 (idempotent ApplyPlan), §4 (Reconcilable contract), §6 (single-kernel today-status), §7 (authorization gate) |
+
+## Context
+
+ADR-092 §2 specifies the substrate boot sequence:
+
+1. Genesis check
+2. Ledger replay
+3. Service registration
+4. **Reconcile loop start** — periodic / on-demand reconciliation begins.
+
+Step 4 is documented but not implemented. Today, `internal/engine/cli_reconcile.go`
+is the only site that executes the full reconcile cycle (LoadConfig → FetchLive →
+ComputePlan → ApplyPlan → BuildState → WriteState). It is a one-shot CLI command
+(`cogos reconcile <type>`), not a daemon-resident loop.
+
+The consequences of this gap:
+
+- Registered Reconcilables (e.g., `ProjectionReconciler` from ADR-094) are never
+  driven at the daemon level. Their state diverges from declared config over time
+  until an operator manually runs the CLI.
+- The autonomic ticker (`autonomic_ticker.go`) probes `Health()` on all providers
+  each tick but does not run reconcile cycles. Health probes detect drift but do
+  not correct it.
+- Specific watch mechanisms (e.g., `ProjectionWatcher` from ADR-094) fire a
+  trigger callback when file-system events arrive, but today nothing wires that
+  callback to a full reconcile cycle.
+
+This ADR closes the gap by specifying and implementing `ReconcileDaemon`: a
+daemon-resident goroutine that periodically iterates registered Reconcilables and
+drives the full per-Reconcilable reconcile cycle.
+
+## Decision
+
+### §1 — Layer placement
+
+`ReconcileDaemon` is a **Kernel**-layer concern per the ADR-091 §2 trichotomy:
+
+- It requires an agent-loop-executing process to be running (it is a goroutine
+  resident in the daemon).
+- It consumes a **Substrate** primitive (`pkg/reconcile.Reconcilable` + the
+  process-local registry via `reconcile.ListProviders` / `reconcile.GetProvider`).
+- It does not project through a specific modality surface (that is the Module layer).
+
+### §2 — Contract
+
+`ReconcileDaemon` provides the following guarantees:
+
+| Property                  | Guarantee                                                                                                                  |
+|---------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| Periodic tick             | Reconcile all registered providers at configurable interval (default 30s).                                                 |
+| Per-provider error isolation | A panic or error in one provider's cycle MUST NOT block or terminate the cycles of other providers. Errors are logged and the provider is counted as `stalled` for that tick. |
+| Idempotent cycle          | Each reconcile cycle conforms to ADR-092 §3: ApplyPlan is idempotent. The daemon does not add further at-most-once guarantees. |
+| Context-aware shutdown    | The daemon exits its loop when `context.Context` is cancelled. In-flight cycles are allowed to complete (graceful) within a configurable shutdown grace period. |
+| Reconcilable contract     | The daemon calls methods in the ADR-092 §4 order: LoadConfig → FetchLive → ComputePlan → ApplyPlan → BuildState → WriteState. |
+| Single-writer rule        | The daemon does not bypass the single-writer-per-session ledger contract (ADR-092 §1). Each provider's reconcile cycle runs sequentially within the daemon (no two goroutines run the same provider concurrently). |
+
+### §3 — State machine
+
+The daemon tracks a coarse lifecycle state:
+
+| State      | Meaning                                                              |
+|------------|----------------------------------------------------------------------|
+| Starting   | Goroutine not yet running (zero value).                              |
+| Live       | Goroutine running; last tick completed without fatal error.          |
+| Stalled    | Running; last tick had one or more provider errors. Daemon continues ticking. |
+| Shutdown   | Context cancelled; goroutine has exited.                             |
+
+State transitions: `Starting → Live` (on first tick start), `Live ↔ Stalled`
+(on per-tick error presence), `{Live,Stalled} → Shutdown` (on context cancel).
+
+### §4 — Watch-trigger integration
+
+Specific Reconcilables may implement event-driven early reconciliation outside
+the periodic tick (e.g., `ProjectionWatcher` from ADR-094 fires on file-system
+writes). The daemon driver is the **general** mechanism; watchers are **specific
+instances** that may enqueue an early trigger.
+
+The integration contract:
+
+- The daemon exposes a `Trigger(providerType string)` method that queues an
+  immediate reconcile for the named provider (non-blocking; drops if already
+  queued).
+- Watchers receive a trigger callback at construction time; callers wire this
+  to `daemon.Trigger(providerType)`.
+- The daemon drains the trigger queue between periodic ticks. A queued trigger
+  for provider P causes P's cycle to run immediately rather than waiting for the
+  next tick; after the cycle, P is removed from the queue.
+
+### §5 — Configuration
+
+| Parameter               | Default | Description                                                         |
+|-------------------------|---------|---------------------------------------------------------------------|
+| `PollInterval`          | 30s     | How often all providers are iterated in the periodic tick loop.     |
+| `MaxConcurrent`         | 1       | Maximum number of providers reconciled concurrently. Default 1 serializes all providers within a tick per ADR-092 §1 single-writer recommendation. |
+| `ShutdownGracePeriod`   | 5s      | How long the daemon waits for in-flight cycles to complete after context cancel before returning. |
+
+Rationale for default `MaxConcurrent = 1`: ADR-092 §1 documents the
+single-writer-per-session concurrency gap in `pkg/cogblock.AppendEvent`. Until
+the per-session mutex lands, serializing provider cycles avoids the chain-break
+risk for providers that emit ledger events. Future work may raise this to N once
+§1 is closed.
+
+### §6 — Wiring at daemon boot
+
+The daemon is started in `runServe` (`internal/engine/cli.go`) after service
+registration (ADR-092 §2 step 3) and before the HTTP server begins serving
+external requests. This places the reconcile loop at boot step 4 per the §2
+sequence.
+
+**Coordination with Orchestrator A's I1 (ProjectionWatcher boot wiring):**
+`ReconcileDaemon` subsumes the narrow ProjectionWatcher.Start() wiring from I1.
+The watcher trigger is wired to `daemon.Trigger("lineage-projection-<kind>")` at
+daemon construction time, making the watcher an early-trigger source for the
+general loop rather than an independent mechanism.
+
+If Orchestrator A's I1 lands first (ProjectionWatcher.Start() at boot as a
+standalone call), this ADR's wiring replaces that standalone call by routing
+the same trigger through the daemon.
+
+### §7 — Telemetry
+
+Each provider reconcile cycle emits:
+
+- A structured slog record at INFO level: provider type, duration, plan summary
+  (creates/updates/deletes/skipped), error if any.
+- An OTel span: `reconcile.daemon.cycle` with attributes `provider.type`,
+  `plan.creates`, `plan.updates`, `plan.deletes`, `plan.skipped`, `cycle.duration_ms`.
+
+These are observatory surfaces: reconcile operations are projections through the
+lineage + autonomic observatories, not silent background work.
+
+### §8 — Migration
+
+Before this ADR: no daemon reconcile loop exists. The on-disk state for any
+Reconcilable reflects the last manual `cogos reconcile <type>` invocation or the
+last time a CLI operator ran the command.
+
+After this ADR: the daemon runs the full reconcile cycle for all registered
+providers on each periodic tick. Existing state files are compatible: the daemon
+passes them to `BuildState` per the standard cycle.
+
+No migration of existing state files is required. The daemon's first tick
+reads each provider's existing state (if any) and produces a new plan from it.
+
+## Rationale
+
+### Why Kernel, not Substrate
+
+Reconcile cycle execution requires a running process with a context, a goroutine
+scheduler, and access to external systems (via FetchLive and ApplyPlan). The
+`pkg/reconcile` interface and registry are Substrate primitives (they exist
+independent of any agent loop), but the daemon driving them is Kernel (it
+requires an agent-loop-executing process).
+
+### Why serial by default (MaxConcurrent = 1)
+
+The ADR-092 §1 gap is an active implementation risk. Until `pkg/cogblock.AppendEvent`
+adds the per-session mutex, concurrent provider cycles could break ledger chains
+for any Reconcilable that emits ledger events. Serial execution is the safe default
+at no functional cost: providers are expected to complete in under 1s in the
+typical case (filesystem operations, cogdoc reads).
+
+### Why the daemon owns the watcher trigger, not the watcher
+
+ProjectionWatcher and future event-driven watchers are Reconcilable-specific.
+They are not general substrate primitives. Routing their trigger through the
+general daemon makes the daemon the authoritative source of reconcile cycle
+scheduling; watcher events become early-trigger signals into the same loop rather
+than separate reconcile paths with separate error handling and telemetry.
+
+## Consequences
+
+### Positive
+
+- ADR-092 §2 step 4 is implemented. Boot sequence is now complete.
+- Registered Reconcilables are driven continuously. Declared-vs-live drift is
+  corrected within one poll interval of occurring.
+- Telemetry provides observatory-visible reconcile activity without operator
+  intervention.
+- Per-provider error isolation prevents one bad provider from stalling the loop.
+
+### Negative
+
+- The daemon now runs background I/O work. A misconfigured Reconcilable with a
+  slow `FetchLive` (e.g., one waiting on an unreachable external service) will
+  consume the full `ctx`-bounded timeout each tick. Operators must set appropriate
+  timeouts inside their `FetchLive` implementations.
+- MaxConcurrent = 1 means a slow provider delays all subsequent providers in the
+  same tick. Future work: per-provider timeout + raise MaxConcurrent once §1 is
+  closed.
+
+### Neutral
+
+- Existing `cogos reconcile <type>` CLI command is unchanged. The daemon loop
+  and the CLI command are independent paths through the same provider interface.
+  Operators may still run one-shot CLI reconciliations at any time.
+
+## Implementation
+
+Files:
+
+- `internal/engine/reconcile_daemon.go` — `ReconcileDaemon` type and goroutine
+- `internal/engine/reconcile_daemon_test.go` — integration tests
+- `internal/engine/cli.go` — wiring at daemon boot (step 4)
+- `docs/adrs/095-daemon-reconcile-loop-driver.md` — this file
+
+The follow-up issue implied by this ADR:
+
+1. **Raise MaxConcurrent once ADR-092 §1 per-session mutex lands** — document
+   in the §1 follow-up issue as a dependent task.
+2. **Per-provider FetchLive timeout** — configurable per-provider timeout so a
+   slow external system doesn't consume the full tick budget.

--- a/internal/engine/cli.go
+++ b/internal/engine/cli.go
@@ -264,6 +264,39 @@ func runServe(workspace string, port int, bindAddr string) {
 		}
 	}
 
+	// ADR-092 §2 step 4: Reconcile loop start.
+	// ReconcileDaemon drives the full reconcile cycle for all registered
+	// Reconcilables on each periodic tick. ADR-095 specifies the contract.
+	reconcileDaemon := NewReconcileDaemon(ReconcileDaemonConfig{
+		WorkspaceRoot: cfg.WorkspaceRoot,
+	})
+	reconcileDaemon.Start(ctx)
+
+	// Wire ProjectionWatcher as an early-trigger source into the daemon.
+	// Each lineage-projection-<kind> Reconcilable gets a watcher that fires
+	// daemon.Trigger on file-system changes to the nodes/ directory.
+	// ADR-095 §4: watchers are specific early-trigger instances; the daemon
+	// driver is the general mechanism.
+	// The watcher is created with a nil-safe best-effort approach: if the
+	// nodes/ directory does not exist (workspace not yet initialized), the
+	// watcher Start call fails gracefully and no watch loop runs. Reconciliation
+	// still occurs on each periodic daemon tick.
+	for _, kind := range AllProjectionKinds {
+		kind := kind
+		nodesDir := cfg.WorkspaceRoot + "/.cog/mem/semantic/lineage/nodes"
+		providerType := "lineage-projection-" + string(kind)
+		watcher := NewProjectionWatcher(nodesDir, func(watchCtx context.Context) error {
+			reconcileDaemon.Trigger(providerType)
+			return nil
+		}, 0)
+		if err := watcher.Start(ctx); err != nil {
+			slog.Debug("projection watcher skipped (nodes dir not present)",
+				"kind", kind, "err", err)
+		} else {
+			slog.Info("projection watcher started", "kind", kind, "nodes_dir", nodesDir)
+		}
+	}
+
 	// Start process goroutine.
 	processDone := make(chan error, 1)
 	go func() {

--- a/internal/engine/gen_ai_attrs.go
+++ b/internal/engine/gen_ai_attrs.go
@@ -1,0 +1,176 @@
+// gen_ai_attrs.go — gen_ai.* OpenTelemetry semantic convention aliasing layer
+// for the cogos kernel.
+//
+// Context: H1 of the mod3-pipecat-otel-batch (2026-05-16).
+//
+// The OTel GenAI semantic conventions (semconv v1.30.0) define a standard
+// attribute namespace for LLM/AI system spans. This file provides a thin
+// aliasing layer that:
+//
+//  1. Exports named attribute constructors for every gen_ai.* key the kernel
+//     emits — callers never hard-code the raw string key.
+//  2. Centralises the semconv import so the rest of the engine doesn't need to
+//     import semconv directly.
+//  3. Adds cogos-kernel–specific extensions (gen_ai.cogos.*) for substrate
+//     fields that have no upstream semconv equivalent.
+//
+// Architectural note:
+//   H1/H2/H3/H4 is one OTel convention applied at multiple call sites — not
+//   four separate tracks. This file is the foundation; H2 wires it into
+//   ProjectionReconciler spans; H3 adds the conversation/turn/service span
+//   hierarchy; H4 wires ProjectionReconciler spans into that hierarchy.
+//
+// Wire compatibility:
+//   These attributes are emitted on OpenTelemetry spans that may be exported
+//   to Jaeger, Prometheus, or any OTel-compatible backend. The cogos.* extension
+//   keys are namespaced to avoid collisions with future upstream GenAI semconv
+//   additions.
+//
+// See: https://opentelemetry.io/docs/specs/semconv/gen-ai/ (v1.30.0)
+package engine
+
+import (
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
+)
+
+// ─── Standard gen_ai.* attribute constructors ────────────────────────────────
+//
+// These wrap the semconv key constants to provide typed, named constructors
+// that read clearly at the call site. All names follow the pattern
+// GenAI<PascalCaseFieldName>(value).
+
+// GenAISystem returns the gen_ai.system attribute identifying the AI provider.
+// Values: "anthropic", "openai", "gemma", "ollama", etc.
+func GenAISystem(system string) attribute.KeyValue {
+	return semconv.GenAISystemKey.String(system)
+}
+
+// GenAIOperationName returns the gen_ai.operation.name attribute.
+// Values: "chat", "text_completion", "embeddings", "reconcile", etc.
+func GenAIOperationName(name string) attribute.KeyValue {
+	return semconv.GenAIOperationNameKey.String(name)
+}
+
+// GenAIRequestModel returns the gen_ai.request.model attribute.
+// The model identifier as requested by the caller (may differ from response model).
+func GenAIRequestModel(model string) attribute.KeyValue {
+	return semconv.GenAIRequestModelKey.String(model)
+}
+
+// GenAIResponseModel returns the gen_ai.response.model attribute.
+// The model identifier as reported in the response (may include version suffix).
+func GenAIResponseModel(model string) attribute.KeyValue {
+	return semconv.GenAIResponseModelKey.String(model)
+}
+
+// GenAIResponseID returns the gen_ai.response.id attribute.
+// Opaque response identifier from the provider.
+func GenAIResponseID(id string) attribute.KeyValue {
+	return semconv.GenAIResponseIDKey.String(id)
+}
+
+// GenAIUsageInputTokens returns the gen_ai.usage.input_tokens attribute.
+func GenAIUsageInputTokens(n int) attribute.KeyValue {
+	return semconv.GenAIUsageInputTokensKey.Int(n)
+}
+
+// GenAIUsageOutputTokens returns the gen_ai.usage.output_tokens attribute.
+func GenAIUsageOutputTokens(n int) attribute.KeyValue {
+	return semconv.GenAIUsageOutputTokensKey.Int(n)
+}
+
+// GenAIRequestMaxTokens returns the gen_ai.request.max_tokens attribute.
+func GenAIRequestMaxTokens(n int) attribute.KeyValue {
+	return semconv.GenAIRequestMaxTokensKey.Int(n)
+}
+
+// GenAIRequestTemperature returns the gen_ai.request.temperature attribute.
+func GenAIRequestTemperature(t float64) attribute.KeyValue {
+	return semconv.GenAIRequestTemperatureKey.Float64(t)
+}
+
+// GenAIRequestTopP returns the gen_ai.request.top_p attribute.
+func GenAIRequestTopP(p float64) attribute.KeyValue {
+	return semconv.GenAIRequestTopPKey.Float64(p)
+}
+
+// GenAIResponseFinishReasons returns the gen_ai.response.finish_reasons attribute.
+// reasons is a slice of finish-reason strings (e.g. ["stop"], ["end_turn"]).
+func GenAIResponseFinishReasons(reasons []string) attribute.KeyValue {
+	return semconv.GenAIResponseFinishReasonsKey.StringSlice(reasons)
+}
+
+// ─── cogos-kernel extension attributes (gen_ai.cogos.*) ──────────────────────
+//
+// Fields with no upstream semconv equivalent. Namespaced under gen_ai.cogos.*
+// to (a) signal they are cogos-specific and (b) stay in the gen_ai.* namespace
+// so they group naturally with the standard attrs in OTel UIs.
+
+const (
+	// cogosSessionIDKey is the cogos session identifier that scopes this AI operation.
+	cogosSessionIDKey = attribute.Key("gen_ai.cogos.session_id")
+
+	// cogosOperationPhaseKey identifies the processing phase within a session turn.
+	// Values: "prompt_eval", "thinking", "answer", "tool_call", "reconcile".
+	cogosOperationPhaseKey = attribute.Key("gen_ai.cogos.operation.phase")
+
+	// cogosProjectionKindKey identifies the projection type for reconcile operations.
+	// Values: "bibliography", "lineage-chain", "convergence-map", etc.
+	cogosProjectionKindKey = attribute.Key("gen_ai.cogos.projection.kind")
+
+	// cogosProjectionNodeCountKey is the number of lineage nodes processed.
+	cogosProjectionNodeCountKey = attribute.Key("gen_ai.cogos.projection.node_count")
+
+	// cogosWorkspaceRootKey is the workspace root path for this operation.
+	cogosWorkspaceRootKey = attribute.Key("gen_ai.cogos.workspace_root")
+
+	// cogosSpanKindKey classifies the span within the conversation hierarchy.
+	// Values: "conversation", "turn", "service".
+	cogosSpanKindKey = attribute.Key("gen_ai.cogos.span.kind")
+)
+
+// CogosSessionID returns the gen_ai.cogos.session_id attribute.
+func CogosSessionID(sessionID string) attribute.KeyValue {
+	return cogosSessionIDKey.String(sessionID)
+}
+
+// CogosOperationPhase returns the gen_ai.cogos.operation.phase attribute.
+func CogosOperationPhase(phase string) attribute.KeyValue {
+	return cogosOperationPhaseKey.String(phase)
+}
+
+// CogosProjectionKind returns the gen_ai.cogos.projection.kind attribute.
+func CogosProjectionKind(kind string) attribute.KeyValue {
+	return cogosProjectionKindKey.String(kind)
+}
+
+// CogosProjectionNodeCount returns the gen_ai.cogos.projection.node_count attribute.
+func CogosProjectionNodeCount(n int) attribute.KeyValue {
+	return cogosProjectionNodeCountKey.Int(n)
+}
+
+// CogosWorkspaceRoot returns the gen_ai.cogos.workspace_root attribute.
+func CogosWorkspaceRoot(root string) attribute.KeyValue {
+	return cogosWorkspaceRootKey.String(root)
+}
+
+// CogosSpanKind returns the gen_ai.cogos.span.kind attribute.
+// Values: "conversation", "turn", "service".
+func CogosSpanKind(kind string) attribute.KeyValue {
+	return cogosSpanKindKey.String(kind)
+}
+
+// ─── Span kind constants ──────────────────────────────────────────────────────
+//
+// These are the valid values for CogosSpanKind, matching the H3 span hierarchy.
+// The conversation > turn > service nesting mirrors Pipecat's GenAI span shape.
+
+const (
+	// SpanKindConversation is the root span for a complete conversation session.
+	SpanKindConversation = "conversation"
+	// SpanKindTurn is a child of conversation — one user-turn + assistant-response.
+	SpanKindTurn = "turn"
+	// SpanKindService is a child of turn — one service call (LLM, STT, TTS, reconcile).
+	SpanKindService = "service"
+)

--- a/internal/engine/reconcile_daemon.go
+++ b/internal/engine/reconcile_daemon.go
@@ -1,0 +1,440 @@
+// reconcile_daemon.go — daemon-resident continuous reconcile loop driver.
+//
+// ReconcileDaemon closes ADR-092 §2 step 4: "Reconcile loop start — periodic /
+// on-demand reconciliation begins." It periodically iterates all registered
+// Reconcilables and drives the full per-provider cycle:
+//
+//	LoadConfig → FetchLive → ComputePlan → ApplyPlan → BuildState → WriteState
+//
+// Each provider's cycle is error-isolated: a panic or error in one provider
+// does not block or terminate the cycles of other providers (ADR-092 §3).
+//
+// Per-provider error isolation is non-negotiable per ADR-092 §3 at-least-once
+// semantics: one bad Reconcilable must not block others.
+//
+// ADR-091 Layer: Kernel (requires a running process; consumes Substrate
+// primitives pkg/reconcile.Reconcilable + process-local registry).
+// ADR-095: this file implements the contract specified therein.
+package engine
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/myrgic/cogos/pkg/reconcile"
+)
+
+// ReconcileDaemonState represents the lifecycle state of the daemon.
+type ReconcileDaemonState string
+
+const (
+	// ReconcileDaemonStarting is the initial state before the goroutine starts.
+	ReconcileDaemonStarting ReconcileDaemonState = "Starting"
+	// ReconcileDaemonLive means the goroutine is running; last tick had no errors.
+	ReconcileDaemonLive ReconcileDaemonState = "Live"
+	// ReconcileDaemonStalled means running but last tick had provider errors.
+	// The daemon continues ticking.
+	ReconcileDaemonStalled ReconcileDaemonState = "Stalled"
+	// ReconcileDaemonShutdown means context was cancelled; goroutine has exited.
+	ReconcileDaemonShutdown ReconcileDaemonState = "Shutdown"
+)
+
+// ReconcileDaemonConfig holds configuration for the ReconcileDaemon.
+type ReconcileDaemonConfig struct {
+	// WorkspaceRoot is the workspace root path, passed to LoadConfig and
+	// reconcile.LoadState / reconcile.WriteState.
+	WorkspaceRoot string
+
+	// PollInterval is how often all registered providers are iterated.
+	// Default: 30 seconds.
+	PollInterval time.Duration
+
+	// MaxConcurrent is the maximum number of providers reconciled concurrently
+	// within a single tick. Default: 1 (serial) per ADR-095 §5 rationale:
+	// serializes all providers to avoid ADR-092 §1 ledger chain-break risk until
+	// the per-session mutex is added to pkg/cogblock.AppendEvent.
+	MaxConcurrent int
+
+	// ShutdownGracePeriod is how long the daemon waits for in-flight cycles to
+	// complete after context cancel before returning. Default: 5 seconds.
+	ShutdownGracePeriod time.Duration
+}
+
+func (c *ReconcileDaemonConfig) withDefaults() ReconcileDaemonConfig {
+	cfg := *c
+	if cfg.PollInterval <= 0 {
+		cfg.PollInterval = 30 * time.Second
+	}
+	if cfg.MaxConcurrent <= 0 {
+		cfg.MaxConcurrent = 1
+	}
+	if cfg.ShutdownGracePeriod <= 0 {
+		cfg.ShutdownGracePeriod = 5 * time.Second
+	}
+	return cfg
+}
+
+// ReconcileDaemon is the daemon-resident goroutine that drives the full
+// reconcile cycle for all registered Reconcilables on each periodic tick.
+//
+// Start the daemon with Start(ctx). Stop it by cancelling the context.
+// Use Trigger to queue an early (out-of-band) reconcile for a specific provider.
+type ReconcileDaemon struct {
+	cfg ReconcileDaemonConfig
+
+	mu    sync.Mutex
+	state ReconcileDaemonState
+
+	// triggerCh is a non-blocking channel for early trigger requests.
+	// Keys are provider type strings. The map is drained at the start of
+	// each tick and after each regular tick.
+	triggerMu sync.Mutex
+	triggered map[string]struct{}
+	triggerCh chan struct{} // notifies the loop that triggers are queued
+}
+
+// NewReconcileDaemon creates a ReconcileDaemon with the given config.
+// Call Start(ctx) to begin the loop.
+func NewReconcileDaemon(cfg ReconcileDaemonConfig) *ReconcileDaemon {
+	return &ReconcileDaemon{
+		cfg:       cfg.withDefaults(),
+		state:     ReconcileDaemonStarting,
+		triggered: make(map[string]struct{}),
+		triggerCh: make(chan struct{}, 1),
+	}
+}
+
+// State returns the current lifecycle state of the daemon.
+func (d *ReconcileDaemon) State() ReconcileDaemonState {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.state
+}
+
+// Trigger queues an immediate (out-of-band) reconcile for the named provider
+// type. Non-blocking: if the provider is already queued, this is a no-op.
+// If the provider is not registered, the trigger is silently dropped.
+//
+// This is the integration point for watch-based early-trigger mechanisms
+// (e.g., ProjectionWatcher). See ADR-095 §4.
+func (d *ReconcileDaemon) Trigger(providerType string) {
+	if !reconcile.HasProvider(providerType) {
+		return
+	}
+	d.triggerMu.Lock()
+	d.triggered[providerType] = struct{}{}
+	d.triggerMu.Unlock()
+
+	// Non-blocking notify: if the channel already has a notification queued,
+	// the loop will drain triggers when it wakes. No need to send again.
+	select {
+	case d.triggerCh <- struct{}{}:
+	default:
+	}
+}
+
+// Start begins the reconcile loop in a background goroutine. The goroutine
+// exits when ctx is cancelled. Start is safe to call only once.
+func (d *ReconcileDaemon) Start(ctx context.Context) {
+	d.mu.Lock()
+	d.state = ReconcileDaemonLive
+	d.mu.Unlock()
+
+	slog.Info("reconcile-daemon: starting",
+		"poll_interval", d.cfg.PollInterval,
+		"max_concurrent", d.cfg.MaxConcurrent,
+		"workspace", d.cfg.WorkspaceRoot,
+	)
+
+	go d.run(ctx)
+}
+
+// run is the main goroutine body. It runs until ctx is cancelled.
+func (d *ReconcileDaemon) run(ctx context.Context) {
+	ticker := time.NewTicker(d.cfg.PollInterval)
+	defer ticker.Stop()
+
+	defer func() {
+		d.mu.Lock()
+		d.state = ReconcileDaemonShutdown
+		d.mu.Unlock()
+		slog.Info("reconcile-daemon: stopped")
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			// Drain any queued triggers with the grace period.
+			d.drainTriggersOnShutdown(ctx)
+			return
+
+		case <-d.triggerCh:
+			// Early trigger from a watcher or external caller.
+			d.runTriggered(ctx)
+
+		case <-ticker.C:
+			// Periodic tick: reconcile all registered providers.
+			d.runTick(ctx)
+		}
+	}
+}
+
+// runTick iterates all registered providers and runs their reconcile cycle.
+// Also drains any pending triggers before iterating (so a trigger that fired
+// between ticks is absorbed into this tick rather than generating a double run).
+func (d *ReconcileDaemon) runTick(ctx context.Context) {
+	// Absorb any outstanding triggers into this tick (they'll be covered by
+	// the full provider scan).
+	d.triggerMu.Lock()
+	d.triggered = make(map[string]struct{})
+	d.triggerMu.Unlock()
+
+	providers := reconcile.ListProviders()
+	if len(providers) == 0 {
+		return
+	}
+
+	slog.Debug("reconcile-daemon: tick", "provider_count", len(providers))
+
+	errCount := d.runProviders(ctx, providers)
+
+	d.mu.Lock()
+	if errCount > 0 {
+		d.state = ReconcileDaemonStalled
+	} else {
+		d.state = ReconcileDaemonLive
+	}
+	d.mu.Unlock()
+}
+
+// runTriggered drains the pending trigger set and runs cycles for only the
+// queued providers. Used for early (out-of-band) reconcile requests.
+func (d *ReconcileDaemon) runTriggered(ctx context.Context) {
+	d.triggerMu.Lock()
+	queued := d.triggered
+	d.triggered = make(map[string]struct{})
+	d.triggerMu.Unlock()
+
+	if len(queued) == 0 {
+		return
+	}
+
+	types := make([]string, 0, len(queued))
+	for t := range queued {
+		types = append(types, t)
+	}
+	slog.Debug("reconcile-daemon: triggered", "providers", types)
+	d.runProviders(ctx, types)
+}
+
+// drainTriggersOnShutdown runs any pending triggers within the shutdown grace period.
+func (d *ReconcileDaemon) drainTriggersOnShutdown(ctx context.Context) {
+	d.triggerMu.Lock()
+	queued := d.triggered
+	d.triggered = make(map[string]struct{})
+	d.triggerMu.Unlock()
+
+	if len(queued) == 0 {
+		return
+	}
+
+	graceCtx, cancel := context.WithTimeout(context.Background(), d.cfg.ShutdownGracePeriod)
+	defer cancel()
+
+	types := make([]string, 0, len(queued))
+	for t := range queued {
+		types = append(types, t)
+	}
+	slog.Info("reconcile-daemon: draining triggers on shutdown", "providers", types)
+	d.runProviders(graceCtx, types)
+}
+
+// runProviders runs the reconcile cycle for each named provider type.
+// Providers are run with MaxConcurrent parallelism (default 1 = serial).
+// Per-provider error isolation: panics and errors are recovered and logged;
+// other providers in the same batch continue unaffected.
+// Returns the number of providers that errored.
+func (d *ReconcileDaemon) runProviders(ctx context.Context, providerTypes []string) int {
+	if d.cfg.MaxConcurrent <= 1 {
+		// Serial path: simple loop, no goroutines needed.
+		errCount := 0
+		for _, pt := range providerTypes {
+			if err := d.runOneCycle(ctx, pt); err != nil {
+				errCount++
+			}
+			// Bail early if context is done.
+			if ctx.Err() != nil {
+				break
+			}
+		}
+		return errCount
+	}
+
+	// Concurrent path: semaphore-bounded goroutines.
+	sem := make(chan struct{}, d.cfg.MaxConcurrent)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	errCount := 0
+
+	for _, pt := range providerTypes {
+		if ctx.Err() != nil {
+			break
+		}
+		pt := pt
+		sem <- struct{}{} // acquire
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }() // release
+			if err := d.runOneCycle(ctx, pt); err != nil {
+				mu.Lock()
+				errCount++
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+	return errCount
+}
+
+// runOneCycle runs the full reconcile cycle for a single provider type.
+// The cycle is:
+//
+//	LoadConfig → FetchLive → ComputePlan → ApplyPlan → BuildState → WriteState
+//
+// Panics are recovered and returned as errors to preserve error isolation.
+// Conforms to ADR-092 §4 Reconcilable contract order.
+func (d *ReconcileDaemon) runOneCycle(ctx context.Context, providerType string) (retErr error) {
+	// Recover from panics so one misbehaving provider can't take down the loop.
+	defer func() {
+		if r := recover(); r != nil {
+			retErr = fmt.Errorf("panic in provider %s: %v", providerType, r)
+			slog.Error("reconcile-daemon: provider panicked",
+				"provider", providerType,
+				"panic", r,
+			)
+		}
+	}()
+
+	tracer := otel.Tracer("cogos.reconcile-daemon")
+	spanCtx, span := tracer.Start(ctx, "reconcile.daemon.cycle")
+	span.SetAttributes(attribute.String("provider.type", providerType))
+	defer span.End()
+
+	start := time.Now()
+
+	provider, err := reconcile.GetProvider(providerType)
+	if err != nil {
+		slog.Warn("reconcile-daemon: provider not found", "provider", providerType, "err", err)
+		return err
+	}
+
+	// Step 1: LoadConfig — read-only disk operation.
+	config, err := provider.LoadConfig(d.cfg.WorkspaceRoot)
+	if err != nil {
+		slog.Warn("reconcile-daemon: LoadConfig failed",
+			"provider", providerType, "err", err)
+		return fmt.Errorf("LoadConfig %s: %w", providerType, err)
+	}
+
+	// Step 2: FetchLive — read-only observation of world state.
+	live, err := provider.FetchLive(spanCtx, config)
+	if err != nil {
+		slog.Warn("reconcile-daemon: FetchLive failed",
+			"provider", providerType, "err", err)
+		return fmt.Errorf("FetchLive %s: %w", providerType, err)
+	}
+
+	// Step 3: Load persisted state.
+	state, _ := reconcile.LoadState(d.cfg.WorkspaceRoot, providerType)
+
+	// Step 4: ComputePlan — pure function, deterministic.
+	plan, err := provider.ComputePlan(config, live, state)
+	if err != nil {
+		slog.Warn("reconcile-daemon: ComputePlan failed",
+			"provider", providerType, "err", err)
+		return fmt.Errorf("ComputePlan %s: %w", providerType, err)
+	}
+
+	span.SetAttributes(
+		attribute.Int("plan.creates", plan.Summary.Creates),
+		attribute.Int("plan.updates", plan.Summary.Updates),
+		attribute.Int("plan.deletes", plan.Summary.Deletes),
+		attribute.Int("plan.skipped", plan.Summary.Skipped),
+	)
+
+	if !plan.Summary.HasChanges() {
+		// No drift — log at debug level and exit early; no write needed.
+		dur := time.Since(start)
+		span.SetAttributes(attribute.Int64("cycle.duration_ms", dur.Milliseconds()))
+		slog.Debug("reconcile-daemon: provider in sync",
+			"provider", providerType,
+			"skipped", plan.Summary.Skipped,
+			"duration_ms", dur.Milliseconds(),
+		)
+		return nil
+	}
+
+	// Step 5: ApplyPlan — idempotent per ADR-092 §3.
+	results, err := provider.ApplyPlan(spanCtx, plan)
+	if err != nil {
+		slog.Warn("reconcile-daemon: ApplyPlan failed",
+			"provider", providerType, "err", err)
+		return fmt.Errorf("ApplyPlan %s: %w", providerType, err)
+	}
+
+	// Count apply failures.
+	applyFailed := 0
+	for _, r := range results {
+		if r.Status == reconcile.ApplyFailed {
+			applyFailed++
+			slog.Warn("reconcile-daemon: action failed",
+				"provider", providerType,
+				"action", r.Action,
+				"name", r.Name,
+				"err", r.Error,
+			)
+		}
+	}
+
+	// Step 6: BuildState — pure function.
+	newState, buildErr := provider.BuildState(config, live, state)
+	if buildErr == nil && newState != nil {
+		// Step 7: WriteState — atomic tmp+rename.
+		if writeErr := reconcile.WriteState(d.cfg.WorkspaceRoot, providerType, newState); writeErr != nil {
+			slog.Warn("reconcile-daemon: WriteState failed",
+				"provider", providerType, "err", writeErr)
+		}
+	} else if buildErr != nil {
+		slog.Warn("reconcile-daemon: BuildState failed",
+			"provider", providerType, "err", buildErr)
+	}
+
+	dur := time.Since(start)
+	span.SetAttributes(attribute.Int64("cycle.duration_ms", dur.Milliseconds()))
+
+	logLevel := slog.LevelInfo
+	if applyFailed > 0 {
+		logLevel = slog.LevelWarn
+	}
+	slog.Log(ctx, logLevel, "reconcile-daemon: cycle complete",
+		"provider", providerType,
+		"creates", plan.Summary.Creates,
+		"updates", plan.Summary.Updates,
+		"deletes", plan.Summary.Deletes,
+		"skipped", plan.Summary.Skipped,
+		"apply_failed", applyFailed,
+		"duration_ms", dur.Milliseconds(),
+	)
+
+	if applyFailed > 0 {
+		return fmt.Errorf("provider %s: %d action(s) failed during apply", providerType, applyFailed)
+	}
+	return nil
+}

--- a/internal/engine/reconcile_daemon_test.go
+++ b/internal/engine/reconcile_daemon_test.go
@@ -1,0 +1,526 @@
+// reconcile_daemon_test.go — integration tests for ReconcileDaemon.
+//
+// Tests are table-driven and cover:
+//   - Daemon ticks at the expected interval and calls full reconcile cycles.
+//   - Per-provider error isolation: one panicking provider does not block others.
+//   - Idempotency on repeated runs (repeated ticks with identical state produce
+//     identical outcomes without side effects).
+//   - Shutdown timing: context cancel causes the daemon to exit within the
+//     shutdown grace period.
+//   - Trigger mechanism: Trigger() queues an early cycle for a named provider.
+//
+// ADR-092 §3: ApplyPlan idempotency is tested by running the same provider twice
+// and asserting apply count increments predictably (not double-applied).
+// ADR-095 §2: per-provider error isolation is the non-negotiable invariant.
+package engine
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/myrgic/cogos/pkg/reconcile"
+)
+
+// ─── No-op Reconcilable for baseline tests ────────────────────────────────────
+
+// noopReconcilable is a minimal Reconcilable that tracks call counts.
+type noopReconcilable struct {
+	typeName     string
+	loadCount    atomic.Int32
+	fetchCount   atomic.Int32
+	computeCount atomic.Int32
+	applyCount   atomic.Int32
+	buildCount   atomic.Int32
+	hasChanges   bool // if true, ComputePlan returns a plan with one create action
+}
+
+func (r *noopReconcilable) Type() string { return r.typeName }
+
+func (r *noopReconcilable) LoadConfig(_ string) (any, error) {
+	r.loadCount.Add(1)
+	return map[string]any{"type": r.typeName}, nil
+}
+
+func (r *noopReconcilable) FetchLive(_ context.Context, _ any) (any, error) {
+	r.fetchCount.Add(1)
+	return map[string]any{"live": true}, nil
+}
+
+func (r *noopReconcilable) ComputePlan(_ any, _ any, _ *reconcile.State) (*reconcile.Plan, error) {
+	r.computeCount.Add(1)
+	plan := &reconcile.Plan{
+		ResourceType: r.typeName,
+		GeneratedAt:  time.Now().UTC().Format(time.RFC3339),
+	}
+	if r.hasChanges {
+		plan.Actions = []reconcile.Action{{
+			Action:       reconcile.ActionCreate,
+			ResourceType: r.typeName,
+			Name:         "test-resource",
+			Details:      map[string]any{},
+		}}
+		plan.Summary.Creates = 1
+	} else {
+		plan.Actions = []reconcile.Action{{
+			Action:       reconcile.ActionSkip,
+			ResourceType: r.typeName,
+			Name:         "test-resource",
+			Details:      map[string]any{"reason": "in sync"},
+		}}
+		plan.Summary.Skipped = 1
+	}
+	return plan, nil
+}
+
+func (r *noopReconcilable) ApplyPlan(_ context.Context, plan *reconcile.Plan) ([]reconcile.Result, error) {
+	r.applyCount.Add(1)
+	var results []reconcile.Result
+	for _, a := range plan.Actions {
+		results = append(results, reconcile.Result{
+			Phase:  "apply",
+			Action: string(a.Action),
+			Name:   a.Name,
+			Status: reconcile.ApplySucceeded,
+		})
+	}
+	return results, nil
+}
+
+func (r *noopReconcilable) BuildState(_ any, _ any, existing *reconcile.State) (*reconcile.State, error) {
+	r.buildCount.Add(1)
+	s := reconcile.NewState(r.typeName)
+	if existing != nil {
+		s.Lineage = existing.Lineage
+		s.Serial = existing.Serial
+	}
+	return s, nil
+}
+
+func (r *noopReconcilable) Health() reconcile.ResourceStatus {
+	return reconcile.NewResourceStatus(reconcile.SyncStatusSynced, reconcile.HealthHealthy)
+}
+
+// ─── Error-injecting Reconcilable ─────────────────────────────────────────────
+
+// errorReconcilable always returns an error from FetchLive.
+type errorReconcilable struct {
+	typeName  string
+	callCount atomic.Int32
+}
+
+func (r *errorReconcilable) Type() string { return r.typeName }
+func (r *errorReconcilable) LoadConfig(_ string) (any, error) {
+	r.callCount.Add(1)
+	return nil, nil
+}
+func (r *errorReconcilable) FetchLive(_ context.Context, _ any) (any, error) {
+	return nil, errors.New("simulated fetch failure")
+}
+func (r *errorReconcilable) ComputePlan(_ any, _ any, _ *reconcile.State) (*reconcile.Plan, error) {
+	return nil, nil
+}
+func (r *errorReconcilable) ApplyPlan(_ context.Context, _ *reconcile.Plan) ([]reconcile.Result, error) {
+	return nil, nil
+}
+func (r *errorReconcilable) BuildState(_ any, _ any, _ *reconcile.State) (*reconcile.State, error) {
+	return nil, nil
+}
+func (r *errorReconcilable) Health() reconcile.ResourceStatus {
+	return reconcile.NewResourceStatus(reconcile.SyncStatusUnknown, reconcile.HealthDegraded)
+}
+
+// ─── Panicking Reconcilable ───────────────────────────────────────────────────
+
+// panicReconcilable panics from ComputePlan to test error isolation.
+type panicReconcilable struct {
+	typeName string
+}
+
+func (r *panicReconcilable) Type() string { return r.typeName }
+func (r *panicReconcilable) LoadConfig(_ string) (any, error) {
+	return nil, nil
+}
+func (r *panicReconcilable) FetchLive(_ context.Context, _ any) (any, error) {
+	return nil, nil
+}
+func (r *panicReconcilable) ComputePlan(_ any, _ any, _ *reconcile.State) (*reconcile.Plan, error) {
+	panic("intentional panic from panicReconcilable")
+}
+func (r *panicReconcilable) ApplyPlan(_ context.Context, _ *reconcile.Plan) ([]reconcile.Result, error) {
+	return nil, nil
+}
+func (r *panicReconcilable) BuildState(_ any, _ any, _ *reconcile.State) (*reconcile.State, error) {
+	return nil, nil
+}
+func (r *panicReconcilable) Health() reconcile.ResourceStatus {
+	return reconcile.NewResourceStatus(reconcile.SyncStatusUnknown, reconcile.HealthDegraded)
+}
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+// mustRegister registers a provider and returns a cleanup func to deregister.
+func mustRegister(t *testing.T, p reconcile.Reconcilable) func() {
+	t.Helper()
+	reconcile.UpsertProvider(p.Type(), p)
+	return func() {
+		reconcile.ResetProviders()
+	}
+}
+
+// newTestDaemon creates a ReconcileDaemon with a fast poll interval for tests.
+func newTestDaemon(root string, pollInterval time.Duration) *ReconcileDaemon {
+	return NewReconcileDaemon(ReconcileDaemonConfig{
+		WorkspaceRoot:       root,
+		PollInterval:        pollInterval,
+		MaxConcurrent:       1,
+		ShutdownGracePeriod: 500 * time.Millisecond,
+	})
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+// TestReconcileDaemon_BasicTick verifies that the daemon ticks and drives the
+// full reconcile cycle (LoadConfig, FetchLive, ComputePlan) for a registered
+// no-op provider within the expected interval.
+func TestReconcileDaemon_BasicTick(t *testing.T) {
+	reconcile.ResetProviders()
+	defer reconcile.ResetProviders()
+
+	provider := &noopReconcilable{typeName: "test-basic", hasChanges: false}
+	reconcile.UpsertProvider(provider.Type(), provider)
+
+	daemon := newTestDaemon(t.TempDir(), 50*time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+
+	daemon.Start(ctx)
+
+	// Wait for context to expire (daemon runs for 400ms with 50ms ticks → ~8 ticks).
+	<-ctx.Done()
+
+	// Allow daemon goroutine to settle.
+	time.Sleep(20 * time.Millisecond)
+
+	if daemon.State() != ReconcileDaemonShutdown {
+		t.Errorf("expected state Shutdown, got %q", daemon.State())
+	}
+
+	// Should have ticked at least 3 times. Be conservative to avoid flakiness.
+	if got := provider.fetchCount.Load(); got < 3 {
+		t.Errorf("expected FetchLive to be called >= 3 times, got %d", got)
+	}
+	if got := provider.computeCount.Load(); got < 3 {
+		t.Errorf("expected ComputePlan to be called >= 3 times, got %d", got)
+	}
+}
+
+// TestReconcileDaemon_ApplyOnDrift verifies that ApplyPlan is called when the
+// provider computes a plan with changes, and not called when there is no drift.
+func TestReconcileDaemon_ApplyOnDrift(t *testing.T) {
+	cases := []struct {
+		name           string
+		hasChanges     bool
+		wantApplyCount int32 // minimum
+	}{
+		{
+			name:           "in-sync provider: no apply",
+			hasChanges:     false,
+			wantApplyCount: 0,
+		},
+		{
+			name:           "drifted provider: apply called",
+			hasChanges:     true,
+			wantApplyCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reconcile.ResetProviders()
+			defer reconcile.ResetProviders()
+
+			provider := &noopReconcilable{
+				typeName:   "test-apply-drift",
+				hasChanges: tc.hasChanges,
+			}
+			reconcile.UpsertProvider(provider.Type(), provider)
+
+			daemon := newTestDaemon(t.TempDir(), 50*time.Millisecond)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+			defer cancel()
+
+			daemon.Start(ctx)
+			<-ctx.Done()
+			time.Sleep(20 * time.Millisecond)
+
+			if !tc.hasChanges && provider.applyCount.Load() != 0 {
+				t.Errorf("no-drift case: expected 0 ApplyPlan calls, got %d",
+					provider.applyCount.Load())
+			}
+			if tc.hasChanges && provider.applyCount.Load() < tc.wantApplyCount {
+				t.Errorf("drift case: expected >= %d ApplyPlan calls, got %d",
+					tc.wantApplyCount, provider.applyCount.Load())
+			}
+		})
+	}
+}
+
+// TestReconcileDaemon_ErrorIsolation verifies that an error in one provider's
+// cycle does not prevent other providers from being reconciled.
+// This is the non-negotiable invariant per ADR-092 §3 and ADR-095 §2.
+func TestReconcileDaemon_ErrorIsolation(t *testing.T) {
+	reconcile.ResetProviders()
+	defer reconcile.ResetProviders()
+
+	good := &noopReconcilable{typeName: "test-good", hasChanges: false}
+	bad := &errorReconcilable{typeName: "test-bad"}
+
+	reconcile.UpsertProvider(good.Type(), good)
+	reconcile.UpsertProvider(bad.Type(), bad)
+
+	daemon := newTestDaemon(t.TempDir(), 50*time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	daemon.Start(ctx)
+	<-ctx.Done()
+	time.Sleep(20 * time.Millisecond)
+
+	// The good provider must have been reconciled despite the bad provider's errors.
+	if got := good.fetchCount.Load(); got < 2 {
+		t.Errorf("error isolation failure: good provider FetchLive called only %d times (expected >= 2)", got)
+	}
+
+	// The bad provider's LoadConfig should also have been called repeatedly,
+	// confirming the daemon kept iterating it (and isolating its FetchLive error).
+	if got := bad.callCount.Load(); got < 2 {
+		t.Errorf("bad provider LoadConfig called only %d times (expected >= 2)", got)
+	}
+}
+
+// TestReconcileDaemon_PanicIsolation verifies that a panic inside a provider's
+// reconcile cycle does not crash the daemon or block other providers.
+// ADR-095 §2: per-provider error isolation covers panics.
+func TestReconcileDaemon_PanicIsolation(t *testing.T) {
+	reconcile.ResetProviders()
+	defer reconcile.ResetProviders()
+
+	panicky := &panicReconcilable{typeName: "test-panicky"}
+	good := &noopReconcilable{typeName: "test-good-panic", hasChanges: false}
+
+	reconcile.UpsertProvider(panicky.Type(), panicky)
+	reconcile.UpsertProvider(good.Type(), good)
+
+	daemon := newTestDaemon(t.TempDir(), 50*time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	// If panic propagates out of the daemon, this test will panic itself and fail.
+	daemon.Start(ctx)
+	<-ctx.Done()
+	time.Sleep(20 * time.Millisecond)
+
+	// Good provider should still have been reconciled.
+	if got := good.fetchCount.Load(); got < 2 {
+		t.Errorf("panic isolation failure: good provider FetchLive called only %d times", got)
+	}
+
+	// Daemon should be Shutdown (not crashed).
+	if daemon.State() != ReconcileDaemonShutdown {
+		t.Errorf("expected state Shutdown after context cancel, got %q", daemon.State())
+	}
+}
+
+// TestReconcileDaemon_IdempotencyOnRepeatedRuns verifies that running the
+// reconcile cycle multiple times against an in-sync provider does not produce
+// additional side effects (no spurious applies).
+// Conforms to ADR-092 §3 idempotency requirement.
+func TestReconcileDaemon_IdempotencyOnRepeatedRuns(t *testing.T) {
+	reconcile.ResetProviders()
+	defer reconcile.ResetProviders()
+
+	// Provider reports no changes (in-sync). ApplyPlan must never be called.
+	provider := &noopReconcilable{typeName: "test-idempotent", hasChanges: false}
+	reconcile.UpsertProvider(provider.Type(), provider)
+
+	daemon := newTestDaemon(t.TempDir(), 30*time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	daemon.Start(ctx)
+	<-ctx.Done()
+	time.Sleep(20 * time.Millisecond)
+
+	// At least several ticks should have run.
+	if got := provider.computeCount.Load(); got < 3 {
+		t.Errorf("expected >= 3 ComputePlan calls, got %d", got)
+	}
+	// No apply should ever have been triggered for an in-sync provider.
+	if got := provider.applyCount.Load(); got != 0 {
+		t.Errorf("idempotency violation: ApplyPlan called %d times for in-sync provider", got)
+	}
+}
+
+// TestReconcileDaemon_ShutdownTiming verifies that the daemon exits within the
+// shutdown grace period after context cancel.
+func TestReconcileDaemon_ShutdownTiming(t *testing.T) {
+	reconcile.ResetProviders()
+	defer reconcile.ResetProviders()
+
+	provider := &noopReconcilable{typeName: "test-shutdown", hasChanges: false}
+	reconcile.UpsertProvider(provider.Type(), provider)
+
+	daemon := NewReconcileDaemon(ReconcileDaemonConfig{
+		WorkspaceRoot:       t.TempDir(),
+		PollInterval:        10 * time.Second, // long interval — won't tick during test
+		MaxConcurrent:       1,
+		ShutdownGracePeriod: 200 * time.Millisecond,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	daemon.Start(ctx)
+
+	// Give the daemon goroutine time to start.
+	time.Sleep(20 * time.Millisecond)
+
+	// Cancel the context and measure how long until the daemon state transitions.
+	cancelTime := time.Now()
+	cancel()
+
+	// Poll for Shutdown state with a generous deadline.
+	deadline := time.After(500 * time.Millisecond)
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("daemon did not reach Shutdown state within 500ms of context cancel")
+		default:
+			if daemon.State() == ReconcileDaemonShutdown {
+				elapsed := time.Since(cancelTime)
+				// Should be well under the grace period (200ms).
+				if elapsed > 300*time.Millisecond {
+					t.Errorf("daemon took %v to stop, expected < 300ms", elapsed)
+				}
+				return
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+}
+
+// TestReconcileDaemon_TriggerMechanism verifies that Trigger causes an immediate
+// reconcile for the named provider outside the periodic tick.
+func TestReconcileDaemon_TriggerMechanism(t *testing.T) {
+	reconcile.ResetProviders()
+	defer reconcile.ResetProviders()
+
+	provider := &noopReconcilable{typeName: "test-trigger", hasChanges: true}
+	reconcile.UpsertProvider(provider.Type(), provider)
+
+	daemon := NewReconcileDaemon(ReconcileDaemonConfig{
+		WorkspaceRoot:       t.TempDir(),
+		PollInterval:        10 * time.Second, // very long — won't tick during test
+		MaxConcurrent:       1,
+		ShutdownGracePeriod: 200 * time.Millisecond,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	daemon.Start(ctx)
+
+	// Give goroutine time to start.
+	time.Sleep(10 * time.Millisecond)
+
+	// Fire a trigger. The periodic tick won't fire within the test window.
+	beforeTrigger := provider.fetchCount.Load()
+	daemon.Trigger(provider.Type())
+
+	// Wait for the triggered cycle to complete.
+	deadline := time.After(300*time.Millisecond)
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("triggered cycle did not complete within 300ms")
+		default:
+			if provider.fetchCount.Load() > beforeTrigger {
+				// Triggered cycle ran.
+				return
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+}
+
+// TestReconcileDaemon_TriggerUnregisteredProviderIsNoOp verifies that Trigger
+// with an unknown provider type is a silent no-op (no crash, no error).
+func TestReconcileDaemon_TriggerUnregisteredProviderIsNoOp(t *testing.T) {
+	reconcile.ResetProviders()
+	defer reconcile.ResetProviders()
+
+	daemon := newTestDaemon(t.TempDir(), 10*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	daemon.Start(ctx)
+	time.Sleep(10 * time.Millisecond)
+
+	// Should not panic or error.
+	daemon.Trigger("nonexistent-provider")
+	time.Sleep(20 * time.Millisecond)
+}
+
+// TestReconcileDaemon_StateTransitions verifies the state machine:
+// Starting → Live (on Start) → Stalled (on error tick) → Shutdown (on cancel).
+func TestReconcileDaemon_StateTransitions(t *testing.T) {
+	reconcile.ResetProviders()
+	defer reconcile.ResetProviders()
+
+	var mu sync.Mutex
+	states := []ReconcileDaemonState{}
+	recordState := func(s ReconcileDaemonState) {
+		mu.Lock()
+		defer mu.Unlock()
+		if len(states) == 0 || states[len(states)-1] != s {
+			states = append(states, s)
+		}
+	}
+
+	// Starting state before Start() is called.
+	daemon := newTestDaemon(t.TempDir(), 50*time.Millisecond)
+	recordState(daemon.State())
+
+	// Register a bad provider so the first tick produces a Stalled state.
+	bad := &errorReconcilable{typeName: "test-state-trans"}
+	reconcile.UpsertProvider(bad.Type(), bad)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	daemon.Start(ctx)
+	recordState(daemon.State()) // should be Live
+
+	<-ctx.Done()
+	time.Sleep(30 * time.Millisecond)
+	recordState(daemon.State()) // should be Shutdown
+
+	// Verify we saw Starting, Live, Shutdown. Stalled may or may not appear
+	// depending on timing — we only assert the required transitions.
+	if len(states) < 2 {
+		t.Fatalf("expected at least 2 state transitions, got %v", states)
+	}
+	if states[0] != ReconcileDaemonStarting {
+		t.Errorf("first state: expected Starting, got %q", states[0])
+	}
+	if states[len(states)-1] != ReconcileDaemonShutdown {
+		t.Errorf("last state: expected Shutdown, got %q", states[len(states)-1])
+	}
+}


### PR DESCRIPTION
## Summary

- **H1** — `internal/engine/gen_ai_attrs.go`: typed aliasing layer over OTel semantic conventions v1.30.0 for LLM/AI spans.
  - Standard `gen_ai.*` constructors for all attributes relevant to the kernel's LLM interaction surface.
  - `gen_ai.cogos.*` extension namespace for substrate-specific fields (session ID, operation phase, projection kind, workspace root, span kind).
  - Span kind constants (`SpanKindConversation`, `SpanKindTurn`, `SpanKindService`) matching Pipecat's GenAI observability shape.
- **I1** — ProjectionWatcher daemon boot wiring is resolved by prior commit `e6bdb04` (daemon reconcile loop driver + ADR-095), which already subsumes I1. No additional work needed; noted in commit message.

## Architecture note

H1/H2/H3/H4 is one OTel convention applied at multiple call sites — not four separate tracks. This file is the foundation layer. H2 (ProjectionReconciler span emission) and H3 (span hierarchy) depend on the constructors defined here.

The `gen_ai.cogos.*` extension namespace avoids collisions with future upstream GenAI semconv additions while keeping substrate attributes grouped naturally with standard attrs in OTel UIs.

## Authorization

Leave open for review — architectural, affects observability surface.

## Test plan

- [x] `go build ./...` passes (zero errors, verified before PR)
- [ ] H2 will add the first actual usage of these constructors in ProjectionReconciler span emission
- [ ] H3 will add conversation/turn/service span hierarchy usage
- [ ] Review gen_ai.cogos.* extension naming conventions