### PR TITLE
feat(substrate): re-export uri, cogfield, bep via pkg/substrate/* (ADR-100 Step 2b)

### DIFF
--- a/pkg/substrate/bep/bep.go
+++ b/pkg/substrate/bep/bep.go
@@ -1,0 +1,173 @@
+// Package bep re-exports the public surface of pkg/bep as
+// pkg/substrate/bep, per ADR-100 Step 2b.
+//
+// All symbols here are Go type aliases or variable/function aliases of their
+// counterparts in github.com/myrgic/cogos/pkg/bep. Consumers of either
+// import path get identical types at the language level — no conversion needed.
+//
+// This package adds no logic. It is a pure re-export layer so downstream code
+// can migrate incrementally to the substrate import path without changing
+// call sites or type assertions.
+package bep
+
+import bep "github.com/myrgic/cogos/pkg/bep"
+
+// --- Version vector ordering ---
+
+type Ordering = bep.Ordering
+
+const (
+	OrderEqual      = bep.OrderEqual
+	OrderGreater    = bep.OrderGreater
+	OrderLesser     = bep.OrderLesser
+	OrderConcurrent = bep.OrderConcurrent
+)
+
+// --- Proto message type enums ---
+
+type MessageType        = bep.MessageType
+type MessageCompression = bep.MessageCompression
+type ErrorCode          = bep.ErrorCode
+
+const (
+	MessageTypeClusterConfig MessageType = bep.MessageTypeClusterConfig
+	MessageTypeIndex         MessageType = bep.MessageTypeIndex
+	MessageTypeIndexUpdate   MessageType = bep.MessageTypeIndexUpdate
+	MessageTypeRequest       MessageType = bep.MessageTypeRequest
+	MessageTypeResponse      MessageType = bep.MessageTypeResponse
+	MessageTypePing          MessageType = bep.MessageTypePing
+	MessageTypeClose         MessageType = bep.MessageTypeClose
+)
+
+const (
+	CompressionNone MessageCompression = bep.CompressionNone
+)
+
+const (
+	ErrorCodeNoError     ErrorCode = bep.ErrorCodeNoError
+	ErrorCodeGeneric     ErrorCode = bep.ErrorCodeGeneric
+	ErrorCodeNoSuchFile  ErrorCode = bep.ErrorCodeNoSuchFile
+	ErrorCodeInvalidFile ErrorCode = bep.ErrorCodeInvalidFile
+)
+
+// BEPMagic is the BEP Hello magic number.
+const BEPMagic uint32 = bep.BEPMagic
+
+// --- Wire size constants ---
+
+const (
+	MaxMessageSize = bep.MaxMessageSize
+	MaxHelloSize   = bep.MaxHelloSize
+)
+
+// --- DeviceID ---
+
+type DeviceID = bep.DeviceID
+
+// --- Config types ---
+
+type Peer               = bep.Peer
+type Config             = bep.Config
+type SyncStatus         = bep.SyncStatus
+type EngineStatus       = bep.EngineStatus
+type PeerStatusSummary  = bep.PeerStatusSummary
+type ReceivedEvent      = bep.ReceivedEvent
+
+// --- Index types ---
+
+type VersionVector  = bep.VersionVector
+type IndexEntry     = bep.IndexEntry
+type DiffResult     = bep.DiffResult
+type PersistedIndex = bep.PersistedIndex
+
+// --- Proto types ---
+
+type Hello         = bep.Hello
+type Header        = bep.Header
+type Device        = bep.Device
+type Folder        = bep.Folder
+type ClusterConfig = bep.ClusterConfig
+type Counter       = bep.Counter
+type Vector        = bep.Vector
+type BlockInfo     = bep.BlockInfo
+type FileInfo      = bep.FileInfo
+type Index         = bep.Index
+type IndexUpdate   = bep.IndexUpdate
+type Request       = bep.Request
+type Response      = bep.Response
+type Ping          = bep.Ping
+type Close         = bep.Close
+
+// --- Wire type ---
+
+type Wire = bep.Wire
+
+// --- Event types ---
+
+type SyncEvent = bep.SyncEvent
+
+// --- Event constants ---
+
+const (
+	SyncEventPeerConnected    = bep.SyncEventPeerConnected
+	SyncEventPeerDisconnected = bep.SyncEventPeerDisconnected
+	SyncEventFileReceived     = bep.SyncEventFileReceived
+	SyncEventFileSent         = bep.SyncEventFileSent
+	SyncEventConflict         = bep.SyncEventConflict
+	SyncEventIndexComplete    = bep.SyncEventIndexComplete
+	SyncEventEngineStarted    = bep.SyncEventEngineStarted
+	SyncEventEngineStopped    = bep.SyncEventEngineStopped
+)
+
+// --- Interface types ---
+
+type Engine       = bep.Engine
+type SyncProvider = bep.SyncProvider
+
+// --- Version vector functions ---
+
+var NewVersionVector    = bep.NewVersionVector
+var VersionVectorFromBEP = bep.VersionVectorFromBEP
+
+// --- Index functions ---
+
+var IndexEntryFromBEP   = bep.IndexEntryFromBEP
+var IsAgentCRDFile      = bep.IsAgentCRDFile
+var ScanLocalIndex      = bep.ScanLocalIndex
+var DiffIndex           = bep.DiffIndex
+var PersistIndex        = bep.PersistIndex
+var LoadPersistedIndex  = bep.LoadPersistedIndex
+var ShortIDFromDeviceID = bep.ShortIDFromDeviceID
+
+// --- TLS / DeviceID functions ---
+
+var GenerateBEPCert      = bep.GenerateBEPCert
+var LoadBEPCert          = bep.LoadBEPCert
+var DeviceIDFromCert     = bep.DeviceIDFromCert
+var DeviceIDFromTLSCert  = bep.DeviceIDFromTLSCert
+var FormatDeviceID       = bep.FormatDeviceID
+var ParseDeviceID        = bep.ParseDeviceID
+var TLSConfig            = bep.TLSConfig
+var CertDir              = bep.CertDir
+var ExpandCertDir        = bep.ExpandCertDir
+
+// --- Proto functions ---
+
+var PBDecode     = bep.PBDecode
+var DecodeVarint  = bep.DecodeVarint
+
+// --- Wire functions ---
+
+var NewWire = bep.NewWire
+
+// --- Event functions ---
+
+var EmitSyncEvent        = bep.EmitSyncEvent
+var EmitPeerConnected    = bep.EmitPeerConnected
+var EmitPeerDisconnected = bep.EmitPeerDisconnected
+var EmitFileReceived     = bep.EmitFileReceived
+var EmitFileSent         = bep.EmitFileSent
+var EmitSyncConflict     = bep.EmitSyncConflict
+var EmitIndexComplete    = bep.EmitIndexComplete
+var EmitEngineStarted    = bep.EmitEngineStarted
+var EmitEngineStopped    = bep.EmitEngineStopped

--- a/pkg/substrate/bep/bep_test.go
+++ b/pkg/substrate/bep/bep_test.go
@@ -1,0 +1,203 @@
+package bep_test
+
+import (
+	"reflect"
+	"testing"
+
+	origin    "github.com/myrgic/cogos/pkg/bep"
+	substrate "github.com/myrgic/cogos/pkg/substrate/bep"
+)
+
+// TestTypeIdentity verifies that type aliases in the substrate re-export layer
+// are identical to their origin types via reflect.TypeOf.
+func TestTypeIdentity(t *testing.T) {
+	cases := []struct {
+		name     string
+		origin   reflect.Type
+		reexport reflect.Type
+	}{
+		{"Ordering", reflect.TypeOf(origin.Ordering(0)), reflect.TypeOf(substrate.Ordering(0))},
+		{"MessageType", reflect.TypeOf(origin.MessageType(0)), reflect.TypeOf(substrate.MessageType(0))},
+		{"MessageCompression", reflect.TypeOf(origin.MessageCompression(0)), reflect.TypeOf(substrate.MessageCompression(0))},
+		{"ErrorCode", reflect.TypeOf(origin.ErrorCode(0)), reflect.TypeOf(substrate.ErrorCode(0))},
+		{"DeviceID", reflect.TypeOf(origin.DeviceID{}), reflect.TypeOf(substrate.DeviceID{})},
+		{"Peer", reflect.TypeOf(origin.Peer{}), reflect.TypeOf(substrate.Peer{})},
+		{"Config", reflect.TypeOf(origin.Config{}), reflect.TypeOf(substrate.Config{})},
+		{"SyncStatus", reflect.TypeOf(origin.SyncStatus{}), reflect.TypeOf(substrate.SyncStatus{})},
+		{"EngineStatus", reflect.TypeOf(origin.EngineStatus{}), reflect.TypeOf(substrate.EngineStatus{})},
+		{"PeerStatusSummary", reflect.TypeOf(origin.PeerStatusSummary{}), reflect.TypeOf(substrate.PeerStatusSummary{})},
+		{"ReceivedEvent", reflect.TypeOf(origin.ReceivedEvent{}), reflect.TypeOf(substrate.ReceivedEvent{})},
+		{"VersionVector", reflect.TypeOf(origin.VersionVector{}), reflect.TypeOf(substrate.VersionVector{})},
+		{"IndexEntry", reflect.TypeOf(origin.IndexEntry{}), reflect.TypeOf(substrate.IndexEntry{})},
+		{"DiffResult", reflect.TypeOf(origin.DiffResult{}), reflect.TypeOf(substrate.DiffResult{})},
+		{"PersistedIndex", reflect.TypeOf(origin.PersistedIndex{}), reflect.TypeOf(substrate.PersistedIndex{})},
+		{"Hello", reflect.TypeOf(origin.Hello{}), reflect.TypeOf(substrate.Hello{})},
+		{"Header", reflect.TypeOf(origin.Header{}), reflect.TypeOf(substrate.Header{})},
+		{"Device", reflect.TypeOf(origin.Device{}), reflect.TypeOf(substrate.Device{})},
+		{"Folder", reflect.TypeOf(origin.Folder{}), reflect.TypeOf(substrate.Folder{})},
+		{"ClusterConfig", reflect.TypeOf(origin.ClusterConfig{}), reflect.TypeOf(substrate.ClusterConfig{})},
+		{"Counter", reflect.TypeOf(origin.Counter{}), reflect.TypeOf(substrate.Counter{})},
+		{"Vector", reflect.TypeOf(origin.Vector{}), reflect.TypeOf(substrate.Vector{})},
+		{"BlockInfo", reflect.TypeOf(origin.BlockInfo{}), reflect.TypeOf(substrate.BlockInfo{})},
+		{"FileInfo", reflect.TypeOf(origin.FileInfo{}), reflect.TypeOf(substrate.FileInfo{})},
+		{"Index", reflect.TypeOf(origin.Index{}), reflect.TypeOf(substrate.Index{})},
+		{"Request", reflect.TypeOf(origin.Request{}), reflect.TypeOf(substrate.Request{})},
+		{"Response", reflect.TypeOf(origin.Response{}), reflect.TypeOf(substrate.Response{})},
+		{"Ping", reflect.TypeOf(origin.Ping{}), reflect.TypeOf(substrate.Ping{})},
+		{"Close", reflect.TypeOf(origin.Close{}), reflect.TypeOf(substrate.Close{})},
+		{"SyncEvent", reflect.TypeOf(origin.SyncEvent{}), reflect.TypeOf(substrate.SyncEvent{})},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.origin != tc.reexport {
+				t.Errorf("%s: origin type %v != substrate type %v (alias is broken)", tc.name, tc.origin, tc.reexport)
+			}
+		})
+	}
+}
+
+// TestConstantIdentity verifies that re-exported constants have the same value.
+func TestConstantIdentity(t *testing.T) {
+	// Ordering constants
+	if origin.OrderEqual != substrate.OrderEqual {
+		t.Errorf("OrderEqual mismatch")
+	}
+	if origin.OrderGreater != substrate.OrderGreater {
+		t.Errorf("OrderGreater mismatch")
+	}
+	if origin.OrderLesser != substrate.OrderLesser {
+		t.Errorf("OrderLesser mismatch")
+	}
+	if origin.OrderConcurrent != substrate.OrderConcurrent {
+		t.Errorf("OrderConcurrent mismatch")
+	}
+
+	// MessageType constants
+	if origin.MessageTypeClusterConfig != substrate.MessageTypeClusterConfig {
+		t.Errorf("MessageTypeClusterConfig mismatch")
+	}
+	if origin.MessageTypeIndex != substrate.MessageTypeIndex {
+		t.Errorf("MessageTypeIndex mismatch")
+	}
+	if origin.MessageTypePing != substrate.MessageTypePing {
+		t.Errorf("MessageTypePing mismatch")
+	}
+	if origin.MessageTypeClose != substrate.MessageTypeClose {
+		t.Errorf("MessageTypeClose mismatch")
+	}
+
+	// ErrorCode constants
+	if origin.ErrorCodeNoError != substrate.ErrorCodeNoError {
+		t.Errorf("ErrorCodeNoError mismatch")
+	}
+	if origin.ErrorCodeGeneric != substrate.ErrorCodeGeneric {
+		t.Errorf("ErrorCodeGeneric mismatch")
+	}
+	if origin.ErrorCodeNoSuchFile != substrate.ErrorCodeNoSuchFile {
+		t.Errorf("ErrorCodeNoSuchFile mismatch")
+	}
+	if origin.ErrorCodeInvalidFile != substrate.ErrorCodeInvalidFile {
+		t.Errorf("ErrorCodeInvalidFile mismatch")
+	}
+
+	// BEP magic
+	if origin.BEPMagic != substrate.BEPMagic {
+		t.Errorf("BEPMagic mismatch: 0x%08X != 0x%08X", origin.BEPMagic, substrate.BEPMagic)
+	}
+
+	// Event string constants
+	if origin.SyncEventPeerConnected != substrate.SyncEventPeerConnected {
+		t.Errorf("SyncEventPeerConnected mismatch")
+	}
+	if origin.SyncEventEngineStarted != substrate.SyncEventEngineStarted {
+		t.Errorf("SyncEventEngineStarted mismatch")
+	}
+	if origin.SyncEventEngineStopped != substrate.SyncEventEngineStopped {
+		t.Errorf("SyncEventEngineStopped mismatch")
+	}
+
+	// Wire size constants
+	if origin.MaxMessageSize != substrate.MaxMessageSize {
+		t.Errorf("MaxMessageSize mismatch")
+	}
+	if origin.MaxHelloSize != substrate.MaxHelloSize {
+		t.Errorf("MaxHelloSize mismatch")
+	}
+}
+
+// TestNewVersionVector verifies the re-exported constructor.
+func TestNewVersionVector(t *testing.T) {
+	vv := substrate.NewVersionVector()
+	if vv == nil {
+		t.Fatalf("NewVersionVector() returned nil")
+	}
+	if len(vv.Counters) != 0 {
+		t.Errorf("NewVersionVector().Counters len = %d, want 0", len(vv.Counters))
+	}
+}
+
+// TestVersionVectorCompare verifies the re-exported version vector comparison.
+func TestVersionVectorCompare(t *testing.T) {
+	a := substrate.NewVersionVector()
+	b := substrate.NewVersionVector()
+	if ord := a.Compare(b); ord != substrate.OrderEqual {
+		t.Errorf("Compare(empty, empty) = %v, want OrderEqual", ord)
+	}
+	a.Increment(1)
+	if ord := a.Compare(b); ord != substrate.OrderGreater {
+		t.Errorf("Compare(incremented, empty) = %v, want OrderGreater", ord)
+	}
+}
+
+// TestIsAgentCRDFile verifies the re-exported file name predicate.
+func TestIsAgentCRDFile(t *testing.T) {
+	if !substrate.IsAgentCRDFile("foo.agent.yaml") {
+		t.Errorf("IsAgentCRDFile(\"foo.agent.yaml\") = false, want true")
+	}
+	if substrate.IsAgentCRDFile("foo.yaml") {
+		t.Errorf("IsAgentCRDFile(\"foo.yaml\") = true, want false")
+	}
+}
+
+// TestFormatParseDeviceID verifies the re-exported DeviceID formatting round-trip.
+func TestFormatParseDeviceID(t *testing.T) {
+	id := substrate.DeviceID{
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+		0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+		0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+	}
+	formatted := substrate.FormatDeviceID(id)
+	if formatted == "" {
+		t.Fatalf("FormatDeviceID returned empty string")
+	}
+	parsed, err := substrate.ParseDeviceID(formatted)
+	if err != nil {
+		t.Fatalf("ParseDeviceID(%q) error: %v", formatted, err)
+	}
+	if parsed != id {
+		t.Errorf("round-trip mismatch: got %v, want %v", parsed, id)
+	}
+}
+
+// TestShortIDFromDeviceID verifies the re-exported short ID derivation.
+func TestShortIDFromDeviceID(t *testing.T) {
+	id := substrate.DeviceID{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	got := substrate.ShortIDFromDeviceID(id)
+	if got == 0 {
+		t.Errorf("ShortIDFromDeviceID returned 0 for non-zero DeviceID")
+	}
+}
+
+// TestEmitSyncEvent verifies the re-exported event emission helper.
+func TestEmitSyncEvent(t *testing.T) {
+	evt := substrate.EmitSyncEvent(substrate.SyncEventEngineStarted, map[string]any{"test": true})
+	if evt.Type != substrate.SyncEventEngineStarted {
+		t.Errorf("SyncEvent.Type = %q, want %q", evt.Type, substrate.SyncEventEngineStarted)
+	}
+	if evt.Timestamp == "" {
+		t.Errorf("SyncEvent.Timestamp is empty")
+	}
+}

--- a/pkg/substrate/cogfield/cogfield.go
+++ b/pkg/substrate/cogfield/cogfield.go
@@ -1,0 +1,91 @@
+// Package cogfield re-exports the public surface of pkg/cogfield as
+// pkg/substrate/cogfield, per ADR-100 Step 2b.
+//
+// All symbols here are Go type aliases or variable/function aliases of their
+// counterparts in github.com/myrgic/cogos/pkg/cogfield. Consumers of either
+// import path get identical types at the language level — no conversion needed.
+//
+// This package adds no logic. It is a pure re-export layer so downstream code
+// can migrate incrementally to the substrate import path without changing
+// call sites or type assertions.
+package cogfield
+
+import cogfield "github.com/myrgic/cogos/pkg/cogfield"
+
+// --- Graph types ---
+
+type Node  = cogfield.Node
+type Edge  = cogfield.Edge
+type Stats = cogfield.Stats
+type Graph = cogfield.Graph
+
+// --- Block types ---
+
+type Block      = cogfield.Block
+type GraphBlock = cogfield.GraphBlock
+
+// --- Adapter types ---
+
+type BlockAdapter       = cogfield.BlockAdapter
+type AdapterNodeConfig  = cogfield.AdapterNodeConfig
+type BlockTypeConfig    = cogfield.BlockTypeConfig
+type ExpandNodeResponse = cogfield.ExpandNodeResponse
+
+// --- Bus types ---
+
+type BusDetail         = cogfield.BusDetail
+type BusRegistryEntry  = cogfield.BusRegistryEntry
+
+// --- Condition types ---
+
+type FieldCondition       = cogfield.FieldCondition
+type TriggeredCondition   = cogfield.TriggeredCondition
+type FieldConditionState  = cogfield.FieldConditionState
+
+// --- Document types ---
+
+type DocRef         = cogfield.DocRef
+type DocumentDetail = cogfield.DocumentDetail
+
+// --- Event types ---
+
+type SessionJSONLEvent = cogfield.SessionJSONLEvent
+
+// --- Session types ---
+
+type SessionMessage = cogfield.SessionMessage
+type SessionDetail  = cogfield.SessionDetail
+
+// --- Signal types ---
+
+type SignalFieldState  = cogfield.SignalFieldState
+type PersistedSignal   = cogfield.PersistedSignal
+
+// --- Graph functions ---
+
+var NormalizeEntityType = cogfield.NormalizeEntityType
+var InferSector         = cogfield.InferSector
+var StrengthFromMetrics = cogfield.StrengthFromMetrics
+var ParseCSVSet         = cogfield.ParseCSVSet
+var FilterNodes         = cogfield.FilterNodes
+var BFSSubgraph         = cogfield.BFSSubgraph
+var ComputeStats        = cogfield.ComputeStats
+var FilterByMeta        = cogfield.FilterByMeta
+
+// --- Adapter functions ---
+
+var GraphBlockToNode = cogfield.GraphBlockToNode
+
+// --- Condition functions ---
+
+var ParseConditionQueryString  = cogfield.ParseConditionQueryString
+var EvaluateFieldConditions    = cogfield.EvaluateFieldConditions
+
+// --- Event functions ---
+
+var ExtractTimestamp = cogfield.ExtractTimestamp
+
+// --- Signal functions ---
+
+var ComputeRelevance = cogfield.ComputeRelevance
+var SignalIsActive   = cogfield.SignalIsActive

--- a/pkg/substrate/cogfield/cogfield_test.go
+++ b/pkg/substrate/cogfield/cogfield_test.go
@@ -1,0 +1,159 @@
+package cogfield_test
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	origin    "github.com/myrgic/cogos/pkg/cogfield"
+	substrate "github.com/myrgic/cogos/pkg/substrate/cogfield"
+)
+
+// TestTypeIdentity verifies that type aliases in the substrate re-export layer
+// are identical to their origin types via reflect.TypeOf.
+func TestTypeIdentity(t *testing.T) {
+	cases := []struct {
+		name     string
+		origin   reflect.Type
+		reexport reflect.Type
+	}{
+		{"Node", reflect.TypeOf(origin.Node{}), reflect.TypeOf(substrate.Node{})},
+		{"Edge", reflect.TypeOf(origin.Edge{}), reflect.TypeOf(substrate.Edge{})},
+		{"Stats", reflect.TypeOf(origin.Stats{}), reflect.TypeOf(substrate.Stats{})},
+		{"Graph", reflect.TypeOf(origin.Graph{}), reflect.TypeOf(substrate.Graph{})},
+		{"Block", reflect.TypeOf(origin.Block{}), reflect.TypeOf(substrate.Block{})},
+		{"GraphBlock", reflect.TypeOf(origin.GraphBlock{}), reflect.TypeOf(substrate.GraphBlock{})},
+		{"AdapterNodeConfig", reflect.TypeOf(origin.AdapterNodeConfig{}), reflect.TypeOf(substrate.AdapterNodeConfig{})},
+		{"BlockTypeConfig", reflect.TypeOf(origin.BlockTypeConfig{}), reflect.TypeOf(substrate.BlockTypeConfig{})},
+		{"ExpandNodeResponse", reflect.TypeOf(origin.ExpandNodeResponse{}), reflect.TypeOf(substrate.ExpandNodeResponse{})},
+		{"BusDetail", reflect.TypeOf(origin.BusDetail{}), reflect.TypeOf(substrate.BusDetail{})},
+		{"BusRegistryEntry", reflect.TypeOf(origin.BusRegistryEntry{}), reflect.TypeOf(substrate.BusRegistryEntry{})},
+		{"FieldCondition", reflect.TypeOf(origin.FieldCondition{}), reflect.TypeOf(substrate.FieldCondition{})},
+		{"TriggeredCondition", reflect.TypeOf(origin.TriggeredCondition{}), reflect.TypeOf(substrate.TriggeredCondition{})},
+		{"FieldConditionState", reflect.TypeOf(origin.FieldConditionState{}), reflect.TypeOf(substrate.FieldConditionState{})},
+		{"DocRef", reflect.TypeOf(origin.DocRef{}), reflect.TypeOf(substrate.DocRef{})},
+		{"DocumentDetail", reflect.TypeOf(origin.DocumentDetail{}), reflect.TypeOf(substrate.DocumentDetail{})},
+		{"SessionJSONLEvent", reflect.TypeOf(origin.SessionJSONLEvent{}), reflect.TypeOf(substrate.SessionJSONLEvent{})},
+		{"SessionMessage", reflect.TypeOf(origin.SessionMessage{}), reflect.TypeOf(substrate.SessionMessage{})},
+		{"SessionDetail", reflect.TypeOf(origin.SessionDetail{}), reflect.TypeOf(substrate.SessionDetail{})},
+		{"SignalFieldState", reflect.TypeOf(origin.SignalFieldState{}), reflect.TypeOf(substrate.SignalFieldState{})},
+		{"PersistedSignal", reflect.TypeOf(origin.PersistedSignal{}), reflect.TypeOf(substrate.PersistedSignal{})},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.origin != tc.reexport {
+				t.Errorf("%s: origin type %v != substrate type %v (alias is broken)", tc.name, tc.origin, tc.reexport)
+			}
+		})
+	}
+}
+
+// TestNormalizeEntityType verifies the re-exported function maps types correctly.
+func TestNormalizeEntityType(t *testing.T) {
+	if got := substrate.NormalizeEntityType("session"); got != "session" {
+		t.Errorf("NormalizeEntityType(\"session\") = %q, want %q", got, "session")
+	}
+	if got := substrate.NormalizeEntityType("unknown_type"); got != "document" {
+		t.Errorf("NormalizeEntityType(\"unknown_type\") = %q, want %q", got, "document")
+	}
+}
+
+// TestInferSector verifies the re-exported sector inference function.
+func TestInferSector(t *testing.T) {
+	got := substrate.InferSector("/mem/semantic/foo.md", "")
+	if got != "semantic" {
+		t.Errorf("InferSector = %q, want %q", got, "semantic")
+	}
+}
+
+// TestStrengthFromMetrics verifies the re-exported strength calculation.
+func TestStrengthFromMetrics(t *testing.T) {
+	// substanceRatio=1.0, refCount=15, wordCount=1500 → 4+3+3=10
+	got := substrate.StrengthFromMetrics(1.0, 15, 1500)
+	if got != 10.0 {
+		t.Errorf("StrengthFromMetrics = %v, want 10.0", got)
+	}
+}
+
+// TestParseCSVSet verifies the re-exported CSV set parser.
+func TestParseCSVSet(t *testing.T) {
+	m := substrate.ParseCSVSet("a,b,c")
+	if len(m) != 3 {
+		t.Errorf("ParseCSVSet len = %d, want 3", len(m))
+	}
+	if !m["a"] || !m["b"] || !m["c"] {
+		t.Errorf("ParseCSVSet missing expected keys: %v", m)
+	}
+	if substrate.ParseCSVSet("") != nil {
+		t.Errorf("ParseCSVSet(\"\") should return nil")
+	}
+}
+
+// TestFilterNodes verifies the re-exported filter function.
+func TestFilterNodes(t *testing.T) {
+	nodes := []substrate.Node{
+		{ID: "n1", EntityType: "document", Sector: "semantic", Strength: 5.0},
+		{ID: "n2", EntityType: "session", Sector: "episodic", Strength: 3.0},
+	}
+	filtered := substrate.FilterNodes(nodes, map[string]bool{"document": true}, nil, nil, 0)
+	if len(filtered) != 1 || filtered[0].ID != "n1" {
+		t.Errorf("FilterNodes = %v, want [{ID:n1}]", filtered)
+	}
+}
+
+// TestComputeStats verifies the re-exported stats computation.
+func TestComputeStats(t *testing.T) {
+	nodes := []substrate.Node{
+		{ID: "n1", EntityType: "document", Sector: "semantic"},
+		{ID: "n2", EntityType: "session", Sector: "episodic"},
+	}
+	edges := []substrate.Edge{
+		{Source: "n1", Target: "n2", Relation: "ref"},
+	}
+	stats := substrate.ComputeStats(nodes, edges)
+	if stats.TotalNodes != 2 {
+		t.Errorf("TotalNodes = %d, want 2", stats.TotalNodes)
+	}
+	if stats.TotalEdges != 1 {
+		t.Errorf("TotalEdges = %d, want 1", stats.TotalEdges)
+	}
+}
+
+// TestGraphBlockToNode verifies the re-exported block-to-node converter.
+func TestGraphBlockToNode(t *testing.T) {
+	gb := substrate.GraphBlock{
+		URI:  "cog://bus/test/1",
+		Type: "bus.message",
+		Ts:   "2026-01-01T00:00:00Z",
+	}
+	n := substrate.GraphBlockToNode(gb)
+	if n.ID != "cog://bus/test/1" {
+		t.Errorf("Node.ID = %q, want %q", n.ID, "cog://bus/test/1")
+	}
+	if n.Sector != "buses" {
+		t.Errorf("Node.Sector = %q, want %q", n.Sector, "buses")
+	}
+}
+
+// TestSignalIsActive verifies the re-exported signal activity check.
+func TestSignalIsActive(t *testing.T) {
+	ps := &substrate.PersistedSignal{
+		Strength:    10.0,
+		DepositedAt: float64(time.Now().Unix()),
+		HalfLife:    24.0, // 24 hour half-life
+	}
+	if !substrate.SignalIsActive(ps, time.Now()) {
+		t.Errorf("SignalIsActive for fresh high-strength signal = false, want true")
+	}
+}
+
+// TestExtractTimestamp verifies the re-exported timestamp extractor.
+func TestExtractTimestamp(t *testing.T) {
+	evt := substrate.SessionJSONLEvent{Ts: "2026-01-01T00:00:00Z"}
+	got := substrate.ExtractTimestamp(evt)
+	if got != "2026-01-01T00:00:00Z" {
+		t.Errorf("ExtractTimestamp = %q, want %q", got, "2026-01-01T00:00:00Z")
+	}
+}

--- a/pkg/substrate/go.mod
+++ b/pkg/substrate/go.mod
@@ -1,7 +1,19 @@
 module github.com/myrgic/cogos/pkg/substrate
 
-go 1.24
+go 1.25.0
 
-require github.com/myrgic/cogos/pkg/reconcile v0.0.0
+require (
+	github.com/myrgic/cogos/pkg/bep v0.0.0
+	github.com/myrgic/cogos/pkg/cogfield v0.0.0
+	github.com/myrgic/cogos/pkg/reconcile v0.0.0
+	github.com/myrgic/cogos/pkg/uri v0.0.0
+)
 
-replace github.com/myrgic/cogos/pkg/reconcile => ../reconcile
+require google.golang.org/protobuf v1.36.11 // indirect
+
+replace (
+	github.com/myrgic/cogos/pkg/bep => ../bep
+	github.com/myrgic/cogos/pkg/cogfield => ../cogfield
+	github.com/myrgic/cogos/pkg/reconcile => ../reconcile
+	github.com/myrgic/cogos/pkg/uri => ../uri
+)

--- a/pkg/substrate/go.sum
+++ b/pkg/substrate/go.sum
@@ -1,0 +1,2 @@
+google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
+google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=

--- a/pkg/substrate/uri/uri.go
+++ b/pkg/substrate/uri/uri.go
@@ -1,0 +1,39 @@
+// Package uri re-exports the public surface of pkg/uri as
+// pkg/substrate/uri, per ADR-100 Step 2b.
+//
+// All symbols here are Go type aliases or variable/function aliases of their
+// counterparts in github.com/myrgic/cogos/pkg/uri. Consumers of either
+// import path get identical types at the language level — no conversion needed.
+//
+// This package adds no logic. It is a pure re-export layer so downstream code
+// can migrate incrementally to the substrate import path without changing
+// call sites or type assertions.
+package uri
+
+import uri "github.com/myrgic/cogos/pkg/uri"
+
+// --- Scheme constants ---
+
+const Scheme       = uri.Scheme
+const SchemeLegacy = uri.SchemeLegacy
+
+// --- Sentinel errors ---
+
+var ErrInvalidURI      = uri.ErrInvalidURI
+var ErrUnknownNamespace = uri.ErrUnknownNamespace
+
+// --- Types ---
+
+type URI   = uri.URI
+type Error = uri.Error
+
+// --- Namespace registry ---
+
+var Namespaces = uri.Namespaces
+
+// --- Functions ---
+
+var Parse              = uri.Parse
+var IsCogURI           = uri.IsCogURI
+var IsValidNamespace   = uri.IsValidNamespace
+var ExtractInlineRefs  = uri.ExtractInlineRefs

--- a/pkg/substrate/uri/uri_test.go
+++ b/pkg/substrate/uri/uri_test.go
@@ -1,0 +1,107 @@
+package uri_test
+
+import (
+	"reflect"
+	"testing"
+
+	origin    "github.com/myrgic/cogos/pkg/uri"
+	substrate "github.com/myrgic/cogos/pkg/substrate/uri"
+)
+
+// TestTypeIdentity verifies that type aliases in the substrate re-export layer
+// are identical to their origin types via reflect.TypeOf. Because Go type
+// aliases share the same runtime type, these must always be equal.
+func TestTypeIdentity(t *testing.T) {
+	cases := []struct {
+		name     string
+		origin   reflect.Type
+		reexport reflect.Type
+	}{
+		{"URI", reflect.TypeOf(origin.URI{}), reflect.TypeOf(substrate.URI{})},
+		{"Error", reflect.TypeOf(origin.Error{}), reflect.TypeOf(substrate.Error{})},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.origin != tc.reexport {
+				t.Errorf("%s: origin type %v != substrate type %v (alias is broken)", tc.name, tc.origin, tc.reexport)
+			}
+		})
+	}
+}
+
+// TestConstantIdentity verifies that re-exported constants have the same value
+// as their origin counterparts.
+func TestConstantIdentity(t *testing.T) {
+	if origin.Scheme != substrate.Scheme {
+		t.Errorf("Scheme mismatch: %q != %q", origin.Scheme, substrate.Scheme)
+	}
+	if origin.SchemeLegacy != substrate.SchemeLegacy {
+		t.Errorf("SchemeLegacy mismatch: %q != %q", origin.SchemeLegacy, substrate.SchemeLegacy)
+	}
+}
+
+// TestParseRoundTrip verifies the re-exported Parse function works correctly.
+func TestParseRoundTrip(t *testing.T) {
+	raw := "cog:mem/semantic/foo"
+	u, err := substrate.Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse(%q) error: %v", raw, err)
+	}
+	if u.Namespace != "mem" {
+		t.Errorf("Namespace = %q, want %q", u.Namespace, "mem")
+	}
+	if u.Path != "semantic/foo" {
+		t.Errorf("Path = %q, want %q", u.Path, "semantic/foo")
+	}
+}
+
+// TestIsCogURI verifies the re-exported predicate.
+func TestIsCogURI(t *testing.T) {
+	if !substrate.IsCogURI("cog:mem/foo") {
+		t.Errorf("IsCogURI(\"cog:mem/foo\") = false, want true")
+	}
+	if substrate.IsCogURI("https://example.com") {
+		t.Errorf("IsCogURI(\"https://example.com\") = true, want false")
+	}
+}
+
+// TestIsValidNamespace verifies the re-exported namespace check.
+func TestIsValidNamespace(t *testing.T) {
+	if !substrate.IsValidNamespace("mem") {
+		t.Errorf("IsValidNamespace(\"mem\") = false, want true")
+	}
+	if substrate.IsValidNamespace("notanamespace") {
+		t.Errorf("IsValidNamespace(\"notanamespace\") = true, want false")
+	}
+}
+
+// TestExtractInlineRefs verifies the re-exported inline ref extractor.
+func TestExtractInlineRefs(t *testing.T) {
+	content := "See cog://mem/semantic/foo and cog://adr/100"
+	refs := substrate.ExtractInlineRefs(content)
+	if len(refs) != 2 {
+		t.Errorf("ExtractInlineRefs len = %d, want 2; refs=%v", len(refs), refs)
+	}
+}
+
+// TestNamespacesMap verifies the re-exported namespace registry is non-empty.
+func TestNamespacesMap(t *testing.T) {
+	if len(substrate.Namespaces) == 0 {
+		t.Errorf("Namespaces map is empty")
+	}
+	if !substrate.Namespaces["mem"] {
+		t.Errorf("Namespaces[\"mem\"] = false, want true")
+	}
+}
+
+// TestErrorSentinels verifies re-exported sentinel errors are the same values.
+func TestErrorSentinels(t *testing.T) {
+	if origin.ErrInvalidURI != substrate.ErrInvalidURI {
+		t.Errorf("ErrInvalidURI mismatch")
+	}
+	if origin.ErrUnknownNamespace != substrate.ErrUnknownNamespace {
+		t.Errorf("ErrUnknownNamespace mismatch")
+	}
+}


### PR DESCRIPTION
## Summary

Extends the `pkg/substrate/` re-export layer (introduced in #283) to three additional foundation modules: `pkg/uri`, `pkg/cogfield`, and `pkg/bep`. Each new sub-package is a pure alias layer — zero logic, zero modifications to source modules or consumers.

## Re-exported public surface

**pkg/substrate/uri** — `URI`, `Error` types; `ErrInvalidURI`, `ErrUnknownNamespace` sentinels; `Scheme`, `SchemeLegacy` constants; `Namespaces` map; `Parse`, `IsCogURI`, `IsValidNamespace`, `ExtractInlineRefs` functions.

**pkg/substrate/cogfield** — `Node`, `Edge`, `Stats`, `Graph`, `Block`, `GraphBlock`, `BlockAdapter`, `AdapterNodeConfig`, `BlockTypeConfig`, `ExpandNodeResponse`, `BusDetail`, `BusRegistryEntry`, `FieldCondition`, `TriggeredCondition`, `FieldConditionState`, `DocRef`, `DocumentDetail`, `SessionJSONLEvent`, `SessionMessage`, `SessionDetail`, `SignalFieldState`, `PersistedSignal` types; all public functions from graph, adapter, condition, event, and signal files.

**pkg/substrate/bep** — `Ordering`, `MessageType`, `MessageCompression`, `ErrorCode`, `DeviceID`, `VersionVector`, `IndexEntry`, `DiffResult`, `PersistedIndex`, `Peer`, `Config`, `SyncStatus`, `EngineStatus`, `PeerStatusSummary`, `ReceivedEvent`, `Hello`, `Header`, `Device`, `Folder`, `ClusterConfig`, `Counter`, `Vector`, `BlockInfo`, `FileInfo`, `Index`, `IndexUpdate`, `Request`, `Response`, `Ping`, `Close`, `Wire`, `SyncEvent`, `Engine`, `SyncProvider` types; all constants and functions including TLS, DeviceID, protowire helpers, version vector, index diff/persist, and sync event emission.

## Changes

- `pkg/substrate/uri/uri.go` + `uri_test.go`
- `pkg/substrate/cogfield/cogfield.go` + `cogfield_test.go`
- `pkg/substrate/bep/bep.go` + `bep_test.go`
- `pkg/substrate/go.mod` — added `require`/`replace` for the three new modules; `google.golang.org/protobuf` pulled in transitively via `pkg/bep`
- `pkg/substrate/go.sum` — created

## Verification

All tests green: `go test ./pkg/substrate/... ./pkg/uri/... ./pkg/cogfield/... ./pkg/bep/...`. `go build ./...` clean. Pure-additive: zero modifications to existing source modules or consumers.

Part of ADR-100 Step 2b. Disjoint from ADR-101 Phase 2 work (touches no overlapping files).