### PR TITLE
fix(worktree-reconciler): make the alarm path idempotent (stop unbounded ledger growth)

### DIFF
--- a/internal/engine/worktree_reconciler.go
+++ b/internal/engine/worktree_reconciler.go
@@ -109,6 +109,15 @@ type WorktreePrunedEvent struct {
 	WorktreeID string
 }
 
+// WorktreeAlarmedEvent records that an alarm was already emitted for a worktree
+// path. The reconciler uses this to short-circuit re-emitting the same alarm on
+// every reconcile cycle — without it, an orphaned worktree re-alarms forever and
+// the ledger grows unbounded. Keyed by path (unknown-binding alarms have no
+// worktree_id).
+type WorktreeAlarmedEvent struct {
+	WorktreePath string
+}
+
 // LedgerReader is the read-side dependency the reconciler uses to load
 // `worktree.*` events for its repo root. Production implementations scan
 // `.cog/ledger/*/events.jsonl`; test implementations return an in-memory list.
@@ -125,6 +134,7 @@ type WorktreeLedgerEvent struct {
 	Created  *WorktreeCreatedEvent
 	Terminal *WorktreeTerminalEvent
 	Pruned   *WorktreePrunedEvent
+	Alarmed  *WorktreeAlarmedEvent
 }
 
 // LedgerWriter is the write-side dependency the reconciler uses to emit
@@ -215,10 +225,11 @@ func (r *WorktreeReconciler) Type() string {
 // derived from the ledger (worktrees with a creation event whose lifecycle is
 // not yet pruned).
 type worktreeConfig struct {
-	RepoRoot        string
-	CreatedByPath   map[string]*WorktreeCreatedEvent  // keyed by worktree path
-	TerminalByID    map[string]*WorktreeTerminalEvent // keyed by worktree_id
-	PrunedByID      map[string]struct{}               // set of pruned worktree IDs
+	RepoRoot      string
+	CreatedByPath map[string]*WorktreeCreatedEvent  // keyed by worktree path
+	TerminalByID  map[string]*WorktreeTerminalEvent // keyed by worktree_id
+	PrunedByID    map[string]struct{}               // set of pruned worktree IDs
+	AlarmedByPath map[string]struct{}               // set of already-alarmed worktree paths
 }
 
 // LoadConfig reads all worktree.* ledger events for this RepoRoot and derives
@@ -248,6 +259,7 @@ func (r *WorktreeReconciler) LoadConfig(workspaceRoot string) (any, error) {
 		CreatedByPath: make(map[string]*WorktreeCreatedEvent),
 		TerminalByID:  make(map[string]*WorktreeTerminalEvent),
 		PrunedByID:    make(map[string]struct{}),
+		AlarmedByPath: make(map[string]struct{}),
 	}
 	for _, ev := range events {
 		switch {
@@ -259,6 +271,8 @@ func (r *WorktreeReconciler) LoadConfig(workspaceRoot string) (any, error) {
 			cfg.TerminalByID[t.WorktreeID] = t
 		case ev.Pruned != nil:
 			cfg.PrunedByID[ev.Pruned.WorktreeID] = struct{}{}
+		case ev.Alarmed != nil:
+			cfg.AlarmedByPath[ev.Alarmed.WorktreePath] = struct{}{}
 		}
 	}
 	return cfg, nil
@@ -367,6 +381,17 @@ func (r *WorktreeReconciler) ComputePlan(config any, live any, _ *reconcile.Stat
 			action.Action = reconcile.ActionDelete
 			plan.Summary.Deletes++
 		case ClassAlarmUncommittedOnTerminalDispatch, ClassAlarmUnknownBinding:
+			// Idempotency guard (mirrors the PrunedByID prune guard above): if a
+			// prior `worktree.alarm` event already exists for this path, do NOT
+			// re-emit. Without this the same orphaned worktree re-alarms every
+			// reconcile cycle, growing the ledger unbounded and keeping the
+			// provider perpetually Degraded with no new information.
+			if _, alreadyAlarmed := cfg.AlarmedByPath[c.Live.Path]; alreadyAlarmed {
+				action.Action = reconcile.ActionSkip
+				action.Details["reason"] = "alarm already emitted per ledger"
+				plan.Summary.Skipped++
+				break
+			}
 			// Alarm is encoded as ActionUpdate with classification=alarm.
 			// The reconcile.Action vocabulary lacks a first-class "alarm"
 			// verb; we reuse Update + the classification detail field to
@@ -392,7 +417,7 @@ func (r *WorktreeReconciler) ComputePlan(config any, live any, _ *reconcile.Stat
 //     - any uncommitted changes -> alarm-uncommitted-on-terminal-dispatch
 //     - reason=merged or reason=abandoned and no uncommitted -> removable-clean
 //     - reason=exited (process died) and branch not yet merged/abandoned ->
-//       alive (operator still owns the lifecycle decision)
+//     alive (operator still owns the lifecycle decision)
 func classifyWorktree(w LiveWorktree, cfg *worktreeConfig) classifiedWorktree {
 	created, hasBinding := cfg.CreatedByPath[w.Path]
 	if !hasBinding {
@@ -662,12 +687,12 @@ func (r *WorktreeReconciler) BuildState(config any, live any, existing *reconcil
 		}
 		c := classifyWorktree(w, cfg)
 		attrs := map[string]any{
-			"classification":            string(c.Classification),
-			"branch":                    w.Branch,
-			"detached":                  w.Detached,
-			"locked":                    w.Locked,
-			"has_uncommitted_changes":   w.HasUncommittedChanges,
-			"has_unmerged_commits":      w.HasUnmergedCommits,
+			"classification":          string(c.Classification),
+			"branch":                  w.Branch,
+			"detached":                w.Detached,
+			"locked":                  w.Locked,
+			"has_uncommitted_changes": w.HasUncommittedChanges,
+			"has_unmerged_commits":    w.HasUnmergedCommits,
 		}
 		if c.Created != nil {
 			attrs["worktree_id"] = c.Created.WorktreeID

--- a/internal/engine/worktree_reconciler_test.go
+++ b/internal/engine/worktree_reconciler_test.go
@@ -86,6 +86,10 @@ func (f *fakeLedger) EmitWorktreeEvent(_ context.Context, eventType CogBlockKind
 		f.events = append(f.events, WorktreeLedgerEvent{Pruned: &WorktreePrunedEvent{
 			WorktreeID: asStringWT(data["worktree_id"]),
 		}})
+	case BlockWorktreeAlarm:
+		f.events = append(f.events, WorktreeLedgerEvent{Alarmed: &WorktreeAlarmedEvent{
+			WorktreePath: asStringWT(data["worktree_path"]),
+		}})
 	}
 	return nil
 }
@@ -231,6 +235,65 @@ func TestWorktreeReconciler_SevenLegacyWorktrees_AllAlarmUnknownBinding(t *testi
 	}
 	if got, want := ledger.emitCountByKind(BlockWorktreeAlarm), len(cases); got != want {
 		t.Errorf("expected %d alarm events emitted, got %d", want, got)
+	}
+}
+
+// TestWorktreeReconcilerAlarmIdempotent verifies the alarm path does not
+// re-emit on every cycle: once a worktree.alarm exists in the ledger for a
+// path, subsequent cycles SKIP it. Without this the ledger grows unbounded
+// (the 280 MB / 453k-event regression the audit found).
+func TestWorktreeReconcilerAlarmIdempotent(t *testing.T) {
+	repoRoot := "/test/cogos"
+	ledger := newFakeLedger(repoRoot)
+	git := newFakeGit(repoRoot)
+	git.addWorktree(LiveWorktree{
+		Path:   "/test/cogos/.claude/worktrees/orphan-xyz",
+		Branch: "orphan-branch",
+	})
+
+	r := NewWorktreeReconciler(repoRoot, ledger, ledger, git)
+	ctx := context.Background()
+
+	runCycle := func() *reconcile.Plan {
+		cfg, err := r.LoadConfig("/test/workspace")
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		live, err := r.FetchLive(ctx, cfg)
+		if err != nil {
+			t.Fatalf("FetchLive: %v", err)
+		}
+		plan, err := r.ComputePlan(cfg, live, nil)
+		if err != nil {
+			t.Fatalf("ComputePlan: %v", err)
+		}
+		if _, err := r.ApplyPlan(ctx, plan); err != nil {
+			t.Fatalf("ApplyPlan: %v", err)
+		}
+		return plan
+	}
+
+	// Cycle 1: no prior alarm → emit one (encoded as an Update action).
+	p1 := runCycle()
+	if p1.Summary.Updates != 1 {
+		t.Errorf("cycle 1: Updates=%d want 1 (alarm emitted)", p1.Summary.Updates)
+	}
+	if got := ledger.emitCountByKind(BlockWorktreeAlarm); got != 1 {
+		t.Fatalf("cycle 1: alarm events=%d want 1", got)
+	}
+
+	// Cycles 2–4: prior alarm in ledger → skip, no re-emit.
+	for i := 2; i <= 4; i++ {
+		p := runCycle()
+		if p.Summary.Updates != 0 {
+			t.Errorf("cycle %d: Updates=%d want 0 (already alarmed)", i, p.Summary.Updates)
+		}
+		if p.Summary.Skipped != 1 {
+			t.Errorf("cycle %d: Skipped=%d want 1", i, p.Summary.Skipped)
+		}
+	}
+	if got := ledger.emitCountByKind(BlockWorktreeAlarm); got != 1 {
+		t.Errorf("after 4 cycles: alarm events=%d want 1 (idempotent — no re-emit)", got)
 	}
 }
 

--- a/internal/engine/worktree_spawn.go
+++ b/internal/engine/worktree_spawn.go
@@ -33,12 +33,12 @@ type WorktreeOpts struct {
 
 // WorktreeHandle is the result of a successful SpawnWorktree call.
 type WorktreeHandle struct {
-	Identity   string    // Canonical identity: worktree-{dispatch_id}
-	Path       string    // Absolute path to the worktree on disk
-	Branch     string    // Branch checked out in this worktree
-	Base       string    // Base ref the branch was cut from
+	Identity   string // Canonical identity: worktree-{dispatch_id}
+	Path       string // Absolute path to the worktree on disk
+	Branch     string // Branch checked out in this worktree
+	Base       string // Base ref the branch was cut from
 	CreatedAt  time.Time
-	DispatchID string    // Bound dispatch identity
+	DispatchID string // Bound dispatch identity
 }
 
 // SpawnWorktree is the canonical entry point for substrate-managed worktree
@@ -293,6 +293,16 @@ func projectWorktreeEvent(env *EventEnvelope, repoRoot string) (WorktreeLedgerEv
 			WorktreeID: asStringWT(data["worktree_id"]),
 		}
 		return WorktreeLedgerEvent{Pruned: p}, true
+
+	case BlockWorktreeAlarm:
+		// Filter by repo_root if specified (alarm events carry repo_root).
+		if rr, _ := data["repo_root"].(string); repoRoot != "" && rr != "" && !isSamePath(rr, repoRoot) {
+			return WorktreeLedgerEvent{}, false
+		}
+		a := &WorktreeAlarmedEvent{
+			WorktreePath: asStringWT(data["worktree_path"]),
+		}
+		return WorktreeLedgerEvent{Alarmed: a}, true
 	}
 	return WorktreeLedgerEvent{}, false
 }


### PR DESCRIPTION
Audit finding: the worktree-reconciler re-emitted a `worktree.alarm` for every orphaned worktree on **every** reconcile cycle → a **280 MB / 453k-event** ledger + permanent Degraded health with no new information. The double-emit was even commented as 'harmless'; it isn't.

**Fix:** mirror the existing `PrunedByID` prune-guard — track already-alarmed paths (`AlarmedByPath`, derived from `worktree.alarm` ledger events) and **skip** re-emitting when an alarm already exists for that path. Adds `worktree.alarm` parsing to the ledger reader + a `WorktreeAlarmedEvent` projection. Keyed by path (unknown-binding alarms carry no worktree_id).

Does **not** truncate the existing bloated ledger (operator is consolidating ledger management separately).

Adds `TestWorktreeReconcilerAlarmIdempotent` (4 cycles → exactly 1 alarm emitted). Gates green: build, vet, windows build, golangci-lint (0), engine tests.