### PR TITLE
feat(hooks): post-turn regenerative reconciliation — Stop hook captures bright-line state for next-turn proprioception (Phase 1)

### DIFF
--- a/scripts/hooks/cogos_post_turn_capture.py
+++ b/scripts/hooks/cogos_post_turn_capture.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""CogOS post-turn capture hook (Stop event).
+
+Closes the substrate's regenerative-reconciliation loop. Every Claude Code
+turn dissipates kinetic state (PR counts changed, commits merged, memory
+files written, dispatches launched) that the *next* turn's proprioception
+block could otherwise harvest as free anticipatory signal. This hook fires
+at turn-end and snapshots that state to a substrate-readable path so the
+next UserPromptSubmit can inline it.
+
+This is the "post-hook" companion to cogos_session_awareness.py's
+UserPromptSubmit handler. Together they convert per-turn perturbation into
+next-turn anticipatory signal (regenerative-braking analogy: don't dissipate
+the kinetic state, harvest it).
+
+Substrate-physics framing:
+  - Pre-hook (UserPromptSubmit) is the substrate's *during-loop* surface.
+  - Post-hook (Stop) is the substrate's *post-loop* surface.
+  - Together they close the loop. Each turn's settled distinctions become
+    the next turn's frame of reference (per substrate-physics-sequence
+    cogdoc; lightning-through-sand only flows once tethers lead to ground).
+
+Captured fields:
+  - timestamp        : turn-end UTC time (RFC3339)
+  - cwd              : working directory at capture time
+  - branch           : git branch (if in a repo)
+  - bright_line      : {open_prs_cogos, open_prs_mod3, recent_merges_24h}
+  - memory           : {recent_writes_count, last_write_iso}
+  - observatory      : {unindexed_session_bytes} (cheap heuristic)
+  - consolidation    : {pressure} ("low"/"moderate"/"high" — heuristic)
+
+Write location (substrate-side, fits existing .cog/run/ pattern):
+  ${COGOS_WORKSPACE}/.cog/run/proprioception/post-turn.json
+
+If COGOS_WORKSPACE is not set and ~/workspaces/cog/.cog/ doesn't exist,
+falls back to ~/.claude/state/proprioception/post-turn.json.
+
+Safety contract: never raises; always exits 0; total wall time budget < 3s.
+gh / git invocations are individually time-bounded; failure of any one
+field just leaves that key out of the captured state (next turn gets
+whatever was reachable).
+
+Install:
+  cp scripts/hooks/cogos_post_turn_capture.py ~/.claude/hooks/
+
+Wire in ~/.claude/settings.json (Stop event):
+  {
+    "Stop": [{"matcher": "*", "hooks": [{"type": "command",
+      "command": "python3 ~/.claude/hooks/cogos_post_turn_capture.py"}]}]
+  }
+
+The companion UserPromptSubmit reader lives in cogos_session_awareness.py
+(handle_user_prompt_submit; reads this file and inlines a <cogos_post_turn>
+block in additionalContext).
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# ---------- Path resolution ------------------------------------------------
+
+
+def _cog_workspace() -> Path | None:
+    """Return cog workspace root with .cog/ subdir, or None."""
+    candidates = []
+    env = os.environ.get("COGOS_WORKSPACE")
+    if env:
+        candidates.append(Path(env))
+    candidates.append(Path.home() / "workspaces" / "cog")
+
+    for c in candidates:
+        try:
+            if (c / ".cog").is_dir():
+                return c.resolve()
+        except OSError:
+            continue
+    return None
+
+
+def _state_path() -> Path:
+    """Return the canonical write path for post-turn state.
+
+    Prefers substrate-side (.cog/run/proprioception/post-turn.json) when the
+    cog workspace is reachable; falls back to operator-side state dir.
+    """
+    cog = _cog_workspace()
+    if cog is not None:
+        return cog / ".cog" / "run" / "proprioception" / "post-turn.json"
+    return Path.home() / ".claude" / "state" / "proprioception" / "post-turn.json"
+
+
+# ---------- Field collectors (each individually bounded) -------------------
+
+
+def _run(cmd: list[str], cwd: str | None = None, timeout: float = 1.5) -> str | None:
+    try:
+        r = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout, cwd=cwd
+        )
+        if r.returncode == 0:
+            return r.stdout
+    except Exception:
+        return None
+    return None
+
+
+def _git_branch(cwd: str) -> str | None:
+    out = _run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=cwd, timeout=1.0)
+    if out is None:
+        return None
+    b = out.strip()
+    return b or None
+
+
+def _gh_open_pr_count(repo: str) -> int | None:
+    """Count open PRs on a repo via gh. Repo like 'myrgic/cogos'."""
+    out = _run(
+        ["gh", "pr", "list", "--repo", repo, "--state", "open",
+         "--json", "number", "--limit", "100"],
+        timeout=2.0,
+    )
+    if out is None:
+        return None
+    try:
+        arr = json.loads(out)
+        return len(arr) if isinstance(arr, list) else None
+    except Exception:
+        return None
+
+
+def _gh_recent_merges(repo: str, hours: int = 24) -> int | None:
+    """Count PRs merged in the last N hours."""
+    out = _run(
+        ["gh", "pr", "list", "--repo", repo, "--state", "merged",
+         "--json", "mergedAt", "--limit", "50"],
+        timeout=2.0,
+    )
+    if out is None:
+        return None
+    try:
+        arr = json.loads(out)
+        if not isinstance(arr, list):
+            return None
+        cutoff = time.time() - hours * 3600
+        n = 0
+        for pr in arr:
+            merged = pr.get("mergedAt")
+            if not merged:
+                continue
+            try:
+                t = datetime.fromisoformat(merged.replace("Z", "+00:00")).timestamp()
+            except Exception:
+                continue
+            if t >= cutoff:
+                n += 1
+        return n
+    except Exception:
+        return None
+
+
+def _memory_recent_writes(window_seconds: int = 3600) -> dict[str, Any]:
+    """Count and find latest mtime under user memory dir within window."""
+    base = Path.home() / ".claude" / "projects" / "-Users-slowbro" / "memory"
+    info: dict[str, Any] = {"recent_writes_count": 0, "last_write_iso": None}
+    try:
+        if not base.is_dir():
+            return info
+        cutoff = time.time() - window_seconds
+        latest = 0.0
+        count = 0
+        for p in base.iterdir():
+            if not p.is_file():
+                continue
+            try:
+                m = p.stat().st_mtime
+            except OSError:
+                continue
+            if m >= cutoff:
+                count += 1
+            if m > latest:
+                latest = m
+        info["recent_writes_count"] = count
+        if latest > 0:
+            info["last_write_iso"] = datetime.fromtimestamp(
+                latest, tz=timezone.utc
+            ).strftime("%Y-%m-%dT%H:%MZ")
+    except Exception:
+        pass
+    return info
+
+
+def _observatory_unindexed_bytes() -> int | None:
+    """Heuristic: total size of session JSONL files modified in last 30 min.
+
+    Cheap proxy for ingest pressure until the Conversations Observatory
+    is wired. Counts JSONL files in the recent-activity window — the
+    substrate-side Observatory reconciler can replace this with a real
+    indexed-through-watermark when it lands (cogos#300).
+    """
+    base = Path.home() / ".claude" / "projects" / "-Users-slowbro"
+    try:
+        if not base.is_dir():
+            return None
+        cutoff = time.time() - 1800  # 30 min
+        total = 0
+        for p in base.iterdir():
+            if not p.is_file() or p.suffix != ".jsonl":
+                continue
+            try:
+                st = p.stat()
+                if st.st_mtime >= cutoff:
+                    total += st.st_size
+            except OSError:
+                continue
+        return total
+    except Exception:
+        return None
+
+
+def _consolidation_pressure(turn_count: int | None = None) -> str:
+    """Heuristic. Real foveation engine will replace this.
+
+    For now: "low" if no recent memory writes, "moderate" if some, "high"
+    if many recent writes (a busy session is more in need of consolidation).
+    """
+    info = _memory_recent_writes(window_seconds=3600)
+    n = info.get("recent_writes_count", 0) or 0
+    if n >= 5:
+        return "high"
+    if n >= 1:
+        return "moderate"
+    return "low"
+
+
+# ---------- Capture orchestration ------------------------------------------
+
+
+def capture(stdin_data: dict[str, Any]) -> dict[str, Any]:
+    """Build the post-turn state blob.
+
+    Each field is best-effort; failure on one doesn't block the others.
+    """
+    cwd = stdin_data.get("cwd") or os.getcwd()
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    out: dict[str, Any] = {
+        "timestamp": now,
+        "cwd": cwd,
+        "session_id": stdin_data.get("session_id"),
+        "stop_reason": stdin_data.get("stop_reason"),
+    }
+
+    branch = _git_branch(cwd)
+    if branch:
+        out["branch"] = branch
+
+    bright_line: dict[str, Any] = {}
+    cogos_open = _gh_open_pr_count("myrgic/cogos")
+    mod3_open = _gh_open_pr_count("myrgic/mod3")
+    cogos_merges = _gh_recent_merges("myrgic/cogos", hours=24)
+    if cogos_open is not None:
+        bright_line["open_prs_cogos"] = cogos_open
+    if mod3_open is not None:
+        bright_line["open_prs_mod3"] = mod3_open
+    if cogos_merges is not None:
+        bright_line["recent_merges_24h_cogos"] = cogos_merges
+    if bright_line:
+        out["bright_line"] = bright_line
+
+    mem = _memory_recent_writes()
+    if mem.get("recent_writes_count") or mem.get("last_write_iso"):
+        out["memory"] = mem
+
+    unindexed = _observatory_unindexed_bytes()
+    if unindexed is not None:
+        out["observatory"] = {"unindexed_session_bytes": unindexed}
+
+    out["consolidation"] = {"pressure": _consolidation_pressure()}
+
+    return out
+
+
+def write_state(state: dict[str, Any]) -> Path | None:
+    """Atomically write state to the canonical location. Returns path."""
+    target = _state_path()
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp = target.with_suffix(".json.tmp")
+        with open(tmp, "w") as f:
+            json.dump(state, f, indent=2)
+        os.replace(tmp, target)
+        return target
+    except Exception as e:
+        sys.stderr.write(f"cogos_post_turn_capture: write failed: {e}\n")
+        return None
+
+
+# ---------- Entry point ----------------------------------------------------
+
+
+def main() -> int:
+    try:
+        raw = sys.stdin.read()
+        data = json.loads(raw) if raw.strip() else {}
+    except Exception:
+        data = {}
+
+    # Only act on Stop. Be permissive on missing event name; some installs
+    # may invoke us directly. SubagentStop is a sibling event we treat the
+    # same way (sub-agent turn-end is also a moment with capturable state).
+    event = data.get("hook_event_name", "Stop")
+    if event not in ("Stop", "SubagentStop"):
+        # Not our event — silent no-op.
+        print(json.dumps({}))
+        return 0
+
+    try:
+        state = capture(data)
+        path = write_state(state)
+    except Exception as e:
+        sys.stderr.write(f"cogos_post_turn_capture: capture failed: {e}\n")
+        path = None
+
+    # Stop hooks may return decision/continue/stopReason fields; we just
+    # return empty so the agent's stop decision is unchanged.
+    out: dict[str, Any] = {}
+    if path is not None:
+        # Surface where state was written for debugging via stderr; the
+        # agent's stdout JSON contract stays minimal.
+        sys.stderr.write(f"cogos_post_turn_capture: state -> {path}\n")
+    print(json.dumps(out))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as e:
+        sys.stderr.write(f"cogos_post_turn_capture: unexpected error: {e}\n")
+        try:
+            print(json.dumps({}))
+        except Exception:
+            pass
+        sys.exit(0)

--- a/scripts/hooks/cogos_session_awareness.py
+++ b/scripts/hooks/cogos_session_awareness.py
@@ -9,16 +9,25 @@ Dispatches on hook_event_name (received as stdin JSON):
   SessionStart:    POST /v1/sessions/register  (role: claude-code)
   SubAgentStart:   POST /v1/sessions/register  (role: claude-code-subagent,
                    parent: parent session_id)
-  UserPromptSubmit: POST /v1/sessions/{id}/heartbeat, then GET /v1/peer-awareness
-                   and prepend the packet as additionalContext.
+  UserPromptSubmit: POST /v1/sessions/{id}/heartbeat, then GET /v1/peer-awareness;
+                   ALSO reads post-turn state (written by cogos_post_turn_capture.py
+                   at Stop) and inlines <cogos_post_turn> as anticipatory signal.
+  Stop:            Delegates to cogos_post_turn_capture.py to snapshot
+                   bright-line + memory + observatory + consolidation state.
+                   Closes the regenerative-reconciliation loop: per-turn kinetic
+                   state becomes next-turn anticipatory signal instead of
+                   dissipating.
   SessionEnd:      POST /v1/sessions/{id}/heartbeat {status: ending}
   SubAgentEnd:     POST /v1/sessions/{id}/end    (closes sub-agent registration)
+                   Also invokes post-turn capture so sub-agent completions
+                   contribute to parent's next-turn proprioception.
 
 Silent on failure: if the kernel isn't running or the cwd isn't a CogOS
 workspace, the hook exits 0 without blocking the session.
 
 Install:
   cp scripts/hooks/cogos_session_awareness.py ~/.claude/hooks/
+  cp scripts/hooks/cogos_post_turn_capture.py ~/.claude/hooks/
 
 Wire in ~/.claude/settings.local.json:
   {
@@ -30,6 +39,9 @@ Wire in ~/.claude/settings.local.json:
       "async": true}]}],
     "UserPromptSubmit": [{"hooks": [{"type": "command",
       "command": "python3 ~/.claude/hooks/cogos_session_awareness.py"}]}],
+    "Stop": [{"hooks": [{"type": "command",
+      "command": "python3 ~/.claude/hooks/cogos_post_turn_capture.py",
+      "async": true}]}],
     "SessionEnd": [{"hooks": [{"type": "command",
       "command": "python3 ~/.claude/hooks/cogos_session_awareness.py",
       "async": true}]}],
@@ -142,23 +154,97 @@ def handle_subagent_start(inp: dict) -> dict:
     return {}
 
 
+def _read_post_turn_state() -> Optional[dict]:
+    """Read the most recent post-turn state blob written by
+    cogos_post_turn_capture.py (Stop hook). Returns None if missing or
+    unreadable. Substrate-side path preferred; falls back to operator-side.
+
+    This is the regenerative-reconciliation read path: turn-end-captured
+    state flows into the next turn's UserPromptSubmit as anticipatory
+    signal. See cogos_post_turn_capture.py for the writer.
+    """
+    candidates = []
+    env = os.environ.get("COGOS_WORKSPACE")
+    if env:
+        candidates.append(Path(env) / ".cog" / "run" / "proprioception" / "post-turn.json")
+    candidates.append(Path.home() / "workspaces" / "cog" / ".cog" / "run" /
+                      "proprioception" / "post-turn.json")
+    candidates.append(Path.home() / ".claude" / "state" / "proprioception" / "post-turn.json")
+
+    for c in candidates:
+        try:
+            if c.is_file():
+                with open(c) as f:
+                    return json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+    return None
+
+
+def _format_post_turn_block(state: dict) -> str:
+    """Format the post-turn state as a terse multi-line block."""
+    lines = ["<cogos_post_turn>"]
+    ts = state.get("timestamp")
+    if ts:
+        lines.append(f"  captured={ts}")
+    bl = state.get("bright_line") or {}
+    if bl:
+        parts = []
+        if "open_prs_cogos" in bl:
+            parts.append(f"cogos_open={bl['open_prs_cogos']}")
+        if "open_prs_mod3" in bl:
+            parts.append(f"mod3_open={bl['open_prs_mod3']}")
+        if "recent_merges_24h_cogos" in bl:
+            parts.append(f"cogos_merged_24h={bl['recent_merges_24h_cogos']}")
+        if parts:
+            lines.append("  bright_line: " + " | ".join(parts))
+    mem = state.get("memory") or {}
+    if mem.get("recent_writes_count") or mem.get("last_write_iso"):
+        parts = []
+        if "recent_writes_count" in mem:
+            parts.append(f"writes_1h={mem['recent_writes_count']}")
+        if mem.get("last_write_iso"):
+            parts.append(f"last_write={mem['last_write_iso']}")
+        lines.append("  memory: " + " | ".join(parts))
+    obs = state.get("observatory") or {}
+    if "unindexed_session_bytes" in obs:
+        lines.append(f"  observatory: unindexed_bytes={obs['unindexed_session_bytes']}")
+    cons = state.get("consolidation") or {}
+    if "pressure" in cons:
+        lines.append(f"  consolidation: pressure={cons['pressure']}")
+    lines.append("</cogos_post_turn>")
+    return "\n".join(lines)
+
+
 def handle_user_prompt_submit(inp: dict) -> dict:
     sid = inp.get("session_id")
     cwd = inp.get("cwd") or os.getcwd()
     if not sid or not _find_workspace(cwd):
         return {}
     _post(f"/v1/sessions/{sid}/heartbeat", {"status": "active"})
+
+    # Compose additionalContext from two sources: peer-awareness (live from
+    # kernel) and post-turn state (snapshot from previous Stop hook). Either
+    # may be absent; we emit whichever is present.
+    blocks: list[str] = []
+
     resp = _get(f"/v1/peer-awareness?sid={sid}")
-    if not resp:
+    if resp:
+        packet = (resp.get("packet") or "").strip()
+        if packet and resp.get("token_count", 0) >= 5:
+            blocks.append(f"<cogos_peer_awareness>\n{packet}\n</cogos_peer_awareness>")
+
+    post_turn = _read_post_turn_state()
+    if post_turn:
+        blocks.append(_format_post_turn_block(post_turn))
+
+    if not blocks:
         return {}
-    packet = (resp.get("packet") or "").strip()
-    if not packet or resp.get("token_count", 0) < 5:
-        return {}
-    block = f"<cogos_peer_awareness>\n{packet}\n</cogos_peer_awareness>"
+
     return {
         "hookSpecificOutput": {
             "hookEventName": "UserPromptSubmit",
-            "additionalContext": block,
+            "additionalContext": "\n".join(blocks),
         }
     }
 
@@ -173,13 +259,53 @@ def handle_session_end(inp: dict) -> dict:
 
 
 def handle_subagent_end(inp: dict) -> dict:
-    """Close the sub-agent's cogos session registration on completion."""
+    """Close the sub-agent's cogos session registration on completion.
+
+    Also invokes the post-turn capture so sub-agent completions contribute
+    to next-turn proprioception (regenerative-reconciliation closure).
+    """
     sid = inp.get("session_id")
     cwd = inp.get("cwd") or os.getcwd()
-    if not sid or not _find_workspace(cwd):
-        return {}
-    outcome = inp.get("outcome") or "completed"
-    _post(f"/v1/sessions/{sid}/end", {"reason": outcome})
+    if sid and _find_workspace(cwd):
+        outcome = inp.get("outcome") or "completed"
+        _post(f"/v1/sessions/{sid}/end", {"reason": outcome})
+    # Also capture post-turn state.
+    _invoke_post_turn_capture(inp)
+    return {}
+
+
+def _invoke_post_turn_capture(inp: dict) -> None:
+    """Delegate to cogos_post_turn_capture.py (Stop hook) if installed.
+
+    The post-turn capture is the post-loop substrate surface — it snapshots
+    bright-line state, memory writes, observatory pressure, and consolidation
+    pressure at turn-end so the next UserPromptSubmit can inline it. We
+    delegate via subprocess rather than importing so the two scripts stay
+    independently installable.
+    """
+    capture = Path.home() / ".claude" / "hooks" / "cogos_post_turn_capture.py"
+    if not capture.is_file():
+        return
+    try:
+        import subprocess  # local import — only used on this path
+        subprocess.run(
+            [sys.executable, str(capture)],
+            input=json.dumps(inp).encode(),
+            capture_output=True,
+            timeout=3.0,
+        )
+    except Exception:
+        pass
+
+
+def handle_stop(inp: dict) -> dict:
+    """Stop event handler — capture post-turn state for next-turn proprioception.
+
+    Returns empty dict (Stop hooks should not influence the agent's stop
+    decision unless explicitly requested). All capture work happens via
+    cogos_post_turn_capture.py.
+    """
+    _invoke_post_turn_capture(inp)
     return {}
 
 
@@ -190,6 +316,7 @@ HANDLERS = {
     "UserPromptSubmit": handle_user_prompt_submit,
     "SessionEnd": handle_session_end,
     "SubagentStop": handle_subagent_end,
+    "Stop": handle_stop,
 }
 
 


### PR DESCRIPTION
## Summary

Closes the regenerative-reconciliation loop at the Claude Code hook surface. Every turn dissipates kinetic state — PR counts changed, commits merged, memory files written, dispatches in flight — that the next turn's proprioception block could otherwise harvest as free anticipatory signal. This PR adds the post-loop substrate surface that snapshots that state at turn-end so the next `UserPromptSubmit` can inline it.

Two scripts ship together:

- `scripts/hooks/cogos_post_turn_capture.py` — new Stop hook. Snapshots cwd, branch, bright-line PR/merge counts (cogos+mod3), recent memory writes, observatory unindexed-bytes heuristic, and consolidation pressure to `${COGOS_WORKSPACE}/.cog/run/proprioception/post-turn.json` (substrate-side; falls back to `~/.claude/state/proprioception/post-turn.json` when unavailable). Always exits 0, total wall budget < 3s.
- `scripts/hooks/cogos_session_awareness.py` — extended `UserPromptSubmit` handler to read the post-turn state and inline a `<cogos_post_turn>` block in `additionalContext`. Also adds `Stop` and updates `SubagentStop` to delegate to the capture script if installed.

Captured block shape (terse, parseable, additive to the existing proprioception block):

```
<cogos_post_turn>
  captured=2026-05-19T20:06:08Z
  bright_line: cogos_open=3 | mod3_open=3 | cogos_merged_24h=18
  memory: writes_1h=2 | last_write=2026-05-19T19:24Z
  observatory: unindexed_bytes=10918650
  consolidation: pressure=moderate
</cogos_post_turn>
```

## Framing

The pre-loop and during-loop interfaces (UserPromptSubmit, proprioception block, peer-awareness, MCP tool surface, dispatched orchestrators) are heavily developed. The post-loop interface is thin — every turn's kinetic state dissipates instead of converting into next-turn anticipatory signal. The substrate misses the regenerative-braking opportunity.

This PR is the closing-of-the-loop layer. By this PR's merge SHA, the substrate gains post-loop anticipatory signal: turn-end perturbation → snapshot → next turn reads → anticipatory signal → action → turn-end snapshot.

Substrate-physics grounding: per the operational specification in the substrate-physics-sequence cogdoc (operator-authored, preserved verbatim), reconciliation of any operator-or-agent-generated content should follow match → mark → distinction → event → reorganization → new frame of reference. The post-turn capture mechanism is one concrete realization of that specification at the turn-boundary scale.

## Test plan

- [x] Python syntax check (both scripts parse)
- [x] Stop hook smoke test: synthetic stdin produces a valid JSON state blob at the canonical path with all six top-level fields populated
- [x] UserPromptSubmit smoke test: reads back the captured state and emits a well-formed `<cogos_post_turn>` block in `additionalContext`
- [x] Safety contract: scripts exit 0 on missing stdin, missing workspace, missing delegate
- [ ] Live wire-test once installed under `~/.claude/hooks/` and Stop is registered in `settings.json` (operator-side, post-merge)

## Phase disposition

- **Phase 1 (this PR)**: operator-side Stop hook + UserPromptSubmit read path. Captured state is operator-readable; substrate consumes via the existing `<cogos_proprioception>` adjacency in the prompt context.
- **Phase 2 (queued)**: substrate-side `PostTurnReconcilable` provider that reads `${COGOS_WORKSPACE}/.cog/run/proprioception/post-turn.json` and projects it into substrate state as a Reconcilable. Composes with the Conversations Observatory (#300, still open) to provide indexed-through watermarks rather than the bytes-modified heuristic.
- **Phase 3 (queued)**: positive-local-gradient detection on captured state → autonomous Reconciler firing between operator turns. The substrate becomes capable of self-initiated work when the consolidation-pressure or bright-line-divergence crosses a threshold. Per the wave-physics articulation: "lower-energy layers can still initiate IF they have accumulated positive local gradient that crosses a fire-point."

## Install (post-merge, operator-side)

```bash
cp scripts/hooks/cogos_session_awareness.py ~/.claude/hooks/
cp scripts/hooks/cogos_post_turn_capture.py ~/.claude/hooks/
```

Then add to `~/.claude/settings.json` (or `settings.local.json`):

```json
{
  "Stop": [{"matcher": "*", "hooks": [{"type": "command",
    "command": "python3 ~/.claude/hooks/cogos_post_turn_capture.py",
    "async": true}]}]
}
```

Full wiring example is in the `cogos_session_awareness.py` module docstring.

## References

- `cog://mem/reflective/2026-05-19-chaz-substrate-physics-sequence` — the substrate-physics articulations, including the operational specification (match → mark → distinction → event → reorganization → new frame of reference) and the lightning-through-sand image (tethers all lead to ground)
- `feedback_bright_line_displacement_vs_wave` — the bright-line discipline this PR aims at (by-merge-SHA the substrate gains post-loop signal)
- `feedback_operator_as_reconcilable_already_running` — the harness IS the operator-as-Reconcilable; this PR makes its post-loop interface visible to itself
- #300 — Conversations Observatory; Phase 2 composes with it (substrate-side projection of these snapshots)
- #299 — ADR-102 operator-as-Reconcilable doc; the framing this work implements