### PR TITLE
Scaffold internal/conductor — port validated ACP-client contract (RFC-036)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/coder/acp-go-sdk v0.13.0
 	github.com/coder/websocket v1.8.14
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-git/go-git/v5 v5.16.4

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQ
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
+github.com/coder/acp-go-sdk v0.13.0 h1:IAKBDIbe/iBfKAGikeIndzb8fowt4ioD+gCtSU4HwMA=
+github.com/coder/acp-go-sdk v0.13.0/go.mod h1:yKzM/3R9uELp4+nBAwwtkS0aN1FOFjo11CNPy37yFko=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=

--- a/internal/conductor/adapter.go
+++ b/internal/conductor/adapter.go
@@ -1,0 +1,344 @@
+// adapter.go backs the portable conductor contract with coder/acp-go-sdk.
+//
+// It is intentionally thin: it translates between the SDK's wire types and the
+// contract's substrate-shaped types, and it wires the SDK's client-side Client
+// handlers (RequestPermission, SessionUpdate, ReadTextFile/WriteTextFile,
+// terminal ops) to the conductor's Governor / LedgerSink / FsPolicy. This is the
+// only file in the package that imports the SDK; everything else speaks contract.
+
+package conductor
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"sync"
+
+	acp "github.com/coder/acp-go-sdk"
+
+	"github.com/myrgic/cogos/internal/conductor/contract"
+)
+
+// clientHandlers implements acp.Client. The SDK invokes these when the agent
+// (cell) calls back to the client (conductor). It routes everything to the
+// substrate-shaped collaborators.
+type clientHandlers struct {
+	ledger contract.LedgerSink
+	gov    contract.Governor
+	fs     contract.FsPolicy
+}
+
+var _ acp.Client = (*clientHandlers)(nil)
+
+// SessionUpdate consumes the streamed update and routes EVERY kind to the
+// ledger (RFC-036 P3 gap 2 + gap 4: consume all kinds, ledger-write-on-update).
+func (h *clientHandlers) SessionUpdate(ctx context.Context, n acp.SessionNotification) error {
+	sid := contract.SessionID(n.SessionId)
+	u := n.Update
+	switch {
+	case u.AgentMessageChunk != nil:
+		h.ledger.Record(contract.LedgerEntry{SessionID: sid, Kind: contract.KindAgentMessage, Text: textOf(u.AgentMessageChunk.Content)})
+	case u.AgentThoughtChunk != nil:
+		h.ledger.Record(contract.LedgerEntry{SessionID: sid, Kind: contract.KindAgentThought, Text: textOf(u.AgentThoughtChunk.Content)})
+	case u.UserMessageChunk != nil:
+		h.ledger.Record(contract.LedgerEntry{SessionID: sid, Kind: contract.KindUserMessage, Text: textOf(u.UserMessageChunk.Content)})
+	case u.ToolCall != nil:
+		h.ledger.Record(contract.LedgerEntry{SessionID: sid, Kind: contract.KindToolCall, Text: u.ToolCall.Title,
+			Detail: map[string]any{"id": string(u.ToolCall.ToolCallId), "status": string(u.ToolCall.Status)}})
+	case u.ToolCallUpdate != nil:
+		status := ""
+		if u.ToolCallUpdate.Status != nil {
+			status = string(*u.ToolCallUpdate.Status)
+		}
+		h.ledger.Record(contract.LedgerEntry{SessionID: sid, Kind: contract.KindToolUpdate, Text: string(u.ToolCallUpdate.ToolCallId),
+			Detail: map[string]any{"status": status}})
+	case u.Plan != nil:
+		h.ledger.Record(contract.LedgerEntry{SessionID: sid, Kind: contract.KindPlan, Text: fmt.Sprintf("%d entries", len(u.Plan.Entries)),
+			Detail: map[string]any{"entries": len(u.Plan.Entries)}})
+	default:
+		// Other kinds (available_commands_update, current_mode_update,
+		// config_option_update, session_info_update, usage_update) are not in
+		// the RFC-036 required set; ignored here.
+	}
+	return nil
+}
+
+// RequestPermission is the governance limb (RFC-036 P4). The cell asks; the
+// conductor's Governor makes the Proposer/Actor decision; the outcome propagates
+// back to the cell as the ACP outcome.
+func (h *clientHandlers) RequestPermission(ctx context.Context, p acp.RequestPermissionRequest) (acp.RequestPermissionResponse, error) {
+	sid := contract.SessionID(p.SessionId)
+	title := ""
+	if p.ToolCall.Title != nil {
+		title = *p.ToolCall.Title
+	}
+	opts := make([]contract.PermissionOption, 0, len(p.Options))
+	for _, o := range p.Options {
+		opts = append(opts, contract.PermissionOption{ID: string(o.OptionId), Name: o.Name, Kind: kindOf(o.Kind)})
+	}
+	req := contract.PermissionRequest{SessionID: sid, ToolTitle: title, Options: opts}
+	h.ledger.Record(contract.LedgerEntry{SessionID: sid, Kind: contract.KindPermissionRequest, Text: title})
+
+	dec := h.gov.Decide(ctx, req)
+	if dec.Denied || dec.OptionID == "" {
+		h.ledger.Record(contract.LedgerEntry{SessionID: sid, Kind: contract.KindPermissionDecision, Text: "denied"})
+		return acp.RequestPermissionResponse{Outcome: acp.RequestPermissionOutcome{Cancelled: &acp.RequestPermissionOutcomeCancelled{}}}, nil
+	}
+	h.ledger.Record(contract.LedgerEntry{SessionID: sid, Kind: contract.KindPermissionDecision, Text: "approved:" + dec.OptionID})
+	return acp.RequestPermissionResponse{Outcome: acp.RequestPermissionOutcome{
+		Selected: &acp.RequestPermissionOutcomeSelected{OptionId: acp.PermissionOptionId(dec.OptionID)},
+	}}, nil
+}
+
+// ReadTextFile gates filesystem reads through FsPolicy (policy gate; can deny).
+func (h *clientHandlers) ReadTextFile(ctx context.Context, p acp.ReadTextFileRequest) (acp.ReadTextFileResponse, error) {
+	if h.fs == nil || !h.fs.AllowRead(ctx, p.Path) {
+		h.ledger.Record(contract.LedgerEntry{Kind: contract.KindFsDenied, Text: "read:" + p.Path})
+		return acp.ReadTextFileResponse{}, fmt.Errorf("fs read denied by policy: %s", p.Path)
+	}
+	h.ledger.Record(contract.LedgerEntry{Kind: contract.KindFsRead, Text: p.Path})
+	// In the scaffold the conductor returns synthetic content; production would
+	// resolve through the substrate URI layer.
+	// TODO(conductor, RFC-036 P5): resolve reads through the substrate URI layer.
+	return acp.ReadTextFileResponse{Content: "policy-allowed:" + p.Path}, nil
+}
+
+// WriteTextFile gates filesystem writes through FsPolicy.
+func (h *clientHandlers) WriteTextFile(ctx context.Context, p acp.WriteTextFileRequest) (acp.WriteTextFileResponse, error) {
+	if h.fs == nil || !h.fs.AllowWrite(ctx, p.Path) {
+		h.ledger.Record(contract.LedgerEntry{Kind: contract.KindFsDenied, Text: "write:" + p.Path})
+		return acp.WriteTextFileResponse{}, fmt.Errorf("fs write denied by policy: %s", p.Path)
+	}
+	h.ledger.Record(contract.LedgerEntry{Kind: contract.KindFsWrite, Text: p.Path})
+	return acp.WriteTextFileResponse{}, nil
+}
+
+// Terminal handlers: deny by default in the scaffold (policy gate). The conductor
+// is not a shell; terminal access is a governed capability.
+func (h *clientHandlers) CreateTerminal(ctx context.Context, p acp.CreateTerminalRequest) (acp.CreateTerminalResponse, error) {
+	return acp.CreateTerminalResponse{}, fmt.Errorf("terminal denied by conductor policy")
+}
+func (h *clientHandlers) KillTerminal(ctx context.Context, p acp.KillTerminalRequest) (acp.KillTerminalResponse, error) {
+	return acp.KillTerminalResponse{}, fmt.Errorf("terminal denied by conductor policy")
+}
+func (h *clientHandlers) ReleaseTerminal(ctx context.Context, p acp.ReleaseTerminalRequest) (acp.ReleaseTerminalResponse, error) {
+	return acp.ReleaseTerminalResponse{}, fmt.Errorf("terminal denied by conductor policy")
+}
+func (h *clientHandlers) TerminalOutput(ctx context.Context, p acp.TerminalOutputRequest) (acp.TerminalOutputResponse, error) {
+	return acp.TerminalOutputResponse{}, fmt.Errorf("terminal denied by conductor policy")
+}
+func (h *clientHandlers) WaitForTerminalExit(ctx context.Context, p acp.WaitForTerminalExitRequest) (acp.WaitForTerminalExitResponse, error) {
+	return acp.WaitForTerminalExitResponse{}, fmt.Errorf("terminal denied by conductor policy")
+}
+
+// SDKConductor backs contract.Conductor with a ClientSideConnection.
+//
+// TODO(conductor, RFC-036 P3+P2): the fleet manager driving N concurrent
+// sessions is not built here. SDKConductor tracks session ids for one ACP
+// connection; the orchestration loop that owns fleet lifecycle is application
+// logic left for the real conductor build. See the package doc scaffold boundary.
+type SDKConductor struct {
+	conn *acp.ClientSideConnection
+	h    *clientHandlers
+
+	mu       sync.Mutex
+	sessions map[contract.SessionID]struct{}
+}
+
+var _ contract.Conductor = (*SDKConductor)(nil)
+
+// New wires a conductor over the given peer streams (an io.Pipe pair or a
+// subprocess' stdin/stdout). gov / ledger / fs are the substrate collaborators.
+func New(peerInput io.Writer, peerOutput io.Reader,
+	ledger contract.LedgerSink, gov contract.Governor, fs contract.FsPolicy) *SDKConductor {
+	h := &clientHandlers{ledger: ledger, gov: gov, fs: fs}
+	conn := acp.NewClientSideConnection(h, peerInput, peerOutput)
+	return &SDKConductor{conn: conn, h: h, sessions: map[contract.SessionID]struct{}{}}
+}
+
+// Done exposes the underlying connection's done channel.
+func (c *SDKConductor) Done() <-chan struct{} { return c.conn.Done() }
+
+// SetLogger directs the client connection's diagnostics to l.
+func (c *SDKConductor) SetLogger(l *slog.Logger) { c.conn.SetLogger(l) }
+
+func (c *SDKConductor) Initialize(ctx context.Context, id contract.Identity) (int, error) {
+	resp, err := c.conn.Initialize(ctx, acp.InitializeRequest{
+		ProtocolVersion: acp.ProtocolVersionNumber,
+		Meta:            id.Meta(),
+		ClientCapabilities: acp.ClientCapabilities{
+			Fs:       acp.FileSystemCapabilities{ReadTextFile: true, WriteTextFile: true},
+			Terminal: true,
+		},
+	})
+	if err != nil {
+		return 0, err
+	}
+	return int(resp.ProtocolVersion), nil
+}
+
+func (c *SDKConductor) NewSession(ctx context.Context, spec contract.SessionSpec) (contract.SessionID, error) {
+	resp, err := c.conn.NewSession(ctx, acp.NewSessionRequest{
+		Cwd:        spec.Cwd,
+		Meta:       spec.Identity.Meta(),
+		McpServers: toMcpServers(spec.McpServers),
+	})
+	if err != nil {
+		return "", err
+	}
+	sid := contract.SessionID(resp.SessionId)
+	c.track(sid)
+	return sid, nil
+}
+
+func (c *SDKConductor) Prompt(ctx context.Context, sid contract.SessionID, text string) (string, error) {
+	resp, err := c.conn.Prompt(ctx, acp.PromptRequest{
+		SessionId: acp.SessionId(sid),
+		Prompt:    []acp.ContentBlock{acp.TextBlock(text)},
+	})
+	if err != nil {
+		return "", err
+	}
+	return string(resp.StopReason), nil
+}
+
+func (c *SDKConductor) Cancel(ctx context.Context, sid contract.SessionID) error {
+	return c.conn.Cancel(ctx, acp.CancelNotification{SessionId: acp.SessionId(sid)})
+}
+
+func (c *SDKConductor) Fork(ctx context.Context, sid contract.SessionID, spec contract.SessionSpec) (contract.SessionID, error) {
+	resp, err := c.conn.UnstableForkSession(ctx, acp.UnstableForkSessionRequest{
+		SessionId: acp.SessionId(sid),
+		Cwd:       spec.Cwd,
+		Meta:      spec.Identity.Meta(),
+	})
+	if err != nil {
+		return "", err
+	}
+	nsid := contract.SessionID(resp.SessionId)
+	c.track(nsid)
+	return nsid, nil
+}
+
+func (c *SDKConductor) List(ctx context.Context) ([]contract.SessionID, error) {
+	resp, err := c.conn.ListSessions(ctx, acp.ListSessionsRequest{})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]contract.SessionID, 0, len(resp.Sessions))
+	for _, s := range resp.Sessions {
+		out = append(out, contract.SessionID(s.SessionId))
+	}
+	return out, nil
+}
+
+func (c *SDKConductor) Resume(ctx context.Context, sid contract.SessionID, spec contract.SessionSpec) error {
+	_, err := c.conn.ResumeSession(ctx, acp.ResumeSessionRequest{
+		SessionId: acp.SessionId(sid),
+		Cwd:       spec.Cwd,
+		Meta:      spec.Identity.Meta(),
+	})
+	return err
+}
+
+func (c *SDKConductor) Load(ctx context.Context, sid contract.SessionID, spec contract.SessionSpec) error {
+	_, err := c.conn.LoadSession(ctx, acp.LoadSessionRequest{
+		SessionId:  acp.SessionId(sid),
+		Cwd:        spec.Cwd,
+		Meta:       spec.Identity.Meta(),
+		McpServers: toMcpServers(spec.McpServers),
+	})
+	return err
+}
+
+func (c *SDKConductor) SetMode(ctx context.Context, sid contract.SessionID, modeID string) error {
+	_, err := c.conn.SetSessionMode(ctx, acp.SetSessionModeRequest{
+		SessionId: acp.SessionId(sid),
+		ModeId:    acp.SessionModeId(modeID),
+	})
+	return err
+}
+
+func (c *SDKConductor) SetConfigOption(ctx context.Context, sid contract.SessionID, configID, value string) error {
+	req := acp.SetSessionConfigOptionRequest{
+		ValueId: &acp.SetSessionConfigOptionValueId{
+			SessionId: acp.SessionId(sid),
+			ConfigId:  acp.SessionConfigId(configID),
+			Value:     acp.SessionConfigValueId(value),
+		},
+	}
+	_, err := c.conn.SetSessionConfigOption(ctx, req)
+	return err
+}
+
+func (c *SDKConductor) CloseSession(ctx context.Context, sid contract.SessionID) error {
+	_, err := c.conn.CloseSession(ctx, acp.CloseSessionRequest{SessionId: acp.SessionId(sid)})
+	if err == nil {
+		c.untrack(sid)
+	}
+	return err
+}
+
+// ErrMcpDirectionUnsupported documents a real SDK-surface gap: MCP-over-ACP in
+// coder/acp-go-sdk is modeled agent-as-caller / client-as-handler only. The
+// mcp/connect + mcp/disconnect methods live on *AgentSideConnection*, and the
+// matching handlers live on the Client (ClientExperimental). There is NO
+// ClientSideConnection.UnstableConnectMcp — so a conductor (ACP client) cannot
+// DRIVE mcp/connect toward a cell over this SDK. The conductor attaches MCP
+// servers to a cell via new_session's McpServers (transport config) instead.
+//
+// TODO(conductor, RFC-036 delta divergence-6): upstream-contribution candidate —
+// ClientSideConnection.UnstableConnectMcp (or a spec clarification).
+var ErrMcpDirectionUnsupported = fmt.Errorf(
+	"MCP-over-ACP mcp/connect is agent→client in coder/acp-go-sdk; " +
+		"a conductor cannot drive it toward a cell (use new_session McpServers config instead)")
+
+func (c *SDKConductor) ConnectMcp(ctx context.Context, acpID string) (string, error) {
+	return "", ErrMcpDirectionUnsupported
+}
+
+func (c *SDKConductor) DisconnectMcp(ctx context.Context, connectionID string) error {
+	return ErrMcpDirectionUnsupported
+}
+
+// --- helpers -----------------------------------------------------------------
+
+func (c *SDKConductor) track(sid contract.SessionID) {
+	c.mu.Lock()
+	c.sessions[sid] = struct{}{}
+	c.mu.Unlock()
+}
+func (c *SDKConductor) untrack(sid contract.SessionID) {
+	c.mu.Lock()
+	delete(c.sessions, sid)
+	c.mu.Unlock()
+}
+
+func textOf(b acp.ContentBlock) string {
+	if b.Text != nil {
+		return b.Text.Text
+	}
+	return ""
+}
+
+func kindOf(k acp.PermissionOptionKind) contract.PermissionKind {
+	switch k {
+	case acp.PermissionOptionKindAllowOnce, acp.PermissionOptionKindAllowAlways:
+		return contract.PermitAllow
+	default:
+		return contract.PermitReject
+	}
+}
+
+// toMcpServers passes opaque []acp.McpServer through if the caller supplied SDK
+// types; otherwise yields an empty slice (new_session requires non-nil).
+func toMcpServers(in []any) []acp.McpServer {
+	out := make([]acp.McpServer, 0, len(in))
+	for _, v := range in {
+		if s, ok := v.(acp.McpServer); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/internal/conductor/cmd/fakeagent/main.go
+++ b/internal/conductor/cmd/fakeagent/main.go
@@ -1,0 +1,77 @@
+// Command fakeagent is a minimal stdio ACP *server* (cell) used by the stdio
+// transport-pluggability test. It mirrors the in-process fakeagent's behavior:
+// echoes `_meta` back on initialize as an agent_message_chunk so the parent can
+// assert identity round-trip over a real OS pipe, streams one agent message, and
+// ends the turn.
+//
+// It is its own package main so `go run ./cmd/fakeagent` spawns a real process
+// the conductor talks to over stdin/stdout — proving the same client works over
+// a stdio-spawned subprocess, not just io.Pipe. This is a test helper for the
+// conductor scaffold, not a production command.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	acp "github.com/coder/acp-go-sdk"
+)
+
+type stdioAgent struct {
+	conn    *acp.AgentSideConnection
+	lastSub string
+}
+
+func (a *stdioAgent) Initialize(ctx context.Context, p acp.InitializeRequest) (acp.InitializeResponse, error) {
+	if p.Meta != nil {
+		if v, ok := p.Meta["cogos.sub"].(string); ok {
+			a.lastSub = v
+		}
+	}
+	return acp.InitializeResponse{ProtocolVersion: acp.ProtocolVersionNumber}, nil
+}
+
+func (a *stdioAgent) Authenticate(ctx context.Context, _ acp.AuthenticateRequest) (acp.AuthenticateResponse, error) {
+	return acp.AuthenticateResponse{}, nil
+}
+
+func (a *stdioAgent) NewSession(ctx context.Context, p acp.NewSessionRequest) (acp.NewSessionResponse, error) {
+	return acp.NewSessionResponse{SessionId: acp.SessionId("stdio_sess_1")}, nil
+}
+
+func (a *stdioAgent) Prompt(ctx context.Context, p acp.PromptRequest) (acp.PromptResponse, error) {
+	// Echo the captured substrate identity so the parent can assert _meta made it
+	// across the OS pipe.
+	_ = a.conn.SessionUpdate(ctx, acp.SessionNotification{
+		SessionId: p.SessionId,
+		Update:    acp.UpdateAgentMessageText(fmt.Sprintf("sub=%s", a.lastSub)),
+	})
+	return acp.PromptResponse{StopReason: acp.StopReasonEndTurn}, nil
+}
+
+func (a *stdioAgent) Cancel(ctx context.Context, _ acp.CancelNotification) error { return nil }
+func (a *stdioAgent) CloseSession(ctx context.Context, _ acp.CloseSessionRequest) (acp.CloseSessionResponse, error) {
+	return acp.CloseSessionResponse{}, nil
+}
+func (a *stdioAgent) ListSessions(ctx context.Context, _ acp.ListSessionsRequest) (acp.ListSessionsResponse, error) {
+	return acp.ListSessionsResponse{Sessions: []acp.SessionInfo{}}, nil
+}
+func (a *stdioAgent) ResumeSession(ctx context.Context, _ acp.ResumeSessionRequest) (acp.ResumeSessionResponse, error) {
+	return acp.ResumeSessionResponse{}, nil
+}
+func (a *stdioAgent) SetSessionMode(ctx context.Context, _ acp.SetSessionModeRequest) (acp.SetSessionModeResponse, error) {
+	return acp.SetSessionModeResponse{}, nil
+}
+func (a *stdioAgent) SetSessionConfigOption(ctx context.Context, _ acp.SetSessionConfigOptionRequest) (acp.SetSessionConfigOptionResponse, error) {
+	return acp.SetSessionConfigOptionResponse{}, nil
+}
+
+func main() {
+	ag := &stdioAgent{}
+	// peerInput = where we write to the peer = os.Stdout; peerOutput = what the
+	// peer sends us = os.Stdin.
+	asc := acp.NewAgentSideConnection(ag, os.Stdout, os.Stdin)
+	ag.conn = asc
+	<-asc.Done()
+}

--- a/internal/conductor/conductor_test.go
+++ b/internal/conductor/conductor_test.go
@@ -1,0 +1,602 @@
+// conductor_test.go validates the conductor↔ACP-client-SDK integration path
+// described by RFC-036. Tests run against the portable contract.Conductor
+// interface, backed by a coder/acp-go-sdk adapter, driving an in-process fake
+// ACP agent (cell) over io.Pipe. The captureSink stands in for the cogos ledger.
+
+package conductor
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	acp "github.com/coder/acp-go-sdk"
+
+	"github.com/myrgic/cogos/internal/conductor/contract"
+)
+
+func ctxT(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+// TestInitialize covers `initialize` with `_meta` identity injection: assert the
+// iss/sub `_meta` round-trips to the agent (RFC-036 P3 gap 6).
+func TestInitialize(t *testing.T) {
+	t.Run("meta_identity_roundtrips", func(t *testing.T) {
+		agent := newFakeAgent()
+		r := newRig(t, agent, nil, nil)
+
+		pv, err := r.cond.Initialize(ctxT(t), testIdentity())
+		if err != nil {
+			t.Fatalf("Initialize: %v", err)
+		}
+		if pv != int(acp.ProtocolVersionNumber) {
+			t.Fatalf("protocol version = %d, want %d", pv, acp.ProtocolVersionNumber)
+		}
+		snap := agent.snapshot()
+		meta, _ := snap["initMeta"].(map[string]any)
+		if meta == nil {
+			t.Fatal("agent received nil _meta on initialize")
+		}
+		if meta["cogos.iss"] != testIss {
+			t.Errorf("iss = %v, want %s", meta["cogos.iss"], testIss)
+		}
+		if meta["cogos.sub"] != testSub {
+			t.Errorf("sub = %v, want %s", meta["cogos.sub"], testSub)
+		}
+	})
+}
+
+// TestNewSession covers `new_session` (cwd, mcpServers, `_meta`).
+func TestNewSession(t *testing.T) {
+	t.Run("cwd_and_meta_roundtrip", func(t *testing.T) {
+		agent := newFakeAgent()
+		r := newRig(t, agent, nil, nil)
+		ctx := ctxT(t)
+		if _, err := r.cond.Initialize(ctx, testIdentity()); err != nil {
+			t.Fatalf("Initialize: %v", err)
+		}
+		sid, err := r.cond.NewSession(ctx, defaultSpec("/work/proj"))
+		if err != nil {
+			t.Fatalf("NewSession: %v", err)
+		}
+		if sid == "" {
+			t.Fatal("empty session id")
+		}
+		agent.mu.Lock()
+		gotCwd := agent.newSessionCwd[string(sid)]
+		gotMeta := agent.newSessMeta
+		agent.mu.Unlock()
+		if gotCwd != "/work/proj" {
+			t.Errorf("cwd = %q, want /work/proj", gotCwd)
+		}
+		if gotMeta["cogos.sub"] != testSub {
+			t.Errorf("new_session _meta sub = %v, want %s", gotMeta["cogos.sub"], testSub)
+		}
+	})
+}
+
+// TestPromptStreamAllKinds covers prompt → consume the session/update stream;
+// assert EVERY required update kind is handled and routed to the ledger sink.
+func TestPromptStreamAllKinds(t *testing.T) {
+	agent := newFakeAgent()
+	agent.promptFn = promptStreamAllKinds
+	r := newRig(t, agent, nil, nil)
+	ctx := ctxT(t)
+
+	if _, err := r.cond.Initialize(ctx, testIdentity()); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	sid, err := r.cond.NewSession(ctx, defaultSpec("/x"))
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	stop, err := r.cond.Prompt(ctx, sid, "hi")
+	if err != nil {
+		t.Fatalf("Prompt: %v", err)
+	}
+	if stop != string(acp.StopReasonEndTurn) {
+		t.Errorf("stop = %q, want end_turn", stop)
+	}
+
+	required := []contract.LedgerEntryKind{
+		contract.KindUserMessage,
+		contract.KindAgentThought,
+		contract.KindAgentMessage,
+		contract.KindToolCall,
+		contract.KindToolUpdate,
+		contract.KindPlan,
+	}
+	for _, k := range required {
+		t.Run(string(k), func(t *testing.T) {
+			if !r.sink.hasKind(sid, k) {
+				t.Errorf("ledger missing kind %q for session %s; got %v", k, sid, r.sink.kindsForSession(sid))
+			}
+		})
+	}
+}
+
+// TestRequestPermission covers the governance limb thoroughly: approve AND deny
+// cases; assert the agent receives the decision and the outcome propagates.
+func TestRequestPermission(t *testing.T) {
+	cases := []struct {
+		name        string
+		gov         func(ctx context.Context, req contract.PermissionRequest) contract.PermissionDecision
+		wantStop    string
+		wantDecided string // ledger decision Text prefix
+	}{
+		{"approve", approveFirstAllow, string(acp.StopReasonEndTurn), "approved:"},
+		{"deny", denyAll, string(acp.StopReasonRefusal), "denied"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			agent := newFakeAgent()
+			agent.promptFn = promptRequestPermission
+			r := newRig(t, agent, fnGovernor{fn: tc.gov}, nil)
+			ctx := ctxT(t)
+			if _, err := r.cond.Initialize(ctx, testIdentity()); err != nil {
+				t.Fatalf("Initialize: %v", err)
+			}
+			sid, err := r.cond.NewSession(ctx, defaultSpec("/x"))
+			if err != nil {
+				t.Fatalf("NewSession: %v", err)
+			}
+			stop, err := r.cond.Prompt(ctx, sid, "do the dangerous thing")
+			if err != nil {
+				t.Fatalf("Prompt: %v", err)
+			}
+			// Outcome propagated to the agent: agent's branch picks stop reason.
+			if stop != tc.wantStop {
+				t.Errorf("stop = %q, want %q (agent did not receive expected decision)", stop, tc.wantStop)
+			}
+			// Conductor recorded the request + the decision in the ledger.
+			if !r.sink.hasKind(sid, contract.KindPermissionRequest) {
+				t.Error("ledger missing permission_request")
+			}
+			var decisionText string
+			for _, e := range r.sink.all() {
+				if e.SessionID == sid && e.Kind == contract.KindPermissionDecision {
+					decisionText = e.Text
+				}
+			}
+			if !strings.HasPrefix(decisionText, tc.wantDecided) {
+				t.Errorf("decision text = %q, want prefix %q", decisionText, tc.wantDecided)
+			}
+		})
+	}
+}
+
+// TestFork covers UnstableForkSession: assert a new session id is returned and
+// `_meta` rides the fork request.
+func TestFork(t *testing.T) {
+	agent := newFakeAgent()
+	r := newRig(t, agent, nil, nil)
+	ctx := ctxT(t)
+	if _, err := r.cond.Initialize(ctx, testIdentity()); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	parent, err := r.cond.NewSession(ctx, defaultSpec("/x"))
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	child, err := r.cond.Fork(ctx, parent, defaultSpec("/x"))
+	if err != nil {
+		t.Fatalf("Fork: %v", err)
+	}
+	if child == "" || child == parent {
+		t.Fatalf("fork returned bad id: parent=%s child=%s", parent, child)
+	}
+	agent.mu.Lock()
+	forkMeta := agent.forkMeta
+	agent.mu.Unlock()
+	if forkMeta["cogos.sub"] != testSub {
+		t.Errorf("fork _meta sub = %v, want %s", forkMeta["cogos.sub"], testSub)
+	}
+}
+
+// TestList covers ListSessions.
+func TestList(t *testing.T) {
+	agent := newFakeAgent()
+	r := newRig(t, agent, nil, nil)
+	ctx := ctxT(t)
+	if _, err := r.cond.Initialize(ctx, testIdentity()); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	s1, _ := r.cond.NewSession(ctx, defaultSpec("/a"))
+	s2, _ := r.cond.NewSession(ctx, defaultSpec("/b"))
+	got, err := r.cond.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	set := map[contract.SessionID]bool{}
+	for _, s := range got {
+		set[s] = true
+	}
+	if !set[s1] || !set[s2] {
+		t.Errorf("List missing sessions: got %v, want includes %s,%s", got, s1, s2)
+	}
+}
+
+// TestResume covers ResumeSession.
+func TestResume(t *testing.T) {
+	agent := newFakeAgent()
+	r := newRig(t, agent, nil, nil)
+	ctx := ctxT(t)
+	if _, err := r.cond.Initialize(ctx, testIdentity()); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	sid, _ := r.cond.NewSession(ctx, defaultSpec("/x"))
+	if err := r.cond.Resume(ctx, sid, defaultSpec("/x")); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	agent.mu.Lock()
+	resumed := agent.resumed[string(sid)]
+	agent.mu.Unlock()
+	if !resumed {
+		t.Error("agent did not record resume")
+	}
+}
+
+// TestLoad covers LoadSession WITH synchronous history replay (delta divergence
+// 4): the replayed session/update frames must reach the ledger before/around the
+// load response.
+func TestLoad(t *testing.T) {
+	agent := newFakeAgent()
+	agent.supportLoad = true
+	r := newRig(t, agent, nil, nil)
+	ctx := ctxT(t)
+	if _, err := r.cond.Initialize(ctx, testIdentity()); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	sid, _ := r.cond.NewSession(ctx, defaultSpec("/x"))
+	if err := r.cond.Load(ctx, sid, defaultSpec("/x")); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	agent.mu.Lock()
+	loaded := agent.loaded[string(sid)]
+	agent.mu.Unlock()
+	if !loaded {
+		t.Error("agent did not record load")
+	}
+	// Replayed history landed in the ledger (user + agent replayed turns).
+	if !r.sink.hasKind(sid, contract.KindUserMessage) || !r.sink.hasKind(sid, contract.KindAgentMessage) {
+		t.Errorf("replayed history not routed to ledger; got %v", r.sink.kindsForSession(sid))
+	}
+}
+
+// TestSetSessionModeAndConfig covers set_session_mode and set_session_config_option
+// (backend / embodiment selection — closes Finding 3).
+func TestSetSessionModeAndConfig(t *testing.T) {
+	t.Run("set_session_mode", func(t *testing.T) {
+		agent := newFakeAgent()
+		r := newRig(t, agent, nil, nil)
+		ctx := ctxT(t)
+		if _, err := r.cond.Initialize(ctx, testIdentity()); err != nil {
+			t.Fatalf("Initialize: %v", err)
+		}
+		sid, _ := r.cond.NewSession(ctx, defaultSpec("/x"))
+		if err := r.cond.SetMode(ctx, sid, "architect"); err != nil {
+			t.Fatalf("SetMode: %v", err)
+		}
+		agent.mu.Lock()
+		mode := agent.modeSet[string(sid)]
+		agent.mu.Unlock()
+		if mode != "architect" {
+			t.Errorf("mode = %q, want architect", mode)
+		}
+	})
+	t.Run("set_session_config_option", func(t *testing.T) {
+		agent := newFakeAgent()
+		r := newRig(t, agent, nil, nil)
+		ctx := ctxT(t)
+		if _, err := r.cond.Initialize(ctx, testIdentity()); err != nil {
+			t.Fatalf("Initialize: %v", err)
+		}
+		sid, _ := r.cond.NewSession(ctx, defaultSpec("/x"))
+		if err := r.cond.SetConfigOption(ctx, sid, "backend", "eclipse-26b"); err != nil {
+			t.Fatalf("SetConfigOption: %v", err)
+		}
+		agent.mu.Lock()
+		cfg := agent.cfgSet[string(sid)]
+		agent.mu.Unlock()
+		if cfg != "eclipse-26b" {
+			t.Errorf("config value = %q, want eclipse-26b", cfg)
+		}
+	})
+}
+
+// TestCancelMidTurn covers cancel mid-turn: clean cancellation + trailing-frame
+// tolerance. The conductor cancels via a context deadline on Prompt; the agent's
+// turn unblocks on ctx.Done, emits a trailing frame, and returns cancelled.
+func TestCancelMidTurn(t *testing.T) {
+	agent := newFakeAgent()
+	agent.promptFn = promptBlockUntilCancel
+	r := newRig(t, agent, nil, nil)
+	bg := ctxT(t)
+	if _, err := r.cond.Initialize(bg, testIdentity()); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	sid, _ := r.cond.NewSession(bg, defaultSpec("/x"))
+
+	// Prompt with a short deadline; the SDK's client.Prompt sends session/cancel
+	// to the agent when ctx expires (see client_gen.go Prompt).
+	pctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_, err := r.cond.Prompt(pctx, sid, "long task")
+	// We expect either a context error or a cancelled stop reason; both are
+	// "clean" — the point is no panic / no deadlock and the cancel propagated.
+	if err == nil {
+		t.Log("Prompt returned without error (agent completed cancel handshake before deadline)")
+	}
+
+	// Give the agent's Cancel handler a moment to fire.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		agent.mu.Lock()
+		canceled := agent.canceled[string(sid)]
+		agent.mu.Unlock()
+		if canceled {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	agent.mu.Lock()
+	canceled := agent.canceled[string(sid)]
+	agent.mu.Unlock()
+	if !canceled {
+		t.Error("agent did not receive session/cancel")
+	}
+	// The conductor recorded the initial frame; trailing frame tolerated (no panic).
+	if !r.sink.hasKind(sid, contract.KindAgentMessage) {
+		t.Error("expected at least the initial agent_message_chunk in ledger")
+	}
+}
+
+// TestCloseSession covers close_session.
+func TestCloseSession(t *testing.T) {
+	agent := newFakeAgent()
+	r := newRig(t, agent, nil, nil)
+	ctx := ctxT(t)
+	if _, err := r.cond.Initialize(ctx, testIdentity()); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	sid, _ := r.cond.NewSession(ctx, defaultSpec("/x"))
+	if err := r.cond.CloseSession(ctx, sid); err != nil {
+		t.Fatalf("CloseSession: %v", err)
+	}
+	agent.mu.Lock()
+	closed := agent.closed[string(sid)]
+	agent.mu.Unlock()
+	if !closed {
+		t.Error("agent did not record close")
+	}
+}
+
+// TestFsPolicyGate covers fs/* handlers: the conductor's Client handlers are
+// invoked and can DENY (policy gate). The agent issues fs reads/writes via the
+// AgentSideConnection; the conductor's FsPolicy decides.
+func TestFsPolicyGate(t *testing.T) {
+	t.Run("allow_read", func(t *testing.T) {
+		agent := newFakeAgent()
+		agent.promptFn = func(ctx context.Context, a *fakeAgent, p acp.PromptRequest) (acp.PromptResponse, error) {
+			resp, err := a.conn.ReadTextFile(ctx, acp.ReadTextFileRequest{Path: "/etc/allowed.txt"})
+			if err != nil {
+				return acp.PromptResponse{}, err
+			}
+			if !strings.Contains(resp.Content, "policy-allowed") {
+				return acp.PromptResponse{}, fmt.Errorf("unexpected content: %q", resp.Content)
+			}
+			return acp.PromptResponse{StopReason: acp.StopReasonEndTurn}, nil
+		}
+		r := newRig(t, agent, nil, allowAllFs())
+		ctx := ctxT(t)
+		_, _ = r.cond.Initialize(ctx, testIdentity())
+		sid, _ := r.cond.NewSession(ctx, defaultSpec("/x"))
+		if _, err := r.cond.Prompt(ctx, sid, "read a file"); err != nil {
+			t.Fatalf("Prompt: %v", err)
+		}
+		if r.sink.countKind(contract.KindFsRead) != 1 {
+			t.Errorf("expected 1 fs_read ledger entry, got %d", r.sink.countKind(contract.KindFsRead))
+		}
+	})
+
+	t.Run("deny_write", func(t *testing.T) {
+		agent := newFakeAgent()
+		var agentErr error
+		var once sync.Once
+		agent.promptFn = func(ctx context.Context, a *fakeAgent, p acp.PromptRequest) (acp.PromptResponse, error) {
+			_, err := a.conn.WriteTextFile(ctx, acp.WriteTextFileRequest{Path: "/etc/passwd", Content: "evil"})
+			once.Do(func() { agentErr = err })
+			// The agent observes the denial as an error; turn ends.
+			return acp.PromptResponse{StopReason: acp.StopReasonEndTurn}, nil
+		}
+		denyWrites := fnFsPolicy{
+			read:  func(ctx context.Context, path string) bool { return true },
+			write: func(ctx context.Context, path string) bool { return false },
+		}
+		r := newRig(t, agent, nil, denyWrites)
+		ctx := ctxT(t)
+		_, _ = r.cond.Initialize(ctx, testIdentity())
+		sid, _ := r.cond.NewSession(ctx, defaultSpec("/x"))
+		if _, err := r.cond.Prompt(ctx, sid, "write a file"); err != nil {
+			t.Fatalf("Prompt: %v", err)
+		}
+		if agentErr == nil {
+			t.Error("agent's WriteTextFile should have returned a policy-denied error")
+		}
+		if r.sink.countKind(contract.KindFsDenied) != 1 {
+			t.Errorf("expected 1 fs_denied ledger entry, got %d", r.sink.countKind(contract.KindFsDenied))
+		}
+	})
+
+	t.Run("terminal_denied", func(t *testing.T) {
+		agent := newFakeAgent()
+		var termErr error
+		agent.promptFn = func(ctx context.Context, a *fakeAgent, p acp.PromptRequest) (acp.PromptResponse, error) {
+			_, termErr = a.conn.CreateTerminal(ctx, acp.CreateTerminalRequest{Command: "rm", Args: []string{"-rf", "/"}})
+			return acp.PromptResponse{StopReason: acp.StopReasonEndTurn}, nil
+		}
+		r := newRig(t, agent, nil, allowAllFs())
+		ctx := ctxT(t)
+		_, _ = r.cond.Initialize(ctx, testIdentity())
+		sid, _ := r.cond.NewSession(ctx, defaultSpec("/x"))
+		if _, err := r.cond.Prompt(ctx, sid, "spawn a shell"); err != nil {
+			t.Fatalf("Prompt: %v", err)
+		}
+		if termErr == nil {
+			t.Error("CreateTerminal should have been denied by conductor policy")
+		}
+	})
+}
+
+// TestMcpOverAcp is a smoke test for ConnectMcp/DisconnectMcp (experimental).
+// The conductor's Client must handle the agent-issued mcp/connect + mcp/disconnect.
+func TestMcpOverAcp(t *testing.T) {
+	t.Run("connect_disconnect_smoke", func(t *testing.T) {
+		agent := newFakeAgent()
+		var (
+			connID  string
+			connErr error
+			discErr error
+		)
+		agent.promptFn = func(ctx context.Context, a *fakeAgent, p acp.PromptRequest) (acp.PromptResponse, error) {
+			resp, err := a.conn.UnstableConnectMcp(ctx, acp.UnstableConnectMcpRequest{AcpId: acp.UnstableMcpServerAcpId("acp-mcp-1")})
+			connErr = err
+			if err == nil {
+				connID = string(resp.ConnectionId)
+				_, discErr = a.conn.UnstableDisconnectMcp(ctx, acp.UnstableDisconnectMcpRequest{ConnectionId: resp.ConnectionId})
+			}
+			return acp.PromptResponse{StopReason: acp.StopReasonEndTurn}, nil
+		}
+		// The conductor's Client must implement the experimental MCP handlers for
+		// the agent's calls to succeed. The SDK adapter's clientHandlers does NOT
+		// implement UnstableConnectMcp/UnstableDisconnectMcp (the conductor consumes
+		// MCP-over-ACP as a CALLER, not as a handler). So these agent→client calls
+		// will get MethodNotFound. That is the documented finding: see skip below.
+		r := newRig(t, agent, nil, nil)
+		ctx := ctxT(t)
+		_, _ = r.cond.Initialize(ctx, testIdentity())
+		sid, _ := r.cond.NewSession(ctx, defaultSpec("/x"))
+		_, _ = r.cond.Prompt(ctx, sid, "use mcp")
+
+		if connErr != nil {
+			t.Skipf("conductor (ACP client) does not handle agent-issued mcp/connect: %v. "+
+				"GAP/FINDING: MCP-over-ACP in this SDK has the agent as the mcp/connect CALLER and "+
+				"the CLIENT as the handler (ClientExperimental.UnstableConnectMcp). The conductor "+
+				"as drawn consumes MCP-over-ACP toward its OWN cells (conductor=caller), which is the "+
+				"opposite direction. To support cells that expose MCP servers back to the conductor, "+
+				"the adapter's clientHandlers must implement ClientExperimental. Documented, not failed.", connErr)
+		}
+		if connID == "" {
+			t.Error("expected non-empty connection id")
+		}
+		if discErr != nil {
+			t.Errorf("DisconnectMcp: %v", discErr)
+		}
+	})
+
+	// Direction the conductor actually drives: conductor → cell. This requires the
+	// FAKE AGENT to implement UnstableConnectMcp as an Agent handler. The SDK only
+	// routes mcp/connect to the CLIENT side (ClientMethodMcpConnect), never to the
+	// agent. So the conductor-as-caller direction is not expressible against this
+	// SDK's method routing. Documented as a skip — highest-value finding.
+	t.Run("conductor_drives_mcp_connect_to_cell", func(t *testing.T) {
+		agent := newFakeAgent()
+		r := newRig(t, agent, nil, nil)
+		ctx := ctxT(t)
+		_, _ = r.cond.Initialize(ctx, testIdentity())
+		_, err := r.cond.ConnectMcp(ctx, "cell-mcp-1")
+		t.Skipf("conductor.ConnectMcp routes to ClientMethodMcpConnect (agent→client direction). "+
+			"The SDK has no agent-side mcp/connect handler, so a conductor cannot drive mcp/connect "+
+			"TOWARD a cell over this SDK. Observed err=%v. FINDING: MCP-over-ACP is modeled "+
+			"agent-as-caller only; conductor-driven MCP attach to a cell needs an upstream method "+
+			"or must ride MCP transport config in new_session instead.", err)
+	})
+}
+
+// TestMultiSessionConcurrency drives N concurrent sessions and asserts no
+// cross-talk: every ledger entry for a session carries that session's id, and
+// each session sees exactly its own stream.
+func TestMultiSessionConcurrency(t *testing.T) {
+	const n = 8
+	agent := newFakeAgent()
+	agent.promptFn = promptStreamAllKinds
+	r := newRig(t, agent, nil, nil)
+	ctx := ctxT(t)
+	if _, err := r.cond.Initialize(ctx, testIdentity()); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	// Create N sessions up front (NewSession mints distinct ids).
+	sids := make([]contract.SessionID, n)
+	for i := 0; i < n; i++ {
+		sid, err := r.cond.NewSession(ctx, defaultSpec(fmt.Sprintf("/s/%d", i)))
+		if err != nil {
+			t.Fatalf("NewSession %d: %v", i, err)
+		}
+		sids[i] = sid
+	}
+
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = r.cond.Prompt(ctx, sids[i], fmt.Sprintf("prompt %d", i))
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("Prompt session %d: %v", i, err)
+		}
+	}
+
+	// Each session must have its full required kind set, and no entry may bear a
+	// foreign session id.
+	required := []contract.LedgerEntryKind{
+		contract.KindUserMessage, contract.KindAgentThought, contract.KindAgentMessage,
+		contract.KindToolCall, contract.KindToolUpdate, contract.KindPlan,
+	}
+	validIDs := map[contract.SessionID]bool{}
+	for _, s := range sids {
+		validIDs[s] = true
+	}
+	for _, e := range r.sink.all() {
+		if !validIDs[e.SessionID] {
+			t.Errorf("ledger entry with unknown session id %q (cross-talk)", e.SessionID)
+		}
+	}
+	for _, sid := range sids {
+		for _, k := range required {
+			if !r.sink.hasKind(sid, k) {
+				t.Errorf("session %s missing kind %q (routing/cross-talk failure)", sid, k)
+			}
+		}
+	}
+}
+
+// TestTransportPluggability_Pipe proves the same conductor works over io.Pipe.
+// (The subprocess-over-stdio variant lives in transport_stdio_test.go.)
+func TestTransportPluggability_Pipe(t *testing.T) {
+	agent := newFakeAgent()
+	r := newRig(t, agent, nil, nil)
+	ctx := ctxT(t)
+	if _, err := r.cond.Initialize(ctx, testIdentity()); err != nil {
+		t.Fatalf("Initialize over io.Pipe: %v", err)
+	}
+	sid, err := r.cond.NewSession(ctx, defaultSpec("/x"))
+	if err != nil {
+		t.Fatalf("NewSession over io.Pipe: %v", err)
+	}
+	if _, err := r.cond.Prompt(ctx, sid, "hi"); err != nil {
+		t.Fatalf("Prompt over io.Pipe: %v", err)
+	}
+}

--- a/internal/conductor/contract/contract.go
+++ b/internal/conductor/contract/contract.go
@@ -1,0 +1,214 @@
+// Package contract distills the portable conductor-facing ACP-client interface
+// derived from RFC-036 ("The Conductor — CogOS-as-ACP-Client as the Substrate's
+// Conducting Seat") and the Hermes/mod3 ACP implementation delta.
+//
+// This is the structural-isomorphism boundary made executable. The conductor —
+// CogOS occupying the ACP *client* role — expects exactly the surface defined
+// here. The coder/acp-go-sdk is one backing for it; a native reimplementation is
+// another. Tests written against this package therefore validate the *contract*,
+// not the SDK, and a SDK swap must keep these tests green.
+//
+// Design rule (RFC-036 structural-isomorphism vendoring): types in this package
+// are SDK-free where the contract can be expressed generically. The conductor
+// thinks in terms of sessions, turns, governance decisions, and ledger traces —
+// not acp.SessionNotification. Where a value is genuinely an opaque protocol
+// payload (an MCP server config, a permission option), the contract carries it
+// as an opaque handle rather than re-typing the SDK.
+package contract
+
+import "context"
+
+// SessionID is the conductor's handle to a conducted cell session.
+type SessionID string
+
+// --- Identity injection (RFC-036 P3 gap 6, delta recommendation 9) ----------
+
+// Identity is the substrate identity the conductor injects into a cell at birth.
+// It rides ACP's `_meta` extension point on initialize / new_session so the cell
+// is "born substrate-bound." iss/sub mirror the substrate's binding model
+// (HarnessBinding URIs per the K8s-RBAC framing): iss = the conducting authority,
+// sub = the bound cell identity.
+//
+// TODO(conductor, RFC-036 P3 gap 6): production derives Iss/Sub from a real
+// HarnessBinding identity record, not a literal. See the package doc scaffold
+// boundary.
+type Identity struct {
+	Iss string // issuing authority (the conductor's substrate identity URI)
+	Sub string // subject (the cell's substrate identity URI)
+}
+
+// Meta renders the identity as the `_meta` map the conductor attaches to ACP
+// requests. The cogos.* namespace keeps substrate keys from colliding with the
+// protocol's reserved space.
+func (i Identity) Meta() map[string]any {
+	return map[string]any{
+		"cogos.iss": i.Iss,
+		"cogos.sub": i.Sub,
+	}
+}
+
+// --- The ledger sink (RFC-036 P5: stigmergic coordination) -------------------
+
+// LedgerEntryKind enumerates every routed event the conductor must persist. The
+// management surface IS the observation surface IS the training corpus, so every
+// session/update kind plus governance decisions must land in the ledger.
+type LedgerEntryKind string
+
+const (
+	// Streamed update kinds (every kind the conductor must consume — RFC-036 P3 gap 2).
+	KindAgentMessage LedgerEntryKind = "agent_message_chunk"
+	KindAgentThought LedgerEntryKind = "agent_thought_chunk"
+	KindUserMessage  LedgerEntryKind = "user_message_chunk"
+	KindToolCall     LedgerEntryKind = "tool_call"
+	KindToolUpdate   LedgerEntryKind = "tool_call_update"
+	KindPlan         LedgerEntryKind = "plan"
+
+	// Governance + lifecycle traces.
+	KindPermissionRequest  LedgerEntryKind = "permission_request"
+	KindPermissionDecision LedgerEntryKind = "permission_decision"
+	KindFsRead             LedgerEntryKind = "fs_read"
+	KindFsWrite            LedgerEntryKind = "fs_write"
+	KindFsDenied           LedgerEntryKind = "fs_denied"
+)
+
+// LedgerEntry is one stigmergic trace. SessionID is load-bearing for the
+// multi-session concurrency guarantee: every entry must be attributable to the
+// session it came from, with no cross-talk.
+type LedgerEntry struct {
+	SessionID SessionID
+	Kind      LedgerEntryKind
+	// Text is the human-readable payload (message text, tool title, decision id).
+	Text string
+	// Detail holds structured payload where Text is insufficient.
+	Detail map[string]any
+}
+
+// LedgerSink is the conductor's persistence boundary. In production this is the
+// cogos ledger; in tests it is a capture sink. It must be safe for concurrent
+// use — N sessions stream updates simultaneously.
+//
+// TODO(conductor, RFC-036 P5 / ADR-013): the production implementation wires
+// this to the real kernel ledger so every update becomes a stigmergic trace.
+type LedgerSink interface {
+	Record(entry LedgerEntry)
+}
+
+// --- Governance (RFC-036 P4: Proposer/Actor consent boundary) ----------------
+
+// PermissionRequest is the conductor's view of a cell asking to do something
+// dangerous mid-turn (ACP session/request_permission, agent→client).
+type PermissionRequest struct {
+	SessionID SessionID
+	// ToolTitle is the human-readable action the cell wants to perform.
+	ToolTitle string
+	// Options are the opaque option identifiers the cell offered. The conductor
+	// chooses one to approve, or chooses none to deny.
+	Options []PermissionOption
+}
+
+// PermissionOption is an offered choice. Kind distinguishes allow/reject so the
+// Proposer/Actor decision can be made without re-typing the SDK enum.
+type PermissionOption struct {
+	ID   string
+	Name string
+	Kind PermissionKind
+}
+
+// PermissionKind is the coarse allow/reject classification of an option.
+type PermissionKind string
+
+const (
+	PermitAllow  PermissionKind = "allow"
+	PermitReject PermissionKind = "reject"
+)
+
+// PermissionDecision is the conductor's governance verdict.
+type PermissionDecision struct {
+	// Approved selects an option by ID. Empty means deny (Cancelled outcome).
+	OptionID string
+	Denied   bool
+}
+
+// Governor makes the Proposer/Actor decision. The conductor (Eigen-as-Proposer)
+// proposes; the policy/operator (Actor) authorizes. This is the substrate's
+// consent boundary realized as the ACP permission flow.
+//
+// TODO(conductor, RFC-036 P4 / RFC-009): the production implementation wires
+// this to the RFC-009 Proposer/Actor consent boundary.
+type Governor interface {
+	Decide(ctx context.Context, req PermissionRequest) PermissionDecision
+}
+
+// --- Filesystem / terminal policy gate (delta: fs/* client callbacks) --------
+
+// FsPolicy gates the cell's filesystem requests. Returning false denies the
+// request — the conductor's Client handler must be able to refuse, not just
+// proxy to the OS.
+type FsPolicy interface {
+	AllowRead(ctx context.Context, path string) bool
+	AllowWrite(ctx context.Context, path string) bool
+}
+
+// --- Session setup payloads --------------------------------------------------
+
+// SessionSpec is the conductor's request to spin up a cell session. Cwd and
+// McpServers map directly onto ACP new_session; Identity rides `_meta`.
+type SessionSpec struct {
+	Cwd      string
+	Identity Identity
+	// McpServers are opaque protocol payloads — the conductor passes them
+	// through without re-typing the SDK's discriminated union.
+	McpServers []any
+}
+
+// --- The conductor's ACP-client contract -------------------------------------
+
+// Conductor is the portable surface the CogOS conductor expects of any ACP
+// client. Every method corresponds to a RFC-036 requirement or one of the six
+// generalization-delta gaps. A backing (SDK adapter, native impl) satisfies
+// this interface; the test suite validates the contract through it.
+type Conductor interface {
+	// Initialize negotiates the protocol and injects substrate identity via
+	// `_meta` (RFC-036 P3 gap 6). Returns the negotiated protocol version.
+	Initialize(ctx context.Context, id Identity) (protocolVersion int, err error)
+
+	// NewSession opens a cell session with cwd, mcpServers, and `_meta` identity.
+	NewSession(ctx context.Context, spec SessionSpec) (SessionID, error)
+
+	// Prompt sends a user message and drives the resulting session/update stream
+	// to completion, routing every update kind to the ledger sink (gap 2 + gap 4).
+	// Returns the stop reason.
+	Prompt(ctx context.Context, sid SessionID, text string) (stopReason string, err error)
+
+	// Cancel requests clean cancellation of an in-flight turn.
+	Cancel(ctx context.Context, sid SessionID) error
+
+	// --- Fleet verbs (RFC-036 P3 gap 5 + P2) ---
+
+	// Fork branches a session (ACP session/fork). Returns the new session id.
+	Fork(ctx context.Context, sid SessionID, spec SessionSpec) (SessionID, error)
+	// List enumerates known sessions (ACP session/list).
+	List(ctx context.Context) ([]SessionID, error)
+	// Resume re-attaches to a prior session without history replay.
+	Resume(ctx context.Context, sid SessionID, spec SessionSpec) error
+	// Load re-attaches with synchronous history replay (delta divergence 4).
+	Load(ctx context.Context, sid SessionID, spec SessionSpec) error
+
+	// --- Backend / embodiment selection (delta recommendation 7) ---
+
+	// SetMode selects a session mode (ACP session/set_mode).
+	SetMode(ctx context.Context, sid SessionID, modeID string) error
+	// SetConfigOption selects a backend/embodiment via SessionConfigOption,
+	// the on-spec hook for model/backend selection (closes Finding 3).
+	SetConfigOption(ctx context.Context, sid SessionID, configID, value string) error
+
+	// CloseSession frees a session's resources (ACP session/close).
+	CloseSession(ctx context.Context, sid SessionID) error
+
+	// --- MCP-over-ACP (experimental, delta) ---
+
+	// ConnectMcp opens an MCP-over-ACP connection by ACP id, returns a connection id.
+	ConnectMcp(ctx context.Context, acpID string) (connectionID string, err error)
+	// DisconnectMcp closes an MCP-over-ACP connection.
+	DisconnectMcp(ctx context.Context, connectionID string) error
+}

--- a/internal/conductor/doc.go
+++ b/internal/conductor/doc.go
@@ -1,0 +1,49 @@
+// Package conductor is the CogOS conductor: the substrate occupying the ACP
+// *client* role, conducting a fleet of orchestrating ACP-*server* cells (Hermes
+// first, then others) over Zed's Agent Client Protocol. It is the operational
+// realization of RFC-036 ("The Conductor — CogOS-as-ACP-Client as the
+// Substrate's Conducting Seat") and ADR-062's Layer 2 (ACP Conductor).
+//
+// Status: scaffold. This package ports the validated integration spike
+// (race-clean, offline) into the kernel as the foundation for the real
+// conductor build. What is real and tested here:
+//
+//   - contract.Conductor — the portable, SDK-free ACP-client interface every
+//     RFC-036 verb maps onto (initialize, new_session, prompt, cancel, the fleet
+//     verbs fork/list/resume/load, set_mode/set_config_option, close).
+//   - adapter.SDKConductor — the only SDK-importing backing, translating between
+//     coder/acp-go-sdk wire types and the contract's substrate-shaped types, and
+//     wiring the SDK client-side handlers to the substrate collaborators.
+//   - The injected collaborators contract.Governor / contract.LedgerSink /
+//     contract.FsPolicy — the consent boundary, the stigmergic persistence
+//     boundary, and the filesystem policy gate.
+//   - The full test suite (in-process fake cell over io.Pipe + a real stdio
+//     subprocess), the executable spec for the contract and for any future
+//     native ACP-client reimplementation.
+//
+// What is stubbed (the scaffold boundary — application logic, NOT the contract):
+//
+//   - TODO(conductor, RFC-036 P3+P2): the fleet manager driving N concurrent
+//     sessions. The contract multiplexes sessions cleanly (validated N=8
+//     race-clean) but the orchestration loop that owns the fleet lifecycle is
+//     not built here.
+//   - TODO(conductor, RFC-036 P5 / ADR-013): wire contract.LedgerSink to the
+//     real kernel ledger. Today the tests use a capture sink; production routes
+//     every session/update to the cogos ledger as a stigmergic trace.
+//   - TODO(conductor, RFC-036 P4 / RFC-009): wire contract.Governor to the
+//     RFC-009 Proposer/Actor consent boundary. Today the tests inject a func
+//     governor; production routes permission requests through the substrate's
+//     policy/operator decision.
+//   - TODO(conductor, RFC-036 P3 gap 6): populate contract.Identity (_meta
+//     iss/sub) from a real HarnessBinding identity. Today the tests inject a
+//     fixed test identity; production derives it from the substrate binding
+//     model (K8s-RBAC framing).
+//
+// Relationship to internal/acp: this package is the ACP *client* side (the
+// conductor drives cells via coder/acp-go-sdk's ClientSideConnection).
+// internal/acp is the claude-subprocess *server/driver* side — ADR-093's
+// stream-json ManagedSession primitive that owns a claude process. They sit on
+// opposite ends of the ACP relationship. Future unification behind one
+// ManagedSession-shaped surface is possible but is explicitly out of scope here;
+// this scaffold does not modify internal/acp.
+package conductor

--- a/internal/conductor/fakeagent_test.go
+++ b/internal/conductor/fakeagent_test.go
@@ -1,0 +1,279 @@
+package conductor
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	acp "github.com/coder/acp-go-sdk"
+)
+
+// fakeAgent is a programmable ACP *server* (the "cell") that the conductor
+// drives. It is an in-process stand-in for Hermes: it satisfies acp.Agent plus
+// the experimental method set (fork, mcp connect/disconnect, set model), and it
+// records what it received so tests can assert `_meta` round-trip and per-session
+// routing. Its Prompt behavior is configurable per scenario via promptFn.
+type fakeAgent struct {
+	conn *acp.AgentSideConnection
+
+	mu sync.Mutex
+	// captured initialize / new_session / fork inbound for _meta assertions.
+	initMeta    map[string]any
+	newSessMeta map[string]any
+	forkMeta    map[string]any
+	// per-session new_session payloads, keyed by minted session id.
+	newSessionCwd map[string]string
+	// sessions registered for list/load/resume bookkeeping.
+	sessions map[string]acp.SessionInfo
+	loaded   map[string]bool
+	resumed  map[string]bool
+	modeSet  map[string]string
+	cfgSet   map[string]string
+	closed   map[string]bool
+	canceled map[string]bool
+
+	// capabilities toggles
+	supportLoad bool
+
+	sessionSeq atomic.Int64
+
+	// promptFn drives the session/update stream + permission flow for a turn.
+	// If nil, a default single agent_message_chunk + end_turn is sent.
+	promptFn func(ctx context.Context, a *fakeAgent, p acp.PromptRequest) (acp.PromptResponse, error)
+}
+
+func newFakeAgent() *fakeAgent {
+	return &fakeAgent{
+		newSessionCwd: map[string]string{},
+		sessions:      map[string]acp.SessionInfo{},
+		loaded:        map[string]bool{},
+		resumed:       map[string]bool{},
+		modeSet:       map[string]string{},
+		cfgSet:        map[string]string{},
+		closed:        map[string]bool{},
+		canceled:      map[string]bool{},
+	}
+}
+
+func (a *fakeAgent) setConn(c *acp.AgentSideConnection) { a.conn = c }
+
+func (a *fakeAgent) mintSessionID() acp.SessionId {
+	n := a.sessionSeq.Add(1)
+	return acp.SessionId(fmt.Sprintf("sess_%d", n))
+}
+
+// --- core acp.Agent ---
+
+func (a *fakeAgent) Initialize(ctx context.Context, p acp.InitializeRequest) (acp.InitializeResponse, error) {
+	a.mu.Lock()
+	a.initMeta = p.Meta
+	a.mu.Unlock()
+	return acp.InitializeResponse{
+		ProtocolVersion: acp.ProtocolVersionNumber,
+		AgentCapabilities: acp.AgentCapabilities{
+			LoadSession: a.supportLoad,
+		},
+	}, nil
+}
+
+func (a *fakeAgent) Authenticate(ctx context.Context, _ acp.AuthenticateRequest) (acp.AuthenticateResponse, error) {
+	return acp.AuthenticateResponse{}, nil
+}
+
+func (a *fakeAgent) NewSession(ctx context.Context, p acp.NewSessionRequest) (acp.NewSessionResponse, error) {
+	sid := a.mintSessionID()
+	a.mu.Lock()
+	a.newSessMeta = p.Meta
+	a.newSessionCwd[string(sid)] = p.Cwd
+	a.sessions[string(sid)] = acp.SessionInfo{SessionId: sid, Cwd: p.Cwd}
+	a.mu.Unlock()
+	return acp.NewSessionResponse{SessionId: sid}, nil
+}
+
+func (a *fakeAgent) Prompt(ctx context.Context, p acp.PromptRequest) (acp.PromptResponse, error) {
+	if a.promptFn != nil {
+		return a.promptFn(ctx, a, p)
+	}
+	_ = a.conn.SessionUpdate(ctx, acp.SessionNotification{
+		SessionId: p.SessionId,
+		Update:    acp.UpdateAgentMessageText("default reply"),
+	})
+	return acp.PromptResponse{StopReason: acp.StopReasonEndTurn}, nil
+}
+
+func (a *fakeAgent) Cancel(ctx context.Context, p acp.CancelNotification) error {
+	a.mu.Lock()
+	a.canceled[string(p.SessionId)] = true
+	a.mu.Unlock()
+	return nil
+}
+
+func (a *fakeAgent) CloseSession(ctx context.Context, p acp.CloseSessionRequest) (acp.CloseSessionResponse, error) {
+	a.mu.Lock()
+	a.closed[string(p.SessionId)] = true
+	delete(a.sessions, string(p.SessionId))
+	a.mu.Unlock()
+	return acp.CloseSessionResponse{}, nil
+}
+
+func (a *fakeAgent) ListSessions(ctx context.Context, p acp.ListSessionsRequest) (acp.ListSessionsResponse, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := make([]acp.SessionInfo, 0, len(a.sessions))
+	for _, s := range a.sessions {
+		out = append(out, s)
+	}
+	return acp.ListSessionsResponse{Sessions: out}, nil
+}
+
+func (a *fakeAgent) ResumeSession(ctx context.Context, p acp.ResumeSessionRequest) (acp.ResumeSessionResponse, error) {
+	a.mu.Lock()
+	a.resumed[string(p.SessionId)] = true
+	a.mu.Unlock()
+	return acp.ResumeSessionResponse{}, nil
+}
+
+func (a *fakeAgent) SetSessionMode(ctx context.Context, p acp.SetSessionModeRequest) (acp.SetSessionModeResponse, error) {
+	a.mu.Lock()
+	a.modeSet[string(p.SessionId)] = string(p.ModeId)
+	a.mu.Unlock()
+	return acp.SetSessionModeResponse{}, nil
+}
+
+func (a *fakeAgent) SetSessionConfigOption(ctx context.Context, p acp.SetSessionConfigOptionRequest) (acp.SetSessionConfigOptionResponse, error) {
+	a.mu.Lock()
+	if p.ValueId != nil {
+		a.cfgSet[string(p.ValueId.SessionId)] = string(p.ValueId.Value)
+	}
+	a.mu.Unlock()
+	return acp.SetSessionConfigOptionResponse{}, nil
+}
+
+// --- AgentLoader (optional) ---
+
+func (a *fakeAgent) LoadSession(ctx context.Context, p acp.LoadSessionRequest) (acp.LoadSessionResponse, error) {
+	// Hermes-shape: replay history synchronously via session/update BEFORE the
+	// load response returns (delta divergence 4).
+	_ = a.conn.SessionUpdate(ctx, acp.SessionNotification{
+		SessionId: p.SessionId,
+		Update:    acp.UpdateUserMessageText("(replayed) prior user turn"),
+	})
+	_ = a.conn.SessionUpdate(ctx, acp.SessionNotification{
+		SessionId: p.SessionId,
+		Update:    acp.UpdateAgentMessageText("(replayed) prior agent turn"),
+	})
+	a.mu.Lock()
+	a.loaded[string(p.SessionId)] = true
+	a.mu.Unlock()
+	return acp.LoadSessionResponse{}, nil
+}
+
+// --- AgentExperimental subset we exercise ---
+
+func (a *fakeAgent) UnstableForkSession(ctx context.Context, p acp.UnstableForkSessionRequest) (acp.UnstableForkSessionResponse, error) {
+	sid := a.mintSessionID()
+	a.mu.Lock()
+	a.forkMeta = p.Meta
+	a.sessions[string(sid)] = acp.SessionInfo{SessionId: sid, Cwd: p.Cwd}
+	a.mu.Unlock()
+	return acp.UnstableForkSessionResponse{SessionId: sid}, nil
+}
+
+// MCP-over-ACP: the agent (cell) is the CALLER of mcp/connect; the conductor's
+// client handles it. So the fakeAgent issues these toward the client. We expose
+// helper methods rather than implementing them as Agent handlers.
+
+// --- helpers for assertions ---
+
+func (a *fakeAgent) snapshot() map[string]any {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return map[string]any{
+		"initMeta":    a.initMeta,
+		"newSessMeta": a.newSessMeta,
+		"forkMeta":    a.forkMeta,
+	}
+}
+
+// promptStreamAllKinds streams one of every required update kind, then ends.
+func promptStreamAllKinds(ctx context.Context, a *fakeAgent, p acp.PromptRequest) (acp.PromptResponse, error) {
+	sid := p.SessionId
+	send := func(u acp.SessionUpdate) {
+		_ = a.conn.SessionUpdate(ctx, acp.SessionNotification{SessionId: sid, Update: u})
+	}
+	send(acp.UpdateUserMessageText("echo: user said hi"))
+	send(acp.UpdateAgentThoughtText("thinking about it"))
+	send(acp.UpdateAgentMessageText("here is my answer"))
+	send(acp.StartToolCall(acp.ToolCallId("call_1"), "run analysis",
+		acp.WithStartKind(acp.ToolKindOther), acp.WithStartStatus(acp.ToolCallStatusPending)))
+	send(acp.UpdateToolCall(acp.ToolCallId("call_1"), acp.WithUpdateStatus(acp.ToolCallStatusCompleted)))
+	send(acp.UpdatePlan(
+		acp.PlanEntry{Content: "step one", Priority: acp.PlanEntryPriorityHigh, Status: acp.PlanEntryStatusPending},
+	))
+	return acp.PromptResponse{StopReason: acp.StopReasonEndTurn}, nil
+}
+
+// promptRequestPermission asks the client for permission mid-turn, then acts on
+// the decision: on approval streams a completed tool call; on deny streams a
+// failed tool call. The outcome is observable to the test via the ledger and via
+// the returned stop reason.
+func promptRequestPermission(ctx context.Context, a *fakeAgent, p acp.PromptRequest) (acp.PromptResponse, error) {
+	sid := p.SessionId
+	_ = a.conn.SessionUpdate(ctx, acp.SessionNotification{
+		SessionId: sid,
+		Update: acp.StartToolCall(acp.ToolCallId("danger_1"), "delete production data",
+			acp.WithStartKind(acp.ToolKindDelete), acp.WithStartStatus(acp.ToolCallStatusPending)),
+	})
+	resp, err := a.conn.RequestPermission(ctx, acp.RequestPermissionRequest{
+		SessionId: sid,
+		ToolCall: acp.ToolCallUpdate{
+			ToolCallId: acp.ToolCallId("danger_1"),
+			Title:      acp.Ptr("delete production data"),
+		},
+		Options: []acp.PermissionOption{
+			{Kind: acp.PermissionOptionKindAllowOnce, Name: "Allow", OptionId: acp.PermissionOptionId("allow")},
+			{Kind: acp.PermissionOptionKindRejectOnce, Name: "Reject", OptionId: acp.PermissionOptionId("reject")},
+		},
+	})
+	if err != nil {
+		return acp.PromptResponse{}, err
+	}
+	if resp.Outcome.Selected != nil && string(resp.Outcome.Selected.OptionId) == "allow" {
+		_ = a.conn.SessionUpdate(ctx, acp.SessionNotification{
+			SessionId: sid,
+			Update:    acp.UpdateToolCall(acp.ToolCallId("danger_1"), acp.WithUpdateStatus(acp.ToolCallStatusCompleted)),
+		})
+		return acp.PromptResponse{StopReason: acp.StopReasonEndTurn}, nil
+	}
+	// Denied / cancelled outcome.
+	_ = a.conn.SessionUpdate(ctx, acp.SessionNotification{
+		SessionId: sid,
+		Update:    acp.UpdateToolCall(acp.ToolCallId("danger_1"), acp.WithUpdateStatus(acp.ToolCallStatusFailed)),
+	})
+	return acp.PromptResponse{StopReason: acp.StopReasonRefusal}, nil
+}
+
+// promptBlockUntilCancel blocks the turn until the context is cancelled, then
+// emits a trailing frame and returns the cancelled stop reason. Exercises clean
+// mid-turn cancellation.
+func promptBlockUntilCancel(ctx context.Context, a *fakeAgent, p acp.PromptRequest) (acp.PromptResponse, error) {
+	sid := p.SessionId
+	_ = a.conn.SessionUpdate(ctx, acp.SessionNotification{
+		SessionId: sid,
+		Update:    acp.UpdateAgentMessageText("starting long work"),
+	})
+	select {
+	case <-ctx.Done():
+		// Trailing frame after cancellation: the SDK keeps inbound ctx alive long
+		// enough to deliver this; the conductor must tolerate it.
+		_ = a.conn.SessionUpdate(context.Background(), acp.SessionNotification{
+			SessionId: sid,
+			Update:    acp.UpdateAgentMessageText("(cancelled, cleaning up)"),
+		})
+		return acp.PromptResponse{StopReason: acp.StopReasonCancelled}, nil
+	case <-time.After(5 * time.Second):
+		return acp.PromptResponse{StopReason: acp.StopReasonEndTurn}, nil
+	}
+}

--- a/internal/conductor/harness_test.go
+++ b/internal/conductor/harness_test.go
@@ -1,0 +1,191 @@
+package conductor
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+
+	acp "github.com/coder/acp-go-sdk"
+
+	"github.com/myrgic/cogos/internal/conductor/contract"
+)
+
+// quietLogger discards SDK connection diagnostics (e.g. "connection closed"
+// INFO lines on pipe teardown) to keep test output focused on assertions.
+var quietLogger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
+// captureSink is the test stand-in for the cogos ledger. Concurrency-safe so it
+// can absorb N sessions streaming simultaneously.
+type captureSink struct {
+	mu      sync.Mutex
+	entries []contract.LedgerEntry
+}
+
+func (s *captureSink) Record(e contract.LedgerEntry) {
+	s.mu.Lock()
+	s.entries = append(s.entries, e)
+	s.mu.Unlock()
+}
+
+func (s *captureSink) all() []contract.LedgerEntry {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]contract.LedgerEntry, len(s.entries))
+	copy(out, s.entries)
+	return out
+}
+
+func (s *captureSink) kindsForSession(sid contract.SessionID) []contract.LedgerEntryKind {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []contract.LedgerEntryKind
+	for _, e := range s.entries {
+		if e.SessionID == sid {
+			out = append(out, e.Kind)
+		}
+	}
+	return out
+}
+
+func (s *captureSink) hasKind(sid contract.SessionID, k contract.LedgerEntryKind) bool {
+	for _, got := range s.kindsForSession(sid) {
+		if got == k {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *captureSink) countKind(k contract.LedgerEntryKind) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for _, e := range s.entries {
+		if e.Kind == k {
+			n++
+		}
+	}
+	return n
+}
+
+// fnGovernor adapts a func to contract.Governor.
+type fnGovernor struct {
+	fn func(ctx context.Context, req contract.PermissionRequest) contract.PermissionDecision
+}
+
+func (g fnGovernor) Decide(ctx context.Context, req contract.PermissionRequest) contract.PermissionDecision {
+	return g.fn(ctx, req)
+}
+
+// approveFirstAllow picks the first option classified as allow; denies if none.
+func approveFirstAllow(ctx context.Context, req contract.PermissionRequest) contract.PermissionDecision {
+	for _, o := range req.Options {
+		if o.Kind == contract.PermitAllow {
+			return contract.PermissionDecision{OptionID: o.ID}
+		}
+	}
+	return contract.PermissionDecision{Denied: true}
+}
+
+// denyAll always denies.
+func denyAll(ctx context.Context, req contract.PermissionRequest) contract.PermissionDecision {
+	return contract.PermissionDecision{Denied: true}
+}
+
+// fnFsPolicy adapts funcs to contract.FsPolicy.
+type fnFsPolicy struct {
+	read  func(ctx context.Context, path string) bool
+	write func(ctx context.Context, path string) bool
+}
+
+func (p fnFsPolicy) AllowRead(ctx context.Context, path string) bool {
+	if p.read == nil {
+		return false
+	}
+	return p.read(ctx, path)
+}
+func (p fnFsPolicy) AllowWrite(ctx context.Context, path string) bool {
+	if p.write == nil {
+		return false
+	}
+	return p.write(ctx, path)
+}
+
+func allowAllFs() fnFsPolicy {
+	return fnFsPolicy{
+		read:  func(ctx context.Context, path string) bool { return true },
+		write: func(ctx context.Context, path string) bool { return true },
+	}
+}
+
+// rig is a fully wired in-process conductor↔cell pair over io.Pipe.
+type rig struct {
+	cond   *SDKConductor
+	agent  *fakeAgent
+	sink   *captureSink
+	asc    *acp.AgentSideConnection
+	closeF func()
+}
+
+// newRig wires a conductor (ACP client) to a fakeAgent (ACP server) over two
+// io.Pipe duplexes. gov / fs default to approve-allow / allow-all if nil.
+func newRig(t *testing.T, agent *fakeAgent, gov contract.Governor, fs contract.FsPolicy) *rig {
+	t.Helper()
+
+	// Two pipes: clientToAgent carries client→agent bytes; agentToClient carries
+	// agent→client bytes. The client writes to clientToAgentW and reads from
+	// agentToClientR; the agent writes to agentToClientW and reads clientToAgentR.
+	c2aR, c2aW := io.Pipe()
+	a2cR, a2cW := io.Pipe()
+
+	sink := &captureSink{}
+	if gov == nil {
+		gov = fnGovernor{fn: approveFirstAllow}
+	}
+	if fs == nil {
+		fs = allowAllFs()
+	}
+
+	cond := New(c2aW, a2cR, sink, gov, fs)
+	cond.SetLogger(quietLogger)
+	asc := acp.NewAgentSideConnection(agent, a2cW, c2aR)
+	asc.SetLogger(quietLogger)
+	agent.setConn(asc)
+
+	closeF := func() {
+		_ = c2aW.Close()
+		_ = a2cW.Close()
+		_ = c2aR.Close()
+		_ = a2cR.Close()
+	}
+	t.Cleanup(closeF)
+
+	return &rig{cond: cond, agent: agent, sink: sink, asc: asc, closeF: closeF}
+}
+
+// newConductorOverStreams wires a conductor to arbitrary peer streams (e.g. a
+// subprocess' stdin/stdout). Proves transport pluggability: the same adapter
+// works over any io.Writer/io.Reader pair.
+func newConductorOverStreams(peerInput io.Writer, peerOutput io.Reader, sink *captureSink) *SDKConductor {
+	c := New(peerInput, peerOutput, sink,
+		fnGovernor{fn: approveFirstAllow}, allowAllFs())
+	c.SetLogger(quietLogger)
+	return c
+}
+
+const testIss = "cog://identity/conductor/darkstar"
+const testSub = "cog://identity/cell/hermes-1"
+
+func testIdentity() contract.Identity {
+	return contract.Identity{Iss: testIss, Sub: testSub}
+}
+
+func defaultSpec(cwd string) contract.SessionSpec {
+	return contract.SessionSpec{
+		Cwd:        cwd,
+		Identity:   testIdentity(),
+		McpServers: nil,
+	}
+}

--- a/internal/conductor/transport_stdio_test.go
+++ b/internal/conductor/transport_stdio_test.go
@@ -1,0 +1,71 @@
+package conductor
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// TestTransportPluggability_Stdio proves the SAME conductor (contract.Conductor
+// backed by the SDK adapter) works over a real stdio-spawned subprocess, not just
+// io.Pipe. It spawns ./cmd/fakeagent, wires the conductor to its stdin/stdout,
+// and runs the initialize → new_session → prompt path, asserting the substrate
+// `_meta` identity survived the OS pipe (the subprocess echoes sub back).
+func TestTransportPluggability_Stdio(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping subprocess transport test in -short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "go", "run", "./cmd/fakeagent")
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatalf("StdinPipe: %v", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("StdoutPipe: %v", err)
+	}
+	cmd.Stderr = nil
+	if err := cmd.Start(); err != nil {
+		t.Skipf("could not start subprocess fake agent (offline `go run` build?): %v", err)
+	}
+	t.Cleanup(func() {
+		_ = stdin.Close()
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		_ = cmd.Wait()
+	})
+
+	sink := &captureSink{}
+	cond := newConductorOverStreams(stdin, stdout, sink)
+
+	callCtx, callCancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer callCancel()
+
+	if _, err := cond.Initialize(callCtx, testIdentity()); err != nil {
+		t.Fatalf("Initialize over stdio: %v", err)
+	}
+	sid, err := cond.NewSession(callCtx, defaultSpec("/x"))
+	if err != nil {
+		t.Fatalf("NewSession over stdio: %v", err)
+	}
+	if _, err := cond.Prompt(callCtx, sid, "echo identity"); err != nil {
+		t.Fatalf("Prompt over stdio: %v", err)
+	}
+
+	// The subprocess echoed the substrate sub back as an agent_message_chunk.
+	var saw bool
+	for _, e := range sink.all() {
+		if e.Kind == "agent_message_chunk" && e.Text == "sub="+testSub {
+			saw = true
+		}
+	}
+	if !saw {
+		t.Errorf("did not observe _meta sub round-trip over stdio; ledger=%v", sink.all())
+	}
+}


### PR DESCRIPTION
## What this is

Scaffolds the kernel `internal/conductor/` package as the foundation for the real conductor build (RFC-036: *The Conductor — CogOS-as-ACP-Client as the Substrate's Conducting Seat*, ADR-062 Layer 2). It ports the validated integration spike (`~/repos/conductor-acp-spike/`, race-clean + offline) into the module: the portable contract, the SDK adapter, the injected collaborators, and the full test suite.

**This is scaffold, not full implementation.** The interfaces + working SDK adapter + tests are real; the conductor's orchestration logic is stubbed with clear TODOs.

## Real and tested (the scaffold boundary)

- **`contract.Conductor`** — the portable, SDK-free ACP-client interface every RFC-036 verb maps onto: `initialize`, `new_session`, `prompt`, `cancel`, the fleet verbs `fork`/`list`/`resume`/`load`, `set_mode`/`set_config_option`, `close`, and the experimental MCP-over-ACP verbs.
- **`SDKConductor`** (`adapter.go`) — the only SDK-importing file, translating between `coder/acp-go-sdk` wire types and the contract's substrate-shaped types, wiring the SDK client-side handlers (`RequestPermission`, `SessionUpdate`, `ReadTextFile`/`WriteTextFile`, terminal ops) to the substrate collaborators.
- **`Governor` / `LedgerSink` / `FsPolicy`** — the RFC-009 consent boundary, the stigmergic (RFC-036 P5 / ADR-013) persistence boundary, and the deny-capable filesystem policy gate.
- **The test suite** — in-process fake cell over `io.Pipe` plus a real stdio-spawned subprocess (`cmd/fakeagent`). All update kinds routed to the ledger, `_meta` identity round-trip (incl. over real stdio), permission approve+deny, fork, list, resume, load-with-replay, set-mode/config, cancel-with-trailing-frame, fs policy gate, terminal deny, and N=8 concurrency with per-`SessionID` attribution (no cross-talk).

`go test -race -count=1 ./internal/conductor/...` → **PASS** (16 PASS, 2 documented SKIPs).

The two MCP-over-ACP subtests **skip** (as in the spike): `coder/acp-go-sdk` models `mcp/connect` agent-as-caller / client-as-handler only — there is no `ClientSideConnection.UnstableConnectMcp`, so a client-seat conductor cannot drive `mcp/connect` toward a cell over this SDK. Workaround today: attach MCP servers via `new_session`'s `McpServers` config. Upstream-contribution candidate noted in `ErrMcpDirectionUnsupported`.

## Stubbed (application logic — `TODO(conductor, RFC-036 ...)` markers + `doc.go`)

- **Fleet manager** (RFC-036 P3+P2): the orchestration loop owning N concurrent sessions. The contract multiplexes sessions cleanly (validated N=8 race-clean); the loop itself is not built here.
- **LedgerSink → real kernel ledger** (RFC-036 P5 / ADR-013): tests use a capture sink; production routes every `session/update` to the cogos ledger.
- **Governor → RFC-009 Proposer/Actor** (RFC-036 P4): tests inject a func governor; production routes permission requests through the substrate's policy/operator decision.
- **`_meta` from a real HarnessBinding identity** (RFC-036 P3 gap 6): tests inject a fixed identity; production derives `iss`/`sub` from the substrate binding model.

## Dependency

`github.com/coder/acp-go-sdk@v0.13.0` added via real `go get` (zero external deps; stdlib-only SDK). **No `replace` directive — this is a normal versioned dependency.** `go.sum` carries the verified hashes. The local-path-replace fallback was not needed.

> Note: `go mod tidy` could not be run to completion in this branch because of a pre-existing `pkg/substrate` submodule-resolution condition under the Go workspace (`go.work`), unrelated to this change — `go mod tidy` resolves submodules per-module and does not honor `go.work`. The `acp-go-sdk` require was placed in the direct-require block manually (exactly what tidy would produce); build, vet, and the full race test pass under the workspace.

## Relationship to `internal/acp` (not modified)

`internal/acp/` is the ADR-093 stream-json claude-CLI *server/subprocess* driver (the substrate owns a claude process). This package is the ACP *client* side (the conductor drives cells via the SDK's `ClientSideConnection`). They sit on opposite ends of the ACP relationship. Future unification behind one `ManagedSession`-shaped surface is possible but explicitly out of scope here; `internal/acp/` is untouched.

## File layout

```
internal/conductor/
  doc.go                     package doc + scaffold-boundary TODOs + internal/acp note
  adapter.go                 SDKConductor (the only SDK-importing file)
  contract/contract.go       contract.Conductor + substrate types (SDK-free)
  conductor_test.go          the verb + governance + concurrency suite
  harness_test.go            rig, captureSink, fn collaborators, test identity
  fakeagent_test.go          in-process programmable fake cell (ACP server)
  transport_stdio_test.go    real stdio-subprocess transport-pluggability test
  cmd/fakeagent/main.go      stdio fake-cell binary (test helper)
```

Ready for review. **Not merged.**