### PR TITLE
feat(engine): factor engine.Boot out of runServe + internal/testkernel scaffold (ADR-101 Phase 1)

### DIFF
--- a/internal/engine/boot.go
+++ b/internal/engine/boot.go
@@ -1,0 +1,252 @@
+// boot.go — engine.Boot: in-process kernel boot, factored out of runServe.
+//
+// ADR-101 Phase 1: factor the boot sequence from runServe into a function
+// that accepts a context and returns a *Kernel handle. runServe becomes a
+// thin wrapper that handles daemon-lifecycle concerns (planServeState,
+// saveDaemonState, signal context) and then calls Boot.
+//
+// Boot does NOT:
+//   - Install OS signal handlers (caller's responsibility).
+//   - Write or clean up the daemon state file.
+//   - Call os.Exit on error (returns error instead).
+//   - Call RegisterProviders or SetProvidersWorkspace (already done by runServe
+//     before Boot is called; these are intentionally nil in test paths).
+//
+// Boot DOES:
+//   - Load the nucleus.
+//   - Build Process, Router, Server, ReconcileDaemon.
+//   - Wire telemetry (no-op if no collector).
+//   - Wire LocalHarnessController if an MCP server is present.
+//   - Start all long-lived goroutines (process loop, HTTP server, reconcile daemon,
+//     projection watchers).
+//   - Block until the HTTP server is ready (listening) before returning.
+//   - Return a *Kernel handle that gives callers Endpoint(), WorkspaceRoot(), and Stop().
+//
+// Phase 2 options (WithIsolatedRegistry, etc.) are not implemented here;
+// the BootOption type and option-application pattern are established so the
+// surface is stable for incremental addition.
+package engine
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"time"
+)
+
+// BootOption is a functional option passed to Boot.
+//
+// Phase 1 defines no options with observable effect; the type exists so
+// that Boot's signature is stable. Phase 2 will add WithIsolatedRegistry,
+// WithPollInterval, etc. without changing callers.
+type BootOption func(*bootConfig)
+
+// bootConfig holds the resolved configuration derived from BootOptions.
+// All fields are optional; zero values mean "use the kernel default".
+type bootConfig struct {
+	// pollInterval overrides the ReconcileDaemon tick interval.
+	// 0 means use the ReconcileDaemon default (30 s).
+	pollInterval time.Duration
+
+	// Phase 2: isolated provider list (nil = use global registry).
+	// providers []reconcile.Reconcilable
+}
+
+func applyBootOptions(opts []BootOption) bootConfig {
+	cfg := bootConfig{}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	return cfg
+}
+
+// Kernel is an opaque handle to a running in-process kernel instance.
+// Obtain via Boot; release via Stop.
+type Kernel struct {
+	cfg             *Config
+	server          *Server
+	process         *Process
+	reconcileDaemon *ReconcileDaemon
+	cancel          context.CancelFunc
+	httpEndpoint    string // resolved actual addr, e.g. "http://127.0.0.1:54321"
+	serverDone      chan error
+	processDone     chan error
+	shutdownTelemetry func(context.Context)
+}
+
+// Endpoint returns the base URL of the kernel's HTTP server,
+// e.g. "http://127.0.0.1:54321".
+func (k *Kernel) Endpoint() string {
+	return k.httpEndpoint
+}
+
+// WorkspaceRoot returns the workspace root path in use.
+func (k *Kernel) WorkspaceRoot() string {
+	return k.cfg.WorkspaceRoot
+}
+
+// Stop cancels the kernel's context and waits for all goroutines to exit
+// within a 10-second deadline. Safe to call multiple times (idempotent after
+// first call; subsequent calls return nil immediately).
+func (k *Kernel) Stop() error {
+	k.cancel()
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer shutdownCancel()
+
+	if err := k.server.Shutdown(shutdownCtx); err != nil {
+		slog.Warn("kernel stop: server shutdown error", "err", err)
+	}
+
+	// Wait for the process goroutine.
+	select {
+	case <-k.processDone:
+	case <-shutdownCtx.Done():
+		slog.Warn("kernel stop: process did not stop in time")
+	}
+
+	if k.shutdownTelemetry != nil {
+		k.shutdownTelemetry(context.Background())
+	}
+
+	return nil
+}
+
+// Boot starts a kernel in-process. It loads the nucleus, builds all kernel
+// subsystems, starts the HTTP server on a pre-allocated listener, and returns
+// a *Kernel handle once the server is accepting connections.
+//
+// The kernel runs until ctx is cancelled or Stop is called.
+//
+// cfg must be a fully resolved *Config (LoadConfig + any flag overrides already
+// applied by the caller). Boot does not call os.Exit; any failure returns error.
+//
+// RegisterProviders / SetProvidersWorkspace are expected to have been called
+// (or intentionally left nil) by the caller before Boot.
+func Boot(ctx context.Context, cfg *Config, opts ...BootOption) (*Kernel, error) {
+	_ = applyBootOptions(opts) // Phase 2 will read these fields.
+
+	// Load nucleus (identity core).
+	nucleus, err := LoadNucleus(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("boot: nucleus load failed: %w", err)
+	}
+	slog.Info("nucleus loaded", "summary", nucleus.Summary())
+
+	// Build the continuous process.
+	process := NewProcess(cfg, nucleus)
+
+	// Load TRM model and embedding index (optional — graceful degradation).
+	if trm, embIdx := loadTRMAtStartup(cfg); trm != nil && embIdx != nil {
+		process.SetTRM(trm, embIdx)
+		slog.Info("trm: wired into context assembly pipeline")
+	}
+
+	// Build the inference router.
+	router, err := BuildRouter(cfg)
+	if err != nil {
+		slog.Warn("router build failed; inference disabled", "err", err)
+	}
+
+	// Build the HTTP server.
+	server := NewServer(cfg, nucleus, process)
+	server.SetRouter(router)
+
+	// Wire the session-activity publisher.
+	if server.busSessions != nil {
+		process.SetSessionActivityPublisher(server.busSessions.AppendEvent)
+	}
+
+	// Initialize telemetry (traces + metrics). No-op if no collector is available.
+	shutdownTelemetry := initTelemetry(ctx)
+
+	// Derived context the kernel owns; caller's ctx cancellation also stops it.
+	kernelCtx, cancel := context.WithCancel(ctx)
+
+	// Wire LocalHarnessController if an MCP server is present.
+	if server.mcpServer != nil {
+		ctrl, err := NewLocalHarnessController(cfg, nucleus, process, server.mcpServer)
+		if err != nil {
+			slog.Warn("local harness disabled", "err", err)
+		} else {
+			ctrl.SetBusSessionManager(server.busSessions)
+			server.SetAgentController(ctrl)
+			ctrl.Start(kernelCtx)
+			slog.Info("local harness started", "agent_id", DefaultAgentID, "interval", ctrl.interval.String())
+		}
+	}
+
+	// ADR-092 §2 step 4: Reconcile loop start.
+	reconcileDaemon := NewReconcileDaemon(ReconcileDaemonConfig{
+		WorkspaceRoot: cfg.WorkspaceRoot,
+	})
+	reconcileDaemon.Start(kernelCtx)
+
+	// Wire ProjectionWatcher as an early-trigger source.
+	for _, kind := range AllProjectionKinds {
+		kind := kind
+		nodesDir := cfg.WorkspaceRoot + "/.cog/mem/semantic/lineage/nodes"
+		providerType := "lineage-projection-" + string(kind)
+		watcher := NewProjectionWatcher(nodesDir, func(watchCtx context.Context) error {
+			reconcileDaemon.Trigger(providerType)
+			return nil
+		}, 0)
+		if err := watcher.Start(kernelCtx); err != nil {
+			slog.Debug("projection watcher skipped (nodes dir not present)",
+				"kind", kind, "err", err)
+		} else {
+			slog.Info("projection watcher started", "kind", kind, "nodes_dir", nodesDir)
+		}
+	}
+
+	// Pre-allocate the listener so we know the actual port before Start returns.
+	// This is necessary when cfg.Port == 0 (OS-assigned ephemeral port) so
+	// that Endpoint() can return a valid URL immediately after Boot.
+	listenAddr := fmt.Sprintf("%s:%d", cfg.BindAddr, cfg.Port)
+	if cfg.BindAddr == "" {
+		listenAddr = fmt.Sprintf("127.0.0.1:%d", cfg.Port)
+	}
+	ln, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("boot: listen %s: %w", listenAddr, err)
+	}
+
+	// Derive the actual endpoint URL from the listener.
+	actualAddr := ln.Addr().(*net.TCPAddr)
+	bindHost := cfg.BindAddr
+	if bindHost == "" {
+		bindHost = "127.0.0.1"
+	}
+	httpEndpoint := fmt.Sprintf("http://%s:%d", bindHost, actualAddr.Port)
+
+	// Start process goroutine.
+	processDone := make(chan error, 1)
+	go func() {
+		processDone <- process.Run(kernelCtx)
+	}()
+
+	// Start HTTP server goroutine using the pre-allocated listener.
+	serverDone := make(chan error, 1)
+	go func() {
+		if err := server.srv.Serve(ln); err != nil {
+			serverDone <- err
+		}
+	}()
+
+	k := &Kernel{
+		cfg:               cfg,
+		server:            server,
+		process:           process,
+		reconcileDaemon:   reconcileDaemon,
+		cancel:            cancel,
+		httpEndpoint:      httpEndpoint,
+		serverDone:        serverDone,
+		processDone:       processDone,
+		shutdownTelemetry: shutdownTelemetry,
+	}
+
+	slog.Info("kernel booted", "endpoint", httpEndpoint, "workspace", cfg.WorkspaceRoot)
+	return k, nil
+}

--- a/internal/engine/cli.go
+++ b/internal/engine/cli.go
@@ -186,6 +186,7 @@ func runServe(workspace string, port int, bindAddr string) {
 		slog.Info("providers workspace wired", "workspace", cfg.WorkspaceRoot)
 	}
 
+	// Daemon-already-running guard. Must stay in runServe, not Boot.
 	if reuse, msg, err := planServeState(cfg, checkDaemonHealth); err != nil {
 		slog.Error("daemon lifecycle failed", "err", err)
 		os.Exit(1)
@@ -194,6 +195,7 @@ func runServe(workspace string, port int, bindAddr string) {
 		return
 	}
 
+	// Daemon state file management. Must stay in runServe, not Boot.
 	state := buildDaemonState(cfg)
 	if err := saveDaemonState(state); err != nil {
 		slog.Error("daemon state write failed", "err", err)
@@ -205,141 +207,37 @@ func runServe(workspace string, port int, bindAddr string) {
 		}
 	}()
 
-	// Load nucleus (identity core).
-	nucleus, err := LoadNucleus(cfg)
-	if err != nil {
-		slog.Error("nucleus load failed", "err", err)
-		os.Exit(1)
-	}
-	slog.Info("nucleus loaded", "summary", nucleus.Summary())
-
-	// Build the continuous process.
-	process := NewProcess(cfg, nucleus)
-
-	// Load TRM model and embedding index (optional — graceful degradation).
-	if trm, embIdx := loadTRMAtStartup(cfg); trm != nil && embIdx != nil {
-		process.SetTRM(trm, embIdx)
-		slog.Info("trm: wired into context assembly pipeline")
-	}
-
-	// Build the inference router.
-	router, err := BuildRouter(cfg)
-	if err != nil {
-		slog.Warn("router build failed; inference disabled", "err", err)
-	}
-
-	// Build the HTTP server.
-	server := NewServer(cfg, nucleus, process)
-	server.SetRouter(router)
-
-	// Wire the session-activity publisher so handleTailerBlock can fan
-	// tailer blocks onto per-session bus channels (Phase 1A of the 4E
-	// cognitive-observer loop). server.busSessions is always non-nil by
-	// NewServer's contract; AppendEvent's signature matches
-	// SessionActivityPublisher by construction.
-	if server.busSessions != nil {
-		process.SetSessionActivityPublisher(server.busSessions.AppendEvent)
-	}
-
-	// Initialize telemetry (traces + metrics). No-op if no collector is available.
+	// Signal context for OS-level shutdown. Must stay in runServe, not Boot.
 	ctx0 := context.Background()
-	shutdownTelemetry := initTelemetry(ctx0)
-
-	// Root context cancelled on SIGINT / SIGTERM.
 	ctx, cancel := signal.NotifyContext(ctx0, syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
-	defer shutdownTelemetry(ctx0)
 
-	if server.mcpServer != nil {
-		ctrl, err := NewLocalHarnessController(cfg, nucleus, process, server.mcpServer)
-		if err != nil {
-			slog.Warn("local harness disabled", "err", err)
-		} else {
-			// Wire the bus layer so each tick emits a KernelHealthSnapshot
-			// to bus_kernel_proprio. This is optional — nil is a safe no-op.
-			ctrl.SetBusSessionManager(server.busSessions)
-			server.SetAgentController(ctrl)
-			ctrl.Start(ctx)
-			slog.Info("local harness started", "agent_id", DefaultAgentID, "interval", ctrl.interval.String())
-		}
+	// Boot the kernel. All subsystem construction, goroutine start, and
+	// listener allocation happen inside Boot. Boot does not call os.Exit.
+	kernel, err := Boot(ctx, cfg)
+	if err != nil {
+		slog.Error("kernel boot failed", "err", err)
+		os.Exit(1)
 	}
 
-	// ADR-092 §2 step 4: Reconcile loop start.
-	// ReconcileDaemon drives the full reconcile cycle for all registered
-	// Reconcilables on each periodic tick. ADR-095 specifies the contract.
-	reconcileDaemon := NewReconcileDaemon(ReconcileDaemonConfig{
-		WorkspaceRoot: cfg.WorkspaceRoot,
-	})
-	reconcileDaemon.Start(ctx)
-
-	// Wire ProjectionWatcher as an early-trigger source into the daemon.
-	// Each lineage-projection-<kind> Reconcilable gets a watcher that fires
-	// daemon.Trigger on file-system changes to the nodes/ directory.
-	// ADR-095 §4: watchers are specific early-trigger instances; the daemon
-	// driver is the general mechanism.
-	// The watcher is created with a nil-safe best-effort approach: if the
-	// nodes/ directory does not exist (workspace not yet initialized), the
-	// watcher Start call fails gracefully and no watch loop runs. Reconciliation
-	// still occurs on each periodic daemon tick.
-	for _, kind := range AllProjectionKinds {
-		kind := kind
-		nodesDir := cfg.WorkspaceRoot + "/.cog/mem/semantic/lineage/nodes"
-		providerType := "lineage-projection-" + string(kind)
-		watcher := NewProjectionWatcher(nodesDir, func(watchCtx context.Context) error {
-			reconcileDaemon.Trigger(providerType)
-			return nil
-		}, 0)
-		if err := watcher.Start(ctx); err != nil {
-			slog.Debug("projection watcher skipped (nodes dir not present)",
-				"kind", kind, "err", err)
-		} else {
-			slog.Info("projection watcher started", "kind", kind, "nodes_dir", nodesDir)
-		}
-	}
-
-	// Start process goroutine.
-	processDone := make(chan error, 1)
-	go func() {
-		processDone <- process.Run(ctx)
-	}()
-
-	// Start HTTP server goroutine.
-	serverDone := make(chan error, 1)
-	go func() {
-		if err := server.Start(); err != nil {
-			serverDone <- err
-		}
-	}()
-
-	// Wait for shutdown signal or fatal error.
+	// Wait for shutdown signal or fatal goroutine error.
 	select {
 	case <-ctx.Done():
 		slog.Info("cogos: shutdown signal received")
-	case err := <-serverDone:
+	case err := <-kernel.serverDone:
 		if err != nil {
 			slog.Error("server error", "err", err)
 			cancel()
 		}
-	case err := <-processDone:
+	case err := <-kernel.processDone:
 		if err != nil {
 			slog.Error("process error", "err", err)
 			cancel()
 		}
 	}
 
-	// Graceful shutdown.
-	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer shutdownCancel()
-
-	if err := server.Shutdown(shutdownCtx); err != nil {
-		slog.Warn("server shutdown error", "err", err)
-	}
-
-	// Wait for process to finish.
-	select {
-	case <-processDone:
-	case <-shutdownCtx.Done():
-		slog.Warn("process did not stop in time")
+	if err := kernel.Stop(); err != nil {
+		slog.Warn("kernel stop error", "err", err)
 	}
 
 	slog.Info("cogos: stopped")

--- a/internal/testkernel/testkernel.go
+++ b/internal/testkernel/testkernel.go
@@ -1,0 +1,205 @@
+// Package testkernel provides an in-process kernel boot harness for
+// daemon-level integration tests.
+//
+// ADR-101 Phase 1: thin wrapper over engine.Boot. Phase 2 will add
+// WithIsolatedRegistry; Phase 3 will add CallTool/HTTPClient; Phase 4 will
+// add goroutine-leak detection.
+//
+// Typical usage:
+//
+//	func TestFoo(t *testing.T) {
+//	    ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+//	    defer cancel()
+//
+//	    k, err := testkernel.Boot(ctx, t)
+//	    if err != nil {
+//	        t.Fatalf("testkernel.Boot: %v", err)
+//	    }
+//	    t.Cleanup(func() {
+//	        if err := k.Stop(); err != nil {
+//	            t.Errorf("testkernel.Stop: %v", err)
+//	        }
+//	    })
+//
+//	    // Probe the HTTP surface.
+//	    resp, err := http.Get(k.Endpoint() + "/health")
+//	    // ...
+//	}
+package testkernel
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/myrgic/cogos/internal/engine"
+)
+
+// Option is a functional option for Boot.
+//
+// Phase 1 defines no options with observable effect; the type exists so that
+// the API surface is stable for Phase 2 additions (WithIsolatedRegistry, etc.).
+type Option func(*config)
+
+// config holds resolved options derived from Option values.
+type config struct {
+	// workspace is the workspace root. Defaults to a t.TempDir() path.
+	workspace string
+
+	// port is the HTTP port. Defaults to 0 (OS-assigned ephemeral port).
+	port int
+
+	// pollInterval overrides the reconcile daemon tick. 0 = use daemon default.
+	// Phase 2 will expose this as WithPollInterval.
+	pollInterval time.Duration
+}
+
+// WithWorkspace sets the workspace root for the kernel under test.
+// Defaults to a temporary directory created at Boot time.
+func WithWorkspace(path string) Option {
+	return func(c *config) { c.workspace = path }
+}
+
+// Kernel is an opaque handle to an in-process kernel instance started by Boot.
+// Call Stop when the test finishes; the idiomatic pattern is t.Cleanup.
+type Kernel struct {
+	kernel   *engine.Kernel
+	endpoint string
+}
+
+// Endpoint returns the base URL of the kernel's HTTP server,
+// e.g. "http://127.0.0.1:54321".
+func (k *Kernel) Endpoint() string {
+	return k.endpoint
+}
+
+// WorkspaceRoot returns the workspace root path used by this kernel.
+func (k *Kernel) WorkspaceRoot() string {
+	return k.kernel.WorkspaceRoot()
+}
+
+// Stop cancels the kernel's context and waits for all goroutines to exit.
+// Safe to call multiple times.
+func (k *Kernel) Stop() error {
+	return k.kernel.Stop()
+}
+
+// Boot starts a kernel in-process with the given options.
+// It creates an isolated temporary workspace (unless WithWorkspace is given),
+// boots the kernel via engine.Boot, and blocks until the HTTP /health endpoint
+// responds 200 or ctx expires.
+//
+// Boot does NOT call RegisterProviders or SetProvidersWorkspace; tests that
+// need real providers must register them before calling Boot (Phase 1 note:
+// the smoke test runs against whatever providers are globally registered at
+// call time, which is none in test binaries — the reconcile daemon will run
+// with an empty provider set, which is fine for proving the harness works).
+func Boot(ctx context.Context, t *testing.T, opts ...Option) (*Kernel, error) {
+	t.Helper()
+
+	cfg := &config{port: 0}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	// Create a minimal workspace if none was provided.
+	workspace := cfg.workspace
+	if workspace == "" {
+		workspace = makeMinimalWorkspace(t)
+	}
+
+	engineCfg, err := engine.LoadConfig(workspace, cfg.port)
+	if err != nil {
+		return nil, fmt.Errorf("testkernel.Boot: load config: %w", err)
+	}
+	// In test paths, always use port 0 (OS-assigned ephemeral port) unless
+	// the caller explicitly set a port via WithPort (not yet exposed in Phase 1).
+	// LoadConfig with port==0 leaves the default 6931; we override explicitly
+	// here to avoid colliding with a running production daemon.
+	if cfg.port == 0 {
+		engineCfg.Port = 0
+	}
+	// Ensure loopback bind so the test can reach the server.
+	if engineCfg.BindAddr == "" {
+		engineCfg.BindAddr = "127.0.0.1"
+	}
+
+	k, err := engine.Boot(ctx, engineCfg)
+	if err != nil {
+		return nil, fmt.Errorf("testkernel.Boot: engine.Boot: %w", err)
+	}
+
+	// Wait for the HTTP server to be accepting connections.
+	if err := waitForHealth(ctx, k.Endpoint()); err != nil {
+		_ = k.Stop()
+		return nil, fmt.Errorf("testkernel.Boot: health check timeout: %w", err)
+	}
+
+	return &Kernel{kernel: k, endpoint: k.Endpoint()}, nil
+}
+
+// waitForHealth polls GET <endpoint>/health until a 200 is received or ctx
+// expires. Uses a 250 ms poll interval. The server goroutine is already
+// running inside engine.Boot, so the window is typically < 50 ms.
+func waitForHealth(ctx context.Context, endpoint string) error {
+	healthURL := endpoint + "/health"
+	client := &http.Client{Timeout: 500 * time.Millisecond}
+
+	for {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := client.Do(req)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(25 * time.Millisecond):
+		}
+	}
+}
+
+// makeMinimalWorkspace creates the directory structure required by LoadNucleus.
+// Mirrors the structure created by makeWorkspace in testhelper_test.go, but
+// lives in an exported package so integration tests outside internal/engine can
+// use it.
+func makeMinimalWorkspace(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+
+	dirs := []string{
+		filepath.Join(root, ".cog", "config"),
+		filepath.Join(root, ".cog", "mem", "semantic"),
+		filepath.Join(root, ".cog", "ledger"),
+		filepath.Join(root, "projects", "cog_lab_package", "identities"),
+	}
+	for _, d := range dirs {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			t.Fatalf("testkernel: makeMinimalWorkspace: mkdir %s: %v", d, err)
+		}
+	}
+
+	identity := "# Test\nRole: test-kernel\n"
+	identityFile := filepath.Join(root, "projects", "cog_lab_package", "identities", "identity_test.md")
+	if err := os.WriteFile(identityFile, []byte(identity), 0644); err != nil {
+		t.Fatalf("testkernel: write identity: %v", err)
+	}
+
+	idCfg := "default_identity: test\nidentity_directory: projects/cog_lab_package/identities\n"
+	if err := os.WriteFile(filepath.Join(root, ".cog", "config", "identity.yaml"), []byte(idCfg), 0644); err != nil {
+		t.Fatalf("testkernel: write identity.yaml: %v", err)
+	}
+
+	return root
+}

--- a/internal/testkernel/testkernel_test.go
+++ b/internal/testkernel/testkernel_test.go
@@ -1,0 +1,81 @@
+package testkernel_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/myrgic/cogos/internal/testkernel"
+)
+
+// TestTestKernel_BootsAndStops is the ADR-101 Phase 1 smoke test.
+// It proves that:
+//  1. Boot returns a Kernel handle without error.
+//  2. The kernel's HTTP server accepts connections and returns a valid
+//     /health response with status "ok".
+//  3. Stop shuts down cleanly without error.
+//
+// Note: this test runs against whatever Reconcilable providers are globally
+// registered at call time — none in the test binary (RegisterProviders is nil).
+// The reconcile daemon operates on an empty provider set, which is correct for
+// Phase 1. Phase 2 (WithIsolatedRegistry) is the mechanism for injecting real
+// providers in parallel-safe tests.
+func TestTestKernel_BootsAndStops(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	k, err := testkernel.Boot(ctx, t)
+	if err != nil {
+		t.Fatalf("testkernel.Boot: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := k.Stop(); err != nil {
+			t.Errorf("testkernel.Stop: %v", err)
+		}
+	})
+
+	// Verify Endpoint is non-empty and looks like an HTTP URL.
+	endpoint := k.Endpoint()
+	if endpoint == "" {
+		t.Fatal("Endpoint() returned empty string")
+	}
+	if len(endpoint) < 7 || endpoint[:7] != "http://" {
+		t.Fatalf("Endpoint() = %q; want http://... prefix", endpoint)
+	}
+
+	// Probe /health.
+	healthURL := endpoint + "/health"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
+	if err != nil {
+		t.Fatalf("build health request: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /health: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /health status = %d; want 200", resp.StatusCode)
+	}
+
+	var body struct {
+		Status string `json:"status"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode /health body: %v", err)
+	}
+	if body.Status != "ok" {
+		t.Errorf("/health status = %q; want \"ok\"", body.Status)
+	}
+
+	// WorkspaceRoot must be non-empty (it's a temp dir allocated by Boot).
+	if k.WorkspaceRoot() == "" {
+		t.Error("WorkspaceRoot() returned empty string")
+	}
+
+	// Stop is called by t.Cleanup above; if it errors the test will report it.
+}


### PR DESCRIPTION
## Summary

ADR-101 Phase 1 (ref: PR #287 `docs/adr-101-testkernel`).

- Factors `engine.Boot(ctx context.Context, cfg *Config, opts ...BootOption) (*Kernel, error)` out of `runServe`.
- `runServe` becomes a one-screen wrapper: it retains daemon-lifecycle concerns and calls `Boot`.
- Scaffolds `internal/testkernel/` with `testkernel.Boot(ctx, t, opts...)` and a smoke test.

## What moved into Boot

Everything after the daemon state file is written:

- `LoadNucleus`
- `NewProcess`, `loadTRMAtStartup`, `BuildRouter`, `NewServer`
- `initTelemetry`
- `NewLocalHarnessController` + `ctrl.Start`
- `NewReconcileDaemon` + `reconcileDaemon.Start`
- `NewProjectionWatcher` (all kinds) + `watcher.Start`
- `process.Run` goroutine
- HTTP server goroutine (using a pre-allocated `net.Listener` so `Kernel.Endpoint()` returns the actual port immediately)

## What stays in runServe

- `RegisterProviders()` / `SetProvidersWorkspace()` (both nil-safe hooks)
- `setupLogger` / `upgradeLoggerWithFileSink`
- `LoadConfig` + bind-address flag override
- `planServeState` (daemon-already-running guard)
- `buildDaemonState` / `saveDaemonState` / `removeDaemonState`
- `signal.NotifyContext` (OS signal handling)

## New signatures

```go
// engine.Boot
func Boot(ctx context.Context, cfg *Config, opts ...BootOption) (*Kernel, error)

// Kernel accessors
func (k *Kernel) Endpoint() string      // e.g. "http://127.0.0.1:54321"
func (k *Kernel) WorkspaceRoot() string
func (k *Kernel) Stop() error           // cancels context; waits for goroutine drain

// testkernel.Boot (test-layer wrapper)
func Boot(ctx context.Context, t *testing.T, opts ...Option) (*Kernel, error)
```

`BootOption` is a `func(*bootConfig)` — the type and option-application pattern are in place; Phase 2 adds `WithIsolatedRegistry`, `WithPollInterval`, etc.

## Smoke test

`internal/testkernel/testkernel_test.go::TestTestKernel_BootsAndStops`

Boots an isolated kernel on an ephemeral port, asserts `GET /health → 200 "ok"`, calls `Stop`, asserts no error. Runs against an empty global provider registry (correct for Phase 1; no providers means the reconcile daemon runs a no-op tick, which is exactly what you want for the foundational smoke test).

## Provider stub-asymmetry note (does not block Phase 1)

The daemon binary at `cmd/cogos/main.go` registers stub providers via `internal/providers/daemon`. The CLI binary at the repo root registers real providers. In production, the daemon's reconcile loop only ever sees stubs. This is a pre-existing architectural concern that Phase 1 does not address. The testkernel will need Phase 2's `WithIsolatedRegistry` to inject real providers for meaningful integration tests — it cannot rely on whatever is globally registered. This is noted here so reviewers are aware; it does not affect the correctness of Phase 1.

## Phases not included

Phase 2 (isolated registry, `WithIsolatedRegistry`, `TriggerReconcile`, `WaitForReconcile`), Phase 3 (`CallTool`, `HTTPClient`), and Phase 4 (goroutine-leak detection, goleak) follow in separate PRs. `BootOption` surface is stable for those additions without breaking callers.

## Test results

```
ok  github.com/myrgic/cogos/internal/engine       10.254s
ok  github.com/myrgic/cogos/internal/testkernel    0.326s
```