### PR TITLE
docs(adr-102): correct tool-name reference (cog_search_traces → cog_search_conversations)

### DIFF
--- a/docs/adrs/102-operator-as-reconcilable.md
+++ b/docs/adrs/102-operator-as-reconcilable.md
@@ -253,13 +253,13 @@ implementation begins.
 **What it is:** A Reconcilable that ingests the session JSONLs from
 `~/.claude/projects/-Users-slowbro/*.jsonl` (and analogous locations on other nodes),
 projects them as cogblocks/events on the substrate bus, and exposes them as queryable
-records via `cog_search_traces` and related MCP tools.
+records via `cog_search_conversations` and related MCP tools.
 
 **Why it is the highest-leverage operator-visibility primitive:** Every operator utterance,
 every tool call, every timestamp, every approval and rejection is already recorded in these
 files. They are the densest operator-coupling artifacts in existence. Today they are
 brute-force-grep only. Once the Observatory is live, every future operator-context retrieval
-becomes `cog_search_traces "<query>"` returning structured cogblocks rather than a
+becomes `cog_search_conversations "<query>"` returning structured cogblocks rather than a
 transcript-walking agent dispatch.
 
 **Reconcilable mapping:**


### PR DESCRIPTION
## Summary

ADR-102 (operator-as-Reconcilable, merged as #299) §6 references `cog_search_traces` when discussing the Conversations Observatory's queryable surface. The actual tool exposed by the Observatory (merged as #300) is `cog_search_conversations`. This corrects the two `cog_search_traces` references in §6/Primitive 1 to match the shipped tool name.

Surfaced during the 2026-05-20 catch-up hygiene pass.

## Scope

- §6 only (two occurrences in Primitive 1). Other ADR sections that reference `cog_search_traces` (in §Four-Stage Growth Path and §Relationship to Existing ADRs) are left as-is for a separate review — they may have the same typo, but were out of scope for this small-blast-radius fix.

## Test plan

- [x] No code changes; ADR markdown only
- [x] `git diff` shows only the two §6 occurrences changed
