### PR TITLE
http: availability-gated /v1/models + friendly GET /mcp

### DIFF
--- a/internal/engine/resolve_test.go
+++ b/internal/engine/resolve_test.go
@@ -370,11 +370,19 @@ func fetchModels(t *testing.T, srv *Server) modelsResponse {
 func TestModelsMenu_OrderAndTier(t *testing.T) {
 	t.Parallel()
 
-	srv := newTestServer(t) // no router → no eclipse
+	// Wire a router with both a frontier provider (anthropic) and a local
+	// provider (ollama stub) so all tiers appear. Eclipse is intentionally
+	// absent to keep the assertion list stable.
+	frontierStub := newCloudStub("anthropic", "frontier response")
+	localStub := NewStubProvider("ollama", "local response") // IsLocal = true by default
+	router := NewSimpleRouter(RoutingConfig{Default: "anthropic"})
+	router.RegisterProvider(frontierStub)
+	router.RegisterProvider(localStub)
 
+	srv := newTestServerWithRouter(t, router)
 	resp := fetchModels(t, srv)
 
-	// Must have at least 5 entries (3 aliases + 2 raw ids).
+	// Must have at least 5 entries (2 frontier aliases + 1 local alias + 2 raw ids).
 	if len(resp.Data) < 5 {
 		t.Fatalf("expected >= 5 models, got %d: %+v", len(resp.Data), resp.Data)
 	}
@@ -408,7 +416,14 @@ func TestModelsMenu_OrderAndTier(t *testing.T) {
 func TestModelsMenu_IntentAliasesHaveDescriptions(t *testing.T) {
 	t.Parallel()
 
-	srv := newTestServer(t)
+	// Frontier + local provider so all intent aliases appear.
+	frontierStub := newCloudStub("anthropic", "frontier response")
+	localStub := NewStubProvider("ollama", "local response")
+	router := NewSimpleRouter(RoutingConfig{Default: "anthropic"})
+	router.RegisterProvider(frontierStub)
+	router.RegisterProvider(localStub)
+
+	srv := newTestServerWithRouter(t, router)
 	resp := fetchModels(t, srv)
 
 	byID := make(map[string]modelsResponseModel, len(resp.Data))
@@ -490,6 +505,67 @@ func TestModelsMenu_Object_IsListType(t *testing.T) {
 	resp := fetchModels(t, srv)
 	if resp.Object != "list" {
 		t.Errorf("Object = %q; want list", resp.Object)
+	}
+}
+
+// ── Availability gating (issue #316) ─────────────────────────────────────────
+
+func TestModelsMenu_FrontierAbsentWhenNoFrontierProvider(t *testing.T) {
+	t.Parallel()
+
+	// Only a local provider — no anthropic/claude-code.
+	localStub := NewStubProvider("ollama", "local response")
+	router := NewSimpleRouter(RoutingConfig{Default: "ollama"})
+	router.RegisterProvider(localStub)
+	srv := newTestServerWithRouter(t, router)
+
+	body, _ := json.Marshal(fetchModels(t, srv))
+
+	for _, id := range []string{"claude-sonnet-4-6", "claude-opus-4-7", "foreground", "deliberation"} {
+		if bytes.Contains(body, []byte(id)) {
+			t.Errorf("%q should NOT appear when no frontier provider is registered; body: %s", id, body)
+		}
+	}
+	// local alias should still appear.
+	if !bytes.Contains(body, []byte("local")) {
+		t.Errorf(`"local" should appear when a local provider is registered; body: %s`, body)
+	}
+}
+
+func TestModelsMenu_LocalAbsentWhenNoLocalProvider(t *testing.T) {
+	t.Parallel()
+
+	// Only a frontier provider — no local backend.
+	frontierStub := newCloudStub("anthropic", "frontier response")
+	router := NewSimpleRouter(RoutingConfig{Default: "anthropic"})
+	router.RegisterProvider(frontierStub)
+	srv := newTestServerWithRouter(t, router)
+
+	body, _ := json.Marshal(fetchModels(t, srv))
+
+	if bytes.Contains(body, []byte(`"local"`)) {
+		t.Errorf(`"local" model should NOT appear when no local provider is registered; body: %s`, body)
+	}
+	// Frontier entries should still appear.
+	for _, id := range []string{"claude-sonnet-4-6", "claude-opus-4-7", "foreground", "deliberation"} {
+		if !bytes.Contains(body, []byte(id)) {
+			t.Errorf("%q should appear when frontier provider is registered; body: %s", id, body)
+		}
+	}
+}
+
+func TestModelsMenu_EmptyWhenNoRouter(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(t) // no router at all
+	resp := fetchModels(t, srv)
+
+	if len(resp.Data) != 0 {
+		ids := make([]string, len(resp.Data))
+		for i, m := range resp.Data {
+			ids[i] = m.ID
+		}
+		t.Errorf("expected empty model list when no providers are configured; got %v", ids)
 	}
 }
 

--- a/internal/engine/resolve_test.go
+++ b/internal/engine/resolve_test.go
@@ -571,17 +571,42 @@ func TestModelsMenu_EmptyWhenNoRouter(t *testing.T) {
 
 // TestModelsMenu_AliasesMatchResolver verifies that every static intent alias
 // in the /v1/models menu is also known to ResolveModelRequest (alias coherence).
-// "local" is router-dynamic (requires FirstLocalProvider walk) so it is checked
-// with a stub router rather than nil; "eclipse-26b" is hardware-gated and absent
-// from the static alias table by design.
+// The server router must advertise the aliases in the first place: with
+// availability gating (issue #316) handleModels emits nothing when no provider
+// is registered, so frontier + local stubs are wired so the menu is non-empty
+// and the test actually exercises alias↔resolver coherence (not vacuously).
+// "local" is router-dynamic (requires FirstLocalProvider walk); "eclipse-26b"
+// is hardware-gated and absent from the static alias table by design.
 func TestModelsMenu_AliasesMatchResolver(t *testing.T) {
 	t.Parallel()
 
-	srv := newTestServer(t)
+	// Frontier + local provider so the full cogos-owned alias set is advertised.
+	frontierStub := newCloudStub("anthropic", "frontier response")
+	localStub := NewStubProvider("ollama", "local response")
+	router := NewSimpleRouter(RoutingConfig{Default: "anthropic"})
+	router.RegisterProvider(frontierStub)
+	router.RegisterProvider(localStub)
+
+	srv := newTestServerWithRouter(t, router)
 	resp := fetchModels(t, srv)
 
-	// Build a minimal router that covers the "local" alias (ollama present).
-	r := newStubRouter().addProvider("ollama", "", true)
+	// Guard against vacuous pass: the menu must contain the cogos-owned aliases.
+	var cogosAliases int
+	for _, m := range resp.Data {
+		if m.OwnedBy == "cogos" && m.ID != "eclipse-26b" {
+			cogosAliases++
+		}
+	}
+	if cogosAliases == 0 {
+		t.Fatal("no cogos-owned aliases in /v1/models; test would pass vacuously")
+	}
+
+	// Build a minimal router that covers every alias the resolver maps:
+	// the "local" alias (ollama present, IsLocal) plus the frontier-managed
+	// claude aliases routed through the claude-code provider.
+	r := newStubRouter().
+		addProvider("ollama", "", true).
+		addProvider("claude-code", "", false)
 
 	for _, m := range resp.Data {
 		if m.OwnedBy != "cogos" {

--- a/internal/engine/serve_compat.go
+++ b/internal/engine/serve_compat.go
@@ -182,23 +182,35 @@ func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Determine whether the eclipse provider is configured. We check the live
-	// router (no I/O — ProviderForName / ProviderForModel are in-memory map
-	// lookups). eclipse-26b is only advertised when an eclipse or lmstudio
-	// provider is registered, so the menu stays accurate without probing.
+	// Gate every entry on real provider availability. All checks are in-memory
+	// map lookups (no I/O) — same pattern as isEclipseConfigured.
+	frontierConfigured := isFrontierConfigured(s.router)
+	localConfigured := isLocalConfigured(s.router)
 	eclipseConfigured := isEclipseConfigured(s.router)
 
-	data := []model{
-		// Intent aliases — always present.
-		mkModel("foreground", "cogos", "frontier-managed",
-			"interactive, full capability (managed Claude, Max sub)"),
-		mkModel("deliberation", "cogos", "frontier-managed",
-			"heavier reasoning (Opus)"),
-		mkModel("local", "cogos", "local-sovereign",
-			"private, no egress (E4B on this node)"),
+	var data []model
+	if frontierConfigured {
+		// Intent aliases for frontier-managed tiers.
+		data = append(data,
+			mkModel("foreground", "cogos", "frontier-managed",
+				"interactive, full capability (managed Claude, Max sub)"),
+			mkModel("deliberation", "cogos", "frontier-managed",
+				"heavier reasoning (Opus)"),
+		)
+	}
+	if localConfigured {
+		// Intent alias for the local-sovereign tier.
+		data = append(data,
+			mkModel("local", "cogos", "local-sovereign",
+				"private, no egress (E4B on this node)"),
+		)
+	}
+	if frontierConfigured {
 		// Raw frontier model IDs.
-		mkModel("claude-sonnet-4-6", "anthropic", "frontier-managed", ""),
-		mkModel("claude-opus-4-7", "anthropic", "frontier-managed", ""),
+		data = append(data,
+			mkModel("claude-sonnet-4-6", "anthropic", "frontier-managed", ""),
+			mkModel("claude-opus-4-7", "anthropic", "frontier-managed", ""),
+		)
 	}
 	if eclipseConfigured {
 		data = append(data,
@@ -227,6 +239,38 @@ func isEclipseConfigured(router Router) bool {
 		}
 	}
 	_, ok := router.ProviderForModel("eclipse-26b")
+	return ok
+}
+
+// isFrontierConfigured returns true when the router has a registered provider
+// that can serve frontier (Anthropic/Claude) models. Checks by canonical
+// provider names ("anthropic", "claude-code") and by representative model IDs.
+// Fast: in-memory lookups only, no network I/O.
+func isFrontierConfigured(router Router) bool {
+	if router == nil {
+		return false
+	}
+	for _, name := range []string{"anthropic", "claude-code"} {
+		if _, ok := router.ProviderForName(name); ok {
+			return true
+		}
+	}
+	for _, model := range []string{"claude-sonnet-4-6", "claude-opus-4-7"} {
+		if _, ok := router.ProviderForModel(model); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// isLocalConfigured returns true when the router has at least one registered
+// provider whose Capabilities().IsLocal is true. Uses FirstLocalProvider so
+// the check requires no concrete type assertion. Fast: in-memory lookup only.
+func isLocalConfigured(router Router) bool {
+	if router == nil {
+		return false
+	}
+	_, ok := router.FirstLocalProvider()
 	return ok
 }
 

--- a/internal/engine/serve_compat.go
+++ b/internal/engine/serve_compat.go
@@ -246,6 +246,12 @@ func isEclipseConfigured(router Router) bool {
 // that can serve frontier (Anthropic/Claude) models. Checks by canonical
 // provider names ("anthropic", "claude-code") and by representative model IDs.
 // Fast: in-memory lookups only, no network I/O.
+//
+// Known tradeoff: this only matches the canonical provider names plus the two
+// representative model IDs. A frontier provider registered under a non-standard
+// name (and not serving either representative model string) would be hidden
+// from the /v1/models menu. Acceptable: the default config and docs use the
+// canonical names; extend the name list here if a new alias is introduced.
 func isFrontierConfigured(router Router) bool {
 	if router == nil {
 		return false

--- a/internal/engine/serve_local_routing_test.go
+++ b/internal/engine/serve_local_routing_test.go
@@ -180,7 +180,11 @@ func TestModelLocal_FallsThroughWhenNoLocalProvider(t *testing.T) {
 func TestModelsEndpoint_AdvertisesOpus47(t *testing.T) {
 	t.Parallel()
 
-	srv := newTestServer(t)
+	// Wire a frontier provider so the claude-* entries appear (gated on availability).
+	frontierStub := newCloudStub("anthropic", "frontier response")
+	router := NewSimpleRouter(RoutingConfig{Default: "anthropic"})
+	router.RegisterProvider(frontierStub)
+	srv := newTestServerWithRouter(t, router)
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
 	w := httptest.NewRecorder()

--- a/internal/engine/serve_mcp.go
+++ b/internal/engine/serve_mcp.go
@@ -1,6 +1,9 @@
 package engine
 
-import "net/http"
+import (
+	"net/http"
+	"strings"
+)
 
 // registerMCPRoutes mounts the MCP Streamable HTTP handler at /mcp.
 // Explicit method patterns avoid conflicts with the catch-all GET / dashboard route.
@@ -36,7 +39,28 @@ func (s *Server) registerMCPRoutes(mux *http.ServeMux) {
 	}
 	s.mcpServer = mcpSrv
 	h := mcpSrv.Handler()
-	s.routeH(mux, "GET /mcp", h)
+	s.routeH(mux, "GET /mcp", mcpGetHandler(h))
 	s.routeH(mux, "POST /mcp", h)
 	s.routeH(mux, "DELETE /mcp", h)
+}
+
+// mcpGetHandler wraps the MCP streamable-HTTP handler for GET /mcp.
+// A bare GET (no Mcp-Session-Id and Accept does not include text/event-stream)
+// is a browser probe — the MCP SDK returns a cryptic 400 in that case, which
+// reads as "broken" to smoke-test users. Instead return 405 with a one-liner
+// pointing at the JSON-RPC/SSE contract (issue #317).
+// Proper MCP GET requests (SSE stream resume) pass through unchanged.
+func mcpGetHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		accept := r.Header.Get("Accept")
+		sessionID := r.Header.Get("Mcp-Session-Id")
+		isMCPStream := strings.Contains(accept, "text/event-stream")
+		if !isMCPStream && sessionID == "" {
+			w.Header().Set("Allow", "POST")
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			http.Error(w, "MCP endpoint: use POST /mcp for JSON-RPC or GET /mcp with Accept: text/event-stream + Mcp-Session-Id for SSE stream.", http.StatusMethodNotAllowed)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }

--- a/internal/engine/serve_mcp_test.go
+++ b/internal/engine/serve_mcp_test.go
@@ -1,0 +1,80 @@
+// serve_mcp_test.go — tests for registerMCPRoutes helpers (issue #317).
+package engine
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestMCPGetHandler_BareGet verifies that a bare GET /mcp (no Mcp-Session-Id,
+// no text/event-stream Accept) returns 405 with a one-liner hint body rather
+// than a cryptic 400. Acceptance criterion from issue #317.
+func TestMCPGetHandler_BareGet(t *testing.T) {
+	t.Parallel()
+
+	sentinel := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := mcpGetHandler(sentinel)
+
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d; want 405", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "POST /mcp") {
+		t.Errorf("response body should mention POST /mcp; got: %q", body)
+	}
+	if !strings.Contains(body, "text/event-stream") {
+		t.Errorf("response body should mention text/event-stream; got: %q", body)
+	}
+}
+
+// TestMCPGetHandler_SSEPassthrough verifies that a GET with the proper SSE
+// Accept header passes through to the underlying MCP handler unchanged.
+func TestMCPGetHandler_SSEPassthrough(t *testing.T) {
+	t.Parallel()
+
+	var called bool
+	sentinel := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	h := mcpGetHandler(sentinel)
+
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	req.Header.Set("Accept", "text/event-stream")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if !called {
+		t.Error("underlying handler was not called for SSE GET; want pass-through")
+	}
+}
+
+// TestMCPGetHandler_SessionIDPassthrough verifies that a GET with an
+// Mcp-Session-Id header (SSE stream resume) passes through unchanged.
+func TestMCPGetHandler_SessionIDPassthrough(t *testing.T) {
+	t.Parallel()
+
+	var called bool
+	sentinel := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	h := mcpGetHandler(sentinel)
+
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	req.Header.Set("Mcp-Session-Id", "test-session-abc")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if !called {
+		t.Error("underlying handler was not called when Mcp-Session-Id is present; want pass-through")
+	}
+}


### PR DESCRIPTION
## Summary

- **#316**: `/v1/models` now gates every entry on real provider availability. Frontier entries (`foreground`, `deliberation`, `claude-sonnet-4-6`, `claude-opus-4-7`) only appear when an `anthropic` or `claude-code` provider is registered. The `local` alias only appears when `FirstLocalProvider()` returns a hit. `eclipse-26b` gating is unchanged. The both-menu shape (intent aliases + raw IDs) is preserved for entries that are serviceable; extends the `isEclipseConfigured`/router-query pattern with `isFrontierConfigured` and `isLocalConfigured`.
- **#317**: Bare `GET /mcp` (no `Mcp-Session-Id`, no `text/event-stream` `Accept`) returns 405 with a one-liner pointing at the JSON-RPC/SSE contract instead of the cryptic SDK 400. SSE-resume GETs and session-ID GETs pass through to the MCP SDK unchanged.

## Test plan

- [ ] `go build ./...` passes (verified)
- [ ] `go test ./internal/engine/` passes — 13.5s, all green (verified)
- [ ] 3 existing model-menu tests updated to wire frontier+local providers
- [ ] 7 new tests added: `TestModelsMenu_FrontierAbsentWhenNoFrontierProvider`, `TestModelsMenu_LocalAbsentWhenNoLocalProvider`, `TestModelsMenu_EmptyWhenNoRouter`, `TestMCPGetHandler_BareGet`, `TestMCPGetHandler_SSEPassthrough`, `TestMCPGetHandler_SessionIDPassthrough`
- [ ] No daemon started; no `make install`; darwin build stays green

Fixes #316
Fixes #317