### PR TITLE
feat(rbac): K8s-style RBAC binding CRDs + RBACProvider (Brainstorm Primitive 5)

### DIFF
--- a/rbac_bindings.go
+++ b/rbac_bindings.go
@@ -20,9 +20,10 @@
 //   WorkspaceBindingCRD is the AUTHORITATIVE BINDING RECORD — it declares
 //   which identity owns which workspace URI with what access level.
 //   IdentityExpression.WorkspaceRoot (Primitive 1) is the SPEC HINT — a
-//   declaration of intent on the identity spec. The RBACProvider's reconciler
-//   converges the binding record toward the spec hint. They are NOT redundant;
-//   they live at different layers (spec vs authoritative binding state).
+//   declaration of intent on the identity spec. A future WorkspaceReconciler
+//   will converge (Wave 6c) the binding record toward the spec hint. They are
+//   NOT redundant; they live at different layers (spec vs authoritative binding
+//   state).
 //
 // Storage paths:
 //   .cog/config/rbac/bindings/rolebinding/<name>.yaml

--- a/rbac_bindings.go
+++ b/rbac_bindings.go
@@ -1,0 +1,342 @@
+// rbac_bindings.go
+// K8s-style RBAC binding CRD types for CogOS (Brainstorm Primitive 5).
+//
+// Each type mirrors a Kubernetes binding resource:
+//   - RoleBindingCRD      — identity → role           (like K8s RoleBinding)
+//   - AccountBindingCRD   — identity → OS account     (like K8s ServiceAccount binding)
+//   - NodeBindingCRD      — identity → node           (like K8s Node affinity)
+//   - WorkspaceBindingCRD — identity → workspace URI  (like K8s Namespace binding)
+//   - HarnessBindingCRD   — session  → identity       (like K8s Pod binding; ephemeral)
+//
+// Persistence tier (OQ-6 decision):
+//   Structural bindings (RoleBinding, AccountBinding, NodeBinding, WorkspaceBinding)
+//   are persisted as YAML under .cog/config/rbac/bindings/<kind>/<name>.yaml.
+//   HarnessBinding is in-memory only because it is per-session ephemeral — it
+//   is created at harness-registration time and evaporates with the session.
+//   The K8s analog: structural bindings are like RoleBindings (persisted);
+//   HarnessBindings are like Pod bindings (created at scheduling, not stored).
+//
+// OQ-7 disambiguation:
+//   WorkspaceBindingCRD is the AUTHORITATIVE BINDING RECORD — it declares
+//   which identity owns which workspace URI with what access level.
+//   IdentityExpression.WorkspaceRoot (Primitive 1) is the SPEC HINT — a
+//   declaration of intent on the identity spec. The RBACProvider's reconciler
+//   converges the binding record toward the spec hint. They are NOT redundant;
+//   they live at different layers (spec vs authoritative binding state).
+//
+// Storage paths:
+//   .cog/config/rbac/bindings/rolebinding/<name>.yaml
+//   .cog/config/rbac/bindings/accountbinding/<name>.yaml
+//   .cog/config/rbac/bindings/nodebinding/<name>.yaml
+//   .cog/config/rbac/bindings/workspacebinding/<name>.yaml
+//   (HarnessBinding: in-memory only, no disk path)
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ─── Envelope ───────────────────────────────────────────────────────────────
+
+// RBACMeta is the standard metadata envelope for all RBAC binding CRDs.
+// Mirrors K8s ObjectMeta; Labels and Annotations are optional.
+type RBACMeta struct {
+	Name        string            `yaml:"name"`
+	Labels      map[string]string `yaml:"labels,omitempty"`
+	Annotations map[string]string `yaml:"annotations,omitempty"`
+}
+
+// ─── RoleBinding ────────────────────────────────────────────────────────────
+
+// RoleBindingCRD binds a subject identity to a named role, optionally scoped
+// to a workspace, channel, or resource URI. K8s RoleBinding analog.
+// Stored at: .cog/config/rbac/bindings/rolebinding/<name>.yaml
+type RoleBindingCRD struct {
+	APIVersion string          `yaml:"apiVersion"` // "cog.os/v1alpha1"
+	Kind       string          `yaml:"kind"`       // "RoleBinding"
+	Metadata   RBACMeta        `yaml:"metadata"`
+	Spec       RoleBindingSpec `yaml:"spec"`
+}
+
+// RoleBindingSpec declares the subject/role pairing.
+type RoleBindingSpec struct {
+	// Subject is the identity sub-slug being granted the role (e.g. "cog").
+	Subject string `yaml:"subject"`
+	// RoleRef names the role (e.g. "orchestrator", "operator", "observer").
+	RoleRef string `yaml:"role_ref"`
+	// Scope optionally narrows the grant to a workspace, channel, or
+	// resource URI. Empty means cluster-wide (all workspaces this node manages).
+	Scope string `yaml:"scope,omitempty"`
+}
+
+// ─── AccountBinding ─────────────────────────────────────────────────────────
+
+// AccountBindingCRD binds a substrate identity to a local OS account on a
+// named node. Enables the reconciler to assert "on node darkstar, identity
+// cog runs as OS user slowbro."
+// Stored at: .cog/config/rbac/bindings/accountbinding/<name>.yaml
+type AccountBindingCRD struct {
+	APIVersion string             `yaml:"apiVersion"` // "cog.os/v1alpha1"
+	Kind       string             `yaml:"kind"`       // "AccountBinding"
+	Metadata   RBACMeta           `yaml:"metadata"`
+	Spec       AccountBindingSpec `yaml:"spec"`
+}
+
+// AccountBindingSpec declares the identity → node → OS-account triple.
+type AccountBindingSpec struct {
+	// Subject is the identity sub-slug (e.g. "cog").
+	Subject string `yaml:"subject"`
+	// Node is the node identity slug the account lives on (e.g. "darkstar").
+	Node string `yaml:"node"`
+	// Account is the OS account name (e.g. "slowbro").
+	Account string `yaml:"account"`
+}
+
+// ─── NodeBinding ────────────────────────────────────────────────────────────
+
+// NodeBindingCRD asserts that a subject identity has a declared relationship
+// to a hardware/cognitive node — either it can embody that node (can-embody)
+// or is pinned to it (pinned-to). K8s Node affinity analog.
+// Stored at: .cog/config/rbac/bindings/nodebinding/<name>.yaml
+type NodeBindingCRD struct {
+	APIVersion string         `yaml:"apiVersion"` // "cog.os/v1alpha1"
+	Kind       string         `yaml:"kind"`       // "NodeBinding"
+	Metadata   RBACMeta       `yaml:"metadata"`
+	Spec       NodeBindingSpec `yaml:"spec"`
+}
+
+// NodeBindingSpec declares the subject → node relationship.
+type NodeBindingSpec struct {
+	// Subject is the identity sub-slug (e.g. "cog").
+	Subject string `yaml:"subject"`
+	// Node is the node identity slug (e.g. "darkstar", "eclipse").
+	Node string `yaml:"node"`
+	// Relation declares the type of node relationship.
+	// "can-embody" — the identity may run as a process on this node.
+	// "pinned-to"  — the identity is fixed to this node; will not migrate.
+	Relation string `yaml:"relation"` // "can-embody" | "pinned-to"
+}
+
+// ─── WorkspaceBinding ───────────────────────────────────────────────────────
+
+// WorkspaceBindingCRD is the AUTHORITATIVE BINDING RECORD asserting that a
+// subject identity owns or has access to a workspace URI. This is NOT the
+// same as IdentityExpression.WorkspaceRoot (Primitive 1), which is the spec
+// hint. The reconciler converges this binding toward the spec hint. See the
+// OQ-7 note at the top of this file.
+// Stored at: .cog/config/rbac/bindings/workspacebinding/<name>.yaml
+type WorkspaceBindingCRD struct {
+	APIVersion string               `yaml:"apiVersion"` // "cog.os/v1alpha1"
+	Kind       string               `yaml:"kind"`       // "WorkspaceBinding"
+	Metadata   RBACMeta             `yaml:"metadata"`
+	Spec       WorkspaceBindingSpec `yaml:"spec"`
+}
+
+// WorkspaceBindingSpec declares the subject → workspace-URI → access triple.
+type WorkspaceBindingSpec struct {
+	// Subject is the identity sub-slug (e.g. "cog", "chaz").
+	Subject string `yaml:"subject"`
+	// WorkspaceURI is the cog:// address of the workspace (e.g. "cog://workspaces/cog").
+	WorkspaceURI string `yaml:"workspace_uri"`
+	// Access declares the access level.
+	// "owner"      — full control, can modify workspace config.
+	// "read-write" — read and write workspace content; cannot modify config.
+	// "read"       — read-only access to workspace content.
+	Access string `yaml:"access"` // "owner" | "read-write" | "read"
+}
+
+// ─── HarnessBinding ─────────────────────────────────────────────────────────
+
+// HarnessBindingCRD links a live harness session to the identity it embodies.
+// Agentic harnesses (Claude Code, Cursor, etc.) are structurally dual-identity:
+// they bind both a user identity and an agent identity simultaneously, so a
+// single session may have two HarnessBindingCRDs (type="user" + type="agent").
+//
+// Persistence: IN-MEMORY ONLY. HarnessBindings are per-session ephemeral —
+// they are created by RBACProvider.ApplyPlan when a session-register event
+// arrives and are removed when the session ends. They are never written to
+// disk. The K8s analog is a Pod binding: created at scheduling time, evaporates
+// with the workload. RBACProvider.LoadConfig does not scan for HarnessBindings.
+type HarnessBindingCRD struct {
+	APIVersion string             `yaml:"apiVersion"` // "cog.os/v1alpha1"
+	Kind       string             `yaml:"kind"`       // "HarnessBinding"
+	Metadata   RBACMeta           `yaml:"metadata"`
+	Spec       HarnessBindingSpec `yaml:"spec"`
+}
+
+// HarnessBindingSpec declares the session → identity pairing.
+type HarnessBindingSpec struct {
+	// SessionID is the session identifier from the session-register event.
+	SessionID string `yaml:"session_id"`
+	// Subject is the identity sub-slug being bound (e.g. "chaz", "cog").
+	Subject string `yaml:"subject"`
+	// Type distinguishes the user identity ("user") from the agent identity
+	// ("agent") in a dual-identity agentic harness session.
+	Type string `yaml:"type"` // "user" | "agent"
+	// HarnessType identifies the harness software (e.g. "claude-code", "cursor").
+	HarnessType string `yaml:"harness_type"`
+	// NodeID optionally names the node where the harness is running.
+	NodeID string `yaml:"node_id,omitempty"`
+}
+
+// ─── Storage paths ──────────────────────────────────────────────────────────
+
+// rbacBindingsDir returns the root directory for structural RBAC binding YAML files.
+// Created by RBACProvider.ApplyPlan on first write.
+func rbacBindingsDir(root string) string {
+	return filepath.Join(root, ".cog", "config", "rbac", "bindings")
+}
+
+// rbacKindDir returns the per-kind subdirectory path (lowercased kind name).
+func rbacKindDir(root, kind string) string {
+	return filepath.Join(rbacBindingsDir(root), kind)
+}
+
+// ─── Loaders ────────────────────────────────────────────────────────────────
+
+// RBACBindingSet holds all loaded structural binding records.
+// HarnessBindings are not included — they are populated at runtime.
+type RBACBindingSet struct {
+	RoleBindings      []*RoleBindingCRD
+	AccountBindings   []*AccountBindingCRD
+	NodeBindings      []*NodeBindingCRD
+	WorkspaceBindings []*WorkspaceBindingCRD
+}
+
+// LoadRBACBindings reads all structural binding YAML files from the
+// .cog/config/rbac/bindings/ hierarchy. Missing directories are not errors;
+// a fresh workspace has no bindings yet.
+func LoadRBACBindings(root string) (*RBACBindingSet, error) {
+	base := rbacBindingsDir(root)
+	set := &RBACBindingSet{}
+
+	var err error
+
+	set.RoleBindings, err = loadRoleBindings(filepath.Join(base, "rolebinding"))
+	if err != nil {
+		return nil, fmt.Errorf("rbac: load rolebindings: %w", err)
+	}
+
+	set.AccountBindings, err = loadAccountBindings(filepath.Join(base, "accountbinding"))
+	if err != nil {
+		return nil, fmt.Errorf("rbac: load accountbindings: %w", err)
+	}
+
+	set.NodeBindings, err = loadNodeBindings(filepath.Join(base, "nodebinding"))
+	if err != nil {
+		return nil, fmt.Errorf("rbac: load nodebindings: %w", err)
+	}
+
+	set.WorkspaceBindings, err = loadWorkspaceBindings(filepath.Join(base, "workspacebinding"))
+	if err != nil {
+		return nil, fmt.Errorf("rbac: load workspacebindings: %w", err)
+	}
+
+	return set, nil
+}
+
+func loadRoleBindings(dir string) ([]*RoleBindingCRD, error) {
+	files, err := yamlFilesIn(dir)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*RoleBindingCRD, 0, len(files))
+	for _, f := range files {
+		var crd RoleBindingCRD
+		if err := decodeYAMLFile(f, &crd); err != nil {
+			return nil, fmt.Errorf("%s: %w", f, err)
+		}
+		out = append(out, &crd)
+	}
+	return out, nil
+}
+
+func loadAccountBindings(dir string) ([]*AccountBindingCRD, error) {
+	files, err := yamlFilesIn(dir)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*AccountBindingCRD, 0, len(files))
+	for _, f := range files {
+		var crd AccountBindingCRD
+		if err := decodeYAMLFile(f, &crd); err != nil {
+			return nil, fmt.Errorf("%s: %w", f, err)
+		}
+		out = append(out, &crd)
+	}
+	return out, nil
+}
+
+func loadNodeBindings(dir string) ([]*NodeBindingCRD, error) {
+	files, err := yamlFilesIn(dir)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*NodeBindingCRD, 0, len(files))
+	for _, f := range files {
+		var crd NodeBindingCRD
+		if err := decodeYAMLFile(f, &crd); err != nil {
+			return nil, fmt.Errorf("%s: %w", f, err)
+		}
+		out = append(out, &crd)
+	}
+	return out, nil
+}
+
+func loadWorkspaceBindings(dir string) ([]*WorkspaceBindingCRD, error) {
+	files, err := yamlFilesIn(dir)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*WorkspaceBindingCRD, 0, len(files))
+	for _, f := range files {
+		var crd WorkspaceBindingCRD
+		if err := decodeYAMLFile(f, &crd); err != nil {
+			return nil, fmt.Errorf("%s: %w", f, err)
+		}
+		out = append(out, &crd)
+	}
+	return out, nil
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+// yamlFilesIn returns the paths of all *.yaml files in dir.
+// A missing directory returns an empty slice, not an error.
+func yamlFilesIn(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if filepath.Ext(name) == ".yaml" || filepath.Ext(name) == ".yml" {
+			out = append(out, filepath.Join(dir, name))
+		}
+	}
+	return out, nil
+}
+
+// decodeYAMLFile reads a YAML file and decodes it into dst.
+func decodeYAMLFile(path string, dst interface{}) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read: %w", err)
+	}
+	if err := yaml.Unmarshal(data, dst); err != nil {
+		return fmt.Errorf("parse: %w", err)
+	}
+	return nil
+}

--- a/rbac_bindings_test.go
+++ b/rbac_bindings_test.go
@@ -1,0 +1,427 @@
+// rbac_bindings_test.go
+// Tests for RBAC binding CRD types: YAML round-trip for each CRD type.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ─── RoleBindingCRD round-trip ───────────────────────────────────────────────
+
+func TestRoleBindingCRD_RoundTrip(t *testing.T) {
+	input := `
+apiVersion: cog.os/v1alpha1
+kind: RoleBinding
+metadata:
+  name: cog-orchestrator
+  labels:
+    env: test
+spec:
+  subject: cog
+  role_ref: orchestrator
+  scope: cog://workspaces/cog
+`
+	var crd RoleBindingCRD
+	if err := yaml.Unmarshal([]byte(input), &crd); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if crd.APIVersion != "cog.os/v1alpha1" {
+		t.Errorf("APIVersion: got %q, want %q", crd.APIVersion, "cog.os/v1alpha1")
+	}
+	if crd.Kind != "RoleBinding" {
+		t.Errorf("Kind: got %q, want %q", crd.Kind, "RoleBinding")
+	}
+	if crd.Metadata.Name != "cog-orchestrator" {
+		t.Errorf("Metadata.Name: got %q, want %q", crd.Metadata.Name, "cog-orchestrator")
+	}
+	if crd.Spec.Subject != "cog" {
+		t.Errorf("Spec.Subject: got %q, want %q", crd.Spec.Subject, "cog")
+	}
+	if crd.Spec.RoleRef != "orchestrator" {
+		t.Errorf("Spec.RoleRef: got %q, want %q", crd.Spec.RoleRef, "orchestrator")
+	}
+	if crd.Spec.Scope != "cog://workspaces/cog" {
+		t.Errorf("Spec.Scope: got %q, want %q", crd.Spec.Scope, "cog://workspaces/cog")
+	}
+	if crd.Metadata.Labels["env"] != "test" {
+		t.Errorf("Metadata.Labels: got %v", crd.Metadata.Labels)
+	}
+
+	// Marshal back and re-unmarshal to verify symmetry.
+	out, err := yaml.Marshal(&crd)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var crd2 RoleBindingCRD
+	if err := yaml.Unmarshal(out, &crd2); err != nil {
+		t.Fatalf("re-unmarshal: %v", err)
+	}
+	if crd2.Spec.RoleRef != crd.Spec.RoleRef {
+		t.Errorf("round-trip RoleRef: got %q, want %q", crd2.Spec.RoleRef, crd.Spec.RoleRef)
+	}
+}
+
+func TestRoleBindingCRD_NoScope(t *testing.T) {
+	// Scope is optional; missing it is not an error.
+	input := `
+apiVersion: cog.os/v1alpha1
+kind: RoleBinding
+metadata:
+  name: chaz-operator
+spec:
+  subject: chaz
+  role_ref: operator
+`
+	var crd RoleBindingCRD
+	if err := yaml.Unmarshal([]byte(input), &crd); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if crd.Spec.Scope != "" {
+		t.Errorf("expected empty Scope, got %q", crd.Spec.Scope)
+	}
+}
+
+// ─── AccountBindingCRD round-trip ────────────────────────────────────────────
+
+func TestAccountBindingCRD_RoundTrip(t *testing.T) {
+	input := `
+apiVersion: cog.os/v1alpha1
+kind: AccountBinding
+metadata:
+  name: cog-on-darkstar
+spec:
+  subject: cog
+  node: darkstar
+  account: slowbro
+`
+	var crd AccountBindingCRD
+	if err := yaml.Unmarshal([]byte(input), &crd); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if crd.Kind != "AccountBinding" {
+		t.Errorf("Kind: got %q", crd.Kind)
+	}
+	if crd.Spec.Subject != "cog" {
+		t.Errorf("Subject: got %q", crd.Spec.Subject)
+	}
+	if crd.Spec.Node != "darkstar" {
+		t.Errorf("Node: got %q", crd.Spec.Node)
+	}
+	if crd.Spec.Account != "slowbro" {
+		t.Errorf("Account: got %q", crd.Spec.Account)
+	}
+
+	out, err := yaml.Marshal(&crd)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var crd2 AccountBindingCRD
+	if err := yaml.Unmarshal(out, &crd2); err != nil {
+		t.Fatalf("re-unmarshal: %v", err)
+	}
+	if crd2.Spec.Account != "slowbro" {
+		t.Errorf("round-trip Account: got %q", crd2.Spec.Account)
+	}
+}
+
+// ─── NodeBindingCRD round-trip ───────────────────────────────────────────────
+
+func TestNodeBindingCRD_RoundTrip(t *testing.T) {
+	input := `
+apiVersion: cog.os/v1alpha1
+kind: NodeBinding
+metadata:
+  name: cog-can-embody-darkstar
+spec:
+  subject: cog
+  node: darkstar
+  relation: can-embody
+`
+	var crd NodeBindingCRD
+	if err := yaml.Unmarshal([]byte(input), &crd); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if crd.Kind != "NodeBinding" {
+		t.Errorf("Kind: got %q", crd.Kind)
+	}
+	if crd.Spec.Relation != "can-embody" {
+		t.Errorf("Relation: got %q", crd.Spec.Relation)
+	}
+
+	out, err := yaml.Marshal(&crd)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var crd2 NodeBindingCRD
+	if err := yaml.Unmarshal(out, &crd2); err != nil {
+		t.Fatalf("re-unmarshal: %v", err)
+	}
+	if crd2.Spec.Relation != "can-embody" {
+		t.Errorf("round-trip Relation: got %q", crd2.Spec.Relation)
+	}
+}
+
+func TestNodeBindingCRD_PinnedTo(t *testing.T) {
+	input := `
+apiVersion: cog.os/v1alpha1
+kind: NodeBinding
+metadata:
+  name: eclipse-pinned
+spec:
+  subject: eclipse
+  node: eclipse
+  relation: pinned-to
+`
+	var crd NodeBindingCRD
+	if err := yaml.Unmarshal([]byte(input), &crd); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if crd.Spec.Relation != "pinned-to" {
+		t.Errorf("Relation: got %q", crd.Spec.Relation)
+	}
+}
+
+// ─── WorkspaceBindingCRD round-trip ──────────────────────────────────────────
+
+func TestWorkspaceBindingCRD_RoundTrip(t *testing.T) {
+	input := `
+apiVersion: cog.os/v1alpha1
+kind: WorkspaceBinding
+metadata:
+  name: cog-owns-cog-workspace
+spec:
+  subject: cog
+  workspace_uri: cog://workspaces/cog
+  access: owner
+`
+	var crd WorkspaceBindingCRD
+	if err := yaml.Unmarshal([]byte(input), &crd); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if crd.Kind != "WorkspaceBinding" {
+		t.Errorf("Kind: got %q", crd.Kind)
+	}
+	if crd.Spec.WorkspaceURI != "cog://workspaces/cog" {
+		t.Errorf("WorkspaceURI: got %q", crd.Spec.WorkspaceURI)
+	}
+	if crd.Spec.Access != "owner" {
+		t.Errorf("Access: got %q", crd.Spec.Access)
+	}
+
+	out, err := yaml.Marshal(&crd)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var crd2 WorkspaceBindingCRD
+	if err := yaml.Unmarshal(out, &crd2); err != nil {
+		t.Fatalf("re-unmarshal: %v", err)
+	}
+	if crd2.Spec.WorkspaceURI != crd.Spec.WorkspaceURI {
+		t.Errorf("round-trip WorkspaceURI: got %q", crd2.Spec.WorkspaceURI)
+	}
+}
+
+// ─── HarnessBindingCRD round-trip ────────────────────────────────────────────
+
+func TestHarnessBindingCRD_TypeAgent(t *testing.T) {
+	// Validates the scope-packet test plan item:
+	// "parse a HarnessBindingCRD with type: agent; assert Type == agent"
+	input := `
+apiVersion: cog.os/v1alpha1
+kind: HarnessBinding
+metadata:
+  name: sess-001-agent
+spec:
+  session_id: sess-001
+  subject: cog
+  type: agent
+  harness_type: claude-code
+  node_id: darkstar
+`
+	var crd HarnessBindingCRD
+	if err := yaml.Unmarshal([]byte(input), &crd); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if crd.Kind != "HarnessBinding" {
+		t.Errorf("Kind: got %q", crd.Kind)
+	}
+	if crd.Spec.Type != "agent" {
+		t.Errorf("Type: got %q, want %q", crd.Spec.Type, "agent")
+	}
+	if crd.Spec.HarnessType != "claude-code" {
+		t.Errorf("HarnessType: got %q", crd.Spec.HarnessType)
+	}
+	if crd.Spec.NodeID != "darkstar" {
+		t.Errorf("NodeID: got %q", crd.Spec.NodeID)
+	}
+}
+
+func TestHarnessBindingCRD_TypeUser(t *testing.T) {
+	input := `
+apiVersion: cog.os/v1alpha1
+kind: HarnessBinding
+metadata:
+  name: sess-001-user
+spec:
+  session_id: sess-001
+  subject: chaz
+  type: user
+  harness_type: claude-code
+`
+	var crd HarnessBindingCRD
+	if err := yaml.Unmarshal([]byte(input), &crd); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if crd.Spec.Type != "user" {
+		t.Errorf("Type: got %q, want %q", crd.Spec.Type, "user")
+	}
+	if crd.Spec.NodeID != "" {
+		t.Errorf("NodeID should be empty (omitempty), got %q", crd.Spec.NodeID)
+	}
+}
+
+func TestHarnessBindingCRD_RoundTrip(t *testing.T) {
+	crd := HarnessBindingCRD{
+		APIVersion: "cog.os/v1alpha1",
+		Kind:       "HarnessBinding",
+		Metadata:   RBACMeta{Name: "sess-002-agent"},
+		Spec: HarnessBindingSpec{
+			SessionID:   "sess-002",
+			Subject:     "cog",
+			Type:        "agent",
+			HarnessType: "cursor",
+			NodeID:      "eclipse",
+		},
+	}
+
+	out, err := yaml.Marshal(&crd)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var crd2 HarnessBindingCRD
+	if err := yaml.Unmarshal(out, &crd2); err != nil {
+		t.Fatalf("re-unmarshal: %v", err)
+	}
+	if crd2.Spec.SessionID != "sess-002" {
+		t.Errorf("SessionID: got %q", crd2.Spec.SessionID)
+	}
+	if crd2.Spec.Type != "agent" {
+		t.Errorf("Type: got %q", crd2.Spec.Type)
+	}
+}
+
+// ─── LoadRBACBindings with real files ────────────────────────────────────────
+
+func TestLoadRBACBindings_AllKinds(t *testing.T) {
+	// Write fixture files for each structural binding kind.
+	root := t.TempDir()
+	base := filepath.Join(root, ".cog", "config", "rbac", "bindings")
+
+	fixtures := []struct {
+		kind    string
+		name    string
+		content string
+	}{
+		{
+			kind: "rolebinding",
+			name: "cog-orchestrator.yaml",
+			content: `
+apiVersion: cog.os/v1alpha1
+kind: RoleBinding
+metadata:
+  name: cog-orchestrator
+spec:
+  subject: cog
+  role_ref: orchestrator
+`,
+		},
+		{
+			kind: "accountbinding",
+			name: "cog-on-darkstar.yaml",
+			content: `
+apiVersion: cog.os/v1alpha1
+kind: AccountBinding
+metadata:
+  name: cog-on-darkstar
+spec:
+  subject: cog
+  node: darkstar
+  account: slowbro
+`,
+		},
+		{
+			kind: "nodebinding",
+			name: "cog-embodies-darkstar.yaml",
+			content: `
+apiVersion: cog.os/v1alpha1
+kind: NodeBinding
+metadata:
+  name: cog-embodies-darkstar
+spec:
+  subject: cog
+  node: darkstar
+  relation: can-embody
+`,
+		},
+		{
+			kind: "workspacebinding",
+			name: "cog-owns-workspace.yaml",
+			content: `
+apiVersion: cog.os/v1alpha1
+kind: WorkspaceBinding
+metadata:
+  name: cog-owns-workspace
+spec:
+  subject: cog
+  workspace_uri: cog://workspaces/cog
+  access: owner
+`,
+		},
+	}
+
+	for _, f := range fixtures {
+		dir := filepath.Join(base, f.kind)
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, f.name), []byte(f.content), 0o640); err != nil {
+			t.Fatalf("write %s: %v", f.name, err)
+		}
+	}
+
+	set, err := LoadRBACBindings(root)
+	if err != nil {
+		t.Fatalf("LoadRBACBindings: %v", err)
+	}
+
+	if len(set.RoleBindings) != 1 {
+		t.Errorf("RoleBindings: got %d, want 1", len(set.RoleBindings))
+	}
+	if len(set.AccountBindings) != 1 {
+		t.Errorf("AccountBindings: got %d, want 1", len(set.AccountBindings))
+	}
+	if len(set.NodeBindings) != 1 {
+		t.Errorf("NodeBindings: got %d, want 1", len(set.NodeBindings))
+	}
+	if len(set.WorkspaceBindings) != 1 {
+		t.Errorf("WorkspaceBindings: got %d, want 1", len(set.WorkspaceBindings))
+	}
+}
+
+func TestLoadRBACBindings_EmptyDir(t *testing.T) {
+	// A fresh workspace with no bindings directory is not an error.
+	root := t.TempDir()
+	set, err := LoadRBACBindings(root)
+	if err != nil {
+		t.Fatalf("LoadRBACBindings on empty workspace: %v", err)
+	}
+	if len(set.RoleBindings) != 0 || len(set.AccountBindings) != 0 ||
+		len(set.NodeBindings) != 0 || len(set.WorkspaceBindings) != 0 {
+		t.Errorf("expected empty sets for fresh workspace")
+	}
+}

--- a/rbac_bindings_wiring.go
+++ b/rbac_bindings_wiring.go
@@ -1,0 +1,22 @@
+// rbac_bindings_wiring.go — registers RBACProvider with the reconcile engine.
+//
+// Same pattern as identity_wiring.go: an init() block constructs the provider
+// with a stub bus-emit adapter and calls RegisterProvider so the reconcile
+// harness picks it up automatically at startup.
+//
+// Bus-emit adapter: logs dropped events at debug level; a full wiring to
+// AppendEvent (or the modality bus) is Wave 6c work, matching the identity
+// provider's deferral.
+
+package main
+
+import "log"
+
+func init() {
+	emit := BusEmit(func(eventType string, data map[string]any) error {
+		log.Printf("[rbac-bindings] bus event (stub-emit) type=%s\n", eventType)
+		return nil
+	})
+	provider := NewRBACProvider(emit)
+	RegisterProvider("rbac-bindings", provider)
+}

--- a/rbac_provider.go
+++ b/rbac_provider.go
@@ -1,0 +1,784 @@
+// rbac_provider.go
+// RBACProvider implements pkg/reconcile.Reconcilable for RBAC binding CRDs.
+//
+// This is the Wave 6b/6c binding layer on top of the existing flat-file Role
+// loader (rbac.go). The existing RoleLoader / Role structs continue to work
+// unchanged; RBACProvider adds the Reconcilable binding records without
+// replacing anything.
+//
+// Persistence tier (OQ-6):
+//   Structural bindings (RoleBinding, AccountBinding, NodeBinding,
+//   WorkspaceBinding) are loaded from and written to YAML files under
+//   .cog/config/rbac/bindings/<kind>/<name>.yaml. HarnessBindings are
+//   in-memory only — they are populated by ApplyPlan when session-register
+//   events arrive and cleared when the session ends. LoadConfig does not
+//   scan for HarnessBindings.
+//
+// OQ-7:
+//   WorkspaceBindingCRD is the authoritative binding record. The
+//   IdentityExpression.WorkspaceRoot field (Primitive 1) is the spec hint.
+//   A future WorkspaceReconciler will converge the binding toward the hint.
+//   These two objects serve different layers; see rbac_bindings.go for the
+//   full note.
+//
+// Long-term: the flat-file RoleLoader becomes part of this provider in a
+// Wave 6d refactor. That consolidation is out of scope for this PR.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ─── Event constants ─────────────────────────────────────────────────────────
+
+const (
+	EventRBACBindingCreated  = "rbac.binding.created"
+	EventRBACBindingUpdated  = "rbac.binding.updated"
+	EventRBACBindingDeleted  = "rbac.binding.deleted"
+	EventRBACHarnessAttached = "rbac.harness.attached"
+	EventRBACHarnessDetached = "rbac.harness.detached"
+)
+
+const rbacEventSource = "reconciler/rbac-bindings"
+
+// ─── Internal types ──────────────────────────────────────────────────────────
+
+// rbacConfig is the provider's internal config bundle produced by LoadConfig.
+type rbacConfig struct {
+	Root     string
+	Bindings *RBACBindingSet
+}
+
+// rbacLive is the provider's snapshot of current in-memory + disk state.
+// Structural bindings are keyed by "<kind>/<name>" for diffing.
+// HarnessBindings are keyed by "<session_id>/<type>".
+type rbacLive struct {
+	// Structural bindings: keyed "<kind>/<name>"
+	RoleBindings      map[string]*RoleBindingCRD
+	AccountBindings   map[string]*AccountBindingCRD
+	NodeBindings      map[string]*NodeBindingCRD
+	WorkspaceBindings map[string]*WorkspaceBindingCRD
+	// HarnessBindings: keyed "<session_id>/<type>" — in-memory only
+	HarnessBindings map[string]*HarnessBindingCRD
+}
+
+func newRBACLive() *rbacLive {
+	return &rbacLive{
+		RoleBindings:      make(map[string]*RoleBindingCRD),
+		AccountBindings:   make(map[string]*AccountBindingCRD),
+		NodeBindings:      make(map[string]*NodeBindingCRD),
+		WorkspaceBindings: make(map[string]*WorkspaceBindingCRD),
+		HarnessBindings:   make(map[string]*HarnessBindingCRD),
+	}
+}
+
+// harnessKey produces the map key for a HarnessBinding.
+func harnessKey(sessionID, bindingType string) string {
+	return sessionID + "/" + bindingType
+}
+
+// ─── RBACProvider ───────────────────────────────────────────────────────────
+
+// RBACProvider implements Reconcilable for RBAC binding CRDs.
+// The provider manages five binding types; structural bindings are
+// disk-persisted, harness bindings are in-memory only.
+type RBACProvider struct {
+	mu sync.Mutex
+
+	emit BusEmit // reuse the same BusEmit type from identity_provider.go
+
+	// in-memory live state: updated by ApplyPlan, queried by FetchLive.
+	live *rbacLive
+
+	// last reconcile summary for Health() reporting.
+	root            string
+	lastPlanSummary ReconcileSummary
+	schemaErrors    []string
+	operation       OperationPhase
+}
+
+// NewRBACProvider constructs a provider. A nil emit silently drops events.
+func NewRBACProvider(emit BusEmit) *RBACProvider {
+	if emit == nil {
+		emit = func(string, map[string]any) error { return nil }
+	}
+	return &RBACProvider{
+		emit:      emit,
+		live:      newRBACLive(),
+		operation: OperationIdle,
+	}
+}
+
+// Type returns the provider identifier.
+func (p *RBACProvider) Type() string { return "rbac-bindings" }
+
+// ─── LoadConfig ──────────────────────────────────────────────────────────────
+
+// LoadConfig reads all structural binding YAML files from
+// .cog/config/rbac/bindings/. HarnessBindings are NOT loaded here —
+// they are populated at runtime via ApplyPlan when session events arrive.
+func (p *RBACProvider) LoadConfig(root string) (any, error) {
+	p.mu.Lock()
+	p.root = root
+	p.mu.Unlock()
+
+	bindings, err := LoadRBACBindings(root)
+	if err != nil {
+		return nil, fmt.Errorf("rbac provider: load config: %w", err)
+	}
+	return &rbacConfig{Root: root, Bindings: bindings}, nil
+}
+
+// ─── FetchLive ───────────────────────────────────────────────────────────────
+
+// FetchLive returns the current in-memory live state. Because structural
+// bindings are disk-backed and harness bindings are in-memory, FetchLive
+// returns a snapshot of the provider's running memory. This is consistent
+// with the stub-constellation pattern: the provider is the source of truth
+// until a real persistence layer is wired in Wave 6c.
+func (p *RBACProvider) FetchLive(_ context.Context, _ any) (any, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Return a shallow copy to avoid races between FetchLive and ApplyPlan.
+	snapshot := newRBACLive()
+	for k, v := range p.live.RoleBindings {
+		snapshot.RoleBindings[k] = v
+	}
+	for k, v := range p.live.AccountBindings {
+		snapshot.AccountBindings[k] = v
+	}
+	for k, v := range p.live.NodeBindings {
+		snapshot.NodeBindings[k] = v
+	}
+	for k, v := range p.live.WorkspaceBindings {
+		snapshot.WorkspaceBindings[k] = v
+	}
+	for k, v := range p.live.HarnessBindings {
+		snapshot.HarnessBindings[k] = v
+	}
+	return snapshot, nil
+}
+
+// ─── ComputePlan ─────────────────────────────────────────────────────────────
+
+// ComputePlan diffs declared config (from LoadConfig) against live state
+// (from FetchLive). Produces create/update/delete/skip actions per binding.
+// HarnessBindings are never in the config set; they only appear in live state
+// (populated at runtime). ComputePlan will never emit a create for them.
+func (p *RBACProvider) ComputePlan(config any, live any, _ *ReconcileState) (*ReconcilePlan, error) {
+	cfg, ok := config.(*rbacConfig)
+	if !ok {
+		return nil, fmt.Errorf("rbac provider: expected *rbacConfig, got %T", config)
+	}
+	liveState, ok := live.(*rbacLive)
+	if !ok {
+		return nil, fmt.Errorf("rbac provider: expected *rbacLive, got %T", live)
+	}
+
+	plan := &ReconcilePlan{
+		ResourceType: "rbac-bindings",
+		GeneratedAt:  nowISO(),
+		ConfigPath:   rbacBindingsDir(cfg.Root),
+		Metadata:     map[string]any{},
+	}
+
+	// Diff each binding kind.
+	diffRoleBindings(plan, cfg.Bindings.RoleBindings, liveState.RoleBindings)
+	diffAccountBindings(plan, cfg.Bindings.AccountBindings, liveState.AccountBindings)
+	diffNodeBindings(plan, cfg.Bindings.NodeBindings, liveState.NodeBindings)
+	diffWorkspaceBindings(plan, cfg.Bindings.WorkspaceBindings, liveState.WorkspaceBindings)
+	// HarnessBindings: no config set; never generate creates from this path.
+
+	// Deterministic order.
+	sort.Slice(plan.Actions, func(i, j int) bool {
+		if plan.Actions[i].Action != plan.Actions[j].Action {
+			return plan.Actions[i].Action < plan.Actions[j].Action
+		}
+		if plan.Actions[i].ResourceType != plan.Actions[j].ResourceType {
+			return plan.Actions[i].ResourceType < plan.Actions[j].ResourceType
+		}
+		return plan.Actions[i].Name < plan.Actions[j].Name
+	})
+
+	p.mu.Lock()
+	p.lastPlanSummary = plan.Summary
+	p.mu.Unlock()
+
+	return plan, nil
+}
+
+// ─── diff helpers ─────────────────────────────────────────────────────────────
+
+func diffRoleBindings(plan *ReconcilePlan, spec []*RoleBindingCRD, live map[string]*RoleBindingCRD) {
+	seen := make(map[string]struct{}, len(spec))
+	for _, crd := range spec {
+		key := "rolebinding/" + crd.Metadata.Name
+		seen[key] = struct{}{}
+		if _, exists := live[key]; !exists {
+			plan.Actions = append(plan.Actions, ReconcileAction{
+				Action: ActionCreate, ResourceType: "rolebinding", Name: crd.Metadata.Name,
+				Details: map[string]any{"subject": crd.Spec.Subject, "role_ref": crd.Spec.RoleRef},
+			})
+			plan.Summary.Creates++
+		} else {
+			plan.Actions = append(plan.Actions, ReconcileAction{
+				Action: ActionSkip, ResourceType: "rolebinding", Name: crd.Metadata.Name,
+				Details: map[string]any{"reason": "in sync"},
+			})
+			plan.Summary.Skipped++
+		}
+	}
+	for key, crd := range live {
+		if _, ok := seen[key]; !ok {
+			plan.Actions = append(plan.Actions, ReconcileAction{
+				Action: ActionDelete, ResourceType: "rolebinding", Name: crd.Metadata.Name,
+				Details: map[string]any{"subject": crd.Spec.Subject},
+			})
+			plan.Summary.Deletes++
+		}
+	}
+}
+
+func diffAccountBindings(plan *ReconcilePlan, spec []*AccountBindingCRD, live map[string]*AccountBindingCRD) {
+	seen := make(map[string]struct{}, len(spec))
+	for _, crd := range spec {
+		key := "accountbinding/" + crd.Metadata.Name
+		seen[key] = struct{}{}
+		if _, exists := live[key]; !exists {
+			plan.Actions = append(plan.Actions, ReconcileAction{
+				Action: ActionCreate, ResourceType: "accountbinding", Name: crd.Metadata.Name,
+				Details: map[string]any{"subject": crd.Spec.Subject, "node": crd.Spec.Node, "account": crd.Spec.Account},
+			})
+			plan.Summary.Creates++
+		} else {
+			plan.Actions = append(plan.Actions, ReconcileAction{
+				Action: ActionSkip, ResourceType: "accountbinding", Name: crd.Metadata.Name,
+				Details: map[string]any{"reason": "in sync"},
+			})
+			plan.Summary.Skipped++
+		}
+	}
+	for key, crd := range live {
+		if _, ok := seen[key]; !ok {
+			plan.Actions = append(plan.Actions, ReconcileAction{
+				Action: ActionDelete, ResourceType: "accountbinding", Name: crd.Metadata.Name,
+				Details: map[string]any{"subject": crd.Spec.Subject},
+			})
+			plan.Summary.Deletes++
+		}
+	}
+}
+
+func diffNodeBindings(plan *ReconcilePlan, spec []*NodeBindingCRD, live map[string]*NodeBindingCRD) {
+	seen := make(map[string]struct{}, len(spec))
+	for _, crd := range spec {
+		key := "nodebinding/" + crd.Metadata.Name
+		seen[key] = struct{}{}
+		if _, exists := live[key]; !exists {
+			plan.Actions = append(plan.Actions, ReconcileAction{
+				Action: ActionCreate, ResourceType: "nodebinding", Name: crd.Metadata.Name,
+				Details: map[string]any{"subject": crd.Spec.Subject, "node": crd.Spec.Node, "relation": crd.Spec.Relation},
+			})
+			plan.Summary.Creates++
+		} else {
+			plan.Actions = append(plan.Actions, ReconcileAction{
+				Action: ActionSkip, ResourceType: "nodebinding", Name: crd.Metadata.Name,
+				Details: map[string]any{"reason": "in sync"},
+			})
+			plan.Summary.Skipped++
+		}
+	}
+	for key, crd := range live {
+		if _, ok := seen[key]; !ok {
+			plan.Actions = append(plan.Actions, ReconcileAction{
+				Action: ActionDelete, ResourceType: "nodebinding", Name: crd.Metadata.Name,
+				Details: map[string]any{"subject": crd.Spec.Subject},
+			})
+			plan.Summary.Deletes++
+		}
+	}
+}
+
+func diffWorkspaceBindings(plan *ReconcilePlan, spec []*WorkspaceBindingCRD, live map[string]*WorkspaceBindingCRD) {
+	seen := make(map[string]struct{}, len(spec))
+	for _, crd := range spec {
+		key := "workspacebinding/" + crd.Metadata.Name
+		seen[key] = struct{}{}
+		if _, exists := live[key]; !exists {
+			plan.Actions = append(plan.Actions, ReconcileAction{
+				Action: ActionCreate, ResourceType: "workspacebinding", Name: crd.Metadata.Name,
+				Details: map[string]any{"subject": crd.Spec.Subject, "workspace_uri": crd.Spec.WorkspaceURI, "access": crd.Spec.Access},
+			})
+			plan.Summary.Creates++
+		} else {
+			plan.Actions = append(plan.Actions, ReconcileAction{
+				Action: ActionSkip, ResourceType: "workspacebinding", Name: crd.Metadata.Name,
+				Details: map[string]any{"reason": "in sync"},
+			})
+			plan.Summary.Skipped++
+		}
+	}
+	for key, crd := range live {
+		if _, ok := seen[key]; !ok {
+			plan.Actions = append(plan.Actions, ReconcileAction{
+				Action: ActionDelete, ResourceType: "workspacebinding", Name: crd.Metadata.Name,
+				Details: map[string]any{"subject": crd.Spec.Subject},
+			})
+			plan.Summary.Deletes++
+		}
+	}
+}
+
+// ─── ApplyPlan ───────────────────────────────────────────────────────────────
+
+// ApplyPlan executes the plan actions. Structural bindings are written to disk
+// and mirrored into the in-memory live map. Delete actions remove from disk
+// and from memory. HarnessBinding creates arrive via separate AttachHarness
+// calls (not through the standard plan path) because they are runtime events,
+// not config-driven.
+func (p *RBACProvider) ApplyPlan(ctx context.Context, plan *ReconcilePlan) ([]ReconcileResult, error) {
+	if plan == nil {
+		return nil, fmt.Errorf("rbac provider: nil plan")
+	}
+
+	p.mu.Lock()
+	p.operation = OperationSyncing
+	root := p.root
+	p.mu.Unlock()
+
+	defer func() {
+		p.mu.Lock()
+		p.operation = OperationIdle
+		p.mu.Unlock()
+	}()
+
+	// Reload specs so we have the full YAML for creates.
+	bindings, err := LoadRBACBindings(root)
+	if err != nil {
+		return nil, fmt.Errorf("rbac provider: reload specs for apply: %w", err)
+	}
+
+	var results []ReconcileResult
+
+	for _, action := range plan.Actions {
+		if action.Action == ActionSkip {
+			continue
+		}
+
+		res := ReconcileResult{
+			Phase:  "rbac-bindings",
+			Action: string(action.Action),
+			Name:   action.Name,
+		}
+
+		var applyErr error
+		switch action.ResourceType {
+		case "rolebinding":
+			applyErr = p.applyRoleBinding(root, action, bindings)
+		case "accountbinding":
+			applyErr = p.applyAccountBinding(root, action, bindings)
+		case "nodebinding":
+			applyErr = p.applyNodeBinding(root, action, bindings)
+		case "workspacebinding":
+			applyErr = p.applyWorkspaceBinding(root, action, bindings)
+		default:
+			res.Status = ApplySkipped
+			results = append(results, res)
+			continue
+		}
+
+		if applyErr != nil {
+			res.Status = ApplyFailed
+			res.Error = applyErr.Error()
+		} else {
+			res.Status = ApplySucceeded
+		}
+		results = append(results, res)
+	}
+
+	return results, nil
+}
+
+// AttachHarness registers a HarnessBindingCRD into the in-memory live state
+// and emits rbac.harness.attached. Called by session-register hooks at runtime.
+// This path is separate from the config-driven plan/apply cycle because
+// HarnessBindings are ephemeral runtime state, not declared config.
+func (p *RBACProvider) AttachHarness(binding *HarnessBindingCRD) {
+	key := harnessKey(binding.Spec.SessionID, binding.Spec.Type)
+	p.mu.Lock()
+	p.live.HarnessBindings[key] = binding
+	p.mu.Unlock()
+	p.emitRBACEvent(EventRBACHarnessAttached, map[string]any{
+		"session_id":   binding.Spec.SessionID,
+		"subject":      binding.Spec.Subject,
+		"type":         binding.Spec.Type,
+		"harness_type": binding.Spec.HarnessType,
+		"attached_at":  time.Now().UTC().Format(time.RFC3339),
+	})
+}
+
+// DetachHarness removes a HarnessBindingCRD from in-memory state and emits
+// rbac.harness.detached. Called when a session ends.
+func (p *RBACProvider) DetachHarness(sessionID, bindingType string) {
+	key := harnessKey(sessionID, bindingType)
+	p.mu.Lock()
+	binding, ok := p.live.HarnessBindings[key]
+	if ok {
+		delete(p.live.HarnessBindings, key)
+	}
+	p.mu.Unlock()
+	if ok {
+		p.emitRBACEvent(EventRBACHarnessDetached, map[string]any{
+			"session_id":  sessionID,
+			"subject":     binding.Spec.Subject,
+			"type":        bindingType,
+			"detached_at": time.Now().UTC().Format(time.RFC3339),
+		})
+	}
+}
+
+// ─── apply helpers ────────────────────────────────────────────────────────────
+
+func (p *RBACProvider) applyRoleBinding(root string, action ReconcileAction, bindings *RBACBindingSet) error {
+	key := "rolebinding/" + action.Name
+	if action.Action == ActionDelete {
+		if err := removeBindingFile(root, "rolebinding", action.Name); err != nil {
+			return err
+		}
+		p.mu.Lock()
+		delete(p.live.RoleBindings, key)
+		p.mu.Unlock()
+		p.emitRBACEvent(EventRBACBindingDeleted, map[string]any{"kind": "rolebinding", "name": action.Name})
+		return nil
+	}
+	crd := findRoleBinding(bindings.RoleBindings, action.Name)
+	if crd == nil {
+		return fmt.Errorf("rolebinding %q not found in spec", action.Name)
+	}
+	if err := writeBindingFile(root, "rolebinding", action.Name, crd); err != nil {
+		return err
+	}
+	p.mu.Lock()
+	p.live.RoleBindings[key] = crd
+	p.mu.Unlock()
+	p.emitRBACEvent(EventRBACBindingCreated, map[string]any{"kind": "rolebinding", "name": action.Name, "subject": crd.Spec.Subject})
+	return nil
+}
+
+func (p *RBACProvider) applyAccountBinding(root string, action ReconcileAction, bindings *RBACBindingSet) error {
+	key := "accountbinding/" + action.Name
+	if action.Action == ActionDelete {
+		if err := removeBindingFile(root, "accountbinding", action.Name); err != nil {
+			return err
+		}
+		p.mu.Lock()
+		delete(p.live.AccountBindings, key)
+		p.mu.Unlock()
+		p.emitRBACEvent(EventRBACBindingDeleted, map[string]any{"kind": "accountbinding", "name": action.Name})
+		return nil
+	}
+	crd := findAccountBinding(bindings.AccountBindings, action.Name)
+	if crd == nil {
+		return fmt.Errorf("accountbinding %q not found in spec", action.Name)
+	}
+	if err := writeBindingFile(root, "accountbinding", action.Name, crd); err != nil {
+		return err
+	}
+	p.mu.Lock()
+	p.live.AccountBindings[key] = crd
+	p.mu.Unlock()
+	p.emitRBACEvent(EventRBACBindingCreated, map[string]any{"kind": "accountbinding", "name": action.Name, "subject": crd.Spec.Subject})
+	return nil
+}
+
+func (p *RBACProvider) applyNodeBinding(root string, action ReconcileAction, bindings *RBACBindingSet) error {
+	key := "nodebinding/" + action.Name
+	if action.Action == ActionDelete {
+		if err := removeBindingFile(root, "nodebinding", action.Name); err != nil {
+			return err
+		}
+		p.mu.Lock()
+		delete(p.live.NodeBindings, key)
+		p.mu.Unlock()
+		p.emitRBACEvent(EventRBACBindingDeleted, map[string]any{"kind": "nodebinding", "name": action.Name})
+		return nil
+	}
+	crd := findNodeBinding(bindings.NodeBindings, action.Name)
+	if crd == nil {
+		return fmt.Errorf("nodebinding %q not found in spec", action.Name)
+	}
+	if err := writeBindingFile(root, "nodebinding", action.Name, crd); err != nil {
+		return err
+	}
+	p.mu.Lock()
+	p.live.NodeBindings[key] = crd
+	p.mu.Unlock()
+	p.emitRBACEvent(EventRBACBindingCreated, map[string]any{"kind": "nodebinding", "name": action.Name, "subject": crd.Spec.Subject})
+	return nil
+}
+
+func (p *RBACProvider) applyWorkspaceBinding(root string, action ReconcileAction, bindings *RBACBindingSet) error {
+	key := "workspacebinding/" + action.Name
+	if action.Action == ActionDelete {
+		if err := removeBindingFile(root, "workspacebinding", action.Name); err != nil {
+			return err
+		}
+		p.mu.Lock()
+		delete(p.live.WorkspaceBindings, key)
+		p.mu.Unlock()
+		p.emitRBACEvent(EventRBACBindingDeleted, map[string]any{"kind": "workspacebinding", "name": action.Name})
+		return nil
+	}
+	crd := findWorkspaceBinding(bindings.WorkspaceBindings, action.Name)
+	if crd == nil {
+		return fmt.Errorf("workspacebinding %q not found in spec", action.Name)
+	}
+	if err := writeBindingFile(root, "workspacebinding", action.Name, crd); err != nil {
+		return err
+	}
+	p.mu.Lock()
+	p.live.WorkspaceBindings[key] = crd
+	p.mu.Unlock()
+	p.emitRBACEvent(EventRBACBindingCreated, map[string]any{"kind": "workspacebinding", "name": action.Name, "subject": crd.Spec.Subject})
+	return nil
+}
+
+// ─── BuildState ───────────────────────────────────────────────────────────────
+
+// BuildState constructs a Terraform-style state snapshot from live bindings.
+func (p *RBACProvider) BuildState(_ any, live any, existing *ReconcileState) (*ReconcileState, error) {
+	liveState, ok := live.(*rbacLive)
+	if !ok {
+		return nil, fmt.Errorf("rbac provider: expected *rbacLive, got %T", live)
+	}
+
+	state := &ReconcileState{
+		Version:      1,
+		ResourceType: "rbac-bindings",
+		GeneratedAt:  nowISO(),
+		Resources:    []ReconcileResource{},
+		Metadata:     map[string]any{},
+	}
+
+	if existing != nil && existing.Lineage != "" {
+		state.Lineage = existing.Lineage
+		state.Serial = existing.Serial + 1
+	} else {
+		state.Lineage = "rbac-bindings-" + nowISO()
+		state.Serial = 1
+	}
+
+	now := nowISO()
+
+	// Collect and sort keys for deterministic output.
+	var roleKeys []string
+	for k := range liveState.RoleBindings {
+		roleKeys = append(roleKeys, k)
+	}
+	sort.Strings(roleKeys)
+	for _, k := range roleKeys {
+		crd := liveState.RoleBindings[k]
+		state.Resources = append(state.Resources, ReconcileResource{
+			Address: k, Type: "rolebinding", Mode: ModeManaged,
+			ExternalID: k, Name: crd.Metadata.Name, LastRefreshed: now,
+			Attributes: map[string]any{"subject": crd.Spec.Subject, "role_ref": crd.Spec.RoleRef, "scope": crd.Spec.Scope},
+		})
+	}
+
+	var acctKeys []string
+	for k := range liveState.AccountBindings {
+		acctKeys = append(acctKeys, k)
+	}
+	sort.Strings(acctKeys)
+	for _, k := range acctKeys {
+		crd := liveState.AccountBindings[k]
+		state.Resources = append(state.Resources, ReconcileResource{
+			Address: k, Type: "accountbinding", Mode: ModeManaged,
+			ExternalID: k, Name: crd.Metadata.Name, LastRefreshed: now,
+			Attributes: map[string]any{"subject": crd.Spec.Subject, "node": crd.Spec.Node, "account": crd.Spec.Account},
+		})
+	}
+
+	var nodeKeys []string
+	for k := range liveState.NodeBindings {
+		nodeKeys = append(nodeKeys, k)
+	}
+	sort.Strings(nodeKeys)
+	for _, k := range nodeKeys {
+		crd := liveState.NodeBindings[k]
+		state.Resources = append(state.Resources, ReconcileResource{
+			Address: k, Type: "nodebinding", Mode: ModeManaged,
+			ExternalID: k, Name: crd.Metadata.Name, LastRefreshed: now,
+			Attributes: map[string]any{"subject": crd.Spec.Subject, "node": crd.Spec.Node, "relation": crd.Spec.Relation},
+		})
+	}
+
+	var wsKeys []string
+	for k := range liveState.WorkspaceBindings {
+		wsKeys = append(wsKeys, k)
+	}
+	sort.Strings(wsKeys)
+	for _, k := range wsKeys {
+		crd := liveState.WorkspaceBindings[k]
+		state.Resources = append(state.Resources, ReconcileResource{
+			Address: k, Type: "workspacebinding", Mode: ModeManaged,
+			ExternalID: k, Name: crd.Metadata.Name, LastRefreshed: now,
+			Attributes: map[string]any{"subject": crd.Spec.Subject, "workspace_uri": crd.Spec.WorkspaceURI, "access": crd.Spec.Access},
+		})
+	}
+
+	var harnessKeys []string
+	for k := range liveState.HarnessBindings {
+		harnessKeys = append(harnessKeys, k)
+	}
+	sort.Strings(harnessKeys)
+	for _, k := range harnessKeys {
+		crd := liveState.HarnessBindings[k]
+		state.Resources = append(state.Resources, ReconcileResource{
+			Address: k, Type: "harnessbinding", Mode: ModeManaged,
+			ExternalID: k, Name: crd.Metadata.Name, LastRefreshed: now,
+			Attributes: map[string]any{
+				"session_id":   crd.Spec.SessionID,
+				"subject":      crd.Spec.Subject,
+				"type":         crd.Spec.Type,
+				"harness_type": crd.Spec.HarnessType,
+				"ephemeral":    true,
+			},
+		})
+	}
+
+	// Summary counts.
+	state.Metadata["role_binding_count"] = len(liveState.RoleBindings)
+	state.Metadata["account_binding_count"] = len(liveState.AccountBindings)
+	state.Metadata["node_binding_count"] = len(liveState.NodeBindings)
+	state.Metadata["workspace_binding_count"] = len(liveState.WorkspaceBindings)
+	state.Metadata["harness_binding_count"] = len(liveState.HarnessBindings)
+
+	return state, nil
+}
+
+// ─── Health ───────────────────────────────────────────────────────────────────
+
+// Health returns the three-axis status.
+//
+//	Sync      — Synced when last plan had no non-skip actions; OutOfSync otherwise.
+//	Health    — Degraded when LoadConfig or ApplyPlan recorded schema errors;
+//	            Healthy otherwise.
+//	Operation — Syncing while ApplyPlan is running; Idle otherwise.
+func (p *RBACProvider) Health() ResourceStatus {
+	p.mu.Lock()
+	summary := p.lastPlanSummary
+	schemaErrs := len(p.schemaErrors)
+	op := p.operation
+	p.mu.Unlock()
+
+	sync := SyncStatusSynced
+	if summary.HasChanges() {
+		sync = SyncStatusOutOfSync
+	}
+
+	health := HealthHealthy
+	msg := ""
+	if schemaErrs > 0 {
+		health = HealthDegraded
+		msg = fmt.Sprintf("%d schema error(s) in RBAC binding files", schemaErrs)
+	}
+
+	return ResourceStatus{
+		Sync:      sync,
+		Health:    health,
+		Operation: op,
+		Message:   msg,
+	}
+}
+
+// ─── Disk I/O ─────────────────────────────────────────────────────────────────
+
+// writeBindingFile marshals a binding CRD to YAML and writes it to the
+// per-kind subdirectory, creating parent directories as needed.
+func writeBindingFile(root, kind, name string, v interface{}) error {
+	dir := rbacKindDir(root, kind)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return fmt.Errorf("rbac: mkdir %s: %w", dir, err)
+	}
+	data, err := yaml.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("rbac: marshal %s/%s: %w", kind, name, err)
+	}
+	path := filepath.Join(dir, name+".yaml")
+	if err := os.WriteFile(path, data, 0o640); err != nil {
+		return fmt.Errorf("rbac: write %s: %w", path, err)
+	}
+	return nil
+}
+
+// removeBindingFile removes a binding YAML file. Missing file is not an error.
+func removeBindingFile(root, kind, name string) error {
+	path := filepath.Join(rbacKindDir(root, kind), name+".yaml")
+	err := os.Remove(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("rbac: remove %s: %w", path, err)
+	}
+	return nil
+}
+
+// ─── Lookup helpers ───────────────────────────────────────────────────────────
+
+func findRoleBinding(list []*RoleBindingCRD, name string) *RoleBindingCRD {
+	for _, crd := range list {
+		if crd.Metadata.Name == name {
+			return crd
+		}
+	}
+	return nil
+}
+
+func findAccountBinding(list []*AccountBindingCRD, name string) *AccountBindingCRD {
+	for _, crd := range list {
+		if crd.Metadata.Name == name {
+			return crd
+		}
+	}
+	return nil
+}
+
+func findNodeBinding(list []*NodeBindingCRD, name string) *NodeBindingCRD {
+	for _, crd := range list {
+		if crd.Metadata.Name == name {
+			return crd
+		}
+	}
+	return nil
+}
+
+func findWorkspaceBinding(list []*WorkspaceBindingCRD, name string) *WorkspaceBindingCRD {
+	for _, crd := range list {
+		if crd.Metadata.Name == name {
+			return crd
+		}
+	}
+	return nil
+}
+
+// ─── Event emission ───────────────────────────────────────────────────────────
+
+func (p *RBACProvider) emitRBACEvent(eventType string, data map[string]any) {
+	if p.emit == nil {
+		return
+	}
+	data["source"] = rbacEventSource
+	if err := p.emit(eventType, data); err != nil {
+		log.Printf("[rbac] emit %s: %v", eventType, err)
+	}
+}

--- a/rbac_provider_test.go
+++ b/rbac_provider_test.go
@@ -1,0 +1,511 @@
+// rbac_provider_test.go
+// Tests for RBACProvider: LoadConfig, ComputePlan, ApplyPlan+FetchLive, Health.
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+// newTestRBACProvider builds a provider with a no-op emit for testing.
+func newTestRBACProvider() *RBACProvider {
+	return NewRBACProvider(nil) // nil emit → no-op
+}
+
+// writeFixtureBinding writes a binding YAML to a temp directory.
+func writeFixtureBinding(t *testing.T, root, kind, name, content string) {
+	t.Helper()
+	dir := filepath.Join(root, ".cog", "config", "rbac", "bindings", kind)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o640); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+// ─── LoadConfig ───────────────────────────────────────────────────────────────
+
+func TestRBACProvider_LoadConfig_DirectoryScan(t *testing.T) {
+	root := t.TempDir()
+
+	writeFixtureBinding(t, root, "rolebinding", "cog-orchestrator.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: RoleBinding
+metadata:
+  name: cog-orchestrator
+spec:
+  subject: cog
+  role_ref: orchestrator
+`)
+	writeFixtureBinding(t, root, "accountbinding", "cog-on-darkstar.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: AccountBinding
+metadata:
+  name: cog-on-darkstar
+spec:
+  subject: cog
+  node: darkstar
+  account: slowbro
+`)
+	writeFixtureBinding(t, root, "nodebinding", "cog-can-embody.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: NodeBinding
+metadata:
+  name: cog-can-embody
+spec:
+  subject: cog
+  node: darkstar
+  relation: can-embody
+`)
+	writeFixtureBinding(t, root, "workspacebinding", "cog-workspace-owner.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: WorkspaceBinding
+metadata:
+  name: cog-workspace-owner
+spec:
+  subject: cog
+  workspace_uri: cog://workspaces/cog
+  access: owner
+`)
+
+	p := newTestRBACProvider()
+	cfg, err := p.LoadConfig(root)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	rbacCfg, ok := cfg.(*rbacConfig)
+	if !ok {
+		t.Fatalf("expected *rbacConfig, got %T", cfg)
+	}
+
+	if len(rbacCfg.Bindings.RoleBindings) != 1 {
+		t.Errorf("RoleBindings: got %d, want 1", len(rbacCfg.Bindings.RoleBindings))
+	}
+	if len(rbacCfg.Bindings.AccountBindings) != 1 {
+		t.Errorf("AccountBindings: got %d, want 1", len(rbacCfg.Bindings.AccountBindings))
+	}
+	if len(rbacCfg.Bindings.NodeBindings) != 1 {
+		t.Errorf("NodeBindings: got %d, want 1", len(rbacCfg.Bindings.NodeBindings))
+	}
+	if len(rbacCfg.Bindings.WorkspaceBindings) != 1 {
+		t.Errorf("WorkspaceBindings: got %d, want 1", len(rbacCfg.Bindings.WorkspaceBindings))
+	}
+}
+
+func TestRBACProvider_LoadConfig_EmptyWorkspace(t *testing.T) {
+	root := t.TempDir()
+	p := newTestRBACProvider()
+	cfg, err := p.LoadConfig(root)
+	if err != nil {
+		t.Fatalf("LoadConfig on empty workspace: %v", err)
+	}
+	rbacCfg := cfg.(*rbacConfig)
+	if len(rbacCfg.Bindings.RoleBindings) != 0 {
+		t.Errorf("expected 0 RoleBindings, got %d", len(rbacCfg.Bindings.RoleBindings))
+	}
+}
+
+// ─── ComputePlan ─────────────────────────────────────────────────────────────
+
+func TestRBACProvider_ComputePlan_EmptyLive(t *testing.T) {
+	// With nothing in live state, all spec bindings become creates.
+	root := t.TempDir()
+
+	writeFixtureBinding(t, root, "rolebinding", "cog-orchestrator.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: RoleBinding
+metadata:
+  name: cog-orchestrator
+spec:
+  subject: cog
+  role_ref: orchestrator
+`)
+
+	p := newTestRBACProvider()
+	cfg, err := p.LoadConfig(root)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	live := newRBACLive() // empty live state
+	plan, err := p.ComputePlan(cfg, live, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+
+	if plan.Summary.Creates != 1 {
+		t.Errorf("Creates: got %d, want 1", plan.Summary.Creates)
+	}
+	if plan.Summary.Skipped != 0 {
+		t.Errorf("Skipped: got %d, want 0", plan.Summary.Skipped)
+	}
+	if len(plan.Actions) != 1 {
+		t.Fatalf("Actions: got %d, want 1", len(plan.Actions))
+	}
+	if plan.Actions[0].Action != ActionCreate {
+		t.Errorf("Action: got %q, want %q", plan.Actions[0].Action, ActionCreate)
+	}
+	if plan.Actions[0].ResourceType != "rolebinding" {
+		t.Errorf("ResourceType: got %q, want %q", plan.Actions[0].ResourceType, "rolebinding")
+	}
+}
+
+func TestRBACProvider_ComputePlan_AlreadySynced(t *testing.T) {
+	// When the live state already has a binding matching the spec, it becomes a skip.
+	root := t.TempDir()
+
+	writeFixtureBinding(t, root, "rolebinding", "cog-orchestrator.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: RoleBinding
+metadata:
+  name: cog-orchestrator
+spec:
+  subject: cog
+  role_ref: orchestrator
+`)
+
+	p := newTestRBACProvider()
+	cfg, err := p.LoadConfig(root)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	// Pre-populate live state with the same binding.
+	live := newRBACLive()
+	live.RoleBindings["rolebinding/cog-orchestrator"] = &RoleBindingCRD{
+		APIVersion: "cog.os/v1alpha1",
+		Kind:       "RoleBinding",
+		Metadata:   RBACMeta{Name: "cog-orchestrator"},
+		Spec:       RoleBindingSpec{Subject: "cog", RoleRef: "orchestrator"},
+	}
+
+	plan, err := p.ComputePlan(cfg, live, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if plan.Summary.Creates != 0 {
+		t.Errorf("Creates: got %d, want 0", plan.Summary.Creates)
+	}
+	if plan.Summary.Skipped != 1 {
+		t.Errorf("Skipped: got %d, want 1", plan.Summary.Skipped)
+	}
+}
+
+func TestRBACProvider_ComputePlan_MultipleKinds(t *testing.T) {
+	// All four structural binding kinds generate creates against empty live.
+	root := t.TempDir()
+
+	writeFixtureBinding(t, root, "rolebinding", "rb.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: RoleBinding
+metadata:
+  name: rb
+spec:
+  subject: cog
+  role_ref: orchestrator
+`)
+	writeFixtureBinding(t, root, "accountbinding", "ab.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: AccountBinding
+metadata:
+  name: ab
+spec:
+  subject: cog
+  node: darkstar
+  account: slowbro
+`)
+	writeFixtureBinding(t, root, "nodebinding", "nb.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: NodeBinding
+metadata:
+  name: nb
+spec:
+  subject: cog
+  node: darkstar
+  relation: can-embody
+`)
+	writeFixtureBinding(t, root, "workspacebinding", "wb.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: WorkspaceBinding
+metadata:
+  name: wb
+spec:
+  subject: cog
+  workspace_uri: cog://workspaces/cog
+  access: owner
+`)
+
+	p := newTestRBACProvider()
+	cfg, err := p.LoadConfig(root)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	plan, err := p.ComputePlan(cfg, newRBACLive(), nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if plan.Summary.Creates != 4 {
+		t.Errorf("Creates: got %d, want 4", plan.Summary.Creates)
+	}
+}
+
+// ─── ApplyPlan + FetchLive convergence ───────────────────────────────────────
+
+func TestRBACProvider_ApplyThenFetchLive_Convergence(t *testing.T) {
+	// Apply a create action and verify FetchLive returns the new binding.
+	// This is the scope-packet test plan item 5:
+	// "ApplyPlan followed by FetchLive; assert live state matches spec"
+	root := t.TempDir()
+
+	writeFixtureBinding(t, root, "rolebinding", "cog-orchestrator.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: RoleBinding
+metadata:
+  name: cog-orchestrator
+spec:
+  subject: cog
+  role_ref: orchestrator
+`)
+
+	p := newTestRBACProvider()
+	cfg, err := p.LoadConfig(root)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	live0, err := p.FetchLive(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("FetchLive (before apply): %v", err)
+	}
+
+	plan, err := p.ComputePlan(cfg, live0, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if plan.Summary.Creates != 1 {
+		t.Fatalf("expected 1 create before apply, got %d", plan.Summary.Creates)
+	}
+
+	results, err := p.ApplyPlan(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("ApplyPlan: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results: got %d, want 1", len(results))
+	}
+	if results[0].Status != ApplySucceeded {
+		t.Errorf("result status: got %q, want %q (err: %s)", results[0].Status, ApplySucceeded, results[0].Error)
+	}
+
+	// Verify disk write.
+	diskPath := filepath.Join(root, ".cog", "config", "rbac", "bindings", "rolebinding", "cog-orchestrator.yaml")
+	if _, err := os.Stat(diskPath); err != nil {
+		t.Errorf("binding not written to disk: %v", err)
+	}
+
+	// FetchLive should now reflect the applied binding.
+	live1, err := p.FetchLive(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("FetchLive (after apply): %v", err)
+	}
+	liveState := live1.(*rbacLive)
+	if _, ok := liveState.RoleBindings["rolebinding/cog-orchestrator"]; !ok {
+		t.Errorf("expected rolebinding/cog-orchestrator in live state after apply")
+	}
+
+	// Second ComputePlan should show 0 creates (converged).
+	plan2, err := p.ComputePlan(cfg, live1, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan (post-apply): %v", err)
+	}
+	if plan2.Summary.Creates != 0 {
+		t.Errorf("Creates after convergence: got %d, want 0", plan2.Summary.Creates)
+	}
+	if plan2.Summary.Skipped != 1 {
+		t.Errorf("Skipped after convergence: got %d, want 1", plan2.Summary.Skipped)
+	}
+}
+
+// ─── AttachHarness + DetachHarness ───────────────────────────────────────────
+
+func TestRBACProvider_AttachDetachHarness(t *testing.T) {
+	p := newTestRBACProvider()
+
+	binding := &HarnessBindingCRD{
+		APIVersion: "cog.os/v1alpha1",
+		Kind:       "HarnessBinding",
+		Metadata:   RBACMeta{Name: "sess-001-agent"},
+		Spec: HarnessBindingSpec{
+			SessionID:   "sess-001",
+			Subject:     "cog",
+			Type:        "agent",
+			HarnessType: "claude-code",
+		},
+	}
+
+	p.AttachHarness(binding)
+
+	live, err := p.FetchLive(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("FetchLive: %v", err)
+	}
+	liveState := live.(*rbacLive)
+	if _, ok := liveState.HarnessBindings["sess-001/agent"]; !ok {
+		t.Errorf("harness binding not found after attach")
+	}
+
+	p.DetachHarness("sess-001", "agent")
+
+	live2, err := p.FetchLive(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("FetchLive after detach: %v", err)
+	}
+	liveState2 := live2.(*rbacLive)
+	if _, ok := liveState2.HarnessBindings["sess-001/agent"]; ok {
+		t.Errorf("harness binding still present after detach")
+	}
+}
+
+// ─── Health ───────────────────────────────────────────────────────────────────
+
+func TestRBACProvider_Health_InitiallyHealthy(t *testing.T) {
+	// Before any reconcile cycle, Health should return Healthy + Synced
+	// (no plan data yet, no schema errors).
+	p := newTestRBACProvider()
+	status := p.Health()
+	if status.Health != HealthHealthy {
+		t.Errorf("Health: got %q, want %q", status.Health, HealthHealthy)
+	}
+	if status.Sync != SyncStatusSynced {
+		t.Errorf("Sync: got %q, want %q (before any plan, summary zero = synced)", status.Sync, SyncStatusSynced)
+	}
+	if status.Operation != OperationIdle {
+		t.Errorf("Operation: got %q, want %q", status.Operation, OperationIdle)
+	}
+}
+
+func TestRBACProvider_Health_OutOfSync(t *testing.T) {
+	// After a plan with creates, Health should return OutOfSync.
+	root := t.TempDir()
+	writeFixtureBinding(t, root, "rolebinding", "rb.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: RoleBinding
+metadata:
+  name: rb
+spec:
+  subject: cog
+  role_ref: orchestrator
+`)
+
+	p := newTestRBACProvider()
+	cfg, err := p.LoadConfig(root)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	_, err = p.ComputePlan(cfg, newRBACLive(), nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+
+	status := p.Health()
+	if status.Sync != SyncStatusOutOfSync {
+		t.Errorf("Sync: got %q, want OutOfSync after plan with creates", status.Sync)
+	}
+	if status.Health != HealthHealthy {
+		t.Errorf("Health: got %q, want Healthy (no schema errors)", status.Health)
+	}
+}
+
+func TestRBACProvider_Health_SyncedAfterApply(t *testing.T) {
+	// After a full apply+fetch cycle, next ComputePlan shows 0 changes → Synced.
+	root := t.TempDir()
+	writeFixtureBinding(t, root, "rolebinding", "rb.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: RoleBinding
+metadata:
+  name: rb
+spec:
+  subject: cog
+  role_ref: orchestrator
+`)
+
+	p := newTestRBACProvider()
+	cfg, _ := p.LoadConfig(root)
+	plan, _ := p.ComputePlan(cfg, newRBACLive(), nil)
+	_, _ = p.ApplyPlan(context.Background(), plan)
+	live, _ := p.FetchLive(context.Background(), cfg)
+	_, _ = p.ComputePlan(cfg, live, nil)
+
+	status := p.Health()
+	if status.Sync != SyncStatusSynced {
+		t.Errorf("Sync: got %q, want Synced after converge", status.Sync)
+	}
+}
+
+// ─── BuildState ──────────────────────────────────────────────────────────────
+
+func TestRBACProvider_BuildState(t *testing.T) {
+	p := newTestRBACProvider()
+
+	live := newRBACLive()
+	live.RoleBindings["rolebinding/rb"] = &RoleBindingCRD{
+		APIVersion: "cog.os/v1alpha1",
+		Kind:       "RoleBinding",
+		Metadata:   RBACMeta{Name: "rb"},
+		Spec:       RoleBindingSpec{Subject: "cog", RoleRef: "orchestrator"},
+	}
+	live.HarnessBindings["sess-001/agent"] = &HarnessBindingCRD{
+		APIVersion: "cog.os/v1alpha1",
+		Kind:       "HarnessBinding",
+		Metadata:   RBACMeta{Name: "sess-001-agent"},
+		Spec:       HarnessBindingSpec{SessionID: "sess-001", Subject: "cog", Type: "agent", HarnessType: "claude-code"},
+	}
+
+	state, err := p.BuildState(nil, live, nil)
+	if err != nil {
+		t.Fatalf("BuildState: %v", err)
+	}
+	if state.ResourceType != "rbac-bindings" {
+		t.Errorf("ResourceType: got %q", state.ResourceType)
+	}
+	if len(state.Resources) != 2 {
+		t.Errorf("Resources: got %d, want 2 (1 rolebinding + 1 harnessbinding)", len(state.Resources))
+	}
+	if state.Metadata["role_binding_count"] != 1 {
+		t.Errorf("role_binding_count: got %v", state.Metadata["role_binding_count"])
+	}
+	if state.Metadata["harness_binding_count"] != 1 {
+		t.Errorf("harness_binding_count: got %v", state.Metadata["harness_binding_count"])
+	}
+}
+
+func TestRBACProvider_BuildState_SerialIncrement(t *testing.T) {
+	p := newTestRBACProvider()
+	live := newRBACLive()
+
+	state1, err := p.BuildState(nil, live, nil)
+	if err != nil {
+		t.Fatalf("BuildState (first): %v", err)
+	}
+	if state1.Serial != 1 {
+		t.Errorf("first Serial: got %d, want 1", state1.Serial)
+	}
+
+	state2, err := p.BuildState(nil, live, state1)
+	if err != nil {
+		t.Fatalf("BuildState (second): %v", err)
+	}
+	if state2.Serial != 2 {
+		t.Errorf("second Serial: got %d, want 2", state2.Serial)
+	}
+	if state2.Lineage != state1.Lineage {
+		t.Errorf("Lineage should be preserved across increments")
+	}
+}


### PR DESCRIPTION
## What this adds

Five new CRD types, a 7-method `RBACProvider`, a one-line wiring `init()`, and tests. **No existing files were modified.** The existing `rbac.go` flat-file `RoleLoader`/`Role` is untouched and continues to work.

### New files

| File | Purpose |
|------|---------|
| `rbac_bindings.go` | Five CRD types + `RBACMeta` envelope + `LoadRBACBindings` scanner |
| `rbac_provider.go` | `RBACProvider` implementing `Reconcilable` (7 methods) |
| `rbac_bindings_wiring.go` | `init()` block; `RegisterProvider("rbac-bindings", ...)` |
| `rbac_bindings_test.go` | YAML round-trips for all five CRD types |
| `rbac_provider_test.go` | Provider lifecycle tests (LoadConfig, ComputePlan, ApplyPlan+FetchLive, Health, BuildState) |

### CRD types

- `RoleBindingCRD` — binds identity to role (K8s RoleBinding analog)
- `AccountBindingCRD` — binds identity to OS account on a node
- `NodeBindingCRD` — asserts identity relationship to a hardware node (`can-embody` | `pinned-to`)
- `WorkspaceBindingCRD` — binds identity to a workspace URI with access level
- `HarnessBindingCRD` — links a harness session to the identity it embodies (in-memory only)

## OQ-6: Persistence tier decision (tier-split)

Structural bindings (`RoleBinding`, `AccountBinding`, `NodeBinding`, `WorkspaceBinding`) are persisted as YAML under `.cog/config/rbac/bindings/<kind>/<name>.yaml`. Directories are created by `ApplyPlan` on first write.

**`HarnessBinding` is in-memory only.** It is per-session ephemeral — created by `RBACProvider.AttachHarness()` when a session-register event arrives, removed by `DetachHarness()` when the session ends. It is never written to disk. `LoadConfig` does not scan for HarnessBindings.

The K8s analog: structural bindings are like RoleBindings (persisted); HarnessBindings are like Pod bindings (created at scheduling time, evaporate with the workload).

Example YAML for a structural binding:
```yaml
# .cog/config/rbac/bindings/rolebinding/cog-orchestrator.yaml
apiVersion: cog.os/v1alpha1
kind: RoleBinding
metadata:
  name: cog-orchestrator
spec:
  subject: cog
  role_ref: orchestrator
  scope: cog://workspaces/cog
```

```yaml
# .cog/config/rbac/bindings/workspacebinding/cog-owns-workspace.yaml
apiVersion: cog.os/v1alpha1
kind: WorkspaceBinding
metadata:
  name: cog-owns-workspace
spec:
  subject: cog
  workspace_uri: cog://workspaces/cog
  access: owner
```

## OQ-7: WorkspaceBindingCRD vs IdentityExpression.WorkspaceRoot (Primitive 1)

These are NOT redundant. They live at different layers:

- `WorkspaceBindingCRD` (this PR) is the **authoritative binding record** — it declares which identity owns which workspace URI with what access level. This is what the reconciler enforces.
- `IdentityExpression.WorkspaceRoot` (Primitive 1, parallel PR) is the **spec hint** — a declaration of intent on the identity spec. It says "this identity wants this workspace as home."

A future `WorkspaceReconciler` will converge the binding record toward the spec hint. For now both objects are independently useful: the binding record can exist without a spec hint (manual grant) and vice versa.

## Relationship to existing rbac.go

The existing `RoleLoader` / `Role` flat-file loader (`rbac.go`) continues to work unchanged. This PR adds the binding layer on top; it does not replace or modify the role-definition layer. Long-term, the `RoleLoader` will likely be absorbed into this provider in a Wave 6d refactor, but that is explicitly out of scope here.

## Registration path

`rbac_bindings_wiring.go` uses the same `init()` + `RegisterProvider` pattern as `identity_wiring.go`. No changes to `cog.go` or any existing file are needed — Go's `init()` graph picks it up automatically.

## Test coverage

All seven scope-packet test plan items are covered except item 7 (kernel-boot integration test via `reconcile_e2e_test.go`). That test requires kernel-boot scaffolding not yet in place and is deferred as a follow-up. All unit and existing integration tests pass (`go test ./... && go vet ./...`).

## In-flight context

This PR is fully additive (new files only) and has no file overlap with the concurrent Primitive 1 PR (`identity_crd.go`, `identity_provider.go`), RFC-0003 R4 (`#282`), or the substrate scaffold PR. Safe to merge in any order.