### PR TITLE
feat(mcp): add cog://kernel/status resource to the MCP sidecar (RFC Phase 1)

### DIFF
--- a/internal/engine/mcp_kernel_status.go
+++ b/internal/engine/mcp_kernel_status.go
@@ -1,0 +1,227 @@
+// mcp_kernel_status.go — `cog://kernel/status` MCP resource (RFC Phase 1).
+//
+// Exposes local kernel reachability as a declarative MCP resource so a harness
+// (or its model) knows whether substrate tools will work THIS turn rather than
+// discovering it only when a kernel-dependent call fails on invocation.
+//
+// Registration: m.server.AddResource(&mcp.Resource{URI: "cog://kernel/status", …}, m.resourceKernelStatus)
+// is called from registerResources in mcp_server.go.
+//
+// Probe mechanics:
+//   - Target: GET http://localhost:<cfg.Port>/health with a 2 s timeout.
+//   - The Port field in Config defaults to 6931 (ln(2)×10⁴).
+//   - Results are cached for kernelStatusCacheTTL (3 s) to avoid per-turn
+//     /health spam when multiple tool reads arrive in quick succession.
+//   - The cache lives on the MCPServer instance (kernelStatusProber), so each
+//     server has an independent cache — critical for both isolation in tests
+//     and correct behaviour when multiple sidecar instances run in the same
+//     process (e.g. integration test harnesses).
+//   - The cache mutex is held for the full probe duration so concurrent readers
+//     block on the single in-flight HTTP call rather than issuing duplicates.
+//
+// Wire shape (reachable):
+//
+//	{
+//	  "reachable":  true,
+//	  "endpoint":   "http://localhost:6931",
+//	  "version":    "0.13.0",
+//	  "identity":   "cog",
+//	  "node_id":    "…",
+//	  "checked_at": "2026-05-28T22:00:00Z",
+//	  "latency_ms": 7
+//	}
+//
+// Wire shape (unreachable):
+//
+//	{
+//	  "reachable":  false,
+//	  "endpoint":   "http://localhost:6931",
+//	  "checked_at": "2026-05-28T22:00:00Z",
+//	  "error":      "connection refused"
+//	}
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const (
+	// kernelStatusCacheTTL is how long a probe result is considered fresh.
+	// 3 s is long enough to absorb per-turn resource reads without hammering
+	// /health, short enough not to mask a daemon restart.
+	kernelStatusCacheTTL = 3 * time.Second
+
+	// kernelStatusProbeTimeout is the per-probe HTTP deadline.
+	// 2 s matches the RFC spec and keeps the MCP turn responsive even when
+	// the daemon is completely unresponsive.
+	kernelStatusProbeTimeout = 2 * time.Second
+)
+
+// kernelStatusEntry is the cached probe outcome stored on each MCPServer.
+type kernelStatusEntry struct {
+	// payload is the JSON-encoded response to return to the MCP client.
+	payload   []byte
+	expiresAt time.Time
+}
+
+// kernelStatusProber holds the per-MCPServer probe cache. It is embedded in
+// MCPServer (as kernelProber) so each server instance has its own independent
+// TTL cache. This avoids cross-test pollution when multiple MCPServer instances
+// exist in the same process (e.g. parallel unit tests).
+type kernelStatusProber struct {
+	mu    sync.Mutex
+	entry *kernelStatusEntry
+	// httpClient is overridable in tests; the zero-value builds a real client
+	// on first use via client().
+	httpClient *http.Client
+}
+
+// client returns the HTTP client to use for /health probes.
+// Defaults to a client with kernelStatusProbeTimeout.
+func (p *kernelStatusProber) client() *http.Client {
+	if p.httpClient != nil {
+		return p.httpClient
+	}
+	return &http.Client{Timeout: kernelStatusProbeTimeout}
+}
+
+// probe returns a cached JSON payload when still fresh; otherwise fires
+// GET <endpoint>/health and caches the result for kernelStatusCacheTTL.
+//
+// The mutex is held for the full duration of the HTTP call so that concurrent
+// readers wait on the single in-flight probe. Latency is bounded by
+// kernelStatusProbeTimeout (2 s), keeping waits short even when the daemon
+// is unresponsive.
+func (p *kernelStatusProber) probe(endpoint string) ([]byte, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	now := time.Now()
+	if p.entry != nil && now.Before(p.entry.expiresAt) {
+		return p.entry.payload, nil
+	}
+
+	payload, err := kernelDoProbe(p.client(), endpoint, now)
+	if err != nil {
+		// json.Marshal error — programming bug, surface immediately.
+		return nil, err
+	}
+
+	p.entry = &kernelStatusEntry{
+		payload:   payload,
+		expiresAt: now.Add(kernelStatusCacheTTL),
+	}
+	return payload, nil
+}
+
+// resourceKernelStatus is the MCP resource handler for cog://kernel/status.
+// It is registered via server.AddResource in registerResources (mcp_server.go).
+func (m *MCPServer) resourceKernelStatus(_ context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	payload, err := m.kernelProber.probe(m.kernelEndpoint())
+	if err != nil {
+		return nil, fmt.Errorf("kernel status probe: %w", err)
+	}
+
+	return &mcp.ReadResourceResult{
+		Contents: []*mcp.ResourceContents{{
+			URI:      req.Params.URI,
+			MIMEType: "application/json",
+			Text:     string(payload),
+		}},
+	}, nil
+}
+
+// kernelEndpoint derives the HTTP base URL for the local kernel from cfg.Port.
+// Falls back to the default port (6931) when cfg is nil or Port is unset.
+func (m *MCPServer) kernelEndpoint() string {
+	if m.cfg != nil && m.cfg.Port > 0 {
+		return fmt.Sprintf("http://localhost:%d", m.cfg.Port)
+	}
+	return "http://localhost:6931"
+}
+
+// kernelDoProbe fires a single GET <endpoint>/health and marshals the outcome
+// into a JSON payload. It does NOT read or write the cache.
+func kernelDoProbe(client *http.Client, endpoint string, probeTime time.Time) ([]byte, error) {
+	start := time.Now()
+	resp, err := client.Get(endpoint + "/health")
+	latencyMS := time.Since(start).Milliseconds()
+	checkedAt := probeTime.UTC().Format(time.RFC3339)
+
+	if err != nil {
+		// Kernel unreachable — connection refused, timeout, DNS failure, etc.
+		result := map[string]any{
+			"reachable":  false,
+			"endpoint":   endpoint,
+			"checked_at": checkedAt,
+			"error":      kernelStripURLFromError(err.Error()),
+		}
+		return json.Marshal(result)
+	}
+	defer resp.Body.Close()
+
+	// Read up to 4 KB of the health response body.
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096))
+
+	if readErr != nil || (resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusServiceUnavailable) {
+		// Unexpected transport error or non-health HTTP status.
+		errMsg := fmt.Sprintf("unexpected status %d", resp.StatusCode)
+		if readErr != nil {
+			errMsg = readErr.Error()
+		}
+		result := map[string]any{
+			"reachable":  false,
+			"endpoint":   endpoint,
+			"checked_at": checkedAt,
+			"error":      errMsg,
+		}
+		return json.Marshal(result)
+	}
+
+	// Parse version/identity/node_id from the health response. Best-effort:
+	// if parsing fails we still return reachable:true with empty string fields
+	// rather than surfacing a false-negative.
+	var healthResp struct {
+		Version  string `json:"version"`
+		Identity string `json:"identity"`
+		NodeID   string `json:"node_id"`
+	}
+	_ = json.Unmarshal(body, &healthResp)
+
+	result := map[string]any{
+		"reachable":  true,
+		"endpoint":   endpoint,
+		"version":    healthResp.Version,
+		"identity":   healthResp.Identity,
+		"node_id":    healthResp.NodeID,
+		"checked_at": checkedAt,
+		"latency_ms": latencyMS,
+	}
+	return json.Marshal(result)
+}
+
+// kernelStripURLFromError removes the embedded URL from Go net/http error
+// messages so the error field in the resource payload reads cleanly.
+//
+// Go wraps dial errors as: `Get "http://localhost:6931/health": connection refused`
+// This function returns `connection refused`.
+func kernelStripURLFromError(msg string) string {
+	const sep = `": `
+	for i := 0; i <= len(msg)-len(sep); i++ {
+		if msg[i:i+len(sep)] == sep {
+			tail := msg[i+len(sep):]
+			if tail != "" {
+				return tail
+			}
+		}
+	}
+	return msg
+}

--- a/internal/engine/mcp_kernel_status_test.go
+++ b/internal/engine/mcp_kernel_status_test.go
@@ -1,0 +1,344 @@
+// mcp_kernel_status_test.go — unit tests for the cog://kernel/status resource.
+//
+// Coverage:
+//   - resourceKernelStatus when kernel is reachable (happy path)
+//   - resourceKernelStatus when kernel is unreachable (connection refused)
+//   - Cache: a second call within TTL does NOT fire another probe
+//   - Cache: a call after TTL expiry fires a fresh probe
+//   - JSON shape: required fields present in both reachable / unreachable cases
+//   - kernelStripURLFromError: verifies URL stripping from Go net error strings
+//   - Round-trip: cog://kernel/status appears in ListResources over in-memory transport
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// newMCPForTestWithProber builds an MCPServer with a pre-configured prober.
+// The prober's httpClient is set to ts.Client() so probes go to the fake server.
+func newMCPForTestWithFakeHealth(t *testing.T, ts *httptest.Server) (*MCPServer, *Config) {
+	t.Helper()
+	root := makeWorkspace(t)
+	port := testExtractPort(ts.URL)
+	cfg := makeConfig(t, root)
+	cfg.Port = port
+	nucleus := makeNucleus("Cog", "tester")
+	process := NewProcess(cfg, nucleus)
+	srv := NewMCPServer(cfg, nucleus, process)
+	// Wire the fake server's transport client so probes avoid the real network.
+	srv.kernelProber.httpClient = ts.Client()
+	return srv, cfg
+}
+
+// fakeHealthServer starts a fake httptest.Server returning a minimal /health JSON.
+func fakeHealthServer(t *testing.T, version, identity, nodeID string) *httptest.Server {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status":   "ok",
+			"version":  version,
+			"identity": identity,
+			"node_id":  nodeID,
+		})
+	}))
+	return ts
+}
+
+// TestResourceKernelStatus_Reachable verifies the happy-path JSON shape.
+func TestResourceKernelStatus_Reachable(t *testing.T) {
+	t.Parallel()
+
+	ts := fakeHealthServer(t, "0.13.0", "cog", "darkstar-1")
+	defer ts.Close()
+
+	srv, _ := newMCPForTestWithFakeHealth(t, ts)
+
+	fakeReq := &mcp.ReadResourceRequest{Params: &mcp.ReadResourceParams{URI: "cog://kernel/status"}}
+	result, err := srv.resourceKernelStatus(context.Background(), fakeReq)
+	if err != nil {
+		t.Fatalf("resourceKernelStatus: %v", err)
+	}
+
+	if len(result.Contents) != 1 {
+		t.Fatalf("len(Contents) = %d; want 1", len(result.Contents))
+	}
+	text := result.Contents[0].Text
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(text), &got); err != nil {
+		t.Fatalf("unmarshal response: %v\nraw: %s", err, text)
+	}
+
+	// Required fields when reachable.
+	for _, key := range []string{"reachable", "endpoint", "version", "identity", "node_id", "checked_at", "latency_ms"} {
+		if _, ok := got[key]; !ok {
+			t.Errorf("missing field %q in response: %s", key, text)
+		}
+	}
+	if got["reachable"] != true {
+		t.Errorf("reachable = %v; want true", got["reachable"])
+	}
+	if got["version"] != "0.13.0" {
+		t.Errorf("version = %v; want 0.13.0", got["version"])
+	}
+	if got["identity"] != "cog" {
+		t.Errorf("identity = %v; want cog", got["identity"])
+	}
+	if got["node_id"] != "darkstar-1" {
+		t.Errorf("node_id = %v; want darkstar-1", got["node_id"])
+	}
+}
+
+// TestResourceKernelStatus_Unreachable verifies the error-path JSON shape.
+func TestResourceKernelStatus_Unreachable(t *testing.T) {
+	t.Parallel()
+
+	root := makeWorkspace(t)
+	// Port 19731 — no listener.
+	cfg := &Config{WorkspaceRoot: root, Port: 19731}
+	nucleus := makeNucleus("cog", "tester")
+	process := NewProcess(cfg, nucleus)
+	srv := NewMCPServer(cfg, nucleus, process)
+	// Very short timeout so the test is fast.
+	srv.kernelProber.httpClient = &http.Client{Timeout: 100 * time.Millisecond}
+
+	fakeReq := &mcp.ReadResourceRequest{Params: &mcp.ReadResourceParams{URI: "cog://kernel/status"}}
+	result, err := srv.resourceKernelStatus(context.Background(), fakeReq)
+	if err != nil {
+		t.Fatalf("resourceKernelStatus returned error: %v (want graceful JSON)", err)
+	}
+	if len(result.Contents) == 0 {
+		t.Fatal("Contents is empty")
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(result.Contents[0].Text), &got); err != nil {
+		t.Fatalf("unmarshal: %v\nraw: %s", err, result.Contents[0].Text)
+	}
+
+	// Required fields when unreachable.
+	for _, key := range []string{"reachable", "endpoint", "checked_at", "error"} {
+		if _, ok := got[key]; !ok {
+			t.Errorf("missing field %q in unreachable response: %s", key, result.Contents[0].Text)
+		}
+	}
+	if got["reachable"] != false {
+		t.Errorf("reachable = %v; want false", got["reachable"])
+	}
+	// "version" must NOT be present when unreachable.
+	if _, ok := got["version"]; ok {
+		t.Errorf("unexpected field version in unreachable response")
+	}
+}
+
+// TestKernelStatusProber_Cache verifies that a second call within TTL does
+// not fire a second HTTP probe.
+func TestKernelStatusProber_Cache(t *testing.T) {
+	t.Parallel()
+
+	var probeCount atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		probeCount.Add(1)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "ok", "version": "1.0.0", "identity": "cog", "node_id": "x",
+		})
+	}))
+	defer ts.Close()
+
+	prober := &kernelStatusProber{httpClient: ts.Client()}
+	endpoint := ts.URL
+
+	// First call — should probe.
+	if _, err := prober.probe(endpoint); err != nil {
+		t.Fatalf("first probe: %v", err)
+	}
+	// Second call within TTL — should NOT probe.
+	if _, err := prober.probe(endpoint); err != nil {
+		t.Fatalf("second probe: %v", err)
+	}
+
+	if n := probeCount.Load(); n != 1 {
+		t.Errorf("probe fired %d times; want exactly 1 (cache miss then hit)", n)
+	}
+}
+
+// TestKernelStatusProber_CacheExpiry verifies that an expired cache entry is
+// replaced by a fresh probe.
+func TestKernelStatusProber_CacheExpiry(t *testing.T) {
+	t.Parallel()
+
+	var probeCount atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		probeCount.Add(1)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "ok", "version": "2.0.0", "identity": "cog2", "node_id": "y",
+		})
+	}))
+	defer ts.Close()
+
+	// Seed the prober with an already-expired entry.
+	prober := &kernelStatusProber{
+		httpClient: ts.Client(),
+		entry: &kernelStatusEntry{
+			payload:   []byte(`{"reachable":false,"error":"stale"}`),
+			expiresAt: time.Now().Add(-1 * time.Second),
+		},
+	}
+
+	payload, err := prober.probe(ts.URL)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(payload, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// Must be the fresh probe's data, not the stale entry.
+	if got["version"] != "2.0.0" {
+		t.Errorf("version = %v; want 2.0.0 (stale cache was not refreshed)", got["version"])
+	}
+	if n := probeCount.Load(); n != 1 {
+		t.Errorf("probe fired %d times; want 1", n)
+	}
+}
+
+// TestKernelStripURLFromError checks URL-stripping of Go net/http error strings.
+func TestKernelStripURLFromError(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: `Get "http://localhost:6931/health": dial tcp 127.0.0.1:6931: connect: connection refused`,
+			want:  `dial tcp 127.0.0.1:6931: connect: connection refused`,
+		},
+		{
+			input: `connection refused`,
+			want:  `connection refused`,
+		},
+		{
+			input: `Get "http://localhost:6931/health": context deadline exceeded (Client.Timeout exceeded while awaiting headers)`,
+			want:  `context deadline exceeded (Client.Timeout exceeded while awaiting headers)`,
+		},
+		{
+			input: ``,
+			want:  ``,
+		},
+	}
+	for _, c := range cases {
+		got := kernelStripURLFromError(c.input)
+		if got != c.want {
+			t.Errorf("kernelStripURLFromError(%q) = %q; want %q", c.input, got, c.want)
+		}
+	}
+}
+
+// TestResourceKernelStatus_ConcurrentSafe verifies that many goroutines
+// calling resourceKernelStatus concurrently do not panic or data-race.
+// Run with: go test -race ./internal/engine/...
+func TestResourceKernelStatus_ConcurrentSafe(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "ok", "version": "1.0.0", "identity": "cog", "node_id": "z",
+		})
+	}))
+	defer ts.Close()
+
+	srv, _ := newMCPForTestWithFakeHealth(t, ts)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := &mcp.ReadResourceRequest{Params: &mcp.ReadResourceParams{URI: "cog://kernel/status"}}
+			_, _ = srv.resourceKernelStatus(context.Background(), req)
+		}()
+	}
+	wg.Wait()
+}
+
+// TestMCPServer_KernelStatusInListResources checks that the resource is
+// advertised in the server's resource list over the in-memory transport.
+func TestMCPServer_KernelStatusInListResources(t *testing.T) {
+	t.Parallel()
+
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	nucleus := makeNucleus("Cog", "tester")
+	process := NewProcess(cfg, nucleus)
+	server := NewMCPServer(cfg, nucleus, process)
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_ = runServerOnTransport(ctx, server, serverTransport)
+	}()
+	defer func() {
+		cancel()
+		done := make(chan struct{})
+		go func() { wg.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Errorf("server goroutine did not exit in 5 s")
+		}
+	}()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client.Connect: %v", err)
+	}
+	defer session.Close()
+
+	resources, err := session.ListResources(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListResources: %v", err)
+	}
+
+	var found bool
+	for _, r := range resources.Resources {
+		if r.URI == "cog://kernel/status" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		uris := make([]string, 0, len(resources.Resources))
+		for _, r := range resources.Resources {
+			uris = append(uris, r.URI)
+		}
+		t.Errorf("cog://kernel/status not found in ListResources; got: %s",
+			strings.Join(uris, ", "))
+	}
+}
+
+// testExtractPort pulls the port number from an "http://127.0.0.1:PORT" URL.
+// Uses the package-level extractPort helper (provider_mlx_supervised.go).
+func testExtractPort(rawURL string) int {
+	return extractPort(rawURL, 6931)
+}

--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -114,6 +114,11 @@ type MCPServer struct {
 	// cog_dispatch_to_harness with target_node routed through here instead of
 	// running locally. Set via SetClusterRouter.
 	clusterRouter RemoteDispatchRouter
+
+	// kernelProber is the per-instance TTL cache for the cog://kernel/status
+	// resource (RFC Phase 1). Each MCPServer has its own prober so that test
+	// instances don't share probe state. See mcp_kernel_status.go.
+	kernelProber kernelStatusProber
 }
 
 // channelSessionBackend is the narrow surface the mod3 session-family MCP
@@ -453,6 +458,17 @@ func (m *MCPServer) registerResources() {
 		Description: "Effective kernel configuration (kernel.yaml resolved against defaults)",
 		MIMEType:    "application/json",
 	}, m.resourceConfig)
+
+	m.server.AddResource(&mcp.Resource{
+		URI:  "cog://kernel/status",
+		Name: "Kernel Status",
+		Description: "Local kernel reachability probe. Reads GET /health on the " +
+			"configured port (default 6931) with a 2 s timeout; result is cached " +
+			"for ~3 s. Shape: {reachable, endpoint, version, identity, node_id, " +
+			"checked_at, latency_ms} when up; {reachable:false, endpoint, " +
+			"checked_at, error} when down.",
+		MIMEType: "application/json",
+	}, m.resourceKernelStatus)
 }
 
 // ── Resource Handlers ───────────────────────────────────────────────────────


### PR DESCRIPTION
Phase 1 of RFC-cogos-mcp-sidecar-kernel-aware. Exposes `cog://kernel/status` as a declarative MCP resource so any MCP harness reads substrate liveness up-front instead of discovering a down kernel via tool-failure.

- `GET /health` probe on `localhost:<port>`, marshals reachable/unreachable JSON (version/identity/node_id from health body)
- single-flight via per-instance mutex; 3s TTL cache so per-turn reads don't spam /health
- registered via `AddResource` (auto-wired into resources/list + resources/read), same pattern as cogos://state

Gates green locally: build (-tags mcpserver), vet, golangci-lint (0), windows build, engine tests (+7 new).