### PR TITLE
feat(cogblock): RFC-0003 R4 — CanonForm field and canonicalization algorithm versioning

### DIFF
--- a/docs/rfcs/0003-cogblock-topology-refinements.md
+++ b/docs/rfcs/0003-cogblock-topology-refinements.md
@@ -2,7 +2,7 @@
 
 | Field         | Value                                                          |
 |---------------|----------------------------------------------------------------|
-| Status        | Draft                                                          |
+| Status        | Partially Implemented (R4 merged; R1, R2, R3, R5 pending)    |
 | Author        | @chazmaniandinkle                                             |
 | Tracking      | [#204](https://github.com/myrgic/cogos/issues/204), [#205](https://github.com/myrgic/cogos/issues/205), [#206](https://github.com/myrgic/cogos/issues/206), [#207](https://github.com/myrgic/cogos/issues/207), [#208](https://github.com/myrgic/cogos/issues/208) |
 | Target        | `v0.6.0`                                                       |
@@ -144,6 +144,17 @@ Migration: existing blocks without CanonForm are read as `"rfc8785-v1"` (no hash
 - `CanonicalizeEvent` includes CanonForm in canonical input.
 - Existing blocks read as `"rfc8785-v1"` on unmarshal.
 - Migration plan sketched in documentation: how `"rfc8785-v2"` would be introduced and how blocks with different CanonForm values are handled at read time.
+
+### Implementation notes (2026-05-19)
+
+- `CanonFormRFC8785V1 = "rfc8785-v1"` constant added to `pkg/cogblock/block.go`.
+- `CanonForm string` added to both `CogBlock` and `EventPayload` (omitempty).
+- `NewEventEnvelope` defaults `CanonForm` to `CanonFormRFC8785V1`.
+- `CanonicalizeEvent` includes `canon_form` in the canonical map when non-empty.
+- Migration path: new events produced after this PR carry `"rfc8785-v1"`. Legacy
+  events (empty CanonForm) hash as before — the field is absent from their
+  canonical map. When `"rfc8785-v2"` is introduced, old and new events coexist
+  unambiguously; a verifier reads `CanonForm` to select the correct algorithm.
 
 ### References
 

--- a/pkg/cogblock/block.go
+++ b/pkg/cogblock/block.go
@@ -42,7 +42,25 @@ type CogBlock struct {
 
 	// Artifacts produced from processing this block.
 	Artifacts []BlockArtifact `json:"artifacts,omitempty"`
+
+	// CanonForm identifies the canonicalization algorithm used to hash this block.
+	// RFC-0003 Refinement 4 — canonicalization algorithm versioning.
+	//
+	// New blocks default to "rfc8785-v1". Existing blocks without CanonForm are
+	// treated as "rfc8785-v1" at read time (no hash change; the algorithm has not
+	// changed). A future "rfc8785-v2" would be declared here when a
+	// canonicalization edge case is fixed; blocks with different CanonForm values
+	// coexist in the ledger and are hashed independently under their declared
+	// algorithm. See docs/rfcs/0003-cogblock-topology-refinements.md §Refinement 4.
+	CanonForm string `json:"canon_form,omitempty"`
 }
+
+// CanonFormRFC8785V1 is the default canonicalization algorithm for CogBlock.
+// It corresponds to RFC 8785 (JSON Canonicalization Scheme) with the
+// initial implementation in pkg/cogblock/ledger.go. Declared as a named
+// constant so callers can reference it without embedding a string literal.
+// RFC-0003 Refinement 4.
+const CanonFormRFC8785V1 = "rfc8785-v1"
 
 // CogBlockKind identifies the type of interaction a CogBlock represents.
 type CogBlockKind string

--- a/pkg/cogblock/ledger.go
+++ b/pkg/cogblock/ledger.go
@@ -44,6 +44,20 @@ type EventPayload struct {
 
 	// Data contains type-specific payload (optional).
 	Data map[string]interface{} `json:"data,omitempty"`
+
+	// CanonForm identifies the canonicalization algorithm used to produce the
+	// canonical bytes that are hashed for this event. RFC-0003 Refinement 4.
+	//
+	// New events default to CanonFormRFC8785V1 ("rfc8785-v1"). Existing events
+	// without this field are treated as "rfc8785-v1" at read time — CanonForm
+	// is omitempty so the wire format is unchanged for legacy events.
+	//
+	// When a future "rfc8785-v2" is introduced (e.g., to fix a Unicode
+	// normalization edge case), events emitted under the new algorithm declare
+	// "rfc8785-v2" here; old and new events coexist in the same ledger without
+	// ambiguity. The CanonForm value is itself included in the canonical bytes,
+	// so the declared algorithm is part of the hash commitment.
+	CanonForm string `json:"canon_form,omitempty"`
 }
 
 // EventMetadata contains information NOT included in the hash.
@@ -68,6 +82,13 @@ type EventMetadata struct {
 //   - No insignificant whitespace
 //   - Unicode normalized (NFC)
 //   - Numbers in canonical form (no leading zeros, etc.)
+//
+// RFC-0003 Refinement 4: if payload.CanonForm is set (non-empty), it is
+// included in the canonical map under the key "canon_form". This commits the
+// declared canonicalization algorithm into the hash, making the hash dependent
+// on which algorithm was used. For new events this is always "rfc8785-v1".
+// Legacy events without CanonForm omit the field from the map (backward
+// compatible — their hashes are unchanged).
 func CanonicalizeEvent(payload *EventPayload) ([]byte, error) {
 	// Convert to map for canonical JSON encoding
 	data := map[string]interface{}{
@@ -82,6 +103,12 @@ func CanonicalizeEvent(payload *EventPayload) ([]byte, error) {
 	}
 	if len(payload.Data) > 0 {
 		data["data"] = payload.Data
+	}
+
+	// RFC-0003 R4: include canon_form in hash when declared. Absent on legacy
+	// events (omitempty) — their canonical bytes and hashes are unchanged.
+	if payload.CanonForm != "" {
+		data["canon_form"] = payload.CanonForm
 	}
 
 	return canonicalJSON(data)
@@ -383,6 +410,9 @@ func VerifyLedger(workspaceRoot, sessionID string) error {
 // === CONVENIENCE CONSTRUCTORS ===
 
 // NewEventEnvelope creates a new event envelope with current timestamp.
+// The CanonForm field defaults to CanonFormRFC8785V1 ("rfc8785-v1") per
+// RFC-0003 Refinement 4 — all new events declare their canonicalization
+// algorithm so future algorithm migrations are unambiguous.
 func NewEventEnvelope(eventType, sessionID string) *EventEnvelope {
 	return &EventEnvelope{
 		HashedPayload: EventPayload{
@@ -390,6 +420,7 @@ func NewEventEnvelope(eventType, sessionID string) *EventEnvelope {
 			Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
 			SessionID: sessionID,
 			Data:      make(map[string]interface{}),
+			CanonForm: CanonFormRFC8785V1,
 		},
 		Metadata: EventMetadata{},
 	}

--- a/pkg/cogblock/ledger_test.go
+++ b/pkg/cogblock/ledger_test.go
@@ -336,3 +336,245 @@ func splitNonEmpty(s string) []string {
 	}
 	return lines
 }
+
+// === RFC-0003 REFINEMENT 4: CANON FORM TESTS ===
+
+// TestCanonicalizeEvent_CanonForm_IncludedInHash verifies that when CanonForm is
+// set, it appears in the canonical bytes and therefore changes the hash.
+func TestCanonicalizeEvent_CanonForm_IncludedInHash(t *testing.T) {
+	base := &EventPayload{
+		Type:      "test.event",
+		SessionID: "session-r4",
+		Timestamp: "2026-05-19T10:00:00Z",
+	}
+
+	withCanonForm := &EventPayload{
+		Type:      "test.event",
+		SessionID: "session-r4",
+		Timestamp: "2026-05-19T10:00:00Z",
+		CanonForm: CanonFormRFC8785V1,
+	}
+
+	bytesBase, err := CanonicalizeEvent(base)
+	if err != nil {
+		t.Fatalf("CanonicalizeEvent(base): %v", err)
+	}
+
+	bytesWithCanon, err := CanonicalizeEvent(withCanonForm)
+	if err != nil {
+		t.Fatalf("CanonicalizeEvent(withCanonForm): %v", err)
+	}
+
+	// The canonical bytes must differ because canon_form is included.
+	if string(bytesBase) == string(bytesWithCanon) {
+		t.Errorf("Expected canonical bytes to differ when CanonForm is set, but they are identical:\n%s", bytesBase)
+	}
+
+	// The canon_form key must appear in the output.
+	if !strings.Contains(string(bytesWithCanon), `"canon_form"`) {
+		t.Errorf("canon_form not found in canonical bytes: %s", bytesWithCanon)
+	}
+	if !strings.Contains(string(bytesWithCanon), CanonFormRFC8785V1) {
+		t.Errorf("canon_form value %q not found in canonical bytes: %s", CanonFormRFC8785V1, bytesWithCanon)
+	}
+}
+
+// TestCanonicalizeEvent_CanonForm_AbsentOnLegacy verifies that EventPayload with
+// empty CanonForm produces canonical bytes without the canon_form key — the
+// backward-compatibility guarantee for pre-R4 ledger events.
+func TestCanonicalizeEvent_CanonForm_AbsentOnLegacy(t *testing.T) {
+	legacy := &EventPayload{
+		Type:      "test.event",
+		SessionID: "session-legacy",
+		Timestamp: "2026-05-19T10:00:00Z",
+	}
+
+	bytes, err := CanonicalizeEvent(legacy)
+	if err != nil {
+		t.Fatalf("CanonicalizeEvent: %v", err)
+	}
+
+	if strings.Contains(string(bytes), "canon_form") {
+		t.Errorf("canon_form must not appear in canonical bytes for legacy event (empty CanonForm): %s", bytes)
+	}
+}
+
+// TestCanonicalizeEvent_CanonForm_ExactBytes verifies the exact canonical form
+// of a new event with CanonForm set. This pins the expected output so that any
+// future canonicalization change is immediately visible.
+func TestCanonicalizeEvent_CanonForm_ExactBytes(t *testing.T) {
+	event := &EventPayload{
+		Type:      "test.event",
+		SessionID: "session-r4",
+		Timestamp: "2026-05-19T10:00:00Z",
+		CanonForm: CanonFormRFC8785V1,
+	}
+
+	bytes, err := CanonicalizeEvent(event)
+	if err != nil {
+		t.Fatalf("CanonicalizeEvent: %v", err)
+	}
+
+	// Keys must be lexicographically sorted: canon_form < session_id < timestamp < type
+	expected := `{"canon_form":"rfc8785-v1","session_id":"session-r4","timestamp":"2026-05-19T10:00:00Z","type":"test.event"}`
+	if string(bytes) != expected {
+		t.Errorf("Unexpected canonical form:\nGot:  %s\nWant: %s", bytes, expected)
+	}
+}
+
+// TestNewEventEnvelope_DefaultsCanonForm verifies that NewEventEnvelope sets
+// CanonForm to CanonFormRFC8785V1 on all new events.
+func TestNewEventEnvelope_DefaultsCanonForm(t *testing.T) {
+	env := NewEventEnvelope("test.event", "session-42")
+
+	if env.HashedPayload.CanonForm != CanonFormRFC8785V1 {
+		t.Errorf("CanonForm = %q; want %q", env.HashedPayload.CanonForm, CanonFormRFC8785V1)
+	}
+}
+
+// TestCanonForm_NewEventHashesDifferFromLegacy verifies that a new event
+// (CanonForm set) produces a different hash from a logically equivalent legacy
+// event (CanonForm empty). This is intentional — the declared algorithm is part
+// of the hash commitment.
+func TestCanonForm_NewEventHashesDifferFromLegacy(t *testing.T) {
+	newEvent := &EventPayload{
+		Type:      "test.event",
+		SessionID: "session-test",
+		Timestamp: "2026-05-19T10:00:00Z",
+		CanonForm: CanonFormRFC8785V1,
+	}
+
+	legacyEvent := &EventPayload{
+		Type:      "test.event",
+		SessionID: "session-test",
+		Timestamp: "2026-05-19T10:00:00Z",
+		// CanonForm intentionally empty — simulates a pre-R4 ledger event.
+	}
+
+	newBytes, err := CanonicalizeEvent(newEvent)
+	if err != nil {
+		t.Fatalf("CanonicalizeEvent(new): %v", err)
+	}
+
+	legacyBytes, err := CanonicalizeEvent(legacyEvent)
+	if err != nil {
+		t.Fatalf("CanonicalizeEvent(legacy): %v", err)
+	}
+
+	newHash, _ := HashEvent(newBytes, "sha256")
+	legacyHash, _ := HashEvent(legacyBytes, "sha256")
+
+	if newHash == legacyHash {
+		t.Errorf("Expected new-event hash to differ from legacy-event hash (CanonForm is part of commitment)")
+	}
+}
+
+// TestAppendEvent_CanonFormPersistedAndVerifiable verifies that a full
+// ledger round-trip with the new default CanonForm passes VerifyLedger.
+func TestAppendEvent_CanonFormPersistedAndVerifiable(t *testing.T) {
+	tmpDir := t.TempDir()
+	sessionID := "test-session-r4"
+
+	// Genesis event sets hash algorithm.
+	genesis := NewEventEnvelope("workspace.genesis", sessionID)
+	genesis.WithData("hash_algorithm", "sha256")
+	if err := AppendEvent(tmpDir, sessionID, genesis); err != nil {
+		t.Fatalf("AppendEvent genesis: %v", err)
+	}
+
+	// Subsequent events with CanonForm set by default.
+	for i := 1; i <= 3; i++ {
+		event := NewEventEnvelope("test.event", sessionID)
+		event.WithData("index", i)
+		if err := AppendEvent(tmpDir, sessionID, event); err != nil {
+			t.Fatalf("AppendEvent %d: %v", i, err)
+		}
+	}
+
+	// All events must have CanonForm in their payload.
+	eventsFile := filepath.Join(tmpDir, ".cog", "ledger", sessionID, "events.jsonl")
+	data, err := os.ReadFile(eventsFile)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	lines := splitNonEmpty(string(data))
+	for i, line := range lines {
+		var env EventEnvelope
+		if err := json.Unmarshal([]byte(line), &env); err != nil {
+			t.Fatalf("Unmarshal line %d: %v", i, err)
+		}
+		if env.HashedPayload.CanonForm != CanonFormRFC8785V1 {
+			t.Errorf("line %d: CanonForm = %q; want %q", i, env.HashedPayload.CanonForm, CanonFormRFC8785V1)
+		}
+	}
+
+	// VerifyLedger must pass — hash chain must be intact with CanonForm included.
+	if err := VerifyLedger(tmpDir, sessionID); err != nil {
+		t.Errorf("VerifyLedger: %v", err)
+	}
+}
+
+// TestCogBlock_CanonFormRoundTrip verifies that CanonForm survives JSON
+// marshal/unmarshal on CogBlock and that omitempty works correctly.
+func TestCogBlock_CanonFormRoundTrip(t *testing.T) {
+	t.Run("with CanonForm", func(t *testing.T) {
+		b := CogBlock{
+			ID:        "block-r4",
+			Kind:      BlockMessage,
+			CanonForm: CanonFormRFC8785V1,
+		}
+
+		data, err := json.Marshal(b)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+
+		if !strings.Contains(string(data), `"canon_form"`) {
+			t.Errorf("canon_form missing from JSON: %s", data)
+		}
+
+		var decoded CogBlock
+		if err := json.Unmarshal(data, &decoded); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+
+		if decoded.CanonForm != CanonFormRFC8785V1 {
+			t.Errorf("CanonForm = %q; want %q", decoded.CanonForm, CanonFormRFC8785V1)
+		}
+	})
+
+	t.Run("without CanonForm (omitempty)", func(t *testing.T) {
+		b := CogBlock{
+			ID:   "block-legacy",
+			Kind: BlockMessage,
+			// CanonForm intentionally omitted
+		}
+
+		data, err := json.Marshal(b)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+
+		if strings.Contains(string(data), "canon_form") {
+			t.Errorf("canon_form should be omitted when empty: %s", data)
+		}
+
+		var decoded CogBlock
+		if err := json.Unmarshal(data, &decoded); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+
+		if decoded.CanonForm != "" {
+			t.Errorf("CanonForm = %q; want empty string for legacy block", decoded.CanonForm)
+		}
+	})
+}
+
+// TestCanonFormRFC8785V1_ConstantValue pins the constant value so any
+// accidental rename or edit fails loudly.
+func TestCanonFormRFC8785V1_ConstantValue(t *testing.T) {
+	if CanonFormRFC8785V1 != "rfc8785-v1" {
+		t.Errorf("CanonFormRFC8785V1 = %q; want %q", CanonFormRFC8785V1, "rfc8785-v1")
+	}
+}


### PR DESCRIPTION
## Summary

Implements RFC-0003 Refinement 4 (issue #207): **CanonForm field for canonicalization algorithm versioning**.

This is the prerequisite for R3 (separate content hash from envelope hash). R3's hash-computation path — `Hash = SHA256(envelope_fields_excluding_payload + Digest)` — needs CanonForm already in place so the algorithm anchor is declared before the hash logic changes.

### What changed

**`pkg/cogblock/block.go`**
- Added `CanonFormRFC8785V1 = "rfc8785-v1"` constant.
- Added `CanonForm string` field to `CogBlock` (omitempty; empty on legacy blocks).

**`pkg/cogblock/ledger.go`**
- Added `CanonForm string` field to `EventPayload` (omitempty; same backward-compat semantics).
- `CanonicalizeEvent`: includes `canon_form` in the canonical map when non-empty. Empty CanonForm → field absent from map → legacy hashes unchanged.
- `NewEventEnvelope`: defaults `CanonForm` to `CanonFormRFC8785V1`. All new events produced after this PR declare their algorithm.

**`docs/rfcs/0003-cogblock-topology-refinements.md`**
- Status updated to "Partially Implemented (R4 merged; R1, R2, R3, R5 pending)".
- Implementation notes added to §Refinement 4.

### Test coverage added (8 new tests)

- `TestCanonicalizeEvent_CanonForm_IncludedInHash` — CanonForm present → appears in canonical bytes, changes hash.
- `TestCanonicalizeEvent_CanonForm_AbsentOnLegacy` — empty CanonForm → field absent from canonical bytes (backward compat).
- `TestCanonicalizeEvent_CanonForm_ExactBytes` — pins exact canonical output for rfc8785-v1 events.
- `TestNewEventEnvelope_DefaultsCanonForm` — constructor defaults to CanonFormRFC8785V1.
- `TestCanonForm_NewEventHashesDifferFromLegacy` — new-event hash != equivalent legacy-event hash (intentional; algo committed into hash).
- `TestAppendEvent_CanonFormPersistedAndVerifiable` — full ledger round-trip passes VerifyLedger with CanonForm set.
- `TestCogBlock_CanonFormRoundTrip` — JSON marshal/unmarshal with and without omitempty.
- `TestCanonFormRFC8785V1_ConstantValue` — pins constant string value.

All 29 `pkg/cogblock` tests pass. Full repo build and test suite clean.

### Migration contract

New events (after this PR): `canon_form: "rfc8785-v1"` in `EventPayload`. Hash includes the declared algorithm.

Legacy events (before this PR): `CanonForm` empty, absent from canonical map → hashes unchanged. Backward compatible at both read and verify time.

Future `"rfc8785-v2"`: set `CanonForm = "rfc8785-v2"` on new events. Old and new events coexist in the same ledger. A verifier reads `CanonForm` to select the correct canonicalization path. No migration tooling needed (each refinement is backward-compatible at read time per RFC-0003 §Non-goals).

### R3 follow-on path

R3 (issue #206) — separate content hash from envelope hash — is now unblocked by this PR. Its hash-computation change:

```
When Digest is set:
  Hash = SHA256(canonical(envelope_fields_excluding_payload + Digest))
Rather than:
  Hash = SHA256(canonical(envelope_with_inline_payload))
```

R3 requires:
1. Add `Digest string` field to `CogBlock` and `EventPayload` (ADR-084 described this field; it was not yet added to the structs).
2. Refactor `CanonicalizeEvent` to have a Digest-present path and a Digest-absent path (inline payload path unchanged).
3. Tests: two blocks with same Digest but different From/Timestamp/SessionID → distinct envelope hashes, shared Digest enables dedup.
4. ADR-059 and ADR-084 doc amendments.

R3 depends on R4 having landed (this PR) because the hash computation change in R3 needs the versioning anchor to be in place so the two paths are unambiguous under different CanonForm values.

Refs: `docs/rfcs/0003-cogblock-topology-refinements.md`, issue #207.