### PR TITLE
daemon: quiet fresh-install WARN spam + reachable default provider

### DIFF
--- a/internal/engine/projection_compiler.go
+++ b/internal/engine/projection_compiler.go
@@ -225,6 +225,10 @@ func (c *ProjectionCompiler) Type() string { return CompilerType }
 
 // LoadConfig resolves the source directory, cogblock.py path, and state
 // path from the workspace root. Read-only disk operation.
+//
+// When cogblock.py is absent (fresh install, Windows, Python not set up),
+// LoadConfig logs at DEBUG and returns a nil config so the reconcile cycle
+// exits with "no drift" rather than WARNing on every tick.
 func (c *ProjectionCompiler) LoadConfig(root string) (any, error) {
 	cfg := &CompilerConfig{
 		SourceDir:    filepath.Join(root, ".cog", "mem", "reflective"),
@@ -232,9 +236,17 @@ func (c *ProjectionCompiler) LoadConfig(root string) (any, error) {
 		StatePath:    filepath.Join(root, ".cog", "state", "projection-compiler.json"),
 	}
 	if _, err := os.Stat(cfg.SourceDir); err != nil {
+		if os.IsNotExist(err) {
+			slog.Debug("projection-compiler: source dir absent, skipping", "dir", cfg.SourceDir)
+			return nil, nil
+		}
 		return nil, fmt.Errorf("source dir: %w", err)
 	}
 	if _, err := os.Stat(cfg.CogblockPath); err != nil {
+		if os.IsNotExist(err) {
+			slog.Debug("projection-compiler: cogblock.py absent, skipping", "path", cfg.CogblockPath)
+			return nil, nil
+		}
 		return nil, fmt.Errorf("cogblock.py at %s: %w", cfg.CogblockPath, err)
 	}
 	return cfg, nil
@@ -253,6 +265,10 @@ func resolveCogblockPath(root string) string {
 // each .cog.md file via cogblock.py, and returns the in-memory sourceCogdoc
 // slice. Read-only against source files.
 func (c *ProjectionCompiler) FetchLive(ctx context.Context, config any) (any, error) {
+	// nil config means cogblock.py or source dir is absent — skip silently.
+	if config == nil {
+		return []*sourceCogdoc{}, nil
+	}
 	cfg, ok := config.(*CompilerConfig)
 	if !ok {
 		return nil, fmt.Errorf("projection-compiler: unexpected config type %T", config)
@@ -360,6 +376,10 @@ func deriveSlug(path string, fm map[string]any) string {
 // block list from the same live snapshot (passed through plan.Metadata) to
 // emit events deterministically.
 func (c *ProjectionCompiler) ComputePlan(config any, live any, _ *reconcile.State) (*reconcile.Plan, error) {
+	// nil config means cogblock.py / source dir absent — nothing to compile.
+	if config == nil {
+		return &reconcile.Plan{ResourceType: c.Type()}, nil
+	}
 	cfg := config.(*CompilerConfig)
 	docs, ok := live.([]*sourceCogdoc)
 	if !ok {
@@ -570,6 +590,10 @@ func buildEventFromAction(action reconcile.Action) (projection.Event, error) {
 // BuildState constructs the reconcile.State snapshot. One Resource per
 // extracted block: address = source URI, external_id = content_hash.
 func (c *ProjectionCompiler) BuildState(config any, live any, existing *reconcile.State) (*reconcile.State, error) {
+	// nil config means cogblock.py / source dir absent — return empty state.
+	if config == nil {
+		return reconcile.NewState(c.Type()), nil
+	}
 	cfg, ok := config.(*CompilerConfig)
 	if !ok {
 		return nil, fmt.Errorf("projection-compiler: unexpected config type %T", config)

--- a/internal/engine/projection_reconciler.go
+++ b/internal/engine/projection_reconciler.go
@@ -33,6 +33,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -170,15 +171,23 @@ func (r *ProjectionReconciler) Type() string {
 
 // LoadConfig discovers the nodes/ directory from the workspace root and
 // returns a ProjectionConfig. This is a read-only disk operation.
+//
+// When the lineage nodes directory does not yet exist (fresh install, or
+// workspace pre-dating the lineage observatory), LoadConfig logs at DEBUG
+// and returns nil so the reconcile cycle exits cleanly with no drift rather
+// than WARNing on every tick. The directory is created by `cogos init` once
+// the user opts into the lineage corpus.
 func (r *ProjectionReconciler) LoadConfig(root string) (any, error) {
 	lineageBase := filepath.Join(root, ".cog", "mem", "semantic", "lineage")
 	nodesDir := filepath.Join(lineageBase, "nodes")
 	projDir := filepath.Join(lineageBase, "projections")
 
-	// Verify nodes directory exists; create projections dir if needed.
+	// Verify nodes directory exists; skip quietly if absent.
 	if _, err := os.Stat(nodesDir); err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("lineage nodes directory not found at %s", nodesDir)
+			slog.Debug("lineage-projection: nodes dir absent, skipping",
+				"kind", r.kind, "dir", nodesDir)
+			return nil, nil
 		}
 		return nil, fmt.Errorf("stat nodes dir: %w", err)
 	}
@@ -196,6 +205,10 @@ func (r *ProjectionReconciler) LoadConfig(root string) (any, error) {
 // FetchLive reads all .cog.md files from the nodes/ directory and parses
 // their frontmatter. This is a read-only observation of the world.
 func (r *ProjectionReconciler) FetchLive(ctx context.Context, config any) (any, error) {
+	// nil config means nodes dir absent — nothing to observe.
+	if config == nil {
+		return []LineageNode{}, nil
+	}
 	cfg, ok := config.(*ProjectionConfig)
 	if !ok {
 		return nil, fmt.Errorf("projection reconciler: unexpected config type %T", config)
@@ -251,6 +264,10 @@ func (r *ProjectionReconciler) FetchLive(ctx context.Context, config any) (any, 
 //
 // This is a pure function: deterministic given (config, live, state).
 func (r *ProjectionReconciler) ComputePlan(config any, live any, state *reconcile.State) (*reconcile.Plan, error) {
+	// nil config means nodes dir absent — nothing to project.
+	if config == nil {
+		return &reconcile.Plan{ResourceType: r.Type()}, nil
+	}
 	cfg := config.(*ProjectionConfig)
 	nodes := live.([]LineageNode)
 
@@ -419,6 +436,10 @@ func (r *ProjectionReconciler) ApplyPlan(ctx context.Context, plan *reconcile.Pl
 // BuildState constructs the reconciler state from live data.
 // Pure function — no side effects.
 func (r *ProjectionReconciler) BuildState(config any, live any, existing *reconcile.State) (*reconcile.State, error) {
+	// nil config means nodes dir absent — return empty state.
+	if config == nil {
+		return reconcile.NewState(r.Type()), nil
+	}
 	nodes := live.([]LineageNode)
 	cfg := config.(*ProjectionConfig)
 

--- a/internal/engine/provider_mlx_supervised_test.go
+++ b/internal/engine/provider_mlx_supervised_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -438,7 +439,14 @@ func TestComputePlanServiceNotRunning(t *testing.T) {
 
 // TestBuildRouterRegistersMLXSupervisedType: when providers.yaml declares a
 // type=mlx-supervised entry, BuildRouter registers an MLXSupervisedProvider.
+//
+// mlx-supervised requires Apple Metal; BuildRouter's makeProvider gate
+// (router.go, case mlxSupervisedType) skips it on non-darwin platforms. The
+// registration assertions below therefore only hold on darwin.
 func TestBuildRouterRegistersMLXSupervisedType(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("mlx-supervised only registers on darwin")
+	}
 	t.Parallel()
 	root := makeWorkspace(t)
 	writeTestFile(t, filepath.Join(root, ".cog", "config", "providers.yaml"), `

--- a/internal/engine/router.go
+++ b/internal/engine/router.go
@@ -8,7 +8,10 @@
 //  5. Record every routing decision for future sentinel training
 //
 // BuildRouter reads .cog/config/providers.yaml and instantiates enabled providers.
-// Falls back to a default Ollama config when no providers.yaml is present.
+// When no providers.yaml is present it probes for a reachable local backend
+// (LM Studio on :1234, then Ollama on :11434) and builds a default config around
+// whichever responds; if neither is up it surfaces a "no local model configured"
+// placeholder rather than a dead default.
 package engine
 
 import (
@@ -329,7 +332,7 @@ func BuildRouter(cfg *Config, opts ...BuildRouterOption) (Router, error) {
 
 	pcfg, err := loadProvidersConfig(cfg)
 	if err != nil {
-		slog.Warn("router: providers.yaml not found, using default (ollama)", "err", err)
+		slog.Warn("router: providers.yaml not found, probing local backends", "err", err)
 		pcfg = defaultProvidersConfig(cfg.LocalModel)
 	}
 

--- a/internal/engine/router.go
+++ b/internal/engine/router.go
@@ -15,8 +15,10 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -546,6 +548,14 @@ func makeProvider(name string, pc ProviderConfig, procMgr *ProcessManager) (Prov
 	case "stub":
 		return NewStubProvider(name, "stub response"), nil
 	case mlxSupervisedType:
+		// mlx-supervised requires Apple Metal (macOS only). On any other OS,
+		// skip the provider rather than registering a dead driver — mirrors the
+		// codex GOOS guard at provider_codex.go:99.
+		if runtime.GOOS != "darwin" {
+			slog.Debug("router: mlx-supervised skipped on non-darwin platform",
+				"name", name, "goos", runtime.GOOS)
+			return nil, fmt.Errorf("mlx-supervised provider %q requires darwin (got %s)", name, runtime.GOOS)
+		}
 		supervisor := ServiceSupervisor(NewLaunchctlController())
 		p, err := newMLXSupervisedProvider(name, pc, supervisor)
 		if err != nil {
@@ -563,27 +573,106 @@ func makeProvider(name string, pc ProviderConfig, procMgr *ProcessManager) (Prov
 	}
 }
 
-// defaultProvidersConfig returns a minimal config pointing at local Ollama.
+// probeLocalBackend probes LM Studio (:1234) then Ollama (:11434) with a
+// short timeout. Returns the first reachable (name, endpoint) pair, or
+// ("", "") when neither is up. Used by defaultProvidersConfig to avoid
+// registering a dead default on fresh installs that have no local LLM stack.
+func probeLocalBackend() (name, endpoint string) {
+	type candidate struct {
+		name     string
+		endpoint string
+		path     string
+	}
+	candidates := []candidate{
+		{name: "lmstudio", endpoint: "http://localhost:1234", path: "/v1/models"},
+		{name: "ollama", endpoint: "http://localhost:11434", path: "/api/version"},
+	}
+	client := &http.Client{Timeout: 1 * time.Second}
+	for _, c := range candidates {
+		resp, err := client.Get(c.endpoint + c.path)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode < 500 {
+				return c.name, c.endpoint
+			}
+		}
+	}
+	return "", ""
+}
+
+// defaultProvidersConfig returns a minimal provider config for use when no
+// providers.yaml is present. It probes LM Studio (:1234) then Ollama (:11434)
+// to pick a reachable backend. When neither is up, the config records the
+// state so the router can surface a clear "no local model configured" signal
+// instead of routing to a dead default.
 func defaultProvidersConfig(localModel string) ProvidersConfig {
 	enabled := true
-	if localModel == "" {
-		localModel = defaultOllamaModel
-	}
-	return ProvidersConfig{
-		Providers: map[string]ProviderConfig{
-			"ollama": {
-				Type:     "ollama",
-				Enabled:  &enabled,
-				Endpoint: "http://localhost:11434",
-				Model:    localModel,
-				Timeout:  60,
+	disabledFalse := false
+
+	backendName, backendEndpoint := probeLocalBackend()
+
+	switch backendName {
+	case "lmstudio":
+		// LM Studio is reachable at :1234 (OpenAI-compat).
+		slog.Info("router: no providers.yaml, auto-selected LM Studio as default local backend")
+		return ProvidersConfig{
+			Providers: map[string]ProviderConfig{
+				"lmstudio": {
+					Type:     "openai-compat",
+					Enabled:  &enabled,
+					Endpoint: backendEndpoint,
+					Model:    localModel, // empty = LM Studio uses the loaded model
+					Timeout:  60,
+				},
 			},
-		},
-		Routing: RoutingConfig{
-			Default:        "ollama",
-			LocalThreshold: 0.8,
-			FallbackChain:  []string{"ollama"},
-		},
+			Routing: RoutingConfig{
+				Default:        "lmstudio",
+				LocalThreshold: 0.8,
+				FallbackChain:  []string{"lmstudio"},
+			},
+		}
+
+	case "ollama":
+		// Ollama is reachable; use the configured or default model.
+		if localModel == "" {
+			localModel = defaultOllamaModel
+		}
+		slog.Info("router: no providers.yaml, auto-selected Ollama as default local backend")
+		return ProvidersConfig{
+			Providers: map[string]ProviderConfig{
+				"ollama": {
+					Type:     "ollama",
+					Enabled:  &enabled,
+					Endpoint: backendEndpoint,
+					Model:    localModel,
+					Timeout:  60,
+				},
+			},
+			Routing: RoutingConfig{
+				Default:        "ollama",
+				LocalThreshold: 0.8,
+				FallbackChain:  []string{"ollama"},
+			},
+		}
+
+	default:
+		// Neither LM Studio nor Ollama is reachable. Register a placeholder
+		// provider that is explicitly disabled so the router can report a clear
+		// "no local model configured" state instead of silently failing on the
+		// first inference request.
+		slog.Warn("router: no providers.yaml and no local LLM backend reachable " +
+			"(tried LM Studio :1234, Ollama :11434); add providers.yaml or start a local server")
+		return ProvidersConfig{
+			Providers: map[string]ProviderConfig{
+				"no-local-model": {
+					Type:    "stub",
+					Enabled: &disabledFalse,
+				},
+			},
+			Routing: RoutingConfig{
+				LocalThreshold: 0.8,
+			},
+		}
 	}
 }
 

--- a/internal/engine/router_test.go
+++ b/internal/engine/router_test.go
@@ -261,14 +261,25 @@ func TestMakeProviderVLLM(t *testing.T) {
 func TestDefaultProvidersConfig(t *testing.T) {
 	t.Parallel()
 	pcfg := defaultProvidersConfig(defaultOllamaModel)
-	if _, ok := pcfg.Providers["ollama"]; !ok {
-		t.Error("default config should have ollama provider")
-	}
-	if pcfg.Routing.Default != "ollama" {
-		t.Errorf("default routing = %q; want ollama", pcfg.Routing.Default)
-	}
-	if pcfg.Providers["ollama"].Model != defaultOllamaModel {
-		t.Errorf("default ollama model = %q; want %q", pcfg.Providers["ollama"].Model, defaultOllamaModel)
+	// defaultProvidersConfig probes LM Studio (:1234) then Ollama (:11434) and
+	// selects whichever is reachable. On machines with neither running it
+	// returns the no-local-model placeholder. Any of these three outcomes is valid.
+	switch {
+	case pcfg.Providers["ollama"].Type == "ollama":
+		if pcfg.Providers["ollama"].Model != defaultOllamaModel {
+			t.Errorf("ollama model = %q; want %q", pcfg.Providers["ollama"].Model, defaultOllamaModel)
+		}
+		if pcfg.Routing.Default != "ollama" {
+			t.Errorf("routing default = %q; want ollama", pcfg.Routing.Default)
+		}
+	case pcfg.Providers["lmstudio"].Type == "openai-compat":
+		if pcfg.Routing.Default != "lmstudio" {
+			t.Errorf("routing default = %q; want lmstudio", pcfg.Routing.Default)
+		}
+	case pcfg.Providers["no-local-model"].Type == "stub":
+		// No local backend reachable — placeholder config is correct.
+	default:
+		t.Errorf("unexpected default providers config: %+v", pcfg.Providers)
 	}
 }
 

--- a/internal/engine/worktree_reconciler.go
+++ b/internal/engine/worktree_reconciler.go
@@ -32,6 +32,7 @@ package engine
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -265,11 +266,19 @@ func (r *WorktreeReconciler) LoadConfig(workspaceRoot string) (any, error) {
 
 // FetchLive runs `git worktree list --porcelain` against the repo root and
 // queries per-worktree git state. Read-only.
+//
+// When git is absent (nil, nil from ListWorktrees) FetchLive returns an empty
+// slice so the reconcile cycle proceeds to ComputePlan with no worktrees — no
+// WARN, no drift, clean first-boot behaviour on machines without git.
 func (r *WorktreeReconciler) FetchLive(ctx context.Context, _ any) (any, error) {
 	live, err := r.GitAdapter.ListWorktrees(ctx, r.RepoRoot)
 	if err != nil {
 		r.setHealth(reconcile.SyncStatusUnknown, reconcile.HealthDegraded, fmt.Sprintf("git list: %v", err))
 		return nil, fmt.Errorf("worktree-reconciler: git list: %w", err)
+	}
+	if live == nil {
+		// git not on PATH; treat as empty worktree set.
+		return []LiveWorktree{}, nil
 	}
 	return live, nil
 }
@@ -718,6 +727,14 @@ type CLIGitAdapter struct{}
 func NewCLIGitAdapter() *CLIGitAdapter { return &CLIGitAdapter{} }
 
 func (a *CLIGitAdapter) ListWorktrees(ctx context.Context, repoRoot string) ([]LiveWorktree, error) {
+	// Check that git is available before attempting the worktree list. On
+	// Windows fresh installs git is frequently absent; missing git is not an
+	// error condition — it just means no worktrees to manage.
+	if _, err := exec.LookPath("git"); err != nil {
+		slog.Debug("worktree-reconciler: git not on PATH, skipping worktree list")
+		return nil, nil
+	}
+
 	cmd := exec.CommandContext(ctx, "git", "worktree", "list", "--porcelain")
 	cmd.Dir = repoRoot
 	out, err := cmd.Output()

--- a/internal/providers/component/component_provider.go
+++ b/internal/providers/component/component_provider.go
@@ -18,6 +18,7 @@ package component
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -112,10 +113,16 @@ func init() {
 func (c *ComponentProvider) Type() string { return "component" }
 
 // LoadConfig loads the component registry from .cog/conf/components.cog.md.
+//
+// When LoadRegistry is nil (daemon binary, or fresh install before the CLI DI
+// seams are wired) LoadConfig returns nil so the reconcile daemon cycle exits
+// with "no drift" rather than WARNing on every tick. The full plan/apply path
+// is only available when this provider is driven from the cog CLI binary.
 func (c *ComponentProvider) LoadConfig(root string) (any, error) {
 	c.root = root
 	if LoadRegistry == nil {
-		return nil, fmt.Errorf("component provider: LoadRegistry dependency not wired")
+		slog.Debug("component provider: LoadRegistry not wired (daemon context), skipping cycle")
+		return nil, nil
 	}
 	return LoadRegistry(root)
 }
@@ -123,6 +130,10 @@ func (c *ComponentProvider) LoadConfig(root string) (any, error) {
 // FetchLive runs the component indexer and loads individual blobs for
 // comparison. Returns map[string]*Blob keyed by component path.
 func (c *ComponentProvider) FetchLive(ctx context.Context, config any) (any, error) {
+	// nil config means LoadRegistry was not wired — nothing to observe.
+	if config == nil {
+		return map[string]*Blob{}, nil
+	}
 	root := c.root
 	if root == "" {
 		return nil, fmt.Errorf("component provider: root not set (call LoadConfig first)")
@@ -153,6 +164,10 @@ func (c *ComponentProvider) FetchLive(ctx context.Context, config any) (any, err
 // ComputePlan compares declared config (registry) against live state (blobs)
 // and produces a reconciliation plan.
 func (c *ComponentProvider) ComputePlan(config any, live any, state *reconcile.State) (*reconcile.Plan, error) {
+	// nil config means LoadRegistry was not wired — nothing to plan.
+	if config == nil {
+		return &reconcile.Plan{ResourceType: "component"}, nil
+	}
 	reg := config.(*Registry)
 	blobs := live.(map[string]*Blob)
 
@@ -310,6 +325,10 @@ func (c *ComponentProvider) ApplyPlan(ctx context.Context, plan *reconcile.Plan)
 
 // BuildState constructs reconcile state from live blobs.
 func (c *ComponentProvider) BuildState(config any, live any, existing *reconcile.State) (*reconcile.State, error) {
+	// nil config means LoadRegistry was not wired — return empty state.
+	if config == nil {
+		return reconcile.NewState("component"), nil
+	}
 	blobs := live.(map[string]*Blob)
 
 	state := &reconcile.State{

--- a/internal/providers/daemon/daemon.go
+++ b/internal/providers/daemon/daemon.go
@@ -156,16 +156,16 @@ func (p *pinProvider) Health() reconcile.ResourceStatus {
 }
 
 func init() {
-	reconcile.RegisterProvider("agent", &agentProvider{})
-	reconcile.RegisterProvider("discord", &discordProvider{})
-	reconcile.RegisterProvider("eval", &evalProvider{})
+	reconcile.RegisterProvider("agent", &agentProvider{stubMethods: stubMethods{name: "agent"}})
+	reconcile.RegisterProvider("discord", &discordProvider{stubMethods: stubMethods{name: "discord"}})
+	reconcile.RegisterProvider("eval", &evalProvider{stubMethods: stubMethods{name: "eval"}})
 	reconcile.RegisterProvider("identity", &identityProvider{stubMethods: stubMethods{name: "identity"}})
-	reconcile.RegisterProvider("mcp-tools", &mcpToolsProvider{})
-	reconcile.RegisterProvider("openclaw-agents", &openclawAgentsProvider{})
-	reconcile.RegisterProvider("openclaw-cron", &openclawCronProvider{})
-	reconcile.RegisterProvider("openclaw-gateway", &openclawGatewayProvider{})
+	reconcile.RegisterProvider("mcp-tools", &mcpToolsProvider{stubMethods: stubMethods{name: "mcp-tools"}})
+	reconcile.RegisterProvider("openclaw-agents", &openclawAgentsProvider{stubMethods: stubMethods{name: "openclaw-agents"}})
+	reconcile.RegisterProvider("openclaw-cron", &openclawCronProvider{stubMethods: stubMethods{name: "openclaw-cron"}})
+	reconcile.RegisterProvider("openclaw-gateway", &openclawGatewayProvider{stubMethods: stubMethods{name: "openclaw-gateway"}})
 	reconcile.RegisterProvider("pin", globalPinProvider)
-	reconcile.RegisterProvider("service", &serviceProvider{})
+	reconcile.RegisterProvider("service", &serviceProvider{stubMethods: stubMethods{name: "service"}})
 }
 
 // resolveRoot returns the workspace root or an error status.
@@ -188,23 +188,47 @@ func resolveRoot() (string, *reconcile.ResourceStatus) {
 }
 
 // stubMethods satisfies the non-Health parts of reconcile.Reconcilable.
-// All operations return "daemon: operation not available" — the daemon only
-// calls Health() through the proprioception block.
+// These daemon-side stubs are Health()-only: they expose proprioception state
+// to the foveated context block but are not driven through the full
+// LoadConfig→FetchLive→ComputePlan→ApplyPlan cycle.
+//
+// LoadConfig returns a sentinel struct so the reconcile daemon's cycle exits
+// cleanly after BuildState (no WARN spam). FetchLive, ComputePlan, ApplyPlan,
+// and BuildState return explicit "not available" errors so any unexpected
+// caller gets a clear diagnostic rather than a silent nil.
 type stubMethods struct{ name string }
 
+// stubNoopConfig is the no-op sentinel returned by stubMethods.LoadConfig.
+// The reconcile daemon checks for this type in ComputePlan and produces an
+// empty plan, avoiding the WARN-per-tick log noise on fresh installs.
+type stubNoopConfig struct{ name string }
+
 func (s *stubMethods) LoadConfig(_ string) (any, error) {
-	return nil, fmt.Errorf("daemon: LoadConfig not available for %s provider", s.name)
+	// Return a no-op config so the daemon cycle does not WARN on LoadConfig.
+	// Health() is the only meaningful operation for daemon-side stub providers.
+	return &stubNoopConfig{name: s.name}, nil
 }
-func (s *stubMethods) FetchLive(_ context.Context, _ any) (any, error) {
+func (s *stubMethods) FetchLive(_ context.Context, cfg any) (any, error) {
+	// Pass through the stub config so the cycle can proceed to ComputePlan.
+	if _, ok := cfg.(*stubNoopConfig); ok {
+		return cfg, nil
+	}
 	return nil, fmt.Errorf("daemon: FetchLive not available for %s provider", s.name)
 }
-func (s *stubMethods) ComputePlan(_ any, _ any, _ *reconcile.State) (*reconcile.Plan, error) {
+func (s *stubMethods) ComputePlan(cfg any, _ any, _ *reconcile.State) (*reconcile.Plan, error) {
+	if nc, ok := cfg.(*stubNoopConfig); ok {
+		// Return an empty plan so the daemon sees "no drift" and exits quietly.
+		return &reconcile.Plan{ResourceType: nc.name}, nil
+	}
 	return nil, fmt.Errorf("daemon: ComputePlan not available for %s provider", s.name)
 }
 func (s *stubMethods) ApplyPlan(_ context.Context, _ *reconcile.Plan) ([]reconcile.Result, error) {
 	return nil, fmt.Errorf("daemon: ApplyPlan not available for %s provider", s.name)
 }
-func (s *stubMethods) BuildState(_ any, _ any, _ *reconcile.State) (*reconcile.State, error) {
+func (s *stubMethods) BuildState(cfg any, _ any, _ *reconcile.State) (*reconcile.State, error) {
+	if nc, ok := cfg.(*stubNoopConfig); ok {
+		return reconcile.NewState(nc.name), nil
+	}
 	return nil, fmt.Errorf("daemon: BuildState not available for %s provider", s.name)
 }
 


### PR DESCRIPTION
## Summary

- Gates all daemon-side stub providers (worktree-reconciler, cogblock/projection-compiler, lineage-projection, component) on feature presence: absent git/cogblock.py/nodes-dir now DEBUG-logs and exits the reconcile cycle cleanly instead of WARNing every 30 s.
- Fixes the two-space empty-name bug in stub `LoadConfig` error messages.
- Gates `mlx-supervised` provider on `runtime.GOOS == "darwin"` (Apple Metal only), mirroring the existing codex guard.
- Default provider now probes LM Studio (:1234) then Ollama (:11434); if neither is reachable, surfaces a clear "no local model configured" state instead of a dead Ollama/gemma4:e4b default.

Fixes #318
Fixes #319