### PR TITLE
feat(modality): ChannelDescriptor Mode + Pipeline fields (Primitive 4)

### DIFF
--- a/pkg/modality/channel.go
+++ b/pkg/modality/channel.go
@@ -12,13 +12,40 @@ import (
 )
 
 // ChannelDescriptor declares a channel's identity and capabilities.
+//
+// Mode controls pipeline composition:
+//
+//   - "intentional" (default): session-scoped, explicit participation. The
+//     user turns the mic on deliberately; the pipeline is mic → VAD → STT →
+//     emit. This is the current default for all Claude Code / MCP channels.
+//
+//   - "ambient": always-on mic, VAD-gated attention, continuous diarization.
+//     The pipeline is mic → VAD → diarize → ecapa_match → STT → attribute →
+//     mention_detect → emit. Cog stays silent unless mentioned or there is
+//     "appropriate silence." This is the multi-human-attendee mode (e.g. Chaz
+//     + Erin with a hot mic where Cog listens and chimes in when addressed).
+//
+// Pipeline overrides the ordered stage list derived from Mode. When empty,
+// the channel runtime uses DEFAULT_PIPELINES[Mode]. Each entry is a stage
+// name; the runtime resolves each name to a registered PipelineStage
+// implementation and skips (with a warning log) any name that is not yet
+// registered, so ambient mode is safe to declare even before all its stages
+// are implemented.
 type ChannelDescriptor struct {
 	ID         string         `json:"id"`                 // "discord-text", "claude-code", etc.
 	Transport  string         `json:"transport"`          // "openclaw-gateway", "mcp", "http", "stdio"
 	Input      []ModalityType `json:"input"`              // modalities this channel can receive
 	Output     []ModalityType `json:"output"`             // modalities this channel can deliver
 	SessionKey string         `json:"session_key"`        // pattern for session binding, e.g. "discord:{guild}:{channel}:{user}"
-	Metadata   map[string]any `json:"metadata,omitempty"` // transport-specific data (guild ID, thread ID, etc.)
+	// Mode governs pipeline composition. "intentional" = session-scoped,
+	// explicit participation (default). "ambient" = always-on, VAD-gated
+	// attention, continuous diarization. Empty string resolves to "intentional".
+	Mode string `json:"mode,omitempty"` // "intentional" | "ambient"
+	// Pipeline declares the ordered stage graph. Empty = use mode default.
+	// Each entry is a stage name; the channel runtime resolves each name to
+	// a registered PipelineStage implementation.
+	Pipeline []string       `json:"pipeline,omitempty"`
+	Metadata map[string]any `json:"metadata,omitempty"` // transport-specific data (guild ID, thread ID, etc.)
 }
 
 // SupportsOutput reports whether this channel can deliver the given modality.

--- a/pkg/modality/channel_test.go
+++ b/pkg/modality/channel_test.go
@@ -1,6 +1,7 @@
 package modality_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/myrgic/cogos/pkg/modality"
@@ -122,5 +123,98 @@ func TestChannelRegistry_ChannelsForSession(t *testing.T) {
 	chs := reg.ChannelsForSession("s1")
 	if len(chs) != 2 {
 		t.Errorf("ChannelsForSession returned %d, want 2", len(chs))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Primitive 4: Mode + Pipeline fields
+// ---------------------------------------------------------------------------
+
+func TestChannelDescriptor_AmbientModeRoundTrip(t *testing.T) {
+	// Construct a descriptor with Mode="ambient" and a Pipeline list.
+	desc := &modality.ChannelDescriptor{
+		ID:        "mic-ambient",
+		Transport: "http",
+		Mode:      "ambient",
+		Pipeline:  []string{"denoise", "vad", "diarize", "ecapa_match", "stt", "attribute", "mention_detect", "emit"},
+	}
+
+	data, err := json.Marshal(desc)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var got modality.ChannelDescriptor
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if got.Mode != "ambient" {
+		t.Errorf("Mode = %q, want %q", got.Mode, "ambient")
+	}
+	if len(got.Pipeline) != len(desc.Pipeline) {
+		t.Fatalf("Pipeline len = %d, want %d", len(got.Pipeline), len(desc.Pipeline))
+	}
+	for i, stage := range desc.Pipeline {
+		if got.Pipeline[i] != stage {
+			t.Errorf("Pipeline[%d] = %q, want %q", i, got.Pipeline[i], stage)
+		}
+	}
+}
+
+func TestChannelDescriptor_IntentionalModeRoundTrip(t *testing.T) {
+	// Explicit intentional mode round-trips correctly.
+	desc := &modality.ChannelDescriptor{
+		ID:       "mic-intentional",
+		Mode:     "intentional",
+		Pipeline: []string{"denoise", "vad", "stt", "emit"},
+	}
+
+	data, err := json.Marshal(desc)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var got modality.ChannelDescriptor
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.Mode != "intentional" {
+		t.Errorf("Mode = %q, want %q", got.Mode, "intentional")
+	}
+}
+
+func TestChannelDescriptor_DefaultModeIsEmpty(t *testing.T) {
+	// When Mode is not set, the JSON field is absent (omitempty) and the
+	// zero value round-trips as empty string. Resolution to "intentional"
+	// is the consumer's responsibility.
+	desc := &modality.ChannelDescriptor{
+		ID:        "default-mode",
+		Transport: "stdio",
+	}
+
+	data, err := json.Marshal(desc)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	// "mode" key must not appear in the JSON when Mode is empty.
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal raw: %v", err)
+	}
+	if _, present := raw["mode"]; present {
+		t.Error("mode key should be absent from JSON when Mode is empty (omitempty)")
+	}
+
+	var got modality.ChannelDescriptor
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.Mode != "" {
+		t.Errorf("Mode = %q, want empty string", got.Mode)
+	}
+	if len(got.Pipeline) != 0 {
+		t.Errorf("Pipeline = %v, want empty", got.Pipeline)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `Mode string` (`"intentional"` | `"ambient"`, omitempty) and `Pipeline []string` (omitempty) fields to `ChannelDescriptor` in `pkg/modality/channel.go`.
- Doc comment names both modes' intent (intentional = session-scoped explicit participation; ambient = always-on VAD-gated continuous diarization for multi-human-attendee scenarios) and the skip-with-warning contract for unregistered stages.
- Three new JSON round-trip tests: ambient mode, intentional mode, and default-empty (omitempty).

**Pair with**: myrgic/mod3#PR (feat/channel-pipeline-composable-graph) — the two PRs need to land together for the `channel_mode` handshake to be end-to-end.

**Primitive**: 4 of 5 from brainstorm-primitives-scope.md. Cogos side is Wave-6b-independent (pure additive schema bump).

**Stages registered today**: none (the schema is declarative; mod3 holds the registry).  
**Deferred stages** (follow-on PRs): `diarize`, `ecapa_match`, `attribute`, `mention_detect`.

## Test plan

- [x] `go test ./pkg/modality/...` — all pass (18 tests including 3 new)
- [x] JSON round-trip for `Mode: "ambient"` + full pipeline stage list
- [x] JSON round-trip for `Mode: "intentional"`
- [x] `mode` key absent from JSON when `Mode` is empty string (omitempty contract)