### PR TITLE
chore(release): prepare v0.9.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 #   make e2e      - Run e2e test in a container
 #   make e2e-local - Run e2e test locally
 
-VERSION := 0.8.0
+VERSION := 0.9.0
 BUILD_TIME := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -s -w -X github.com/myrgic/cogos/internal/engine.BuildTime=$(BUILD_TIME)
 BUILD_TAGS := fts5


### PR DESCRIPTION
## Summary

- Bump `Makefile` `VERSION` `0.8.0` → `0.9.0`

Covers all changes since v0.8.0:
- ADR-091 + ADR-092: substrate as named architectural layer + substrate contracts (#264)
- Lineage observatory: ProjectionReconciler + ADR-094 (#265)
- Daemon reconcile loop driver + ADR-095 (#267)
- gen_ai.* OTel attribute aliasing layer + span kind constants (#268)
- gen_ai.* OTel span emission + conversation/turn/service hierarchy (#269)
- peer.utterance event type + from_session attribution to cog_emit_event (#270 — merged today)

## Test plan

- [x] CI green on this PR before merge
- [x] After squash-merge: tag `v0.9.0` on main, push tag
- [x] Verify `release.yml` fires and builds cross-compiled binaries