### PR TITLE
fix(engine): E4B as hard floor for local model fallback, reconcile LMS-style names

### DIFF
--- a/internal/engine/local_llm.go
+++ b/internal/engine/local_llm.go
@@ -200,13 +200,65 @@ func isLocalEndpoint(endpoint string) bool {
 	return false
 }
 
+// normalizeModelNameForOllama converts an LM-Studio / MLX-style model name
+// (e.g. "google/gemma-4-26b-a4b") to the Ollama tag format ("gemma4:26b")
+// so that cross-format configured names can be matched against the list of
+// locally installed Ollama models.
+//
+// Conversion rules (applied in order):
+//  1. Strip a leading "vendor/" prefix (e.g. "google/gemma-4-26b-a4b" →
+//     "gemma-4-26b-a4b").
+//  2. Replace "gemma-4" with "gemma4" to align with Ollama's naming.
+//  3. Truncate at the size tag (e.g. "26b" or "e4b") and convert
+//     "gemma4-NNb" → "gemma4:NNb".
+//
+// If the name does not look like an LMS-style cross-format name (no "/" and
+// already matches the "family:tag" Ollama shape), the original string is
+// returned unchanged so normal prefix matching still applies.
+var lmsModelPattern = regexp.MustCompile(`^(?:[^/]+/)?gemma-4-([0-9]+[bB]|e[0-9]+[bB])`)
+
+func normalizeModelNameForOllama(name string) string {
+	name = strings.TrimSpace(name)
+	if !strings.Contains(name, "/") && !strings.HasPrefix(strings.ToLower(name), "gemma-4") {
+		// Not an LMS-style name; return as-is so prefix matching is unaffected.
+		return name
+	}
+	lower := strings.ToLower(name)
+	m := lmsModelPattern.FindStringSubmatch(lower)
+	if len(m) < 2 {
+		return name
+	}
+	sizeTag := strings.ToLower(m[1]) // e.g. "26b", "e4b"
+	return "gemma4:" + sizeTag
+}
+
 func resolvePreferredLocalModel(models []string, preferred string) string {
 	preferred = strings.TrimSpace(preferred)
 	if preferred != "" {
+		// First pass: exact match or Ollama-prefix match.
 		for _, model := range models {
 			if model == preferred || strings.HasPrefix(model, preferred) {
 				return model
 			}
+		}
+		// Second pass: try the normalized (Ollama-format) equivalent of the
+		// configured name. This handles LM-Studio / MLX style names like
+		// "google/gemma-4-26b-a4b" that map to Ollama tags like "gemma4:26b".
+		normalized := normalizeModelNameForOllama(preferred)
+		if normalized != preferred {
+			for _, model := range models {
+				if model == normalized || strings.HasPrefix(model, normalized) {
+					return model
+				}
+			}
+		}
+	}
+	// No preferred match: fall back to the canonical E4B floor model if it is
+	// available, rather than returning models[0] which may be a smaller or
+	// unrelated model (e.g. "llama3.2:1b").
+	for _, model := range models {
+		if model == defaultOllamaModel || strings.HasPrefix(model, defaultOllamaModel) {
+			return model
 		}
 	}
 	if len(models) > 0 {
@@ -247,7 +299,12 @@ func resolveDispatchLocalModel(models []string, preferred string, requested Disp
 		if selected == "" {
 			return "", DispatchModelE4B, "no local models are loaded"
 		}
-		if preferred != "" && selected != preferred {
+		// Report a mismatch when neither the preferred name nor its
+		// normalized Ollama equivalent was found, so the operator can
+		// diagnose configuration drift.  "selected" at this point is the
+		// E4B floor (from resolvePreferredLocalModel's fallback logic)
+		// rather than an arbitrary models[0].
+		if preferred != "" && selected != preferred && selected != normalizeModelNameForOllama(preferred) {
 			return selected, DispatchModelE4B, fmt.Sprintf("configured local model %q not loaded, using %q", preferred, selected)
 		}
 		return selected, DispatchModelE4B, ""

--- a/internal/engine/local_llm_test.go
+++ b/internal/engine/local_llm_test.go
@@ -5,6 +5,193 @@ import (
 	"testing"
 )
 
+// ── normalizeModelNameForOllama ───────────────────────────────────────────────
+
+func TestNormalizeModelNameForOllama(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want string
+	}{
+		// LMS-style vendor-prefixed names → Ollama tags
+		{"google/gemma-4-26b-a4b", "gemma4:26b"},
+		{"google/gemma-4-e4b", "gemma4:e4b"},
+		{"google/gemma-4-E4B", "gemma4:e4b"},
+		{"google/gemma-4-27b-something", "gemma4:27b"},
+		// Already-Ollama names are returned unchanged
+		{"gemma4:e4b", "gemma4:e4b"},
+		{"gemma4:26b", "gemma4:26b"},
+		{"llama3.2:1b", "llama3.2:1b"},
+		// Bare gemma-4 without vendor prefix
+		{"gemma-4-26b-a4b", "gemma4:26b"},
+		{"gemma-4-e4b-mlx", "gemma4:e4b"},
+		// Empty stays empty
+		{"", ""},
+	}
+	for _, tc := range cases {
+		got := normalizeModelNameForOllama(tc.in)
+		if got != tc.want {
+			t.Errorf("normalizeModelNameForOllama(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// ── resolvePreferredLocalModel ────────────────────────────────────────────────
+
+func TestResolvePreferredLocalModelExactMatch(t *testing.T) {
+	t.Parallel()
+	models := []string{"gemma4:e4b", "gemma4:26b", "llama3.2:1b"}
+	got := resolvePreferredLocalModel(models, "gemma4:e4b")
+	if got != "gemma4:e4b" {
+		t.Errorf("exact match: got %q; want %q", got, "gemma4:e4b")
+	}
+}
+
+func TestResolvePreferredLocalModelPrefixMatch(t *testing.T) {
+	t.Parallel()
+	models := []string{"gemma4:26b-instruct", "gemma4:e4b", "llama3.2:1b"}
+	got := resolvePreferredLocalModel(models, "gemma4:26b")
+	if got != "gemma4:26b-instruct" {
+		t.Errorf("prefix match: got %q; want %q", got, "gemma4:26b-instruct")
+	}
+}
+
+// TestResolvePreferredLocalModelLMSStyleName verifies that a name in LM-Studio
+// format ("google/gemma-4-26b-a4b") matches the equivalent Ollama model
+// ("gemma4:26b") via normalizeModelNameForOllama rather than falling through to
+// an arbitrary models[0].
+func TestResolvePreferredLocalModelLMSStyleName(t *testing.T) {
+	t.Parallel()
+	// The models list mirrors what Ollama would report; no "google/..." entry.
+	models := []string{"gemma4:26b", "gemma4:e4b", "llama3.2:1b"}
+	got := resolvePreferredLocalModel(models, "google/gemma-4-26b-a4b")
+	if got != "gemma4:26b" {
+		t.Errorf("LMS-style name: got %q; want %q", got, "gemma4:26b")
+	}
+}
+
+// TestResolvePreferredLocalModelFallsToE4B verifies that when the preferred
+// model is absent and the LMS-style normalization also fails to match, the
+// function returns defaultOllamaModel ("gemma4:e4b") rather than an arbitrary
+// small model (e.g. "llama3.2:1b").
+func TestResolvePreferredLocalModelFallsToE4B(t *testing.T) {
+	t.Parallel()
+	// "configured-but-not-loaded" is not present in models; neither is the
+	// normalized form; E4B is available.
+	models := []string{"llama3.2:1b", "gemma4:e4b"}
+	got := resolvePreferredLocalModel(models, "configured-but-not-loaded")
+	if got != defaultOllamaModel {
+		t.Errorf("fallback to E4B floor: got %q; want %q (defaultOllamaModel)", got, defaultOllamaModel)
+	}
+}
+
+// TestResolvePreferredLocalModelE4BNotAvailableFallsToFirst verifies that when
+// neither the preferred model nor defaultOllamaModel is available, the function
+// returns models[0] as a last resort (preserving existing behavior for
+// edge-case deployments).
+func TestResolvePreferredLocalModelE4BNotAvailableFallsToFirst(t *testing.T) {
+	t.Parallel()
+	models := []string{"llama3.2:1b", "mistral:7b"}
+	got := resolvePreferredLocalModel(models, "configured-but-not-loaded")
+	if got != "llama3.2:1b" {
+		t.Errorf("last-resort first model: got %q; want %q", got, "llama3.2:1b")
+	}
+}
+
+// ── resolveDispatchLocalModel ─────────────────────────────────────────────────
+
+// TestResolveDispatchLocalModelE4BExact: configured model is present → no note.
+func TestResolveDispatchLocalModelE4BExact(t *testing.T) {
+	t.Parallel()
+	models := []string{"gemma4:e4b", "llama3.2:1b"}
+	model, route, note := resolveDispatchLocalModel(models, "gemma4:e4b", DispatchModelE4B)
+	if model != "gemma4:e4b" {
+		t.Errorf("model: got %q; want %q", model, "gemma4:e4b")
+	}
+	if route != DispatchModelE4B {
+		t.Errorf("route: got %q; want %q", route, DispatchModelE4B)
+	}
+	if note != "" {
+		t.Errorf("note: got %q; want empty", note)
+	}
+}
+
+// TestResolveDispatchLocalModelLMSNameResolvesToOllama verifies defect 1 fix:
+// when kernel.yaml has local_model="google/gemma-4-26b-a4b" and Ollama has
+// "gemma4:26b", resolveDispatchLocalModel should resolve to the Ollama name
+// rather than falling back.
+func TestResolveDispatchLocalModelLMSNameResolvesToOllama(t *testing.T) {
+	t.Parallel()
+	models := []string{"gemma4:26b", "gemma4:e4b"}
+	// localModelHint() would return "google/gemma-4-26b-a4b" from kernel.yaml
+	model, route, note := resolveDispatchLocalModel(models, "google/gemma-4-26b-a4b", DispatchModelE4B)
+	if model != "gemma4:26b" {
+		t.Errorf("LMS name resolved to wrong model: got %q; want %q", model, "gemma4:26b")
+	}
+	if route != DispatchModelE4B {
+		t.Errorf("route: got %q; want %q", route, DispatchModelE4B)
+	}
+	// Normalized match → no mismatch note expected.
+	if note != "" {
+		t.Errorf("note: got %q; want empty (normalized match)", note)
+	}
+}
+
+// TestResolveDispatchLocalModelFallsToE4BNotLlama verifies defect 2 fix:
+// when the configured local model is absent, the fallback must be
+// defaultOllamaModel ("gemma4:e4b"), NOT whatever happens to be models[0]
+// (e.g. "llama3.2:1b").
+func TestResolveDispatchLocalModelFallsToE4BNotLlama(t *testing.T) {
+	t.Parallel()
+	// models list matches the scenario from the bug report: llama3.2:1b sorts
+	// first (or is the only model besides e4b). Configured model not present.
+	models := []string{"llama3.2:1b", "gemma4:e4b"}
+	model, route, note := resolveDispatchLocalModel(models, "google/gemma-4-26b-a4b", DispatchModelE4B)
+	if model != defaultOllamaModel {
+		t.Errorf("wrong fallback: got %q; want %q (defaultOllamaModel, not llama3.2:1b)", model, defaultOllamaModel)
+	}
+	if route != DispatchModelE4B {
+		t.Errorf("route: got %q; want %q", route, DispatchModelE4B)
+	}
+	if note == "" {
+		t.Error("note: expected a mismatch note, got empty")
+	}
+}
+
+// TestResolveDispatchLocalModel26BDegradesToE4B verifies that the 26B path,
+// when no large model is loaded, degrades to E4B via the preferred-model chain
+// rather than returning an arbitrary first model.
+func TestResolveDispatchLocalModel26BDegradesToE4B(t *testing.T) {
+	t.Parallel()
+	// No model with ≥26B parameter count; E4B is present alongside a small model.
+	models := []string{"llama3.2:1b", "gemma4:e4b"}
+	model, route, note := resolveDispatchLocalModel(models, "gemma4:e4b", DispatchModel26B)
+	if model != "gemma4:e4b" {
+		t.Errorf("26B fallback: got %q; want %q (E4B floor)", model, "gemma4:e4b")
+	}
+	if route != DispatchModelE4B {
+		t.Errorf("route: got %q; want %q", route, DispatchModelE4B)
+	}
+	if note == "" {
+		t.Error("note: expected degradation warning, got empty")
+	}
+}
+
+// TestResolveDispatchLocalModelNoModels verifies the empty-models sentinel.
+func TestResolveDispatchLocalModelNoModels(t *testing.T) {
+	t.Parallel()
+	model, route, note := resolveDispatchLocalModel(nil, "gemma4:e4b", DispatchModelE4B)
+	if model != "" {
+		t.Errorf("no models: got %q; want empty", model)
+	}
+	if route != DispatchModelE4B {
+		t.Errorf("route: got %q; want %q", route, DispatchModelE4B)
+	}
+	if note == "" {
+		t.Error("note: expected error note, got empty")
+	}
+}
+
 // TestResolveLocalProviderTimeoutNilConfig: nil cfg yields 0 (caller falls
 // back to localProviderDefaultTimeoutSec). Important for unit-test paths and
 // the brief window during construction before cfg is wired.


### PR DESCRIPTION
Fixes local-model selection falling through to `llama3.2:1b`.

- **Name mismatch:** `google/gemma-4-26b-a4b` never matched Ollama's `gemma4:26b` tag. Adds `normalizeModelNameForOllama` (strips vendor/ prefix, rewrites gemma-4-NNb -> gemma4:NNb) + two-pass lookup.
- **Wrong floor:** final fallback was `models[0]` (first Ollama-listed = llama3.2:1b). Now scans for `gemma4:e4b` before ever using models[0]. E4B is the hard floor.

+11 tests incl. the exact bug scenario. Gates green: build, vet, golangci-lint (0), windows build, engine tests.