### PR TITLE
Add peer.utterance event type and from_session attribution to cog_emit_event

### DIFF
--- a/internal/engine/mcp_emit_event_test.go
+++ b/internal/engine/mcp_emit_event_test.go
@@ -1,0 +1,391 @@
+// mcp_emit_event_test.go — unit tests for the cog_emit_event MCP tool.
+//
+// Covers:
+//   - Existing four event types still accepted (regression guard).
+//   - peer.utterance: valid and all rejection cases.
+//   - from_session: recorded correctly; rejection on unregistered session;
+//     rejection on mismatch with payload.from.
+//   - Unknown event type is rejected.
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// makeServerWithSessions creates an MCPServer with a live Process and a
+// pre-wired session registry. Returns the server and registry so tests can
+// seed sessions before calling toolEmitEvent.
+func makeServerWithSessions(t *testing.T) (*MCPServer, *SessionRegistry) {
+	t.Helper()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	process := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	server := NewMCPServer(cfg, makeNucleus("Cog", "tester"), process)
+
+	bus := NewBusSessionManager(root)
+	registry := NewSessionRegistry()
+	handoffs := NewHandoffRegistry()
+	server.SetSessionsBackend(bus, registry, handoffs)
+
+	return server, registry
+}
+
+// registerTestSession seeds the registry with a live session for use in tests.
+func registerTestSession(t *testing.T, registry *SessionRegistry, sessionID string) {
+	t.Helper()
+	now := time.Now().UTC()
+	state := SessionState{
+		SessionID:    sessionID,
+		Workspace:    "/tmp/test",
+		Role:         "peer-cog",
+		RegisteredAt: now,
+		LastSeen:     now,
+	}
+	_, _, err := registry.ApplyRegister(state, defaultActiveWithinSeconds*time.Second, now, nil)
+	if err != nil {
+		t.Fatalf("registerTestSession %q: %v", sessionID, err)
+	}
+}
+
+// callEmitEvent is a thin wrapper that calls toolEmitEvent and returns the
+// decoded text content of the first result element. If the result is a JSON
+// object it is returned as-is; if it is a plain error message string, that
+// string is returned. The caller can inspect it for expected substrings.
+func callEmitEvent(t *testing.T, server *MCPServer, input emitEventInput) string {
+	t.Helper()
+	result, _, err := server.toolEmitEvent(context.Background(), nil, input)
+	if err != nil {
+		t.Fatalf("toolEmitEvent returned Go error (unexpected): %v", err)
+	}
+	if result == nil || len(result.Content) == 0 {
+		t.Fatal("toolEmitEvent returned nil/empty result")
+	}
+	tc, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("content[0] type = %T; want *mcp.TextContent", result.Content[0])
+	}
+	return tc.Text
+}
+
+// ─── existing event types (regression guard) ─────────────────────────────────
+
+func TestToolEmitEvent_ExistingTypesAccepted(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		input   emitEventInput
+		wantKey string // key expected in JSON response
+	}{
+		{
+			name:    "attention.boost",
+			input:   emitEventInput{Type: "attention.boost", Payload: map[string]any{"uri": "cog://mem/semantic/test.cog.md", "weight": 1.5}},
+			wantKey: "emitted",
+		},
+		{
+			name:    "session.marker",
+			input:   emitEventInput{Type: "session.marker", Payload: map[string]any{"label": "checkpoint"}},
+			wantKey: "emitted",
+		},
+		{
+			name:    "insight.captured",
+			input:   emitEventInput{Type: "insight.captured", Payload: map[string]any{"summary": "test insight", "tags": []string{"test"}}},
+			wantKey: "emitted",
+		},
+		{
+			name:    "decision.made",
+			input:   emitEventInput{Type: "decision.made", Payload: map[string]any{"decision": "use Go", "rationale": "performance"}},
+			wantKey: "emitted",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			server, _ := makeServerWithSessions(t)
+			got := callEmitEvent(t, server, tc.input)
+			var resp map[string]any
+			if err := json.Unmarshal([]byte(got), &resp); err != nil {
+				t.Fatalf("response is not JSON: %q", got)
+			}
+			if _, ok := resp[tc.wantKey]; !ok {
+				t.Errorf("response missing key %q; got %v", tc.wantKey, resp)
+			}
+		})
+	}
+}
+
+// ─── unknown event type ───────────────────────────────────────────────────────
+
+func TestToolEmitEvent_UnknownTypeRejected(t *testing.T) {
+	t.Parallel()
+	server, _ := makeServerWithSessions(t)
+	got := callEmitEvent(t, server, emitEventInput{Type: "banana.split"})
+	if !strings.Contains(got, "unknown event type") {
+		t.Errorf("expected 'unknown event type' in response; got %q", got)
+	}
+}
+
+func TestToolEmitEvent_EmptyTypeRejected(t *testing.T) {
+	t.Parallel()
+	server, _ := makeServerWithSessions(t)
+	got := callEmitEvent(t, server, emitEventInput{Type: ""})
+	if !strings.Contains(got, "event type is required") {
+		t.Errorf("expected 'event type is required' in response; got %q", got)
+	}
+}
+
+// ─── peer.utterance: valid ───────────────────────────────────────────────────
+
+func TestToolEmitEvent_PeerUtteranceValid(t *testing.T) {
+	t.Parallel()
+	server, registry := makeServerWithSessions(t)
+	registerTestSession(t, registry, "opus-cog-darkstar")
+	registerTestSession(t, registry, "gemma-cog-eclipse")
+
+	input := emitEventInput{
+		Type:        "peer.utterance",
+		FromSession: "opus-cog-darkstar",
+		Payload: map[string]any{
+			"from":    "opus-cog-darkstar",
+			"to":      "gemma-cog-eclipse",
+			"content": "What is the eigenform?",
+			"turn":    float64(1),
+		},
+	}
+	got := callEmitEvent(t, server, input)
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(got), &resp); err != nil {
+		t.Fatalf("expected JSON response; got %q", got)
+	}
+	if emitted, _ := resp["emitted"].(bool); !emitted {
+		t.Errorf("expected emitted=true; got %v", resp)
+	}
+	if resp["from_session"] != "opus-cog-darkstar" {
+		t.Errorf("from_session = %v; want opus-cog-darkstar", resp["from_session"])
+	}
+}
+
+// ─── peer.utterance: rejection cases ─────────────────────────────────────────
+
+func TestToolEmitEvent_PeerUtterance_MissingFromSession(t *testing.T) {
+	t.Parallel()
+	server, registry := makeServerWithSessions(t)
+	registerTestSession(t, registry, "opus-cog-darkstar")
+	registerTestSession(t, registry, "gemma-cog-eclipse")
+
+	input := emitEventInput{
+		Type: "peer.utterance",
+		// FromSession intentionally omitted
+		Payload: map[string]any{
+			"from":    "opus-cog-darkstar",
+			"to":      "gemma-cog-eclipse",
+			"content": "Hello",
+			"turn":    float64(1),
+		},
+	}
+	got := callEmitEvent(t, server, input)
+	if !strings.Contains(got, "requires from_session") {
+		t.Errorf("expected 'requires from_session' in response; got %q", got)
+	}
+}
+
+func TestToolEmitEvent_PeerUtterance_UnregisteredFrom(t *testing.T) {
+	t.Parallel()
+	server, registry := makeServerWithSessions(t)
+	// Register only the "to" session; "from" is not registered.
+	registerTestSession(t, registry, "gemma-cog-eclipse")
+
+	input := emitEventInput{
+		Type:        "peer.utterance",
+		FromSession: "opus-cog-darkstar", // not registered
+		Payload: map[string]any{
+			"from":    "opus-cog-darkstar",
+			"to":      "gemma-cog-eclipse",
+			"content": "Hello",
+			"turn":    float64(1),
+		},
+	}
+	got := callEmitEvent(t, server, input)
+	if !strings.Contains(got, "not a registered session") {
+		t.Errorf("expected 'not a registered session' in response; got %q", got)
+	}
+}
+
+func TestToolEmitEvent_PeerUtterance_UnregisteredTo(t *testing.T) {
+	t.Parallel()
+	server, registry := makeServerWithSessions(t)
+	registerTestSession(t, registry, "opus-cog-darkstar")
+	// "to" session not registered
+
+	input := emitEventInput{
+		Type:        "peer.utterance",
+		FromSession: "opus-cog-darkstar",
+		Payload: map[string]any{
+			"from":    "opus-cog-darkstar",
+			"to":      "gemma-cog-eclipse", // not registered
+			"content": "Hello",
+			"turn":    float64(1),
+		},
+	}
+	got := callEmitEvent(t, server, input)
+	if !strings.Contains(got, "not a registered session") {
+		t.Errorf("expected 'not a registered session' in response; got %q", got)
+	}
+}
+
+func TestToolEmitEvent_PeerUtterance_FromSessionMismatch(t *testing.T) {
+	t.Parallel()
+	server, registry := makeServerWithSessions(t)
+	registerTestSession(t, registry, "opus-cog-darkstar")
+	registerTestSession(t, registry, "gemma-cog-eclipse")
+	registerTestSession(t, registry, "haiku-cog-aux")
+
+	input := emitEventInput{
+		Type:        "peer.utterance",
+		FromSession: "haiku-cog-aux", // differs from payload.from
+		Payload: map[string]any{
+			"from":    "opus-cog-darkstar",
+			"to":      "gemma-cog-eclipse",
+			"content": "Hello",
+			"turn":    float64(1),
+		},
+	}
+	got := callEmitEvent(t, server, input)
+	if !strings.Contains(got, "must match payload.from") {
+		t.Errorf("expected 'must match payload.from' in response; got %q", got)
+	}
+}
+
+func TestToolEmitEvent_PeerUtterance_EmptyContent(t *testing.T) {
+	t.Parallel()
+	server, registry := makeServerWithSessions(t)
+	registerTestSession(t, registry, "opus-cog-darkstar")
+	registerTestSession(t, registry, "gemma-cog-eclipse")
+
+	input := emitEventInput{
+		Type:        "peer.utterance",
+		FromSession: "opus-cog-darkstar",
+		Payload: map[string]any{
+			"from":    "opus-cog-darkstar",
+			"to":      "gemma-cog-eclipse",
+			"content": "", // empty
+			"turn":    float64(1),
+		},
+	}
+	got := callEmitEvent(t, server, input)
+	if !strings.Contains(got, "non-empty 'content'") {
+		t.Errorf("expected content error; got %q", got)
+	}
+}
+
+func TestToolEmitEvent_PeerUtterance_MissingTurn(t *testing.T) {
+	t.Parallel()
+	server, registry := makeServerWithSessions(t)
+	registerTestSession(t, registry, "opus-cog-darkstar")
+	registerTestSession(t, registry, "gemma-cog-eclipse")
+
+	input := emitEventInput{
+		Type:        "peer.utterance",
+		FromSession: "opus-cog-darkstar",
+		Payload: map[string]any{
+			"from":    "opus-cog-darkstar",
+			"to":      "gemma-cog-eclipse",
+			"content": "Hello",
+			// turn missing
+		},
+	}
+	got := callEmitEvent(t, server, input)
+	if !strings.Contains(got, "turn") {
+		t.Errorf("expected turn error; got %q", got)
+	}
+}
+
+func TestToolEmitEvent_PeerUtterance_NonPositiveTurn(t *testing.T) {
+	t.Parallel()
+	server, registry := makeServerWithSessions(t)
+	registerTestSession(t, registry, "opus-cog-darkstar")
+	registerTestSession(t, registry, "gemma-cog-eclipse")
+
+	input := emitEventInput{
+		Type:        "peer.utterance",
+		FromSession: "opus-cog-darkstar",
+		Payload: map[string]any{
+			"from":    "opus-cog-darkstar",
+			"to":      "gemma-cog-eclipse",
+			"content": "Hello",
+			"turn":    float64(0), // invalid: must be >= 1
+		},
+	}
+	got := callEmitEvent(t, server, input)
+	if !strings.Contains(got, "positive integer") {
+		t.Errorf("expected positive integer error; got %q", got)
+	}
+}
+
+// ─── from_session: other event types ─────────────────────────────────────────
+
+func TestToolEmitEvent_FromSession_RecordedOnInsightCaptured(t *testing.T) {
+	t.Parallel()
+	server, registry := makeServerWithSessions(t)
+	registerTestSession(t, registry, "opus-cog-darkstar")
+
+	input := emitEventInput{
+		Type:        "insight.captured",
+		FromSession: "opus-cog-darkstar",
+		Payload:     map[string]any{"summary": "binding event is the smallest unit of maintenance"},
+	}
+	got := callEmitEvent(t, server, input)
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(got), &resp); err != nil {
+		t.Fatalf("expected JSON response; got %q", got)
+	}
+	if resp["from_session"] != "opus-cog-darkstar" {
+		t.Errorf("from_session = %v; want opus-cog-darkstar", resp["from_session"])
+	}
+	if emitted, _ := resp["emitted"].(bool); !emitted {
+		t.Errorf("emitted = %v; want true", resp["emitted"])
+	}
+}
+
+func TestToolEmitEvent_FromSession_UnregisteredSessionRejected(t *testing.T) {
+	t.Parallel()
+	server, _ := makeServerWithSessions(t)
+	// Registry is empty — no sessions registered.
+
+	input := emitEventInput{
+		Type:        "session.marker",
+		FromSession: "opus-cog-darkstar", // not registered
+		Payload:     map[string]any{"label": "checkpoint"},
+	}
+	got := callEmitEvent(t, server, input)
+	if !strings.Contains(got, "not a registered session") {
+		t.Errorf("expected 'not a registered session' in response; got %q", got)
+	}
+}
+
+func TestToolEmitEvent_FromSession_OmittedKeepsLegacyBehavior(t *testing.T) {
+	t.Parallel()
+	server, _ := makeServerWithSessions(t)
+
+	input := emitEventInput{
+		Type:    "session.marker",
+		Payload: map[string]any{"label": "checkpoint"},
+	}
+	got := callEmitEvent(t, server, input)
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(got), &resp); err != nil {
+		t.Fatalf("expected JSON response; got %q", got)
+	}
+	if emitted, _ := resp["emitted"].(bool); !emitted {
+		t.Errorf("emitted = %v; want true", resp["emitted"])
+	}
+	if _, has := resp["from_session"]; has {
+		t.Errorf("from_session should be absent when not provided; got %v", resp["from_session"])
+	}
+}

--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -228,8 +228,13 @@ func (m *MCPServer) registerTools() {
 	}), withToolObserver(m, "cog_assemble_context", m.toolAssembleContext))
 
 	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
-		Name:        "cog_emit_event",
-		Description: "Emit a typed event to the workspace ledger. Events: attention.boost (uri + weight), session.marker (label), insight.captured (summary), decision.made (decision + rationale). Fallback: events are JSONL in .cog/ledger/",
+		Name: "cog_emit_event",
+		Description: "Emit a typed event to the workspace ledger. " +
+			"Events: attention.boost (uri + weight), session.marker (label), " +
+			"insight.captured (summary), decision.made (decision + rationale), " +
+			"peer.utterance (from + to + content + turn; both sessions must be registered). " +
+			"Optional from_session: records the emitting session as event source; required for peer.utterance and must match payload.from. " +
+			"Fallback: events are JSONL in .cog/ledger/",
 	}), withToolObserver(m, "cog_emit_event", m.toolEmitEvent))
 
 	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
@@ -660,8 +665,9 @@ type memoryIndexResult struct {
 }
 
 type emitEventInput struct {
-	Type    string         `json:"type" jsonschema:"Event type: attention.boost, session.marker, insight.captured, decision.made"`
-	Payload map[string]any `json:"payload,omitempty" jsonschema:"Event payload. attention.boost: {uri, weight}. session.marker: {label}. insight.captured: {summary, tags}. decision.made: {decision, rationale}."`
+	Type        string         `json:"type" jsonschema:"Event type: attention.boost, session.marker, insight.captured, decision.made, peer.utterance"`
+	Payload     map[string]any `json:"payload,omitempty" jsonschema:"Event payload. attention.boost: {uri, weight}. session.marker: {label}. insight.captured: {summary, tags}. decision.made: {decision, rationale}. peer.utterance: {from, to, content, turn, in_reply_to (optional)}."`
+	FromSession string         `json:"from_session,omitempty" jsonschema:"Optional sender session_id. If provided, must be a registered session; recorded as event source. Required for peer.utterance events and must match payload.from."`
 }
 
 type readLedgerInput struct {
@@ -1338,12 +1344,72 @@ func WriteCogDoc(workspaceRoot string, path string, opts CogDocWriteOpts) (strin
 	return uri, nil
 }
 
+// allowedEventTypes is the closed set of event types accepted by toolEmitEvent.
+// Extend this list when new peer or substrate event types are ratified.
+var allowedEventTypes = map[string]bool{
+	"attention.boost":  true,
+	"session.marker":   true,
+	"insight.captured": true,
+	"decision.made":    true,
+	"peer.utterance":   true,
+}
+
 func (m *MCPServer) toolEmitEvent(ctx context.Context, req *mcp.CallToolRequest, input emitEventInput) (*mcp.CallToolResult, any, error) {
 	if input.Type == "" {
-		return textResult("event type is required. Valid types: attention.boost, session.marker, insight.captured, decision.made")
+		return textResult("event type is required. Valid types: attention.boost, session.marker, insight.captured, decision.made, peer.utterance")
+	}
+	if !allowedEventTypes[input.Type] {
+		return textResult(fmt.Sprintf("unknown event type %q. Valid types: attention.boost, session.marker, insight.captured, decision.made, peer.utterance", input.Type))
 	}
 	if m.process == nil {
 		return fallbackResult("process not initialized", "echo '{\"type\":\"...\"}' >> .cog/ledger/<session_id>/events.jsonl")
+	}
+
+	// Validate from_session if provided: must be a registered session.
+	if input.FromSession != "" {
+		if err := ValidateSessionID(input.FromSession); err != nil {
+			return textResult("from_session: " + err.Error())
+		}
+		if m.sessionRegistry != nil {
+			if _, ok := m.sessionRegistry.Get(input.FromSession); !ok {
+				return textResult(fmt.Sprintf("from_session %q is not a registered session", input.FromSession))
+			}
+		}
+	}
+
+	// Validate peer.utterance payload fields.
+	if input.Type == "peer.utterance" {
+		if input.FromSession == "" {
+			return textResult("peer.utterance requires from_session (must match payload.from)")
+		}
+		fromPayload, _ := input.Payload["from"].(string)
+		if fromPayload == "" {
+			return textResult("peer.utterance payload requires 'from' field")
+		}
+		if fromPayload != input.FromSession {
+			return textResult(fmt.Sprintf("peer.utterance: from_session %q must match payload.from %q", input.FromSession, fromPayload))
+		}
+		toPayload, _ := input.Payload["to"].(string)
+		if toPayload == "" {
+			return textResult("peer.utterance payload requires 'to' field")
+		}
+		if m.sessionRegistry != nil {
+			if _, ok := m.sessionRegistry.Get(toPayload); !ok {
+				return textResult(fmt.Sprintf("peer.utterance payload.to %q is not a registered session", toPayload))
+			}
+		}
+		contentPayload, _ := input.Payload["content"].(string)
+		if contentPayload == "" {
+			return textResult("peer.utterance payload requires non-empty 'content' field")
+		}
+		turnPayload, hasTurn := input.Payload["turn"]
+		if !hasTurn {
+			return textResult("peer.utterance payload requires 'turn' field (positive integer, 1-indexed)")
+		}
+		turnNum, ok := turnPayload.(float64) // JSON numbers unmarshal as float64.
+		if !ok || turnNum < 1 || turnNum != float64(int(turnNum)) {
+			return textResult("peer.utterance payload.turn must be a positive integer")
+		}
 	}
 
 	// Build the event data. Legacy shape exposed payload under a separate
@@ -1353,6 +1419,12 @@ func (m *MCPServer) toolEmitEvent(ctx context.Context, req *mcp.CallToolRequest,
 	data := map[string]any{}
 	if input.Payload != nil {
 		data["payload"] = input.Payload
+	}
+
+	// Record from_session as the attributed source in event data so
+	// downstream consumers see consistent sender attribution.
+	if input.FromSession != "" {
+		data["from_session"] = input.FromSession
 	}
 
 	// Handle attention.boost: resolve URI to field key, then boost. Side
@@ -1374,16 +1446,24 @@ func (m *MCPServer) toolEmitEvent(ctx context.Context, req *mcp.CallToolRequest,
 	// Route every emission through AppendEvent (hash chain + broker fan-out).
 	// Fixes the cogos#10 orphan-file bug: pre-refactor writes landed in a
 	// flat .cog/ledger/events.jsonl bypassing both the chain and the bus.
-	if err := m.process.EmitEvent(input.Type, data, "mcp-client"); err != nil {
+	source := "mcp-client"
+	if input.FromSession != "" {
+		source = "mcp-client:" + input.FromSession
+	}
+	if err := m.process.EmitEvent(input.Type, data, source); err != nil {
 		return fallbackResult(fmt.Sprintf("emit failed: %v", err),
 			"echo '{\"type\":\"...\"}' >> .cog/ledger/<session_id>/events.jsonl")
 	}
 
-	return marshalResult(map[string]any{
+	result := map[string]any{
 		"emitted":    true,
 		"type":       input.Type,
 		"session_id": m.process.SessionID(),
-	})
+	}
+	if input.FromSession != "" {
+		result["from_session"] = input.FromSession
+	}
+	return marshalResult(result)
 }
 
 func (m *MCPServer) toolReadLedger(ctx context.Context, req *mcp.CallToolRequest, input readLedgerInput) (*mcp.CallToolResult, any, error) {


### PR DESCRIPTION
## Summary

- **Change 1**: Adds `peer.utterance` as the fifth allowed event type on `cog_emit_event`. Payload shape: `{from, to, content, turn (positive int, 1-indexed), in_reply_to (optional)}`. Both `from` and `to` must be registered sessions. `from_session` is required for `peer.utterance` and must match `payload.from`. Content must be non-empty. Turn must be a positive integer.

- **Change 2**: Adds optional `from_session` parameter to `cog_emit_event` for all event types. When provided it must be a registered session; is recorded in event data under `from_session`; and is reflected in the `source` field as `"mcp-client:<session_id>"`. When omitted, behavior is backward-compatible (kernel-minted source, no attribution in response).

- Also extracts the event-type allowlist into an `allowedEventTypes` map so future additions are a single-line change rather than a string update in three places.

## Motivation

These gaps were surfaced during the first live cog-to-cog peer-conversation run (2026-05-16, opus-cog-darkstar ↔ gemma-cog-eclipse). The workaround was abusing `insight.captured` with tags. These changes make the bus vocabulary native to peer dispatch.

Relevant substrate memory:
- `~/.claude/projects/-Users-slowbro/memory/feedback_cog_to_cog_peer_conversation_pattern.md` — validated dispatch pattern and known tool gaps
- `~/.claude/projects/-Users-slowbro/memory/feedback_substrate_identity_as_maintenance_cluster.md` — the substantive outputs this pattern produces when the gaps are worked around

## Test plan

- [x] `TestToolEmitEvent_ExistingTypesAccepted`: all four prior event types still accepted (regression guard)
- [x] `TestToolEmitEvent_PeerUtteranceValid`: valid peer.utterance accepted with registered sessions
- [x] `TestToolEmitEvent_PeerUtterance_MissingFromSession`: rejected when from_session omitted
- [x] `TestToolEmitEvent_PeerUtterance_UnregisteredFrom`: rejected when from session not registered
- [x] `TestToolEmitEvent_PeerUtterance_UnregisteredTo`: rejected when to session not registered
- [x] `TestToolEmitEvent_PeerUtterance_FromSessionMismatch`: rejected when from_session ≠ payload.from
- [x] `TestToolEmitEvent_PeerUtterance_EmptyContent`: rejected on empty content
- [x] `TestToolEmitEvent_PeerUtterance_MissingTurn`: rejected when turn absent
- [x] `TestToolEmitEvent_PeerUtterance_NonPositiveTurn`: rejected on turn < 1
- [x] `TestToolEmitEvent_FromSession_RecordedOnInsightCaptured`: from_session recorded in response
- [x] `TestToolEmitEvent_FromSession_UnregisteredSessionRejected`: rejected on unregistered from_session
- [x] `TestToolEmitEvent_FromSession_OmittedKeepsLegacyBehavior`: absent from response when not provided
- [x] `TestToolEmitEvent_UnknownTypeRejected`: unknown type string rejected
- [x] `TestToolEmitEvent_EmptyTypeRejected`: empty type rejected
- [x] Full `./internal/engine/...` suite: passes (7.8s)

## Post-merge note

The kernel daemon needs a restart after merge for the updated `cog_emit_event` tool schema to be visible to MCP clients (`cogos serve` → restart).