### PR TITLE
feat(engine): WithIsolatedRegistry for testkernel provider injection (ADR-101 Phase 2)

### DIFF
--- a/internal/engine/boot.go
+++ b/internal/engine/boot.go
@@ -22,9 +22,9 @@
 //   - Block until the HTTP server is ready (listening) before returning.
 //   - Return a *Kernel handle that gives callers Endpoint(), WorkspaceRoot(), and Stop().
 //
-// Phase 2 options (WithIsolatedRegistry, etc.) are not implemented here;
-// the BootOption type and option-application pattern are established so the
-// surface is stable for incremental addition.
+// Phase 2 adds WithIsolatedRegistry: callers can inject an explicit provider
+// list so the ReconcileDaemon bypasses the global registry. This is the
+// integration-test isolation mechanism (ADR-101 Decision 3).
 package engine
 
 import (
@@ -33,6 +33,8 @@ import (
 	"log/slog"
 	"net"
 	"time"
+
+	"github.com/myrgic/cogos/pkg/reconcile"
 )
 
 // BootOption is a functional option passed to Boot.
@@ -49,8 +51,10 @@ type bootConfig struct {
 	// 0 means use the ReconcileDaemon default (30 s).
 	pollInterval time.Duration
 
-	// Phase 2: isolated provider list (nil = use global registry).
-	// providers []reconcile.Reconcilable
+	// providers, when non-nil, is passed to ReconcileDaemonConfig.Providers so
+	// the daemon iterates this list instead of the global registry.
+	// Set via WithIsolatedRegistry. nil = use global registry (default).
+	providers []reconcile.Reconcilable
 }
 
 func applyBootOptions(opts []BootOption) bootConfig {
@@ -59,6 +63,23 @@ func applyBootOptions(opts []BootOption) bootConfig {
 		o(&cfg)
 	}
 	return cfg
+}
+
+// WithIsolatedRegistry returns a BootOption that injects an explicit provider
+// list into the ReconcileDaemon, bypassing the global registry.
+//
+// When this option is set the daemon iterates only the supplied providers;
+// the global registry (which in daemon-binary code paths contains stub
+// providers) is never consulted. This is the ADR-101 Phase 2 mechanism for
+// writing integration tests that exercise real plan/apply without stub
+// interference.
+//
+// Production callers should not use this option; pass nil or omit it to
+// preserve the default global-registry behaviour.
+func WithIsolatedRegistry(providers ...reconcile.Reconcilable) BootOption {
+	return func(c *bootConfig) {
+		c.providers = providers
+	}
 }
 
 // Kernel is an opaque handle to a running in-process kernel instance.
@@ -84,6 +105,13 @@ func (k *Kernel) Endpoint() string {
 // WorkspaceRoot returns the workspace root path in use.
 func (k *Kernel) WorkspaceRoot() string {
 	return k.cfg.WorkspaceRoot
+}
+
+// ReconcileDaemon returns the kernel's ReconcileDaemon, exposing Trigger and
+// State for integration tests that need to drive or observe reconcile cycles.
+// The daemon is already running when Boot returns.
+func (k *Kernel) ReconcileDaemon() *ReconcileDaemon {
+	return k.reconcileDaemon
 }
 
 // Stop cancels the kernel's context and waits for all goroutines to exit
@@ -125,7 +153,7 @@ func (k *Kernel) Stop() error {
 // RegisterProviders / SetProvidersWorkspace are expected to have been called
 // (or intentionally left nil) by the caller before Boot.
 func Boot(ctx context.Context, cfg *Config, opts ...BootOption) (*Kernel, error) {
-	_ = applyBootOptions(opts) // Phase 2 will read these fields.
+	bootCfg := applyBootOptions(opts)
 
 	// Load nucleus (identity core).
 	nucleus, err := LoadNucleus(cfg)
@@ -178,8 +206,11 @@ func Boot(ctx context.Context, cfg *Config, opts ...BootOption) (*Kernel, error)
 	}
 
 	// ADR-092 §2 step 4: Reconcile loop start.
+	// When WithIsolatedRegistry was passed (testkernel path), bootCfg.providers
+	// is non-nil and the daemon bypasses the global registry.
 	reconcileDaemon := NewReconcileDaemon(ReconcileDaemonConfig{
 		WorkspaceRoot: cfg.WorkspaceRoot,
+		Providers:     bootCfg.providers,
 	})
 	reconcileDaemon.Start(kernelCtx)
 

--- a/internal/engine/reconcile_daemon.go
+++ b/internal/engine/reconcile_daemon.go
@@ -64,6 +64,14 @@ type ReconcileDaemonConfig struct {
 	// ShutdownGracePeriod is how long the daemon waits for in-flight cycles to
 	// complete after context cancel before returning. Default: 5 seconds.
 	ShutdownGracePeriod time.Duration
+
+	// Providers, when non-nil, is an explicit list of Reconcilables the daemon
+	// iterates instead of the global registry. This is the ADR-101 Phase 2
+	// registry-isolation mechanism: integration tests inject real providers here
+	// without touching the global registry (which may contain daemon-binary stub
+	// providers). When nil, the daemon uses reconcile.ListProviders() as before.
+	// Production code leaves this nil; only testkernel sets it.
+	Providers []reconcile.Reconcilable
 }
 
 func (c *ReconcileDaemonConfig) withDefaults() ReconcileDaemonConfig {
@@ -117,14 +125,61 @@ func (d *ReconcileDaemon) State() ReconcileDaemonState {
 	return d.state
 }
 
+// ─── Isolated-registry helpers ───────────────────────────────────────────────
+//
+// When cfg.Providers is nil these helpers delegate to the global registry,
+// preserving all pre-Phase-2 behaviour exactly. When cfg.Providers is set
+// (testkernel isolation path) they operate solely on that list.
+
+// hasProvider reports whether providerType is available in the active provider
+// source (injected list or global registry).
+func (d *ReconcileDaemon) hasProvider(pt string) bool {
+	if d.cfg.Providers != nil {
+		for _, p := range d.cfg.Providers {
+			if p.Type() == pt {
+				return true
+			}
+		}
+		return false
+	}
+	return reconcile.HasProvider(pt)
+}
+
+// listProviderTypes returns the ordered type strings for all active providers.
+func (d *ReconcileDaemon) listProviderTypes() []string {
+	if d.cfg.Providers != nil {
+		names := make([]string, len(d.cfg.Providers))
+		for i, p := range d.cfg.Providers {
+			names[i] = p.Type()
+		}
+		return names
+	}
+	return reconcile.ListProviders()
+}
+
+// getProvider returns the Reconcilable for the given type from the active
+// provider source (injected list or global registry).
+func (d *ReconcileDaemon) getProvider(pt string) (reconcile.Reconcilable, error) {
+	if d.cfg.Providers != nil {
+		for _, p := range d.cfg.Providers {
+			if p.Type() == pt {
+				return p, nil
+			}
+		}
+		return nil, fmt.Errorf("provider %q not in injected list", pt)
+	}
+	return reconcile.GetProvider(pt)
+}
+
 // Trigger queues an immediate (out-of-band) reconcile for the named provider
 // type. Non-blocking: if the provider is already queued, this is a no-op.
-// If the provider is not registered, the trigger is silently dropped.
+// If the provider is not registered (or not in the injected list when one is
+// set), the trigger is silently dropped.
 //
 // This is the integration point for watch-based early-trigger mechanisms
 // (e.g., ProjectionWatcher). See ADR-095 §4.
 func (d *ReconcileDaemon) Trigger(providerType string) {
-	if !reconcile.HasProvider(providerType) {
+	if !d.hasProvider(providerType) {
 		return
 	}
 	d.triggerMu.Lock()
@@ -185,9 +240,11 @@ func (d *ReconcileDaemon) run(ctx context.Context) {
 	}
 }
 
-// runTick iterates all registered providers and runs their reconcile cycle.
-// Also drains any pending triggers before iterating (so a trigger that fired
-// between ticks is absorbed into this tick rather than generating a double run).
+// runTick iterates all providers and runs their reconcile cycle.
+// When cfg.Providers is set, iterates the injected list; otherwise uses the
+// global registry. Also drains any pending triggers before iterating (so a
+// trigger that fired between ticks is absorbed into this tick rather than
+// generating a double run).
 func (d *ReconcileDaemon) runTick(ctx context.Context) {
 	// Absorb any outstanding triggers into this tick (they'll be covered by
 	// the full provider scan).
@@ -195,7 +252,7 @@ func (d *ReconcileDaemon) runTick(ctx context.Context) {
 	d.triggered = make(map[string]struct{})
 	d.triggerMu.Unlock()
 
-	providers := reconcile.ListProviders()
+	providers := d.listProviderTypes()
 	if len(providers) == 0 {
 		return
 	}
@@ -329,7 +386,7 @@ func (d *ReconcileDaemon) runOneCycle(ctx context.Context, providerType string) 
 
 	start := time.Now()
 
-	provider, err := reconcile.GetProvider(providerType)
+	provider, err := d.getProvider(providerType)
 	if err != nil {
 		slog.Warn("reconcile-daemon: provider not found", "provider", providerType, "err", err)
 		return err

--- a/internal/testkernel/isolated_registry_test.go
+++ b/internal/testkernel/isolated_registry_test.go
@@ -1,0 +1,238 @@
+// isolated_registry_test.go — ADR-101 Phase 2 proving test.
+//
+// Verifies that WithIsolatedRegistry causes the kernel's ReconcileDaemon to
+// operate exclusively on the injected provider list, with zero calls to the
+// global registry. This is the key invariant that lets integration tests run
+// real plan/apply cycles in parallel without stub interference.
+//
+// Two tests:
+//
+//  1. TestIsolatedRegistry_OnlyFakeRuns — boots with a single fake Reconcilable
+//     whose Type() returns "fake-isolated". Triggers a reconcile, waits for the
+//     cycle to complete, then asserts:
+//     - The fake's LoadConfig/FetchLive counts went up (cycle actually ran).
+//     - No provider in the global registry was ever called (registry is empty in
+//       test binaries, so this is implicitly verified; the test additionally
+//       confirms that re-registering a sentinel into the global registry after
+//       boot doesn't cause it to be called by the daemon).
+//
+//  2. TestIsolatedRegistry_GlobalSentinelNotCalled — registers a sentinel
+//     Reconcilable into the global registry BEFORE booting, then boots with an
+//     injected "fake-isolated" provider. Asserts the global sentinel is never
+//     called while the fake is called. This is the strongest form of the
+//     isolation proof.
+package testkernel_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/myrgic/cogos/internal/engine"
+	"github.com/myrgic/cogos/internal/testkernel"
+	"github.com/myrgic/cogos/pkg/reconcile"
+)
+
+// ─── fakeReconcilable ────────────────────────────────────────────────────────
+
+// fakeReconcilable is a minimal Reconcilable whose call counts are tracked via
+// atomics so they are safe to read from the test goroutine.
+type fakeReconcilable struct {
+	typeName     string
+	loadCount    atomic.Int32
+	fetchCount   atomic.Int32
+	computeCount atomic.Int32
+}
+
+func newFake(typeName string) *fakeReconcilable {
+	return &fakeReconcilable{typeName: typeName}
+}
+
+func (f *fakeReconcilable) Type() string { return f.typeName }
+
+func (f *fakeReconcilable) LoadConfig(_ string) (any, error) {
+	f.loadCount.Add(1)
+	return map[string]any{"type": f.typeName}, nil
+}
+
+func (f *fakeReconcilable) FetchLive(_ context.Context, _ any) (any, error) {
+	f.fetchCount.Add(1)
+	return map[string]any{"live": true}, nil
+}
+
+func (f *fakeReconcilable) ComputePlan(_ any, _ any, _ *reconcile.State) (*reconcile.Plan, error) {
+	f.computeCount.Add(1)
+	return &reconcile.Plan{
+		ResourceType: f.typeName,
+		GeneratedAt:  time.Now().UTC().Format(time.RFC3339),
+		Actions: []reconcile.Action{{
+			Action:       reconcile.ActionSkip,
+			ResourceType: f.typeName,
+			Name:         "test",
+			Details:      map[string]any{"reason": "in sync"},
+		}},
+		Summary: reconcile.Summary{Skipped: 1},
+	}, nil
+}
+
+func (f *fakeReconcilable) ApplyPlan(_ context.Context, plan *reconcile.Plan) ([]reconcile.Result, error) {
+	var results []reconcile.Result
+	for _, a := range plan.Actions {
+		results = append(results, reconcile.Result{
+			Phase:  "apply",
+			Action: string(a.Action),
+			Name:   a.Name,
+			Status: reconcile.ApplySucceeded,
+		})
+	}
+	return results, nil
+}
+
+func (f *fakeReconcilable) BuildState(_ any, _ any, existing *reconcile.State) (*reconcile.State, error) {
+	s := reconcile.NewState(f.typeName)
+	if existing != nil {
+		s.Lineage = existing.Lineage
+		s.Serial = existing.Serial
+	}
+	return s, nil
+}
+
+func (f *fakeReconcilable) Health() reconcile.ResourceStatus {
+	return reconcile.NewResourceStatus(reconcile.SyncStatusSynced, reconcile.HealthHealthy)
+}
+
+// ─── waitForCycle ─────────────────────────────────────────────────────────────
+
+// waitForCycle polls until fake.fetchCount exceeds threshold or deadline is
+// reached. The ReconcileDaemon tick interval is set very high so the only way
+// fetchCount increases is through an explicit Trigger call.
+func waitForCycle(t *testing.T, fake *fakeReconcilable, threshold int32, deadline time.Duration) {
+	t.Helper()
+	dl := time.After(deadline)
+	for {
+		select {
+		case <-dl:
+			t.Fatalf("waitForCycle: FetchLive count did not reach %d within %v (got %d)",
+				threshold, deadline, fake.fetchCount.Load())
+		default:
+			if fake.fetchCount.Load() >= threshold {
+				return
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+// TestIsolatedRegistry_OnlyFakeRuns verifies that when WithIsolatedRegistry is
+// used, only the injected "fake-isolated" provider is ever reconciled. A trigger
+// on the fake type fires the cycle; the test waits for FetchLive to be called
+// and confirms call counts are positive.
+func TestIsolatedRegistry_OnlyFakeRuns(t *testing.T) {
+	// Ensure global registry is clean for this test. Other tests in this package
+	// may leave entries; reset before and after.
+	reconcile.ResetProviders()
+	defer reconcile.ResetProviders()
+
+	fake := newFake("fake-isolated")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	k, err := testkernel.Boot(ctx, t,
+		testkernel.WithIsolatedRegistry(fake),
+	)
+	if err != nil {
+		t.Fatalf("testkernel.Boot: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := k.Stop(); err != nil {
+			t.Errorf("testkernel.Stop: %v", err)
+		}
+	})
+
+	daemon := k.ReconcileDaemon()
+
+	// Fire a trigger for the fake provider. The daemon's poll interval is the
+	// default (30 s); without a trigger this test would wait a long time.
+	daemon.Trigger("fake-isolated")
+
+	// Wait for FetchLive to be called at least once (one full cycle).
+	waitForCycle(t, fake, 1, 5*time.Second)
+
+	// Confirm all three stages ran.
+	if got := fake.loadCount.Load(); got < 1 {
+		t.Errorf("LoadConfig count = %d; want >= 1", got)
+	}
+	if got := fake.fetchCount.Load(); got < 1 {
+		t.Errorf("FetchLive count = %d; want >= 1", got)
+	}
+	if got := fake.computeCount.Load(); got < 1 {
+		t.Errorf("ComputePlan count = %d; want >= 1", got)
+	}
+
+	// Daemon must still be live (not stalled or shut down).
+	if got := daemon.State(); got == engine.ReconcileDaemonShutdown {
+		t.Errorf("daemon state = %q; want not Shutdown", got)
+	}
+}
+
+// TestIsolatedRegistry_GlobalSentinelNotCalled is the strongest isolation proof.
+// A sentinel is registered into the global registry before boot. The kernel is
+// booted with WithIsolatedRegistry(fake). After a full cycle of the fake, the
+// sentinel's call counts must remain zero — confirming the daemon never touched
+// the global registry.
+func TestIsolatedRegistry_GlobalSentinelNotCalled(t *testing.T) {
+	reconcile.ResetProviders()
+	defer reconcile.ResetProviders()
+
+	// sentinel lives in the global registry. If the daemon ever queries the
+	// global registry its LoadConfig/FetchLive counters will go up.
+	sentinel := newFake("global-sentinel")
+	reconcile.UpsertProvider(sentinel.Type(), sentinel)
+
+	fake := newFake("fake-isolated-sentinel-test")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	k, err := testkernel.Boot(ctx, t,
+		testkernel.WithIsolatedRegistry(fake),
+	)
+	if err != nil {
+		t.Fatalf("testkernel.Boot: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := k.Stop(); err != nil {
+			t.Errorf("testkernel.Stop: %v", err)
+		}
+	})
+
+	daemon := k.ReconcileDaemon()
+
+	// Trigger the fake's cycle explicitly.
+	daemon.Trigger(fake.Type())
+
+	// Wait for the fake to complete at least one cycle.
+	waitForCycle(t, fake, 1, 5*time.Second)
+
+	// Give the event loop a moment to settle, then check the sentinel counts.
+	time.Sleep(20 * time.Millisecond)
+
+	if got := sentinel.loadCount.Load(); got != 0 {
+		t.Errorf("isolation breach: global sentinel LoadConfig called %d times; want 0", got)
+	}
+	if got := sentinel.fetchCount.Load(); got != 0 {
+		t.Errorf("isolation breach: global sentinel FetchLive called %d times; want 0", got)
+	}
+	if got := sentinel.computeCount.Load(); got != 0 {
+		t.Errorf("isolation breach: global sentinel ComputePlan called %d times; want 0", got)
+	}
+
+	// Fake must have run.
+	if got := fake.fetchCount.Load(); got < 1 {
+		t.Errorf("fake FetchLive count = %d; want >= 1", got)
+	}
+}

--- a/internal/testkernel/testkernel.go
+++ b/internal/testkernel/testkernel.go
@@ -1,9 +1,11 @@
 // Package testkernel provides an in-process kernel boot harness for
 // daemon-level integration tests.
 //
-// ADR-101 Phase 1: thin wrapper over engine.Boot. Phase 2 will add
-// WithIsolatedRegistry; Phase 3 will add CallTool/HTTPClient; Phase 4 will
-// add goroutine-leak detection.
+// ADR-101 Phase 1: thin wrapper over engine.Boot.
+// ADR-101 Phase 2: WithIsolatedRegistry injects an explicit provider list so
+// tests can exercise real plan/apply without touching the global registry.
+// Phase 3 will add CallTool/HTTPClient; Phase 4 will add goroutine-leak
+// detection.
 //
 // Typical usage:
 //
@@ -37,12 +39,10 @@ import (
 	"time"
 
 	"github.com/myrgic/cogos/internal/engine"
+	"github.com/myrgic/cogos/pkg/reconcile"
 )
 
 // Option is a functional option for Boot.
-//
-// Phase 1 defines no options with observable effect; the type exists so that
-// the API surface is stable for Phase 2 additions (WithIsolatedRegistry, etc.).
 type Option func(*config)
 
 // config holds resolved options derived from Option values.
@@ -54,14 +54,30 @@ type config struct {
 	port int
 
 	// pollInterval overrides the reconcile daemon tick. 0 = use daemon default.
-	// Phase 2 will expose this as WithPollInterval.
 	pollInterval time.Duration
+
+	// providers, when non-nil, is forwarded to engine.WithIsolatedRegistry so
+	// the daemon bypasses the global registry. nil = use global registry.
+	providers []reconcile.Reconcilable
 }
 
 // WithWorkspace sets the workspace root for the kernel under test.
 // Defaults to a temporary directory created at Boot time.
 func WithWorkspace(path string) Option {
 	return func(c *config) { c.workspace = path }
+}
+
+// WithIsolatedRegistry injects an explicit set of Reconcilable providers into
+// the kernel's ReconcileDaemon, bypassing the global registry.
+//
+// Use this in integration tests that need to exercise real plan/apply cycles
+// with specific providers without interference from globally-registered stubs.
+// Any provider type NOT in the supplied list will never be touched by the
+// daemon for the lifetime of this kernel.
+//
+// This is the ADR-101 Phase 2 test-isolation mechanism.
+func WithIsolatedRegistry(providers ...reconcile.Reconcilable) Option {
+	return func(c *config) { c.providers = providers }
 }
 
 // Kernel is an opaque handle to an in-process kernel instance started by Boot.
@@ -82,6 +98,12 @@ func (k *Kernel) WorkspaceRoot() string {
 	return k.kernel.WorkspaceRoot()
 }
 
+// ReconcileDaemon returns the kernel's ReconcileDaemon so tests can call
+// Trigger and inspect State without going through the HTTP surface.
+func (k *Kernel) ReconcileDaemon() *engine.ReconcileDaemon {
+	return k.kernel.ReconcileDaemon()
+}
+
 // Stop cancels the kernel's context and waits for all goroutines to exit.
 // Safe to call multiple times.
 func (k *Kernel) Stop() error {
@@ -93,11 +115,9 @@ func (k *Kernel) Stop() error {
 // boots the kernel via engine.Boot, and blocks until the HTTP /health endpoint
 // responds 200 or ctx expires.
 //
-// Boot does NOT call RegisterProviders or SetProvidersWorkspace; tests that
-// need real providers must register them before calling Boot (Phase 1 note:
-// the smoke test runs against whatever providers are globally registered at
-// call time, which is none in test binaries — the reconcile daemon will run
-// with an empty provider set, which is fine for proving the harness works).
+// Boot does NOT call RegisterProviders or SetProvidersWorkspace. Tests that
+// need real providers should pass WithIsolatedRegistry (Phase 2) rather than
+// touching the global registry.
 func Boot(ctx context.Context, t *testing.T, opts ...Option) (*Kernel, error) {
 	t.Helper()
 
@@ -117,7 +137,7 @@ func Boot(ctx context.Context, t *testing.T, opts ...Option) (*Kernel, error) {
 		return nil, fmt.Errorf("testkernel.Boot: load config: %w", err)
 	}
 	// In test paths, always use port 0 (OS-assigned ephemeral port) unless
-	// the caller explicitly set a port via WithPort (not yet exposed in Phase 1).
+	// the caller explicitly set a port via WithPort.
 	// LoadConfig with port==0 leaves the default 6931; we override explicitly
 	// here to avoid colliding with a running production daemon.
 	if cfg.port == 0 {
@@ -128,7 +148,13 @@ func Boot(ctx context.Context, t *testing.T, opts ...Option) (*Kernel, error) {
 		engineCfg.BindAddr = "127.0.0.1"
 	}
 
-	k, err := engine.Boot(ctx, engineCfg)
+	// Build engine BootOptions from testkernel config.
+	var bootOpts []engine.BootOption
+	if cfg.providers != nil {
+		bootOpts = append(bootOpts, engine.WithIsolatedRegistry(cfg.providers...))
+	}
+
+	k, err := engine.Boot(ctx, engineCfg, bootOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("testkernel.Boot: engine.Boot: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Adds `Providers []reconcile.Reconcilable` to `ReconcileDaemonConfig` (ADR-101 Decision 3). When non-nil, the daemon iterates this list exclusively; when nil, the global `reconcile.ListProviders()` path is preserved exactly — zero behaviour change for production.
- Adds `engine.WithIsolatedRegistry(...reconcile.Reconcilable) BootOption` and `testkernel.WithIsolatedRegistry(...)  Option` so tests can inject real providers without touching the global registry that contains daemon-binary stub providers.
- Adds `engine.Kernel.ReconcileDaemon()` and `testkernel.Kernel.ReconcileDaemon()` accessors so tests can drive `Trigger` and inspect `State` directly without going through HTTP.

## Proving tests (`internal/testkernel/isolated_registry_test.go`)

Two tests, both pass:

1. **`TestIsolatedRegistry_OnlyFakeRuns`** — boots with a single `fakeReconcilable` (type `"fake-isolated"`), fires `Trigger("fake-isolated")`, polls until `FetchLive` count goes above zero. Asserts all three stages (LoadConfig / FetchLive / ComputePlan) executed.

2. **`TestIsolatedRegistry_GlobalSentinelNotCalled`** — registers a `global-sentinel` into the global registry *before* boot, boots with a different injected fake, fires a trigger, waits for the fake to complete a cycle, then asserts `global-sentinel.loadCount == 0`, `fetchCount == 0`, `computeCount == 0`. This is the hard isolation proof: a provider in the global registry is never touched when the injected list is set.

## What this unlocks

Before this PR, the testkernel could only see whatever was globally registered at call time (nothing in test binaries, or stubs in daemon-binary paths). After this PR, integration tests can boot the daemon with real `IdentityProvider`, `RBACProvider`, etc. and exercise actual plan/apply cycles.

Closes the daemon-binary stub asymmetry described in #287.

Builds on top of #289 (Phase 1).

## Test plan

- [x] `go test ./internal/engine/` — all 8 existing `TestReconcileDaemon_*` tests pass
- [x] `go test ./internal/testkernel/` — Phase 1 smoke test + 2 new isolation tests pass
- [x] `go test ./...` — full suite green (12 packages, 0 failures)
- [ ] Bonus IdentityProvider test deferred to Phase 2.5 (requires wiring IdentityProvider workspace path to test temp dir, non-trivial fixture work beyond this PR's scope)