### PR TITLE
perf(router): probe provider availability off the request hot path

### DIFF
--- a/internal/engine/boot.go
+++ b/internal/engine/boot.go
@@ -199,8 +199,10 @@ func Boot(ctx context.Context, cfg *Config, opts ...BootOption) (*Kernel, error)
 		slog.Info("trm: wired into context assembly pipeline")
 	}
 
-	// Build the inference router.
-	router, err := BuildRouter(cfg)
+	// Build the inference router. Pass the kernel context so the router runs its
+	// background availability maintainer (provider readiness is probed off the
+	// request hot path) and stops cleanly on shutdown.
+	router, err := BuildRouter(cfg, WithRouterContext(ctx))
 	if err != nil {
 		slog.Warn("router build failed; inference disabled", "err", err)
 	}

--- a/internal/engine/router.go
+++ b/internal/engine/router.go
@@ -34,6 +34,19 @@ import (
 
 var toolCallRejectionsByProvider sync.Map // map[string]*atomic.Int64
 
+// availState is a single provider's last observed readiness.
+type availState struct {
+	ready    bool
+	lastSeen time.Time
+}
+
+// availSnapshot is an immutable map of provider name → readiness, swapped
+// atomically by the background maintainer so Route reads it lock-free.
+type availSnapshot map[string]availState
+
+// defaultAvailTTL is the interval between background availability probes.
+const defaultAvailTTL = 10 * time.Second
+
 // SimpleRouter implements Router with rule-based provider selection.
 type SimpleRouter struct {
 	mu        sync.RWMutex
@@ -41,6 +54,22 @@ type SimpleRouter struct {
 	byName    map[string]Provider
 
 	cfg RoutingConfig
+
+	// Provider availability maintained off the request hot path. A background
+	// goroutine (Start) probes every provider concurrently on availTTL and
+	// swaps an immutable snapshot; Route reads it lock-free via available().
+	// When the snapshot is cold/stale (no maintainer running, just-registered
+	// provider, or stalled ticker) available() falls back to a bounded inline
+	// probe so short-lived callers that never call Start stay correct.
+	//
+	// This is the fix for the per-request blocking probe: a dead provider deep
+	// in the fallback chain used to cost its full TCP timeout on every request
+	// (it was probed inline in Route); now that cost is paid in the background,
+	// concurrently, once per availTTL, and never on a request.
+	avail    atomic.Pointer[availSnapshot]
+	availTTL time.Duration
+	stopCh   chan struct{}
+	stopOnce sync.Once
 
 	// Atomics for lock-free stats.
 	totalRequests atomic.Int64
@@ -52,8 +81,10 @@ type SimpleRouter struct {
 // NewSimpleRouter creates an empty router with the given routing config.
 func NewSimpleRouter(cfg RoutingConfig) *SimpleRouter {
 	return &SimpleRouter{
-		cfg:    cfg,
-		byName: make(map[string]Provider),
+		cfg:      cfg,
+		byName:   make(map[string]Provider),
+		availTTL: defaultAvailTTL,
+		stopCh:   make(chan struct{}),
 	}
 }
 
@@ -170,7 +201,7 @@ func (r *SimpleRouter) Route(ctx context.Context, req *CompletionRequest) (Provi
 	for i, p := range ordered {
 		caps := p.Capabilities()
 		capsMet := caps.HasAllCapabilities(req.Metadata.RequiredCapabilities)
-		avail := p.Available(ctx)
+		avail := r.available(ctx, p)
 
 		score := ProviderScore{
 			Provider:        p.Name(),
@@ -227,6 +258,94 @@ func (r *SimpleRouter) Route(ctx context.Context, req *CompletionRequest) (Provi
 		"latency_us", time.Since(start).Microseconds())
 
 	return selected, decision, nil
+}
+
+// available reports whether provider p is ready, reading the maintained
+// availability snapshot when it holds a fresh entry and falling back to a
+// bounded inline probe otherwise. The fast path is lock-free and O(1); the
+// fallback exists so callers that never start the background maintainer (and
+// freshly-registered providers not yet probed) still observe real readiness.
+func (r *SimpleRouter) available(ctx context.Context, p Provider) bool {
+	ttl := r.availTTL
+	if ttl <= 0 {
+		ttl = defaultAvailTTL
+	}
+	if snap := r.avail.Load(); snap != nil {
+		if st, ok := (*snap)[p.Name()]; ok && time.Since(st.lastSeen) <= 3*ttl {
+			return st.ready // maintained readiness — no probe on the hot path
+		}
+	}
+	// Cold or stale: probe inline, but bound it so a dead provider can't hang
+	// the request beyond probeTimeout.
+	pctx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+	return p.Available(pctx)
+}
+
+// probeTimeout bounds a single availability probe (background or inline
+// fallback) so one unreachable endpoint can't stall a whole probe cycle.
+const probeTimeout = 2 * time.Second
+
+// probeAll probes every registered provider concurrently, each bounded by
+// probeTimeout, and atomically swaps in the resulting snapshot. A cycle costs
+// roughly the slowest single probe — not the sum — and never blocks Route.
+func (r *SimpleRouter) probeAll(ctx context.Context) {
+	r.mu.RLock()
+	ps := make([]Provider, len(r.providers))
+	copy(ps, r.providers)
+	r.mu.RUnlock()
+
+	next := make(availSnapshot, len(ps))
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for _, p := range ps {
+		wg.Add(1)
+		go func(p Provider) {
+			defer wg.Done()
+			pctx, cancel := context.WithTimeout(ctx, probeTimeout)
+			defer cancel()
+			ready := p.Available(pctx)
+			mu.Lock()
+			next[p.Name()] = availState{ready: ready, lastSeen: time.Now()}
+			mu.Unlock()
+		}(p)
+	}
+	wg.Wait()
+	r.avail.Store(&next)
+}
+
+// Start primes the availability cache synchronously, then maintains it on a
+// ticker until ctx is cancelled or Close is called. Idempotent callers that
+// never invoke Start keep working via available()'s inline-probe fallback.
+func (r *SimpleRouter) Start(ctx context.Context) {
+	if r.availTTL <= 0 {
+		r.availTTL = defaultAvailTTL
+	}
+	r.probeAll(ctx) // warm the cache before the first request can read it
+	go func() {
+		t := time.NewTicker(r.availTTL)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-r.stopCh:
+				return
+			case <-t.C:
+				r.probeAll(ctx)
+			}
+		}
+	}()
+}
+
+// Close stops the background availability maintainer. Safe to call more than
+// once and safe to call when Start was never invoked.
+func (r *SimpleRouter) Close() {
+	r.stopOnce.Do(func() {
+		if r.stopCh != nil {
+			close(r.stopCh)
+		}
+	})
 }
 
 // Stats returns current routing statistics.
@@ -354,11 +473,19 @@ func BuildRouter(cfg *Config, opts ...BuildRouterOption) (Router, error) {
 	// Auto-discover OpenAI-compatible servers on well-known ports.
 	autoDiscoverOpenAICompat(router, pcfg)
 
+	// Start the background availability maintainer when a lifecycle context is
+	// provided (the long-running daemon). Short-lived callers omit it and rely
+	// on available()'s inline-probe fallback.
+	if bro.ctx != nil {
+		router.Start(bro.ctx)
+	}
+
 	return router, nil
 }
 
 type buildRouterOpts struct {
 	procMgr *ProcessManager
+	ctx     context.Context
 }
 
 // BuildRouterOption configures BuildRouter.
@@ -367,6 +494,15 @@ type BuildRouterOption func(*buildRouterOpts)
 // WithProcessManager provides a ProcessManager for providers that spawn subprocesses.
 func WithProcessManager(pm *ProcessManager) BuildRouterOption {
 	return func(o *buildRouterOpts) { o.procMgr = pm }
+}
+
+// WithRouterContext ties the router's background availability maintainer to
+// ctx. When provided, BuildRouter starts the maintainer (warming the cache
+// before returning); when cancelled, the maintainer stops. Omit it for
+// short-lived callers (one-shot CLIs, tests) — they fall back to inline
+// availability probing and start no goroutine.
+func WithRouterContext(ctx context.Context) BuildRouterOption {
+	return func(o *buildRouterOpts) { o.ctx = ctx }
 }
 
 func loadProvidersConfig(cfg *Config) (ProvidersConfig, error) {

--- a/internal/engine/router_availability_test.go
+++ b/internal/engine/router_availability_test.go
@@ -1,0 +1,158 @@
+// router_availability_test.go — tests for the off-hot-path availability cache.
+//
+// These lock in the contract that Route reads maintained readiness (the
+// background-probed snapshot) when it is fresh, and falls back to a bounded
+// inline probe when the snapshot is cold (no maintainer) or stale (ticker
+// stalled). The fast path is what removes the per-request blocking probe.
+package engine
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// When a fresh snapshot exists, Route trusts it over a live probe — even if the
+// provider has since recovered at the live layer. This is the property that
+// keeps a dead provider's TCP timeout off the request path.
+func TestRouterUsesAvailabilityCache(t *testing.T) {
+	t.Parallel()
+	r := NewSimpleRouter(RoutingConfig{
+		Default:       "primary",
+		FallbackChain: []string{"primary", "backup"},
+	})
+	primary := NewStubProvider("primary", "primary reply")
+	primary.available = false // down when the maintainer probes
+	backup := NewStubProvider("backup", "backup reply")
+	r.RegisterProvider(primary)
+	r.RegisterProvider(backup)
+
+	r.probeAll(context.Background()) // maintainer records primary=down, backup=up
+
+	// primary "recovers" at the live layer *after* the probe; the fresh cache
+	// still says down, so Route must not select it.
+	primary.available = true
+
+	p, dec, err := r.Route(context.Background(), &CompletionRequest{
+		Metadata: RequestMetadata{RequestID: "cache-1"},
+	})
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if p.Name() != "backup" {
+		t.Errorf("selected = %q; want backup (fresh cache says primary down)", p.Name())
+	}
+	if !dec.FallbackUsed {
+		t.Error("FallbackUsed should be true (primary cached down)")
+	}
+}
+
+// With no maintainer ever started, the snapshot is nil and Route must inline
+// probe so short-lived callers (one-shot CLIs, tests) still filter dead
+// providers. Guards against a regression where cold cache == "all available".
+func TestRouterColdCacheInlineFallback(t *testing.T) {
+	t.Parallel()
+	r := NewSimpleRouter(RoutingConfig{
+		Default:       "primary",
+		FallbackChain: []string{"primary", "backup"},
+	})
+	primary := NewStubProvider("primary", "")
+	primary.available = false
+	backup := NewStubProvider("backup", "backup reply")
+	r.RegisterProvider(primary)
+	r.RegisterProvider(backup)
+
+	if r.avail.Load() != nil {
+		t.Fatal("precondition: snapshot should be nil before Start/probeAll")
+	}
+
+	p, dec, err := r.Route(context.Background(), &CompletionRequest{
+		Metadata: RequestMetadata{RequestID: "cold-1"},
+	})
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if p.Name() != "backup" {
+		t.Errorf("selected = %q; want backup (inline probe sees primary down)", p.Name())
+	}
+	if !dec.FallbackUsed {
+		t.Error("FallbackUsed should be true")
+	}
+}
+
+// A stale entry (older than 3×TTL) must be ignored and re-probed inline, so a
+// stalled maintainer can't pin routing to outdated "down" verdicts.
+func TestRouterStaleCacheFallsBackToInline(t *testing.T) {
+	t.Parallel()
+	r := NewSimpleRouter(RoutingConfig{Default: "primary"})
+	primary := NewStubProvider("primary", "primary reply")
+	primary.available = true
+	r.RegisterProvider(primary)
+
+	stale := availSnapshot{
+		"primary": {ready: false, lastSeen: time.Now().Add(-time.Hour)},
+	}
+	r.avail.Store(&stale)
+
+	p, _, err := r.Route(context.Background(), &CompletionRequest{
+		Metadata: RequestMetadata{RequestID: "stale-1"},
+	})
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if p.Name() != "primary" {
+		t.Errorf("selected = %q; want primary (stale 'down' ignored, inline sees up)", p.Name())
+	}
+}
+
+// probeAll records every registered provider's readiness in the snapshot.
+func TestRouterProbeAllPopulatesSnapshot(t *testing.T) {
+	t.Parallel()
+	r := NewSimpleRouter(RoutingConfig{Default: "a"})
+	a := NewStubProvider("a", "")
+	a.available = true
+	b := NewStubProvider("b", "")
+	b.available = false
+	r.RegisterProvider(a)
+	r.RegisterProvider(b)
+
+	r.probeAll(context.Background())
+
+	snap := r.avail.Load()
+	if snap == nil {
+		t.Fatal("snapshot nil after probeAll")
+	}
+	if st, ok := (*snap)["a"]; !ok || !st.ready {
+		t.Errorf("a: got %+v, ok=%v; want ready", st, ok)
+	}
+	if st, ok := (*snap)["b"]; !ok || st.ready {
+		t.Errorf("b: got %+v, ok=%v; want not ready", st, ok)
+	}
+}
+
+// Close is safe to call repeatedly and when Start was never invoked.
+func TestRouterCloseIdempotent(t *testing.T) {
+	t.Parallel()
+	r := NewSimpleRouter(RoutingConfig{Default: "a"})
+	r.Close()
+	r.Close()
+}
+
+// Start primes the cache before returning and stops on context cancellation.
+func TestRouterStartPrimesAndStops(t *testing.T) {
+	t.Parallel()
+	r := NewSimpleRouter(RoutingConfig{Default: "a"})
+	a := NewStubProvider("a", "")
+	a.available = true
+	r.RegisterProvider(a)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	r.Start(ctx) // primes synchronously
+
+	if snap := r.avail.Load(); snap == nil {
+		t.Fatal("Start should prime the snapshot synchronously")
+	} else if st, ok := (*snap)["a"]; !ok || !st.ready {
+		t.Errorf("primed entry for a: got %+v, ok=%v; want ready", st, ok)
+	}
+	cancel() // maintainer goroutine observes ctx.Done and returns
+}


### PR DESCRIPTION
## Problem

`SimpleRouter.Route()` probed every candidate provider inline on every request:

```go
avail := p.Available(ctx)   // router.go, inside the candidate loop
```

The loop has no early break and there is no availability caching, so each request pays a blocking `Available()` call for every provider in the fallback chain. When a provider in the chain is unreachable (for example an offline local inference node), its `Available()` performs an HTTP round-trip that blocks on a TCP timeout. Measured at roughly 7.8s per request, paid before the actual inference, on every request routed through the affected chain.

## Change

Move provider readiness off the request hot path:

- A background maintainer (`SimpleRouter.Start`) probes all providers **concurrently**, each bounded by a 2s timeout, once per `availTTL` (default 10s), and atomically swaps an immutable snapshot.
- `Route()` reads that snapshot lock-free via a new `available()` helper. The existing priority selection (first ready-and-capable provider in fallback order) is unchanged; only the probe is relocated.
- Cold or stale snapshots fall back to a bounded inline probe, so callers that never start the maintainer (the one-shot CLI paths: chat, experiment, benchmark) keep their current behavior and start no goroutine.
- The daemon opts in through `BuildRouter(cfg, WithRouterContext(ctx))` in `boot.go`; the maintainer stops on context cancellation.

Net effect: an unreachable provider's timeout is absorbed by one background cycle (concurrent, once per TTL) instead of by every request.

## Tests

`router_availability_test.go` covers:

- maintained-cache fast path (a fresh snapshot is trusted over a live probe)
- cold-cache inline fallback (no maintainer started, inline probe still filters dead providers)
- stale-cache re-probe (entries older than 3×TTL are ignored)
- snapshot population, `Start` priming, `Close` idempotency

Full `internal/engine` package passes; router tests pass under `-race`.

## Follow-up (not in this PR)

The kernel already maintains supervised-provider state in the reconcile registry (`reconcile.UpsertProvider`, used for mlx-supervised providers). A natural next step is to make provider availability a first-class reconciled quantity maintained by the existing autonomic ticker, so readiness is observable across the kernel rather than held in a router-private cache. Worth a short RFC.
