### PR TITLE
fix(config): patch kernel.yaml in place to preserve comments and avoid zeroing absent fields

### DIFF
--- a/internal/engine/config_write.go
+++ b/internal/engine/config_write.go
@@ -621,9 +621,31 @@ func writeConfigPatchLocked(root string, patch map[string]any, opts WriteConfigO
 	}
 
 	// 7. Serialize + atomic write.
-	out, merr := yaml.Marshal(&merged)
-	if merr != nil {
-		return WriteConfigResult{}, fmt.Errorf("marshal merged config: %w", merr)
+	//
+	// Instead of marshalling the full merged struct (which destroys comments,
+	// zeroes absent fields, and emits a spurious duplicate v3: block), we
+	// patch only the keys the caller actually set, leaving everything else
+	// untouched in the YAML node tree.
+	var out []byte
+	if exists {
+		// Re-read raw bytes (same file we backed up; read again to avoid
+		// holding the bytes across the backup path).
+		rawBytes, rerr2 := os.ReadFile(path)
+		if rerr2 != nil {
+			return WriteConfigResult{}, fmt.Errorf("re-read %s for node patch: %w", path, rerr2)
+		}
+		patched, perr := patchYAMLNodes(rawBytes, patch, opts.Scope)
+		if perr != nil {
+			return WriteConfigResult{}, fmt.Errorf("node-patch kernel.yaml: %w", perr)
+		}
+		out = patched
+	} else {
+		// New file: write only the patched keys under the appropriate scope.
+		minimal, merr := buildMinimalYAML(patch, opts.Scope)
+		if merr != nil {
+			return WriteConfigResult{}, fmt.Errorf("build minimal kernel.yaml: %w", merr)
+		}
+		out = minimal
 	}
 	if werr := atomicWriteConfigFile(path, out); werr != nil {
 		return WriteConfigResult{}, fmt.Errorf("write %s: %w", path, werr)
@@ -784,6 +806,234 @@ func RollbackConfig(root string, opts RollbackOptions) (RollbackResult, error) {
 		Backups:         backupsAfter,
 		Path:            path,
 	}, nil
+}
+
+// ── YAML node-tree patching ─────────────────────────────────────────────────
+
+// patchYAMLNodes parses existing YAML bytes as a yaml.Node document, then
+// sets/updates only the keys present in patch, leaving comments, key order,
+// and all untouched keys intact. For scope "v3" the patch keys land under
+// the v3: mapping (created only if at least one v3 key is patched). The
+// updated document is marshalled back to bytes and returned.
+func patchYAMLNodes(existing []byte, patch map[string]any, scope string) ([]byte, error) {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(existing, &doc); err != nil {
+		return nil, fmt.Errorf("parse existing yaml: %w", err)
+	}
+
+	// yaml.Unmarshal with a *yaml.Node yields a DocumentNode wrapping the root.
+	// Ensure we have a usable document + root mapping.
+	if doc.Kind == 0 {
+		// Empty file — build a fresh document node.
+		doc = yaml.Node{
+			Kind: yaml.DocumentNode,
+			Content: []*yaml.Node{
+				{Kind: yaml.MappingNode, Tag: "!!map"},
+			},
+		}
+	}
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
+		return nil, fmt.Errorf("unexpected yaml node kind %v", doc.Kind)
+	}
+	root := doc.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("root yaml node is not a mapping (kind=%v)", root.Kind)
+	}
+
+	switch scope {
+	case "v3":
+		// Find or create the v3: key inside root.
+		v3Map := findMappingValue(root, "v3")
+		if v3Map == nil {
+			// Create a new v3: key with an empty mapping.
+			keyNode := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "v3"}
+			valNode := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+			root.Content = append(root.Content, keyNode, valNode)
+			v3Map = valNode
+		}
+		for k, v := range patch {
+			setYAMLKey(v3Map, k, v)
+		}
+	default: // "top"
+		for k, v := range patch {
+			setYAMLKey(root, k, v)
+		}
+	}
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(&doc); err != nil {
+		return nil, fmt.Errorf("re-encode yaml: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("close yaml encoder: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// findMappingValue looks for a key in a yaml.MappingNode and returns its
+// value node, or nil if not found.
+func findMappingValue(m *yaml.Node, key string) *yaml.Node {
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Value == key {
+			return m.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// setYAMLKey sets key=val in a yaml.MappingNode. If the key already exists
+// its value node is updated in place; otherwise a new key+value pair is
+// appended. val==nil removes the key (RFC 7396 null → delete).
+func setYAMLKey(m *yaml.Node, key string, val any) {
+	// nil → remove the key from the mapping.
+	if val == nil {
+		for i := 0; i+1 < len(m.Content); i += 2 {
+			if m.Content[i].Value == key {
+				m.Content = append(m.Content[:i], m.Content[i+2:]...)
+				return
+			}
+		}
+		return
+	}
+
+	valNode := anyToYAMLNode(val)
+
+	// Update existing.
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Value == key {
+			// Preserve the existing key node (it may carry a comment).
+			m.Content[i+1] = valNode
+			return
+		}
+	}
+
+	// Append new key+value.
+	keyNode := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}
+	m.Content = append(m.Content, keyNode, valNode)
+}
+
+// anyToYAMLNode converts a Go value to a yaml.Node suitable for embedding in a
+// node tree. Supports scalars (string, bool, int, float64), map[string]any, and
+// map[string]string (digest_paths).
+func anyToYAMLNode(v any) *yaml.Node {
+	switch val := v.(type) {
+	case string:
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: val}
+	case bool:
+		s := "false"
+		if val {
+			s = "true"
+		}
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: s}
+	case int:
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: fmt.Sprintf("%d", val)}
+	case float64:
+		// Prefer integer representation when there is no fractional part.
+		if val == float64(int64(val)) {
+			return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: fmt.Sprintf("%d", int64(val))}
+		}
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!float", Value: fmt.Sprintf("%g", val)}
+	case map[string]any:
+		n := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+		// Sort keys for stable output.
+		keys := make([]string, 0, len(val))
+		for k := range val {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			n.Content = append(n.Content,
+				&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: k},
+				anyToYAMLNode(val[k]),
+			)
+		}
+		return n
+	case map[string]string:
+		n := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+		keys := make([]string, 0, len(val))
+		for k := range val {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			n.Content = append(n.Content,
+				&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: k},
+				&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: val[k]},
+			)
+		}
+		return n
+	case []string:
+		n := &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
+		for _, s := range val {
+			n.Content = append(n.Content, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: s})
+		}
+		return n
+	case []any:
+		n := &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
+		for _, s := range val {
+			n.Content = append(n.Content, anyToYAMLNode(s))
+		}
+		return n
+	default:
+		// Fallback: marshal via yaml then parse back to a node.
+		raw, err := yaml.Marshal(v)
+		if err != nil {
+			return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: fmt.Sprintf("%v", v)}
+		}
+		var node yaml.Node
+		if err := yaml.Unmarshal(raw, &node); err != nil {
+			return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: fmt.Sprintf("%v", v)}
+		}
+		if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+			return node.Content[0]
+		}
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: fmt.Sprintf("%v", v)}
+	}
+}
+
+// buildMinimalYAML produces a minimal YAML document from the patch map alone,
+// writing keys only at the relevant scope. No zero-value fields, no empty v3:
+// block unless the scope is "v3".
+func buildMinimalYAML(patch map[string]any, scope string) ([]byte, error) {
+	root := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+
+	switch scope {
+	case "v3":
+		if len(patch) > 0 {
+			v3Val := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+			for k, v := range patch {
+				if v != nil {
+					setYAMLKey(v3Val, k, v)
+				}
+			}
+			if len(v3Val.Content) > 0 {
+				root.Content = append(root.Content,
+					&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "v3"},
+					v3Val,
+				)
+			}
+		}
+	default:
+		for k, v := range patch {
+			if v != nil {
+				setYAMLKey(root, k, v)
+			}
+		}
+	}
+
+	doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(doc); err != nil {
+		return nil, err
+	}
+	if err := enc.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 // ── Atomic Writer ───────────────────────────────────────────────────────────

--- a/internal/engine/config_write_test.go
+++ b/internal/engine/config_write_test.go
@@ -1,18 +1,18 @@
 // config_write_test.go — unit tests for the Config Mutation API.
 //
 // Covers the spec from agent-O-config-mutation-design §Test plan:
-//   1.  Full patch, happy path
-//   2.  Sparse patch, single field
-//   3.  Patch reload-safe field
-//   4.  Null removes a field
-//   5.  Scope: v3 override
-//   6.  Validation rejects bad heartbeat
-//   7.  Validation rejects out-of-range port
-//   8.  Dry run does not touch disk
-//   9.  Atomic write semantics (no torn file under failure)
-//  10.  Backup rotation keeps 10
-//  11.  Corrupt existing file is refused
-//  12.  Concurrent writes serialize
+//  1. Full patch, happy path
+//  2. Sparse patch, single field
+//  3. Patch reload-safe field
+//  4. Null removes a field
+//  5. Scope: v3 override
+//  6. Validation rejects bad heartbeat
+//  7. Validation rejects out-of-range port
+//  8. Dry run does not touch disk
+//  9. Atomic write semantics (no torn file under failure)
+//  10. Backup rotation keeps 10
+//  11. Corrupt existing file is refused
+//  12. Concurrent writes serialize
 //
 // Plus MCP + HTTP roundtrip tests (see config_write_wire_test.go).
 package engine
@@ -47,8 +47,8 @@ func readKernelYAML(t *testing.T, path string) kernelConfig {
 	return kc
 }
 
-// 1. Full patch on a fresh workspace populates every field + creates a backup
-//    when an existing file was overwritten.
+//  1. Full patch on a fresh workspace populates every field + creates a backup
+//     when an existing file was overwritten.
 func TestWriteConfigPatch_FullPatchHappyPath(t *testing.T) {
 	t.Parallel()
 	root := makeWorkspace(t)
@@ -131,8 +131,8 @@ func TestWriteConfigPatch_SparsePatchPreservesOthers(t *testing.T) {
 	}
 }
 
-// 3. Reload-safe field: requires_restart is still true in v1 (we always
-//    persist + restart), but changed_fields reveals the field is reload-safe.
+//  3. Reload-safe field: requires_restart is still true in v1 (we always
+//     persist + restart), but changed_fields reveals the field is reload-safe.
 func TestWriteConfigPatch_ReloadSafeFieldChange(t *testing.T) {
 	t.Parallel()
 	root := makeWorkspace(t)
@@ -302,8 +302,8 @@ func TestWriteConfigPatch_DryRun(t *testing.T) {
 	}
 }
 
-// 9. Atomic write semantics — a successful write never produces a torn file,
-//    and the backup is a full copy of the prior content.
+//  9. Atomic write semantics — a successful write never produces a torn file,
+//     and the backup is a full copy of the prior content.
 func TestWriteConfigPatch_AtomicWrite(t *testing.T) {
 	t.Parallel()
 	root := makeWorkspace(t)
@@ -372,7 +372,7 @@ func TestWriteConfigPatch_BackupRotation(t *testing.T) {
 	}
 }
 
-// 11. Corrupt existing file is refused — the write path refuses to clobber
+//  11. Corrupt existing file is refused — the write path refuses to clobber
 //     unparseable YAML without a rollback first.
 func TestWriteConfigPatch_RefusesCorruptFile(t *testing.T) {
 	t.Parallel()
@@ -402,7 +402,7 @@ func TestWriteConfigPatch_RefusesCorruptFile(t *testing.T) {
 	}
 }
 
-// 12. Concurrent writes serialize — 8 goroutines all set port to different
+//  12. Concurrent writes serialize — 8 goroutines all set port to different
 //     values; no corruption and the final file is a valid YAML with one of
 //     the candidate ports.
 func TestWriteConfigPatch_ConcurrentWritesSerialize(t *testing.T) {
@@ -484,5 +484,113 @@ func TestRollbackConfig_RestoresPriorBackup(t *testing.T) {
 	kc := readKernelYAML(t, path)
 	if kc.LocalModel != "gemma4:b" {
 		t.Errorf("LocalModel after rollback = %q; want gemma4:b", kc.LocalModel)
+	}
+}
+
+//  15. In-place patch preserves comments and does NOT emit zeroed absent fields
+//     or a spurious top-level v3: block — the three clobber modes from issue #342.
+func TestWriteConfigPatch_PreservesCommentsNoZeroNoV3(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	fixture := "# workspace kernel config\n# managed by hand\nollama_embed_model: bge-m3:latest\n"
+	path := seedKernelYAML(t, root, fixture)
+
+	result, err := WriteConfigPatch(root, map[string]any{"local_model": "gemma4:e4b"}, WriteConfigOptions{})
+	if err != nil {
+		t.Fatalf("WriteConfigPatch: %v", err)
+	}
+	if !result.Written {
+		t.Fatalf("expected written=true, got violations=%+v", result.Violations)
+	}
+
+	raw, rerr := os.ReadFile(path)
+	if rerr != nil {
+		t.Fatalf("read result: %v", rerr)
+	}
+	out := string(raw)
+
+	// (a) Original comment lines survive.
+	if !strings.Contains(out, "# workspace kernel config") {
+		t.Errorf("comment '# workspace kernel config' not found in output:\n%s", out)
+	}
+	if !strings.Contains(out, "# managed by hand") {
+		t.Errorf("comment '# managed by hand' not found in output:\n%s", out)
+	}
+
+	// (b) No zeroed port field.
+	if strings.Contains(out, "port: 0") {
+		t.Errorf("spurious 'port: 0' found in output:\n%s", out)
+	}
+
+	// (c) No spurious top-level v3: block.
+	if strings.Contains(out, "\nv3:") || strings.HasPrefix(out, "v3:") {
+		t.Errorf("spurious 'v3:' block found in output:\n%s", out)
+	}
+
+	// (d) Original field preserved.
+	if !strings.Contains(out, "ollama_embed_model: bge-m3:latest") {
+		t.Errorf("ollama_embed_model not preserved in output:\n%s", out)
+	}
+
+	// (e) Patched field present.
+	if !strings.Contains(out, "local_model: gemma4:e4b") {
+		t.Errorf("local_model not set in output:\n%s", out)
+	}
+}
+
+//  16. v3-scope patch lands under v3: without zeroing top-level keys and
+//     without an empty v3: block being emitted before the patch.
+func TestWriteConfigPatch_V3ScopeNodePatch(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	// File has only a top-level key and NO v3: section.
+	fixture := "# top comment\nollama_embed_model: bge-m3:latest\n"
+	path := seedKernelYAML(t, root, fixture)
+
+	result, err := WriteConfigPatch(root, map[string]any{"local_model": "gemma4:26b"}, WriteConfigOptions{Scope: "v3"})
+	if err != nil {
+		t.Fatalf("WriteConfigPatch v3: %v", err)
+	}
+	if !result.Written {
+		t.Fatalf("expected written=true, got violations=%+v", result.Violations)
+	}
+
+	raw, rerr := os.ReadFile(path)
+	if rerr != nil {
+		t.Fatalf("read result: %v", rerr)
+	}
+	out := string(raw)
+
+	// Top-level comment preserved.
+	if !strings.Contains(out, "# top comment") {
+		t.Errorf("comment '# top comment' not found in output:\n%s", out)
+	}
+
+	// Top-level field preserved, not zeroed.
+	if !strings.Contains(out, "ollama_embed_model: bge-m3:latest") {
+		t.Errorf("ollama_embed_model not preserved in output:\n%s", out)
+	}
+
+	// v3: block created and contains the patched field.
+	if !strings.Contains(out, "v3:") {
+		t.Errorf("v3: section not found in output:\n%s", out)
+	}
+	if !strings.Contains(out, "local_model: gemma4:26b") {
+		t.Errorf("local_model not found under v3: in output:\n%s", out)
+	}
+
+	// No zeroed top-level port.
+	if strings.Contains(out, "port: 0") {
+		t.Errorf("spurious 'port: 0' found in output:\n%s", out)
+	}
+
+	// The v3 section should contain local_model; verify via struct parse.
+	kc := readKernelYAML(t, path)
+	if kc.V3.LocalModel != "gemma4:26b" {
+		t.Errorf("V3.LocalModel = %q; want gemma4:26b", kc.V3.LocalModel)
+	}
+	// Top-level OllamaEmbedModel still present.
+	if kc.OllamaEmbedModel != "bge-m3:latest" {
+		t.Errorf("OllamaEmbedModel = %q; want bge-m3:latest (top-level, unchanged)", kc.OllamaEmbedModel)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes three clobber modes introduced by the full-struct `yaml.Marshal` in `writeConfigPatchLocked` (step 7 of `internal/engine/config_write.go`):

- **Comments destroyed** — struct marshal emits no comments.
- **Absent fields zeroed** — `kernelConfigSection` fields lack `omitempty`, so fields not present in the file (e.g. `port` resolved from `--port` flag) were written as explicit `port: 0`, `salience_floor: null`, silently inverting the documented `flag > env > file > default` precedence.
- **Duplicate `v3:` block** — `kernelConfig` embeds `kernelConfigSection` inline plus a `V3 kernelConfigSection` field, so every round-trip emitted the whole config a second time under `v3:`.

## Before / After

**Before:** `WriteConfigPatch(root, {"local_model": "gemma4:e4b"}, top)` on a file with leading comments and only `ollama_embed_model: bge-m3:latest` set would produce something like:
```yaml
port: 0
consolidation_interval: 0
...
ollama_embed_model: ""
local_model: gemma4:e4b
...
v3:
    port: 0
    ...
```
Comments gone, every absent field zeroed, and a spurious `v3:` block added.

**After:** Same call produces:
```yaml
# workspace kernel config
# managed by hand
ollama_embed_model: bge-m3:latest
local_model: gemma4:e4b
```
Only the patched key is added; everything else is untouched.

## Implementation

- When the file **exists**: parse the on-disk bytes into a `yaml.Node` document. For each key in `patch`, set/update only that node — at the top-level mapping for scope `"top"`, or inside the `v3:` mapping for scope `"v3"` (created only if at least one v3 key is patched). All other keys, comments, and formatting are left intact. Marshal the node tree back.
- When the file **does not exist**: build a minimal `yaml.Node` document from `patch` only — no zero-value fields, no empty `v3:` block unless scope is `"v3"`.
- Validation, diff, dry-run, and backup/rotate logic are unchanged.

## Test plan

- [ ] `go build ./...` — clean
- [ ] `go test ./internal/engine/ -run 'Config|Write'` — all 16 Config/Write tests pass
- [ ] `gofmt -l` — clean on touched files
- [ ] New test `TestWriteConfigPatch_PreservesCommentsNoZeroNoV3` gates all three clobber modes for top-scope patches
- [ ] New test `TestWriteConfigPatch_V3ScopeNodePatch` gates v3-scope patches landing under `v3:` without zeroing top-level keys

Closes #342