### PR TITLE
fix(engine): converge lineage projections by ignoring _Last generated: timestamp

### DIFF
--- a/internal/engine/projection_reconciler.go
+++ b/internal/engine/projection_reconciler.go
@@ -37,7 +37,6 @@ package engine
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"fmt"
 	"log"
@@ -311,7 +310,7 @@ func (r *ProjectionReconciler) ComputePlan(config any, live any, state *reconcil
 		return nil, fmt.Errorf("reading projection %s: %w", projPath, err)
 	}
 
-	if err != nil || !bytes.Equal(existing, []byte(projected)) {
+	if err != nil || !equalIgnoringTimestamp(existing, []byte(projected)) {
 		action := reconcile.ActionCreate
 		if err == nil {
 			action = reconcile.ActionUpdate

--- a/internal/engine/projection_reconciler_convergence_test.go
+++ b/internal/engine/projection_reconciler_convergence_test.go
@@ -1,0 +1,25 @@
+// projection_reconciler_convergence_test.go — regression test for the lineage
+// projection convergence fix. The reconciler must treat two projections that
+// differ ONLY in their "_Last generated:" timestamp line as equal, otherwise it
+// rewrites the 6 lineage projections on every reconcile cycle forever.
+package engine
+
+import "testing"
+
+func TestConvergenceIgnoresTimestampLine(t *testing.T) {
+	a := []byte("# Lineage\n\n_Last generated: 2026-06-05T10:00:00Z_\n\nnode-a -> node-b\n")
+	b := []byte("# Lineage\n\n_Last generated: 2026-06-05T10:00:30Z_\n\nnode-a -> node-b\n")
+
+	if !equalIgnoringTimestamp(a, b) {
+		t.Fatalf("expected projections differing only in the _Last generated: line to compare EQUAL, but they did not — reconciler would never converge")
+	}
+}
+
+func TestConvergenceDetectsRealContentDifference(t *testing.T) {
+	a := []byte("# Lineage\n\n_Last generated: 2026-06-05T10:00:00Z_\n\nnode-a -> node-b\n")
+	b := []byte("# Lineage\n\n_Last generated: 2026-06-05T10:00:00Z_\n\nnode-a -> node-c\n")
+
+	if equalIgnoringTimestamp(a, b) {
+		t.Fatalf("expected projections with a real content difference to compare UNEQUAL, but they compared equal — a genuine change would never be projected")
+	}
+}


### PR DESCRIPTION
## Summary

The 6 `lineage-projection-*` providers rewrite themselves on **every 30s reconcile cycle, forever** — a sustained CPU burn on the kernel daemon (`updates=1` per lineage projection, every cycle, never converging to `skipped`).

## Root cause

`generateProjection` embeds a `_Last generated: <time.Now()>_` line into the projection **content**. `ComputePlan` (`projection_reconciler.go`) then compares the freshly-generated content (new timestamp) byte-for-byte against the on-disk file (old timestamp) via `bytes.Equal`:

```
< _Last generated: 2026-06-05T18:41:33Z_
> _Last generated: 2026-06-05T18:42:03Z_
```

The timestamp line is the *sole* difference, so the check always returns "changed" → `ActionUpdate` → rewrite with yet another new timestamp. It can never converge.

## Fix

Swap `bytes.Equal` for the existing in-package helper `equalIgnoringTimestamp` (`decision_lineage_reconciler.go:371`), which strips the `_Last generated:` line before comparing — **exactly what the sibling decision-lineage reconciler already does** (`decision_lineage_reconciler.go:147`) for the same reason. Drop the now-unused `bytes` import. Add a regression test covering both invariants:
- timestamp-only diff → **must converge** (equal)
- real content diff → **must still project** (unequal)

One-line behavioral change; the helper is proven against a live sibling call site.

## Scope

This is the **lineage-projection convergence loop** only. It is a **separate concern from #366** (projection-compiler state persistence — the `creates=N every cycle` loop). One concern per PR. Both are needed to fully unwedge the kernel reconcile daemon; this PR addresses loop #2.

## Verification

```
go build ./internal/engine/   # OK
go vet ./internal/engine/     # clean
go test ./internal/engine/    # ok, no regressions; new convergence tests pass
```

## Diagnosis provenance

Root-caused via spindump + per-cycle `kernel.log.jsonl` evidence + byte-level projection diff; the Eclipse-peer-dial hypothesis was falsified (`lsof` showed the connection ESTABLISHED, not retrying). The hot path is the local reconcile loops, not network dial.
