### PR TITLE
feat(engine): add output_path param to mod3_speak for large audio files

### DIFF
--- a/internal/engine/mcp_modality_proxy.go
+++ b/internal/engine/mcp_modality_proxy.go
@@ -137,7 +137,10 @@ func (m *MCPServer) registerMod3Tools() {
 			"endpoint. Required: text. Optional: session_id, voice, speed, " +
 			"emotion, skip_playback (return raw base64 bytes without queuing), " +
 			"format (audio container: \"wav\" default, \"pcm\" raw 16-bit LE, " +
-			"\"ogg\" audio/ogg;codecs=opus — most useful with skip_playback=true). " +
+			"\"ogg\" audio/ogg;codecs=opus — most useful with skip_playback=true), " +
+			"output_path (when set with skip_playback=true, writes audio bytes " +
+			"to this path and returns {ok, path, bytes} instead of base64 — " +
+			"avoids the MCP output-cap hit for large audio files). " +
 			"Returns mod3's queue state: status (speaking|queued), job_id, " +
 			"queue_position (0=playing immediately, N=queued at position N). " +
 			"Concurrent calls are serialized by mod3's drain thread — no " +
@@ -239,6 +242,12 @@ type mod3SpeakInput struct {
 	// passes format through to mod3 but playback support depends on mod3's
 	// drain thread.
 	Format string `json:"format,omitempty"`
+	// OutputPath, when set together with skip_playback=true, causes the
+	// kernel to write the audio bytes directly to this path and return
+	// {"ok":true,"path":"...","bytes":N} instead of the audio_base64 blob.
+	// This avoids the ~240k char MCP output cap hit from base64-encoding
+	// large audio files. The path must be writable by the kernel process.
+	OutputPath string `json:"output_path,omitempty"`
 }
 
 type mod3StopInput struct {
@@ -333,12 +342,32 @@ func (m *MCPServer) toolMod3SpeakRawBytes(ctx context.Context, in mod3SpeakInput
 	}
 
 	metrics := extractMod3Metrics(headers)
+
+	// OutputPath: write bytes directly to disk and return path+size.
+	// This avoids base64 encoding (and the MCP ~240k char output cap)
+	// for callers that only need the file on disk.
+	if in.OutputPath != "" {
+		if writeErr := os.WriteFile(in.OutputPath, audio, 0o644); writeErr != nil {
+			return mod3ErrorResult(fmt.Sprintf("write output_path %q: %v", in.OutputPath, writeErr))
+		}
+		result := map[string]any{
+			"ok":      true,
+			"path":    in.OutputPath,
+			"bytes":   len(audio),
+			"metrics": metrics,
+		}
+		if in.SessionID != "" {
+			result["session_id"] = in.SessionID
+		}
+		return marshalResult(result)
+	}
+
 	result := map[string]any{
-		"ok":           true,
-		"bytes":        len(audio),
-		"metrics":      metrics,
-		"session_id":   in.SessionID,
-		"audio_base64": base64.StdEncoding.EncodeToString(audio),
+		"ok":              true,
+		"bytes":           len(audio),
+		"metrics":         metrics,
+		"session_id":      in.SessionID,
+		"audio_base64":    base64.StdEncoding.EncodeToString(audio),
 		"playback_status": "skipped",
 	}
 	return marshalResult(result)

--- a/internal/engine/mcp_modality_proxy_test.go
+++ b/internal/engine/mcp_modality_proxy_test.go
@@ -1675,3 +1675,75 @@ func TestMod3Speak_QueuePath_FormatOgg_SentToSpeak(t *testing.T) {
 		t.Fatalf("expected format=ogg in forwarded speak body, got %v", got["format"])
 	}
 }
+
+// TestMod3Speak_OutputPath_WritesFileAndReturnsPath verifies that when
+// output_path is set together with skip_playback=true the audio is written
+// to disk and the response contains {ok, path, bytes} with no audio_base64.
+func TestMod3Speak_OutputPath_WritesFileAndReturnsPath(t *testing.T) {
+	fm := newFakeMod3Proxy(t)
+	m := newProxyMCP(t, fm)
+
+	tmpFile := t.TempDir() + "/reply.ogg"
+
+	res, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{
+		Text:         "write to disk",
+		SkipPlayback: true,
+		Format:       "ogg",
+		OutputPath:   tmpFile,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected success, got error: %v", decodeToolText(t, res))
+	}
+
+	out := decodeToolText(t, res)
+
+	// Must have ok=true, path=tmpFile, bytes>0.
+	if ok, _ := out["ok"].(bool); !ok {
+		t.Fatalf("expected ok=true, got %v", out["ok"])
+	}
+	if p, _ := out["path"].(string); p != tmpFile {
+		t.Fatalf("expected path=%q, got %q", tmpFile, p)
+	}
+	if b, _ := out["bytes"].(float64); b <= 0 {
+		t.Fatalf("expected bytes>0, got %v", out["bytes"])
+	}
+
+	// Must NOT include audio_base64 (that's the whole point).
+	if _, present := out["audio_base64"]; present {
+		t.Fatal("audio_base64 must be absent when output_path is set")
+	}
+
+	// Verify the file exists on disk and has the expected byte count.
+	data, readErr := os.ReadFile(tmpFile)
+	if readErr != nil {
+		t.Fatalf("file not written: %v", readErr)
+	}
+	if bytesField, _ := out["bytes"].(float64); int(bytesField) != len(data) {
+		t.Fatalf("bytes field %v != file size %d", out["bytes"], len(data))
+	}
+}
+
+// TestMod3Speak_OutputPath_WriteError_ReturnsToolError verifies that a
+// write failure (unwritable path) is surfaced as a tool error, not a Go error.
+func TestMod3Speak_OutputPath_WriteError_ReturnsToolError(t *testing.T) {
+	fm := newFakeMod3Proxy(t)
+	m := newProxyMCP(t, fm)
+
+	// Use an obviously unwritable path: a nonexistent nested dir.
+	badPath := t.TempDir() + "/no/such/dir/reply.ogg"
+
+	res, _, err := m.toolMod3Speak(context.Background(), nil, mod3SpeakInput{
+		Text:         "bad path",
+		SkipPlayback: true,
+		OutputPath:   badPath,
+	})
+	if err != nil {
+		t.Fatalf("unexpected Go error (should be tool error): %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected IsError=true for unwritable output_path")
+	}
+}


### PR DESCRIPTION
When `output_path` is set together with `skip_playback=true`, the kernel writes the synthesized audio bytes directly to that path and returns `{"ok":true,"path":"...","bytes":N}` instead of the `audio_base64` blob.

This avoids hitting the MCP ~240k character output cap when generating longer audio files, which was causing silent truncation on large TTS responses.