### PR TITLE
fix(engine): reject unknown model ids at kernel boundary with 400

### DIFF
--- a/internal/engine/provider_stub.go
+++ b/internal/engine/provider_stub.go
@@ -12,6 +12,7 @@ import (
 // StubProvider is an in-memory Provider for testing.
 type StubProvider struct {
 	name         string
+	model        string // reported by Model(); empty by default
 	response     string
 	err          error
 	latency      time.Duration
@@ -45,7 +46,7 @@ func NewStubProvider(name, response string) *StubProvider {
 }
 
 func (s *StubProvider) Name() string                       { return s.name }
-func (s *StubProvider) Model() string                      { return "" }
+func (s *StubProvider) Model() string                      { return s.model }
 func (s *StubProvider) Available(_ context.Context) bool   { return s.available }
 func (s *StubProvider) Capabilities() ProviderCapabilities { return s.capabilities }
 

--- a/internal/engine/resolve.go
+++ b/internal/engine/resolve.go
@@ -130,3 +130,81 @@ func ResolveModelRequest(router Router, model string, requestID string) ModelRes
 	}
 	return res
 }
+
+// IsKnownModel reports whether a non-empty model string resolves to a real
+// routing target: an intent alias, the dynamic "local" alias, a registered
+// provider name, or a model served by some registered provider. It is the
+// kernel-boundary admission check used by the gateway to reject unknown model
+// ids with HTTP 400 instead of forwarding them to the default provider (which
+// would POST a bogus id upstream and surface an opaque 500-wrapped 404).
+//
+// The empty string is treated as KNOWN (it means "default routing", which is a
+// valid request — see ResolveModelRequest). A nil router can only validate the
+// static alias table; callers on the nil-router path (dispatch) must not use
+// this as a hard gate, because provider-name / provider-model matches require a
+// live router. The gateway always passes a live router.
+//
+// Like ResolveModelRequest, this function is side-effect-free.
+func IsKnownModel(router Router, model string) bool {
+	if model == "" {
+		return true // default routing is always valid
+	}
+	if _, ok := intentAliases[model]; ok {
+		return true
+	}
+	if model == "local" {
+		// "local" is a valid alias; whether a local provider is actually
+		// registered is handled by ResolveModelRequest's fallback-to-default
+		// behaviour, so do not reject it here.
+		return true
+	}
+	if router == nil {
+		// Without a live router only the static alias table is knowable.
+		return false
+	}
+	if _, ok := router.ProviderForName(model); ok {
+		return true
+	}
+	if _, ok := router.ProviderForModel(model); ok {
+		return true
+	}
+	return false
+}
+
+// AvailableModelIDs returns the menu of model ids the kernel accepts, in a
+// stable order: the intent aliases ("local" included), the raw frontier model
+// ids exposed at GET /v1/models, then any registered provider names not already
+// listed. Used to build the 400 response body when an unknown model is
+// rejected so the caller sees exactly what they may request. Side-effect-free.
+func AvailableModelIDs(router Router) []string {
+	// Intent aliases + the dynamic "local" alias, in a deterministic order
+	// that mirrors the /v1/models menu's intent-first layout.
+	ids := []string{
+		"foreground", "deliberation", "local",
+		"claude-sonnet-4-6", "claude-opus-4-7", "claude-haiku-4-5-20251001",
+	}
+	seen := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		seen[id] = true
+	}
+	// Append remaining static intent aliases (claude, codex, ollama, etc.)
+	// that are not already in the menu, for completeness.
+	for alias := range intentAliases {
+		if !seen[alias] {
+			ids = append(ids, alias)
+			seen[alias] = true
+		}
+	}
+	// Append registered provider names (e.g. claude-oauth, ollama, lmstudio).
+	if sr, ok := router.(*SimpleRouter); ok && sr != nil {
+		sr.mu.RLock()
+		for _, p := range sr.providers {
+			if name := p.Name(); name != "" && !seen[name] {
+				ids = append(ids, name)
+				seen[name] = true
+			}
+		}
+		sr.mu.RUnlock()
+	}
+	return ids
+}

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -926,6 +926,34 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 	// the gateway and dispatch tool share a single source of truth. The
 	// InjectKernelTools flag is handled below (kernel-agent / ollama path).
 	{
+		// Kernel-boundary admission: reject a non-empty model id that resolves
+		// to no known routing target (alias / "local" / provider name /
+		// provider-served model) with HTTP 400 + the available menu. Without
+		// this guard an unknown id (e.g. "gpt-4") falls through to the default
+		// provider, which POSTs the bogus id upstream and surfaces an opaque
+		// 500-wrapped 404. "" (default routing) and all known ids pass through.
+		if !IsKnownModel(s.router, req.Model) {
+			menu := AvailableModelIDs(s.router)
+			slog.Warn("chat: rejected unknown model id at kernel boundary",
+				"request_id", creq.Metadata.RequestID,
+				"model", req.Model,
+			)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{
+					"type": "invalid_request_error",
+					"message": fmt.Sprintf(
+						"unknown model %q; available models: %s",
+						req.Model, strings.Join(menu, ", "),
+					),
+					"param":            "model",
+					"available_models": menu,
+				},
+			})
+			return
+		}
+
 		mres := ResolveModelRequest(s.router, req.Model, creq.Metadata.RequestID)
 		creq.Metadata.PreferProvider = mres.PreferProvider
 		creq.ModelOverride = mres.ModelOverride

--- a/internal/engine/serve_unknown_model_test.go
+++ b/internal/engine/serve_unknown_model_test.go
@@ -1,0 +1,185 @@
+// serve_unknown_model_test.go — kernel-boundary guard for unknown model ids.
+//
+// Regression for the opaque-500 bug: a non-empty `model` string that matches
+// NONE of (intent alias / "local" / provider name / provider-served model)
+// used to fall through to the default provider (claude-oauth), which POSTed
+// the bogus id to Anthropic and surfaced a 404 not_found_error wrapped as an
+// HTTP 500. The guard rejects unknown models at the gateway boundary with a
+// 400 + the available-model menu, and must NOT regress the empty-string,
+// known-alias, or provider-served-model paths.
+package engine
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// postChat issues a /v1/chat/completions request against srv.handleChat and
+// returns the recorder.
+func postChat(t *testing.T, srv *Server, model string) *httptest.ResponseRecorder {
+	t.Helper()
+	body := `{"model":` + jsonQuote(model) + `,"messages":[{"role":"user","content":"hi"}],"stream":false}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleChat(w, req)
+	return w
+}
+
+func jsonQuote(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+// TestGateway_UnknownModel_Returns400 is the core failing-first assertion:
+// a bogus model id must be rejected with HTTP 400 before any provider call,
+// and the body must name the unknown model and list the available menu.
+func TestGateway_UnknownModel_Returns400(t *testing.T) {
+	t.Parallel()
+
+	ccStub := NewStubProvider("claude-oauth", "should not be reached")
+	router := NewSimpleRouter(RoutingConfig{Default: "claude-oauth"})
+	router.RegisterProvider(ccStub)
+
+	srv := newTestServerWithRouter(t, router)
+
+	for _, bogus := range []string{"gpt-4", "totally-bogus-model-xyz"} {
+		w := postChat(t, srv, bogus)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("model=%q: status = %d; want 400", bogus, w.Code)
+		}
+		// The default provider must NOT have been invoked.
+		if ccStub.lastRequest != nil {
+			t.Errorf("model=%q: default provider was called; want guard to short-circuit", bogus)
+			ccStub.lastRequest = nil // reset for next iteration
+		}
+		// The body should name the unknown model and advertise the menu.
+		bodyStr := w.Body.String()
+		if !strings.Contains(bodyStr, bogus) {
+			t.Errorf("model=%q: body does not name the unknown model: %s", bogus, bodyStr)
+		}
+		if !strings.Contains(bodyStr, "foreground") {
+			t.Errorf("model=%q: body does not advertise the available menu (missing 'foreground'): %s", bogus, bodyStr)
+		}
+	}
+}
+
+// TestGateway_EmptyModel_StillDefaults verifies the "" path is unchanged:
+// default routing reaches the configured provider and returns 200.
+func TestGateway_EmptyModel_StillDefaults(t *testing.T) {
+	t.Parallel()
+
+	ccStub := NewStubProvider("claude-oauth", "default response")
+	router := NewSimpleRouter(RoutingConfig{Default: "claude-oauth"})
+	router.RegisterProvider(ccStub)
+
+	srv := newTestServerWithRouter(t, router)
+	w := postChat(t, srv, "")
+	if w.Code != http.StatusOK {
+		t.Errorf("empty model: status = %d; want 200", w.Code)
+	}
+	if ccStub.lastRequest == nil {
+		t.Error("empty model: default provider was not called")
+	}
+}
+
+// TestGateway_KnownAlias_StillResolves verifies a known intent alias still
+// routes to its provider (no false 400).
+func TestGateway_KnownAlias_StillResolves(t *testing.T) {
+	t.Parallel()
+
+	ccStub := NewStubProvider("claude-oauth", "alias response")
+	router := NewSimpleRouter(RoutingConfig{Default: "claude-oauth"})
+	router.RegisterProvider(ccStub)
+
+	srv := newTestServerWithRouter(t, router)
+	w := postChat(t, srv, "foreground")
+	if w.Code != http.StatusOK {
+		t.Errorf("foreground: status = %d; want 200", w.Code)
+	}
+	if ccStub.lastRequest == nil {
+		t.Error("foreground: provider was not called")
+	}
+}
+
+// TestGateway_ProviderServedModel_StillResolves verifies a model id served by
+// a registered provider (ProviderForModel match) still resolves and is NOT
+// rejected by the guard.
+func TestGateway_ProviderServedModel_StillResolves(t *testing.T) {
+	t.Parallel()
+
+	served := newModelStub("my-provider", "served-model-v2", "served response")
+	router := NewSimpleRouter(RoutingConfig{Default: "my-provider"})
+	router.RegisterProvider(served)
+
+	srv := newTestServerWithRouter(t, router)
+	w := postChat(t, srv, "served-model-v2")
+	if w.Code != http.StatusOK {
+		t.Errorf("served-model-v2: status = %d; want 200", w.Code)
+	}
+	if served.lastRequest == nil {
+		t.Error("served-model-v2: provider was not called")
+	}
+}
+
+// TestGateway_ProviderName_StillResolves verifies that targeting a provider by
+// its registered name (ProviderForName match) still resolves.
+func TestGateway_ProviderName_StillResolves(t *testing.T) {
+	t.Parallel()
+
+	p := NewStubProvider("my-provider", "by-name response")
+	router := NewSimpleRouter(RoutingConfig{Default: "my-provider"})
+	router.RegisterProvider(p)
+
+	srv := newTestServerWithRouter(t, router)
+	w := postChat(t, srv, "my-provider")
+	if w.Code != http.StatusOK {
+		t.Errorf("provider-name: status = %d; want 200", w.Code)
+	}
+	if p.lastRequest == nil {
+		t.Error("provider-name: provider was not called")
+	}
+}
+
+// TestIsKnownModel_NilRouterUnknownStringNotAGate guards invariant #2: the
+// dispatch (nil-router) path must NOT be hardened into an error path by this
+// change. ResolveModelRequest(nil, <unknown>, ...) must still fall through to an
+// empty ModelResolution{} (no 400, no panic) — IsKnownModel is only a hard gate
+// on the gateway path where a live router is always present. We assert both the
+// IsKnownModel verdict (false: unverifiable without a router) AND that the
+// underlying ResolveModelRequest contract is unchanged for the nil-router case.
+func TestIsKnownModel_NilRouterUnknownStringNotAGate(t *testing.T) {
+	t.Parallel()
+
+	// "" is always known (default routing is valid) regardless of router.
+	if !IsKnownModel(nil, "") {
+		t.Error(`IsKnownModel(nil, "") = false; want true (empty = default routing)`)
+	}
+	// A static alias is knowable without a router.
+	if !IsKnownModel(nil, "foreground") {
+		t.Error(`IsKnownModel(nil, "foreground") = false; want true (static alias)`)
+	}
+	// An unknown string is *unverifiable* without a router → false. This is why
+	// the dispatch (nil-router) path must NOT treat IsKnownModel as a hard gate.
+	if IsKnownModel(nil, "totally-bogus-model-xyz") {
+		t.Error(`IsKnownModel(nil, "totally-bogus-model-xyz") = true; want false (unverifiable, no router)`)
+	}
+
+	// Invariant #2 contract: the nil-router resolve path still degrades to an
+	// empty ModelResolution{} for an unknown string — no error, no panic.
+	res := ResolveModelRequest(nil, "totally-bogus-model-xyz", "req-nilrouter")
+	if res.PreferProvider != "" || res.ModelOverride != "" || res.InjectKernelTools {
+		t.Errorf("nil-router unknown model: want zero ModelResolution{}, got %+v", res)
+	}
+}
+
+// newModelStub returns a StubProvider whose Model() reports modelID, so
+// ProviderForModel(modelID) resolves to this provider.
+func newModelStub(name, modelID, response string) *StubProvider {
+	s := NewStubProvider(name, response)
+	s.model = modelID
+	return s
+}


### PR DESCRIPTION
## Problem

In `ResolveModelRequest` (resolve.go) + `handleChat` (serve.go), a non-empty `model` string that is **not** a known intent alias, not `"local"`, not a provider name (`ProviderForName`), and not a model served by any provider (`ProviderForModel`) fell through as a `ModelOverride` to the default provider (claude-oauth). That provider then POSTed the bogus model id to Anthropic, which returned a 404 `not_found_error`, and `handleChat` wrapped it as an opaque **HTTP 500**.

## Fix

The kernel now admits requests at the boundary. `handleChat` calls a new side-effect-free `IsKnownModel(router, model)`; an unknown non-empty id is rejected with a clean **HTTP 400** whose body names the offending model and lists the available menu (`AvailableModelIDs(router)`), before any provider is invoked.

## Invariants preserved

- Empty `""` → default routing → claude-oauth uses its configured model → **200** (unchanged).
- nil-router dispatch path is **not** hardened into an error path: unknown strings still fall through to empty `ModelResolution{}` (the 400 gate only fires on the gateway path where `router != nil`).
- `ResolveModelRequest` stays side-effect-free.
- Known aliases (foreground, deliberation, sonnet/opus/haiku, codex, local, claude-sonnet-4-6, …) and valid provider-served / provider-name ids still resolve → **200**.

## Tests

New `internal/engine/serve_unknown_model_test.go`:
- `TestGateway_UnknownModel_Returns400` — bogus id → 400, menu in body, default provider never called.
- `TestGateway_EmptyModel_StillDefaults` — `""` → 200.
- `TestGateway_KnownAlias_StillResolves` — `foreground` → 200.
- `TestGateway_ProviderServedModel_StillResolves` — `ProviderForModel` match → 200.
- `TestGateway_ProviderName_StillResolves` — `ProviderForName` match → 200.
- `TestIsKnownModel_NilRouterUnknownStringNotAGate` — nil-router unknown string still degrades to empty resolution (no 400 / no panic).

Full `go test ./internal/engine/ -count=1` and `go vet ./internal/engine/` are green.