### PR TITLE
fix(rbac): validate required fields + wire schemaErrors into Health (closes #285 followups)

### DIFF
--- a/rbac_bindings.go
+++ b/rbac_bindings.go
@@ -212,97 +212,234 @@ type RBACBindingSet struct {
 // LoadRBACBindings reads all structural binding YAML files from the
 // .cog/config/rbac/bindings/ hierarchy. Missing directories are not errors;
 // a fresh workspace has no bindings yet.
-func LoadRBACBindings(root string) (*RBACBindingSet, error) {
+//
+// Two error categories are distinguished:
+//   - Fatal I/O errors (unreadable directory, unreadable file) cause an
+//     immediate return with nil set and a non-nil error.
+//   - Schema errors (YAML parse failures, missing required fields) are
+//     accumulated into schemaErrors and the valid files are still returned.
+//     This allows partial-load: a single bad file does not block the rest.
+//
+// Callers that need to surface schema errors in health reporting should
+// capture the schemaErrors slice (e.g. into RBACProvider.schemaErrors).
+func LoadRBACBindings(root string) (set *RBACBindingSet, schemaErrors []string, err error) {
 	base := rbacBindingsDir(root)
-	set := &RBACBindingSet{}
+	set = &RBACBindingSet{}
 
-	var err error
-
-	set.RoleBindings, err = loadRoleBindings(filepath.Join(base, "rolebinding"))
+	var roleErrs []string
+	set.RoleBindings, roleErrs, err = loadRoleBindings(filepath.Join(base, "rolebinding"))
 	if err != nil {
-		return nil, fmt.Errorf("rbac: load rolebindings: %w", err)
+		return nil, nil, fmt.Errorf("rbac: load rolebindings: %w", err)
 	}
+	schemaErrors = append(schemaErrors, roleErrs...)
 
-	set.AccountBindings, err = loadAccountBindings(filepath.Join(base, "accountbinding"))
+	var acctErrs []string
+	set.AccountBindings, acctErrs, err = loadAccountBindings(filepath.Join(base, "accountbinding"))
 	if err != nil {
-		return nil, fmt.Errorf("rbac: load accountbindings: %w", err)
+		return nil, nil, fmt.Errorf("rbac: load accountbindings: %w", err)
 	}
+	schemaErrors = append(schemaErrors, acctErrs...)
 
-	set.NodeBindings, err = loadNodeBindings(filepath.Join(base, "nodebinding"))
+	var nodeErrs []string
+	set.NodeBindings, nodeErrs, err = loadNodeBindings(filepath.Join(base, "nodebinding"))
 	if err != nil {
-		return nil, fmt.Errorf("rbac: load nodebindings: %w", err)
+		return nil, nil, fmt.Errorf("rbac: load nodebindings: %w", err)
 	}
+	schemaErrors = append(schemaErrors, nodeErrs...)
 
-	set.WorkspaceBindings, err = loadWorkspaceBindings(filepath.Join(base, "workspacebinding"))
+	var wsErrs []string
+	set.WorkspaceBindings, wsErrs, err = loadWorkspaceBindings(filepath.Join(base, "workspacebinding"))
 	if err != nil {
-		return nil, fmt.Errorf("rbac: load workspacebindings: %w", err)
+		return nil, nil, fmt.Errorf("rbac: load workspacebindings: %w", err)
 	}
+	schemaErrors = append(schemaErrors, wsErrs...)
 
-	return set, nil
+	return set, schemaErrors, nil
 }
 
-func loadRoleBindings(dir string) ([]*RoleBindingCRD, error) {
+// loadRoleBindings reads all RoleBindingCRD files from dir. Returns valid
+// bindings, any schema errors encountered, and a fatal I/O error if one occurs.
+func loadRoleBindings(dir string) ([]*RoleBindingCRD, []string, error) {
 	files, err := yamlFilesIn(dir)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	out := make([]*RoleBindingCRD, 0, len(files))
+	var errs []string
 	for _, f := range files {
 		var crd RoleBindingCRD
 		if err := decodeYAMLFile(f, &crd); err != nil {
-			return nil, fmt.Errorf("%s: %w", f, err)
+			errs = append(errs, fmt.Sprintf("%s: %v", f, err))
+			continue
+		}
+		if err := validateRoleBinding(&crd); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", f, err))
+			continue
 		}
 		out = append(out, &crd)
 	}
-	return out, nil
+	return out, errs, nil
 }
 
-func loadAccountBindings(dir string) ([]*AccountBindingCRD, error) {
+// loadAccountBindings reads all AccountBindingCRD files from dir. Returns valid
+// bindings, any schema errors encountered, and a fatal I/O error if one occurs.
+func loadAccountBindings(dir string) ([]*AccountBindingCRD, []string, error) {
 	files, err := yamlFilesIn(dir)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	out := make([]*AccountBindingCRD, 0, len(files))
+	var errs []string
 	for _, f := range files {
 		var crd AccountBindingCRD
 		if err := decodeYAMLFile(f, &crd); err != nil {
-			return nil, fmt.Errorf("%s: %w", f, err)
+			errs = append(errs, fmt.Sprintf("%s: %v", f, err))
+			continue
+		}
+		if err := validateAccountBinding(&crd); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", f, err))
+			continue
 		}
 		out = append(out, &crd)
 	}
-	return out, nil
+	return out, errs, nil
 }
 
-func loadNodeBindings(dir string) ([]*NodeBindingCRD, error) {
+// loadNodeBindings reads all NodeBindingCRD files from dir. Returns valid
+// bindings, any schema errors encountered, and a fatal I/O error if one occurs.
+func loadNodeBindings(dir string) ([]*NodeBindingCRD, []string, error) {
 	files, err := yamlFilesIn(dir)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	out := make([]*NodeBindingCRD, 0, len(files))
+	var errs []string
 	for _, f := range files {
 		var crd NodeBindingCRD
 		if err := decodeYAMLFile(f, &crd); err != nil {
-			return nil, fmt.Errorf("%s: %w", f, err)
+			errs = append(errs, fmt.Sprintf("%s: %v", f, err))
+			continue
+		}
+		if err := validateNodeBinding(&crd); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", f, err))
+			continue
 		}
 		out = append(out, &crd)
 	}
-	return out, nil
+	return out, errs, nil
 }
 
-func loadWorkspaceBindings(dir string) ([]*WorkspaceBindingCRD, error) {
+// loadWorkspaceBindings reads all WorkspaceBindingCRD files from dir. Returns
+// valid bindings, any schema errors encountered, and a fatal I/O error if one occurs.
+func loadWorkspaceBindings(dir string) ([]*WorkspaceBindingCRD, []string, error) {
 	files, err := yamlFilesIn(dir)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	out := make([]*WorkspaceBindingCRD, 0, len(files))
+	var errs []string
 	for _, f := range files {
 		var crd WorkspaceBindingCRD
 		if err := decodeYAMLFile(f, &crd); err != nil {
-			return nil, fmt.Errorf("%s: %w", f, err)
+			errs = append(errs, fmt.Sprintf("%s: %v", f, err))
+			continue
+		}
+		if err := validateWorkspaceBinding(&crd); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", f, err))
+			continue
 		}
 		out = append(out, &crd)
 	}
-	return out, nil
+	return out, errs, nil
+}
+
+// ─── Validators ─────────────────────────────────────────────────────────────
+
+// validateRoleBinding checks that required fields are present.
+// Returns a descriptive error if any required field is empty.
+func validateRoleBinding(crd *RoleBindingCRD) error {
+	if crd.Metadata.Name == "" {
+		return fmt.Errorf("binding: metadata.name is required")
+	}
+	if crd.Spec.Subject == "" {
+		return fmt.Errorf("binding %q: spec.subject is required", crd.Metadata.Name)
+	}
+	if crd.Spec.RoleRef == "" {
+		return fmt.Errorf("binding %q: spec.role_ref is required", crd.Metadata.Name)
+	}
+	return nil
+}
+
+// validateAccountBinding checks that required fields are present.
+func validateAccountBinding(crd *AccountBindingCRD) error {
+	if crd.Metadata.Name == "" {
+		return fmt.Errorf("binding: metadata.name is required")
+	}
+	if crd.Spec.Subject == "" {
+		return fmt.Errorf("binding %q: spec.subject is required", crd.Metadata.Name)
+	}
+	if crd.Spec.Node == "" {
+		return fmt.Errorf("binding %q: spec.node is required", crd.Metadata.Name)
+	}
+	if crd.Spec.Account == "" {
+		return fmt.Errorf("binding %q: spec.account is required", crd.Metadata.Name)
+	}
+	return nil
+}
+
+// validateNodeBinding checks that required fields are present.
+func validateNodeBinding(crd *NodeBindingCRD) error {
+	if crd.Metadata.Name == "" {
+		return fmt.Errorf("binding: metadata.name is required")
+	}
+	if crd.Spec.Subject == "" {
+		return fmt.Errorf("binding %q: spec.subject is required", crd.Metadata.Name)
+	}
+	if crd.Spec.Node == "" {
+		return fmt.Errorf("binding %q: spec.node is required", crd.Metadata.Name)
+	}
+	if crd.Spec.Relation == "" {
+		return fmt.Errorf("binding %q: spec.relation is required", crd.Metadata.Name)
+	}
+	return nil
+}
+
+// validateWorkspaceBinding checks that required fields are present.
+func validateWorkspaceBinding(crd *WorkspaceBindingCRD) error {
+	if crd.Metadata.Name == "" {
+		return fmt.Errorf("binding: metadata.name is required")
+	}
+	if crd.Spec.Subject == "" {
+		return fmt.Errorf("binding %q: spec.subject is required", crd.Metadata.Name)
+	}
+	if crd.Spec.WorkspaceURI == "" {
+		return fmt.Errorf("binding %q: spec.workspace_uri is required", crd.Metadata.Name)
+	}
+	if crd.Spec.Access == "" {
+		return fmt.Errorf("binding %q: spec.access is required", crd.Metadata.Name)
+	}
+	return nil
+}
+
+// validateHarnessBinding checks that required fields are present.
+// Used by callers that construct HarnessBindingCRDs at runtime (AttachHarness).
+func validateHarnessBinding(crd *HarnessBindingCRD) error {
+	if crd.Metadata.Name == "" {
+		return fmt.Errorf("binding: metadata.name is required")
+	}
+	if crd.Spec.SessionID == "" {
+		return fmt.Errorf("binding %q: spec.session_id is required", crd.Metadata.Name)
+	}
+	if crd.Spec.Subject == "" {
+		return fmt.Errorf("binding %q: spec.subject is required", crd.Metadata.Name)
+	}
+	if crd.Spec.Type == "" {
+		return fmt.Errorf("binding %q: spec.type is required", crd.Metadata.Name)
+	}
+	if crd.Spec.HarnessType == "" {
+		return fmt.Errorf("binding %q: spec.harness_type is required", crd.Metadata.Name)
+	}
+	return nil
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────

--- a/rbac_bindings_test.go
+++ b/rbac_bindings_test.go
@@ -1,11 +1,13 @@
 // rbac_bindings_test.go
-// Tests for RBAC binding CRD types: YAML round-trip for each CRD type.
+// Tests for RBAC binding CRD types: YAML round-trip for each CRD type,
+// required-field validation, and partial-load behavior.
 
 package main
 
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -394,9 +396,12 @@ spec:
 		}
 	}
 
-	set, err := LoadRBACBindings(root)
+	set, schemaErrs, err := LoadRBACBindings(root)
 	if err != nil {
 		t.Fatalf("LoadRBACBindings: %v", err)
+	}
+	if len(schemaErrs) != 0 {
+		t.Errorf("unexpected schema errors: %v", schemaErrs)
 	}
 
 	if len(set.RoleBindings) != 1 {
@@ -416,12 +421,251 @@ spec:
 func TestLoadRBACBindings_EmptyDir(t *testing.T) {
 	// A fresh workspace with no bindings directory is not an error.
 	root := t.TempDir()
-	set, err := LoadRBACBindings(root)
+	set, schemaErrs, err := LoadRBACBindings(root)
 	if err != nil {
 		t.Fatalf("LoadRBACBindings on empty workspace: %v", err)
+	}
+	if len(schemaErrs) != 0 {
+		t.Errorf("unexpected schema errors on empty workspace: %v", schemaErrs)
 	}
 	if len(set.RoleBindings) != 0 || len(set.AccountBindings) != 0 ||
 		len(set.NodeBindings) != 0 || len(set.WorkspaceBindings) != 0 {
 		t.Errorf("expected empty sets for fresh workspace")
+	}
+}
+
+// ─── Validation: required-field checks ───────────────────────────────────────
+
+func TestValidateRoleBinding_MissingSubject(t *testing.T) {
+	crd := &RoleBindingCRD{
+		APIVersion: "cog.os/v1alpha1",
+		Kind:       "RoleBinding",
+		Metadata:   RBACMeta{Name: "test-rb"},
+		Spec:       RoleBindingSpec{Subject: "", RoleRef: "orchestrator"},
+	}
+	err := validateRoleBinding(crd)
+	if err == nil {
+		t.Fatal("expected error for missing subject, got nil")
+	}
+	if !strings.Contains(err.Error(), "spec.subject") {
+		t.Errorf("error should mention spec.subject, got: %v", err)
+	}
+}
+
+func TestValidateRoleBinding_MissingRoleRef(t *testing.T) {
+	crd := &RoleBindingCRD{
+		APIVersion: "cog.os/v1alpha1",
+		Kind:       "RoleBinding",
+		Metadata:   RBACMeta{Name: "test-rb"},
+		Spec:       RoleBindingSpec{Subject: "cog", RoleRef: ""},
+	}
+	err := validateRoleBinding(crd)
+	if err == nil {
+		t.Fatal("expected error for missing role_ref, got nil")
+	}
+	if !strings.Contains(err.Error(), "spec.role_ref") {
+		t.Errorf("error should mention spec.role_ref, got: %v", err)
+	}
+}
+
+func TestValidateRoleBinding_MissingName(t *testing.T) {
+	crd := &RoleBindingCRD{
+		APIVersion: "cog.os/v1alpha1",
+		Kind:       "RoleBinding",
+		Metadata:   RBACMeta{Name: ""},
+		Spec:       RoleBindingSpec{Subject: "cog", RoleRef: "orchestrator"},
+	}
+	err := validateRoleBinding(crd)
+	if err == nil {
+		t.Fatal("expected error for missing name, got nil")
+	}
+	if !strings.Contains(err.Error(), "metadata.name") {
+		t.Errorf("error should mention metadata.name, got: %v", err)
+	}
+}
+
+func TestValidateRoleBinding_Valid(t *testing.T) {
+	crd := &RoleBindingCRD{
+		APIVersion: "cog.os/v1alpha1",
+		Kind:       "RoleBinding",
+		Metadata:   RBACMeta{Name: "cog-orchestrator"},
+		Spec:       RoleBindingSpec{Subject: "cog", RoleRef: "orchestrator"},
+	}
+	if err := validateRoleBinding(crd); err != nil {
+		t.Errorf("expected nil error for valid binding, got: %v", err)
+	}
+}
+
+func TestValidateAccountBinding_MissingFields(t *testing.T) {
+	cases := []struct {
+		name string
+		crd  *AccountBindingCRD
+		want string
+	}{
+		{
+			name: "missing subject",
+			crd: &AccountBindingCRD{
+				Metadata: RBACMeta{Name: "ab"},
+				Spec:     AccountBindingSpec{Subject: "", Node: "darkstar", Account: "slowbro"},
+			},
+			want: "spec.subject",
+		},
+		{
+			name: "missing node",
+			crd: &AccountBindingCRD{
+				Metadata: RBACMeta{Name: "ab"},
+				Spec:     AccountBindingSpec{Subject: "cog", Node: "", Account: "slowbro"},
+			},
+			want: "spec.node",
+		},
+		{
+			name: "missing account",
+			crd: &AccountBindingCRD{
+				Metadata: RBACMeta{Name: "ab"},
+				Spec:     AccountBindingSpec{Subject: "cog", Node: "darkstar", Account: ""},
+			},
+			want: "spec.account",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateAccountBinding(tc.crd)
+			if err == nil {
+				t.Fatalf("expected error for %s, got nil", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error should mention %q, got: %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestValidateNodeBinding_MissingRelation(t *testing.T) {
+	crd := &NodeBindingCRD{
+		Metadata: RBACMeta{Name: "nb"},
+		Spec:     NodeBindingSpec{Subject: "cog", Node: "darkstar", Relation: ""},
+	}
+	err := validateNodeBinding(crd)
+	if err == nil {
+		t.Fatal("expected error for missing relation, got nil")
+	}
+	if !strings.Contains(err.Error(), "spec.relation") {
+		t.Errorf("error should mention spec.relation, got: %v", err)
+	}
+}
+
+func TestValidateWorkspaceBinding_MissingWorkspaceURI(t *testing.T) {
+	crd := &WorkspaceBindingCRD{
+		Metadata: RBACMeta{Name: "wb"},
+		Spec:     WorkspaceBindingSpec{Subject: "cog", WorkspaceURI: "", Access: "owner"},
+	}
+	err := validateWorkspaceBinding(crd)
+	if err == nil {
+		t.Fatal("expected error for missing workspace_uri, got nil")
+	}
+	if !strings.Contains(err.Error(), "spec.workspace_uri") {
+		t.Errorf("error should mention spec.workspace_uri, got: %v", err)
+	}
+}
+
+func TestValidateHarnessBinding_MissingType(t *testing.T) {
+	crd := &HarnessBindingCRD{
+		Metadata: RBACMeta{Name: "hb"},
+		Spec:     HarnessBindingSpec{SessionID: "s1", Subject: "cog", Type: "", HarnessType: "claude-code"},
+	}
+	err := validateHarnessBinding(crd)
+	if err == nil {
+		t.Fatal("expected error for missing type, got nil")
+	}
+	if !strings.Contains(err.Error(), "spec.type") {
+		t.Errorf("error should mention spec.type, got: %v", err)
+	}
+}
+
+// ─── Partial-load: valid + invalid in same directory ─────────────────────────
+
+// TestLoadRBACBindings_PartialLoad verifies that a directory containing one
+// valid and one invalid binding loads the valid one and returns the schema error
+// for the invalid one — without aborting the whole load.
+func TestLoadRBACBindings_PartialLoad(t *testing.T) {
+	root := t.TempDir()
+	base := filepath.Join(root, ".cog", "config", "rbac", "bindings", "rolebinding")
+	if err := os.MkdirAll(base, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Good binding: fully valid.
+	goodYAML := `
+apiVersion: cog.os/v1alpha1
+kind: RoleBinding
+metadata:
+  name: cog-orchestrator
+spec:
+  subject: cog
+  role_ref: orchestrator
+`
+	if err := os.WriteFile(filepath.Join(base, "good.yaml"), []byte(goodYAML), 0o640); err != nil {
+		t.Fatalf("write good: %v", err)
+	}
+
+	// Bad binding: missing required subject field.
+	badYAML := `
+apiVersion: cog.os/v1alpha1
+kind: RoleBinding
+metadata:
+  name: missing-subject
+spec:
+  role_ref: orchestrator
+`
+	if err := os.WriteFile(filepath.Join(base, "bad.yaml"), []byte(badYAML), 0o640); err != nil {
+		t.Fatalf("write bad: %v", err)
+	}
+
+	set, schemaErrs, err := LoadRBACBindings(root)
+	if err != nil {
+		t.Fatalf("LoadRBACBindings returned fatal error: %v", err)
+	}
+
+	// The valid binding should still load.
+	if len(set.RoleBindings) != 1 {
+		t.Errorf("RoleBindings: got %d, want 1 (only the valid binding)", len(set.RoleBindings))
+	}
+	if len(set.RoleBindings) == 1 && set.RoleBindings[0].Metadata.Name != "cog-orchestrator" {
+		t.Errorf("loaded wrong binding: got %q, want cog-orchestrator", set.RoleBindings[0].Metadata.Name)
+	}
+
+	// The invalid binding should produce exactly one schema error.
+	if len(schemaErrs) != 1 {
+		t.Errorf("schemaErrs: got %d, want 1; errors: %v", len(schemaErrs), schemaErrs)
+	}
+	if len(schemaErrs) > 0 && !strings.Contains(schemaErrs[0], "spec.subject") {
+		t.Errorf("schema error should mention spec.subject, got: %q", schemaErrs[0])
+	}
+}
+
+// TestLoadRBACBindings_UnparseableYAML verifies that a completely malformed
+// YAML file produces a schema error (not a fatal error) and skips the file.
+func TestLoadRBACBindings_UnparseableYAML(t *testing.T) {
+	root := t.TempDir()
+	base := filepath.Join(root, ".cog", "config", "rbac", "bindings", "rolebinding")
+	if err := os.MkdirAll(base, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Unparseable YAML.
+	if err := os.WriteFile(filepath.Join(base, "corrupt.yaml"),
+		[]byte("not: valid: yaml: at: all: [unclosed\n"), 0o640); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	set, schemaErrs, err := LoadRBACBindings(root)
+	if err != nil {
+		t.Fatalf("LoadRBACBindings returned fatal error: %v", err)
+	}
+	if len(set.RoleBindings) != 0 {
+		t.Errorf("expected 0 valid bindings from corrupt file, got %d", len(set.RoleBindings))
+	}
+	if len(schemaErrs) == 0 {
+		t.Error("expected at least one schema error for unparseable YAML, got none")
 	}
 }

--- a/rbac_provider.go
+++ b/rbac_provider.go
@@ -127,15 +127,25 @@ func (p *RBACProvider) Type() string { return "rbac-bindings" }
 // LoadConfig reads all structural binding YAML files from
 // .cog/config/rbac/bindings/. HarnessBindings are NOT loaded here —
 // they are populated at runtime via ApplyPlan when session events arrive.
+//
+// Schema errors (YAML parse failures, missing required fields) are stored in
+// p.schemaErrors so that Health() can report them. Valid files are still loaded;
+// schema errors do not abort the load. Fatal I/O errors cause LoadConfig to
+// return a non-nil error.
 func (p *RBACProvider) LoadConfig(root string) (any, error) {
 	p.mu.Lock()
 	p.root = root
 	p.mu.Unlock()
 
-	bindings, err := LoadRBACBindings(root)
+	bindings, schemaErrs, err := LoadRBACBindings(root)
 	if err != nil {
 		return nil, fmt.Errorf("rbac provider: load config: %w", err)
 	}
+
+	p.mu.Lock()
+	p.schemaErrors = schemaErrs
+	p.mu.Unlock()
+
 	return &rbacConfig{Root: root, Bindings: bindings}, nil
 }
 
@@ -364,7 +374,11 @@ func (p *RBACProvider) ApplyPlan(ctx context.Context, plan *ReconcilePlan) ([]Re
 	}()
 
 	// Reload specs so we have the full YAML for creates.
-	bindings, err := LoadRBACBindings(root)
+	// Schema errors from this reload are intentionally not re-stored in
+	// p.schemaErrors here — LoadConfig is the authoritative load path for
+	// health tracking. ApplyPlan uses the reload only to fetch CRD structs
+	// for creates; any new schema errors will surface on the next LoadConfig.
+	bindings, _, err := LoadRBACBindings(root)
 	if err != nil {
 		return nil, fmt.Errorf("rbac provider: reload specs for apply: %w", err)
 	}

--- a/rbac_provider_test.go
+++ b/rbac_provider_test.go
@@ -509,3 +509,132 @@ func TestRBACProvider_BuildState_SerialIncrement(t *testing.T) {
 		t.Errorf("Lineage should be preserved across increments")
 	}
 }
+
+// ─── schemaErrors wiring + Health.Degraded ───────────────────────────────────
+
+// TestRBACProvider_LoadConfig_SchemaErrorsStored verifies that LoadConfig
+// populates p.schemaErrors when a binding file has a missing required field,
+// and that the valid bindings in the same directory are still loaded.
+func TestRBACProvider_LoadConfig_SchemaErrorsStored(t *testing.T) {
+	root := t.TempDir()
+
+	// One valid binding.
+	writeFixtureBinding(t, root, "rolebinding", "valid.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: RoleBinding
+metadata:
+  name: cog-orchestrator
+spec:
+  subject: cog
+  role_ref: orchestrator
+`)
+	// One invalid binding: subject missing.
+	writeFixtureBinding(t, root, "rolebinding", "bad.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: RoleBinding
+metadata:
+  name: missing-subject
+spec:
+  role_ref: orchestrator
+`)
+
+	p := newTestRBACProvider()
+	cfg, err := p.LoadConfig(root)
+	if err != nil {
+		t.Fatalf("LoadConfig returned fatal error: %v", err)
+	}
+
+	// Valid bindings still present in returned config.
+	rbacCfg, ok := cfg.(*rbacConfig)
+	if !ok {
+		t.Fatalf("expected *rbacConfig, got %T", cfg)
+	}
+	if len(rbacCfg.Bindings.RoleBindings) != 1 {
+		t.Errorf("RoleBindings: got %d, want 1 (only valid binding)", len(rbacCfg.Bindings.RoleBindings))
+	}
+
+	// schemaErrors populated.
+	p.mu.Lock()
+	gotErrs := len(p.schemaErrors)
+	p.mu.Unlock()
+	if gotErrs != 1 {
+		t.Errorf("schemaErrors: got %d, want 1", gotErrs)
+	}
+}
+
+// TestRBACProvider_Health_DegradedOnSchemaError verifies that Health() reports
+// Degraded when LoadConfig stored at least one schema error. This closes the
+// dead-code path for p.schemaErrors that was identified in the PR #285 review.
+func TestRBACProvider_Health_DegradedOnSchemaError(t *testing.T) {
+	root := t.TempDir()
+
+	// Write a binding with a missing required field.
+	writeFixtureBinding(t, root, "rolebinding", "bad.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: RoleBinding
+metadata:
+  name: missing-subject
+spec:
+  role_ref: orchestrator
+`)
+
+	p := newTestRBACProvider()
+	_, err := p.LoadConfig(root)
+	if err != nil {
+		t.Fatalf("LoadConfig returned fatal error: %v", err)
+	}
+
+	h := p.Health()
+	if h.Health != HealthDegraded {
+		t.Errorf("Health.Health = %q, want Degraded after schema error", h.Health)
+	}
+	if h.Message == "" {
+		t.Error("Health.Message should be non-empty when Degraded")
+	}
+}
+
+// TestRBACProvider_Health_HealthyAfterCleanReload verifies that a subsequent
+// LoadConfig with valid files clears the schema errors and restores Healthy.
+// This confirms per-call accumulation semantics: each LoadConfig replaces
+// schemaErrors rather than appending cumulatively.
+func TestRBACProvider_Health_HealthyAfterCleanReload(t *testing.T) {
+	root := t.TempDir()
+
+	// First load: bad binding → Degraded.
+	writeFixtureBinding(t, root, "rolebinding", "bad.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: RoleBinding
+metadata:
+  name: missing-subject
+spec:
+  role_ref: orchestrator
+`)
+
+	p := newTestRBACProvider()
+	if _, err := p.LoadConfig(root); err != nil {
+		t.Fatalf("first LoadConfig: %v", err)
+	}
+	if p.Health().Health != HealthDegraded {
+		t.Fatal("expected Degraded after first load with bad binding")
+	}
+
+	// Fix the bad binding in place.
+	writeFixtureBinding(t, root, "rolebinding", "bad.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: RoleBinding
+metadata:
+  name: now-valid
+spec:
+  subject: cog
+  role_ref: orchestrator
+`)
+
+	// Second load: all bindings valid → Healthy.
+	if _, err := p.LoadConfig(root); err != nil {
+		t.Fatalf("second LoadConfig: %v", err)
+	}
+	h := p.Health()
+	if h.Health != HealthHealthy {
+		t.Errorf("Health.Health = %q, want Healthy after clean reload", h.Health)
+	}
+}


### PR DESCRIPTION
## What this fixes

Two bugs surfaced by the e2e tests in PR #286, both in \`RBACProvider\` as shipped in #285.

### Bug 1 — Dead \`schemaErrors\` field

\`RBACProvider\` has a \`schemaErrors []string\` field and \`Health()\` reads it to report \`Degraded\` status. But \`LoadConfig\` / \`LoadRBACBindings\` never wrote to it — errors were returned directly from \`LoadConfig\` instead. The \`Health() → Degraded\` path was dead code; \`Health()\` always showed \`Healthy\` regardless of bad files.

**Fix:** \`LoadRBACBindings\` now returns a \`[]string\` schema-error slice as its second return value. \`LoadConfig\` stores that slice into \`p.schemaErrors\`. \`Health()\` now has live data to report against. Per-call accumulation semantics: each \`LoadConfig\` replaces \`schemaErrors\` so a subsequent clean reload restores \`Healthy\`.

### Bug 2 — Missing required-field validation in \`LoadRBACBindings\`

YAML deserialization silently assigns empty string to missing fields — a binding file with \`spec.subject\` absent just deserializes to \`Subject: ""\`. No error was surfaced. #286's \`TestRBACProvider_E2E_HealthOnSchemaError\` had to use completely unparseable YAML to hit any error path.

**Fix:** Five \`validate*\` functions — one per CRD type — check all required fields after decode. Example error:

```
binding "missing-subject": spec.subject is required
```

Required fields validated per CRD:
| CRD | Required fields |
|-----|----------------|
| RoleBinding | \`metadata.name\`, \`spec.subject\`, \`spec.role_ref\` |
| AccountBinding | \`metadata.name\`, \`spec.subject\`, \`spec.node\`, \`spec.account\` |
| NodeBinding | \`metadata.name\`, \`spec.subject\`, \`spec.node\`, \`spec.relation\` |
| WorkspaceBinding | \`metadata.name\`, \`spec.subject\`, \`spec.workspace_uri\`, \`spec.access\` |
| HarnessBinding | \`metadata.name\`, \`spec.session_id\`, \`spec.subject\`, \`spec.type\`, \`spec.harness_type\` |

**Partial-load behavior:** YAML parse failures and validation errors go into the \`schemaErrors\` slice; valid files in the same directory are still loaded. \`LoadRBACBindings\` signature changes from \`(*RBACBindingSet, error)\` to \`(*RBACBindingSet, []string, error)\`. Fatal I/O errors (unreadable directory/file) remain a hard error.

## Tests added

**\`rbac_bindings_test.go\`**
- \`TestValidateRoleBinding_*\` — missing subject, role_ref, name
- \`TestValidateAccountBinding_MissingFields\` — table test for all three fields
- \`TestValidateNodeBinding_MissingRelation\`
- \`TestValidateWorkspaceBinding_MissingWorkspaceURI\`
- \`TestValidateHarnessBinding_MissingType\`
- \`TestLoadRBACBindings_PartialLoad\` — valid+invalid in same dir; valid loads, one schema error returned
- \`TestLoadRBACBindings_UnparseableYAML\` — parse failure goes to schemaErrors, zero bindings loaded

**\`rbac_provider_test.go\`**
- \`TestRBACProvider_LoadConfig_SchemaErrorsStored\` — p.schemaErrors populated; valid binding still in config
- \`TestRBACProvider_Health_DegradedOnSchemaError\` — Health() returns Degraded after LoadConfig with missing-field binding
- \`TestRBACProvider_Health_HealthyAfterCleanReload\` — clean reload restores Healthy

## Follow-up: PR #286

\`TestRBACProvider_E2E_HealthOnSchemaError\` in #286 currently uses unparseable YAML to hit the error path. Now that required-field validation is wired, that test should be converted to use a missing-field binding (the more natural form). This conversion should happen in a separate PR after both this fix and #286 merge, to avoid a three-way merge.