### PR TITLE
chore(release): prepare v0.10.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 #   make e2e      - Run e2e test in a container
 #   make e2e-local - Run e2e test locally
 
-VERSION := 0.9.0
+VERSION := 0.10.0
 BUILD_TIME := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -s -w -X github.com/myrgic/cogos/internal/engine.BuildTime=$(BUILD_TIME)
 BUILD_TAGS := fts5


### PR DESCRIPTION
Bumps `VERSION` in `Makefile` from `0.9.0` to `0.10.0`.

This is the release prep commit. After merge, tag `v0.10.0` on main — the GHA release workflow will build binaries for all platforms and attach them to the release.