### PR TITLE
feat(substrate): ADR-100 Step 3d minimal — SessionTracking → pkg/substrate/session

### DIFF
--- a/pkg/substrate/session/doc.go
+++ b/pkg/substrate/session/doc.go
@@ -1,0 +1,23 @@
+// Package session is the substrate-canonical home for session-tracking
+// schema — the data type describing an in-progress CogOS session and its
+// spawned/active/reaped agent rosters as persisted to .cog/status/.session.
+//
+// Per ADR-100 Step 3d, the Tracking struct extracted from the root
+// session.go file lives here. Per RFC-034 §3.3 (diagnostic rule): "if the
+// behavior can be tested without a running process, it belongs in the
+// substrate library." Tracking is a pure schema type — JSON tags only,
+// no behavior beyond what struct serialization provides.
+//
+// The session command handlers (sessionInit, sessionTrackSpawn,
+// sessionTrackReap, sessionStatus, sessionEnd) and the runtime
+// SessionManager remain kernel-resident because they depend on workspace
+// resolution, git invocation, and concurrent state. They consume this
+// schema; they do not define it.
+//
+// Scope note: this package covers session-tracking schema only. The
+// richer context-engine session lifecycle types (SessionState,
+// SessionRotation, WorkingMemory, SessionManagerConfig) live in the root
+// package's context_engine_types.go. Their extraction is a follow-up
+// scoping decision pending an operator resolution of which types are
+// pure substrate schema versus engine-internal request-pipeline detail.
+package session

--- a/pkg/substrate/session/tracking.go
+++ b/pkg/substrate/session/tracking.go
@@ -1,0 +1,28 @@
+// Package session holds the substrate-canonical session-tracking schema.
+//
+// This file holds pure schema only — no I/O, no goroutines, no kernel
+// coupling. The .cog/status/.session file is structured as a Tracking
+// document; its readers (sessionStatus, sessionEnd) and writers
+// (sessionInit, sessionTrackSpawn, sessionTrackReap) live in the kernel
+// root package and consume this type.
+package session
+
+// Tracking represents the persisted session-tracking record at
+// .cog/status/.session. It carries the session identifier, the branch
+// the session was opened on, lifecycle timestamps, and the
+// spawned/active/reaped agent rosters maintained as agents come and go.
+//
+// Naming per ADR-100 substrate convention: the redundant "Session"
+// prefix is dropped now that the type lives in package session. Callers
+// at the root use the alias SessionTracking from session.go.
+type Tracking struct {
+	SessionID     string   `json:"sessionId"`
+	Branch        string   `json:"branch"`
+	StartedAt     string   `json:"startedAt"`
+	EndedAt       *string  `json:"endedAt,omitempty"`
+	Status        *string  `json:"status,omitempty"`
+	RootAgent     string   `json:"rootAgent"`
+	SpawnedAgents []string `json:"spawnedAgents"`
+	ActiveAgents  []string `json:"activeAgents"`
+	ReapedAgents  []string `json:"reapedAgents"`
+}

--- a/pkg/substrate/session/tracking_test.go
+++ b/pkg/substrate/session/tracking_test.go
@@ -1,0 +1,119 @@
+package session
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestTrackingRoundtrip verifies that Tracking marshals to the wire
+// shape kernel consumers expect (camelCase JSON tags, omitempty on
+// EndedAt and Status) and unmarshals back to an equal struct.
+func TestTrackingRoundtrip(t *testing.T) {
+	ended := "2026-05-23T12:00:00Z"
+	status := "ended"
+	in := Tracking{
+		SessionID:     "feat/adr-100-step3d",
+		Branch:        "feat/adr-100-step3d",
+		StartedAt:     "2026-05-23T10:00:00Z",
+		EndedAt:       &ended,
+		Status:        &status,
+		RootAgent:     "root",
+		SpawnedAgents: []string{"a1", "a2"},
+		ActiveAgents:  []string{"a1"},
+		ReapedAgents:  []string{"a2"},
+	}
+
+	data, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var out Tracking
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if out.SessionID != in.SessionID {
+		t.Errorf("SessionID: got %q want %q", out.SessionID, in.SessionID)
+	}
+	if out.Branch != in.Branch {
+		t.Errorf("Branch: got %q want %q", out.Branch, in.Branch)
+	}
+	if out.StartedAt != in.StartedAt {
+		t.Errorf("StartedAt: got %q want %q", out.StartedAt, in.StartedAt)
+	}
+	if out.EndedAt == nil || *out.EndedAt != *in.EndedAt {
+		t.Errorf("EndedAt mismatch")
+	}
+	if out.Status == nil || *out.Status != *in.Status {
+		t.Errorf("Status mismatch")
+	}
+	if out.RootAgent != in.RootAgent {
+		t.Errorf("RootAgent: got %q want %q", out.RootAgent, in.RootAgent)
+	}
+	if len(out.SpawnedAgents) != 2 || out.SpawnedAgents[0] != "a1" || out.SpawnedAgents[1] != "a2" {
+		t.Errorf("SpawnedAgents: %v", out.SpawnedAgents)
+	}
+	if len(out.ActiveAgents) != 1 || out.ActiveAgents[0] != "a1" {
+		t.Errorf("ActiveAgents: %v", out.ActiveAgents)
+	}
+	if len(out.ReapedAgents) != 1 || out.ReapedAgents[0] != "a2" {
+		t.Errorf("ReapedAgents: %v", out.ReapedAgents)
+	}
+}
+
+// TestTrackingOmitEmpty verifies that EndedAt and Status are omitted from
+// JSON output when nil — preserving the wire shape that the existing
+// .cog/status/.session readers expect.
+func TestTrackingOmitEmpty(t *testing.T) {
+	in := Tracking{
+		SessionID:     "s",
+		Branch:        "b",
+		StartedAt:     "t",
+		RootAgent:     "root",
+		SpawnedAgents: []string{},
+		ActiveAgents:  []string{},
+		ReapedAgents:  []string{},
+	}
+	data, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := raw["endedAt"]; ok {
+		t.Errorf("endedAt should be omitted when nil")
+	}
+	if _, ok := raw["status"]; ok {
+		t.Errorf("status should be omitted when nil")
+	}
+}
+
+// TestTrackingFieldNames pins the JSON field-name surface so the
+// kernel↔substrate boundary cannot drift silently.
+func TestTrackingFieldNames(t *testing.T) {
+	in := Tracking{
+		SessionID:     "s",
+		Branch:        "b",
+		StartedAt:     "t",
+		RootAgent:     "root",
+		SpawnedAgents: []string{},
+		ActiveAgents:  []string{},
+		ReapedAgents:  []string{},
+	}
+	data, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, want := range []string{"sessionId", "branch", "startedAt", "rootAgent", "spawnedAgents", "activeAgents", "reapedAgents"} {
+		if _, ok := raw[want]; !ok {
+			t.Errorf("missing field %q in JSON output", want)
+		}
+	}
+}

--- a/session.go
+++ b/session.go
@@ -9,20 +9,14 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/myrgic/cogos/pkg/substrate/session"
 )
 
-// SessionTracking represents session tracking information
-type SessionTracking struct {
-	SessionID     string   `json:"sessionId"`
-	Branch        string   `json:"branch"`
-	StartedAt     string   `json:"startedAt"`
-	EndedAt       *string  `json:"endedAt,omitempty"`
-	Status        *string  `json:"status,omitempty"`
-	RootAgent     string   `json:"rootAgent"`
-	SpawnedAgents []string `json:"spawnedAgents"`
-	ActiveAgents  []string `json:"activeAgents"`
-	ReapedAgents  []string `json:"reapedAgents"`
-}
+// SessionTracking is a thin alias of session.Tracking. The canonical
+// schema lives in pkg/substrate/session per ADR-100 Step 3d. New code
+// should prefer the substrate import path directly.
+type SessionTracking = session.Tracking
 
 // getSessionFile returns the path to the session tracking file
 func getSessionFile(root string) string {


### PR DESCRIPTION
## Summary

ADR-100 Step 3d, minimal-extraction path. Moves `SessionTracking` from root `session.go` into `pkg/substrate/session/` as `session.Tracking`, following the Step 3 substrate-rename convention (drop redundant prefix once the package name supplies the namespace). The root file keeps a thin alias so existing call sites compile unchanged.

## Scope decision

Yesterday's reviewer flagged that the broader "session schema" intent in ADR-100 Step 3 (SessionState, SessionRotation, WorkingMemory, SessionManagerConfig) maps to types that actually live in `context_engine_types.go`, not `session.go`. The investigation behind this PR confirms that — `context_engine_types.go:53-99` is the actual lifecycle-schema home and all of those types are pure schema with zero kernel coupling, but `SessionState` alone has 14 caller files in the kernel and that's a larger surgery worth scoping deliberately.

This PR ships the unambiguous slice: `SessionTracking` is pure schema (JSON tags only, no behavior), single-file usage (only `session.go` references it), and is exactly what ADR-100 Step 3's table calls out under "`session.go` ... type declarations." The full untangle is deferred for operator scoping — investigation results are in `~/.claude/projects/-Users-slowbro/memory/adr_100_next_phase_plan_2026-05-23.md`.

## What's in the package

- `pkg/substrate/session/doc.go` — package doc + scope note pointing at the follow-up untangle question
- `pkg/substrate/session/tracking.go` — `Tracking` struct (the schema)
- `pkg/substrate/session/tracking_test.go` — 3 tests: JSON roundtrip, omitempty pinning, field-name surface pinning

## Test plan

- [x] `go build ./...` green at repo root
- [x] `go test -count=1 ./...` green at repo root (all packages)
- [x] `cd pkg/substrate && go test -count=1 ./...` green (8 substrate packages, including the new session one)
- [x] `git diff` shows only intended files (no binary state files; the .cog/.state/constellation.db touched at runtime is excluded from staging)

## Composes with

- ADR-100 (Substrate Library Extraction) — Step 3d
- ADR-091 (Substrate as Named Architectural Layer)
- RFC-034 §3.3 (diagnostic rule: testable without a running process → substrate)

## Follow-up

- ADR-100 Step 3d (full untangle) — scoping decision needed: split `context_engine_types.go` between substrate-bound and engine-internal, then extract `SessionState`/`SessionRotation`/`WorkingMemory`/`SessionManagerConfig` to `pkg/substrate/session/`. 14 kernel files reference `SessionState` alone, so this wants its own PR pass.
- ADR-100 Step 4-adjacent: legacy `pkg/{reconcile,uri,bep,cogfield}` paths now have zero kernel callers (all kernel imports flow through `pkg/substrate/*`). The remaining importers are the substrate re-export shims themselves. Inverting these (substrate becomes canonical, legacy paths become deprecation shims) is a clean win available now, parallel to Step 4's CogBlock unification. Surfaced for operator scoping; not in this PR.