### PR TITLE
fix(engine): Claude Code OAuth credential is read-only (PATCH-007 port)

### DIFF
--- a/internal/engine/provider_claudeoauth.go
+++ b/internal/engine/provider_claudeoauth.go
@@ -430,6 +430,140 @@ func claudeOAuthRefresh(ctx context.Context, refreshToken string) (OAuthCredenti
 	return OAuthCredential{}, fmt.Errorf("claude-oauth: all token endpoints failed")
 }
 
+// ── claude_code read-only refresh (PATCH-007 port) ───────────────────────────
+//
+// The credential the managed-subscription provider mirrors (source ==
+// claude_code) is OWNED and rotated by Claude Code itself, which is the sole
+// writer of the macOS keychain entry "Claude Code-credentials". The refresh
+// token is SINGLE-USE. If the kernel POSTs that refresh token to the Anthropic
+// OAuth endpoint it (a) races Claude Code for the one-shot rotation, and (b)
+// lands the rotated pair only in ~/.claude/.credentials.json — a file Claude
+// Code >=2.1.114 ignores in favour of the keychain — orphaning the rotation and
+// causing hung/cancelled inference requests after every `claude /login` or
+// token rotation.
+//
+// So for the claude_code source the kernel is a READ-ONLY keychain MIRROR. It
+// NEVER POSTs the refresh token. When its mirrored credential is stale it
+// delegates the refresh to the OWNER (Claude Code) by running the user-space
+// actuator ~/.hermes/bin/claude-token-refresh (a single-flight headless
+// `claude -p`; fast-exits 0 if the token is already fresh), then re-mirrors.
+// If the keychain is still stale after that, the refresh token is likely
+// revoked and the credential surfaces as unavailable (needs interactive
+// `claude /login`) — the kernel does NOT loop and does NOT POST as a fallback.
+//
+// Architecture mirrors the canonical Python fix verbatim in ordering:
+//
+//	Reference: ~/.hermes/hermes-agent/agent/credential_pool.py
+//	           CredentialPool._refresh_entry, the PATCH-007 branch
+//	           (commit 5752ef82d). Python sequence:
+//	             synced = _sync_anthropic_entry_from_credentials_file(entry)   # mirror
+//	             if not _entry_needs_refresh(synced): return synced
+//	             run ~/.hermes/bin/claude-token-refresh (timeout 45)           # actuator
+//	             synced = _sync_anthropic_entry_from_credentials_file(synced)  # re-mirror
+//	             if not _entry_needs_refresh(synced): return synced
+//	             if force: _mark_exhausted(entry)                              # surface stale
+//	             return None
+//
+// In the Go kernel the equivalent of "_sync_anthropic_entry_from_credentials_file"
+// (keychain-first read) is the CredentialSource.Resolve already wired into the
+// CredentialLifecycle, and "_entry_needs_refresh" is the lifecycle's isFresh.
+// We express the read-only behaviour as the provider's RefreshFunc so the POST
+// path (claudeOAuthRefresh, above — preserved unchanged for any non-claude_code
+// OAuth source) is structurally unreachable for the managed subscription.
+
+// claudeTokenRefreshActuator is the user-space owner-delegating refresh actuator.
+// Source: EXT-010, ~/.hermes/bin/claude-token-refresh.
+var claudeTokenRefreshActuator = filepath.Join(os.Getenv("HOME"), ".hermes", "bin", "claude-token-refresh")
+
+// claudeTokenRefreshActuatorTimeout bounds the actuator subprocess. Matches the
+// Python reference (subprocess.run(..., timeout=45)).
+const claudeTokenRefreshActuatorTimeout = 45 * time.Second
+
+// runClaudeTokenRefreshActuator delegates the OAuth refresh to its owner (Claude
+// Code) by running the EXT-010 actuator. It is bounded by a context timeout,
+// tolerates a missing binary (no-op), and passes NO secret on argv — the
+// actuator reads/writes the keychain itself. stdin/stdout/stderr are detached
+// (the actuator's only side effect we care about is the refreshed keychain
+// token, which we pick up on the subsequent re-mirror).
+//
+// Source: PATCH-007 actuator invocation in _refresh_entry (subprocess.run with
+// DEVNULL on all three streams, timeout=45).
+func runClaudeTokenRefreshActuator(ctx context.Context, actuatorPath string) {
+	if actuatorPath == "" {
+		return
+	}
+	if _, err := os.Stat(actuatorPath); err != nil {
+		// Actuator absent (e.g. non-Hermes host) — tolerate; we simply cannot
+		// delegate a refresh and will surface the stale credential below.
+		slog.Debug("claude-oauth: refresh actuator not present; skipping owner delegation",
+			"actuator", actuatorPath, "err", err)
+		return
+	}
+	runCtx, cancel := context.WithTimeout(ctx, claudeTokenRefreshActuatorTimeout)
+	defer cancel()
+
+	// No arguments: the actuator takes no credential on argv (no secret leak to
+	// process listings); it operates on the keychain directly.
+	cmd := exec.CommandContext(runCtx, actuatorPath)
+	cmd.Stdin = nil
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	if err := cmd.Run(); err != nil {
+		// Non-fatal: a failed/timed-out actuator just means we couldn't trigger
+		// an owner refresh. The caller re-mirrors and surfaces staleness; it
+		// never falls back to POSTing the refresh token.
+		slog.Debug("claude-oauth: refresh actuator returned error (delegation best-effort)",
+			"actuator", actuatorPath, "err", err)
+	}
+}
+
+// newClaudeCodeReadOnlyRefresh builds the RefreshFunc used by the managed
+// subscription (source == claude_code). It NEVER POSTs the refresh token.
+//
+// The CredentialLifecycle calls this only after it has already re-resolved the
+// source and found nothing fresher (see freshTokenLocked: it re-reads the
+// source keychain-first before invoking RefreshFunc). This RefreshFunc adds the
+// owner-delegation step: run the actuator, then re-mirror by resolving the
+// source again. If the freshly-mirrored credential is now fresh, it is returned
+// (and adopted by the lifecycle); otherwise an error is returned so the provider
+// surfaces Unavailable / needs-interactive-login rather than presenting a stale
+// bearer or POSTing.
+//
+// The returned func ignores the refreshToken argument entirely — by contract we
+// never exchange it. This is the structural no-POST invariant.
+func newClaudeCodeReadOnlyRefresh(src CredentialSource, actuatorPath string) RefreshFunc {
+	return func(ctx context.Context, _ /* refreshToken — intentionally unused: never POSTed */ string) (OAuthCredential, error) {
+		// Step 1 (mirror): re-read what Claude Code currently holds
+		// (keychain-first). The lifecycle already did this once before calling
+		// us, but re-reading here keeps this func correct in isolation and
+		// matches the Python branch's leading _sync call.
+		if cred, err := src.Resolve(); err == nil && isFresh(cred) {
+			return cred, nil
+		}
+
+		// Step 2 (delegate): ask the owner (Claude Code) to refresh its own
+		// keychain token via the user-space actuator. Bounded, best-effort,
+		// no secret on argv, tolerates a missing binary.
+		runClaudeTokenRefreshActuator(ctx, actuatorPath)
+
+		// Step 3 (re-mirror): read the (hopefully) owner-refreshed keychain token.
+		cred, err := src.Resolve()
+		if err != nil {
+			return OAuthCredential{}, fmt.Errorf("claude-oauth: read-only refresh: re-mirror after actuator: %w", err)
+		}
+		if isFresh(cred) {
+			return cred, nil
+		}
+
+		// Step 4 (surface stale): still stale after owner delegation. The
+		// refresh token is likely revoked → needs interactive `claude /login`.
+		// Return an error (the lifecycle propagates it as Unavailable). We do
+		// NOT loop and do NOT POST the refresh token as a fallback.
+		return OAuthCredential{}, fmt.Errorf(
+			"claude-oauth: credential stale after owner refresh; interactive `claude /login` required (refresh token likely revoked)")
+	}
+}
+
 // ── ClaudeOAuthProvider ───────────────────────────────────────────────────────
 
 // ClaudeOAuthProvider implements Provider against the Anthropic Messages API
@@ -471,7 +605,14 @@ func NewClaudeOAuthProvider(name string, cfg ProviderConfig, fallback Provider) 
 	}
 
 	src := newClaudeCodeCredentialSource()
-	lc := NewCredentialLifecycle(src, claudeOAuthRefresh)
+	// The mirrored credential (source == claude_code) is owned and rotated by
+	// Claude Code itself. The kernel is a READ-ONLY keychain mirror: its
+	// RefreshFunc NEVER POSTs the single-use refresh token. When the mirror is
+	// stale it delegates the refresh to the owner (Claude Code) via the
+	// user-space actuator, then re-mirrors. See newClaudeCodeReadOnlyRefresh /
+	// PATCH-007. The POST-ing claudeOAuthRefresh is retained for any future
+	// non-claude_code OAuth source but is intentionally NOT wired here.
+	lc := NewCredentialLifecycle(src, newClaudeCodeReadOnlyRefresh(src, claudeTokenRefreshActuator))
 
 	return &ClaudeOAuthProvider{
 		name:      name,

--- a/internal/engine/provider_claudeoauth_test.go
+++ b/internal/engine/provider_claudeoauth_test.go
@@ -807,3 +807,189 @@ func TestMakeProviderClaudeOAuth(t *testing.T) {
 // min is available as a builtin since Go 1.21; kept as local for test-file clarity.
 // (shadowing the builtin is fine inside a function, but a package-level redeclaration
 //  is a compilation error in Go 1.21+)
+
+// ── PATCH-007: claude_code read-only refresh (no-POST invariant) ──────────────
+//
+// The managed-subscription provider (source == claude_code) mirrors a credential
+// OWNED by Claude Code. It must NEVER POST the single-use refresh token. These
+// tests pin the no-POST invariant and the read-only-mirror behaviour. If anyone
+// reintroduces the POST path for claude_code, TestClaudeOAuthReadOnlyRefresh_NeverPOSTs
+// fails because the token endpoint marks the test failed on any hit.
+
+// postSentinelSource is a CredentialSource whose Resolve returns a programmable
+// sequence of credentials (one per call), emulating the keychain being
+// re-mirrored across the read-only refresh steps. It records WriteBack calls so
+// the test can assert the read-only path never writes back the file either.
+type postSentinelSource struct {
+	creds      []OAuthCredential
+	idx        int
+	resolveErr error
+	writebacks []OAuthCredential
+}
+
+func (s *postSentinelSource) Resolve() (OAuthCredential, error) {
+	if s.resolveErr != nil {
+		return OAuthCredential{}, s.resolveErr
+	}
+	if s.idx < len(s.creds) {
+		c := s.creds[s.idx]
+		s.idx++
+		return c, nil
+	}
+	// After the scripted sequence, keep returning the last credential.
+	if len(s.creds) > 0 {
+		return s.creds[len(s.creds)-1], nil
+	}
+	return OAuthCredential{}, fmt.Errorf("no credential")
+}
+
+func (s *postSentinelSource) WriteBack(cred OAuthCredential) error {
+	s.writebacks = append(s.writebacks, cred)
+	return nil
+}
+
+// staleCred returns a credential that is already past the freshness buffer, so
+// the lifecycle must attempt a refresh.
+func staleCred() OAuthCredential {
+	return OAuthCredential{
+		AccessToken:  "cc-stale-access-token",
+		RefreshToken: "cc-single-use-refresh-token",
+		ExpiresAtMS:  time.Now().Add(-1 * time.Minute).UnixMilli(),
+	}
+}
+
+// TestClaudeOAuthReadOnlyRefresh_NeverPOSTs proves that the claude_code refresh
+// path delegates to the owner actuator and re-mirrors the keychain, and NEVER
+// POSTs the single-use refresh token to any OAuth token endpoint. A token
+// endpoint is stood up that FAILS THE TEST if it is ever hit; the read-only
+// refresh func is wired in front of it (with a non-existent actuator path so the
+// owner-delegation is a tolerated no-op), and the source is scripted to present
+// a stale token first, then a fresh one (as if the owner rotated the keychain).
+func TestClaudeOAuthReadOnlyRefresh_NeverPOSTs(t *testing.T) {
+	t.Parallel()
+
+	// A token endpoint that marks the test failed on ANY request. If a future
+	// regression reintroduced a POST in the claude_code refresh path, the only
+	// way it could succeed is by hitting a token endpoint; this server asserts
+	// that never happens.
+	var tokenEndpointHits atomic.Int32
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenEndpointHits.Add(1)
+		t.Errorf("token endpoint was hit (%s %s) — claude_code path must NEVER POST the refresh token", r.Method, r.URL.Path)
+		http.Error(w, "must not POST", http.StatusInternalServerError)
+	}))
+	defer tokenSrv.Close()
+
+	// Source: first Resolve (lifecycle's pre-refresh re-read) returns stale;
+	// second Resolve (read-only func's step-1 mirror) returns stale; third
+	// Resolve (step-3 re-mirror after the no-op actuator) returns FRESH, as if
+	// Claude Code rotated the keychain. The fresh token has a distinctive value.
+	freshToken := "cc-owner-rotated-keychain-token"
+	src := &postSentinelSource{creds: []OAuthCredential{
+		staleCred(),
+		staleCred(),
+		{
+			AccessToken:  freshToken,
+			RefreshToken: "cc-next-single-use-refresh-token",
+			ExpiresAtMS:  time.Now().Add(60 * time.Minute).UnixMilli(),
+		},
+	}}
+
+	// Wire the read-only refresh func with a deliberately absent actuator so the
+	// owner-delegation step is a tolerated no-op (no real `claude` is launched
+	// in the test). The re-mirror still picks up the scripted fresh token.
+	missingActuator := filepath.Join(t.TempDir(), "no-such-claude-token-refresh")
+	lc := NewCredentialLifecycle(src, newClaudeCodeReadOnlyRefresh(src, missingActuator))
+
+	// FreshToken must drive: pre-refresh re-read (stale) → read-only refresh
+	// (mirror stale → actuator no-op → re-mirror FRESH) → adopt fresh token.
+	tok, err := lc.FreshToken(context.Background())
+	if err != nil {
+		t.Fatalf("FreshToken: unexpected error: %v", err)
+	}
+	if tok != freshToken {
+		t.Errorf("FreshToken = %q; want the owner-rotated keychain token %q (read-only mirror must adopt it)", tok, freshToken)
+	}
+	if n := tokenEndpointHits.Load(); n != 0 {
+		t.Errorf("token endpoint hits = %d; want 0 — the claude_code path POSTed the refresh token", n)
+	}
+}
+
+// TestClaudeOAuthReadOnlyRefresh_FreshMirrorNoNetwork proves that when the
+// keychain mirror is already fresh, the read-only refresh func adopts it
+// directly with NO actuator launch and NO network call. (The lifecycle's fast
+// path would normally short-circuit a fresh token, so we call the refresh func
+// directly to exercise its step-1 mirror-adopt branch in isolation.)
+func TestClaudeOAuthReadOnlyRefresh_FreshMirrorNoNetwork(t *testing.T) {
+	t.Parallel()
+
+	freshToken := "cc-already-fresh-keychain-token"
+	src := &postSentinelSource{creds: []OAuthCredential{{
+		AccessToken:  freshToken,
+		RefreshToken: "cc-refresh",
+		ExpiresAtMS:  time.Now().Add(60 * time.Minute).UnixMilli(),
+	}}}
+
+	// An actuator path that, if ever executed, would error the test. But step-1
+	// (fresh mirror) must return before we ever reach the actuator, so it is
+	// never run.
+	sentinelActuator := filepath.Join(t.TempDir(), "actuator-must-not-run.sh")
+	if err := os.WriteFile(sentinelActuator, []byte("#!/bin/sh\nexit 0\n"), 0700); err != nil {
+		t.Fatalf("seed sentinel actuator: %v", err)
+	}
+
+	refresh := newClaudeCodeReadOnlyRefresh(src, sentinelActuator)
+	cred, err := refresh(context.Background(), "ignored-refresh-token")
+	if err != nil {
+		t.Fatalf("read-only refresh on fresh mirror: %v", err)
+	}
+	if cred.AccessToken != freshToken {
+		t.Errorf("AccessToken = %q; want fresh mirror token %q", cred.AccessToken, freshToken)
+	}
+	// Step-1 fresh-adopt must consume exactly one Resolve and no more.
+	if src.idx != 1 {
+		t.Errorf("Resolve calls = %d; want 1 (fresh mirror adopted without actuator/re-mirror)", src.idx)
+	}
+}
+
+// TestClaudeOAuthReadOnlyRefresh_StaleKeychainSurfacesUnavailable proves the
+// terminal behaviour: when the keychain itself stays stale even after the owner
+// actuator runs (refresh token revoked), the read-only func returns an error so
+// the provider surfaces Unavailable / needs-`claude /login` — it does NOT hang
+// (the original bug) and does NOT POST as a fallback.
+func TestClaudeOAuthReadOnlyRefresh_StaleKeychainSurfacesUnavailable(t *testing.T) {
+	t.Parallel()
+
+	// Every Resolve returns a stale credential — the owner could not refresh it.
+	src := &postSentinelSource{creds: []OAuthCredential{staleCred()}}
+	missingActuator := filepath.Join(t.TempDir(), "absent-actuator")
+	refresh := newClaudeCodeReadOnlyRefresh(src, missingActuator)
+
+	_, err := refresh(context.Background(), "ignored")
+	if err == nil {
+		t.Fatal("want error when keychain is stale after owner refresh (needs-interactive-login); got nil")
+	}
+	if !strings.Contains(err.Error(), "login") {
+		t.Errorf("error should signal interactive login is required; got: %v", err)
+	}
+}
+
+// TestClaudeOAuthProviderUsesReadOnlyRefresh is a wiring guard: a provider built
+// via NewClaudeOAuthProvider must initialise its lifecycle, and the POST-ing
+// claudeOAuthRefresh must remain only a sentinel-referenced symbol (not the func
+// wired for the claude_code source).
+func TestClaudeOAuthProviderUsesReadOnlyRefresh(t *testing.T) {
+	t.Parallel()
+	p := NewClaudeOAuthProvider("claude-oauth", ProviderConfig{Model: "m"}, nil)
+	if p.lc == nil {
+		t.Fatal("provider lifecycle not initialised")
+	}
+	if claudeOAuthRefreshSentinel == nil {
+		t.Fatal("claudeOAuthRefresh POST path unexpectedly nil")
+	}
+}
+
+// claudeOAuthRefreshSentinel keeps the POST-ing refresh func referenced (so it
+// is not flagged dead) while making explicit in the test that it is the path the
+// claude_code source must NEVER use.
+var claudeOAuthRefreshSentinel RefreshFunc = claudeOAuthRefresh


### PR DESCRIPTION
## Root cause

The kernel's `claude-oauth` provider mirrors a credential whose `source == claude_code`. That OAuth **refresh token is single-use** and owned by Claude Code, the sole writer of the macOS keychain entry `Claude Code-credentials`. The provider POSTed that refresh token to the Anthropic OAuth token endpoint and wrote the rotated pair **only** to `~/.claude/.credentials.json` — which Claude Code >=2.1.114 **ignores** in favour of the keychain. Result: the kernel raced Claude Code on the single-use token, orphaned the rotation, and produced **hung → timed-out → cancelled** inference requests on the Cog profile. This is the kernel-side twin of Hermes PATCH-007.

## Fix

Port of Hermes `PATCH-007` (`credential_pool.py` @ `5752ef82d`). For `source == claude_code` the provider is now a **read-only keychain mirror**:

- It **NEVER POSTs** the single-use refresh token.
- When the mirror is stale, it delegates the refresh to the **owner** (Claude Code) via the existing user-space actuator `~/.hermes/bin/claude-token-refresh` (single-flight headless `claude -p`), then re-mirrors.
- If still stale, it surfaces **Unavailable** (needs interactive `claude /login`) — no loop, no POST fallback, no hang.

The read-only behaviour **is** the provider's `RefreshFunc` (`newClaudeCodeReadOnlyRefresh`), so the POST path (`claudeOAuthRefresh`) is **structurally unreachable** for the managed subscription (verified: zero production callers).

## Test evidence

`internal/engine/provider_claudeoauth_test.go` (+186): `TestClaudeOAuthReadOnlyRefresh_NeverPOSTs` stands up an httptest token endpoint that fails the test on **any** hit and asserts `tokenEndpointHits == 0`; `_StaleKeychainSurfacesUnavailable` and `_FreshMirrorNoNetwork` cover the terminal-stale and fresh-mirror paths.

- `CGO_ENABLED=1 go build -tags fts5 ./...` → exit 0
- `CGO_ENABLED=1 go test -tags fts5 ./internal/engine/ -run OAuth -v` → all PASS
- `CGO_ENABLED=1 go vet -tags fts5 ./internal/engine/` → clean

## Review

Closed-loop seam review: **OVERALL: GO** (6/6 seams, file:line evidence). No-POST invariant independently re-verified by the orchestrator.

## ⚠️ DO NOT AUTO-MERGE

Auth + dispatch credential code in a live identity's path. **Operator review + merge call required.** Once merged, Tier 1 rebuilds the kernel with `-tags fts5` (which also restores the dead Tier-4 semantic search) and restarts — a separate operator-gated step that bounces live Cog.
