### PR TITLE
feat(session-reg): Fix A — add iss/sub to ChannelSessionRecord (SYNC half)

### DIFF
--- a/internal/engine/serve_sessions_channel.go
+++ b/internal/engine/serve_sessions_channel.go
@@ -85,6 +85,19 @@ type ChannelSessionRecord struct {
 	// Source records whether the session_id came from the caller or was
 	// minted. Useful for audit; no functional impact.
 	IDSource string `json:"id_source,omitempty"` // "caller" | "minted"
+
+	// Iss / Sub carry the OIDC identity claims forwarded from mod3's seat
+	// registration (Fix A — session-registration-unification). These are the
+	// user_iss/user_sub fields from the channel-client seat; carrying them on
+	// the kernel record makes the WHO visible to kernel consumers without
+	// requiring a second round-trip to mod3.
+	//
+	// Dependency: fully populated only when mod3 is running the
+	// feat/mod3-session-identity-claims branch or later (merged into main).
+	// Callers that don't supply these fields leave them empty; the kernel
+	// record is still valid and the callback is still idempotent.
+	Iss string `json:"iss,omitempty"`
+	Sub string `json:"sub,omitempty"`
 }
 
 // ChannelSessionRegistry is the in-memory map keyed by session_id. It holds
@@ -198,6 +211,12 @@ type channelSessionRegisterRequest struct {
 	Priority              int            `json:"priority,omitempty"`
 	Kinds                 []string       `json:"kinds,omitempty"`
 	Metadata              map[string]any `json:"metadata,omitempty"`
+	// Iss / Sub are OIDC identity claims forwarded from the mod3 seat that
+	// triggered this register callback (Fix A — session-registration-unification).
+	// Optional; absent means the seat was unattributed or the caller does not
+	// carry identity (e.g. a direct kernel-originated registration).
+	Iss string `json:"iss,omitempty"`
+	Sub string `json:"sub,omitempty"`
 }
 
 // channelSessionResponse is the merged shape returned from the kernel. The
@@ -292,6 +311,8 @@ func (s *Server) RegisterChannelSession(ctx context.Context, req channelSessionR
 		RegisteredAt:          now,
 		LastSeen:              now,
 		IDSource:              idSource,
+		Iss:                   req.Iss,
+		Sub:                   req.Sub,
 	}
 
 	// Forward to mod3 with the kernel-issued session_id. Mod3's body is the

--- a/internal/engine/serve_sessions_channel_test.go
+++ b/internal/engine/serve_sessions_channel_test.go
@@ -625,3 +625,86 @@ func TestMintChannelSessionID_ShapeAndUniqueness(t *testing.T) {
 		seen[id] = true
 	}
 }
+
+// TestChannelSessionRegister_IssSub_StoredOnRecord verifies Fix A — that
+// iss/sub identity claims supplied via the mod3 seat callback land on the
+// kernel ChannelSessionRecord.
+//
+// This is the kernel half of the session-registration-unification spec: a
+// seat-register that mod3 proxies in must produce a kernel record carrying
+// the WHO (iss/sub) so downstream consumers (cog_list_sessions, the HUD,
+// reconcilers) can see identity without a second mod3 round-trip.
+func TestChannelSessionRegister_IssSub_StoredOnRecord(t *testing.T) {
+	fm := newFakeMod3(t)
+	s, front := newChannelServer(t, fm)
+
+	body, _ := json.Marshal(map[string]any{
+		"session_id":     "cs-identity-test",
+		"participant_id": "channel-client::claude-code-channel",
+		"iss":            "https://cogos.local",
+		"sub":            "chaz",
+	})
+	resp, err := http.Post(front.URL+"/v1/channel-sessions/register",
+		"application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST register: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d; body: %s", resp.StatusCode, raw)
+	}
+
+	// Kernel record must carry the identity claims.
+	rec, ok := s.channelSessionRegistry.Get("cs-identity-test")
+	if !ok {
+		t.Fatal("expected kernel registry to hold record after register")
+	}
+	if rec.Iss != "https://cogos.local" {
+		t.Fatalf("expected Iss=https://cogos.local on record, got %q", rec.Iss)
+	}
+	if rec.Sub != "chaz" {
+		t.Fatalf("expected Sub=chaz on record, got %q", rec.Sub)
+	}
+}
+
+// TestChannelSessionRegister_IssSub_IdempotentOnReregister verifies that a
+// re-register with the same session_id overwrites the kernel record, preserving
+// the idempotency invariant required by the mod3 → kernel callback.
+// (ChannelSessionRegistry.Put overwrites by session_id — safe to call on
+// every seat re-register.)
+func TestChannelSessionRegister_IssSub_IdempotentOnReregister(t *testing.T) {
+	fm := newFakeMod3(t)
+	s, front := newChannelServer(t, fm)
+
+	registerWith := func(sub string) {
+		body, _ := json.Marshal(map[string]any{
+			"session_id":     "cs-idem-test",
+			"participant_id": "channel-client::claude-code-channel",
+			"iss":            "https://cogos.local",
+			"sub":            sub,
+		})
+		resp, err := http.Post(front.URL+"/v1/channel-sessions/register",
+			"application/json", bytes.NewReader(body))
+		if err != nil {
+			t.Fatalf("POST register (sub=%s): %v", sub, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200 (sub=%s), got %d", sub, resp.StatusCode)
+		}
+	}
+
+	registerWith("chaz")
+	rec, _ := s.channelSessionRegistry.Get("cs-idem-test")
+	if rec.Sub != "chaz" {
+		t.Fatalf("expected Sub=chaz after first register, got %q", rec.Sub)
+	}
+
+	// Re-register with updated sub — Put overwrites.
+	registerWith("chaz-updated")
+	rec, _ = s.channelSessionRegistry.Get("cs-idem-test")
+	if rec.Sub != "chaz-updated" {
+		t.Fatalf("expected Sub=chaz-updated after re-register, got %q", rec.Sub)
+	}
+}


### PR DESCRIPTION
Adds `Iss`/`Sub` OIDC claim fields to `ChannelSessionRecord` and copies them from the mod3 channel-sessions callback request; registration stays idempotent (Put overwrites by session_id). The kernel-side half of the cross-repo session-registration-unify feature (pairs with myrgic/mod3 #118).

Scope: **Fix A (SYNC half) only** — Fix B (heartbeat/reaper) is deferred. +21/+83 (impl/test), 2 new tests, merges clean against main.