### PR TITLE
feat(identity): VoiceProfile + cog://voices namespace; remove legacy Voice string (Primitive 3)

### DIFF
--- a/identity_crd.go
+++ b/identity_crd.go
@@ -142,6 +142,40 @@ type AuthFactorEntry struct {
 	Claims map[string]any `yaml:"claims,omitempty"`
 }
 
+// VoiceProfile separates the generative TTS head from the discriminative
+// speaker-recognition head. Both are URI-addressed substrate records so
+// their file locations are projections, not the binding. This makes voice
+// assets substrate-addressable via cog://voices/* — the same pattern used
+// for skills (cog://skills/*) and memory (cog://mem/*).
+type VoiceProfile struct {
+	// Generative is the TTS conditioning head (Chatterbox-Turbo or compatible).
+	// When non-nil, the identity can speak via mod3 using these conditionals.
+	Generative *VoiceGenerativeHead `yaml:"generative,omitempty"`
+	// Discriminative is the speaker-recognition head (ECAPA-TDNN or compatible).
+	// When non-nil, the pipeline can identify this speaker from raw audio.
+	// Schema only in this wave — no live ECAPA integration yet.
+	Discriminative *VoiceDiscriminativeHead `yaml:"discriminative,omitempty"`
+}
+
+// VoiceGenerativeHead holds TTS conditioning parameters for one engine.
+// ConditionalsRef is a cog://voices/<name> URI that resolves to the
+// safetensors file containing the Chatterbox speaker conditionals.
+type VoiceGenerativeHead struct {
+	Engine          string `yaml:"engine"`                    // e.g. "chatterbox-turbo"
+	ConditionalsRef string `yaml:"conditionals_ref"`           // cog://voices/<name>
+	EnrolledAt      string `yaml:"enrolled_at,omitempty"`      // RFC3339; set by enrollment
+}
+
+// VoiceDiscriminativeHead holds speaker-recognition parameters.
+// EmbeddingRef is a cog://voices/<name>/ecapa-embedding URI that
+// resolves to the ECAPA-TDNN speaker embedding vector.
+// Schema only in this wave — ECAPA integration is a follow-up.
+type VoiceDiscriminativeHead struct {
+	Model        string `yaml:"model"`                  // e.g. "speechbrain/spkrec-ecapa-voxceleb"
+	EmbeddingRef string `yaml:"embedding_ref"`           // cog://voices/<name>/ecapa-embedding
+	EnrolledAt   string `yaml:"enrolled_at,omitempty"`   // RFC3339
+}
+
 // IdentityExpression is one projection of an identity into a specific audience.
 // At least one expression per Identity. The reconciler matches by `aud`:
 //
@@ -154,8 +188,13 @@ type IdentityExpression struct {
 	DisplayName string   `yaml:"display_name,omitempty"`
 	Role        string   `yaml:"role,omitempty"`
 	Skills      []string `yaml:"skills,omitempty"`
-	Voice       string   `yaml:"voice,omitempty"`
-	Sudo        bool     `yaml:"sudo,omitempty"`
+	// VoiceProfile holds structured voice configuration for this expression.
+	// Replaces the former Voice string field (removed in Wave 6c, 2026-05-19).
+	// Generative head: TTS conditioning via cog://voices/* URIs.
+	// Discriminative head: speaker-recognition embedding (schema only; no live
+	// ECAPA integration in this wave).
+	VoiceProfile *VoiceProfile `yaml:"voice_profile,omitempty"`
+	Sudo         bool          `yaml:"sudo,omitempty"`
 	// MemoryNamespace optionally scopes this expression's memory reads/writes
 	// (e.g., "cog://" for root, "cog://agents/sandy/" for a scoped agent).
 	MemoryNamespace string `yaml:"memory_namespace,omitempty"`

--- a/identity_crd_test.go
+++ b/identity_crd_test.go
@@ -746,3 +746,117 @@ spec:
 		})
 	}
 }
+
+// ─── VoiceProfile (Primitive 3) ─────────────────────────────────────────────────
+
+// TestLoadIdentityCRD_VoiceProfile_GenerativeOnly asserts that a YAML with
+// only a generative head parses correctly and discriminative is nil.
+func TestLoadIdentityCRD_VoiceProfile_GenerativeOnly(t *testing.T) {
+	dir := t.TempDir()
+	idDir := filepath.Join(dir, ".cog", "config", "identities")
+	_ = os.MkdirAll(idDir, 0o755)
+	writeTempCRD(t, idDir, "cog.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: Identity
+metadata:
+  name: cog
+spec:
+  iss: cogos-dev
+  sub: cog
+  type: agent
+  expressions:
+    - aud: "*"
+      display_name: Cog
+      voice_profile:
+        generative:
+          engine: chatterbox-turbo
+          conditionals_ref: "cog://voices/cog"
+          enrolled_at: "2026-05-19T00:00:00Z"
+`)
+	crd, err := LoadIdentityCRD(dir, "cog")
+	if err != nil {
+		t.Fatalf("LoadIdentityCRD: %v", err)
+	}
+	exp := crd.Spec.Expressions[0]
+	if exp.VoiceProfile == nil {
+		t.Fatal("VoiceProfile is nil; expected populated")
+	}
+	if exp.VoiceProfile.Generative == nil {
+		t.Fatal("VoiceProfile.Generative is nil; expected populated")
+	}
+	if exp.VoiceProfile.Generative.Engine != "chatterbox-turbo" {
+		t.Errorf("Engine = %q, want %q", exp.VoiceProfile.Generative.Engine, "chatterbox-turbo")
+	}
+	if exp.VoiceProfile.Generative.ConditionalsRef != "cog://voices/cog" {
+		t.Errorf("ConditionalsRef = %q, want %q", exp.VoiceProfile.Generative.ConditionalsRef, "cog://voices/cog")
+	}
+	if exp.VoiceProfile.Discriminative != nil {
+		t.Errorf("Discriminative should be nil, got %+v", exp.VoiceProfile.Discriminative)
+	}
+}
+
+// TestLoadIdentityCRD_VoiceProfile_BothHeads asserts that a YAML with both
+// generative and discriminative heads round-trips all fields correctly.
+func TestLoadIdentityCRD_VoiceProfile_BothHeads(t *testing.T) {
+	dir := t.TempDir()
+	idDir := filepath.Join(dir, ".cog", "config", "identities")
+	_ = os.MkdirAll(idDir, 0o755)
+	writeTempCRD(t, idDir, "cog.yaml", `
+apiVersion: cog.os/v1alpha1
+kind: Identity
+metadata:
+  name: cog
+spec:
+  iss: cogos-dev
+  sub: cog
+  type: agent
+  expressions:
+    - aud: "*"
+      display_name: Cog
+      voice_profile:
+        generative:
+          engine: chatterbox-turbo
+          conditionals_ref: "cog://voices/cog"
+        discriminative:
+          model: "speechbrain/spkrec-ecapa-voxceleb"
+          embedding_ref: "cog://voices/cog/ecapa-embedding"
+          enrolled_at: "2026-05-19T00:00:00Z"
+`)
+	crd, err := LoadIdentityCRD(dir, "cog")
+	if err != nil {
+		t.Fatalf("LoadIdentityCRD: %v", err)
+	}
+	exp := crd.Spec.Expressions[0]
+	if exp.VoiceProfile == nil {
+		t.Fatal("VoiceProfile is nil")
+	}
+	if exp.VoiceProfile.Generative == nil {
+		t.Fatal("Generative is nil")
+	}
+	if exp.VoiceProfile.Discriminative == nil {
+		t.Fatal("Discriminative is nil")
+	}
+	if exp.VoiceProfile.Discriminative.Model != "speechbrain/spkrec-ecapa-voxceleb" {
+		t.Errorf("Model = %q", exp.VoiceProfile.Discriminative.Model)
+	}
+	if exp.VoiceProfile.Discriminative.EmbeddingRef != "cog://voices/cog/ecapa-embedding" {
+		t.Errorf("EmbeddingRef = %q", exp.VoiceProfile.Discriminative.EmbeddingRef)
+	}
+}
+
+// TestLoadIdentityCRD_VoiceProfile_Absent asserts that an identity without
+// voice_profile has VoiceProfile == nil and loads without error.
+func TestLoadIdentityCRD_VoiceProfile_Absent(t *testing.T) {
+	dir := t.TempDir()
+	idDir := filepath.Join(dir, ".cog", "config", "identities")
+	_ = os.MkdirAll(idDir, 0o755)
+	writeTempCRD(t, idDir, "cog.yaml", minimalValidIdentityYAML)
+	crd, err := LoadIdentityCRD(dir, "cog")
+	if err != nil {
+		t.Fatalf("LoadIdentityCRD: %v", err)
+	}
+	exp := crd.Spec.Expressions[0]
+	if exp.VoiceProfile != nil {
+		t.Errorf("expected VoiceProfile nil when absent, got %+v", exp.VoiceProfile)
+	}
+}

--- a/identity_provider.go
+++ b/identity_provider.go
@@ -83,6 +83,11 @@ type IdentityProjection struct {
 	// first) expression so callers can resolve the identity's home URI without
 	// iterating the full expression list.
 	WorkspaceRoot string               `json:"workspace_root,omitempty"`
+	// VoiceProfile carries the voice_profile from the primary (catch-all or
+	// first) expression so callers can resolve the identity's voice config
+	// without iterating the full expression list. Both generative (TTS) and
+	// discriminative (speaker recognition) heads are carried when present.
+	VoiceProfile *VoiceProfile `json:"voice_profile,omitempty"`
 }
 
 // ParticipantRow matches the kernel's existing `participants` table schema
@@ -608,13 +613,16 @@ func (p *IdentityProvider) applyUpsert(ctx context.Context, root string, crd *Id
 	projectionPath := filepath.Join(".cog", "id", sub+".cog.md")
 	absProjection := filepath.Join(root, projectionPath)
 
-	// Pull WorkspaceRoot from the primary expression so callers don't need to
-	// iterate expressions to find the home URI.
+	// Pull WorkspaceRoot and VoiceProfile from the primary expression so callers
+	// don't need to iterate expressions to find the home URI or voice config.
 	var workspaceRoot string
+	var voiceProfile *VoiceProfile
 	if exp := crd.Spec.ExpressionFor("*"); exp != nil {
 		workspaceRoot = exp.WorkspaceRoot
+		voiceProfile = exp.VoiceProfile
 	} else if len(crd.Spec.Expressions) > 0 {
 		workspaceRoot = crd.Spec.Expressions[0].WorkspaceRoot
+		voiceProfile = crd.Spec.Expressions[0].VoiceProfile
 	}
 
 	proj := IdentityProjection{
@@ -626,6 +634,7 @@ func (p *IdentityProvider) applyUpsert(ctx context.Context, root string, crd *Id
 		Expressions:   append([]IdentityExpression(nil), crd.Spec.Expressions...),
 		ContentPath:   projectionPath,
 		WorkspaceRoot: workspaceRoot,
+		VoiceProfile:  voiceProfile,
 	}
 
 	// Write projection cogdoc first — if it fails we haven't touched the DB.
@@ -853,8 +862,15 @@ func writeIdentityProjectionCogDoc(absPath string, crd *IdentityCRD, specHash st
 		if exp.Role != "" {
 			fmt.Fprintf(&buf, "**Role:** %s\n\n", exp.Role)
 		}
-		if exp.Voice != "" {
-			fmt.Fprintf(&buf, "**Voice:** %s\n\n", exp.Voice)
+		if vp := exp.VoiceProfile; vp != nil {
+			if vp.Generative != nil {
+				fmt.Fprintf(&buf, "**Voice (generative):** engine=%s ref=%s\n\n",
+					vp.Generative.Engine, vp.Generative.ConditionalsRef)
+			}
+			if vp.Discriminative != nil {
+				fmt.Fprintf(&buf, "**Voice (discriminative):** model=%s ref=%s\n\n",
+					vp.Discriminative.Model, vp.Discriminative.EmbeddingRef)
+			}
 		}
 		if len(exp.Skills) > 0 {
 			buf.WriteString("**Skills:**\n")

--- a/identity_provider_test.go
+++ b/identity_provider_test.go
@@ -991,3 +991,114 @@ func TestIdentityProvider_WorkspaceRoot_AbsentIsEmpty(t *testing.T) {
 		t.Errorf("WorkspaceRoot = %q, want empty string when unset", proj.WorkspaceRoot)
 	}
 }
+
+// ─── VoiceProfile projection (Primitive 3) ──────────────────────────────────────
+
+// writeIdentityCRDWithVoiceProfile writes a CRD that includes a full
+// voice_profile (both generative and discriminative heads) in its catch-all
+// expression.
+func writeIdentityCRDWithVoiceProfile(t *testing.T, root, sub string) {
+	t.Helper()
+	dir := identityCRDDir(root)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	body := fmt.Sprintf(`apiVersion: cog.os/v1alpha1
+kind: Identity
+metadata:
+  name: %s
+spec:
+  iss: cogos-dev
+  sub: %s
+  type: agent
+  expressions:
+    - aud: "*"
+      display_name: %q
+      voice_profile:
+        generative:
+          engine: chatterbox-turbo
+          conditionals_ref: "cog://voices/%s"
+        discriminative:
+          model: "speechbrain/spkrec-ecapa-voxceleb"
+          embedding_ref: "cog://voices/%s/ecapa-embedding"
+`, sub, sub, sub, sub, sub)
+	path := filepath.Join(dir, sub+".yaml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// TestIdentityProvider_VoiceProfile_ProjectionPopulated verifies that after a
+// full reconcile cycle, IdentityProjection.VoiceProfile carries the generative
+// and discriminative heads declared in the CRD's catch-all expression.
+func TestIdentityProvider_VoiceProfile_ProjectionPopulated(t *testing.T) {
+	fx := setupProvider(t)
+	writeIdentityCRDWithVoiceProfile(t, fx.root, "cog")
+
+	cfg, _ := fx.prov.LoadConfig(fx.root)
+	live, _ := fx.prov.FetchLive(context.Background(), cfg)
+	plan, _ := fx.prov.ComputePlan(cfg, live, nil)
+	results, err := fx.prov.ApplyPlan(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("ApplyPlan: %v", err)
+	}
+	if len(results) != 1 || results[0].Status != ApplySucceeded {
+		t.Fatalf("results = %+v, want 1 succeeded", results)
+	}
+
+	proj, err := fx.db.GetProjection(context.Background(), "cog")
+	if err != nil {
+		t.Fatalf("GetProjection: %v", err)
+	}
+	if proj == nil {
+		t.Fatal("projection is nil")
+	}
+	if proj.VoiceProfile == nil {
+		t.Fatal("VoiceProfile is nil; expected populated")
+	}
+	if proj.VoiceProfile.Generative == nil {
+		t.Fatal("VoiceProfile.Generative is nil")
+	}
+	if proj.VoiceProfile.Generative.Engine != "chatterbox-turbo" {
+		t.Errorf("Engine = %q, want chatterbox-turbo", proj.VoiceProfile.Generative.Engine)
+	}
+	if proj.VoiceProfile.Generative.ConditionalsRef != "cog://voices/cog" {
+		t.Errorf("ConditionalsRef = %q, want cog://voices/cog", proj.VoiceProfile.Generative.ConditionalsRef)
+	}
+	if proj.VoiceProfile.Discriminative == nil {
+		t.Fatal("VoiceProfile.Discriminative is nil")
+	}
+	if proj.VoiceProfile.Discriminative.EmbeddingRef != "cog://voices/cog/ecapa-embedding" {
+		t.Errorf("EmbeddingRef = %q, want cog://voices/cog/ecapa-embedding",
+			proj.VoiceProfile.Discriminative.EmbeddingRef)
+	}
+}
+
+// TestIdentityProvider_VoiceProfile_AbsentIsNil verifies that reconciling an
+// identity with no voice_profile yields VoiceProfile == nil on the projection.
+func TestIdentityProvider_VoiceProfile_AbsentIsNil(t *testing.T) {
+	fx := setupProvider(t)
+	writeIdentityCRD(t, fx.root, "cog", "cogos-dev", "Cog", "")
+
+	cfg, _ := fx.prov.LoadConfig(fx.root)
+	live, _ := fx.prov.FetchLive(context.Background(), cfg)
+	plan, _ := fx.prov.ComputePlan(cfg, live, nil)
+	results, err := fx.prov.ApplyPlan(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("ApplyPlan: %v", err)
+	}
+	if len(results) != 1 || results[0].Status != ApplySucceeded {
+		t.Fatalf("results = %+v, want 1 succeeded", results)
+	}
+
+	proj, err := fx.db.GetProjection(context.Background(), "cog")
+	if err != nil {
+		t.Fatalf("GetProjection: %v", err)
+	}
+	if proj == nil {
+		t.Fatal("projection is nil")
+	}
+	if proj.VoiceProfile != nil {
+		t.Errorf("VoiceProfile should be nil when absent, got %+v", proj.VoiceProfile)
+	}
+}

--- a/internal/engine/uri_registry.go
+++ b/internal/engine/uri_registry.go
@@ -331,7 +331,8 @@ func isProjectionNamespace(s string) bool {
 		"src", "adr", "ledger", "inference", "kernel", "hooks",
 		"spec", "specs", "status", "canonical", "handoff", "handoffs",
 		"crystal", "role", "roles", "skill", "skills", "agent", "agents",
-		"conf", "config", "ontology", "work", "artifact", "artifacts", "docs":
+		"conf", "config", "ontology", "work", "artifact", "artifacts", "docs",
+		"voices": // cog:voices/* — voice profile records (Primitive 3)
 		return true
 	}
 	return false

--- a/pkg/uri/namespace.go
+++ b/pkg/uri/namespace.go
@@ -45,6 +45,14 @@ var Namespaces = map[string]bool{
 	"skill":  true, // cog:skill/* → Skill definitions
 	"skills": true, // cog:skills/* → Skills (plural alias)
 
+	// ── Voice assets ──────────────────────────────────────────────────────────
+	// cog:voices/<name>                  → VoiceProfile record (generative + discriminative heads)
+	// cog:voices/<name>/ecapa-embedding  → ECAPA-TDNN speaker embedding vector
+	// Resolution: the kernel projects cog:voices/* to ~/.mod3/voices/<name>.{json,safetensors}.
+	// Pattern mirrors cog:skills/* and cog:mem/* — voice assets are
+	// substrate-addressable records, not hidden name lookups.
+	"voices": true, // cog:voices/* → Voice profile records
+
 	// ── Handoffs / artifacts ──────────────────────────────────────────────────
 	"handoff":   true, // cog:handoff/* → Handoff documents
 	"handoffs":  true, // cog:handoffs/* → Handoffs (plural alias)

--- a/pkg/uri/uri_test.go
+++ b/pkg/uri/uri_test.go
@@ -382,6 +382,50 @@ func TestParseBothFormsRoundTrip(t *testing.T) {
 	}
 }
 
+// ── cog://voices/* namespace (Primitive 3 — VoiceProfile) ──────────────────────
+
+// TestParseVoicesNamespace verifies that cog://voices/* URIs are accepted by
+// the parser now that "voices" is registered in the Namespaces map (Wave 6c).
+func TestParseVoicesNamespace(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		raw      string
+		wantNS   string
+		wantPath string
+	}{
+		{"cog:voices/cog", "voices", "cog"},
+		{"cog://voices/cog", "voices", "cog"},
+		{"cog:voices/cog/ecapa-embedding", "voices", "cog/ecapa-embedding"},
+		{"cog:voices/bm_lewis", "voices", "bm_lewis"},
+		{"cog:voices/eng_uk_m_davids", "voices", "eng_uk_m_davids"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.raw, func(t *testing.T) {
+			t.Parallel()
+			u, err := Parse(tc.raw)
+			if err != nil {
+				t.Fatalf("Parse(%q): %v", tc.raw, err)
+			}
+			if u.Namespace != tc.wantNS {
+				t.Errorf("Namespace = %q; want %q", u.Namespace, tc.wantNS)
+			}
+			if u.Path != tc.wantPath {
+				t.Errorf("Path = %q; want %q", u.Path, tc.wantPath)
+			}
+		})
+	}
+}
+
+// TestIsValidNamespace_Voices asserts that "voices" is recognized as a valid
+// cog: namespace after the Wave 6c registration.
+func TestIsValidNamespace_Voices(t *testing.T) {
+	t.Parallel()
+	if !IsValidNamespace("voices") {
+		t.Error("IsValidNamespace(\"voices\") = false; want true")
+	}
+}
+
 // ── Fragment-before-query rejection in canonical parser (issue #171 follow-up) ──
 
 // TestParseFragmentBeforeQuery_Rejected verifies that pkg/uri.Parse rejects a URI

--- a/sdk/uri.go
+++ b/sdk/uri.go
@@ -84,6 +84,14 @@ var Namespaces = map[string]bool{
 	"artifact":  true, // cog:artifact/* → Artifacts
 	"artifacts": true, // cog:artifacts/* → Artifacts (plural alias)
 
+	// ── Voice assets ──────────────────────────────────────────────────────────
+	// cog:voices/<name>                  → VoiceProfile record (generative + discriminative heads)
+	// cog:voices/<name>/ecapa-embedding  → ECAPA-TDNN speaker embedding vector
+	// Resolution: the kernel projects cog:voices/* to ~/.mod3/voices/<name>.{json,safetensors}.
+	// Pattern mirrors cog:skills/* and cog:mem/* — voice assets are
+	// substrate-addressable records, not hidden name lookups.
+	"voices": true, // cog:voices/* → Voice profile records
+
 	// ── Context / signal / thread (SDK-layer namespaces) ──────────────────────
 	"context":   true, // cog:context → 4-tier context assembly
 	"signals":   true, // cog:signals/* → Signal field


### PR DESCRIPTION
## Summary

- Removes the bare `Voice string` field from `IdentityExpression` (operator decision OQ-4 option c: remove immediately, no deprecation period — 2026-05-19).
- Adds `VoiceProfile`, `VoiceGenerativeHead`, and `VoiceDiscriminativeHead` Go structs to `identity_crd.go` so both TTS conditioning and speaker-recognition heads are URI-addressed substrate records.
- Registers the `voices` namespace in `pkg/uri/namespace.go` so `cog://voices/<name>` and `cog://voices/<name>/ecapa-embedding` are valid parsed URIs — voice assets are now substrate-addressable artifacts, not hidden name lookups. Pattern mirrors `cog://skills/*` and `cog://mem/*`.
- Extends `IdentityProjection` with a `VoiceProfile` field populated from the primary expression during `applyUpsert` (alongside `WorkspaceRoot`).
- Updates `writeIdentityProjectionCogDoc` to render generative/discriminative heads instead of the legacy string.

## Operator context

This is Primitive 3 from the Wave 6c brainstorm-primitives scope packet. The Voice string removal was the trigger; the `cog://voices/*` namespace is the structural win. The discriminative head is schema-only in this wave — no live ECAPA integration. Voice enrollment is a follow-up skill.

**Paired mod3 PR:** myrgic/mod3#XX (adopt VoiceProfile schema + cog://voices URI resolver) — needs to land after this one.

## Test plan

- `identity_crd_test.go`: 3 new tests — generative-only YAML parses, both-heads YAML round-trips, absent voice_profile is nil
- `identity_provider_test.go`: 2 new tests — projection carries VoiceProfile after ApplyPlan, absent voice_profile yields nil on projection
- `pkg/uri/uri_test.go`: TestParseVoicesNamespace (5 URI forms), TestIsValidNamespace_Voices
- All existing tests pass (`go test . ./pkg/uri/` green)

## Key invariants

- `Voice string` is gone. No backward-compat field. No dual-path resolution. Zero code paths check `exp.Voice`.
- `cog://voices/*` is now a valid cog: URI namespace — will be rejected by `pkg/uri.Parse` before this PR and accepted after.