### PR TITLE
fix(sdk): correct stale cogdoc-type test assertion (mem → memory)

### DIFF
--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -212,7 +212,7 @@ func TestCogdocTypeValidation(t *testing.T) {
 		// Core types
 		{"identity", true},
 		{"ontology", true},
-		{"mem", true},
+		{"memory", true},
 		{"schema", true},
 		{"decision", true},
 		{"session", true},


### PR DESCRIPTION
Found by the substrate audit (issue #296). `TestCogdocTypeValidation` asserted `{"mem", true}` but the canonical `CogdocType` is `"memory"` (`types/cogdoc.go:17`) — there's no `"mem"` type. `ValidateType` was correct; the **test** was stale and red on main. The pervasive "mem" elsewhere is the `cog://mem/` *namespace*, a separate axis.

Closes #296.

**Follow-up flagged (not in this PR):** this test is in the `./sdk` go.work submodule, which the root CI `go test ./...` never enters — so this red test was invisible and the **entire SDK module is untested in CI**. Recommend adding an SDK-module test step to `ci.yml`.