### PR TITLE
fix(conversations): guard Index maps with RWMutex to stop kernel crash-loop

### DIFF
--- a/internal/conversations/index.go
+++ b/internal/conversations/index.go
@@ -1,9 +1,10 @@
 // index.go — in-memory full-text index for conversation turns.
 //
 // The index is a flat in-memory structure backed by a projection directory:
-//   .cog/state/conversations/
-//     <session_id>.json   — JSON array of Turn (one file per session)
-//     _meta.json          — JSON object: session_id → SessionMeta
+//
+//	.cog/state/conversations/
+//	  <session_id>.json   — JSON array of Turn (one file per session)
+//	  _meta.json          — JSON object: session_id → SessionMeta
 //
 // This is intentionally not SQLite FTS5 — the observatory aims for zero
 // additional runtime dependencies. Text search uses strings.Contains on
@@ -20,12 +21,24 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 )
 
 // Index holds all indexed turns in memory plus a reference to the projection
 // directory for persistence.
+//
+// All access to the sessions/turns maps is guarded by mu. The reconcile daemon
+// and the autonomic ticker both drive FetchLive concurrently (which calls
+// Load), and MCP tool handlers read the index concurrently with those; without
+// this lock those paths raced on the maps and crashed the kernel with
+// "fatal error: concurrent map writes".
 type Index struct {
+	// mu guards sessions and turns. Use RLock for read-only methods and Lock
+	// for methods that mutate the maps. Disk I/O is performed outside the lock
+	// where possible (see Load).
+	mu sync.RWMutex
+
 	projDir string
 
 	// sessions maps session_id → SessionMeta.
@@ -50,30 +63,45 @@ func NewIndex(projDir string) (*Index, error) {
 
 // Load reads all projection files from projDir into memory.
 // Call once at startup (FetchLive). Subsequent operations keep state in sync.
+//
+// Disk reads are performed into freshly-allocated local maps with no lock held,
+// then swapped into the index under a single write lock. This keeps the
+// (potentially slow) file I/O off the lock while still making the visible map
+// state mutation atomic with respect to concurrent readers and other Loads.
 func (idx *Index) Load() error {
-	metaPath := idx.metaPath()
-	if data, err := os.ReadFile(metaPath); err == nil {
+	sessions := make(map[string]SessionMeta)
+	if data, err := os.ReadFile(idx.metaPath()); err == nil {
 		var m map[string]SessionMeta
 		if jsonErr := json.Unmarshal(data, &m); jsonErr == nil {
-			idx.sessions = m
+			sessions = m
 		}
 	}
 
-	// Load turns for each known session.
-	for sid := range idx.sessions {
-		turns, err := idx.loadTurnsFile(sid)
+	// Load turns for each known session into a local map.
+	turns := make(map[string][]Turn, len(sessions))
+	for sid := range sessions {
+		t, err := idx.loadTurnsFile(sid)
 		if err != nil {
 			// Corrupt turn file — remove from index; will be re-projected.
-			delete(idx.sessions, sid)
+			delete(sessions, sid)
 			continue
 		}
-		idx.turns[sid] = turns
+		turns[sid] = t
 	}
+
+	// Atomically swap in the freshly loaded state.
+	idx.mu.Lock()
+	idx.sessions = sessions
+	idx.turns = turns
+	idx.mu.Unlock()
 	return nil
 }
 
 // UpsertSession writes session meta + turns to memory and to disk.
 func (idx *Index) UpsertSession(meta SessionMeta, turns []Turn) error {
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+
 	idx.sessions[meta.SessionID] = meta
 	idx.turns[meta.SessionID] = turns
 
@@ -81,12 +109,15 @@ func (idx *Index) UpsertSession(meta SessionMeta, turns []Turn) error {
 	if err := idx.writeTurnsFile(meta.SessionID, turns); err != nil {
 		return fmt.Errorf("conversations/index: write turns %s: %w", meta.SessionID, err)
 	}
-	// Persist meta index.
-	return idx.writeMetaFile()
+	// Persist meta index (marshals idx.sessions; must hold the lock).
+	return idx.writeMetaFileLocked()
 }
 
 // DeleteSession removes a session from memory and disk.
 func (idx *Index) DeleteSession(sessionID string) error {
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+
 	delete(idx.sessions, sessionID)
 	delete(idx.turns, sessionID)
 
@@ -94,17 +125,22 @@ func (idx *Index) DeleteSession(sessionID string) error {
 	if err := os.Remove(turnsPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("conversations/index: remove turns file: %w", err)
 	}
-	return idx.writeMetaFile()
+	return idx.writeMetaFileLocked()
 }
 
 // GetMeta returns the SessionMeta for a session, or false if not indexed.
 func (idx *Index) GetMeta(sessionID string) (SessionMeta, bool) {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
 	m, ok := idx.sessions[sessionID]
 	return m, ok
 }
 
 // ListSessions returns all indexed SessionMetas sorted by LastTurnAt descending.
 func (idx *Index) ListSessions(since, until time.Time, identity string) []SessionMeta {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+
 	var out []SessionMeta
 	for _, m := range idx.sessions {
 		if !since.IsZero() && m.LastTurnAt.Before(since) {
@@ -126,6 +162,9 @@ func (idx *Index) ListSessions(since, until time.Time, identity string) []Sessio
 
 // GetTurn returns the Turn at turnIndex within session, or false.
 func (idx *Index) GetTurn(sessionID string, turnIndex int) (Turn, bool) {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+
 	turns, ok := idx.turns[sessionID]
 	if !ok || turnIndex < 0 || turnIndex >= len(turns) {
 		return Turn{}, false
@@ -137,6 +176,9 @@ func (idx *Index) GetTurn(sessionID string, turnIndex int) (Turn, bool) {
 // Filters: since/until bound timestamps; sessionID restricts to one session;
 // identity filters by session identity; limit caps results (0 = no limit).
 func (idx *Index) Search(query string, since, until time.Time, sessionID, identity string, limit int) []SearchHit {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+
 	lq := strings.ToLower(query)
 	var hits []SearchHit
 
@@ -200,7 +242,9 @@ func (idx *Index) turnsPath(sessionID string) string {
 	return filepath.Join(idx.projDir, sessionID+".json")
 }
 
-func (idx *Index) writeMetaFile() error {
+// writeMetaFileLocked persists the session meta index. Callers must hold
+// idx.mu (write lock) because it marshals idx.sessions.
+func (idx *Index) writeMetaFileLocked() error {
 	b, err := json.MarshalIndent(idx.sessions, "", "  ")
 	if err != nil {
 		return err

--- a/internal/conversations/index_race_test.go
+++ b/internal/conversations/index_race_test.go
@@ -1,0 +1,100 @@
+// index_race_test.go — concurrency regression test for the in-memory Index.
+//
+// Reproduces the crash-loop root cause: the reconcile daemon and the autonomic
+// ticker both drive Provider.FetchLive concurrently, which calls Index.Load
+// (a map writer), while MCP tool handlers concurrently read the index via
+// Search / ListSessions / GetTurn. Before the mutex was added this raced and
+// the kernel died with "fatal error: concurrent map writes".
+//
+// Run with: go test -race ./internal/conversations/...
+package conversations
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestIndexConcurrentLoadAndRead exercises concurrent Load (write path) and
+// readers against a single Index, mirroring the two-daemon FetchLive pattern.
+// It must pass under -race.
+func TestIndexConcurrentLoadAndRead(t *testing.T) {
+	t.Parallel()
+
+	idx, err := NewIndex(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewIndex: %v", err)
+	}
+
+	// Seed some sessions so Load has files to read back and readers have data.
+	const nSessions = 8
+	now := time.Now()
+	for i := 0; i < nSessions; i++ {
+		sid := "session-" + strconv.Itoa(i)
+		meta := SessionMeta{
+			SessionID:   sid,
+			TurnCount:   2,
+			FirstTurnAt: now,
+			LastTurnAt:  now,
+		}
+		turns := []Turn{
+			{UUID: sid + "-0", SessionID: sid, TurnIndex: 0, Role: "user", Timestamp: now, Text: "hello world " + sid},
+			{UUID: sid + "-1", SessionID: sid, TurnIndex: 1, Role: "assistant", Timestamp: now, Text: "reply " + sid},
+		}
+		if err := idx.UpsertSession(meta, turns); err != nil {
+			t.Fatalf("seed UpsertSession: %v", err)
+		}
+	}
+
+	const goroutines = 16
+	const iterations = 200
+
+	var wg sync.WaitGroup
+
+	// Writers: concurrent Load (the FetchLive path from daemon + ticker).
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				if err := idx.Load(); err != nil {
+					t.Errorf("Load: %v", err)
+					return
+				}
+			}
+		}()
+	}
+
+	// Writers: concurrent UpsertSession (the ApplyPlan path).
+	for g := 0; g < goroutines/2; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				sid := "writer-" + strconv.Itoa(g) + "-" + strconv.Itoa(i%4)
+				_ = idx.UpsertSession(
+					SessionMeta{SessionID: sid, TurnCount: 1, FirstTurnAt: now, LastTurnAt: now},
+					[]Turn{{UUID: sid, SessionID: sid, TurnIndex: 0, Role: "user", Timestamp: now, Text: "x " + sid}},
+				)
+			}
+		}(g)
+	}
+
+	// Readers: Search / ListSessions / GetTurn (the MCP tool path).
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var zero time.Time
+			for i := 0; i < iterations; i++ {
+				_ = idx.Search("hello", zero, zero, "", "", 0)
+				_ = idx.ListSessions(zero, zero, "")
+				_, _ = idx.GetTurn("session-0", 0)
+				_, _ = idx.GetMeta("session-1")
+			}
+		}()
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
Found by the substrate audit: the kernel was hitting `fatal error: concurrent map writes` (~378 relaunchd crash cycles in serve.log).

**Root cause:** `internal/conversations/index.go` held its `sessions`/`turns` maps with no lock. `FetchLive` releases the Provider mutex *before* `Index.Load()`, so the two FetchLive drivers (`reconcile_daemon.go` + `autonomic_ticker.go`) wrote the maps concurrently while MCP handlers read them.

**Fix:** `sync.RWMutex` owned by `Index`. Readers (Search/ListSessions/GetTurn/GetMeta) RLock; writers (UpsertSession/DeleteSession) Lock. `Load()` does all disk I/O into fresh local maps with no lock held, then takes the write lock only for the atomic swap — I/O stays off the lock.

Adds `index_race_test.go` (passes `-race`; reliably races without the locks). Gates green: build, vet, `go test -race ./internal/conversations/`, windows build, golangci-lint (0).

Note: the held `feat/hermes-observer` branch's `internal/hermes/index.go` has the identical missing-mutex pattern and will need the same fix before it lands.