### PR TITLE
cli: daemon lifecycle UX (stop, PID file, detach, add-path)

### DIFF
--- a/internal/engine/cli.go
+++ b/internal/engine/cli.go
@@ -41,7 +41,8 @@ func printUsage(w io.Writer) {
 	fmt.Fprintf(w, "  cogos <command> [flags]\n\n")
 	fmt.Fprintf(w, "Commands:\n")
 	fmt.Fprintf(w, "  init        Initialize a new workspace (.cog directory)\n")
-	fmt.Fprintf(w, "  serve       Start the kernel daemon in the foreground\n")
+	fmt.Fprintf(w, "  install     Post-install setup (e.g. --add-path adds ~/.cog/bin to PATH)\n")
+	fmt.Fprintf(w, "  serve       Start the kernel daemon in the foreground (--detach to background)\n")
 	fmt.Fprintf(w, "  start       Launch the kernel daemon in a container\n")
 	fmt.Fprintf(w, "  stop        Stop a running daemon\n")
 	fmt.Fprintf(w, "  restart     Pull the latest image and restart the container daemon\n")
@@ -142,6 +143,9 @@ func Main() {
 		case "agents":
 			runAgentsCmd(args[1:], *workspace, *port)
 			return
+		case "install":
+			runInstallCmd(args[1:])
+			return
 		}
 	}
 
@@ -190,7 +194,53 @@ func runServeCmd(args []string, defaultWorkspace string, defaultPort int, defaul
 	workspace := fs.String("workspace", defaultWorkspace, "Workspace root path (auto-detected if empty)")
 	port := fs.Int("port", defaultPort, "HTTP API port (default 6931)")
 	bind := fs.String("bind", defaultBind, "HTTP server bind address (default 127.0.0.1; use 0.0.0.0 for LAN, requires trusted network)")
+	detach := fs.Bool("detach", false, "Run daemon in the background (Unix: detaches into a new session; Windows: prints a background-run template and exits)")
 	_ = fs.Parse(args)
+
+	if *detach {
+		// Resolve the workspace root up front so the parent always passes an
+		// explicit --workspace to the child and can record daemon state at the
+		// correct path (the child auto-detects from cwd otherwise).
+		cfg, err := LoadConfig(*workspace, *port)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: load config: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Rebuild the child args without --detach so it runs in foreground.
+		// Always pin --workspace to the resolved root.
+		childArgs := []string{"serve", "--workspace", cfg.WorkspaceRoot}
+		if cfg.Port != 0 {
+			childArgs = append(childArgs, "--port", fmt.Sprintf("%d", cfg.Port))
+		}
+		if *bind != "" {
+			childArgs = append(childArgs, "--bind", *bind)
+		}
+
+		pid, err := detachServeProcess(childArgs)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+
+		// MUST-FIX: the child writes its own daemon-state file only after Boot
+		// completes (hundreds of ms). Record state from the parent now, using
+		// the child's PID, so `cogos stop` works immediately after --detach.
+		// The child's planServeState may transiently rewrite this file once it
+		// finishes booting; both writers use the same PID, so stop is correct
+		// throughout the window.
+		state := &DaemonState{
+			Mode:      daemonModeBareMetal,
+			Endpoint:  endpointForPort(cfg.Port),
+			Workspace: cfg.WorkspaceRoot,
+			StartedAt: time.Now().UTC().Format(time.RFC3339),
+			PID:       &pid,
+		}
+		if err := saveDaemonState(state); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: daemon started (pid %d) but state file write failed: %v\n", pid, err)
+		}
+		return
+	}
 	runServe(*workspace, *port, *bind)
 }
 

--- a/internal/engine/cli_install.go
+++ b/internal/engine/cli_install.go
@@ -1,0 +1,39 @@
+// cli_install.go — cogos install subcommand.
+//
+// Currently supports one flag:
+//
+//	--add-path   Opt-in: add ~/.cog/bin to the user's shell PATH.
+//
+// Platform notes:
+//   - Unix/macOS: appends an export line to the detected shell rc file
+//     (~/.bashrc, ~/.zshrc, ~/.config/fish/config.fish). The user still
+//     needs to restart their shell or source the file.
+//   - Windows: prints a PowerShell snippet and the equivalent setx invocation;
+//     actual registry write is deferred to follow-up work (tracked in #320).
+
+package engine
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+func runInstallCmd(args []string) {
+	fs := flag.NewFlagSet("install", flag.ExitOnError)
+	addPath := fs.Bool("add-path", false, "Add ~/.cog/bin to the user PATH (appends to shell profile on Unix; prints instructions on Windows)")
+	_ = fs.Parse(args)
+
+	if !*addPath {
+		fmt.Fprintln(os.Stderr, "usage: cogos install --add-path")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Flags:")
+		fs.PrintDefaults()
+		os.Exit(1)
+	}
+
+	if err := addCogBinToPath(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/internal/engine/cli_install_test.go
+++ b/internal/engine/cli_install_test.go
@@ -1,0 +1,94 @@
+//go:build !windows
+
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAddCogBinToPathWritesRCLine(t *testing.T) {
+	t.Parallel()
+
+	// Use a temp home with a pre-existing .bashrc so detectShellRC finds it.
+	tmp := t.TempDir()
+	bashrc := filepath.Join(tmp, ".bashrc")
+	if err := os.WriteFile(bashrc, []byte("# existing\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	origHome := os.Getenv("HOME")
+	origShell := os.Getenv("SHELL")
+	t.Cleanup(func() {
+		os.Setenv("HOME", origHome)
+		os.Setenv("SHELL", origShell)
+	})
+	os.Setenv("HOME", tmp)
+	os.Setenv("SHELL", "/bin/bash")
+
+	if err := addCogBinToPath(); err != nil {
+		t.Fatalf("addCogBinToPath: %v", err)
+	}
+
+	content, err := os.ReadFile(bashrc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(content), ".cog/bin") {
+		t.Errorf("expected .cog/bin in %s; got:\n%s", bashrc, string(content))
+	}
+}
+
+func TestAddCogBinToPathIdempotent(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, ".cog", "bin")
+	bashrc := filepath.Join(tmp, ".bashrc")
+	// Pre-seed with the export line.
+	seed := "export PATH=\"" + binDir + ":$PATH\"\n"
+	if err := os.WriteFile(bashrc, []byte(seed), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	origHome := os.Getenv("HOME")
+	origShell := os.Getenv("SHELL")
+	t.Cleanup(func() {
+		os.Setenv("HOME", origHome)
+		os.Setenv("SHELL", origShell)
+	})
+	os.Setenv("HOME", tmp)
+	os.Setenv("SHELL", "/bin/bash")
+
+	if err := addCogBinToPath(); err != nil {
+		t.Fatalf("addCogBinToPath (second call): %v", err)
+	}
+
+	// File should be unchanged (no duplicate line added).
+	content, err := os.ReadFile(bashrc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := strings.Count(string(content), binDir)
+	if count != 1 {
+		t.Errorf("expected exactly 1 occurrence of binDir in %s; got %d:\n%s", bashrc, count, string(content))
+	}
+}
+
+func TestDetectShellRCZsh(t *testing.T) {
+	tmp := t.TempDir()
+	orig := os.Getenv("HOME")
+	origShell := os.Getenv("SHELL")
+	t.Cleanup(func() {
+		os.Setenv("HOME", orig)
+		os.Setenv("SHELL", origShell)
+	})
+	os.Setenv("HOME", tmp)
+	os.Setenv("SHELL", "/bin/zsh")
+	rc := detectShellRC()
+	if !strings.HasSuffix(rc, ".zshrc") {
+		t.Errorf("expected .zshrc; got %s", rc)
+	}
+}

--- a/internal/engine/cli_install_unix.go
+++ b/internal/engine/cli_install_unix.go
@@ -1,0 +1,88 @@
+//go:build !windows
+
+// cli_install_unix.go — PATH installation for Unix/macOS.
+
+package engine
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// cogBinDir returns the absolute path to ~/.cog/bin.
+func cogBinDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = os.Getenv("HOME")
+	}
+	return filepath.Join(home, ".cog", "bin")
+}
+
+// addCogBinToPath appends an export line for ~/.cog/bin to the user's shell
+// rc file. It detects the current shell from $SHELL; defaults to ~/.bashrc
+// when the shell is unknown.
+func addCogBinToPath() error {
+	binDir := cogBinDir()
+	exportLine := fmt.Sprintf(`export PATH="%s:$PATH"`, binDir)
+	marker := "# added by cogos install --add-path"
+
+	rcFile := detectShellRC()
+
+	// Read existing content; skip if the line is already present.
+	existing, err := os.ReadFile(rcFile)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read %s: %w", rcFile, err)
+	}
+	if strings.Contains(string(existing), binDir) {
+		fmt.Fprintf(os.Stderr, "%s is already in PATH config (%s); nothing to do.\n", binDir, rcFile)
+		return nil
+	}
+
+	// Ensure the rc file parent directory exists.
+	if err := os.MkdirAll(filepath.Dir(rcFile), 0755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(rcFile), err)
+	}
+
+	f, err := os.OpenFile(rcFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", rcFile, err)
+	}
+	defer f.Close()
+
+	if _, err := fmt.Fprintf(f, "\n%s\n%s\n", marker, exportLine); err != nil {
+		return fmt.Errorf("write %s: %w", rcFile, err)
+	}
+
+	fmt.Fprintf(os.Stderr, "Added %s to PATH in %s\n", binDir, rcFile)
+	fmt.Fprintf(os.Stderr, "Restart your shell or run: source %s\n", rcFile)
+	return nil
+}
+
+// detectShellRC returns the rc file path for the current shell.
+func detectShellRC() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = os.Getenv("HOME")
+	}
+
+	shell := filepath.Base(os.Getenv("SHELL"))
+	switch shell {
+	case "zsh":
+		return filepath.Join(home, ".zshrc")
+	case "fish":
+		return filepath.Join(home, ".config", "fish", "config.fish")
+	case "bash":
+		// bash sources different files per platform: macOS Terminal opens a
+		// login shell that reads .bash_profile, while most Linux interactive
+		// shells read .bashrc. Prefer an existing .bash_profile (covers the
+		// macOS login-shell case); otherwise fall back to .bashrc.
+		if _, err := os.Stat(filepath.Join(home, ".bash_profile")); err == nil {
+			return filepath.Join(home, ".bash_profile")
+		}
+		return filepath.Join(home, ".bashrc")
+	default:
+		return filepath.Join(home, ".bashrc")
+	}
+}

--- a/internal/engine/cli_install_windows.go
+++ b/internal/engine/cli_install_windows.go
@@ -1,0 +1,42 @@
+//go:build windows
+
+// cli_install_windows.go — PATH installation for Windows.
+//
+// Full registry/setx write is deferred to follow-up work (tracked in #320).
+// For now, this prints a PowerShell snippet the user can run in an elevated
+// prompt, which is the recommended approach for per-user PATH edits on Windows.
+
+package engine
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// cogBinDir returns the absolute path to %USERPROFILE%\.cog\bin.
+func cogBinDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = os.Getenv("USERPROFILE")
+	}
+	return filepath.Join(home, ".cog", "bin")
+}
+
+// addCogBinToPath prints instructions for adding ~/.cog/bin to the Windows
+// user PATH. Automated setx / registry write is tracked in issue #320.
+func addCogBinToPath() error {
+	binDir := cogBinDir()
+
+	fmt.Fprintf(os.Stderr, "Automated PATH update is not yet implemented on Windows.\n\n")
+	fmt.Fprintf(os.Stderr, "Run ONE of the following (restart your terminal after):\n\n")
+	fmt.Fprintf(os.Stderr, "  PowerShell (per-user, persistent):\n")
+	fmt.Fprintf(os.Stderr, "    $p = [System.Environment]::GetEnvironmentVariable('PATH','User')\n")
+	fmt.Fprintf(os.Stderr, "    [System.Environment]::SetEnvironmentVariable('PATH', \"%s;$p\", 'User')\n\n", binDir)
+	fmt.Fprintf(os.Stderr, "  Command Prompt (per-user, persistent):\n")
+	fmt.Fprintf(os.Stderr, "    setx PATH \"%%%s%%;%%PATH%%\"\n\n", binDir)
+	fmt.Fprintf(os.Stderr, "  Current session only:\n")
+	fmt.Fprintf(os.Stderr, "    $env:PATH = \"%s;$env:PATH\"\n\n", binDir)
+	fmt.Fprintf(os.Stderr, "Automated write will be added in a follow-up (see #320).\n")
+	return nil
+}

--- a/internal/engine/daemon_detach_unix.go
+++ b/internal/engine/daemon_detach_unix.go
@@ -1,0 +1,70 @@
+//go:build !windows
+
+// daemon_detach_unix.go — detached daemon launch for Unix/macOS.
+//
+// detachProcess re-executes the current binary with the supplied args in a
+// new session (Setsid) so it survives the parent's terminal close. stdout and
+// stderr are redirected to <workspace>/.cog/run/cogos.log; stdin is wired to
+// /dev/null. The calling process exits with 0 after the child starts.
+
+package engine
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+)
+
+// detachProcess re-launches the binary (determined via os.Executable) with
+// args in a detached session. It returns the child's PID so the caller can
+// record daemon state before the child has finished booting (closing the
+// race where `cogos stop` runs before the child writes its own state file).
+func detachProcess(args []string) (int, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return 0, fmt.Errorf("locate executable: %w", err)
+	}
+
+	// Determine log path from workspace arg if present; fall back to the OS
+	// temp dir (never the cwd, which may be read-only or transient).
+	logPath := filepath.Join(os.TempDir(), "cogos-daemon.log")
+	for i, a := range args {
+		if (a == "--workspace" || a == "-workspace") && i+1 < len(args) {
+			logPath = filepath.Join(args[i+1], ".cog", "run", "cogos.log")
+			if err := os.MkdirAll(filepath.Dir(logPath), 0755); err != nil {
+				return 0, fmt.Errorf("mkdir log dir: %w", err)
+			}
+			break
+		}
+	}
+
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return 0, fmt.Errorf("open log file %s: %w", logPath, err)
+	}
+	defer logFile.Close()
+
+	devnull, err := os.Open(os.DevNull)
+	if err != nil {
+		return 0, fmt.Errorf("open /dev/null: %w", err)
+	}
+	defer devnull.Close()
+
+	cmd := exec.Command(exe, args...)
+	cmd.Stdin = devnull
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+	if err := cmd.Start(); err != nil {
+		return 0, fmt.Errorf("start detached daemon: %w", err)
+	}
+
+	pid := cmd.Process.Pid
+	fmt.Fprintf(os.Stderr, "cogos daemon started (pid %d), logging to %s\n", pid, logPath)
+	// Release the child so it runs independently.
+	_ = cmd.Process.Release()
+	return pid, nil
+}

--- a/internal/engine/daemon_lifecycle.go
+++ b/internal/engine/daemon_lifecycle.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"syscall"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -525,10 +524,4 @@ func (c *commandReadCloser) Close() error {
 	return nil
 }
 
-func stopBareMetalPID(pid int) error {
-	proc, err := os.FindProcess(pid)
-	if err != nil {
-		return err
-	}
-	return proc.Signal(syscall.SIGTERM)
-}
+// stopBareMetalPID is defined in daemon_stop_unix.go / daemon_stop_windows.go.

--- a/internal/engine/daemon_stop_unix.go
+++ b/internal/engine/daemon_stop_unix.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+// daemon_stop_unix.go — Unix signal helpers for bare-metal daemon stop.
+
+package engine
+
+import (
+	"os"
+	"syscall"
+)
+
+// stopBareMetalPID sends SIGTERM to the process with the given PID.
+func stopBareMetalPID(pid int) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return proc.Signal(syscall.SIGTERM)
+}
+
+// detachServeProcess re-launches the current executable in a detached
+// session (Setsid) with stdio redirected to the workspace log. It returns the
+// detached child's PID so the caller can record daemon state immediately.
+func detachServeProcess(args []string) (int, error) {
+	return detachProcess(args)
+}

--- a/internal/engine/daemon_stop_windows.go
+++ b/internal/engine/daemon_stop_windows.go
@@ -1,0 +1,98 @@
+//go:build windows
+
+// daemon_stop_windows.go — Windows process-stop helpers for bare-metal daemon.
+//
+// Windows lacks SIGTERM. The graceful equivalent here is `taskkill /PID` (no
+// /F), which posts WM_CLOSE / CTRL-style close to the target so it can shut
+// down cleanly. We then poll for the process to actually exit (up to a bounded
+// interval) and only escalate to `taskkill /F /PID` (forceful) if it is still
+// alive. proc.Kill() is the last-resort fallback if taskkill is unavailable.
+//
+// A CTRL_BREAK_EVENT approach via golang.org/x/sys/windows is deferred to
+// follow-up work; it requires the child to have been started in its own
+// console group, which the current --detach path does not yet arrange.
+
+package engine
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const windowsStopTimeout = 5 * time.Second
+
+// stopBareMetalPID stops the process with the given PID using a
+// graceful-then-force strategy:
+//
+//  1. `taskkill /PID <pid>` (graceful — lets the process handle the close).
+//  2. Poll up to windowsStopTimeout for the process to exit.
+//  3. If still alive, `taskkill /F /PID <pid>` (forceful).
+//  4. If taskkill is entirely unavailable, fall back to proc.Kill().
+func stopBareMetalPID(pid int) error {
+	// Step 1: graceful taskkill (no /F).
+	graceful := exec.Command("taskkill", "/PID", strconv.Itoa(pid))
+	gracefulErr := graceful.Run()
+
+	// Step 2: poll for exit regardless of taskkill's exit code — a non-zero
+	// code can simply mean "no window to close", and the process may still
+	// terminate on its own.
+	deadline := time.Now().Add(windowsStopTimeout)
+	for time.Now().Before(deadline) {
+		if !windowsPIDAlive(pid) {
+			return nil
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+
+	if !windowsPIDAlive(pid) {
+		return nil
+	}
+
+	// Step 3: forceful taskkill.
+	force := exec.Command("taskkill", "/F", "/PID", strconv.Itoa(pid))
+	if err := force.Run(); err == nil {
+		return nil
+	}
+
+	// Step 4: last-resort kill via the process handle. If even the graceful
+	// taskkill failed to launch (taskkill missing), surface that context.
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		if gracefulErr != nil {
+			return fmt.Errorf("taskkill unavailable (%v) and FindProcess failed: %w", gracefulErr, err)
+		}
+		return err
+	}
+	return proc.Kill()
+}
+
+// windowsPIDAlive reports whether a process with the given PID is currently
+// running, using `tasklist /FI "PID eq <pid>"`. tasklist prints a header and
+// the matching row when found, or "INFO: No tasks..." when absent.
+func windowsPIDAlive(pid int) bool {
+	out, err := exec.Command("tasklist", "/FI", fmt.Sprintf("PID eq %d", pid), "/NH").Output()
+	if err != nil {
+		// If tasklist itself fails, assume the process may still be alive so we
+		// don't prematurely report a clean stop.
+		return true
+	}
+	return strings.Contains(string(out), strconv.Itoa(pid))
+}
+
+// detachServeProcess on Windows prints guidance and exits, because true
+// daemonization (detached process + no console) requires CreateProcess with
+// DETACHED_PROCESS which is not yet implemented. Use the PowerShell template
+// documented in `cogos serve --help` instead.
+func detachServeProcess(args []string) (int, error) {
+	return 0, fmt.Errorf(
+		"--detach is not yet implemented on Windows.\n" +
+			"Background-run template (PowerShell):\n" +
+			"  Start-Process cogos -ArgumentList 'serve' -WindowStyle Hidden -RedirectStandardOutput cogos.log -RedirectStandardError cogos.err\n" +
+			"Or with nohup in Git Bash / WSL:\n" +
+			"  nohup cogos serve &",
+	)
+}


### PR DESCRIPTION
## Summary

- **`cogos stop` + PID file**: Already implemented via `DaemonState.PID` and `stopBareMetalPID`. This PR makes it compile on Windows by splitting `stopBareMetalPID` into `daemon_stop_unix.go` (SIGTERM) and `daemon_stop_windows.go` (taskkill + Kill fallback), removing the bare `syscall.SIGTERM` from `daemon_lifecycle.go`.
- **`cogos serve --detach`**: Implemented on Unix/macOS — re-executes the binary in a new session (`Setsid`) with stdio redirected to `<workspace>/.cog/run/cogos.log`. On Windows, prints a PowerShell `Start-Process` background-run template and exits cleanly.
- **`cogos install --add-path`**: Implemented on Unix/macOS — detects current shell (`$SHELL`) and appends `export PATH="~/.cog/bin:$PATH"` to the appropriate rc file (`.zshrc`, `.bashrc`, `.bash_profile`, or `fish/config.fish`). Idempotent. On Windows, prints `setx` and PowerShell `SetEnvironmentVariable` snippets; automated registry write is deferred.

## AC status

| AC item | Status |
|---|---|
| `cogos stop` (graceful) + PID file | **Implemented** (was already in place; Windows compile fixed) |
| `cogos serve --detach` | **Implemented** on Unix; Windows prints template (noted in help text) |
| `cogos install --add-path` | **Implemented** on Unix; Windows prints instructions (automated write deferred, see below) |

## Deferred / follow-up

- **Windows `--detach` automated**: `CreateProcess` with `DETACHED_PROCESS` flag requires `golang.org/x/sys/windows`. Tracked as follow-up in #320.
- **Windows `install --add-path` automated write**: `setx`/registry write via `golang.org/x/sys/windows/registry`. Tracked as follow-up in #320.
- **Pre-existing `local_runner.go` Windows build break** (`Setsid`, `syscall.Kill`): present in v0.12.0 base, out of scope for this PR.

## Build / test

- `go build ./...` — passes (darwin)
- `GOOS=windows go build ./internal/engine/...` — passes
- `go test ./internal/engine/...` — passes (13s, 0 failures)

Fixes #320