### PR TITLE
fix(engine): MCP tooling polish — URI hint, type-aware validator, FTS quoting

### DIFF
--- a/internal/engine/context_assembly.go
+++ b/internal/engine/context_assembly.go
@@ -1063,11 +1063,24 @@ func extractFrontmatterYAML(content string) (string, string, bool) {
 	return yamlBlock, body, true
 }
 
+// descriptionExemptTypes lists cogdoc types that intentionally omit the
+// description field — flagging them as missing would be a false positive.
+var descriptionExemptTypes = map[string]bool{
+	"session":           true,
+	"observation-index": true,
+	"audit":             true,
+	"pointer":           true,
+}
+
 func missingSchemaIssues(content string) []string {
 	presence := frontmatterPresence(content)
 	var issues []string
+	// Skip the description check for subtypes that don't use it.
+	// Read the raw type value so we can exempt known subtypes.
 	if !presence["description"] {
-		issues = append(issues, "missing_description")
+		if docType := frontmatterTypeValue(content); !descriptionExemptTypes[docType] {
+			issues = append(issues, "missing_description")
+		}
 	}
 	if !presence["tags"] {
 		issues = append(issues, "missing_tags")
@@ -1076,6 +1089,21 @@ func missingSchemaIssues(content string) []string {
 		issues = append(issues, "missing_type")
 	}
 	return issues
+}
+
+// frontmatterTypeValue extracts the raw string value of the "type" field from
+// YAML frontmatter.  Returns "" if the frontmatter is absent or type is unset.
+func frontmatterTypeValue(content string) string {
+	yamlBlock, _, ok := extractFrontmatterYAML(content)
+	if !ok {
+		return ""
+	}
+	var raw map[string]any
+	if err := yaml.Unmarshal([]byte(yamlBlock), &raw); err != nil {
+		return ""
+	}
+	t, _ := raw["type"].(string)
+	return t
 }
 
 func frontmatterPresence(content string) map[string]bool {

--- a/internal/engine/mcp_stubs.go
+++ b/internal/engine/mcp_stubs.go
@@ -124,15 +124,18 @@ func searchMemoryFTS(dbPath, workspaceRoot, query string, limit int, sector stri
 }
 
 // buildFTSQuery converts a plain search string into an FTS5 query.
-// Multi-word queries become OR-joined terms so each word matches
+// All terms are double-quoted to prevent FTS5 syntax errors from special
+// characters like leading '-' or 'type:' prefixes.
+// Multi-word queries become OR-joined quoted terms so each word matches
 // independently, matching the constellation SDK behaviour.
-// Single words are passed through as-is.
 func buildFTSQuery(raw string) string {
 	words := strings.Fields(strings.TrimSpace(raw))
-	if len(words) <= 1 {
+	if len(words) == 0 {
 		return raw
 	}
-	// Quote each word to avoid FTS5 syntax issues with special characters.
+	// Quote each word to avoid FTS5 syntax issues with special characters
+	// (e.g. leading '-', 'type:' prefix, etc.).  Always quote, even for a
+	// single term, so that queries like '-foo' don't produce FTS5 errors.
 	parts := make([]string, len(words))
 	for i, w := range words {
 		// Strip characters that could break FTS5 quoting.

--- a/internal/engine/mcp_stubs_test.go
+++ b/internal/engine/mcp_stubs_test.go
@@ -173,7 +173,7 @@ func TestBuildFTSQuery(t *testing.T) {
 		input string
 		want  string
 	}{
-		{"claude", "claude"},
+		{"claude", `"claude"`},
 		{"claude code", `"claude" OR "code"`},
 		{"  spaced  query  ", `"spaced" OR "query"`},
 	}

--- a/internal/engine/uri.go
+++ b/internal/engine/uri.go
@@ -252,7 +252,7 @@ func ResolveURI(workspaceRoot, uri string) (*URIResolution, error) {
 				// If the registry also can't resolve it, fall through to
 				// ErrUnknownAuthority (preserves fail-closed semantics).
 			}
-			return nil, fmt.Errorf("%w: workspace %q in URI %q", ErrUnknownAuthority, uriType, uri)
+			return nil, fmt.Errorf("%w: workspace %q in URI %q — cross-workspace registry not implemented; for a local doc use the bare form: cog:mem/<path>", ErrUnknownAuthority, uriType, uri)
 		}
 		return nil, fmt.Errorf("unknown cog: projection %q in URI %q", uriType, uri)
 	}


### PR DESCRIPTION
Three small UX/correctness fixes to the MCP tooling surface, identified in a tooling audit on 2026-06-01.

## Changes

**1. URI error hint** (`uri.go`)
When `cog://workspace/...` or other cross-workspace forms are used, the error now says: *cross-workspace registry not implemented; for a local doc use the bare form: `cog:mem/<path>`*. Previously the error gave no guidance.

**2. Type-aware schema validator** (`context_assembly.go`)
`missingSchemaIssues()` was unconditionally checking for `description` regardless of doc type. Session cogdocs (`type: session`), audit docs, observation-index, and pointer docs don't carry a `description` by design. The function now exempts those subtypes from the description check.

**3. Single-word FTS quoting** (`mcp_stubs.go`)
`buildFTSQuery()` now quotes single-word inputs (same as multi-word), preventing FTS5 parse errors on inputs like `-foo` or `type:bar`.

Follows squash-merge convention. No Co-Authored-By trailers.