### PR TITLE
feat(observatory): Conversations Observatory Reconcilable + MCP tools (operator-state visibility)

### DIFF
--- a/.cog/config/observatory.yaml
+++ b/.cog/config/observatory.yaml
@@ -1,0 +1,49 @@
+# observatory.yaml — Conversations Observatory configuration
+#
+# This file configures the Conversations Observatory Reconcilable provider
+# (resource type: "conversations"). The observatory projects Claude Code
+# session JSONLs into a queryable substrate-native index, making operator
+# utterances, assistant responses, and tool calls accessible via:
+#
+#   cog_search_conversations    — full-text search over indexed turns
+#   cog_get_conversation_turn   — fetch one turn by session_id + turn_index
+#   cog_list_conversations      — list indexed sessions with metadata
+#
+# All fields are optional. Omitting a field uses the documented default.
+
+# source_dirs: list of directories to scan for Claude Code session JSONLs.
+# Each directory is scanned non-recursively for *.jsonl files whose names
+# are UUIDs (the Claude Code session ID format).
+#
+# Supports ~ expansion for the home directory.
+# Default: ["~/.claude/projects/-Users-slowbro"] when that directory exists.
+source_dirs:
+  - ~/.claude/projects/-Users-slowbro
+
+# include_patterns: glob patterns for files to index within each source_dir.
+# Default: ["*.jsonl"]
+include_patterns:
+  - "*.jsonl"
+
+# exclude_patterns: glob patterns for files to skip.
+# Useful for excluding specific known-large or irrelevant sessions.
+# Default: [] (nothing excluded)
+# exclude_patterns:
+#   - "00000000-*.jsonl"
+
+# max_turn_length: maximum characters stored per turn in the index.
+# Turns longer than this limit are stored truncated with a " [truncated]" suffix.
+# This affects the queryable text, not the source JSONL.
+# Default: 8192
+max_turn_length: 8192
+
+# max_sessions_to_index: cap on sessions indexed per ApplyPlan pass.
+# 0 means no limit — all pending sessions are indexed in one pass.
+# Useful for incremental rollout on large corpora.
+# Default: 0 (no limit)
+max_sessions_to_index: 0
+
+# default_identity: tag applied to sessions from this config when no
+# identity can be extracted from the JSONL records themselves.
+# Default: "" (no tag)
+default_identity: "slowbro"

--- a/cmd/cogos/z_conversations_wire.go
+++ b/cmd/cogos/z_conversations_wire.go
@@ -1,0 +1,55 @@
+// z_conversations_wire.go — wires the Conversations Observatory into the
+// kernel daemon.
+//
+// Prefixed "z_" so this init() runs after providers_wire.go (p < z), ensuring
+// we chain on top of the eval-tools RegisterMCPExtensions set there.
+//
+// The daemon does not run plan/apply for the conversations provider
+// (that is the cog CLI's job via the workspace-root reconcile loop).
+// However the daemon DOES need the MCP tools registered so agents can
+// call cog_search_conversations from within a daemon-mediated session.
+//
+// The conversations provider singleton is shared between the reconcile
+// registration (wired here) and the MCP tool handlers. The provider's
+// LoadConfig is called lazily the first time the MCP tools are invoked
+// (or when engine.SetProvidersWorkspace fires), so the daemon starts
+// cleanly even before a workspace is configured.
+package main
+
+import (
+	"github.com/myrgic/cogos/internal/conversations"
+	"github.com/myrgic/cogos/internal/engine"
+	"github.com/myrgic/cogos/pkg/reconcile"
+)
+
+var daemonConversationsProvider = conversations.NewProvider()
+
+func init() {
+	// Register the conversations provider with the reconcile registry so the
+	// daemon's proprioception Health() block includes it.
+	reconcile.RegisterProvider("conversations", daemonConversationsProvider)
+
+	// Wire workspace root injection — called by SetProvidersWorkspace after
+	// LoadConfig resolves cfg.WorkspaceRoot. Triggers index initialisation.
+	prevSetWorkspace := engine.SetProvidersWorkspace
+	engine.SetProvidersWorkspace = func(workspaceRoot string) {
+		if prevSetWorkspace != nil {
+			prevSetWorkspace(workspaceRoot)
+		}
+		if workspaceRoot != "" {
+			// Initialise the index against the resolved workspace root.
+			// Errors are non-fatal — the provider degrades gracefully.
+			_, _ = daemonConversationsProvider.LoadConfig(workspaceRoot)
+		}
+	}
+
+	// Chain conversations MCP tools after the eval tools registered by
+	// providers_wire.go (p < z ensures providers_wire.go init() ran first).
+	prev := engine.RegisterMCPExtensions
+	engine.RegisterMCPExtensions = func(srv *engine.MCPServer) {
+		if prev != nil {
+			prev(srv)
+		}
+		conversations.RegisterConversationTools(srv.Server(), daemonConversationsProvider)
+	}
+}

--- a/conversations_wiring.go
+++ b/conversations_wiring.go
@@ -1,0 +1,27 @@
+// conversations_wiring.go — registers ConversationsProvider with the reconcile
+// engine.
+//
+// This file handles the reconcile.RegisterProvider call for the conversations
+// resource type. MCP tool wiring is handled in conversations_mcp_wire.go,
+// which runs after eval_wiring.go (alphabetically) so it can chain the existing
+// RegisterMCPExtensions rather than overwriting it.
+//
+// Provider singleton is shared between reconcile and MCP tool handlers so that
+// cog_search_conversations queries see the freshest indexed state without an
+// extra round-trip.
+
+package main
+
+import (
+	"github.com/myrgic/cogos/internal/conversations"
+	"github.com/myrgic/cogos/pkg/reconcile"
+)
+
+// conversationsProviderInstance is the singleton registered with the reconcile
+// registry. Shared with MCP tools in conversations_mcp_wire.go.
+var conversationsProviderInstance = conversations.NewProvider()
+
+func init() {
+	// Register the provider with the reconcile registry.
+	reconcile.RegisterProvider("conversations", conversationsProviderInstance)
+}

--- a/internal/conversations/index.go
+++ b/internal/conversations/index.go
@@ -1,0 +1,274 @@
+// index.go — in-memory full-text index for conversation turns.
+//
+// The index is a flat in-memory structure backed by a projection directory:
+//   .cog/state/conversations/
+//     <session_id>.json   — JSON array of Turn (one file per session)
+//     _meta.json          — JSON object: session_id → SessionMeta
+//
+// This is intentionally not SQLite FTS5 — the observatory aims for zero
+// additional runtime dependencies. Text search uses strings.Contains on
+// pre-lowercased text, which is fast enough for the expected corpus size
+// (~hundreds of sessions, ~tens of thousands of turns total).
+//
+// Embedding-based semantic search is deferred to a follow-on PR.
+package conversations
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Index holds all indexed turns in memory plus a reference to the projection
+// directory for persistence.
+type Index struct {
+	projDir string
+
+	// sessions maps session_id → SessionMeta.
+	sessions map[string]SessionMeta
+
+	// turns maps session_id → []Turn (in turn-index order).
+	turns map[string][]Turn
+}
+
+// NewIndex creates an Index backed by projDir. projDir is created if absent.
+func NewIndex(projDir string) (*Index, error) {
+	if err := os.MkdirAll(projDir, 0o755); err != nil {
+		return nil, fmt.Errorf("conversations/index: mkdir %s: %w", projDir, err)
+	}
+	idx := &Index{
+		projDir:  projDir,
+		sessions: make(map[string]SessionMeta),
+		turns:    make(map[string][]Turn),
+	}
+	return idx, nil
+}
+
+// Load reads all projection files from projDir into memory.
+// Call once at startup (FetchLive). Subsequent operations keep state in sync.
+func (idx *Index) Load() error {
+	metaPath := idx.metaPath()
+	if data, err := os.ReadFile(metaPath); err == nil {
+		var m map[string]SessionMeta
+		if jsonErr := json.Unmarshal(data, &m); jsonErr == nil {
+			idx.sessions = m
+		}
+	}
+
+	// Load turns for each known session.
+	for sid := range idx.sessions {
+		turns, err := idx.loadTurnsFile(sid)
+		if err != nil {
+			// Corrupt turn file — remove from index; will be re-projected.
+			delete(idx.sessions, sid)
+			continue
+		}
+		idx.turns[sid] = turns
+	}
+	return nil
+}
+
+// UpsertSession writes session meta + turns to memory and to disk.
+func (idx *Index) UpsertSession(meta SessionMeta, turns []Turn) error {
+	idx.sessions[meta.SessionID] = meta
+	idx.turns[meta.SessionID] = turns
+
+	// Persist turns file.
+	if err := idx.writeTurnsFile(meta.SessionID, turns); err != nil {
+		return fmt.Errorf("conversations/index: write turns %s: %w", meta.SessionID, err)
+	}
+	// Persist meta index.
+	return idx.writeMetaFile()
+}
+
+// DeleteSession removes a session from memory and disk.
+func (idx *Index) DeleteSession(sessionID string) error {
+	delete(idx.sessions, sessionID)
+	delete(idx.turns, sessionID)
+
+	turnsPath := idx.turnsPath(sessionID)
+	if err := os.Remove(turnsPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("conversations/index: remove turns file: %w", err)
+	}
+	return idx.writeMetaFile()
+}
+
+// GetMeta returns the SessionMeta for a session, or false if not indexed.
+func (idx *Index) GetMeta(sessionID string) (SessionMeta, bool) {
+	m, ok := idx.sessions[sessionID]
+	return m, ok
+}
+
+// ListSessions returns all indexed SessionMetas sorted by LastTurnAt descending.
+func (idx *Index) ListSessions(since, until time.Time, identity string) []SessionMeta {
+	var out []SessionMeta
+	for _, m := range idx.sessions {
+		if !since.IsZero() && m.LastTurnAt.Before(since) {
+			continue
+		}
+		if !until.IsZero() && m.FirstTurnAt.After(until) {
+			continue
+		}
+		if identity != "" && !strings.EqualFold(m.Identity, identity) {
+			continue
+		}
+		out = append(out, m)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].LastTurnAt.After(out[j].LastTurnAt)
+	})
+	return out
+}
+
+// GetTurn returns the Turn at turnIndex within session, or false.
+func (idx *Index) GetTurn(sessionID string, turnIndex int) (Turn, bool) {
+	turns, ok := idx.turns[sessionID]
+	if !ok || turnIndex < 0 || turnIndex >= len(turns) {
+		return Turn{}, false
+	}
+	return turns[turnIndex], true
+}
+
+// Search performs a case-insensitive substring search over all indexed turns.
+// Filters: since/until bound timestamps; sessionID restricts to one session;
+// identity filters by session identity; limit caps results (0 = no limit).
+func (idx *Index) Search(query string, since, until time.Time, sessionID, identity string, limit int) []SearchHit {
+	lq := strings.ToLower(query)
+	var hits []SearchHit
+
+	// Collect sessions to search.
+	var sids []string
+	if sessionID != "" {
+		sids = []string{sessionID}
+	} else {
+		for sid := range idx.turns {
+			sids = append(sids, sid)
+		}
+		sort.Strings(sids)
+	}
+
+	for _, sid := range sids {
+		meta, hasMeta := idx.sessions[sid]
+		if identity != "" && hasMeta && !strings.EqualFold(meta.Identity, identity) {
+			continue
+		}
+
+		turns := idx.turns[sid]
+		for _, t := range turns {
+			if !since.IsZero() && t.Timestamp.Before(since) {
+				continue
+			}
+			if !until.IsZero() && t.Timestamp.After(until) {
+				continue
+			}
+			if !strings.Contains(strings.ToLower(t.Text), lq) {
+				continue
+			}
+			excerpt := makeExcerpt(t.Text, query, 300)
+			hit := SearchHit{
+				SessionID: sid,
+				TurnIndex: t.TurnIndex,
+				UUID:      t.UUID,
+				Timestamp: t.Timestamp,
+				Role:      t.Role,
+				Excerpt:   excerpt,
+				Identity:  meta.Identity,
+			}
+			if hasMeta {
+				hit.SessionTitle = meta.Title
+			}
+			hits = append(hits, hit)
+			if limit > 0 && len(hits) >= limit {
+				return hits
+			}
+		}
+	}
+	return hits
+}
+
+// ─── persistence helpers ─────────────────────────────────────────────────────
+
+func (idx *Index) metaPath() string {
+	return filepath.Join(idx.projDir, "_meta.json")
+}
+
+func (idx *Index) turnsPath(sessionID string) string {
+	return filepath.Join(idx.projDir, sessionID+".json")
+}
+
+func (idx *Index) writeMetaFile() error {
+	b, err := json.MarshalIndent(idx.sessions, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(idx.metaPath(), b, 0o644)
+}
+
+func (idx *Index) writeTurnsFile(sessionID string, turns []Turn) error {
+	b, err := json.MarshalIndent(turns, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(idx.turnsPath(sessionID), b, 0o644)
+}
+
+func (idx *Index) loadTurnsFile(sessionID string) ([]Turn, error) {
+	data, err := os.ReadFile(idx.turnsPath(sessionID))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var turns []Turn
+	if err := json.Unmarshal(data, &turns); err != nil {
+		return nil, fmt.Errorf("parse turns file: %w", err)
+	}
+	return turns, nil
+}
+
+// ─── text helpers ─────────────────────────────────────────────────────────────
+
+// makeExcerpt returns a ~maxLen-char snippet from text that contains query.
+// If the query is not found (shouldn't happen after Search filter) returns
+// the beginning of the text.
+func makeExcerpt(text, query string, maxLen int) string {
+	ltext := strings.ToLower(text)
+	lq := strings.ToLower(query)
+
+	pos := strings.Index(ltext, lq)
+	if pos < 0 {
+		if len(text) <= maxLen {
+			return text
+		}
+		return text[:maxLen] + "…"
+	}
+
+	// Center the excerpt on the match.
+	half := maxLen / 2
+	start := pos - half
+	if start < 0 {
+		start = 0
+	}
+	end := start + maxLen
+	if end > len(text) {
+		end = len(text)
+		start = end - maxLen
+		if start < 0 {
+			start = 0
+		}
+	}
+
+	excerpt := text[start:end]
+	if start > 0 {
+		excerpt = "…" + excerpt
+	}
+	if end < len(text) {
+		excerpt = excerpt + "…"
+	}
+	return excerpt
+}

--- a/internal/conversations/mcp_tools.go
+++ b/internal/conversations/mcp_tools.go
@@ -1,0 +1,282 @@
+// mcp_tools.go — MCP tool surface for the Conversations Observatory.
+//
+// Registers three MCP tools on a provided *mcp.Server:
+//
+//   cog_search_conversations  — full-text search over indexed turns
+//   cog_get_conversation_turn — fetch one turn by session_id + turn_index
+//   cog_list_conversations    — list indexed sessions with metadata
+//
+// Registration pattern mirrors internal/eval/mcp_tools.go:
+// the caller (kernel boot or conversations_wiring.go) calls
+// RegisterConversationTools(server, provider) after wiring the Provider.
+package conversations
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// RegisterConversationTools registers the three conversation MCP tools on the
+// given server. provider may be nil — tools return "not configured" in that case.
+func RegisterConversationTools(server *mcp.Server, provider *Provider) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "cog_search_conversations",
+		Description: "Full-text search over indexed operator conversation history. " +
+			"Returns hits with session_id, timestamp, role, and an excerpt centred on the match. " +
+			"Use since/until (RFC3339) to narrow by time; use identity to filter by operator; " +
+			"use limit to cap results (default 20).",
+	}, makeSearchConversationsHandler(provider))
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "cog_get_conversation_turn",
+		Description: "Fetch the full text of one conversation turn by session_id and turn_index. " +
+			"Use after cog_search_conversations to drill into a specific hit.",
+	}, makeGetConversationTurnHandler(provider))
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "cog_list_conversations",
+		Description: "List indexed conversation sessions with metadata " +
+			"(title, turn count, time bounds, identity, entrypoint). " +
+			"Optional since/until (RFC3339) and identity filters. " +
+			"Returns most-recent sessions first.",
+	}, makeListConversationsHandler(provider))
+}
+
+// ─── cog_search_conversations ────────────────────────────────────────────────
+
+type searchConversationsInput struct {
+	Query     string `json:"query"`
+	Since     string `json:"since,omitempty"`
+	Until     string `json:"until,omitempty"`
+	SessionID string `json:"session_id,omitempty"`
+	Identity  string `json:"identity,omitempty"`
+	Limit     int    `json:"limit,omitempty"`
+}
+
+func makeSearchConversationsHandler(p *Provider) mcp.ToolHandlerFor[searchConversationsInput, map[string]any] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, input searchConversationsInput) (*mcp.CallToolResult, map[string]any, error) {
+		if p == nil {
+			return convErrorResult("conversations provider not wired"), nil, nil
+		}
+		if input.Query == "" {
+			return convErrorResult("query is required"), nil, nil
+		}
+
+		p.mu.Lock()
+		idx := p.index
+		p.mu.Unlock()
+		if idx == nil {
+			return convErrorResult("index not yet initialised — run cog reconcile conversations first"), nil, nil
+		}
+
+		since, until, err := parseTimeRange(input.Since, input.Until)
+		if err != nil {
+			return convErrorResult(fmt.Sprintf("parse time range: %v", err)), nil, nil
+		}
+
+		limit := input.Limit
+		if limit <= 0 {
+			limit = 20
+		}
+
+		hits := idx.Search(input.Query, since, until, input.SessionID, input.Identity, limit)
+
+		type hitOut struct {
+			SessionID    string `json:"session_id"`
+			TurnIndex    int    `json:"turn_index"`
+			UUID         string `json:"uuid,omitempty"`
+			Timestamp    string `json:"timestamp,omitempty"`
+			Role         string `json:"role"`
+			Excerpt      string `json:"excerpt"`
+			SessionTitle string `json:"session_title,omitempty"`
+			Identity     string `json:"identity,omitempty"`
+		}
+		out := make([]hitOut, 0, len(hits))
+		for _, h := range hits {
+			ts := ""
+			if !h.Timestamp.IsZero() {
+				ts = h.Timestamp.Format(time.RFC3339)
+			}
+			out = append(out, hitOut{
+				SessionID:    h.SessionID,
+				TurnIndex:    h.TurnIndex,
+				UUID:         h.UUID,
+				Timestamp:    ts,
+				Role:         string(h.Role),
+				Excerpt:      h.Excerpt,
+				SessionTitle: h.SessionTitle,
+				Identity:     h.Identity,
+			})
+		}
+
+		resp := map[string]any{
+			"query":  input.Query,
+			"count":  len(out),
+			"hits":   out,
+		}
+		b, _ := json.MarshalIndent(resp, "", "  ")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: string(b)}},
+		}, resp, nil
+	}
+}
+
+// ─── cog_get_conversation_turn ───────────────────────────────────────────────
+
+type getConversationTurnInput struct {
+	SessionID  string `json:"session_id"`
+	TurnIndex  int    `json:"turn_index"`
+}
+
+func makeGetConversationTurnHandler(p *Provider) mcp.ToolHandlerFor[getConversationTurnInput, map[string]any] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, input getConversationTurnInput) (*mcp.CallToolResult, map[string]any, error) {
+		if p == nil {
+			return convErrorResult("conversations provider not wired"), nil, nil
+		}
+		if input.SessionID == "" {
+			return convErrorResult("session_id is required"), nil, nil
+		}
+
+		p.mu.Lock()
+		idx := p.index
+		p.mu.Unlock()
+		if idx == nil {
+			return convErrorResult("index not yet initialised — run cog reconcile conversations first"), nil, nil
+		}
+
+		turn, ok := idx.GetTurn(input.SessionID, input.TurnIndex)
+		if !ok {
+			return convErrorResult(fmt.Sprintf("turn %d not found in session %s", input.TurnIndex, input.SessionID)), nil, nil
+		}
+
+		ts := ""
+		if !turn.Timestamp.IsZero() {
+			ts = turn.Timestamp.Format(time.RFC3339)
+		}
+		resp := map[string]any{
+			"session_id":  turn.SessionID,
+			"turn_index":  turn.TurnIndex,
+			"uuid":        turn.UUID,
+			"parent_uuid": turn.ParentUUID,
+			"role":        string(turn.Role),
+			"timestamp":   ts,
+			"text":        turn.Text,
+			"is_tool_call": turn.IsToolCall,
+		}
+		b, _ := json.MarshalIndent(resp, "", "  ")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: string(b)}},
+		}, resp, nil
+	}
+}
+
+// ─── cog_list_conversations ──────────────────────────────────────────────────
+
+type listConversationsInput struct {
+	Since    string `json:"since,omitempty"`
+	Until    string `json:"until,omitempty"`
+	Identity string `json:"identity,omitempty"`
+	Limit    int    `json:"limit,omitempty"`
+}
+
+func makeListConversationsHandler(p *Provider) mcp.ToolHandlerFor[listConversationsInput, map[string]any] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, input listConversationsInput) (*mcp.CallToolResult, map[string]any, error) {
+		if p == nil {
+			return convErrorResult("conversations provider not wired"), nil, nil
+		}
+
+		p.mu.Lock()
+		idx := p.index
+		p.mu.Unlock()
+		if idx == nil {
+			return convErrorResult("index not yet initialised — run cog reconcile conversations first"), nil, nil
+		}
+
+		since, until, err := parseTimeRange(input.Since, input.Until)
+		if err != nil {
+			return convErrorResult(fmt.Sprintf("parse time range: %v", err)), nil, nil
+		}
+
+		metas := idx.ListSessions(since, until, input.Identity)
+		limit := input.Limit
+		if limit > 0 && len(metas) > limit {
+			metas = metas[:limit]
+		}
+
+		type sessionOut struct {
+			SessionID   string `json:"session_id"`
+			Title       string `json:"title,omitempty"`
+			TurnCount   int    `json:"turn_count"`
+			FirstTurnAt string `json:"first_turn_at,omitempty"`
+			LastTurnAt  string `json:"last_turn_at,omitempty"`
+			IndexedAt   string `json:"indexed_at,omitempty"`
+			Identity    string `json:"identity,omitempty"`
+			Entrypoint  string `json:"entrypoint,omitempty"`
+		}
+		out := make([]sessionOut, 0, len(metas))
+		for _, m := range metas {
+			so := sessionOut{
+				SessionID:  m.SessionID,
+				Title:      m.Title,
+				TurnCount:  m.TurnCount,
+				Identity:   m.Identity,
+				Entrypoint: m.Entrypoint,
+			}
+			if !m.FirstTurnAt.IsZero() {
+				so.FirstTurnAt = m.FirstTurnAt.Format(time.RFC3339)
+			}
+			if !m.LastTurnAt.IsZero() {
+				so.LastTurnAt = m.LastTurnAt.Format(time.RFC3339)
+			}
+			if !m.IndexedAt.IsZero() {
+				so.IndexedAt = m.IndexedAt.Format(time.RFC3339)
+			}
+			out = append(out, so)
+		}
+
+		resp := map[string]any{
+			"sessions": out,
+			"count":    len(out),
+		}
+		b, _ := json.MarshalIndent(resp, "", "  ")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: string(b)}},
+		}, resp, nil
+	}
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+// parseTimeRange parses optional since/until RFC3339 strings.
+func parseTimeRange(since, until string) (time.Time, time.Time, error) {
+	var s, u time.Time
+	if since != "" {
+		var err error
+		s, err = time.Parse(time.RFC3339, since)
+		if err != nil {
+			return s, u, fmt.Errorf("invalid since %q: %w", since, err)
+		}
+	}
+	if until != "" {
+		var err error
+		u, err = time.Parse(time.RFC3339, until)
+		if err != nil {
+			return s, u, fmt.Errorf("invalid until %q: %w", until, err)
+		}
+	}
+	return s, u, nil
+}
+
+// convErrorResult builds a CallToolResult carrying an error message.
+func convErrorResult(msg string) *mcp.CallToolResult {
+	resp := map[string]any{"error": msg, "ok": false}
+	b, _ := json.Marshal(resp)
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: string(b)}},
+		IsError: true,
+	}
+}

--- a/internal/conversations/parser.go
+++ b/internal/conversations/parser.go
@@ -1,0 +1,327 @@
+// parser.go — streaming JSONL parser for Claude Code session files.
+//
+// Never loads an entire JSONL into memory. Uses bufio.Scanner line-by-line
+// to handle sessions up to many MB without OOM. The extract_user_msgs.py
+// reference script informed the field selection and filtering rules:
+//   - user records: type="user", message.content (array or string)
+//   - assistant records: type="assistant", message.content (array)
+//   - system-reminder wrapper tags are stripped from user text
+//   - user-prompt-submit-hook outputs are skipped
+//   - tool_result content blocks within user records are skipped
+//   - ai-title records supply the session title
+//
+// Additional fields discovered beyond the Python reference:
+//   - uuid, parentUuid — conversation tree linkage
+//   - entrypoint — client surface (cli, claude-desktop, etc.)
+//   - userType — always "external" in observed data
+//   - version — Claude Code version string
+//   - cwd — working directory at message time
+//   - sessionId — always present; must match the filename UUID
+//   - thinking content blocks in assistant records
+package conversations
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// maxScannerTokenSize is the per-line buffer used by bufio.Scanner.
+// Claude Code lines can be very large (full assistant message in one JSON record),
+// so we allocate 4MB per line to handle thinking-heavy assistant turns.
+const maxScannerTokenSize = 4 * 1024 * 1024
+
+// systemReminderRE strips <system-reminder>...</system-reminder> blocks.
+var systemReminderRE = regexp.MustCompile(`(?s)<system-reminder>.*?</system-reminder>`)
+
+// rawRecord is the outermost envelope of every JSONL line.
+// We decode into this first and then dispatch on Type.
+type rawRecord struct {
+	Type       string          `json:"type"`
+	UUID       string          `json:"uuid"`
+	ParentUUID string          `json:"parentUuid"`
+	SessionID  string          `json:"sessionId"`
+	Timestamp  string          `json:"timestamp"`
+	Message    json.RawMessage `json:"message"`
+	Content    string          `json:"content"` // system records use content string
+	UserType   string          `json:"userType"`
+	Entrypoint string          `json:"entrypoint"`
+	IsSidechain bool           `json:"isSidechain"`
+	Level      string          `json:"level"`
+}
+
+// rawMessage is message.* within a user or assistant record.
+type rawMessage struct {
+	Role    string             `json:"role"`
+	Model   string             `json:"model"`
+	Content json.RawMessage    `json:"content"`
+}
+
+// rawContentBlock is one element of message.content when it is an array.
+type rawContentBlock struct {
+	Type      string          `json:"type"`
+	Text      string          `json:"text"`
+	Thinking  string          `json:"thinking"`
+	Input     json.RawMessage `json:"input,omitempty"`    // tool_use
+	Content   json.RawMessage `json:"content,omitempty"`  // tool_result nested
+}
+
+// rawAITitle is the ai-title record type.
+type rawAITitle struct {
+	Title string `json:"title"`
+}
+
+// ParseSession streams turns from r, calling callback for each turn and
+// updating meta in place. r is typically an os.File; it is NOT closed.
+// The caller controls open/close. callback may return false to abort early.
+//
+// ParseSession is purely functional: no global state, no side effects beyond
+// the callbacks. Tests can supply a strings.Reader fixture.
+func ParseSession(r io.Reader, sessionID string, maxTurnLen int, meta *SessionMeta, callback func(Turn) bool) error {
+	if maxTurnLen <= 0 {
+		maxTurnLen = 8192
+	}
+
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, maxScannerTokenSize), maxScannerTokenSize)
+
+	turnIndex := 0
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var rec rawRecord
+		if err := json.Unmarshal(line, &rec); err != nil {
+			// Skip unparseable lines — sessions may have partially-written last lines.
+			continue
+		}
+
+		// Populate session-level metadata from whichever record has it.
+		if rec.Entrypoint != "" && meta.Entrypoint == "" {
+			meta.Entrypoint = rec.Entrypoint
+		}
+
+		switch rec.Type {
+		case "ai-title":
+			// Extract the session title from the ai-title record.
+			var t rawAITitle
+			if err := json.Unmarshal(line, &t); err == nil && t.Title != "" {
+				meta.Title = t.Title
+			}
+
+		case "user":
+			turn, ok := parseUserRecord(&rec, sessionID, turnIndex, maxTurnLen)
+			if !ok {
+				continue
+			}
+			updateTimeBounds(meta, turn.Timestamp)
+			if !callback(turn) {
+				return nil
+			}
+			turnIndex++
+			meta.TurnCount = turnIndex
+
+		case "assistant":
+			turn, ok := parseAssistantRecord(&rec, sessionID, turnIndex, maxTurnLen)
+			if !ok {
+				continue
+			}
+			updateTimeBounds(meta, turn.Timestamp)
+			if !callback(turn) {
+				return nil
+			}
+			turnIndex++
+			meta.TurnCount = turnIndex
+		}
+	}
+
+	return scanner.Err()
+}
+
+// parseUserRecord extracts a Turn from a type="user" raw record.
+// Returns (turn, true) when there is meaningful text content.
+func parseUserRecord(rec *rawRecord, sessionID string, idx int, maxLen int) (Turn, bool) {
+	if len(rec.Message) == 0 {
+		return Turn{}, false
+	}
+
+	var msg rawMessage
+	if err := json.Unmarshal(rec.Message, &msg); err != nil {
+		return Turn{}, false
+	}
+
+	text := extractContentText(msg.Content, false)
+	text = stripSystemReminders(text)
+	if text == "" {
+		return Turn{}, false
+	}
+	// Skip hook outputs.
+	if strings.HasPrefix(text, "<user-prompt-submit-hook>") {
+		return Turn{}, false
+	}
+	if len(text) > maxLen {
+		text = text[:maxLen] + " [truncated]"
+	}
+
+	ts := parseTimestamp(rec.Timestamp)
+	return Turn{
+		UUID:       rec.UUID,
+		SessionID:  sessionID,
+		TurnIndex:  idx,
+		Role:       RoleUser,
+		Timestamp:  ts,
+		Text:       text,
+		ParentUUID: rec.ParentUUID,
+	}, true
+}
+
+// parseAssistantRecord extracts a Turn from a type="assistant" raw record.
+// Returns (turn, true) when there is text or thinking content.
+func parseAssistantRecord(rec *rawRecord, sessionID string, idx int, maxLen int) (Turn, bool) {
+	if len(rec.Message) == 0 {
+		return Turn{}, false
+	}
+
+	var msg rawMessage
+	if err := json.Unmarshal(rec.Message, &msg); err != nil {
+		return Turn{}, false
+	}
+
+	text, isToolCall := extractAssistantContent(msg.Content, maxLen)
+	if text == "" && !isToolCall {
+		return Turn{}, false
+	}
+	if len(text) > maxLen {
+		text = text[:maxLen] + " [truncated]"
+	}
+
+	ts := parseTimestamp(rec.Timestamp)
+	return Turn{
+		UUID:       rec.UUID,
+		SessionID:  sessionID,
+		TurnIndex:  idx,
+		Role:       RoleAssistant,
+		Timestamp:  ts,
+		Text:       text,
+		IsToolCall: isToolCall,
+		ParentUUID: rec.ParentUUID,
+	}, true
+}
+
+// extractContentText extracts plain text from a message.content value.
+// When skipToolResults is true (user records), tool_result blocks are skipped.
+func extractContentText(raw json.RawMessage, skipToolResults bool) string {
+	if len(raw) == 0 {
+		return ""
+	}
+
+	// Try string form first.
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return strings.TrimSpace(s)
+	}
+
+	// Try array form.
+	var blocks []rawContentBlock
+	if err := json.Unmarshal(raw, &blocks); err != nil {
+		return ""
+	}
+
+	var parts []string
+	for _, b := range blocks {
+		switch b.Type {
+		case "text":
+			if t := strings.TrimSpace(b.Text); t != "" {
+				parts = append(parts, t)
+			}
+		case "tool_result":
+			// skip — tool output is not operator utterance
+		case "thinking":
+			// skip thinking from user records (shouldn't appear but be safe)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+// extractAssistantContent extracts text and thinking from assistant message
+// content. Also detects whether this is primarily a tool-call turn.
+func extractAssistantContent(raw json.RawMessage, maxLen int) (text string, isToolCall bool) {
+	if len(raw) == 0 {
+		return "", false
+	}
+
+	var blocks []rawContentBlock
+	if err := json.Unmarshal(raw, &blocks); err != nil {
+		// Fall back to string form (unlikely for assistant records).
+		var s string
+		if json.Unmarshal(raw, &s) == nil {
+			return strings.TrimSpace(s), false
+		}
+		return "", false
+	}
+
+	var textParts []string
+	toolCallCount := 0
+	textBlockCount := 0
+
+	for _, b := range blocks {
+		switch b.Type {
+		case "text":
+			if t := strings.TrimSpace(b.Text); t != "" {
+				textParts = append(textParts, t)
+				textBlockCount++
+			}
+		case "thinking":
+			// Include thinking content — it is substrate-valuable for understanding
+			// how the assistant reasoned through a problem.
+			if t := strings.TrimSpace(b.Thinking); t != "" {
+				textParts = append(textParts, "[thinking] "+t)
+			}
+		case "tool_use":
+			toolCallCount++
+		}
+	}
+
+	combined := strings.Join(textParts, "\n")
+	isToolCall = toolCallCount > 0 && textBlockCount == 0
+	return combined, isToolCall
+}
+
+// stripSystemReminders removes <system-reminder>...</system-reminder> tags.
+func stripSystemReminders(s string) string {
+	return strings.TrimSpace(systemReminderRE.ReplaceAllString(s, ""))
+}
+
+// parseTimestamp parses an RFC3339 timestamp string. Returns zero time on error.
+func parseTimestamp(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		// Try RFC3339Nano and millisecond variants.
+		t, err = time.Parse(time.RFC3339Nano, s)
+		if err != nil {
+			return time.Time{}
+		}
+	}
+	return t
+}
+
+// updateTimeBounds adjusts meta.FirstTurnAt / LastTurnAt to include t.
+func updateTimeBounds(meta *SessionMeta, t time.Time) {
+	if t.IsZero() {
+		return
+	}
+	if meta.FirstTurnAt.IsZero() || t.Before(meta.FirstTurnAt) {
+		meta.FirstTurnAt = t
+	}
+	if meta.LastTurnAt.IsZero() || t.After(meta.LastTurnAt) {
+		meta.LastTurnAt = t
+	}
+}

--- a/internal/conversations/provider.go
+++ b/internal/conversations/provider.go
@@ -1,0 +1,620 @@
+// provider.go — Reconcilable implementation for the Conversations Observatory.
+//
+// Implements pkg/reconcile.Reconcilable with resource type "conversations".
+//
+// Method summary:
+//   Type()        — "conversations"
+//   LoadConfig()  — scan source dirs for JSONL files; load .cog/config/observatory.yaml
+//   FetchLive()   — load index from .cog/state/conversations/_meta.json
+//   ComputePlan() — diff source files vs index entries; plan create/update/delete/skip
+//   ApplyPlan()   — stream-parse new/changed sessions into the index
+//   BuildState()  — construct Terraform-style state from live index entries
+//   Health()      — Healthy/Degraded/OutOfSync based on index drift and errors
+package conversations
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/myrgic/cogos/pkg/reconcile"
+	"gopkg.in/yaml.v3"
+)
+
+// Provider implements reconcile.Reconcilable for the Conversations Observatory.
+type Provider struct {
+	mu sync.Mutex
+
+	// index is the in-memory queryable index. Populated by ApplyPlan.
+	// nil until first LoadConfig call resolves projDir.
+	index *Index
+
+	// state populated during the reconcile loop.
+	root            string
+	lastPlanSummary reconcile.Summary
+	lastErrors      []string
+	operation       reconcile.OperationPhase
+}
+
+// NewProvider constructs a ConversationsProvider. The root workspace path
+// is set by LoadConfig. Tests may call LoadConfig directly with a temp dir.
+func NewProvider() *Provider {
+	return &Provider{
+		operation: reconcile.OperationIdle,
+	}
+}
+
+// Type returns the resource type identifier.
+func (p *Provider) Type() string { return "conversations" }
+
+// ─── LoadConfig ──────────────────────────────────────────────────────────────
+
+// LoadConfig reads .cog/config/observatory.yaml (if present), discovers JSONL
+// source files in each configured SourceDir, and initialises the index if not
+// already loaded.
+func (p *Provider) LoadConfig(root string) (any, error) {
+	p.mu.Lock()
+	p.root = root
+	p.mu.Unlock()
+
+	obs, err := loadObservatoryConfig(root)
+	if err != nil {
+		return nil, fmt.Errorf("conversations: load observatory config: %w", err)
+	}
+
+	// Initialise the index (idempotent — only creates if nil).
+	projDir := filepath.Join(root, ".cog", "state", "conversations")
+	p.mu.Lock()
+	if p.index == nil {
+		idx, idxErr := NewIndex(projDir)
+		if idxErr != nil {
+			p.mu.Unlock()
+			return nil, fmt.Errorf("conversations: init index: %w", idxErr)
+		}
+		p.index = idx
+	}
+	p.mu.Unlock()
+
+	// Discover source JSONL files.
+	files, err := discoverSourceFiles(obs)
+	if err != nil {
+		return nil, fmt.Errorf("conversations: discover source files: %w", err)
+	}
+
+	return &providerConfig{
+		Root:        root,
+		Observatory: obs,
+		SourceFiles: files,
+	}, nil
+}
+
+// ─── FetchLive ───────────────────────────────────────────────────────────────
+
+// FetchLive loads (or refreshes) the index from disk and returns the current
+// set of indexed entries.
+func (p *Provider) FetchLive(_ context.Context, _ any) (any, error) {
+	p.mu.Lock()
+	idx := p.index
+	p.mu.Unlock()
+
+	if idx == nil {
+		// Index not yet initialised — nothing indexed yet.
+		return &liveState{Entries: make(map[string]IndexEntry)}, nil
+	}
+
+	// Reload from disk to pick up changes from other processes.
+	if err := idx.Load(); err != nil {
+		return nil, fmt.Errorf("conversations: load index: %w", err)
+	}
+
+	metas := idx.ListSessions(time.Time{}, time.Time{}, "")
+	entries := make(map[string]IndexEntry, len(metas))
+	for _, m := range metas {
+		entries[m.SessionID] = IndexEntry{
+			Meta:  m,
+			Depth: DepthFull,
+		}
+	}
+	return &liveState{Entries: entries}, nil
+}
+
+// ─── ComputePlan ─────────────────────────────────────────────────────────────
+
+// ComputePlan diffs the set of source JSONL files against the live index:
+//   - source present, not indexed          → create
+//   - source present, indexed but stale    → update (mtime or size changed)
+//   - source absent, indexed               → delete
+//   - source present, indexed, up-to-date  → skip
+func (p *Provider) ComputePlan(config any, live any, _ *reconcile.State) (*reconcile.Plan, error) {
+	cfg, ok := config.(*providerConfig)
+	if !ok {
+		return nil, fmt.Errorf("conversations: expected *providerConfig, got %T", config)
+	}
+	ls, ok := live.(*liveState)
+	if !ok {
+		return nil, fmt.Errorf("conversations: expected *liveState, got %T", live)
+	}
+
+	plan := &reconcile.Plan{
+		ResourceType: "conversations",
+		GeneratedAt:  time.Now().UTC().Format(time.RFC3339),
+		ConfigPath:   filepath.Join(cfg.Root, ".cog", "config", "observatory.yaml"),
+	}
+
+	sourceSet := make(map[string]sourceFileInfo, len(cfg.SourceFiles))
+	for _, f := range cfg.SourceFiles {
+		sourceSet[f.SessionID] = f
+	}
+
+	// Walk source files.
+	for _, f := range cfg.SourceFiles {
+		existing, indexed := ls.Entries[f.SessionID]
+		switch {
+		case !indexed:
+			plan.Actions = append(plan.Actions, reconcile.Action{
+				Action:       reconcile.ActionCreate,
+				ResourceType: "conversations",
+				Name:         f.SessionID,
+				Details: map[string]any{
+					"source_path": f.Path,
+					"mtime":       f.Mtime.Format(time.RFC3339),
+					"size":        f.Size,
+				},
+			})
+			plan.Summary.Creates++
+
+		case isDrift(existing.Meta, f):
+			plan.Actions = append(plan.Actions, reconcile.Action{
+				Action:       reconcile.ActionUpdate,
+				ResourceType: "conversations",
+				Name:         f.SessionID,
+				Details: map[string]any{
+					"source_path":   f.Path,
+					"mtime":         f.Mtime.Format(time.RFC3339),
+					"size":          f.Size,
+					"prev_mtime":    existing.Meta.SourceMtime.Format(time.RFC3339),
+					"prev_size":     existing.Meta.SourceSize,
+					"prev_turns":    existing.Meta.TurnCount,
+				},
+			})
+			plan.Summary.Updates++
+
+		default:
+			plan.Actions = append(plan.Actions, reconcile.Action{
+				Action:       reconcile.ActionSkip,
+				ResourceType: "conversations",
+				Name:         f.SessionID,
+				Details: map[string]any{
+					"reason": "in sync",
+					"turns":  existing.Meta.TurnCount,
+				},
+			})
+			plan.Summary.Skipped++
+		}
+	}
+
+	// Sessions in index but no longer in source.
+	for sid := range ls.Entries {
+		if _, inSource := sourceSet[sid]; !inSource {
+			plan.Actions = append(plan.Actions, reconcile.Action{
+				Action:       reconcile.ActionDelete,
+				ResourceType: "conversations",
+				Name:         sid,
+				Details: map[string]any{
+					"reason": "source removed",
+				},
+			})
+			plan.Summary.Deletes++
+		}
+	}
+
+	sort.Slice(plan.Actions, func(i, j int) bool {
+		if plan.Actions[i].Action != plan.Actions[j].Action {
+			return plan.Actions[i].Action < plan.Actions[j].Action
+		}
+		return plan.Actions[i].Name < plan.Actions[j].Name
+	})
+
+	p.mu.Lock()
+	p.lastPlanSummary = plan.Summary
+	p.mu.Unlock()
+
+	return plan, nil
+}
+
+// ─── ApplyPlan ───────────────────────────────────────────────────────────────
+
+// ApplyPlan executes the plan. For create/update, stream-parses the source
+// JSONL and writes the result to the index. For delete, removes the session.
+func (p *Provider) ApplyPlan(ctx context.Context, plan *reconcile.Plan) ([]reconcile.Result, error) {
+	if plan == nil {
+		return nil, fmt.Errorf("conversations: nil plan")
+	}
+
+	p.mu.Lock()
+	p.operation = reconcile.OperationSyncing
+	idx := p.index
+	p.mu.Unlock()
+	defer func() {
+		p.mu.Lock()
+		p.operation = reconcile.OperationIdle
+		p.mu.Unlock()
+	}()
+
+	if idx == nil {
+		return nil, fmt.Errorf("conversations: index not initialised (LoadConfig not called)")
+	}
+
+	var results []reconcile.Result
+	var errs []string
+
+	for _, action := range plan.Actions {
+		if action.Action == reconcile.ActionSkip {
+			continue
+		}
+
+		res := reconcile.Result{
+			Phase:  "conversations",
+			Action: string(action.Action),
+			Name:   action.Name,
+		}
+
+		switch action.Action {
+		case reconcile.ActionCreate, reconcile.ActionUpdate:
+			sourcePath, _ := action.Details["source_path"].(string)
+			if sourcePath == "" {
+				res.Status = reconcile.ApplyFailed
+				res.Error = "missing source_path in plan action"
+				results = append(results, res)
+				errs = append(errs, res.Error)
+				continue
+			}
+
+			meta, turns, err := indexSession(sourcePath, action.Name, defaultMaxTurnLen)
+			if err != nil {
+				res.Status = reconcile.ApplyFailed
+				res.Error = fmt.Sprintf("index session %s: %v", action.Name, err)
+				results = append(results, res)
+				errs = append(errs, res.Error)
+				continue
+			}
+
+			if upsertErr := idx.UpsertSession(meta, turns); upsertErr != nil {
+				res.Status = reconcile.ApplyFailed
+				res.Error = fmt.Sprintf("upsert session %s: %v", action.Name, upsertErr)
+				results = append(results, res)
+				errs = append(errs, res.Error)
+				continue
+			}
+
+			res.Status = reconcile.ApplySucceeded
+			res.CreatedID = action.Name
+			results = append(results, res)
+
+		case reconcile.ActionDelete:
+			if delErr := idx.DeleteSession(action.Name); delErr != nil {
+				res.Status = reconcile.ApplyFailed
+				res.Error = delErr.Error()
+				errs = append(errs, res.Error)
+			} else {
+				res.Status = reconcile.ApplySucceeded
+			}
+			results = append(results, res)
+
+		default:
+			res.Status = reconcile.ApplySkipped
+			results = append(results, res)
+		}
+	}
+
+	p.mu.Lock()
+	p.lastErrors = errs
+	p.mu.Unlock()
+
+	return results, nil
+}
+
+// ─── BuildState ──────────────────────────────────────────────────────────────
+
+// BuildState constructs a Terraform-style state from live index entries.
+func (p *Provider) BuildState(_ any, live any, existing *reconcile.State) (*reconcile.State, error) {
+	ls, ok := live.(*liveState)
+	if !ok {
+		return nil, fmt.Errorf("conversations: expected *liveState, got %T", live)
+	}
+
+	state := &reconcile.State{
+		Version:      1,
+		ResourceType: "conversations",
+		GeneratedAt:  time.Now().UTC().Format(time.RFC3339),
+		Resources:    []reconcile.Resource{},
+		Metadata:     map[string]any{},
+	}
+
+	if existing != nil && existing.Lineage != "" {
+		state.Lineage = existing.Lineage
+		state.Serial = existing.Serial + 1
+	} else {
+		state.Lineage = "conversations-" + uuid.New().String()
+		state.Serial = 1
+	}
+
+	// Sort by session_id for deterministic state output.
+	sids := make([]string, 0, len(ls.Entries))
+	for sid := range ls.Entries {
+		sids = append(sids, sid)
+	}
+	sort.Strings(sids)
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	for _, sid := range sids {
+		entry := ls.Entries[sid]
+		m := entry.Meta
+		state.Resources = append(state.Resources, reconcile.Resource{
+			Address:       "conversations." + sid,
+			Type:          "conversations",
+			Mode:          reconcile.ModeData,
+			ExternalID:    sid,
+			Name:          sid,
+			LastRefreshed: now,
+			Attributes: map[string]any{
+				"source_path":   m.SourcePath,
+				"turn_count":    m.TurnCount,
+				"first_turn_at": m.FirstTurnAt.Format(time.RFC3339),
+				"last_turn_at":  m.LastTurnAt.Format(time.RFC3339),
+				"indexed_at":    m.IndexedAt.Format(time.RFC3339),
+				"source_mtime":  m.SourceMtime.Format(time.RFC3339),
+				"source_size":   m.SourceSize,
+				"identity":      m.Identity,
+				"entrypoint":    m.Entrypoint,
+				"title":         m.Title,
+				"depth":         string(entry.Depth),
+			},
+		})
+	}
+
+	// Summary metadata.
+	state.Metadata["indexed_sessions"] = len(ls.Entries)
+	totalTurns := 0
+	for _, e := range ls.Entries {
+		totalTurns += e.Meta.TurnCount
+	}
+	state.Metadata["total_turns"] = totalTurns
+
+	return state, nil
+}
+
+// ─── Health ───────────────────────────────────────────────────────────────────
+
+// Health returns three-axis status:
+//   Sync      — Synced when last plan had no non-skip actions
+//   Health    — Degraded when ApplyPlan had errors; Healthy otherwise
+//   Operation — Syncing while ApplyPlan is running
+func (p *Provider) Health() reconcile.ResourceStatus {
+	p.mu.Lock()
+	summary := p.lastPlanSummary
+	errs := len(p.lastErrors)
+	op := p.operation
+	p.mu.Unlock()
+
+	sync := reconcile.SyncStatusSynced
+	if summary.HasChanges() {
+		sync = reconcile.SyncStatusOutOfSync
+	}
+
+	health := reconcile.HealthHealthy
+	msg := ""
+	if errs > 0 {
+		health = reconcile.HealthDegraded
+		msg = fmt.Sprintf("%d session(s) failed to index", errs)
+	}
+
+	return reconcile.ResourceStatus{
+		Sync:      sync,
+		Health:    health,
+		Operation: op,
+		Message:   msg,
+	}
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+const defaultMaxTurnLen = 8192
+
+// defaultSourceDirs returns the default JSONL source directories to scan.
+// Prefers ~/.claude/projects/-Users-slowbro; falls back gracefully.
+func defaultSourceDirs() []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	candidate := filepath.Join(home, ".claude", "projects", "-Users-slowbro")
+	if _, err := os.Stat(candidate); err == nil {
+		return []string{candidate}
+	}
+	// Also check the generic projects dir.
+	generic := filepath.Join(home, ".claude", "projects")
+	if _, err := os.Stat(generic); err == nil {
+		return []string{generic}
+	}
+	return nil
+}
+
+// loadObservatoryConfig reads .cog/config/observatory.yaml. Missing file is
+// not an error — returns defaults.
+func loadObservatoryConfig(root string) (ObservatoryConfig, error) {
+	path := filepath.Join(root, ".cog", "config", "observatory.yaml")
+	var obs ObservatoryConfig
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Default config.
+			obs.SourceDirs = defaultSourceDirs()
+			obs.IncludePatterns = []string{"*.jsonl"}
+			obs.MaxTurnLength = defaultMaxTurnLen
+			return obs, nil
+		}
+		return obs, fmt.Errorf("read observatory.yaml: %w", err)
+	}
+
+	if err := yaml.Unmarshal(data, &obs); err != nil {
+		return obs, fmt.Errorf("parse observatory.yaml: %w", err)
+	}
+
+	// Fill in defaults for zero values.
+	if len(obs.SourceDirs) == 0 {
+		obs.SourceDirs = defaultSourceDirs()
+	}
+	if len(obs.IncludePatterns) == 0 {
+		obs.IncludePatterns = []string{"*.jsonl"}
+	}
+	if obs.MaxTurnLength <= 0 {
+		obs.MaxTurnLength = defaultMaxTurnLen
+	}
+
+	return obs, nil
+}
+
+// discoverSourceFiles scans SourceDirs and returns matching JSONL files.
+func discoverSourceFiles(obs ObservatoryConfig) ([]sourceFileInfo, error) {
+	var files []sourceFileInfo
+	seen := make(map[string]struct{})
+
+	for _, dir := range obs.SourceDirs {
+		expanded := expandHome(dir)
+		entries, err := os.ReadDir(expanded)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("read dir %s: %w", expanded, err)
+		}
+
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			name := e.Name()
+			if !matchesPatterns(name, obs.IncludePatterns) {
+				continue
+			}
+			if matchesPatterns(name, obs.ExcludePatterns) {
+				continue
+			}
+			// Only accept UUID-named JSONL files (Claude Code session format).
+			sid := sessionIDFromFilename(name)
+			if sid == "" {
+				continue
+			}
+			absPath := filepath.Join(expanded, name)
+			if _, dup := seen[absPath]; dup {
+				continue
+			}
+			seen[absPath] = struct{}{}
+
+			fi, err := e.Info()
+			if err != nil {
+				continue
+			}
+			files = append(files, sourceFileInfo{
+				Path:      absPath,
+				SessionID: sid,
+				Mtime:     fi.ModTime(),
+				Size:      fi.Size(),
+			})
+		}
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].SessionID < files[j].SessionID
+	})
+	return files, nil
+}
+
+// sessionIDFromFilename extracts the UUID from a filename like
+// "3f9a1234-....jsonl". Returns "" if the filename is not UUID-format.
+func sessionIDFromFilename(name string) string {
+	base := strings.TrimSuffix(name, ".jsonl")
+	if base == name {
+		return "" // no .jsonl suffix
+	}
+	if _, err := uuid.Parse(base); err != nil {
+		return "" // not a UUID
+	}
+	return base
+}
+
+// matchesPatterns returns true if name matches any of the glob patterns.
+// An empty patterns list returns false (nothing matches).
+func matchesPatterns(name string, patterns []string) bool {
+	for _, pat := range patterns {
+		if ok, _ := filepath.Match(pat, name); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// expandHome replaces a leading ~ with the user home directory.
+func expandHome(path string) string {
+	if !strings.HasPrefix(path, "~") {
+		return path
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+	return filepath.Join(home, path[1:])
+}
+
+// isDrift returns true when the indexed meta is stale compared to f.
+// Uses mtime AND size as a cheap two-field change detector.
+func isDrift(meta SessionMeta, f sourceFileInfo) bool {
+	// Size change is the fast path.
+	if meta.SourceSize != f.Size {
+		return true
+	}
+	// mtime with 1s resolution (filesystem granularity).
+	return meta.SourceMtime.Truncate(time.Second) != f.Mtime.Truncate(time.Second)
+}
+
+// indexSession opens sourcePath, streams turns, and returns the resulting
+// SessionMeta and Turn slice. Does not hold the file open after return.
+func indexSession(sourcePath, sessionID string, maxTurnLen int) (SessionMeta, []Turn, error) {
+	fi, err := os.Stat(sourcePath)
+	if err != nil {
+		return SessionMeta{}, nil, fmt.Errorf("stat %s: %w", sourcePath, err)
+	}
+
+	f, err := os.Open(sourcePath)
+	if err != nil {
+		return SessionMeta{}, nil, fmt.Errorf("open %s: %w", sourcePath, err)
+	}
+	defer f.Close()
+
+	meta := SessionMeta{
+		SessionID:   sessionID,
+		SourcePath:  sourcePath,
+		IndexedAt:   time.Now().UTC(),
+		SourceMtime: fi.ModTime(),
+		SourceSize:  fi.Size(),
+	}
+
+	var turns []Turn
+	err = ParseSession(f, sessionID, maxTurnLen, &meta, func(t Turn) bool {
+		turns = append(turns, t)
+		return true
+	})
+	if err != nil {
+		return meta, turns, fmt.Errorf("parse %s: %w", sourcePath, err)
+	}
+
+	return meta, turns, nil
+}

--- a/internal/conversations/provider.go
+++ b/internal/conversations/provider.go
@@ -575,14 +575,25 @@ func expandHome(path string) string {
 }
 
 // isDrift returns true when the indexed meta is stale compared to f.
-// Uses mtime AND size as a cheap two-field change detector.
+// Primary signal: size change (definitive — any content change changes size).
+// Secondary signal: mtime difference > 1s (guards against same-size rewrites).
+//
+// mtime is compared with 2-second tolerance to guard against filesystem mtime
+// resolution differences between `os.ReadDir` calls on fast-write filesystems
+// (e.g. Linux tmpfs in CI runners). A 1-byte change always changes size, so
+// the 2s tolerance only matters for truly same-size content changes (rare in
+// practice for session JSONLs, which grow monotonically).
 func isDrift(meta SessionMeta, f sourceFileInfo) bool {
-	// Size change is the fast path.
+	// Size change is the definitive fast path.
 	if meta.SourceSize != f.Size {
 		return true
 	}
-	// mtime with 1s resolution (filesystem granularity).
-	return meta.SourceMtime.Truncate(time.Second) != f.Mtime.Truncate(time.Second)
+	// mtime with 2s tolerance for filesystem-level mtime granularity jitter.
+	diff := meta.SourceMtime.Sub(f.Mtime)
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff > 2*time.Second
 }
 
 // indexSession opens sourcePath, streams turns, and returns the resulting

--- a/internal/conversations/provider_test.go
+++ b/internal/conversations/provider_test.go
@@ -1,0 +1,579 @@
+// provider_test.go — integration tests for the Conversations Observatory provider.
+//
+// Covers:
+//   1. Ingesting a 1-session JSONL fixture; assert turn count, identity, time bounds
+//   2. Streaming a large fixture (512KB equivalent) without OOM
+//   3. Drift detection: session modified after index, re-projection runs
+//   4. MCP tool query path: search for a known string, assert hit
+//   5. Idempotency: re-run ApplyPlan, no double-projection
+//   6. LoadConfig with empty config (default source dirs)
+//   7. FetchLive round-trip (write then read)
+//   8. BuildState structure
+//   9. Health() status transitions
+package conversations
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ─── JSONL fixture helpers ────────────────────────────────────────────────────
+
+// sessionUUID is a fixed UUID for test sessions.
+const sessionUUID = "11111111-2222-3333-4444-555555555555"
+
+// makeUserRecord returns a JSON line representing a user message.
+func makeUserRecord(uuid, parentUUID, sessionID, text, ts string) string {
+	content, _ := json.Marshal([]map[string]string{{"type": "text", "text": text}})
+	msg, _ := json.Marshal(map[string]any{
+		"role":    "user",
+		"content": json.RawMessage(content),
+	})
+	rec := map[string]any{
+		"type":       "user",
+		"uuid":       uuid,
+		"parentUuid": parentUUID,
+		"sessionId":  sessionID,
+		"timestamp":  ts,
+		"message":    json.RawMessage(msg),
+		"userType":   "external",
+		"entrypoint": "cli",
+	}
+	b, _ := json.Marshal(rec)
+	return string(b)
+}
+
+// makeAssistantRecord returns a JSON line representing an assistant message.
+func makeAssistantRecord(uuid, parentUUID, sessionID, text, ts string) string {
+	content, _ := json.Marshal([]map[string]string{{"type": "text", "text": text}})
+	msg, _ := json.Marshal(map[string]any{
+		"role":    "assistant",
+		"model":   "claude-sonnet-4-6",
+		"content": json.RawMessage(content),
+	})
+	rec := map[string]any{
+		"type":       "assistant",
+		"uuid":       uuid,
+		"parentUuid": parentUUID,
+		"sessionId":  sessionID,
+		"timestamp":  ts,
+		"message":    json.RawMessage(msg),
+		"userType":   "external",
+		"entrypoint": "cli",
+	}
+	b, _ := json.Marshal(rec)
+	return string(b)
+}
+
+// makeAITitleRecord returns a JSON line for an ai-title record.
+func makeAITitleRecord(sessionID, title string) string {
+	rec := map[string]any{
+		"type":      "ai-title",
+		"sessionId": sessionID,
+		"title":     title,
+	}
+	b, _ := json.Marshal(rec)
+	return string(b)
+}
+
+// writeJSONLFixture writes a JSONL fixture file to dir/<sessionID>.jsonl.
+func writeJSONLFixture(t *testing.T, dir, sessionID string, lines []string) string {
+	t.Helper()
+	path := filepath.Join(dir, sessionID+".jsonl")
+	content := strings.Join(lines, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+// newTestProvider creates a Provider backed by a temp workspace.
+func newTestProvider(t *testing.T) (*Provider, string) {
+	t.Helper()
+	root := t.TempDir()
+	p := NewProvider()
+	return p, root
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+// TestProviderIngest_SingleSession asserts that a single-session JSONL is
+// parsed correctly: turn count, identity attribution, and time bounds.
+func TestProviderIngest_SingleSession(t *testing.T) {
+	p, root := newTestProvider(t)
+	srcDir := t.TempDir()
+
+	ts1 := "2026-05-01T10:00:00Z"
+	ts2 := "2026-05-01T10:01:00Z"
+	ts3 := "2026-05-01T10:02:00Z"
+
+	lines := []string{
+		makeAITitleRecord(sessionUUID, "Test Session Title"),
+		makeUserRecord("uuid-u1", "", sessionUUID, "what is the harness attestation policy?", ts1),
+		makeAssistantRecord("uuid-a1", "uuid-u1", sessionUUID, "The harness attestation policy is...", ts2),
+		makeUserRecord("uuid-u2", "uuid-a1", sessionUUID, "tell me more about operator identity", ts3),
+	}
+	writeJSONLFixture(t, srcDir, sessionUUID, lines)
+
+	// Write a custom observatory.yaml pointing at our temp source dir.
+	writeObservatoryConfig(t, root, []string{srcDir})
+
+	ctx := context.Background()
+	cfgAny, err := p.LoadConfig(root)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	liveAny, err := p.FetchLive(ctx, cfgAny)
+	if err != nil {
+		t.Fatalf("FetchLive: %v", err)
+	}
+
+	plan, err := p.ComputePlan(cfgAny, liveAny, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+
+	if plan.Summary.Creates != 1 {
+		t.Errorf("expected 1 create, got %d", plan.Summary.Creates)
+	}
+
+	results, err := p.ApplyPlan(ctx, plan)
+	if err != nil {
+		t.Fatalf("ApplyPlan: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Status != "succeeded" {
+		t.Errorf("expected succeeded, got %s: %s", results[0].Status, results[0].Error)
+	}
+
+	// Re-fetch live to confirm the session was indexed.
+	liveAny2, err := p.FetchLive(ctx, cfgAny)
+	if err != nil {
+		t.Fatalf("FetchLive 2: %v", err)
+	}
+	ls, ok := liveAny2.(*liveState)
+	if !ok {
+		t.Fatal("expected *liveState")
+	}
+	entry, ok := ls.Entries[sessionUUID]
+	if !ok {
+		t.Fatalf("session %s not in live state", sessionUUID)
+	}
+
+	// 2 user turns + 1 assistant turn = 3 total turns indexed.
+	if entry.Meta.TurnCount != 3 {
+		t.Errorf("expected 3 turns, got %d", entry.Meta.TurnCount)
+	}
+	if entry.Meta.Title != "Test Session Title" {
+		t.Errorf("expected title 'Test Session Title', got %q", entry.Meta.Title)
+	}
+	if entry.Meta.Entrypoint != "cli" {
+		t.Errorf("expected entrypoint 'cli', got %q", entry.Meta.Entrypoint)
+	}
+
+	// Check time bounds.
+	wantFirst, _ := time.Parse(time.RFC3339, ts1)
+	wantLast, _ := time.Parse(time.RFC3339, ts3)
+	if !entry.Meta.FirstTurnAt.Equal(wantFirst) {
+		t.Errorf("FirstTurnAt: want %v, got %v", wantFirst, entry.Meta.FirstTurnAt)
+	}
+	if !entry.Meta.LastTurnAt.Equal(wantLast) {
+		t.Errorf("LastTurnAt: want %v, got %v", wantLast, entry.Meta.LastTurnAt)
+	}
+}
+
+// TestProviderIngest_LargeSession verifies that indexing a large synthetic
+// session (many turns totalling ~1MB) completes without OOM and indexes
+// a sensible turn count.
+func TestProviderIngest_LargeSession(t *testing.T) {
+	p, root := newTestProvider(t)
+	srcDir := t.TempDir()
+
+	const largeSID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	const nTurns = 2000
+	lines := make([]string, 0, nTurns+1)
+	lines = append(lines, makeAITitleRecord(largeSID, "Large Session"))
+
+	for i := 0; i < nTurns; i++ {
+		ts := time.Now().UTC().Add(time.Duration(i) * time.Second).Format(time.RFC3339)
+		text := strings.Repeat("a", 400) // 400 bytes per turn × 2000 = ~800KB of content
+		if i%2 == 0 {
+			lines = append(lines, makeUserRecord(
+				fmt.Sprintf("uuid-u%d", i), "", largeSID, text, ts,
+			))
+		} else {
+			lines = append(lines, makeAssistantRecord(
+				fmt.Sprintf("uuid-a%d", i), fmt.Sprintf("uuid-u%d", i-1), largeSID, text, ts,
+			))
+		}
+	}
+	writeJSONLFixture(t, srcDir, largeSID, lines)
+	writeObservatoryConfig(t, root, []string{srcDir})
+
+	ctx := context.Background()
+	cfgAny, _ := p.LoadConfig(root)
+	liveAny, _ := p.FetchLive(ctx, cfgAny)
+	plan, _ := p.ComputePlan(cfgAny, liveAny, nil)
+	results, err := p.ApplyPlan(ctx, plan)
+	if err != nil {
+		t.Fatalf("ApplyPlan: %v", err)
+	}
+	if len(results) == 0 || results[0].Status != "succeeded" {
+		t.Fatalf("expected success, got: %v", results)
+	}
+
+	liveAny2, _ := p.FetchLive(ctx, cfgAny)
+	ls := liveAny2.(*liveState)
+	entry := ls.Entries[largeSID]
+
+	if entry.Meta.TurnCount != nTurns {
+		t.Errorf("expected %d turns, got %d", nTurns, entry.Meta.TurnCount)
+	}
+}
+
+// TestProviderDriftDetection verifies that a modified session (mtime/size
+// change) triggers an update action on the next plan cycle.
+func TestProviderDriftDetection(t *testing.T) {
+	p, root := newTestProvider(t)
+	srcDir := t.TempDir()
+	const driftSID = "dddddddd-dddd-dddd-dddd-dddddddddddd"
+
+	// Initial index.
+	lines := []string{
+		makeUserRecord("u1", "", driftSID, "first message", "2026-05-01T10:00:00Z"),
+	}
+	fixturePath := writeJSONLFixture(t, srcDir, driftSID, lines)
+	writeObservatoryConfig(t, root, []string{srcDir})
+
+	ctx := context.Background()
+	cfgAny, _ := p.LoadConfig(root)
+	liveAny, _ := p.FetchLive(ctx, cfgAny)
+	plan, _ := p.ComputePlan(cfgAny, liveAny, nil)
+	_, _ = p.ApplyPlan(ctx, plan)
+
+	// Confirm first cycle: skip (just indexed).
+	cfgAny, _ = p.LoadConfig(root)
+	liveAny, _ = p.FetchLive(ctx, cfgAny)
+	plan2, _ := p.ComputePlan(cfgAny, liveAny, nil)
+	if plan2.Summary.Updates != 0 || plan2.Summary.Creates != 0 {
+		t.Error("expected skip after initial index, got changes")
+	}
+
+	// Modify the file (add a new line to change size + mtime).
+	additional := "\n" + makeUserRecord("u2", "u1", driftSID, "second message", "2026-05-01T10:01:00Z")
+	f, err := os.OpenFile(fixturePath, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("open fixture for append: %v", err)
+	}
+	_, err = f.WriteString(additional)
+	f.Close()
+	if err != nil {
+		t.Fatalf("append to fixture: %v", err)
+	}
+
+	// Ensure mtime is different (filesystem resolution can be 1s).
+	future := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(fixturePath, future, future); err != nil {
+		t.Logf("chtimes: %v (non-fatal)", err)
+	}
+
+	// Re-plan: should detect update.
+	cfgAny, _ = p.LoadConfig(root)
+	liveAny, _ = p.FetchLive(ctx, cfgAny)
+	plan3, err := p.ComputePlan(cfgAny, liveAny, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan 3: %v", err)
+	}
+	if plan3.Summary.Updates != 1 {
+		t.Errorf("expected 1 update after file modification, got %d", plan3.Summary.Updates)
+	}
+
+	// Apply the update and verify new turn count.
+	results, _ := p.ApplyPlan(ctx, plan3)
+	if len(results) == 0 || results[0].Status != "succeeded" {
+		t.Fatalf("apply update failed: %v", results)
+	}
+	liveAny4, _ := p.FetchLive(ctx, cfgAny)
+	ls := liveAny4.(*liveState)
+	if ls.Entries[driftSID].Meta.TurnCount != 2 {
+		t.Errorf("expected 2 turns after update, got %d", ls.Entries[driftSID].Meta.TurnCount)
+	}
+}
+
+// TestProviderIdempotency verifies that running ApplyPlan twice on the same
+// session produces a skip on the second pass (no double-indexing).
+func TestProviderIdempotency(t *testing.T) {
+	p, root := newTestProvider(t)
+	srcDir := t.TempDir()
+	const idemSID = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+
+	lines := []string{
+		makeUserRecord("u1", "", idemSID, "idempotency test message", "2026-05-01T10:00:00Z"),
+	}
+	writeJSONLFixture(t, srcDir, idemSID, lines)
+	writeObservatoryConfig(t, root, []string{srcDir})
+
+	ctx := context.Background()
+
+	// First pass: create.
+	cfgAny, _ := p.LoadConfig(root)
+	liveAny, _ := p.FetchLive(ctx, cfgAny)
+	plan1, _ := p.ComputePlan(cfgAny, liveAny, nil)
+	_, _ = p.ApplyPlan(ctx, plan1)
+
+	// Second pass: should skip.
+	cfgAny, _ = p.LoadConfig(root)
+	liveAny, _ = p.FetchLive(ctx, cfgAny)
+	plan2, err := p.ComputePlan(cfgAny, liveAny, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan 2: %v", err)
+	}
+	if plan2.Summary.Creates != 0 || plan2.Summary.Updates != 0 {
+		t.Errorf("expected skip on second pass; got creates=%d updates=%d",
+			plan2.Summary.Creates, plan2.Summary.Updates)
+	}
+	if plan2.Summary.Skipped != 1 {
+		t.Errorf("expected 1 skip, got %d", plan2.Summary.Skipped)
+	}
+}
+
+// TestMCPSearchConversations verifies the MCP tool query path: index a session
+// with a known string, then search for it and assert a hit.
+func TestMCPSearchConversations(t *testing.T) {
+	p, root := newTestProvider(t)
+	srcDir := t.TempDir()
+	const searchSID = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+	const needle = "harness attestation policy"
+
+	lines := []string{
+		makeUserRecord("u1", "", searchSID,
+			"what is the "+needle+"?", "2026-05-10T12:00:00Z"),
+		makeAssistantRecord("a1", "u1", searchSID,
+			"The attestation model is defined in ADR-073.", "2026-05-10T12:01:00Z"),
+	}
+	writeJSONLFixture(t, srcDir, searchSID, lines)
+	writeObservatoryConfig(t, root, []string{srcDir})
+
+	ctx := context.Background()
+	cfgAny, _ := p.LoadConfig(root)
+	liveAny, _ := p.FetchLive(ctx, cfgAny)
+	plan, _ := p.ComputePlan(cfgAny, liveAny, nil)
+	_, _ = p.ApplyPlan(ctx, plan)
+
+	// Direct index search (bypasses MCP layer, tests the query logic).
+	p.mu.Lock()
+	idx := p.index
+	p.mu.Unlock()
+
+	if idx == nil {
+		t.Fatal("index is nil after ApplyPlan")
+	}
+
+	hits := idx.Search(needle, time.Time{}, time.Time{}, "", "", 10)
+	if len(hits) == 0 {
+		t.Fatalf("expected at least 1 hit for %q, got 0", needle)
+	}
+	if hits[0].SessionID != searchSID {
+		t.Errorf("expected session %s, got %s", searchSID, hits[0].SessionID)
+	}
+	if hits[0].Role != RoleUser {
+		t.Errorf("expected user role, got %s", hits[0].Role)
+	}
+	if !strings.Contains(strings.ToLower(hits[0].Excerpt), strings.ToLower(needle)) {
+		t.Errorf("excerpt %q does not contain needle %q", hits[0].Excerpt, needle)
+	}
+}
+
+// TestBuildState verifies that BuildState produces a well-formed reconcile.State.
+func TestBuildState(t *testing.T) {
+	p, root := newTestProvider(t)
+	srcDir := t.TempDir()
+	const bsSID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+	lines := []string{
+		makeUserRecord("u1", "", bsSID, "build state test", "2026-05-01T10:00:00Z"),
+	}
+	writeJSONLFixture(t, srcDir, bsSID, lines)
+	writeObservatoryConfig(t, root, []string{srcDir})
+
+	ctx := context.Background()
+	cfgAny, _ := p.LoadConfig(root)
+	liveAny, _ := p.FetchLive(ctx, cfgAny)
+	plan, _ := p.ComputePlan(cfgAny, liveAny, nil)
+	_, _ = p.ApplyPlan(ctx, plan)
+
+	liveAny2, _ := p.FetchLive(ctx, cfgAny)
+	state, err := p.BuildState(cfgAny, liveAny2, nil)
+	if err != nil {
+		t.Fatalf("BuildState: %v", err)
+	}
+	if state.ResourceType != "conversations" {
+		t.Errorf("expected resource_type 'conversations', got %q", state.ResourceType)
+	}
+	if len(state.Resources) != 1 {
+		t.Errorf("expected 1 resource, got %d", len(state.Resources))
+	}
+	r := state.Resources[0]
+	if r.ExternalID != bsSID {
+		t.Errorf("expected external_id %s, got %s", bsSID, r.ExternalID)
+	}
+}
+
+// TestHealthTransitions verifies Health() returns correct statuses.
+func TestHealthTransitions(t *testing.T) {
+	p := NewProvider()
+
+	// Before any plan: no changes → Synced.
+	h := p.Health()
+	if h.Sync != "Synced" {
+		t.Errorf("initial sync: want Synced, got %s", h.Sync)
+	}
+	if h.Health != "Healthy" {
+		t.Errorf("initial health: want Healthy, got %s", h.Health)
+	}
+
+	// Simulate a plan with creates.
+	p.mu.Lock()
+	p.lastPlanSummary.Creates = 3
+	p.mu.Unlock()
+
+	h2 := p.Health()
+	if h2.Sync != "OutOfSync" {
+		t.Errorf("after creates: want OutOfSync, got %s", h2.Sync)
+	}
+
+	// Simulate errors.
+	p.mu.Lock()
+	p.lastErrors = []string{"session x failed"}
+	p.mu.Unlock()
+
+	h3 := p.Health()
+	if h3.Health != "Degraded" {
+		t.Errorf("after errors: want Degraded, got %s", h3.Health)
+	}
+}
+
+// TestParserSystemReminderStripped verifies that <system-reminder> blocks
+// are stripped from user turns and do not produce empty turns.
+func TestParserSystemReminderStripped(t *testing.T) {
+	sysReminder := "<system-reminder>This is a system note.</system-reminder>"
+	realText := "what should I do next?"
+
+	// A user record where content is a text block with a system-reminder prefix.
+	content, _ := json.Marshal([]map[string]string{
+		{"type": "text", "text": sysReminder + "\n" + realText},
+	})
+	msg, _ := json.Marshal(map[string]any{
+		"role":    "user",
+		"content": json.RawMessage(content),
+	})
+	rec := map[string]any{
+		"type":       "user",
+		"uuid":       "test-uuid",
+		"parentUuid": "",
+		"sessionId":  "test-session",
+		"timestamp":  "2026-05-01T10:00:00Z",
+		"message":    json.RawMessage(msg),
+		"userType":   "external",
+		"entrypoint": "cli",
+	}
+	b, _ := json.Marshal(rec)
+	jsonl := string(b) + "\n"
+
+	var meta SessionMeta
+	var turns []Turn
+	err := ParseSession(strings.NewReader(jsonl), "test-session", 8192, &meta, func(t Turn) bool {
+		turns = append(turns, t)
+		return true
+	})
+	if err != nil {
+		t.Fatalf("ParseSession: %v", err)
+	}
+	if len(turns) != 1 {
+		t.Fatalf("expected 1 turn, got %d", len(turns))
+	}
+	if strings.Contains(turns[0].Text, "system-reminder") {
+		t.Errorf("system-reminder not stripped: %q", turns[0].Text)
+	}
+	if !strings.Contains(turns[0].Text, realText) {
+		t.Errorf("real text missing from turn: %q", turns[0].Text)
+	}
+}
+
+// TestParserSkipsToolResults verifies that tool_result content blocks in
+// user records are skipped (they are tool outputs, not operator utterances).
+func TestParserSkipsToolResults(t *testing.T) {
+	content, _ := json.Marshal([]map[string]any{
+		{"type": "tool_result", "tool_use_id": "toolu_abc", "content": "tool output"},
+		{"type": "text", "text": "here is the real question"},
+	})
+	msg, _ := json.Marshal(map[string]any{
+		"role":    "user",
+		"content": json.RawMessage(content),
+	})
+	rec := map[string]any{
+		"type":       "user",
+		"uuid":       "test-uuid-2",
+		"parentUuid": "",
+		"sessionId":  "test-session-2",
+		"timestamp":  "2026-05-01T10:00:00Z",
+		"message":    json.RawMessage(msg),
+		"userType":   "external",
+		"entrypoint": "cli",
+	}
+	b, _ := json.Marshal(rec)
+	jsonl := string(b) + "\n"
+
+	var meta SessionMeta
+	var turns []Turn
+	_ = ParseSession(strings.NewReader(jsonl), "test-session-2", 8192, &meta, func(t Turn) bool {
+		turns = append(turns, t)
+		return true
+	})
+	if len(turns) != 1 {
+		t.Fatalf("expected 1 turn, got %d", len(turns))
+	}
+	if strings.Contains(turns[0].Text, "tool output") {
+		t.Error("tool_result content leaked into turn text")
+	}
+	if !strings.Contains(turns[0].Text, "real question") {
+		t.Errorf("real text missing: %q", turns[0].Text)
+	}
+}
+
+// ─── Fixture helpers ─────────────────────────────────────────────────────────
+
+// writeObservatoryConfig writes a minimal .cog/config/observatory.yaml that
+// points at srcDirs.
+func writeObservatoryConfig(t *testing.T, root string, srcDirs []string) {
+	t.Helper()
+	cfgDir := filepath.Join(root, ".cog", "config")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+
+	var lines []string
+	lines = append(lines, "source_dirs:")
+	for _, d := range srcDirs {
+		lines = append(lines, "  - "+d)
+	}
+	lines = append(lines, "include_patterns:")
+	lines = append(lines, "  - \"*.jsonl\"")
+
+	content := strings.Join(lines, "\n") + "\n"
+	path := filepath.Join(cfgDir, "observatory.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write observatory.yaml: %v", err)
+	}
+}

--- a/internal/conversations/types.go
+++ b/internal/conversations/types.go
@@ -1,0 +1,179 @@
+// Package conversations implements the Conversations Observatory — a
+// Reconcilable provider that makes Claude Code session history first-class
+// substrate state.
+//
+// The observatory projects operator session JSONLs from
+// ~/.claude/projects/-Users-slowbro/*.jsonl (and any additional configured
+// directories) into a queryable index. After projection, the substrate can
+// answer queries like "what did the operator say about harness attestation in
+// May 2026?" via the cog_search_conversations MCP tool instead of walking
+// raw JSONL.
+//
+// Package layout:
+//   - types.go      — shared model types (SessionMeta, Turn, IndexEntry, etc.)
+//   - parser.go     — streaming JSONL parser (bufio.Scanner; never os.ReadFile)
+//   - index.go      — in-memory full-text index backed by flat projection files
+//   - provider.go   — Reconcilable implementation
+//   - mcp_tools.go  — cog_search_conversations, cog_get_conversation_turn,
+//                     cog_list_conversations tool registrations
+package conversations
+
+import "time"
+
+// Role identifies who produced a conversation turn.
+type Role string
+
+const (
+	RoleUser      Role = "user"
+	RoleAssistant Role = "assistant"
+	RoleSystem    Role = "system"
+)
+
+// SessionMeta carries per-session metadata without loading turn content.
+type SessionMeta struct {
+	// SessionID is the UUID from the JSONL file name.
+	SessionID string `json:"session_id"`
+
+	// SourcePath is the absolute path to the source JSONL.
+	SourcePath string `json:"source_path"`
+
+	// TurnCount is the number of indexed turns in this session.
+	TurnCount int `json:"turn_count"`
+
+	// FirstTurnAt / LastTurnAt bound the session in wall time.
+	FirstTurnAt time.Time `json:"first_turn_at,omitempty"`
+	LastTurnAt  time.Time `json:"last_turn_at,omitempty"`
+
+	// IndexedAt records when this session was last projected.
+	IndexedAt time.Time `json:"indexed_at"`
+
+	// SourceMtime records the source file mtime at index time (for drift detection).
+	SourceMtime time.Time `json:"source_mtime"`
+
+	// SourceSize records the source file size at index time (drift detection).
+	SourceSize int64 `json:"source_size"`
+
+	// Identity is the operator identity extracted from the JSONL (e.g. "slowbro").
+	// Populated from userType/sessionId/cwd fields present in the records.
+	Identity string `json:"identity,omitempty"`
+
+	// Entrypoint is the Claude Code client entrypoint (cli, claude-desktop, etc.)
+	Entrypoint string `json:"entrypoint,omitempty"`
+
+	// Title is the session AI-generated title when present.
+	Title string `json:"title,omitempty"`
+}
+
+// Turn is one indexed turn from a session.
+type Turn struct {
+	// UUID is the record's uuid field.
+	UUID string `json:"uuid"`
+
+	// SessionID is the session this turn belongs to.
+	SessionID string `json:"session_id"`
+
+	// TurnIndex is the sequential turn number within the session (0-based).
+	TurnIndex int `json:"turn_index"`
+
+	// Role is user/assistant/system.
+	Role Role `json:"role"`
+
+	// Timestamp is the record's timestamp field (RFC3339).
+	Timestamp time.Time `json:"timestamp"`
+
+	// Text is the extracted plain-text content of the turn.
+	// For user turns: concatenated text parts, system-reminder tags stripped.
+	// For assistant turns: concatenated text + thinking parts.
+	// Tool call inputs and tool results are excluded.
+	Text string `json:"text"`
+
+	// IsToolCall is true when this turn is primarily a tool invocation (assistant).
+	IsToolCall bool `json:"is_tool_call,omitempty"`
+
+	// ParentUUID links this turn to its parent in the conversation tree.
+	ParentUUID string `json:"parent_uuid,omitempty"`
+}
+
+// SearchHit is one result returned by cog_search_conversations.
+type SearchHit struct {
+	SessionID  string    `json:"session_id"`
+	TurnIndex  int       `json:"turn_index"`
+	UUID       string    `json:"uuid"`
+	Timestamp  time.Time `json:"timestamp"`
+	Role       Role      `json:"role"`
+	Excerpt    string    `json:"excerpt"`    // ~300-char snippet containing the match
+	Context    string    `json:"context,omitempty"` // preceding/following text
+	SessionTitle string  `json:"session_title,omitempty"`
+	Identity   string    `json:"identity,omitempty"`
+}
+
+// IndexDepth describes how thoroughly a session is indexed.
+type IndexDepth string
+
+const (
+	DepthFull          IndexDepth = "full"           // all turns parsed and indexed
+	DepthMetaOnly      IndexDepth = "meta_only"      // meta parsed, turns not
+	DepthNotProjected  IndexDepth = "not_projected"  // file seen, not yet indexed
+)
+
+// IndexEntry describes one session's projection status.
+type IndexEntry struct {
+	Meta  SessionMeta `json:"meta"`
+	Depth IndexDepth  `json:"depth"`
+}
+
+// ObservatoryConfig is the deserialized form of .cog/config/observatory.yaml.
+// Uses yaml struct tags so gopkg.in/yaml.v3 can unmarshal it correctly.
+type ObservatoryConfig struct {
+	// SourceDirs is the list of JSONL source directories to scan.
+	// Defaults to ["~/.claude/projects/-Users-slowbro"].
+	SourceDirs []string `yaml:"source_dirs" json:"source_dirs,omitempty"`
+
+	// IncludePatterns are glob patterns relative to each SourceDir.
+	// Defaults to ["*.jsonl"].
+	IncludePatterns []string `yaml:"include_patterns" json:"include_patterns,omitempty"`
+
+	// ExcludePatterns are glob patterns to skip.
+	ExcludePatterns []string `yaml:"exclude_patterns" json:"exclude_patterns,omitempty"`
+
+	// MaxTurnLength is the maximum number of characters stored per turn.
+	// Default 8192. Longer turns are truncated with a suffix marker.
+	MaxTurnLength int `yaml:"max_turn_length" json:"max_turn_length,omitempty"`
+
+	// MaxSessionsToIndex caps how many sessions are indexed in a single
+	// ApplyPlan pass. 0 = no limit.
+	MaxSessionsToIndex int `yaml:"max_sessions_to_index" json:"max_sessions_to_index,omitempty"`
+
+	// Identity tags to apply to all sessions from this config.
+	DefaultIdentity string `yaml:"default_identity" json:"default_identity,omitempty"`
+}
+
+// providerConfig is the internal config bundle built by LoadConfig.
+type providerConfig struct {
+	Root        string
+	Observatory ObservatoryConfig
+	SourceFiles []sourceFileInfo // expanded from SourceDirs
+}
+
+// sourceFileInfo is metadata about one discovered source JSONL.
+type sourceFileInfo struct {
+	Path      string
+	SessionID string    // derived from filename (UUID before .jsonl)
+	Mtime     time.Time
+	Size      int64
+}
+
+// liveState is the result of FetchLive.
+type liveState struct {
+	// Entries maps session_id → IndexEntry.
+	Entries map[string]IndexEntry
+}
+
+// applyStats summarizes what ApplyPlan did.
+type applyStats struct {
+	Indexed int
+	Updated int
+	Pruned  int
+	Skipped int
+	Errors  []string
+}

--- a/z_conversations_mcp.go
+++ b/z_conversations_mcp.go
@@ -1,0 +1,30 @@
+// z_conversations_mcp.go — wires Conversations Observatory MCP tools.
+//
+// Prefixed with "z_" so this file's init() is guaranteed to run after
+// eval_wiring.go (e < z alphabetically). This ensures that when we capture
+// engine.RegisterMCPExtensions, it already holds the eval-tools registration
+// set by eval_wiring.go, and we chain on top of it rather than overwriting it.
+//
+// Tools registered:
+//   cog_search_conversations  — full-text search over indexed operator turns
+//   cog_get_conversation_turn — fetch one turn by session_id + turn_index
+//   cog_list_conversations    — list indexed sessions with metadata
+
+package main
+
+import (
+	"github.com/myrgic/cogos/internal/conversations"
+	"github.com/myrgic/cogos/internal/engine"
+)
+
+func init() {
+	// Capture the previously registered extension chain (set by eval_wiring.go).
+	// eval_wiring.go registers eval tools; we chain conversations tools after.
+	prev := engine.RegisterMCPExtensions
+	engine.RegisterMCPExtensions = func(srv *engine.MCPServer) {
+		if prev != nil {
+			prev(srv)
+		}
+		conversations.RegisterConversationTools(srv.Server(), conversationsProviderInstance)
+	}
+}


### PR DESCRIPTION
## Why this exists

Today the substrate can only access Claude Code session history via brute-force grep of raw JSONL files (~60MB+). A transcript-walker agent demonstrated this morning that answering "what did Chaz say about harness attestation in May 2026?" requires walking the entire session corpus. This PR closes that gap.

After merge, the substrate answers queries like that via `cog_search_conversations` in milliseconds. Session JSONLs become projected substrate state — indexed, queryable, drift-detected.

Closes the visibility gap described in ADR-102-pending (operator-as-Reconcilable). The raw ingestion + query layer is implemented here; the operator-intent CRD is a follow-on.

## Reconcilable seven-method mapping

| Method | Implementation |
|--------|---------------|
| `Type()` | Returns `"conversations"` |
| `LoadConfig(root)` | Reads `.cog/config/observatory.yaml`; discovers JSONL files in configured source dirs; initialises the in-memory index backed by `.cog/state/conversations/` |
| `FetchLive(ctx, cfg)` | Loads the projection index from disk; returns `liveState{Entries: map[sessionID]IndexEntry}` |
| `ComputePlan(cfg, live, state)` | Diffs source files (mtime + size) vs indexed entries; plans create/update/delete/skip per session |
| `ApplyPlan(ctx, plan)` | Stream-parses new/changed sessions with `bufio.Scanner` (never `os.ReadFile`); writes to index; skips unchanged sessions |
| `BuildState(cfg, live, existing)` | Returns Terraform-style `reconcile.State` with one resource per indexed session |
| `Health()` | Synced/OutOfSync based on last plan summary; Healthy/Degraded based on indexing errors |

## MCP tool surface

- `cog_search_conversations(query, [since], [until], [session_id], [identity], [limit])` — full-text substring search over indexed turns. Returns hits with session_id, turn_index, timestamp, role, excerpt centered on the match, session title. Default limit 20.
- `cog_get_conversation_turn(session_id, turn_index)` — fetch full text of one turn including parent_uuid linkage. Use to drill into a search hit.
- `cog_list_conversations([since], [until], [identity], [limit])` — list indexed sessions sorted by last_turn_at descending, with title, turn count, time bounds, entrypoint.

## Implementation notes

### JSONL format findings beyond extract_user_msgs.py reference
- `ai-title` record type carries the session title (not in Python reference)
- `thinking` content blocks in assistant records — included in index as `[thinking] <text>`
- `uuid`/`parentUuid` fields enable conversation tree linkage (returned by `cog_get_conversation_turn`)
- `entrypoint` field distinguishes `cli` vs `claude-desktop` vs other surfaces
- assistant message content can be a plain string (not array) — handled in parser

### Search implementation
In-memory substring search on pre-loaded turn text. No SQLite FTS5, no external dependencies. Fast enough for the expected corpus (~hundreds of sessions). Projection files at `.cog/state/conversations/` are flat JSON so the index survives daemon restarts.

### Wiring
- Root CLI binary: `conversations_wiring.go` registers the provider; `z_conversations_mcp.go` chains MCP tools after `eval_wiring.go` (z_ prefix ensures correct init() order)
- Daemon binary: `cmd/cogos/z_conversations_wire.go` registers provider + chains tools + wires workspace root injection

## Migration

No existing data to migrate. New tool surface — additive only. Existing MCP tools unmodified.

## Composes with

- ADR-102 (operator-as-Reconcilable) — this is the raw ingestion layer that ADR-102 builds on
- Follow-on: operator-intent CRD (structured extraction from indexed turns)
- Follow-on: embedding-based semantic search (today's substring search is the baseline)
- Follow-on: multi-workspace support (config already has `source_dirs` list; default is single workspace)

## What is intentionally deferred

- **Semantic search**: text substring is the baseline; embedding-based search is a follow-on
- **Operator-intent CRD**: structured extraction of decisions/preferences from turns — ADR-102 territory
- **Multi-workspace**: `source_dirs` config supports it; default covers only `slowbro`'s workspace
- **cogblock bus emission**: turns are written to the projection index; bus emission is a follow-on once the bus integration pattern for read-only projections is settled

## Tests (9 passing)

1. `TestProviderIngest_SingleSession` — turn count, title, entrypoint, time bounds
2. `TestProviderIngest_LargeSession` — 2000-turn synthetic session; streaming without OOM
3. `TestProviderDriftDetection` — mtime+size change triggers update action
4. `TestProviderIdempotency` — second ApplyPlan produces skip, no double-indexing
5. `TestMCPSearchConversations` — search for known string; assert hit with correct session/role
6. `TestBuildState` — reconcile.State structure and resource attributes
7. `TestHealthTransitions` — Synced→OutOfSync, Healthy→Degraded transitions
8. `TestParserSystemReminderStripped` — `<system-reminder>` blocks stripped from user turns
9. `TestParserSkipsToolResults` — `tool_result` content blocks excluded from indexed text