### PR TITLE
feat(substrate): scaffold pkg/substrate + reconcile re-export (ADR-100 Step 1+2a)

### DIFF
--- a/go.work
+++ b/go.work
@@ -10,6 +10,7 @@ use (
 	./pkg/coordination
 	./pkg/modality
 	./pkg/reconcile
+	./pkg/substrate
 	./pkg/uri
 	./sdk
 )

--- a/pkg/substrate/README.md
+++ b/pkg/substrate/README.md
@@ -1,0 +1,27 @@
+# pkg/substrate
+
+Substrate library extraction target per [ADR-100](../../docs/adrs/100-substrate-library-extraction.md).
+
+## Layout
+
+Each module from the CogOS kernel is re-exported under a subdirectory:
+
+```
+pkg/substrate/
+  go.mod                  # module github.com/myrgic/cogos/pkg/substrate
+  reconcile/              # re-exports pkg/reconcile
+  ...                     # further modules added in Steps 2b–5
+```
+
+## Design
+
+- **Subtree path** (`github.com/myrgic/cogos/pkg/substrate`): intentional. Option 1
+  from the ADR-100 decision packet. Enables incremental extraction without a repo split.
+- **Re-exports use Go type aliases** (`type Foo = reconcile.Foo`) so consumers can use
+  either import path without conversion. The types are identical at the language level.
+- **Naming**: "substrate" only. No conversation-formed names.
+
+## Status
+
+Step 1 (scaffold) and Step 2a (reconcile re-export) are complete. Steps 2b–5 follow
+in separate PRs per the ADR-100 extraction sequence.

--- a/pkg/substrate/go.mod
+++ b/pkg/substrate/go.mod
@@ -1,0 +1,7 @@
+module github.com/myrgic/cogos/pkg/substrate
+
+go 1.24
+
+require github.com/myrgic/cogos/pkg/reconcile v0.0.0
+
+replace github.com/myrgic/cogos/pkg/reconcile => ../reconcile

--- a/pkg/substrate/reconcile/reconcile.go
+++ b/pkg/substrate/reconcile/reconcile.go
@@ -1,0 +1,178 @@
+// Package reconcile re-exports the public surface of pkg/reconcile as
+// pkg/substrate/reconcile, per ADR-100 Step 2a.
+//
+// All symbols here are Go type aliases or variable/function aliases of their
+// counterparts in github.com/myrgic/cogos/pkg/reconcile. Consumers of either
+// import path get identical types at the language level — no conversion needed.
+//
+// This package adds no logic. It is a pure re-export layer so downstream code
+// can migrate incrementally to the substrate import path without changing
+// call sites or type assertions.
+package reconcile
+
+import reconcile "github.com/myrgic/cogos/pkg/reconcile"
+
+// --- Status enums ---
+
+type SyncStatus = reconcile.SyncStatus
+
+const (
+	SyncStatusSynced    = reconcile.SyncStatusSynced
+	SyncStatusOutOfSync = reconcile.SyncStatusOutOfSync
+	SyncStatusUnknown   = reconcile.SyncStatusUnknown
+)
+
+type HealthStatus = reconcile.HealthStatus
+
+const (
+	HealthHealthy     = reconcile.HealthHealthy
+	HealthDegraded    = reconcile.HealthDegraded
+	HealthProgressing = reconcile.HealthProgressing
+	HealthMissing     = reconcile.HealthMissing
+	HealthSuspended   = reconcile.HealthSuspended
+)
+
+type OperationPhase = reconcile.OperationPhase
+
+const (
+	OperationIdle    = reconcile.OperationIdle
+	OperationSyncing = reconcile.OperationSyncing
+	OperationWaiting = reconcile.OperationWaiting
+)
+
+// --- Composite status type ---
+
+type ResourceStatus = reconcile.ResourceStatus
+
+// --- Action / Resource enums ---
+
+type ActionType = reconcile.ActionType
+
+const (
+	ActionCreate = reconcile.ActionCreate
+	ActionUpdate = reconcile.ActionUpdate
+	ActionDelete = reconcile.ActionDelete
+	ActionSkip   = reconcile.ActionSkip
+)
+
+type ResourceMode = reconcile.ResourceMode
+
+const (
+	ModeManaged   = reconcile.ModeManaged
+	ModeUnmanaged = reconcile.ModeUnmanaged
+	ModeData      = reconcile.ModeData
+)
+
+type ApplyStatus = reconcile.ApplyStatus
+
+const (
+	ApplySucceeded = reconcile.ApplySucceeded
+	ApplyFailed    = reconcile.ApplyFailed
+	ApplySkipped   = reconcile.ApplySkipped
+)
+
+// --- Plan / Action / Summary / Result ---
+
+type Plan    = reconcile.Plan
+type Action  = reconcile.Action
+type Summary = reconcile.Summary
+type Result  = reconcile.Result
+
+// --- State / Resource ---
+
+type State    = reconcile.State
+type Resource = reconcile.Resource
+
+// --- Provider interfaces ---
+
+type Reconcilable   = reconcile.Reconcilable
+type Tokenable      = reconcile.Tokenable
+type ConfigExporter = reconcile.ConfigExporter
+
+// --- types.go helpers ---
+
+var NewResourceStatus     = reconcile.NewResourceStatus
+var ResourceIndex         = reconcile.ResourceIndex
+var ResourceByExternalID  = reconcile.ResourceByExternalID
+
+// --- state.go ---
+
+var StatePath        = reconcile.StatePath
+var LoadState        = reconcile.LoadState
+var WriteState       = reconcile.WriteState
+var NewState         = reconcile.NewState
+var GenerateLineage  = reconcile.GenerateLineage
+
+// --- registry.go ---
+
+var RegisterProvider = reconcile.RegisterProvider
+var GetProvider      = reconcile.GetProvider
+var ListProviders    = reconcile.ListProviders
+var HasProvider      = reconcile.HasProvider
+var UpsertProvider   = reconcile.UpsertProvider
+var ResetProviders   = reconcile.ResetProviders
+
+// --- events.go constants ---
+
+const (
+	EventPlanStart    = reconcile.EventPlanStart
+	EventPlanComplete = reconcile.EventPlanComplete
+	EventApplyStart   = reconcile.EventApplyStart
+	EventApplyAction  = reconcile.EventApplyAction
+	EventApplyComplete = reconcile.EventApplyComplete
+	EventDrift        = reconcile.EventDrift
+	EventError        = reconcile.EventError
+)
+
+// --- events.go types / functions ---
+
+type Event = reconcile.Event
+
+var EmitEvent          = reconcile.EmitEvent
+var EmitPlanStart      = reconcile.EmitPlanStart
+var EmitPlanComplete   = reconcile.EmitPlanComplete
+var EmitApplyStart     = reconcile.EmitApplyStart
+var EmitApplyAction    = reconcile.EmitApplyAction
+var EmitApplyComplete  = reconcile.EmitApplyComplete
+var EmitDriftDetected  = reconcile.EmitDriftDetected
+var EmitError          = reconcile.EmitError
+
+// --- meta.go types ---
+
+type MetaResource = reconcile.MetaResource
+type MetaConfig   = reconcile.MetaConfig
+type MetaResult   = reconcile.MetaResult
+type MetaOpts     = reconcile.MetaOpts
+
+// --- meta.go functions ---
+
+var ResolveOrder          = reconcile.ResolveOrder
+var AutoDiscoverResources = reconcile.AutoDiscoverResources
+var RunMeta               = reconcile.RunMeta
+var ConfigureProvider     = reconcile.ConfigureProvider
+var ResolveToken          = reconcile.ResolveToken
+
+// --- cogdoc_review_types.go types ---
+
+type CogdocReviewClass       = reconcile.CogdocReviewClass
+type CogdocProposal          = reconcile.CogdocProposal
+type SimilarityCandidate     = reconcile.SimilarityCandidate
+type AcknowledgmentDecision  = reconcile.AcknowledgmentDecision
+type CandidateAcknowledgment = reconcile.CandidateAcknowledgment
+type ReviewActionTaken       = reconcile.ReviewActionTaken
+type ProvenanceRecord        = reconcile.ProvenanceRecord
+type ReviewTRMTuple          = reconcile.ReviewTRMTuple
+
+// --- cogdoc_review_types.go constants ---
+
+const (
+	AckReadDistinct    = reconcile.AckReadDistinct
+	AckAmendInstead    = reconcile.AckAmendInstead
+	ReviewActionAuthored  = reconcile.ReviewActionAuthored
+	ReviewActionAmended   = reconcile.ReviewActionAmended
+	ReviewActionAbandoned = reconcile.ReviewActionAbandoned
+)
+
+// --- cogdoc_review_types.go functions ---
+
+var DefaultCogdocReviewClass = reconcile.DefaultCogdocReviewClass

--- a/pkg/substrate/reconcile/reconcile_test.go
+++ b/pkg/substrate/reconcile/reconcile_test.go
@@ -1,0 +1,258 @@
+package reconcile_test
+
+import (
+	"reflect"
+	"testing"
+
+	origin "github.com/myrgic/cogos/pkg/reconcile"
+	substrate "github.com/myrgic/cogos/pkg/substrate/reconcile"
+)
+
+// TestTypeIdentity verifies that type aliases in the substrate re-export layer
+// are identical to their origin types via reflect.TypeOf. Because Go type
+// aliases share the same runtime type, these must always be equal.
+func TestTypeIdentity(t *testing.T) {
+	cases := []struct {
+		name    string
+		origin  reflect.Type
+		reexport reflect.Type
+	}{
+		{"SyncStatus", reflect.TypeOf(origin.SyncStatus("")), reflect.TypeOf(substrate.SyncStatus(""))},
+		{"HealthStatus", reflect.TypeOf(origin.HealthStatus("")), reflect.TypeOf(substrate.HealthStatus(""))},
+		{"OperationPhase", reflect.TypeOf(origin.OperationPhase("")), reflect.TypeOf(substrate.OperationPhase(""))},
+		{"ActionType", reflect.TypeOf(origin.ActionType("")), reflect.TypeOf(substrate.ActionType(""))},
+		{"ResourceMode", reflect.TypeOf(origin.ResourceMode("")), reflect.TypeOf(substrate.ResourceMode(""))},
+		{"ApplyStatus", reflect.TypeOf(origin.ApplyStatus("")), reflect.TypeOf(substrate.ApplyStatus(""))},
+		{"AcknowledgmentDecision", reflect.TypeOf(origin.AcknowledgmentDecision("")), reflect.TypeOf(substrate.AcknowledgmentDecision(""))},
+		{"ReviewActionTaken", reflect.TypeOf(origin.ReviewActionTaken("")), reflect.TypeOf(substrate.ReviewActionTaken(""))},
+		{"ResourceStatus", reflect.TypeOf(origin.ResourceStatus{}), reflect.TypeOf(substrate.ResourceStatus{})},
+		{"Plan", reflect.TypeOf(origin.Plan{}), reflect.TypeOf(substrate.Plan{})},
+		{"Action", reflect.TypeOf(origin.Action{}), reflect.TypeOf(substrate.Action{})},
+		{"Summary", reflect.TypeOf(origin.Summary{}), reflect.TypeOf(substrate.Summary{})},
+		{"Result", reflect.TypeOf(origin.Result{}), reflect.TypeOf(substrate.Result{})},
+		{"State", reflect.TypeOf(origin.State{}), reflect.TypeOf(substrate.State{})},
+		{"Resource", reflect.TypeOf(origin.Resource{}), reflect.TypeOf(substrate.Resource{})},
+		{"Event", reflect.TypeOf(origin.Event{}), reflect.TypeOf(substrate.Event{})},
+		{"MetaResource", reflect.TypeOf(origin.MetaResource{}), reflect.TypeOf(substrate.MetaResource{})},
+		{"MetaConfig", reflect.TypeOf(origin.MetaConfig{}), reflect.TypeOf(substrate.MetaConfig{})},
+		{"MetaResult", reflect.TypeOf(origin.MetaResult{}), reflect.TypeOf(substrate.MetaResult{})},
+		{"MetaOpts", reflect.TypeOf(origin.MetaOpts{}), reflect.TypeOf(substrate.MetaOpts{})},
+		{"CogdocReviewClass", reflect.TypeOf(origin.CogdocReviewClass{}), reflect.TypeOf(substrate.CogdocReviewClass{})},
+		{"CogdocProposal", reflect.TypeOf(origin.CogdocProposal{}), reflect.TypeOf(substrate.CogdocProposal{})},
+		{"SimilarityCandidate", reflect.TypeOf(origin.SimilarityCandidate{}), reflect.TypeOf(substrate.SimilarityCandidate{})},
+		{"CandidateAcknowledgment", reflect.TypeOf(origin.CandidateAcknowledgment{}), reflect.TypeOf(substrate.CandidateAcknowledgment{})},
+		{"ProvenanceRecord", reflect.TypeOf(origin.ProvenanceRecord{}), reflect.TypeOf(substrate.ProvenanceRecord{})},
+		{"ReviewTRMTuple", reflect.TypeOf(origin.ReviewTRMTuple{}), reflect.TypeOf(substrate.ReviewTRMTuple{})},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.origin != tc.reexport {
+				t.Errorf("%s: origin type %v != substrate type %v (alias is broken)", tc.name, tc.origin, tc.reexport)
+			}
+		})
+	}
+}
+
+// TestConstantIdentity verifies that re-exported constants have the same value
+// as their origin counterparts.
+func TestConstantIdentity(t *testing.T) {
+	// SyncStatus constants
+	if origin.SyncStatusSynced != substrate.SyncStatusSynced {
+		t.Errorf("SyncStatusSynced mismatch")
+	}
+	if origin.SyncStatusOutOfSync != substrate.SyncStatusOutOfSync {
+		t.Errorf("SyncStatusOutOfSync mismatch")
+	}
+	if origin.SyncStatusUnknown != substrate.SyncStatusUnknown {
+		t.Errorf("SyncStatusUnknown mismatch")
+	}
+
+	// HealthStatus constants
+	if origin.HealthHealthy != substrate.HealthHealthy {
+		t.Errorf("HealthHealthy mismatch")
+	}
+	if origin.HealthDegraded != substrate.HealthDegraded {
+		t.Errorf("HealthDegraded mismatch")
+	}
+	if origin.HealthProgressing != substrate.HealthProgressing {
+		t.Errorf("HealthProgressing mismatch")
+	}
+	if origin.HealthMissing != substrate.HealthMissing {
+		t.Errorf("HealthMissing mismatch")
+	}
+	if origin.HealthSuspended != substrate.HealthSuspended {
+		t.Errorf("HealthSuspended mismatch")
+	}
+
+	// OperationPhase constants
+	if origin.OperationIdle != substrate.OperationIdle {
+		t.Errorf("OperationIdle mismatch")
+	}
+	if origin.OperationSyncing != substrate.OperationSyncing {
+		t.Errorf("OperationSyncing mismatch")
+	}
+	if origin.OperationWaiting != substrate.OperationWaiting {
+		t.Errorf("OperationWaiting mismatch")
+	}
+
+	// ActionType constants
+	if origin.ActionCreate != substrate.ActionCreate {
+		t.Errorf("ActionCreate mismatch")
+	}
+	if origin.ActionUpdate != substrate.ActionUpdate {
+		t.Errorf("ActionUpdate mismatch")
+	}
+	if origin.ActionDelete != substrate.ActionDelete {
+		t.Errorf("ActionDelete mismatch")
+	}
+	if origin.ActionSkip != substrate.ActionSkip {
+		t.Errorf("ActionSkip mismatch")
+	}
+
+	// ResourceMode constants
+	if origin.ModeManaged != substrate.ModeManaged {
+		t.Errorf("ModeManaged mismatch")
+	}
+	if origin.ModeUnmanaged != substrate.ModeUnmanaged {
+		t.Errorf("ModeUnmanaged mismatch")
+	}
+	if origin.ModeData != substrate.ModeData {
+		t.Errorf("ModeData mismatch")
+	}
+
+	// ApplyStatus constants
+	if origin.ApplySucceeded != substrate.ApplySucceeded {
+		t.Errorf("ApplySucceeded mismatch")
+	}
+	if origin.ApplyFailed != substrate.ApplyFailed {
+		t.Errorf("ApplyFailed mismatch")
+	}
+	if origin.ApplySkipped != substrate.ApplySkipped {
+		t.Errorf("ApplySkipped mismatch")
+	}
+
+	// Event constants
+	if origin.EventPlanStart != substrate.EventPlanStart {
+		t.Errorf("EventPlanStart mismatch")
+	}
+	if origin.EventPlanComplete != substrate.EventPlanComplete {
+		t.Errorf("EventPlanComplete mismatch")
+	}
+	if origin.EventApplyStart != substrate.EventApplyStart {
+		t.Errorf("EventApplyStart mismatch")
+	}
+	if origin.EventApplyAction != substrate.EventApplyAction {
+		t.Errorf("EventApplyAction mismatch")
+	}
+	if origin.EventApplyComplete != substrate.EventApplyComplete {
+		t.Errorf("EventApplyComplete mismatch")
+	}
+	if origin.EventDrift != substrate.EventDrift {
+		t.Errorf("EventDrift mismatch")
+	}
+	if origin.EventError != substrate.EventError {
+		t.Errorf("EventError mismatch")
+	}
+
+	// Acknowledgment / Review constants
+	if origin.AckReadDistinct != substrate.AckReadDistinct {
+		t.Errorf("AckReadDistinct mismatch")
+	}
+	if origin.AckAmendInstead != substrate.AckAmendInstead {
+		t.Errorf("AckAmendInstead mismatch")
+	}
+	if origin.ReviewActionAuthored != substrate.ReviewActionAuthored {
+		t.Errorf("ReviewActionAuthored mismatch")
+	}
+	if origin.ReviewActionAmended != substrate.ReviewActionAmended {
+		t.Errorf("ReviewActionAmended mismatch")
+	}
+	if origin.ReviewActionAbandoned != substrate.ReviewActionAbandoned {
+		t.Errorf("ReviewActionAbandoned mismatch")
+	}
+}
+
+// TestSummaryHelpers verifies that re-exported method-bearing types work correctly.
+// Since Summary is an alias, its methods are available unchanged.
+func TestSummaryHelpers(t *testing.T) {
+	s := substrate.Summary{Creates: 2, Updates: 1, Deletes: 0, Skipped: 3}
+	if got := s.Total(); got != 6 {
+		t.Errorf("Total() = %d, want 6", got)
+	}
+	if !s.HasChanges() {
+		t.Errorf("HasChanges() = false, want true")
+	}
+
+	empty := substrate.Summary{}
+	if empty.HasChanges() {
+		t.Errorf("empty Summary HasChanges() = true, want false")
+	}
+}
+
+// TestNewResourceStatus verifies the re-exported constructor sets defaults.
+func TestNewResourceStatus(t *testing.T) {
+	rs := substrate.NewResourceStatus(substrate.SyncStatusSynced, substrate.HealthHealthy)
+	if rs.Sync != substrate.SyncStatusSynced {
+		t.Errorf("Sync = %v, want Synced", rs.Sync)
+	}
+	if rs.Health != substrate.HealthHealthy {
+		t.Errorf("Health = %v, want Healthy", rs.Health)
+	}
+	if rs.Operation != substrate.OperationIdle {
+		t.Errorf("Operation = %v, want Idle", rs.Operation)
+	}
+}
+
+// TestGenerateLineage verifies that re-exported GenerateLineage produces
+// non-empty, non-identical successive values.
+func TestGenerateLineage(t *testing.T) {
+	a := substrate.GenerateLineage()
+	b := substrate.GenerateLineage()
+	if a == "" {
+		t.Errorf("GenerateLineage() returned empty string")
+	}
+	if a == b {
+		t.Errorf("GenerateLineage() returned identical consecutive values: %q", a)
+	}
+}
+
+// TestDefaultCogdocReviewClass verifies the re-exported constructor has sane defaults.
+func TestDefaultCogdocReviewClass(t *testing.T) {
+	cls := substrate.DefaultCogdocReviewClass()
+	if !cls.Enabled {
+		t.Errorf("DefaultCogdocReviewClass().Enabled = false, want true")
+	}
+	if cls.SimilarityThreshold != 0.70 {
+		t.Errorf("SimilarityThreshold = %v, want 0.70", cls.SimilarityThreshold)
+	}
+	if cls.TopN != 5 {
+		t.Errorf("TopN = %v, want 5", cls.TopN)
+	}
+}
+
+// TestResourceIndex verifies re-exported helper builds index correctly.
+func TestResourceIndex(t *testing.T) {
+	state := &substrate.State{
+		Resources: []substrate.Resource{
+			{Address: "discord://server1", ExternalID: "ext1"},
+			{Address: "discord://server2", ExternalID: "ext2"},
+		},
+	}
+	idx := substrate.ResourceIndex(state)
+	if len(idx) != 2 {
+		t.Errorf("ResourceIndex len = %d, want 2", len(idx))
+	}
+	if _, ok := idx["discord://server1"]; !ok {
+		t.Errorf("missing address 'discord://server1'")
+	}
+
+	byExt := substrate.ResourceByExternalID(state)
+	if len(byExt) != 2 {
+		t.Errorf("ResourceByExternalID len = %d, want 2", len(byExt))
+	}
+	if _, ok := byExt["ext1"]; !ok {
+		t.Errorf("missing external_id 'ext1'")
+	}
+}


### PR DESCRIPTION
## Summary

- **Step 1**: scaffolds `pkg/substrate/` as a new Go module (`github.com/myrgic/cogos/pkg/substrate`) and adds it to `go.work`. No logic, no imports — just the module boundary and README.
- **Step 2a**: adds `pkg/substrate/reconcile/` as a pure re-export of `pkg/reconcile` using Go type aliases (`type Foo = reconcile.Foo`) and variable aliases (`var Bar = reconcile.Bar`). Consumers of either import path get identical runtime types — no conversion needed.
- **No consumer code was modified.** Every `import` in `internal/` and the root package still points at `pkg/reconcile`. Migration of call sites is deliberately deferred to a follow-up so this PR is pure-additive.

## Why this order

`pkg/reconcile` has 31 import sites across `internal/` and the root — highest fanout of all extraction candidates. Proving the re-export pattern here first validates the approach before touching anything with fewer consumers. If aliases misbehave, we catch it on the simplest case.

## Relation to ADR-100

Implements Step 1 + Step 2a of the extraction sequence from the ADR-100 decision packet (Option 1: subtree path, keep module as `pkg/substrate` subtree through Steps 1–5). The ADR doc is in #281 (proposed, not yet merged) — this implementation is additive and does not gate on #281 merging.

## Re-exported symbols from pkg/reconcile

**Types (aliases):** `SyncStatus`, `HealthStatus`, `OperationPhase`, `ResourceStatus`, `ActionType`, `ResourceMode`, `ApplyStatus`, `Plan`, `Action`, `Summary`, `Result`, `State`, `Resource`, `Event`, `MetaResource`, `MetaConfig`, `MetaResult`, `MetaOpts`, `CogdocReviewClass`, `CogdocProposal`, `SimilarityCandidate`, `AcknowledgmentDecision`, `CandidateAcknowledgment`, `ReviewActionTaken`, `ProvenanceRecord`, `ReviewTRMTuple`

**Interfaces (aliases):** `Reconcilable`, `Tokenable`, `ConfigExporter`

**Constants:** all `SyncStatus*`, `Health*`, `Operation*`, `Action*`, `Mode*`, `Apply*`, `Event*`, `Ack*`, `ReviewAction*` constants

**Functions (var aliases):** `NewResourceStatus`, `ResourceIndex`, `ResourceByExternalID`, `StatePath`, `LoadState`, `WriteState`, `NewState`, `GenerateLineage`, `RegisterProvider`, `GetProvider`, `ListProviders`, `HasProvider`, `UpsertProvider`, `ResetProviders`, `EmitEvent`, `EmitPlanStart`, `EmitPlanComplete`, `EmitApplyStart`, `EmitApplyAction`, `EmitApplyComplete`, `EmitDriftDetected`, `EmitError`, `ResolveOrder`, `AutoDiscoverResources`, `RunMeta`, `ConfigureProvider`, `ResolveToken`, `DefaultCogdocReviewClass`

## Test plan

- [x] `go test ./pkg/substrate/...` — passes (type identity assertions + constant equality + helper round-trips)
- [x] `go test ./pkg/reconcile/...` — passes (no regressions)
- [x] `go test -race -count=1 ./...` — all 16 test packages pass
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [ ] CI green (watching)

## Related

- ADR-100 doc PR: #281
- RFC-0003 R4 (pkg/cogblock, no conflict): #282