### PR TITLE
fix(build): always rebuild cogos binary so internal/pkg/cmd changes are never stale

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,14 +33,12 @@ GOARCH := $(shell go env GOARCH)
 # Build targets
 PLATFORMS := darwin-arm64 darwin-amd64 linux-amd64 linux-arm64 android-arm64 windows-amd64 windows-arm64
 
-.PHONY: all build clean test test-coverage test-integration bench install push image run e2e e2e-local $(PLATFORMS)
+.PHONY: all build clean test test-coverage test-integration bench install push image run e2e e2e-local $(PLATFORMS) $(BINARY)
 
 # Default: build for current platform
 build: $(BINARY)
 
-GO_SOURCES := $(wildcard *.go) $(wildcard harness/*.go)
-
-$(BINARY): $(GO_SOURCES) go.mod harness/go.mod
+$(BINARY):
 	$(GO) build -tags "$(BUILD_TAGS)" -ldflags="$(LDFLAGS)" -o $(BINARY) ./cmd/cogos
 
 # Build for all platforms


### PR DESCRIPTION
## Summary

- **Root cause**: `Makefile:41` used `$(wildcard *.go) $(wildcard harness/*.go)` as the `$(BINARY)` prerequisites. `$(wildcard ...)` is non-recursive, so the ~3383 files under `internal/`, `pkg/`, and `cmd/` were never tracked. Make treated `./cog` as up-to-date on changes confined to those directories, silently shipping the stale binary — exactly what happened after #343 (`config_write.go`).
- **Fix**: add `$(BINARY)` to `.PHONY` and remove the `GO_SOURCES` prerequisite list. `go build` always runs; Go's content-addressed build cache makes a no-op rebuild ~instant and is dependency-correct. The now-unused `GO_SOURCES` variable is also removed.
- The `-tags "$(BUILD_TAGS)"` (fts5) and `-ldflags="$(LDFLAGS)"` (Version/BuildTime stamp) are preserved exactly as before. The `install` target's backup + atomic-mv + version-check behavior is unchanged.

## Before / after rebuild proof

**Build 1** (no change to `internal/`):
```
SHA-256: fa23b02b04cb0a900ca0d597be024e7447ecc98d514368b9ae6247b05abc5cc4
cogos version=0.13.0 build=2026-05-27T22:43:36Z
```

**`touch internal/engine/config_write.go` → `make build`**:
```
SHA-256: 3dca7837ed6c165b334b279ffcef50693a3adf9fc1f9598f6c7d16bd643601f7
cogos version=0.13.0 build=2026-05-27T22:43:46Z
```

Build timestamp advanced and SHA changed — the rebuild triggers unconditionally, as required. `make -n install` confirms the full install recipe (backup + atomic-mv + version-check) still runs after the build step.

Closes #344