### PR TITLE
fix(engine): guard against assistant-terminated Anthropic requests (I7 trailing-user)

### DIFF
--- a/internal/engine/anthropic_normalize.go
+++ b/internal/engine/anthropic_normalize.go
@@ -45,6 +45,7 @@ type RepairReport struct {
 	EmptyAssistantDropped   int // I5: empty assistant messages dropped
 	EmptyUserDropped        int // I5: empty user messages dropped (defensive)
 	ThinkingStripped        int // I6: thinking/redacted_thinking blocks stripped
+	TrailingDropped         int // I7: trailing non-user (assistant) messages dropped
 	SettleIterations        int // how many settle-loop passes ran (1 = clean first pass)
 }
 
@@ -54,7 +55,7 @@ func (r RepairReport) Total() int {
 		r.OrphanToolUseDropped + r.OrphanToolResultDropped +
 		r.EmptyMsgAfterPairing + r.BlockOrderReordered +
 		r.EmptyAssistantDropped + r.EmptyUserDropped +
-		r.ThinkingStripped
+		r.ThinkingStripped + r.TrailingDropped
 }
 
 // emit logs the repair report via slog when any repair was performed.
@@ -75,6 +76,7 @@ func (r RepairReport) emit(site string) {
 		"empty_assistant_dropped", r.EmptyAssistantDropped,
 		"empty_user_dropped", r.EmptyUserDropped,
 		"thinking_stripped", r.ThinkingStripped,
+		"trailing_dropped", r.TrailingDropped,
 		"settle_iterations", r.SettleIterations,
 	)
 }
@@ -219,6 +221,11 @@ func normalizeAnthropicMessages(msgs []anthropicMessage) ([]anthropicMessage, Re
 		// Pass 5: I1 leading-user-drop.
 		msgs, rpt = passLeadingUser(msgs, rpt)
 
+		// Pass 6: I7 trailing-user-drop (symmetric to I1). Runs inside the settle
+		// loop so a dropped trailing assistant can expose an orphan tool_result that
+		// I3 then cleans up on the next iteration, and vice-versa, before fixpoint.
+		msgs, rpt = passTrailingUser(msgs, rpt)
+
 		rpt.SettleIterations = iter + 1
 
 		// Fixpoint: length didn't change AND no repair counters changed.
@@ -231,7 +238,8 @@ func normalizeAnthropicMessages(msgs []anthropicMessage) ([]anthropicMessage, Re
 			rpt.OrphanToolResultDropped != beforeRpt.OrphanToolResultDropped ||
 			rpt.EmptyMsgAfterPairing != beforeRpt.EmptyMsgAfterPairing ||
 			rpt.EmptyAssistantDropped != beforeRpt.EmptyAssistantDropped ||
-			rpt.EmptyUserDropped != beforeRpt.EmptyUserDropped
+			rpt.EmptyUserDropped != beforeRpt.EmptyUserDropped ||
+			rpt.TrailingDropped != beforeRpt.TrailingDropped
 		if !changed {
 			break
 		}
@@ -519,6 +527,24 @@ func passLeadingUser(msgs []anthropicMessage, rpt RepairReport) ([]anthropicMess
 	return msgs, rpt
 }
 
+// passTrailingUser handles I7: drop trailing non-user (assistant) messages so the
+// conversation ends with a user turn. The Anthropic Messages API rejects a request
+// whose final message is an assistant message ("does not support assistant message
+// prefill. The conversation must end with a user message") with HTTP 400.
+//
+// A request can end on an assistant message after upstream context eviction drops
+// the trailing tool_result(s) that followed an assistant tool_use turn: passToolPairing
+// (I3) then strips the now-orphaned tool_use blocks, leaving an assistant text-only
+// message as the tail. This is the symmetric counterpart to passLeadingUser (I1):
+// I1 guarantees the sequence starts with user, I7 guarantees it ends with user.
+func passTrailingUser(msgs []anthropicMessage, rpt RepairReport) ([]anthropicMessage, RepairReport) {
+	for len(msgs) > 0 && msgs[len(msgs)-1].Role != "user" {
+		msgs = msgs[:len(msgs)-1]
+		rpt.TrailingDropped++
+	}
+	return msgs, rpt
+}
+
 // ── validateAnthropicMessages ─────────────────────────────────────────────────
 
 // validateAnthropicMessages is a pure checker returning one human-readable
@@ -546,6 +572,15 @@ func validateAnthropicMessages(msgs []anthropicMessage) []string {
 		violations = append(violations, fmt.Sprintf(
 			"I1: first message must be user, got %q",
 			msgs[0].Role,
+		))
+	}
+
+	// V-I7: last message must be user (Anthropic rejects assistant-terminated
+	// requests — "the conversation must end with a user message").
+	if last := msgs[len(msgs)-1]; last.Role != "user" {
+		violations = append(violations, fmt.Sprintf(
+			"I7: last message must be user, got %q",
+			last.Role,
 		))
 	}
 

--- a/internal/engine/provider_anthropic_normalizer_test.go
+++ b/internal/engine/provider_anthropic_normalizer_test.go
@@ -187,6 +187,62 @@ func Test_GoldenCase_LeadingAssistant(t *testing.T) {
 	}
 }
 
+// Test_GoldenCase_TrailingAssistant: I7 — a conversation ending with an assistant
+// message must be repaired to end with a user message (Anthropic rejects
+// assistant-terminated requests with HTTP 400 "must end with a user message").
+func Test_GoldenCase_TrailingAssistant(t *testing.T) {
+	t.Parallel()
+	input := []anthropicMessage{
+		{Role: "user", Content: "hello"},
+		{Role: "assistant", Content: []anthropicContentBlock{{Type: "text", Text: "trailing"}}},
+	}
+
+	// RED: raw input must fail the checker with an I7 violation.
+	rawViolations := validateAnthropicMessages(input)
+	if !containsPrefix(rawViolations, "I7:") {
+		t.Fatalf("RED phase failed: raw input did not trigger I7 violation; got %v", rawViolations)
+	}
+
+	// GREEN: normalized output must be checker-clean and end with a user message.
+	normalized, rpt := normalizeAnthropicMessages(input)
+	greenViolations := validateAnthropicMessages(normalized)
+	if len(greenViolations) != 0 {
+		t.Fatalf("GREEN phase failed: normalized output still violates: %v", greenViolations)
+	}
+	if len(normalized) != 1 || normalized[len(normalized)-1].Role != "user" {
+		t.Errorf("expected sequence ending in user; got %+v", normalized)
+	}
+	if rpt.TrailingDropped == 0 {
+		t.Error("expected TrailingDropped > 0 in RepairReport")
+	}
+}
+
+// Test_GoldenCase_EvictionOrphanedToolCall: the live-bug scenario. Upstream context
+// eviction drops the trailing tool_result that followed an assistant tool_use turn;
+// passToolPairing (I3) strips the now-orphaned tool_use, leaving an assistant
+// text-only tail; passTrailingUser (I7) must then drop that tail so the request ends
+// with the user message — preventing the 400 "must end with a user message".
+func Test_GoldenCase_EvictionOrphanedToolCall(t *testing.T) {
+	t.Parallel()
+	input := []anthropicMessage{
+		{Role: "user", Content: "do the thing"},
+		{Role: "assistant", Content: []anthropicContentBlock{
+			{Type: "text", Text: "calling tool"},
+			{Type: "tool_use", ID: "toolu_1", Name: "search", Input: json.RawMessage(`{}`)},
+		}},
+		// tool_result for toolu_1 was evicted upstream — assistant tool_use is now orphaned.
+	}
+
+	normalized, _ := normalizeAnthropicMessages(input)
+	greenViolations := validateAnthropicMessages(normalized)
+	if len(greenViolations) != 0 {
+		t.Fatalf("normalized output violates invariants: %v", greenViolations)
+	}
+	if len(normalized) == 0 || normalized[len(normalized)-1].Role != "user" {
+		t.Errorf("expected sequence ending in user after orphan+trailing repair; got %+v", normalized)
+	}
+}
+
 // Test_GoldenCase_ConsecutiveUser: I2 user adjacency, merged.
 func Test_GoldenCase_ConsecutiveUser(t *testing.T) {
 	t.Parallel()
@@ -194,6 +250,8 @@ func Test_GoldenCase_ConsecutiveUser(t *testing.T) {
 		{Role: "user", Content: "a"},
 		{Role: "user", Content: "b"},
 		{Role: "assistant", Content: []anthropicContentBlock{{Type: "text", Text: "ok"}}},
+		// trailing user keeps the fixture I2-only (a valid request ends with user).
+		{Role: "user", Content: "c"},
 	}
 
 	rawViolations := validateAnthropicMessages(input)
@@ -206,8 +264,8 @@ func Test_GoldenCase_ConsecutiveUser(t *testing.T) {
 	if len(greenViolations) != 0 {
 		t.Fatalf("GREEN phase failed: %v", greenViolations)
 	}
-	if len(normalized) != 2 {
-		t.Errorf("expected 2 messages after merge; got %d", len(normalized))
+	if len(normalized) != 3 {
+		t.Errorf("expected 3 messages after merge (user, assistant, user); got %d", len(normalized))
 	}
 	if rpt.ConsecutiveMerged == 0 {
 		t.Error("expected ConsecutiveMerged > 0 in RepairReport")
@@ -227,6 +285,8 @@ func Test_GoldenCase_ConsecutiveAssistant(t *testing.T) {
 			{Type: "text", Text: "ans2"},
 			{Type: "thinking", Thinking: "t2", Signature: "sig2"},
 		}},
+		// trailing user keeps the fixture I2-only (a valid request ends with user).
+		{Role: "user", Content: "followup"},
 	}
 
 	rawViolations := validateAnthropicMessages(input)
@@ -239,8 +299,8 @@ func Test_GoldenCase_ConsecutiveAssistant(t *testing.T) {
 	if len(greenViolations) != 0 {
 		t.Fatalf("GREEN phase failed: %v", greenViolations)
 	}
-	if len(normalized) != 2 {
-		t.Errorf("expected 2 messages; got %d", len(normalized))
+	if len(normalized) != 3 {
+		t.Errorf("expected 3 messages (user, merged-assistant, user); got %d", len(normalized))
 	}
 	if rpt.ConsecutiveMerged == 0 {
 		t.Error("expected ConsecutiveMerged > 0")


### PR DESCRIPTION
## What

Adds **I7 (trailing-user guard)** to the Anthropic message normalizer: drop trailing non-user messages so every request ends with a user turn. Symmetric to the existing **I1 (leading-user guard)**.

## Why

The Anthropic Messages API rejects a request whose final message is an assistant message:

```
400 invalid_request_error: "This model does not support assistant message prefill.
The conversation must end with a user message."
```

This was hit live (Hermes `cog` agent → kernel `claude-oauth`): a conversation whose OpenAI-format tail was `...assistant(tool_use), tool_result, tool_result` lost its trailing `tool_result`s to upstream context eviction (oversized context evicted to the 32K budget). `passToolPairing` (I3) then stripped the now-orphaned `tool_use` blocks, leaving an **assistant text-only** message as the tail → 400.

The normalizer had `passLeadingUser` (I1) guaranteeing the sequence *starts* with user, but **no symmetric pass** guaranteeing it *ends* with user.

## Change

- `passTrailingUser` (I7): drops trailing non-user messages. Runs inside the settle loop so a dropped trailing assistant and a newly-exposed orphan `tool_result` clean each other up before fixpoint. `RepairReport.TrailingDropped` counter + `emit` logging.
- `validateAnthropicMessages`: add **V-I7** (last message must be user) — the symmetric counterpart to V-I1.
- Two golden-case fixtures (`ConsecutiveUser`, `ConsecutiveAssistant`) that previously ended on an assistant message are made I2-only by ending them with a user turn (an Anthropic-valid request ends with user; those fixtures were incidentally I7-invalid).

## Test

- New golden cases: `Test_GoldenCase_TrailingAssistant` (RED→GREEN on the I7 violation) and `Test_GoldenCase_EvictionOrphanedToolCall` (the live-bug shape: orphaned tool_use tail repaired to end with user).
- `go test ./internal/engine/` — full package green (15s).

## Scope / follow-up (not in this PR)

This is the **deterministic wire-layer fix** for the 400 — it holds regardless of how eviction mangles the tail. The *condition* that triggers it is a separate resource concern: uncapped CogOS MCP tool output (`cog_tail_kernel_log` etc. return 60K+ bytes via `marshalResult` with no cap) inflates context to ~283K, forcing heavy eviction against the 32K budget. Capping `cog_*` tool output (and/or aligning the kernel budget with the caller's context window) is a recommended follow-up that reduces the eviction pressure and the per-turn cost, but is orthogonal to this correctness fix.
