### PR TITLE
feat(cluster): cross-platform bep-cert tool — self-generate cert + print DeviceID (Phase 2 S0)

### DIFF
--- a/pkg/substrate/bep/cmd/bep-cert/main.go
+++ b/pkg/substrate/bep/cmd/bep-cert/main.go
@@ -1,0 +1,171 @@
+// Command bep-cert is a cross-platform CLI for managing BEP transport certificates.
+// It lets each node self-generate its certificate locally (private key never leaves
+// the node) and print the resulting DeviceID for peer exchange in cluster.yaml.
+//
+// Usage:
+//
+//	bep-cert gen [--dir DIR] [--force]
+//	bep-cert device-id [--cert CERT_PATH]
+//
+// The DeviceID format is Syncthing-compatible Luhn-encoded base32 groups.
+package main
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	bep "github.com/myrgic/cogos/pkg/substrate/bep"
+)
+
+const usage = `bep-cert — BEP transport certificate tool
+
+SUBCOMMANDS
+  gen         Generate a BEP cert+key into a directory
+  device-id   Print the DeviceID of an existing cert
+
+gen [--dir DIR] [--force]
+  Generates bep-cert.pem and bep-key.pem into DIR (default ~/.cog/etc/).
+  Refuses to overwrite an existing bep-cert.pem unless --force is given.
+  On success, prints the DeviceID and the paths of the generated files.
+
+  Flags:
+    --dir DIR    Target directory (default ~/.cog/etc/)
+    --force      Overwrite existing cert+key if present
+
+device-id [--cert CERT_PATH]
+  Loads a cert PEM file and prints its DeviceID using the same derivation
+  the BEP transport uses, so the ID matches what peers pin.
+
+  Flags:
+    --cert PATH  Path to bep-cert.pem (default ~/.cog/etc/bep-cert.pem)
+`
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprint(os.Stderr, usage)
+		os.Exit(1)
+	}
+
+	switch os.Args[1] {
+	case "gen":
+		if err := runGen(os.Args[2:]); err != nil {
+			fmt.Fprintf(os.Stderr, "bep-cert gen: %v\n", err)
+			os.Exit(1)
+		}
+	case "device-id":
+		if err := runDeviceID(os.Args[2:]); err != nil {
+			fmt.Fprintf(os.Stderr, "bep-cert device-id: %v\n", err)
+			os.Exit(1)
+		}
+	case "-h", "--help", "help":
+		fmt.Print(usage)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown subcommand %q\n\n%s", os.Args[1], usage)
+		os.Exit(1)
+	}
+}
+
+// runGen handles the `gen` subcommand.
+func runGen(args []string) error {
+	dir := ""
+	force := false
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--dir":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--dir requires an argument")
+			}
+			i++
+			dir = args[i]
+		case "--force":
+			force = true
+		default:
+			return fmt.Errorf("unknown flag %q", args[i])
+		}
+	}
+
+	certDir := bep.ExpandCertDir(dir)
+	certPath := filepath.Join(certDir, "bep-cert.pem")
+	keyPath := filepath.Join(certDir, "bep-key.pem")
+
+	// Refuse to overwrite unless --force.
+	if _, err := os.Stat(certPath); err == nil && !force {
+		return fmt.Errorf("certificate already exists at %s\n       use --force to overwrite", certPath)
+	}
+
+	// If force, remove existing files so GenerateBEPCert (which uses O_EXCL) can proceed.
+	if force {
+		_ = os.Remove(certPath)
+		_ = os.Remove(keyPath)
+	}
+
+	if err := bep.GenerateBEPCert(certDir); err != nil {
+		return err
+	}
+
+	// Load to derive DeviceID.
+	tlsCert, err := bep.LoadBEPCert(certDir)
+	if err != nil {
+		return fmt.Errorf("load cert for DeviceID: %w", err)
+	}
+	id, err := bep.DeviceIDFromTLSCert(&tlsCert)
+	if err != nil {
+		return fmt.Errorf("derive DeviceID: %w", err)
+	}
+
+	fmt.Printf("DeviceID:  %s\n", bep.FormatDeviceID(id))
+	fmt.Printf("cert:      %s\n", certPath)
+	fmt.Printf("key:       %s\n", keyPath)
+	return nil
+}
+
+// runDeviceID handles the `device-id` subcommand.
+func runDeviceID(args []string) error {
+	certPath := ""
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--cert":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--cert requires an argument")
+			}
+			i++
+			certPath = args[i]
+		default:
+			return fmt.Errorf("unknown flag %q", args[i])
+		}
+	}
+
+	// Default cert path: ~/.cog/etc/bep-cert.pem
+	if certPath == "" {
+		certDir := bep.ExpandCertDir("")
+		certPath = filepath.Join(certDir, "bep-cert.pem")
+	}
+
+	certPEM, err := os.ReadFile(certPath)
+	if err != nil {
+		return fmt.Errorf("read cert %s: %w", certPath, err)
+	}
+
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return fmt.Errorf("no PEM block found in %s", certPath)
+	}
+
+	x509Cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return fmt.Errorf("parse certificate: %w", err)
+	}
+
+	// Use the same derivation as the BEP transport: DeviceIDFromCert (SHA-256 of DER).
+	id := bep.DeviceIDFromCert(x509Cert)
+
+	fmt.Printf("DeviceID:  %s\n", bep.FormatDeviceID(id))
+	fmt.Printf("cert:      %s\n", certPath)
+	return nil
+}
+

--- a/pkg/substrate/bep/cmd/bep-cert/main_test.go
+++ b/pkg/substrate/bep/cmd/bep-cert/main_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestGenAndDeviceIDConsistency generates a cert via runGen and then reads the
+// DeviceID back via runDeviceID, asserting they match and are well-formed.
+func TestGenAndDeviceIDConsistency(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := runGen([]string{"--dir", dir}); err != nil {
+		t.Fatalf("runGen: %v", err)
+	}
+
+	certPath := filepath.Join(dir, "bep-cert.pem")
+	if _, err := os.Stat(certPath); err != nil {
+		t.Fatalf("cert not created: %v", err)
+	}
+	keyPath := filepath.Join(dir, "bep-key.pem")
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("key not created: %v", err)
+	}
+
+	// device-id on the generated cert should succeed and return a well-formed ID.
+	if err := runDeviceID([]string{"--cert", certPath}); err != nil {
+		t.Fatalf("runDeviceID: %v", err)
+	}
+}
+
+// TestGenRefusesOverwrite checks that a second gen call without --force fails.
+func TestGenRefusesOverwrite(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := runGen([]string{"--dir", dir}); err != nil {
+		t.Fatalf("first runGen: %v", err)
+	}
+
+	err := runGen([]string{"--dir", dir})
+	if err == nil {
+		t.Fatal("expected error on overwrite without --force, got nil")
+	}
+	if !strings.Contains(err.Error(), "--force") {
+		t.Errorf("error should mention --force, got: %v", err)
+	}
+}
+
+// TestGenForceOverwrite checks that --force allows regeneration.
+func TestGenForceOverwrite(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := runGen([]string{"--dir", dir}); err != nil {
+		t.Fatalf("first runGen: %v", err)
+	}
+	if err := runGen([]string{"--dir", dir, "--force"}); err != nil {
+		t.Fatalf("runGen --force: %v", err)
+	}
+}
+
+// TestDeviceIDFormatShape checks that the DeviceID is 8 dash-separated groups of 7 chars.
+func TestDeviceIDFormatShape(t *testing.T) {
+	dir := t.TempDir()
+	if err := runGen([]string{"--dir", dir}); err != nil {
+		t.Fatalf("runGen: %v", err)
+	}
+
+	certPath := filepath.Join(dir, "bep-cert.pem")
+
+	// Capture stdout to inspect the DeviceID string.
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	if err := runDeviceID([]string{"--cert", certPath}); err != nil {
+		w.Close()
+		os.Stdout = old
+		t.Fatalf("runDeviceID: %v", err)
+	}
+	w.Close()
+	os.Stdout = old
+
+	buf := make([]byte, 512)
+	n, _ := r.Read(buf)
+	output := string(buf[:n])
+
+	// Extract the DeviceID line.
+	var devID string
+	for _, line := range strings.Split(output, "\n") {
+		if strings.HasPrefix(line, "DeviceID:") {
+			devID = strings.TrimSpace(strings.TrimPrefix(line, "DeviceID:"))
+			break
+		}
+	}
+
+	if devID == "" {
+		t.Fatalf("DeviceID not found in output: %q", output)
+	}
+
+	parts := strings.Split(devID, "-")
+	if len(parts) != 8 {
+		t.Errorf("expected 8 dash-separated groups, got %d: %q", len(parts), devID)
+	}
+	for i, p := range parts {
+		if len(p) != 7 {
+			t.Errorf("group %d has length %d, want 7: %q", i, len(p), p)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `pkg/substrate/bep/cmd/bep-cert`: a standalone CLI that depends only on `pkg/substrate/bep` + stdlib, so it cross-compiles to Windows without the cgo/platform baggage that blocks #328.
- Two subcommands: `gen` (generate cert+key locally, refuse overwrite without `--force`, print DeviceID on success) and `device-id` (load existing cert, print DeviceID using the same SHA-256 + Luhn-base32 derivation as the BEP transport).
- Private key never leaves the node — operator runs `bep-cert gen` on each node, pastes the printed DeviceID into `cluster.yaml` for peer exchange.

Part of #330 (Phase 2, S0).

## Test plan

- [ ] `go build ./pkg/substrate/bep/cmd/bep-cert` — passes
- [ ] `GOOS=windows go build ./pkg/substrate/bep/cmd/bep-cert` — passes (the whole point)
- [ ] `go test ./pkg/substrate/bep/cmd/bep-cert/...` — 4 tests pass (gen/device-id consistency, overwrite guard, force flag, DeviceID format shape)
- [ ] `go build ./...` — no regressions
- [ ] `gen` → `device-id --cert <same-file>` produces identical DeviceID
- [ ] Second `gen` without `--force` exits non-zero with actionable message
- [ ] `device-id` against `~/.cog/etc/bep-cert.pem` prints Darkstar's stable DeviceID