### PR TITLE
feat(cluster): remote dispatch over BEP — cog_dispatch_to_harness(target_node) (Phase 2 S4)

### DIFF
--- a/internal/engine/agent_dispatch.go
+++ b/internal/engine/agent_dispatch.go
@@ -104,6 +104,14 @@ type DispatchRequest struct {
 	// Identity propagates OIDC-shaped caller claims for trace metadata.
 	// Optional; see DispatchIdentity for forward-compat notes.
 	Identity DispatchIdentity
+
+	// TargetNode, when non-empty, routes this dispatch to the named peer node
+	// over the authenticated BEP channel instead of running locally. The
+	// remote daemon receives a MessageTypeDispatch, executes the request
+	// against its own harness, and returns a MessageTypeDispatchResult.
+	// Requires cluster.enabled=true and the named peer to be connected.
+	// Empty string (the default) runs locally — unchanged behavior.
+	TargetNode string `json:"target_node,omitempty"`
 }
 
 // DispatchToolCallSummary is the digest of one tool invocation made during a
@@ -182,4 +190,16 @@ type AgentDispatcher interface {
 	// once every slot has either completed, errored, or timed out. The
 	// returned batch is always non-nil when the error is nil.
 	DispatchToHarness(ctx context.Context, req DispatchRequest) (*DispatchBatchResult, error)
+}
+
+// RemoteDispatchRouter is satisfied by BEPEngine (Phase 2 S4). It is the
+// narrow surface QueryDispatchToHarness uses to route a dispatch with a
+// non-empty TargetNode over the authenticated BEP channel to the named peer.
+// Separate from AgentDispatcher so the engine can implement it without
+// becoming an AgentController.
+type RemoteDispatchRouter interface {
+	// RemoteDispatch sends req to the peer named targetNode and blocks until
+	// the result arrives or ctx is cancelled. Returns the batch result or an
+	// AgentControllerError describing the failure.
+	RemoteDispatch(ctx context.Context, targetNode string, req DispatchRequest) (*DispatchBatchResult, error)
 }

--- a/internal/engine/agent_dispatch_query.go
+++ b/internal/engine/agent_dispatch_query.go
@@ -84,7 +84,37 @@ func (r *DispatchRequest) Normalize() error {
 // QueryDispatchToHarness wraps an AgentDispatcher with normalization and the
 // "controller installed?" check. Returns ErrAgentUnavailable when the
 // controller is nil or doesn't implement AgentDispatcher.
+//
+// When req.TargetNode is non-empty and a RemoteDispatchRouter is wired (Phase 2
+// S4), the request is forwarded to the named peer over the authenticated BEP
+// channel instead of running locally. Gated on cluster.enabled: when no router
+// is wired and TargetNode is set, the call fails fast with a clear error.
 func QueryDispatchToHarness(ctx context.Context, ctrl AgentController, req DispatchRequest) (*DispatchBatchResult, error) {
+	return QueryDispatchToHarnessRouted(ctx, ctrl, nil, req)
+}
+
+// QueryDispatchToHarnessRouted is the cluster-aware variant used by
+// toolDispatchToHarness (MCPServer) and the HTTP serve_agents path. When
+// router is non-nil and req.TargetNode is non-empty the dispatch is forwarded
+// to the named peer over BEP; otherwise it behaves identically to
+// QueryDispatchToHarness.
+func QueryDispatchToHarnessRouted(ctx context.Context, ctrl AgentController, router RemoteDispatchRouter, req DispatchRequest) (*DispatchBatchResult, error) {
+	// Remote path: TargetNode set + a live cluster router available.
+	if req.TargetNode != "" {
+		if router == nil {
+			return nil, &AgentControllerError{
+				Code:    "cluster_disabled",
+				Message: fmt.Sprintf("target_node=%q requested but cluster transport is not running (cluster.enabled=false or BEP engine not started)", req.TargetNode),
+			}
+		}
+		// Normalize before forwarding so the remote receives a clean request.
+		if err := req.Normalize(); err != nil {
+			return nil, err
+		}
+		return router.RemoteDispatch(ctx, req.TargetNode, req)
+	}
+
+	// Local path — unchanged from before.
 	if ctrl == nil {
 		return nil, ErrAgentUnavailable
 	}

--- a/internal/engine/bep_dispatch.go
+++ b/internal/engine/bep_dispatch.go
@@ -1,0 +1,236 @@
+// bep_dispatch.go — Phase 2 S4: remote harness dispatch over BEP.
+//
+// Adds two message types to the existing BEP channel:
+//   MessageTypeDispatch       (8) — caller sends a DispatchRequest JSON body
+//   MessageTypeDispatchResult (9) — remote sends a DispatchBatchResult JSON body
+//
+// Correlation: each in-flight dispatch is given a uint32 ID embedded in a thin
+// envelope (dispatchEnvelope). The receive side echoes the same ID back so that
+// concurrent dispatches on a single connection don't cross.
+//
+// The gate is cluster.enabled: when no BEPEngine is wired, or when no peer
+// matches the requested TargetNode, the call fails fast with a clear error.
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	bep "github.com/myrgic/cogos/pkg/substrate/bep"
+)
+
+// ─── Correlation envelope ────────────────────────────────────────────────────
+
+// dispatchEnvelope is the wire format for MessageTypeDispatch and
+// MessageTypeDispatchResult. The ID field correlates request↔result so that
+// concurrent dispatches over a single connection don't mix up their responses.
+type dispatchEnvelope struct {
+	ID      uint32           `json:"id"`
+	Request *DispatchRequest `json:"request,omitempty"` // set on request side
+	Result  *DispatchBatchResult `json:"result,omitempty"`  // set on result side
+	Error   string           `json:"error,omitempty"`   // set on result side for fatal errors
+}
+
+// ─── BEPEngine dispatch extensions ──────────────────────────────────────────
+
+// dispatchInFlight tracks pending remote dispatch calls keyed by correlation ID.
+type dispatchInFlight struct {
+	ch chan dispatchEnvelope
+}
+
+// dispatchCounter is the global correlation ID generator (atomic, per-process).
+var dispatchCounter uint32
+
+// nextDispatchID returns the next unique correlation ID.
+func nextDispatchID() uint32 {
+	return atomic.AddUint32(&dispatchCounter, 1)
+}
+
+// SetDispatcher wires an AgentDispatcher into the engine so the receive side
+// can run DispatchToHarness locally when a MessageTypeDispatch arrives from a
+// peer. Call this after constructing the engine and before Start().
+func (e *BEPEngine) SetDispatcher(d AgentDispatcher) {
+	e.mu.Lock()
+	e.dispatcher = d
+	e.mu.Unlock()
+}
+
+// findPeerByName returns the PeerConnection whose Name matches target (case-
+// sensitive), or nil if no connected peer has that name.
+func (e *BEPEngine) findPeerByName(target string) *PeerConnection {
+	e.peersMu.RLock()
+	defer e.peersMu.RUnlock()
+	for _, pc := range e.peers {
+		if pc.Name == target {
+			return pc
+		}
+	}
+	return nil
+}
+
+// RemoteDispatch sends a DispatchRequest to the peer named target and blocks
+// until the matching result arrives or the context deadline fires. It is
+// called by QueryDispatchToHarness when DispatchRequest.TargetNode is set.
+func (e *BEPEngine) RemoteDispatch(ctx context.Context, target string, req DispatchRequest) (*DispatchBatchResult, error) {
+	pc := e.findPeerByName(target)
+	if pc == nil {
+		return nil, &AgentControllerError{
+			Code:    "peer_not_connected",
+			Message: fmt.Sprintf("cluster dispatch: peer %q is not connected", target),
+		}
+	}
+
+	id := nextDispatchID()
+	env := dispatchEnvelope{ID: id, Request: &req}
+	payload, err := json.Marshal(env)
+	if err != nil {
+		return nil, fmt.Errorf("cluster dispatch: marshal request: %w", err)
+	}
+
+	// Register in-flight channel before sending so we never miss the reply.
+	ch := make(chan dispatchEnvelope, 1)
+	e.inflightMu.Lock()
+	e.inflight[id] = &dispatchInFlight{ch: ch}
+	e.inflightMu.Unlock()
+
+	defer func() {
+		e.inflightMu.Lock()
+		delete(e.inflight, id)
+		e.inflightMu.Unlock()
+	}()
+
+	if err := pc.Wire.WriteMessage(bep.MessageTypeDispatch, payload); err != nil {
+		return nil, &AgentControllerError{
+			Code:    "peer_send_error",
+			Message: fmt.Sprintf("cluster dispatch: send to %q: %v", target, err),
+		}
+	}
+
+	select {
+	case reply := <-ch:
+		if reply.Error != "" {
+			return nil, &AgentControllerError{
+				Code:    "remote_error",
+				Message: fmt.Sprintf("cluster dispatch: remote %q: %s", target, reply.Error),
+			}
+		}
+		if reply.Result == nil {
+			return nil, &AgentControllerError{
+				Code:    "remote_error",
+				Message: fmt.Sprintf("cluster dispatch: remote %q returned nil result", target),
+			}
+		}
+		return reply.Result, nil
+	case <-ctx.Done():
+		return nil, &AgentControllerError{
+			Code:    "timeout",
+			Message: fmt.Sprintf("cluster dispatch: timed out waiting for result from %q", target),
+		}
+	}
+}
+
+// handleDispatchMessage is called from the peer loop when a MessageTypeDispatch
+// arrives. It runs the request locally (clearing TargetNode to prevent loops)
+// and sends back a MessageTypeDispatchResult.
+func (e *BEPEngine) handleDispatchMessage(pc *PeerConnection, payload []byte) {
+	var env dispatchEnvelope
+	if err := json.Unmarshal(payload, &env); err != nil {
+		log.Printf("[bep-dispatch] bad dispatch envelope from %s: %v", pc.Name, err)
+		return
+	}
+	if env.Request == nil {
+		log.Printf("[bep-dispatch] dispatch envelope from %s has nil request", pc.Name)
+		return
+	}
+
+	e.mu.Lock()
+	d := e.dispatcher
+	e.mu.Unlock()
+
+	var reply dispatchEnvelope
+	reply.ID = env.ID
+
+	if d == nil {
+		reply.Error = "no dispatcher configured on this node"
+	} else {
+		// Clear TargetNode to prevent routing loops.
+		req := *env.Request
+		req.TargetNode = ""
+		if err := req.Normalize(); err != nil {
+			reply.Error = fmt.Sprintf("normalize: %v", err)
+		} else {
+			// Use a fresh background context with the request's own timeout.
+			timeout := time.Duration(req.TimeoutSeconds) * time.Second
+			if timeout <= 0 {
+				timeout = 30 * time.Second
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), timeout+5*time.Second)
+			defer cancel()
+
+			result, err := d.DispatchToHarness(ctx, req)
+			if err != nil {
+				reply.Error = err.Error()
+			} else {
+				reply.Result = result
+			}
+		}
+	}
+
+	out, err := json.Marshal(reply)
+	if err != nil {
+		log.Printf("[bep-dispatch] marshal result for %s: %v", pc.Name, err)
+		return
+	}
+	if err := pc.Wire.WriteMessage(bep.MessageTypeDispatchResult, out); err != nil {
+		log.Printf("[bep-dispatch] send result to %s: %v", pc.Name, err)
+	}
+}
+
+// handleDispatchResultMessage is called from the peer loop when a
+// MessageTypeDispatchResult arrives. It delivers the envelope to the matching
+// in-flight channel.
+func (e *BEPEngine) handleDispatchResultMessage(payload []byte) {
+	var env dispatchEnvelope
+	if err := json.Unmarshal(payload, &env); err != nil {
+		log.Printf("[bep-dispatch] bad dispatch result envelope: %v", err)
+		return
+	}
+
+	e.inflightMu.Lock()
+	inf, ok := e.inflight[env.ID]
+	e.inflightMu.Unlock()
+
+	if !ok {
+		log.Printf("[bep-dispatch] no in-flight dispatch for id=%d (already timed out?)", env.ID)
+		return
+	}
+	select {
+	case inf.ch <- env:
+	default:
+		log.Printf("[bep-dispatch] in-flight channel full for id=%d, dropping result", env.ID)
+	}
+}
+
+// ─── Additional BEPEngine fields (stored via mu) ────────────────────────────
+// dispatcher and inflight are declared in bep_engine_dispatch_fields.go
+// (injected into BEPEngine struct via the fields file below).
+
+// inflightMu is intentionally a separate mutex from BEPEngine.mu to avoid
+// deadlock: the peer loop holds no external locks when delivering results.
+
+// See bep_engine.go — the struct fields are added there directly.
+// This comment exists so the reader can trace back to the field declarations.
+
+// ─── Wire-up helpers (used from bep_engine.go peer loop) ────────────────────
+
+// dispatchFields is embedded into BEPEngine (see bep_engine.go additions).
+type dispatchFields struct {
+	dispatcher AgentDispatcher
+	inflightMu sync.Mutex
+	inflight   map[uint32]*dispatchInFlight
+}

--- a/internal/engine/bep_engine.go
+++ b/internal/engine/bep_engine.go
@@ -52,6 +52,9 @@ type BEPEngine struct {
 	stopCh  chan struct{}
 	stopped bool
 	wg      sync.WaitGroup
+
+	// Phase 2 S4: remote dispatch over BEP (see bep_dispatch.go).
+	dispatchFields
 }
 
 // PeerConnection represents an active connection to a peer node.
@@ -115,6 +118,9 @@ func NewBEPEngine(root string, config *bep.Config, provider *BEPProvider) (*BEPE
 		provider:  provider,
 		peers:     make(map[bep.DeviceID]*PeerConnection),
 		stopCh:    make(chan struct{}),
+		dispatchFields: dispatchFields{
+			inflight: make(map[uint32]*dispatchInFlight),
+		},
 	}
 
 	// Create sync model.
@@ -518,6 +524,23 @@ func (e *BEPEngine) runPeerLoop(pc *PeerConnection, peerID bep.DeviceID) {
 					log.Printf("[bep-engine] pong to %s failed: %v", peerShort, err)
 					return
 				}
+
+			case bep.MessageTypeDispatch:
+				// Phase 2 S4: incoming remote dispatch request — run locally
+				// and send the result back to the peer. Runs in a goroutine so
+				// the peer loop is never blocked while a dispatch executes.
+				capturedPc := pc
+				capturedPayload := msg.payload
+				e.wg.Add(1)
+				go func() {
+					defer e.wg.Done()
+					e.handleDispatchMessage(capturedPc, capturedPayload)
+				}()
+
+			case bep.MessageTypeDispatchResult:
+				// Phase 2 S4: incoming result for a locally-initiated remote
+				// dispatch — deliver to the waiting RemoteDispatch caller.
+				e.handleDispatchResultMessage(msg.payload)
 
 			case bep.MessageTypeClose:
 				cl := &bep.Close{}

--- a/internal/engine/boot.go
+++ b/internal/engine/boot.go
@@ -368,6 +368,17 @@ func Boot(ctx context.Context, cfg *Config, opts ...BootOption) (*Kernel, error)
 
 					bepEngineHandle = eng
 					server.bepEngine = eng
+
+					// Phase 2 S4: wire the cluster dispatch router into the
+					// MCP surface so cog_dispatch_to_harness(target_node=...)
+					// routes over BEP. Also wire the local dispatcher into the
+					// engine so it can serve incoming MessageTypeDispatch from
+					// remote peers.
+					server.SetClusterRouter(eng)
+					if ctrl, ok := server.agentController.(AgentDispatcher); ok {
+						eng.SetDispatcher(ctrl)
+					}
+
 					slog.Info("cluster: BEP engine started",
 						"listen_port", clusterCfg.ListenPort,
 						"peers", len(clusterCfg.Peers),

--- a/internal/engine/cluster_dispatch_test.go
+++ b/internal/engine/cluster_dispatch_test.go
@@ -1,0 +1,327 @@
+// cluster_dispatch_test.go — Phase 2 S4: in-process two-node remote dispatch.
+//
+// TestClusterDispatch proves that:
+//
+//  1. cog_dispatch_to_harness(target_node="B") on engine A is forwarded over
+//     the authenticated BEP channel to engine B.
+//  2. B executes the request against its stub local dispatcher.
+//  3. B's result arrives back at A and is returned to the caller.
+//  4. Concurrent dispatches from the same caller don't mix up their results
+//     (each reply carries the correct correlation ID).
+//  5. A dispatch with target_node set when no cluster router is wired fails
+//     fast with code="cluster_disabled".
+//
+// The test uses a stub AgentDispatcher on B so it does not require a real model.
+// Bounded waits (no infinite blocks) — safe for CI with the race detector.
+
+package engine
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	bep "github.com/myrgic/cogos/pkg/substrate/bep"
+)
+
+// ─── Stub dispatcher ─────────────────────────────────────────────────────────
+
+// stubDispatcher is a minimal AgentDispatcher that returns a canned result
+// echoing the task text back. Used as B's local harness so no real model is
+// needed.
+type stubDispatcher struct {
+	mu      sync.Mutex
+	history []DispatchRequest
+}
+
+func (s *stubDispatcher) DispatchToHarness(_ context.Context, req DispatchRequest) (*DispatchBatchResult, error) {
+	s.mu.Lock()
+	s.history = append(s.history, req)
+	s.mu.Unlock()
+	return &DispatchBatchResult{
+		Results: []DispatchResult{{
+			Index:   0,
+			Success: true,
+			Content: "stub-ok: " + req.Task,
+		}},
+		TotalDurationSec: 0.001,
+	}, nil
+}
+
+// ─── Helper: build a two-engine loopback cluster ─────────────────────────────
+
+type twoNodeCluster struct {
+	engineA *BEPEngine
+	engineB *BEPEngine
+	stubB   *stubDispatcher
+}
+
+func buildTwoNodeCluster(t *testing.T) *twoNodeCluster {
+	t.Helper()
+
+	rootA, certDirA, idA := setupEngineWorkspace(t)
+	rootB, certDirB, idB := setupEngineWorkspace(t)
+
+	cfgB := &bep.Config{
+		Enabled:    true,
+		DeviceID:   bep.FormatDeviceID(idB),
+		NodeName:   "nodeB",
+		ListenPort: 0,
+		CertDir:    certDirB,
+		Peers: []bep.Peer{{
+			DeviceID: bep.FormatDeviceID(idA),
+			Name:     "nodeA",
+			Trusted:  true,
+		}},
+		Discovery: "static",
+	}
+
+	providerB := NewBEPProvider(rootB)
+	engineB, err := NewBEPEngine(rootB, cfgB, providerB)
+	if err != nil {
+		t.Fatalf("NewBEPEngine B: %v", err)
+	}
+	stubB := &stubDispatcher{}
+	engineB.SetDispatcher(stubB)
+
+	if err := engineB.Start(); err != nil {
+		t.Fatalf("engineB.Start: %v", err)
+	}
+	t.Cleanup(engineB.Stop)
+
+	bAddr := engineB.ListenerAddr()
+
+	cfgA := &bep.Config{
+		Enabled:    true,
+		DeviceID:   bep.FormatDeviceID(idA),
+		NodeName:   "nodeA",
+		ListenPort: 0,
+		CertDir:    certDirA,
+		Peers: []bep.Peer{{
+			DeviceID: bep.FormatDeviceID(idB),
+			Name:     "nodeB",
+			Address:  bAddr,
+			Trusted:  true,
+		}},
+		Discovery: "static",
+	}
+
+	providerA := NewBEPProvider(rootA)
+	engineA, err := NewBEPEngine(rootA, cfgA, providerA)
+	if err != nil {
+		t.Fatalf("NewBEPEngine A: %v", err)
+	}
+	if err := engineA.Start(); err != nil {
+		t.Fatalf("engineA.Start: %v", err)
+	}
+	t.Cleanup(engineA.Stop)
+
+	// Wait for A to connect to B.
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		engineA.peersMu.RLock()
+		n := len(engineA.peers)
+		engineA.peersMu.RUnlock()
+		if n > 0 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	engineA.peersMu.RLock()
+	connected := len(engineA.peers) > 0
+	engineA.peersMu.RUnlock()
+	if !connected {
+		t.Fatal("engines failed to connect within 10s")
+	}
+
+	return &twoNodeCluster{engineA: engineA, engineB: engineB, stubB: stubB}
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+// TestClusterDispatch_BasicRoundTrip sends one dispatch from A targeting B and
+// verifies the result content comes from B's stub dispatcher.
+func TestClusterDispatch_BasicRoundTrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping cluster E2E in short mode")
+	}
+
+	cluster := buildTwoNodeCluster(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	req := DispatchRequest{
+		Task:           "hello-from-A",
+		TimeoutSeconds: 10,
+	}
+	result, err := cluster.engineA.RemoteDispatch(ctx, "nodeB", req)
+	if err != nil {
+		t.Fatalf("RemoteDispatch: %v", err)
+	}
+	if len(result.Results) != 1 {
+		t.Fatalf("expected 1 result slot, got %d", len(result.Results))
+	}
+	if !result.Results[0].Success {
+		t.Errorf("result[0].Success = false; want true")
+	}
+	want := "stub-ok: hello-from-A"
+	if result.Results[0].Content != want {
+		t.Errorf("content = %q; want %q", result.Results[0].Content, want)
+	}
+}
+
+// TestClusterDispatch_TargetNodeClearedOnReceive verifies that the request
+// forwarded to B has TargetNode cleared (loop-prevention).
+func TestClusterDispatch_TargetNodeClearedOnReceive(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping cluster E2E in short mode")
+	}
+
+	cluster := buildTwoNodeCluster(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	req := DispatchRequest{
+		Task:           "check-target-cleared",
+		TargetNode:     "nodeB", // will be cleared before B's dispatcher sees it
+		TimeoutSeconds: 10,
+	}
+	_, err := cluster.engineA.RemoteDispatch(ctx, "nodeB", req)
+	if err != nil {
+		t.Fatalf("RemoteDispatch: %v", err)
+	}
+
+	cluster.stubB.mu.Lock()
+	defer cluster.stubB.mu.Unlock()
+	if len(cluster.stubB.history) == 0 {
+		t.Fatal("B's dispatcher was never called")
+	}
+	last := cluster.stubB.history[len(cluster.stubB.history)-1]
+	if last.TargetNode != "" {
+		t.Errorf("TargetNode not cleared on B; got %q", last.TargetNode)
+	}
+}
+
+// TestClusterDispatch_ConcurrentRequests sends N dispatches in parallel from A
+// to B and verifies each result matches its own task string (no cross-mixing).
+func TestClusterDispatch_ConcurrentRequests(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping cluster E2E in short mode")
+	}
+
+	cluster := buildTwoNodeCluster(t)
+
+	const n = 5
+	type outcome struct {
+		idx     int
+		content string
+		err     error
+	}
+	results := make([]outcome, n)
+	var wg sync.WaitGroup
+
+	for i := 0; i < n; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			defer cancel()
+			req := DispatchRequest{
+				Task:           fmt.Sprintf("task-%d", i),
+				TimeoutSeconds: 15,
+			}
+			res, err := cluster.engineA.RemoteDispatch(ctx, "nodeB", req)
+			if err != nil {
+				results[i] = outcome{idx: i, err: err}
+				return
+			}
+			var content string
+			if len(res.Results) > 0 {
+				content = res.Results[0].Content
+			}
+			results[i] = outcome{idx: i, content: content}
+		}()
+	}
+	wg.Wait()
+
+	for _, r := range results {
+		if r.err != nil {
+			t.Errorf("slot %d: error: %v", r.idx, r.err)
+			continue
+		}
+		want := fmt.Sprintf("stub-ok: task-%d", r.idx)
+		if r.content != want {
+			t.Errorf("slot %d: content = %q; want %q", r.idx, r.content, want)
+		}
+	}
+}
+
+// TestClusterDispatch_NoRouterError verifies that QueryDispatchToHarnessRouted
+// with a nil router and non-empty TargetNode returns code=cluster_disabled,
+// with no connection or goroutine activity (pure unit gate).
+func TestClusterDispatch_NoRouterError(t *testing.T) {
+	t.Parallel()
+
+	disp := &fakeAgentDispatcher{cannedOk: true}
+	req := DispatchRequest{Task: "x", TargetNode: "remote"}
+
+	_, err := QueryDispatchToHarnessRouted(context.Background(), disp, nil, req)
+	if err == nil {
+		t.Fatal("expected error when TargetNode set but no router")
+	}
+	ace, ok := err.(*AgentControllerError)
+	if !ok {
+		t.Fatalf("expected AgentControllerError, got %T: %v", err, err)
+	}
+	if ace.Code != "cluster_disabled" {
+		t.Errorf("code = %q; want cluster_disabled", ace.Code)
+	}
+}
+
+// TestClusterDispatch_PeerNotConnected verifies that RemoteDispatch with an
+// unknown target name returns code=peer_not_connected immediately.
+func TestClusterDispatch_PeerNotConnected(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping cluster E2E in short mode")
+	}
+
+	// Build a single-node engine with no peers connected.
+	root, certDir, id := setupEngineWorkspace(t)
+	cfg := &bep.Config{
+		Enabled:    true,
+		DeviceID:   bep.FormatDeviceID(id),
+		NodeName:   "solo",
+		ListenPort: 0,
+		CertDir:    certDir,
+		Discovery:  "static",
+	}
+	eng, err := NewBEPEngine(root, cfg, NewBEPProvider(root))
+	if err != nil {
+		t.Fatalf("NewBEPEngine: %v", err)
+	}
+	if err := eng.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer eng.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err = eng.RemoteDispatch(ctx, "nonexistent", DispatchRequest{Task: "x", TimeoutSeconds: 5})
+	if err == nil {
+		t.Fatal("expected error for disconnected peer")
+	}
+	ace, ok := err.(*AgentControllerError)
+	if !ok {
+		t.Fatalf("expected AgentControllerError, got %T: %v", err, err)
+	}
+	if ace.Code != "peer_not_connected" {
+		t.Errorf("code = %q; want peer_not_connected", ace.Code)
+	}
+}

--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -108,6 +108,12 @@ type MCPServer struct {
 	// envelope when IdentityNakedDefault is true (G2 PART C). Nil when not
 	// wired — gates are skipped (permit-by-default). Set via SetCapabilityResolver.
 	capResolver capabilityGater
+
+	// clusterRouter is the Phase 2 S4 BEP dispatch router. Non-nil only when
+	// cluster.enabled=true and the BEPEngine started successfully. When set,
+	// cog_dispatch_to_harness with target_node routed through here instead of
+	// running locally. Set via SetClusterRouter.
+	clusterRouter RemoteDispatchRouter
 }
 
 // channelSessionBackend is the narrow surface the mod3 session-family MCP
@@ -170,6 +176,15 @@ func NewMCPServerWithAgentController(cfg *Config, nucleus *Nucleus, process *Pro
 // unchanged because the tools resolve the current controller on each call.
 func (m *MCPServer) SetAgentController(ctrl AgentController) {
 	m.agentController = ctrl
+}
+
+// SetClusterRouter wires the Phase 2 S4 BEP dispatch router so that
+// cog_dispatch_to_harness calls with a non-empty target_node are forwarded to
+// the named peer over the authenticated BEP channel. Nil is the default (no
+// cluster transport); the tool returns a clear error when target_node is set
+// but no router is wired.
+func (m *MCPServer) SetClusterRouter(r RemoteDispatchRouter) {
+	m.clusterRouter = r
 }
 
 // SetChannelSessionBackend wires the kernel-owned channel-session minting
@@ -776,6 +791,7 @@ type dispatchToHarnessInput struct {
 	Sub          string                 `json:"sub,omitempty" jsonschema:"OIDC-shaped identity claim: subject (e.g. session id, user handle)."`
 	Aud          string                 `json:"aud,omitempty" jsonschema:"OIDC-shaped identity claim: audience (e.g. \"cogos.kernel\")."`
 	Claims       map[string]interface{} `json:"claims,omitempty" jsonschema:"Free-form OIDC claim bag forwarded to the dispatch's trace metadata."`
+	TargetNode   string                 `json:"target_node,omitempty" jsonschema:"Phase 2 S4: when set, forward this dispatch to the named peer node over the authenticated BEP cluster channel. Requires cluster.enabled=true and the peer to be connected. Empty (default) runs on the local harness."`
 }
 
 // readToolCallsInput mirrors ToolCallQuery for the MCP surface. Time bounds
@@ -1895,8 +1911,9 @@ func (m *MCPServer) toolDispatchToHarness(ctx context.Context, req *mcp.CallTool
 			Aud:    input.Aud,
 			Claims: input.Claims,
 		},
+		TargetNode: input.TargetNode,
 	}
-	result, err := QueryDispatchToHarness(ctx, m.agentController, dr)
+	result, err := QueryDispatchToHarnessRouted(ctx, m.agentController, m.clusterRouter, dr)
 	if err != nil {
 		return agentErrorResult(err, "curl -X POST http://localhost:6931/v1/agents/primary/dispatch -d @body.json")
 	}

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -298,6 +298,15 @@ func (s *Server) SetAgentController(ctrl AgentController) {
 	if s.mcpServer != nil {
 		s.mcpServer.SetAgentController(ctrl)
 	}
+	// Phase 2 S4: propagate the dispatcher to the BEP engine if it is already
+	// running (e.g. when SetAgentController is called after Boot). The engine
+	// needs a live AgentDispatcher so it can serve incoming MessageTypeDispatch
+	// from remote peers. No-op when cluster is dark (bepEngine == nil).
+	if s.bepEngine != nil {
+		if d, ok := ctrl.(AgentDispatcher); ok {
+			s.bepEngine.SetDispatcher(d)
+		}
+	}
 	// Piece 2+3: wire dashboard bus into the harness so runCycle drains
 	// pending messages and the respond tool has a publish target. Also bind
 	// the controller to the inlet so incoming messages trigger an immediate
@@ -317,6 +326,17 @@ func (s *Server) SetHarnessBackend(h HarnessAttacher) {
 	s.harnessBackend = h
 	if s.mcpServer != nil {
 		s.mcpServer.SetHarnessBackend(h)
+	}
+}
+
+// SetClusterRouter wires the Phase 2 S4 BEP dispatch router into both the
+// Server and its MCP server so cog_dispatch_to_harness with target_node
+// forwards dispatches to remote peers over the authenticated BEP channel.
+// Called from Boot() after the BEPEngine starts successfully. Nil-safe:
+// when not called, target_node requests return a clear "cluster_disabled" error.
+func (s *Server) SetClusterRouter(r RemoteDispatchRouter) {
+	if s.mcpServer != nil {
+		s.mcpServer.SetClusterRouter(r)
 	}
 }
 

--- a/pkg/substrate/bep/proto.go
+++ b/pkg/substrate/bep/proto.go
@@ -18,13 +18,15 @@ import (
 type MessageType int32
 
 const (
-	MessageTypeClusterConfig MessageType = 0
-	MessageTypeIndex         MessageType = 1
-	MessageTypeIndexUpdate   MessageType = 2
-	MessageTypeRequest       MessageType = 3
-	MessageTypeResponse      MessageType = 4
-	MessageTypePing          MessageType = 6
-	MessageTypeClose         MessageType = 7
+	MessageTypeClusterConfig  MessageType = 0
+	MessageTypeIndex          MessageType = 1
+	MessageTypeIndexUpdate    MessageType = 2
+	MessageTypeRequest        MessageType = 3
+	MessageTypeResponse       MessageType = 4
+	MessageTypePing           MessageType = 6
+	MessageTypeClose          MessageType = 7
+	MessageTypeDispatch       MessageType = 8 // Phase 2 S4: remote harness dispatch request
+	MessageTypeDispatchResult MessageType = 9 // Phase 2 S4: remote harness dispatch result
 )
 
 type MessageCompression int32


### PR DESCRIPTION
## Summary

Part of #330 (S4). Adds cross-node harness dispatch over the authenticated BEP channel.

- **`MessageTypeDispatch` (8) / `MessageTypeDispatchResult` (9)** added to `pkg/substrate/bep/proto.go` (no collision — existing max was 7)
- **`DispatchRequest.TargetNode`** field: empty = local (unchanged), non-empty = route to named peer
- **Send side** (`RemoteDispatch` on `BEPEngine`): find peer by name, marshal a correlation envelope (uint32 ID), send `MessageTypeDispatch`, await matching `MessageTypeDispatchResult` on a per-call channel; bounded by caller's context
- **Receive side** (peer loop, `handleDispatchMessage`): unmarshal, clear `TargetNode` (loop-prevention), normalize, run `DispatchToHarness` locally in a goroutine, marshal result with same ID, send `MessageTypeDispatchResult`
- **Correlation**: `dispatchEnvelope{ID, Request/Result}` — each in-flight call has its own buffered channel keyed by ID; concurrent dispatches on one connection never cross
- **MCP surface**: `target_node` added to `cog_dispatch_to_harness` input; `MCPServer.clusterRouter` (nil when cluster off); `QueryDispatchToHarnessRouted` routes remotely when both field and router are set
- **Gate**: `cluster.enabled=false` → `clusterRouter=nil` → `target_node` calls return `code=cluster_disabled`; zero behavior change when dark

## Test plan

- [ ] `TestClusterDispatch_BasicRoundTrip` — one dispatch A→B, verifies content from B's stub
- [ ] `TestClusterDispatch_TargetNodeClearedOnReceive` — loop-prevention: B sees `TargetNode=""`
- [ ] `TestClusterDispatch_ConcurrentRequests` — 5 parallel dispatches, each result matches its own task (correlation correctness)
- [ ] `TestClusterDispatch_NoRouterError` — nil router + `target_node` → `cluster_disabled` (pure unit)
- [ ] `TestClusterDispatch_PeerNotConnected` — unknown target name → `peer_not_connected` fast-fail
- [ ] `go test -race -run TestClusterDispatch -count=5 ./internal/engine/` — PASS (race-clean, 5 consecutive runs)
- [ ] `go test -race -count=1 -timeout=180s ./internal/engine/...` — full suite PASS
- [ ] `go build ./...`, `go build ./cmd/cogos`, `GOOS=windows go build ./cmd/cogos`, `GOOS=linux go vet ./internal/engine/...` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)