### PR TITLE
fix(engine): make claude-oauth WriteBack a no-op (read-only mirror) — fixes #363

### DIFF
--- a/internal/engine/provider_claudeoauth.go
+++ b/internal/engine/provider_claudeoauth.go
@@ -276,74 +276,27 @@ func (s *claudeCodeCredentialSource) readCredFile() (OAuthCredential, bool) {
 	}, true
 }
 
-// WriteBack writes the refreshed credential back to ~/.claude/.credentials.json,
-// preserving other top-level fields and the existing scopes field.
-// Source: _write_claude_code_credentials (Python reference).
+// WriteBack is intentionally a NO-OP for the Claude Code credential source.
 //
-// Security: the temp file is created with O_EXCL at 0600, so it is never
-// world-readable even briefly. os.Rename is atomic on POSIX.
-func (s *claudeCodeCredentialSource) WriteBack(cred OAuthCredential) error {
-	// Read existing file to preserve other top-level fields and scopes.
-	existing := make(map[string]json.RawMessage)
-	if data, err := os.ReadFile(s.credPath); err == nil {
-		_ = json.Unmarshal(data, &existing)
-	}
-
-	// Build the claudeAiOauth sub-object, preserving existing scopes if not
-	// returned by the refresh response.
-	oauthObj := claudeAiOauthJSON{
-		AccessToken:  cred.AccessToken,
-		RefreshToken: cred.RefreshToken,
-		ExpiresAt:    cred.ExpiresAtMS,
-	}
-	// Preserve scopes from the existing record.
-	if raw, ok := existing["claudeAiOauth"]; ok {
-		var prev claudeAiOauthJSON
-		if err := json.Unmarshal(raw, &prev); err == nil {
-			oauthObj.Scopes = prev.Scopes
-		}
-	}
-
-	oauthRaw, err := json.Marshal(oauthObj)
-	if err != nil {
-		return fmt.Errorf("claude-oauth: marshal oauth: %w", err)
-	}
-	existing["claudeAiOauth"] = json.RawMessage(oauthRaw)
-
-	newData, err := json.MarshalIndent(existing, "", "  ")
-	if err != nil {
-		return fmt.Errorf("claude-oauth: marshal credentials: %w", err)
-	}
-
-	// Ensure parent directory exists.
-	if err := os.MkdirAll(filepath.Dir(s.credPath), 0700); err != nil {
-		return fmt.Errorf("claude-oauth: mkdir: %w", err)
-	}
-
-	// Write to a temp file at 0600 then rename atomically.
-	tmp := s.credPath + fmt.Sprintf(".tmp.%d", os.Getpid())
-	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
-	if err != nil {
-		return fmt.Errorf("claude-oauth: create tmp: %w", err)
-	}
-	_, writeErr := f.Write(newData)
-	syncErr := f.Sync()
-	closeErr := f.Close()
-	if writeErr != nil || syncErr != nil || closeErr != nil {
-		_ = os.Remove(tmp)
-		if writeErr != nil {
-			return fmt.Errorf("claude-oauth: write tmp: %w", writeErr)
-		}
-		if syncErr != nil {
-			return fmt.Errorf("claude-oauth: sync tmp: %w", syncErr)
-		}
-		return fmt.Errorf("claude-oauth: close tmp: %w", closeErr)
-	}
-
-	if err := os.Rename(tmp, s.credPath); err != nil {
-		_ = os.Remove(tmp)
-		return fmt.Errorf("claude-oauth: rename: %w", err)
-	}
+// Claude Code is the sole owner and writer of ~/.claude/.credentials.json and
+// the macOS keychain entry it mirrors. The kernel is a strict READ-ONLY mirror
+// of that credential (see newClaudeCodeReadOnlyRefresh): it never POSTs the
+// single-use refresh token, and it must likewise never WRITE the credential
+// file. The read-only refresh only ever surfaces the current keychain value
+// (or a Resolve() fallback that may be stale), so a WriteBack here can only
+// either redundantly rewrite the keychain value — churning the file mtime — or
+// poison Claude Code's file fallback store with a stale token, which forces an
+// interactive `claude /login`.
+//
+// Observed live 2026-06-04 (issue #363): under an eclipse-down fallback loop
+// the kernel routed periodic inference to claude-oauth ~every 10s; each refresh
+// triggered this WriteBack, rewriting the file every ~10s and injecting a stale
+// token, causing repeated "OAuth token revoked · Please run /login" logouts
+// with only a single claude-code process running. #361 made the refresh
+// read-only but left this write active; making WriteBack a no-op completes the
+// read-only-mirror discipline. The generic CredentialLifecycle WriteBack call
+// is retained for other OAuth sources that legitimately own their own store.
+func (s *claudeCodeCredentialSource) WriteBack(_ OAuthCredential) error {
 	return nil
 }
 

--- a/internal/engine/provider_claudeoauth.go
+++ b/internal/engine/provider_claudeoauth.go
@@ -8,8 +8,8 @@
 //
 //  1. claudeCodeCredentialSource — a CredentialSource that reads from (in
 //     priority order) the macOS keychain, CLAUDE_CODE_OAUTH_TOKEN env var,
-//     and ~/.claude/.credentials.json.  WriteBack writes atomically to the
-//     JSON file only (the keychain is updated by the official client).
+//     and ~/.claude/.credentials.json.  WriteBack is a NO-OP: Claude Code owns
+//     that store and the kernel is a strict read-only mirror (see issue #363).
 //
 //  2. claudeOAuthRefreshFunc — a RefreshFunc that calls the Anthropic OAuth
 //     token endpoint with the refresh token and returns a new OAuthCredential.
@@ -188,8 +188,8 @@ func getClaudeCodeVersion() string {
 // claudeCodeCredentialSource reads Claude Code OAuth credentials from the
 // macOS keychain ("Claude Code-credentials"), CLAUDE_CODE_OAUTH_TOKEN env var,
 // and ~/.claude/.credentials.json (in that priority order).
-// WriteBack writes to ~/.claude/.credentials.json only (the keychain is managed
-// by the official Claude Code client).
+// WriteBack is a no-op: Claude Code is the sole owner/writer of that store; the
+// kernel must never write it (see WriteBack and issue #363).
 type claudeCodeCredentialSource struct {
 	credPath string // defaults to claudeCredentialsFile; overridable in tests
 }

--- a/internal/engine/provider_claudeoauth_test.go
+++ b/internal/engine/provider_claudeoauth_test.go
@@ -691,7 +691,10 @@ func TestClaudeOAuthStreamHTTPError(t *testing.T) {
 // ── claudeCodeCredentialSource.WriteBack ──────────────────────────────────────
 
 func TestClaudeCodeCredentialSourceWriteBack(t *testing.T) {
-	// Not parallel: uses a temp dir.
+	// WriteBack is a NO-OP for the Claude Code source: the kernel is a read-only
+	// mirror and Claude Code owns ~/.claude/.credentials.json (issue #363).
+	// Seeding a file then calling WriteBack must leave it byte-for-byte UNCHANGED
+	// and must NOT write the kernel-supplied token. Not parallel: uses a temp dir.
 	dir := t.TempDir()
 	credPath := filepath.Join(dir, "credentials.json")
 
@@ -709,6 +712,7 @@ func TestClaudeCodeCredentialSourceWriteBack(t *testing.T) {
 	}
 	raw, _ := json.Marshal(initial)
 	_ = os.WriteFile(credPath, raw, 0600)
+	before, _ := os.ReadFile(credPath)
 
 	newCred := OAuthCredential{
 		AccessToken:  "new-access",
@@ -719,48 +723,31 @@ func TestClaudeCodeCredentialSourceWriteBack(t *testing.T) {
 		t.Fatalf("WriteBack: %v", err)
 	}
 
-	// Read back and verify.
-	data, err := os.ReadFile(credPath)
+	// File must be unchanged (no-op).
+	after, err := os.ReadFile(credPath)
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)
 	}
+	if string(before) != string(after) {
+		t.Errorf("WriteBack must be a no-op but file changed.\nbefore: %s\nafter:  %s", before, after)
+	}
+
+	// The kernel-supplied token must NOT have been written into CC's file.
 	var doc map[string]json.RawMessage
-	if err := json.Unmarshal(data, &doc); err != nil {
+	if err := json.Unmarshal(after, &doc); err != nil {
 		t.Fatalf("Unmarshal: %v", err)
 	}
-
-	// Other top-level fields must be preserved.
-	if _, ok := doc["primaryApiKey"]; !ok {
-		t.Error("primaryApiKey should be preserved")
-	}
-
-	// claudeAiOauth must be updated.
 	var oauth claudeAiOauthJSON
 	if err := json.Unmarshal(doc["claudeAiOauth"], &oauth); err != nil {
 		t.Fatalf("Unmarshal claudeAiOauth: %v", err)
 	}
-	if oauth.AccessToken != "new-access" {
-		t.Errorf("accessToken = %q; want new-access", oauth.AccessToken)
-	}
-	if oauth.RefreshToken != "new-refresh" {
-		t.Errorf("refreshToken = %q; want new-refresh", oauth.RefreshToken)
-	}
-	if oauth.ExpiresAt != 99999 {
-		t.Errorf("expiresAt = %d; want 99999", oauth.ExpiresAt)
-	}
-	// Scopes from old record should be preserved.
-	if len(oauth.Scopes) == 0 {
-		t.Error("scopes should be preserved from prior record")
-	}
-
-	// File permissions must be 0600.
-	fi, _ := os.Stat(credPath)
-	if fi.Mode().Perm() != 0600 {
-		t.Errorf("file mode = %o; want 0600", fi.Mode().Perm())
+	if oauth.AccessToken == "new-access" {
+		t.Error("WriteBack wrote the kernel token into Claude Code's credential file; must be read-only")
 	}
 }
 
 func TestClaudeCodeCredentialSourceWriteBackNoExisting(t *testing.T) {
+	// No-op WriteBack must NOT create the credential file (issue #363).
 	// Not parallel: uses a temp dir.
 	dir := t.TempDir()
 	credPath := filepath.Join(dir, "credentials.json")
@@ -775,13 +762,8 @@ func TestClaudeCodeCredentialSourceWriteBackNoExisting(t *testing.T) {
 		t.Fatalf("WriteBack on new file: %v", err)
 	}
 
-	data, _ := os.ReadFile(credPath)
-	var doc map[string]json.RawMessage
-	_ = json.Unmarshal(data, &doc)
-	var oauth claudeAiOauthJSON
-	_ = json.Unmarshal(doc["claudeAiOauth"], &oauth)
-	if oauth.AccessToken != "tok" {
-		t.Errorf("accessToken = %q; want tok", oauth.AccessToken)
+	if _, err := os.Stat(credPath); !os.IsNotExist(err) {
+		t.Errorf("WriteBack created the credential file; must be a no-op (read-only mirror)")
 	}
 }
 


### PR DESCRIPTION
## What

Makes `claudeCodeCredentialSource.WriteBack` a **no-op**. The kernel is a strict read-only mirror of the Claude Code OAuth credential; CC is the sole owner/writer of `~/.claude/.credentials.json` and the keychain entry it mirrors.

Fixes #363.

## Why

#361 (`a73e330`) made the *refresh* read-only — `newClaudeCodeReadOnlyRefresh` never POSTs the single-use refresh token — but left `WriteBack` active. The lifecycle still calls `go func(){ lc.source.WriteBack(newCred) }()` (`credential_lifecycle.go:235`) after every refresh, so the kernel kept **writing CC's credential file**.

The read-only refresh only ever surfaces the current keychain value (or a `Resolve()` fallback that can be stale), so this WriteBack can only (a) redundantly rewrite the keychain value, churning the file, or (b) write a stale token, poisoning CC's file fallback store.

### Observed live (2026-06-04)

With the local provider `eclipse` down, the kernel fell back to `claude-oauth` for periodic inference ~every 10s. A file/keychain watcher captured, repeatably:
- `~/.claude/.credentials.json` rewritten every ~10s with **one** `claude-code` process running (not a multi-instance race);
- a **foreign access token** (matching neither the prior nor next keychain token) injected at the start of each burst → file↔keychain desync while the keychain stayed valid;
- repeated **"OAuth token revoked · Please run /login"** logouts, ending only on manual `claude /login`.

## Change

- `claudeCodeCredentialSource.WriteBack` → no-op returning `nil`, with a comment explaining the read-only-mirror invariant and referencing #363. (−65 net lines: the temp-file/rename write machinery is removed.)
- The generic `CredentialLifecycle` WriteBack call is **left intact** for other OAuth sources that legitimately own their store.
- `TestClaudeCodeCredentialSourceWriteBack` / `...NoExisting` updated to pin the no-op invariant (seeded file unchanged byte-for-byte; new file not created).

## Test

- `go build ./internal/engine/` — clean.
- `go test ./internal/engine/` — full package passes (15.7s), incl. the existing no-POST read-only-refresh invariant tests.

## Scope / follow-ups (not in this PR)

- The ~10s trigger cadence is driven by `eclipse` being unreachable and the kernel hammering `claude-oauth` as fallback. Worth a separate look at the fallback-retry behavior, but the WriteBack no-op is the necessary fix regardless.
- Requires a **kernel rebuild + redeploy** to take effect on the running node (the live binary predates this change).
