### PR TITLE
fix: Windows root-package build (#328) + BEP default port off Syncthing range (#336)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,26 @@ jobs:
       - name: Build (with MCP)
         run: go build -tags mcpserver -o cogos-mcp ./cmd/cogos
 
+  # Cross-compile the entire module for Windows. The build job above only
+  # builds ./cmd/cogos (the daemon), which already cross-compiled cleanly —
+  # but the repo-root package main (cog node init, BEP, local runner) carried
+  # unguarded Unix-only syscalls and broke GOOS=windows undetected (#328).
+  # This guards the whole module against platform regressions.
+  windows-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
+      - name: Cross-compile for Windows
+        env:
+          GOOS: windows
+          GOARCH: amd64
+        run: go build ./...
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/bep_provider_test.go
+++ b/bep_provider_test.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	bep "github.com/myrgic/cogos/pkg/substrate/bep"
 )
 
 // ─── Helpers ────────────────────────────────────────────────────────────────────
@@ -312,7 +314,7 @@ func TestBEPDiffAndNotify(t *testing.T) {
 	current := map[string]time.Time{
 		"existing.agent.yaml": now,                      // unchanged
 		"modified.agent.yaml": now.Add(1 * time.Second), // modified
-		"created.agent.yaml":  now,                       // new
+		"created.agent.yaml":  now,                      // new
 		// deleted.agent.yaml is absent → deletion
 	}
 
@@ -715,6 +717,48 @@ discovery: tailscale
 	if len(cfg.SyncDirs) != 1 {
 		t.Errorf("SyncDirs count = %d, want 1", len(cfg.SyncDirs))
 	}
+}
+
+// TestBEPLoadConfigDefaultPort covers the #336 default-port behavior: an
+// enabled node that omits listenPort is assigned bep.DefaultListenPort (off
+// the Syncthing range), an explicit port is preserved, and a disabled config
+// is left untouched.
+func TestBEPLoadConfigDefaultPort(t *testing.T) {
+	t.Run("enabled without listenPort gets default", func(t *testing.T) {
+		root := t.TempDir()
+		writeClusterConfig(t, root, "enabled: true\ndeviceId: node-alpha\ndiscovery: static\n")
+		cfg, err := NewBEPProvider(root).LoadConfig()
+		if err != nil {
+			t.Fatalf("LoadConfig failed: %v", err)
+		}
+		if cfg.ListenPort != bep.DefaultListenPort {
+			t.Errorf("ListenPort = %d, want default %d", cfg.ListenPort, bep.DefaultListenPort)
+		}
+	})
+
+	t.Run("explicit listenPort preserved", func(t *testing.T) {
+		root := t.TempDir()
+		writeClusterConfig(t, root, "enabled: true\ndeviceId: node-alpha\nlistenPort: 22000\ndiscovery: static\n")
+		cfg, err := NewBEPProvider(root).LoadConfig()
+		if err != nil {
+			t.Fatalf("LoadConfig failed: %v", err)
+		}
+		if cfg.ListenPort != 22000 {
+			t.Errorf("ListenPort = %d, want explicit 22000", cfg.ListenPort)
+		}
+	})
+
+	t.Run("disabled config not defaulted", func(t *testing.T) {
+		root := t.TempDir()
+		writeClusterConfig(t, root, "enabled: false\ndiscovery: static\n")
+		cfg, err := NewBEPProvider(root).LoadConfig()
+		if err != nil {
+			t.Fatalf("LoadConfig failed: %v", err)
+		}
+		if cfg.ListenPort != 0 {
+			t.Errorf("ListenPort = %d, want 0 (disabled, untouched)", cfg.ListenPort)
+		}
+	})
 }
 
 func TestBEPLoadConfigInvalidYAML(t *testing.T) {

--- a/internal/engine/bep_engine.go
+++ b/internal/engine/bep_engine.go
@@ -158,7 +158,8 @@ func (e *BEPEngine) Start() error {
 	defer e.mu.Unlock()
 
 	// ListenPort 0 means OS-assigned random port (useful for tests).
-	// Default 22000 is set at config creation time (cluster init / cluster.yaml).
+	// Enabled nodes loaded from cluster.yaml are defaulted to
+	// bep.DefaultListenPort by BEPProvider.LoadConfig when unset (#336).
 	addr := fmt.Sprintf(":%d", e.config.ListenPort)
 	ln, err := tls.Listen("tcp", addr, e.tlsConfig)
 	if err != nil {

--- a/internal/engine/bep_provider.go
+++ b/internal/engine/bep_provider.go
@@ -37,17 +37,17 @@ type BEPSyncStatus = bep.SyncStatus
 // Phase 1: file watching + local change detection.
 // Phase 2 (current): integrated with BEPEngine for cross-node sync.
 type BEPProvider struct {
-	root     string // workspace root
-	watchDir string // .cog/bin/agents/definitions/
-	peers    []bep.Peer
-	mu       sync.Mutex
-	running  bool
-	stopCh   chan struct{}
+	root             string // workspace root
+	watchDir         string // .cog/bin/agents/definitions/
+	peers            []bep.Peer
+	mu               sync.Mutex
+	running          bool
+	stopCh           chan struct{}
 	onChange         func(filename string)   // primary callback when a CRD file changes
 	onChangeHandlers []func(filename string) // additional change handlers (e.g., BEPEngine)
-	lastSync time.Time
-	watcher  *fsnotify.Watcher // nil if fsnotify unavailable; falls back to polling
-	receiver *receiverState    // ring buffer for received CRD events
+	lastSync         time.Time
+	watcher          *fsnotify.Watcher // nil if fsnotify unavailable; falls back to polling
+	receiver         *receiverState    // ring buffer for received CRD events
 }
 
 // ─── Constructor ────────────────────────────────────────────────────────────────
@@ -83,6 +83,14 @@ func (p *BEPProvider) LoadConfig() (*bep.Config, error) {
 	var cfg bep.Config
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("parse cluster config: %w", err)
+	}
+
+	// An enabled node that omits listenPort gets the package default
+	// (bep.DefaultListenPort), not an OS-assigned random port — peers need a
+	// stable address to dial. Tests that want a random port construct
+	// bep.Config{} directly and bypass this path. See #336.
+	if cfg.Enabled && cfg.ListenPort == 0 {
+		cfg.ListenPort = bep.DefaultListenPort
 	}
 
 	return &cfg, nil

--- a/local_runner.go
+++ b/local_runner.go
@@ -425,7 +425,9 @@ func LocalStart(root string, crd *ServiceCRD) (*LocalProcess, error) {
 	}
 	// Detach from the kernel's session/process group so kernel shutdown
 	// (or any signal we propagate) doesn't cascade to supervised services.
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	// Platform-specific: Setsid on Unix, CREATE_NEW_PROCESS_GROUP on Windows
+	// (see local_runner_unix.go / local_runner_windows.go).
+	configureProcessGroup(cmd)
 
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("service %s: start: %w", crd.Metadata.Name, err)
@@ -461,7 +463,7 @@ func LocalStart(root string, crd *ServiceCRD) (*LocalProcess, error) {
 // cmd+args. If they don't match (PID reuse after a crash/reboot, manual
 // replacement, etc.), we log a warning and clear the stale PID file *without
 // sending any signal* — otherwise we'd kill an unrelated user process and,
-// worse, its whole process group, since we start with Setsid.
+// worse, its whole process group, since we start it in its own group.
 func LocalStop(root, name string) error {
 	p, err := readLocalProcess(root, name)
 	if err != nil {
@@ -488,9 +490,9 @@ func LocalStop(root, name string) error {
 		return nil
 	}
 
-	// Signal the whole process group since we start with Setsid.
-	_ = syscall.Kill(-p.PID, syscall.SIGTERM)
-	_ = proc.Signal(syscall.SIGTERM)
+	// Graceful stop of the whole process group (platform-specific:
+	// Kill(-pid, SIGTERM) on Unix, taskkill /T on Windows).
+	terminateProcessGroup(proc, p.PID)
 
 	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
@@ -500,8 +502,8 @@ func LocalStop(root, name string) error {
 		time.Sleep(250 * time.Millisecond)
 	}
 
-	_ = syscall.Kill(-p.PID, syscall.SIGKILL)
-	_ = proc.Signal(syscall.SIGKILL)
+	// Still alive after the grace period — force-kill the group.
+	killProcessGroup(proc, p.PID)
 	return nil
 }
 

--- a/local_runner_unix.go
+++ b/local_runner_unix.go
@@ -1,0 +1,39 @@
+//go:build !windows
+
+// local_runner_unix.go — Unix process-group primitives for the bare-metal
+// service supervisor.
+//
+// Supervised services are started in their own session (Setsid) so that
+// signals propagated to the kernel's process group do not cascade into the
+// children, and so that stopping a service can tear down its whole subtree via
+// a negative-PID signal. See local_runner_windows.go for the Windows analog
+// (CREATE_NEW_PROCESS_GROUP + taskkill /T).
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// configureProcessGroup starts the child in its own session/process group so
+// kernel shutdown (or any signal we propagate) does not cascade to supervised
+// services, and so the whole subtree can be signaled later via -PID.
+func configureProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}
+
+// terminateProcessGroup sends SIGTERM to the whole process group (negative
+// PID) and to the leader process directly. Both are best-effort.
+func terminateProcessGroup(proc *os.Process, pid int) {
+	_ = syscall.Kill(-pid, syscall.SIGTERM)
+	_ = proc.Signal(syscall.SIGTERM)
+}
+
+// killProcessGroup sends SIGKILL to the whole process group and to the leader
+// process directly. Both are best-effort.
+func killProcessGroup(proc *os.Process, pid int) {
+	_ = syscall.Kill(-pid, syscall.SIGKILL)
+	_ = proc.Signal(syscall.SIGKILL)
+}

--- a/local_runner_windows.go
+++ b/local_runner_windows.go
@@ -1,0 +1,45 @@
+//go:build windows
+
+// local_runner_windows.go — Windows process-group primitives for the
+// bare-metal service supervisor.
+//
+// Windows has no Setsid / negative-PID signaling. The analog is to start the
+// child in a new process group (CREATE_NEW_PROCESS_GROUP) and tear down the
+// whole subtree with `taskkill /T` (tree). Graceful stop uses taskkill without
+// /F (posts a close request the child can handle); force-kill adds /F and, as
+// a last resort, falls back to the process handle's Kill(). See
+// local_runner_unix.go for the Unix analog (Setsid + Kill(-pid)).
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"strconv"
+	"syscall"
+)
+
+// configureProcessGroup starts the child in its own process group so kernel
+// shutdown does not cascade to supervised services, and so the whole subtree
+// can be torn down later via `taskkill /T`.
+func configureProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP}
+}
+
+// terminateProcessGroup requests a graceful stop of the process tree via
+// `taskkill /PID <pid> /T` (no /F). Best-effort; the caller polls for exit and
+// escalates to killProcessGroup if the process survives the grace period.
+func terminateProcessGroup(_ *os.Process, pid int) {
+	_ = exec.Command("taskkill", "/PID", strconv.Itoa(pid), "/T").Run()
+}
+
+// killProcessGroup force-kills the process tree via `taskkill /F /PID <pid> /T`
+// and falls back to the process handle's Kill() if taskkill is unavailable.
+func killProcessGroup(proc *os.Process, pid int) {
+	if err := exec.Command("taskkill", "/F", "/PID", strconv.Itoa(pid), "/T").Run(); err == nil {
+		return
+	}
+	if proc != nil {
+		_ = proc.Kill()
+	}
+}

--- a/pkg/substrate/bep/config.go
+++ b/pkg/substrate/bep/config.go
@@ -8,10 +8,24 @@ package bep
 
 import "time"
 
+// DefaultListenPort is the BEP listen port assigned to an enabled node that
+// does not specify one in cluster.yaml.
+//
+// It is deliberately NOT 22000. BEP is Syncthing-derived, and 22000 is
+// Syncthing's canonical sync port — so inheriting it collided out of the box
+// for anyone already running personal Syncthing (observed during the Eclipse
+// node bring-up, #336). 6932 sits one above the kernel daemon's HTTP port
+// (6931 = ln(2)×10⁴) and is clear of the Syncthing range (22000/21027/22067).
+//
+// A node can still bind 22000 explicitly via `listenPort: 22000` if it wants
+// to share Syncthing's port deliberately. Per-node port negotiation/discovery
+// (rather than a fixed default) is left as follow-up.
+const DefaultListenPort = 6932
+
 // Peer represents a known peer node in the BEP cluster.
 type Peer struct {
 	DeviceID string    `json:"deviceId" yaml:"deviceId"`
-	Address  string    `json:"address" yaml:"address"`     // host:port or tailscale address
+	Address  string    `json:"address" yaml:"address"` // host:port or tailscale address
 	Name     string    `json:"name" yaml:"name"`
 	Trusted  bool      `json:"trusted" yaml:"trusted"`
 	LastSeen time.Time `json:"lastSeen,omitempty" yaml:"lastSeen,omitempty"`
@@ -19,14 +33,14 @@ type Peer struct {
 
 // Config holds cluster configuration loaded from .cog/config/cluster.yaml.
 type Config struct {
-	Enabled    bool   `yaml:"enabled"`
-	DeviceID   string `yaml:"deviceId,omitempty"`   // this node's ID
-	NodeName   string `yaml:"nodeName,omitempty"`   // human-readable node name
-	ListenPort int    `yaml:"listenPort,omitempty"` // BEP listen port (default 22000)
-	CertDir    string `yaml:"certDir,omitempty"`    // TLS cert directory (default ~/.cog/etc)
-	Peers      []Peer `yaml:"peers,omitempty"`
-	SyncDirs   []string `yaml:"syncDirs,omitempty"` // directories to sync
-	Discovery  string `yaml:"discovery,omitempty"`   // "static", "tailscale", "mdns"
+	Enabled    bool     `yaml:"enabled"`
+	DeviceID   string   `yaml:"deviceId,omitempty"`   // this node's ID
+	NodeName   string   `yaml:"nodeName,omitempty"`   // human-readable node name
+	ListenPort int      `yaml:"listenPort,omitempty"` // BEP listen port (default DefaultListenPort; 0 = OS-assigned random)
+	CertDir    string   `yaml:"certDir,omitempty"`    // TLS cert directory (default ~/.cog/etc)
+	Peers      []Peer   `yaml:"peers,omitempty"`
+	SyncDirs   []string `yaml:"syncDirs,omitempty"`  // directories to sync
+	Discovery  string   `yaml:"discovery,omitempty"` // "static", "tailscale", "mdns"
 }
 
 // SyncStatus returns current sync state for the BEP provider.


### PR DESCRIPTION
Two v0.13.0 release-blockers, both inside the Phase 2 cluster code that landed since v0.12.0.

## #328 — root package didn't compile for Windows (bug)
The repo-root `package main` (`cog node init`, BEP, local runner) used Unix-only process primitives with no build-tag guard, so `GOOS=windows go build ./...` failed: `SysProcAttr{Setsid}` and `syscall.Kill(-pid, …)` in `local_runner.go`.

- Split the three process-group operations behind build tags, mirroring the `daemon_stop_unix.go`/`daemon_stop_windows.go` pattern from #325:
  - `local_runner_unix.go` — `Setsid` + `Kill(-pid, sig)`
  - `local_runner_windows.go` — `CREATE_NEW_PROCESS_GROUP` + `taskkill /T`
- `processAlive`/`verifyOwnership` already runtime-guarded Windows; left as-is.
- **CI guard:** new `windows-build` job cross-compiles the whole module (`GOOS=windows go build ./...`). The existing `build` job only built `./cmd/cogos` (which already cross-compiled cleanly), which is why this slipped through.

## #336 — BEP default port collided with Syncthing
BEP is Syncthing-derived and inherited Syncthing's canonical sync port (22000) as its documented default, colliding for anyone running personal Syncthing (hit during Eclipse bring-up).

- Add `bep.DefaultListenPort = 6932` as the single source of truth — one above the kernel daemon's `6931` (`ln(2)×10⁴`), clear of the Syncthing range (22000/21027/22067).
- `BEPProvider.LoadConfig` assigns it to an **enabled** node that omits `listenPort` (peers need a stable dial address) instead of falling to an OS-random port. Explicit `listenPort: 22000` still honored. The `0 = random` test path (direct `bep.Config{}` construction) is preserved, since it bypasses `LoadConfig`.
- Per-node port negotiation/discovery left as follow-up.

## Verification
- `GOOS=windows go build ./...` ✅ and native `go build ./...` ✅
- `go vet ./...` ✅, gofmt clean
- `go test` on root + `internal/engine` + `pkg/substrate/bep` ✅ (incl. new `TestBEPLoadConfigDefaultPort`)

Closes #328
Closes #336