### PR TITLE
fix(engine): unwedge memory consolidation — scanner cap + projection-compiler state persistence

### DIFF
--- a/internal/engine/consolidate.go
+++ b/internal/engine/consolidate.go
@@ -152,6 +152,7 @@ func readLedgerEvents(workspaceRoot string) ([]consolidationEvent, map[consolida
 		}
 
 		scanner := bufio.NewScanner(f)
+		scanner.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024) // raise token cap: ledger events can hold large payloads
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			if len(line) == 0 {
@@ -365,6 +366,7 @@ func ArchivedSessions(workspaceRoot, sessionID string) (map[string]struct{}, err
 	defer f.Close()
 
 	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024) // raise token cap: ledger events can hold large payloads
 	for scanner.Scan() {
 		line := scanner.Bytes()
 		if len(line) == 0 {

--- a/internal/engine/projection_compiler.go
+++ b/internal/engine/projection_compiler.go
@@ -27,9 +27,9 @@
 // not a markdown parser; per ADR §Implementation §Dependencies cogblock.py
 // is the reference implementation. The path is resolved via, in order:
 //
-//   1. ProjectionCompilerConfig.CogblockPath (explicit injection)
-//   2. environment variable COGBLOCK_PY
-//   3. <workspaceRoot>/scripts/cogblock.py
+//  1. ProjectionCompilerConfig.CogblockPath (explicit injection)
+//  2. environment variable COGBLOCK_PY
+//  3. <workspaceRoot>/scripts/cogblock.py
 //
 // Per ADR-091 layering this file is Kernel (engine package). The event
 // types it emits live in pkg/substrate/projection (Substrate layer).
@@ -392,6 +392,10 @@ func (c *ProjectionCompiler) ComputePlan(config any, live any, _ *reconcile.Stat
 		ResourceType: c.Type(),
 		GeneratedAt:  time.Now().UTC().Format(time.RFC3339),
 		ConfigPath:   cfg.SourceDir,
+		// Stamp the config so ApplyPlan can persist HashByAnchor state via
+		// writeCompilerState. Without this the daemon re-creates all blocks
+		// every cycle (creates=N forever) because state never persists.
+		Metadata: map[string]any{"compiler_config": cfg},
 	}
 
 	for _, doc := range docs {

--- a/internal/engine/projection_compiler.go
+++ b/internal/engine/projection_compiler.go
@@ -523,9 +523,9 @@ func (c *ProjectionCompiler) ApplyPlan(ctx context.Context, plan *reconcile.Plan
 	return results, nil
 }
 
-// compilerCfgFromPlan is a defensive accessor; ComputePlan does not stash the
-// config on the plan today, but ApplyPlan may receive one via test harnesses
-// that pre-stamp plan.Metadata.
+// compilerCfgFromPlan retrieves the *CompilerConfig that ComputePlan stamps
+// into plan.Metadata["compiler_config"], so ApplyPlan can persist compiler
+// state. Returns an error if absent (e.g. a plan from a different producer).
 func compilerCfgFromPlan(plan *reconcile.Plan) (*CompilerConfig, error) {
 	if plan == nil || plan.Metadata == nil {
 		return nil, fmt.Errorf("no plan metadata")

--- a/internal/engine/projection_compiler_test.go
+++ b/internal/engine/projection_compiler_test.go
@@ -108,11 +108,13 @@ func runReconcileCycle(
 		t.Fatalf("ComputePlan: %v", err)
 	}
 
-	// Stash the cfg on plan metadata so ApplyPlan can persist state.
-	if plan.Metadata == nil {
-		plan.Metadata = map[string]any{}
+	// ComputePlan must stamp compiler_config into plan.Metadata so ApplyPlan can
+	// persist HashByAnchor state. Asserting it here exercises the production path
+	// (the daemon relies on this auto-stamp; do NOT hand-stamp it in the harness,
+	// or the test would mask a regression of that wiring).
+	if got, ok := plan.Metadata["compiler_config"].(*CompilerConfig); !ok || got != cfg {
+		t.Fatalf("ComputePlan did not stamp compiler_config into plan.Metadata (got %v, ok=%v)", plan.Metadata["compiler_config"], ok)
 	}
-	plan.Metadata["compiler_config"] = cfg
 
 	results, err := c.ApplyPlan(ctx, plan)
 	if err != nil {


### PR DESCRIPTION
## Problem

The reconcile daemon was spinning a CPU core (~140%) indefinitely while the kernel reported `state: dormant`. Diagnosed on the Darkstar node via process sampling + serve.log.

Two stacked defects:

### 1. Consolidation scanner choked on large ledger events
`readLedgerEvents` (and `ArchivedSessions`) created `bufio.Scanner` with the default 64KB `MaxScanTokenSize`. Ledger events with large `hashed_payload.data` blobs (>64KB — observed up to 120KB) triggered `bufio.Scanner: token too long` **every** consolidation cycle (4,500+ failures logged), failing the cycle and retrying on the next tick. Fix: raise the buffer to 16MB.

### 2. projection-compiler never converged
`ComputePlan` built the plan without stamping `compiler_config` into `plan.Metadata`, so `compilerCfgFromPlan` returned nil in `ApplyPlan`, so `writeCompilerState` was never called and `HashByAnchor` state never persisted. Every cycle reloaded empty state and reclassified all blocks as `Create` (`creates=23 skipped=0`, ~900ms/cycle, re-reading the full lineage corpus each time). Fix: stamp the config onto the plan so `ApplyPlan` persists state; subsequent cycles converge to `skipped=N creates=0`.

The idempotency acceptance test (`TestAcceptance_A4_Idempotency`) already injected this config manually in its harness, which masked the production gap.

## Verification
- `go build ./...`, `go vet` clean
- Full `internal/engine` + `pkg/cogblock` test suites pass
- On the live node: after fixing oversized ledger lines (separate data repair), the `token too long` error count froze immediately; this PR makes both fixes permanent in code so it can't recur.

## Notes
- The oversized ledger events themselves are a symptom of an uncapped write seam (`cogblock.AppendEvent` / `WithData`). A follow-up could cap payload size at write time so events never exceed a sane bound. Filed as a note, not in this PR (keeping one concern per change).