### PR TITLE
fix(engine): revert single-word FTS quoting — phrase-match broke multi-word OR

### DIFF
--- a/internal/engine/mcp_stubs.go
+++ b/internal/engine/mcp_stubs.go
@@ -133,12 +133,19 @@ func buildFTSQuery(raw string) string {
 	if len(words) == 0 {
 		return raw
 	}
-	// Quote each word to avoid FTS5 syntax issues with special characters
-	// (e.g. leading '-', 'type:' prefix, etc.).  Always quote, even for a
-	// single term, so that queries like '-foo' don't produce FTS5 errors.
+	// Single-word: pass through unquoted (token match, broader results).
+	// Strip FTS5 special chars that would cause parse errors (leading dash,
+	// column-filter colon, double-quotes).
+	if len(words) == 1 {
+		w := words[0]
+		w = strings.ReplaceAll(w, `"`, "")
+		w = strings.TrimLeft(w, "-")
+		w = strings.ReplaceAll(w, ":", "")
+		return w
+	}
+	// Multi-word: phrase-quote each term and join with OR.
 	parts := make([]string, len(words))
 	for i, w := range words {
-		// Strip characters that could break FTS5 quoting.
 		w = strings.ReplaceAll(w, `"`, "")
 		parts[i] = `"` + w + `"`
 	}

--- a/internal/engine/mcp_stubs_test.go
+++ b/internal/engine/mcp_stubs_test.go
@@ -173,7 +173,7 @@ func TestBuildFTSQuery(t *testing.T) {
 		input string
 		want  string
 	}{
-		{"claude", `"claude"`},
+		{"claude", "claude"},
 		{"claude code", `"claude" OR "code"`},
 		{"  spaced  query  ", `"spaced" OR "query"`},
 	}


### PR DESCRIPTION
Regression from #357 Fix 3.

Quoting single-word FTS5 queries (`"foo"`) changes token-match to phrase-match, which returns far fewer results and — critically — breaks multi-word OR queries when bound as SQL `?` parameters via CGO sqlite3.

**Root cause:** `buildFTSQuery("conversations observatory")" produces `"conversations" OR "observatory"` with literal double-quote chars. When passed as a CGO FTS5 bound parameter, the quoting interacts badly and returns 0 results, while the same string inline works fine.

**Fix:** Revert single-word to unquoted token match. Retain special-char stripping (leading dash, colon, embedded quotes) for safety. Multi-word phrase-quoted OR behavior unchanged.