### PR TITLE
feat(conversations): schema-driven ingest surface v0.1, term-AND search, turn dedup

### DIFF
--- a/internal/conversations/index.go
+++ b/internal/conversations/index.go
@@ -172,14 +172,22 @@ func (idx *Index) GetTurn(sessionID string, turnIndex int) (Turn, bool) {
 	return turns[turnIndex], true
 }
 
-// Search performs a case-insensitive substring search over all indexed turns.
+// Search performs a case-insensitive multi-term search over all indexed turns.
+//
+// Query parsing rules:
+//   - Double-quoted substrings are matched as exact (case-insensitive) phrases.
+//   - Unquoted tokens separated by whitespace form an AND conjunction: a turn
+//     matches only when ALL tokens are present as substrings of its text.
+//   - A single unquoted token behaves identically to the original single-term
+//     substring match (backward-compatible).
+//
 // Filters: since/until bound timestamps; sessionID restricts to one session;
 // identity filters by session identity; limit caps results (0 = no limit).
 func (idx *Index) Search(query string, since, until time.Time, sessionID, identity string, limit int) []SearchHit {
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
 
-	lq := strings.ToLower(query)
+	terms := parseSearchQuery(query)
 	var hits []SearchHit
 
 	// Collect sessions to search.
@@ -207,10 +215,15 @@ func (idx *Index) Search(query string, since, until time.Time, sessionID, identi
 			if !until.IsZero() && t.Timestamp.After(until) {
 				continue
 			}
-			if !strings.Contains(strings.ToLower(t.Text), lq) {
+			if !matchesAllTerms(t.Text, terms) {
 				continue
 			}
-			excerpt := makeExcerpt(t.Text, query, 300)
+			// Use the first term as the excerpt anchor for multi-term queries.
+			anchor := query
+			if len(terms) > 0 {
+				anchor = terms[0]
+			}
+			excerpt := makeExcerpt(t.Text, anchor, 300)
 			hit := SearchHit{
 				SessionID: sid,
 				TurnIndex: t.TurnIndex,
@@ -222,6 +235,7 @@ func (idx *Index) Search(query string, since, until time.Time, sessionID, identi
 			}
 			if hasMeta {
 				hit.SessionTitle = meta.Title
+				hit.Source = meta.Source
 			}
 			hits = append(hits, hit)
 			if limit > 0 && len(hits) >= limit {
@@ -232,14 +246,87 @@ func (idx *Index) Search(query string, since, until time.Time, sessionID, identi
 	return hits
 }
 
+// parseSearchQuery splits a query string into individual match terms.
+// Double-quoted substrings are extracted as single exact-match terms.
+// Remaining text is split on whitespace.
+//
+// Examples:
+//
+//	`foo bar`            → ["foo", "bar"]
+//	`"foo bar" baz`      → ["foo bar", "baz"]
+//	`"exact phrase"`     → ["exact phrase"]
+//	`hello`              → ["hello"]
+func parseSearchQuery(query string) []string {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil
+	}
+
+	var terms []string
+	rest := query
+	for {
+		rest = strings.TrimSpace(rest)
+		if rest == "" {
+			break
+		}
+		if rest[0] == '"' {
+			// Find closing quote.
+			end := strings.Index(rest[1:], "\"")
+			if end < 0 {
+				// Unclosed quote: treat remainder as literal term.
+				terms = append(terms, rest[1:])
+				break
+			}
+			phrase := rest[1 : end+1]
+			if phrase != "" {
+				terms = append(terms, phrase)
+			}
+			rest = rest[end+2:]
+		} else {
+			// Take until next whitespace or quote.
+			i := strings.IndexAny(rest, " \t\r\n\"")
+			if i < 0 {
+				terms = append(terms, rest)
+				break
+			}
+			terms = append(terms, rest[:i])
+			rest = rest[i:]
+		}
+	}
+	return terms
+}
+
+// matchesAllTerms returns true when text contains ALL terms as
+// case-insensitive substrings.
+func matchesAllTerms(text string, terms []string) bool {
+	if len(terms) == 0 {
+		return true
+	}
+	ltext := strings.ToLower(text)
+	for _, term := range terms {
+		if !strings.Contains(ltext, strings.ToLower(term)) {
+			return false
+		}
+	}
+	return true
+}
+
 // ─── persistence helpers ─────────────────────────────────────────────────────
 
 func (idx *Index) metaPath() string {
 	return filepath.Join(idx.projDir, "_meta.json")
 }
 
+// turnsFilename derives a safe flat filename from sessionID. Composite keys
+// for normalized ingest sessions take the form "<source>/<session_id>"; the
+// "/" is replaced with "__" so the file stays in projDir without creating
+// subdirectories.
+func turnsFilename(sessionID string) string {
+	return strings.ReplaceAll(sessionID, "/", "__") + ".json"
+}
+
 func (idx *Index) turnsPath(sessionID string) string {
-	return filepath.Join(idx.projDir, sessionID+".json")
+	return filepath.Join(idx.projDir, turnsFilename(sessionID))
 }
 
 // writeMetaFileLocked persists the session meta index. Callers must hold

--- a/internal/conversations/ingest_features_test.go
+++ b/internal/conversations/ingest_features_test.go
@@ -1,8 +1,11 @@
 // ingest_features_test.go — table-driven tests for the three new features:
 //
-//  1. Normalized ingest source: schema validation/rejection, (source, session_id) keying
+//  1. Normalized ingest source: schema validation/rejection, per-record
+//     session_id grouping (file = transport, not session), sessions spanning
+//     files, (source, session_id) keying
 //  2. Term-AND search with phrase quoting
-//  3. UUID dedup on the CC parser path; content-hash dedup on the ingest path
+//  3. UUID dedup on the CC parser path; stable_id/content-hash dedup on the
+//     ingest path
 package conversations
 
 import (
@@ -33,6 +36,25 @@ func makeIngestRecord(source, sessionID, role, text, ts string, extras map[strin
 	}
 	b, _ := json.Marshal(rec)
 	return string(b)
+}
+
+// parseIngestLines feeds lines through a fresh accumulator and returns it.
+func parseIngestLines(t *testing.T, lines []string, maxTurnLen int) *ingestAccumulator {
+	t.Helper()
+	acc := newIngestAccumulator(maxTurnLen)
+	if err := acc.ConsumeFile(strings.NewReader(strings.Join(lines, "\n") + "\n")); err != nil {
+		t.Fatalf("ConsumeFile: %v", err)
+	}
+	return acc
+}
+
+// totalTurns sums turns across all sessions in the accumulator.
+func totalTurns(acc *ingestAccumulator) int {
+	n := 0
+	for _, s := range acc.Sessions() {
+		n += len(s.Turns)
+	}
+	return n
 }
 
 // writeIngestDir creates <ingestRoot>/<source>/<filename>.jsonl and returns the path.
@@ -90,16 +112,50 @@ func writeObservatoryConfigFull(t *testing.T, root string, srcDirs, ingestDirs [
 	}
 }
 
+// reconcileOnce runs one full LoadConfig→FetchLive→ComputePlan→ApplyPlan
+// cycle, asserts every applied action succeeded, and returns the plan's
+// create count plus the refreshed live state.
+func reconcileOnce(t *testing.T, p *Provider, root string) (planSummaryCreates int, ls *liveState) {
+	t.Helper()
+	ctx := context.Background()
+	cfgAny, err := p.LoadConfig(root)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	liveAny, err := p.FetchLive(ctx, cfgAny)
+	if err != nil {
+		t.Fatalf("FetchLive: %v", err)
+	}
+	plan, err := p.ComputePlan(cfgAny, liveAny, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	results, err := p.ApplyPlan(ctx, plan)
+	if err != nil {
+		t.Fatalf("ApplyPlan: %v", err)
+	}
+	for _, r := range results {
+		if r.Status == "failed" {
+			t.Fatalf("apply action %s/%s failed: %s", r.Action, r.Name, r.Error)
+		}
+	}
+	liveAny2, err := p.FetchLive(ctx, cfgAny)
+	if err != nil {
+		t.Fatalf("FetchLive 2: %v", err)
+	}
+	return plan.Summary.Creates, liveAny2.(*liveState)
+}
+
 // ─── Feature 1: Normalized ingest source ─────────────────────────────────────
 
 // TestIngestSchemaValidation verifies that records with unknown schema values
 // are rejected and logged, while valid records are accepted.
 func TestIngestSchemaValidation(t *testing.T) {
 	cases := []struct {
-		name          string
-		schema        string
-		wantRejected  int
-		wantTurns     int
+		name         string
+		schema       string
+		wantRejected int
+		wantTurns    int
 	}{
 		{
 			name:         "valid schema accepted",
@@ -138,22 +194,13 @@ func TestIngestSchemaValidation(t *testing.T) {
 				"text":       "hello world",
 			}
 			b, _ := json.Marshal(rec)
-			line := string(b) + "\n"
 
-			var meta SessionMeta
-			var turns []Turn
-			rejected, err := ParseIngestSession(strings.NewReader(line), "test-source/test-session", 8192, &meta, func(t Turn) bool {
-				turns = append(turns, t)
-				return true
-			})
-			if err != nil {
-				t.Fatalf("ParseIngestSession: %v", err)
+			acc := parseIngestLines(t, []string{string(b)}, 8192)
+			if acc.RejectedSchemas != tc.wantRejected {
+				t.Errorf("rejected=%d want %d", acc.RejectedSchemas, tc.wantRejected)
 			}
-			if rejected != tc.wantRejected {
-				t.Errorf("rejected=%d want %d", rejected, tc.wantRejected)
-			}
-			if len(turns) != tc.wantTurns {
-				t.Errorf("turns=%d want %d", len(turns), tc.wantTurns)
+			if got := totalTurns(acc); got != tc.wantTurns {
+				t.Errorf("turns=%d want %d", got, tc.wantTurns)
 			}
 		})
 	}
@@ -173,9 +220,9 @@ func TestIngestRequiredFields(t *testing.T) {
 	}
 
 	cases := []struct {
-		name       string
-		dropField  string
-		wantTurns  int
+		name      string
+		dropField string
+		wantTurns int
 	}{
 		{"all fields present", "", 1},
 		{"missing source", "source", 0},
@@ -195,19 +242,10 @@ func TestIngestRequiredFields(t *testing.T) {
 				delete(rec, tc.dropField)
 			}
 			b, _ := json.Marshal(rec)
-			line := string(b) + "\n"
 
-			var meta SessionMeta
-			var turns []Turn
-			_, err := ParseIngestSession(strings.NewReader(line), "test-src/sess-1", 8192, &meta, func(t Turn) bool {
-				turns = append(turns, t)
-				return true
-			})
-			if err != nil {
-				t.Fatalf("ParseIngestSession: %v", err)
-			}
-			if len(turns) != tc.wantTurns {
-				t.Errorf("turns=%d want %d (field=%s)", len(turns), tc.wantTurns, tc.dropField)
+			acc := parseIngestLines(t, []string{string(b)}, 8192)
+			if got := totalTurns(acc); got != tc.wantTurns {
+				t.Errorf("turns=%d want %d (field=%s)", got, tc.wantTurns, tc.dropField)
 			}
 		})
 	}
@@ -239,22 +277,210 @@ func TestIngestRoleValidation(t *testing.T) {
 				"text":       "test",
 			}
 			b, _ := json.Marshal(rec)
-			var meta SessionMeta
-			var turns []Turn
-			_, _ = ParseIngestSession(strings.NewReader(string(b)+"\n"), "src/s1", 8192, &meta, func(t Turn) bool {
-				turns = append(turns, t)
-				return true
-			})
-			if len(turns) != tc.wantTurns {
-				t.Errorf("role=%q: turns=%d want %d", tc.role, len(turns), tc.wantTurns)
+			acc := parseIngestLines(t, []string{string(b)}, 8192)
+			if got := totalTurns(acc); got != tc.wantTurns {
+				t.Errorf("role=%q: turns=%d want %d", tc.role, got, tc.wantTurns)
 			}
 		})
 	}
 }
 
+// TestIngestMultiSessionFanOut verifies the core transport semantics: ONE
+// ingest file containing records from 3 different session_ids fans out into
+// 3 distinct sessions in the index.
+func TestIngestMultiSessionFanOut(t *testing.T) {
+	p, root := newTestProvider(t)
+	ingestRoot := t.TempDir()
+
+	source := "hermes-fan"
+	ts := "2026-06-01T10:00:00Z"
+
+	// One transport file, three interleaved sessions — mirrors real observer
+	// output where a single run exports the whole state.db.
+	lines := []string{
+		makeIngestRecord(source, "sess-alpha", "user", "alpha question", ts,
+			map[string]any{"refs": map[string]any{"stable_id": source + ":1"}}),
+		makeIngestRecord(source, "sess-beta", "user", "beta question", ts,
+			map[string]any{"refs": map[string]any{"stable_id": source + ":2"}, "session_title": "Beta Session"}),
+		makeIngestRecord(source, "sess-alpha", "assistant", "alpha answer", ts,
+			map[string]any{"refs": map[string]any{"stable_id": source + ":3"}}),
+		makeIngestRecord(source, "sess-gamma", "user", "gamma question", ts,
+			map[string]any{"refs": map[string]any{"stable_id": source + ":4"}}),
+		makeIngestRecord(source, "sess-beta", "assistant", "beta answer", ts,
+			map[string]any{"refs": map[string]any{"stable_id": source + ":5"}}),
+	}
+	writeIngestDir(t, ingestRoot, source, "20260601T100000Z-run1", lines)
+	writeObservatoryConfigFull(t, root, nil, []string{ingestRoot})
+
+	creates, ls := reconcileOnce(t, p, root)
+	if creates != 1 {
+		t.Errorf("expected 1 create (per source), got %d", creates)
+	}
+
+	wantSessions := map[string]int{ // composite key → expected turn count
+		source + "/sess-alpha": 2,
+		source + "/sess-beta":  2,
+		source + "/sess-gamma": 1,
+	}
+	if len(ls.Entries) != len(wantSessions) {
+		t.Fatalf("expected %d sessions, got %d: %v", len(wantSessions), len(ls.Entries), liveStateKeys(ls))
+	}
+	for key, wantTurnCount := range wantSessions {
+		entry, ok := ls.Entries[key]
+		if !ok {
+			t.Errorf("missing session %q", key)
+			continue
+		}
+		if entry.Meta.TurnCount != wantTurnCount {
+			t.Errorf("session %q: TurnCount=%d want %d", key, entry.Meta.TurnCount, wantTurnCount)
+		}
+		if entry.Meta.Source != source {
+			t.Errorf("session %q: Source=%q want %q", key, entry.Meta.Source, source)
+		}
+	}
+
+	// session_title propagated per session from any record carrying it.
+	if got := ls.Entries[source+"/sess-beta"].Meta.Title; got != "Beta Session" {
+		t.Errorf("sess-beta Title=%q want %q", got, "Beta Session")
+	}
+	if got := ls.Entries[source+"/sess-alpha"].Meta.Title; got != "" {
+		t.Errorf("sess-alpha Title=%q want empty", got)
+	}
+}
+
+// TestIngestSessionSpansFiles verifies that the same session_id spanning two
+// observer-run files merges into ONE session, with stable_id dedup absorbing
+// the overlapping record.
+func TestIngestSessionSpansFiles(t *testing.T) {
+	p, root := newTestProvider(t)
+	ingestRoot := t.TempDir()
+
+	source := "hermes-span"
+	sessionID := "sess-spanning"
+	key := source + "/" + sessionID
+
+	stable := func(n int) map[string]any {
+		return map[string]any{"refs": map[string]any{"stable_id": fmt.Sprintf("%s:%d", source, n)}}
+	}
+
+	// Run 1: messages 1-2.
+	writeIngestDir(t, ingestRoot, source, "20260601T100000Z-run1", []string{
+		makeIngestRecord(source, sessionID, "user", "first message", "2026-06-01T10:00:00Z", stable(1)),
+		makeIngestRecord(source, sessionID, "assistant", "second message", "2026-06-01T10:00:01Z", stable(2)),
+	})
+	// Run 2 (incremental): re-emits message 2 (overlap) plus new message 3.
+	writeIngestDir(t, ingestRoot, source, "20260601T110000Z-run2", []string{
+		makeIngestRecord(source, sessionID, "assistant", "second message", "2026-06-01T10:00:01Z", stable(2)),
+		makeIngestRecord(source, sessionID, "user", "third message", "2026-06-01T10:05:00Z", stable(3)),
+	})
+	writeObservatoryConfigFull(t, root, nil, []string{ingestRoot})
+
+	creates, ls := reconcileOnce(t, p, root)
+	if creates != 1 {
+		t.Errorf("expected 1 create, got %d", creates)
+	}
+	if len(ls.Entries) != 1 {
+		t.Fatalf("expected exactly 1 session (merged across files), got %d: %v",
+			len(ls.Entries), liveStateKeys(ls))
+	}
+	entry, ok := ls.Entries[key]
+	if !ok {
+		t.Fatalf("missing merged session %q", key)
+	}
+	// 3 distinct turns: overlap (stable_id src:2) deduplicated.
+	if entry.Meta.TurnCount != 3 {
+		t.Errorf("TurnCount=%d want 3 (overlapping record must dedup)", entry.Meta.TurnCount)
+	}
+
+	// Verify the turn UUIDs are the raw stable_ids, in order, no duplicates.
+	p.mu.Lock()
+	idx := p.index
+	p.mu.Unlock()
+	wantUUIDs := []string{source + ":1", source + ":2", source + ":3"}
+	for i, want := range wantUUIDs {
+		turn, ok := idx.GetTurn(key, i)
+		if !ok {
+			t.Fatalf("turn %d not found in %q", i, key)
+		}
+		if turn.UUID != want {
+			t.Errorf("turn[%d].UUID=%q want %q", i, turn.UUID, want)
+		}
+	}
+
+	// Time bounds span both files.
+	wantFirst, _ := time.Parse(time.RFC3339, "2026-06-01T10:00:00Z")
+	wantLast, _ := time.Parse(time.RFC3339, "2026-06-01T10:05:00Z")
+	if !entry.Meta.FirstTurnAt.Equal(wantFirst) {
+		t.Errorf("FirstTurnAt=%v want %v", entry.Meta.FirstTurnAt, wantFirst)
+	}
+	if !entry.Meta.LastTurnAt.Equal(wantLast) {
+		t.Errorf("LastTurnAt=%v want %v", entry.Meta.LastTurnAt, wantLast)
+	}
+}
+
+// TestIngestIncrementalRunDrift verifies that appending a new observer-run
+// file to a source triggers an update on the next plan cycle and the merged
+// session grows.
+func TestIngestIncrementalRunDrift(t *testing.T) {
+	p, root := newTestProvider(t)
+	ingestRoot := t.TempDir()
+
+	source := "hermes-incr"
+	sessionID := "sess-1"
+	key := source + "/" + sessionID
+	stable := func(n int) map[string]any {
+		return map[string]any{"refs": map[string]any{"stable_id": fmt.Sprintf("%s:%d", source, n)}}
+	}
+
+	writeIngestDir(t, ingestRoot, source, "20260601T100000Z-run1", []string{
+		makeIngestRecord(source, sessionID, "user", "first", "2026-06-01T10:00:00Z", stable(1)),
+	})
+	writeObservatoryConfigFull(t, root, nil, []string{ingestRoot})
+
+	_, ls := reconcileOnce(t, p, root)
+	if ls.Entries[key].Meta.TurnCount != 1 {
+		t.Fatalf("after run1: TurnCount=%d want 1", ls.Entries[key].Meta.TurnCount)
+	}
+
+	// Second cycle without changes: skip (no drift).
+	ctx := context.Background()
+	cfgAny, _ := p.LoadConfig(root)
+	liveAny, _ := p.FetchLive(ctx, cfgAny)
+	plan2, _ := p.ComputePlan(cfgAny, liveAny, nil)
+	if plan2.Summary.Creates != 0 || plan2.Summary.Updates != 0 {
+		t.Errorf("expected skip with no new files; got creates=%d updates=%d",
+			plan2.Summary.Creates, plan2.Summary.Updates)
+	}
+
+	// New observer run appends a second file for the same session.
+	writeIngestDir(t, ingestRoot, source, "20260601T110000Z-run2", []string{
+		makeIngestRecord(source, sessionID, "assistant", "second", "2026-06-01T10:00:01Z", stable(2)),
+	})
+
+	cfgAny, _ = p.LoadConfig(root)
+	liveAny, _ = p.FetchLive(ctx, cfgAny)
+	plan3, _ := p.ComputePlan(cfgAny, liveAny, nil)
+	if plan3.Summary.Updates != 1 {
+		t.Errorf("expected 1 update after new run file, got %d", plan3.Summary.Updates)
+	}
+	results, err := p.ApplyPlan(ctx, plan3)
+	if err != nil {
+		t.Fatalf("ApplyPlan: %v", err)
+	}
+	if len(results) == 0 || results[0].Status != "succeeded" {
+		t.Fatalf("apply update failed: %v", results)
+	}
+
+	liveAny2, _ := p.FetchLive(ctx, cfgAny)
+	ls2 := liveAny2.(*liveState)
+	if ls2.Entries[key].Meta.TurnCount != 2 {
+		t.Errorf("after run2: TurnCount=%d want 2 (merged across files)", ls2.Entries[key].Meta.TurnCount)
+	}
+}
+
 // TestIngestSourceSessionIDKeying verifies that ingest sessions are keyed as
-// "<source>/<session_id>" in the index and that the Source field is populated
-// in the returned SessionMeta.
+// "<source>/<session_id>" (from the RECORD's session_id, not the file name)
+// and that the Source field is populated in the returned SessionMeta.
 func TestIngestSourceSessionIDKeying(t *testing.T) {
 	p, root := newTestProvider(t)
 	ingestRoot := t.TempDir()
@@ -268,33 +494,15 @@ func TestIngestSourceSessionIDKeying(t *testing.T) {
 		makeIngestRecord(source, sessionID, "assistant", "hello back", "2026-06-01T10:00:01Z",
 			map[string]any{"session_title": "Hermes Test Session"}),
 	}
-	writeIngestDir(t, ingestRoot, source, sessionID, lines)
+	// File name deliberately differs from session_id — keying must come from
+	// the record, not from the transport file name.
+	writeIngestDir(t, ingestRoot, source, "20260601T999999Z-transport-artifact", lines)
 	writeObservatoryConfigFull(t, root, nil, []string{ingestRoot})
 
-	ctx := context.Background()
-	cfgAny, err := p.LoadConfig(root)
-	if err != nil {
-		t.Fatalf("LoadConfig: %v", err)
+	creates, ls := reconcileOnce(t, p, root)
+	if creates != 1 {
+		t.Fatalf("expected 1 create, got %d", creates)
 	}
-	liveAny, _ := p.FetchLive(ctx, cfgAny)
-	plan, err := p.ComputePlan(cfgAny, liveAny, nil)
-	if err != nil {
-		t.Fatalf("ComputePlan: %v", err)
-	}
-	if plan.Summary.Creates != 1 {
-		t.Fatalf("expected 1 create, got %d", plan.Summary.Creates)
-	}
-
-	results, err := p.ApplyPlan(ctx, plan)
-	if err != nil {
-		t.Fatalf("ApplyPlan: %v", err)
-	}
-	if len(results) != 1 || results[0].Status != "succeeded" {
-		t.Fatalf("expected 1 success, got: %v", results)
-	}
-
-	liveAny2, _ := p.FetchLive(ctx, cfgAny)
-	ls := liveAny2.(*liveState)
 
 	entry, ok := ls.Entries[indexKey]
 	if !ok {
@@ -324,29 +532,43 @@ func TestIngestSourceSessionIDKeying(t *testing.T) {
 }
 
 // TestIngestMonotonicTurnIndex verifies that monotonic turn_index is assigned
-// per (source, session_id) when the records do not supply turn_index.
+// per (source, session_id) when the records do not supply turn_index — and
+// that the counter is per-session even when sessions interleave.
 func TestIngestMonotonicTurnIndex(t *testing.T) {
 	lines := []string{
-		makeIngestRecord("src", "sess", "user", "first", "2026-06-01T10:00:00Z", nil),
-		makeIngestRecord("src", "sess", "assistant", "second", "2026-06-01T10:00:01Z", nil),
-		makeIngestRecord("src", "sess", "user", "third", "2026-06-01T10:00:02Z", nil),
+		makeIngestRecord("src", "sess-a", "user", "a-first", "2026-06-01T10:00:00Z", nil),
+		makeIngestRecord("src", "sess-b", "user", "b-first", "2026-06-01T10:00:01Z", nil),
+		makeIngestRecord("src", "sess-a", "assistant", "a-second", "2026-06-01T10:00:02Z", nil),
+		makeIngestRecord("src", "sess-a", "user", "a-third", "2026-06-01T10:00:03Z", nil),
+		makeIngestRecord("src", "sess-b", "assistant", "b-second", "2026-06-01T10:00:04Z", nil),
+	}
+	acc := parseIngestLines(t, lines, 8192)
+
+	sessions := acc.Sessions()
+	if len(sessions) != 2 {
+		t.Fatalf("expected 2 sessions, got %d", len(sessions))
+	}
+	byKey := make(map[string]*ingestSessionAccum)
+	for _, s := range sessions {
+		byKey[s.Meta.SessionID] = s
 	}
 
-	var meta SessionMeta
-	var turns []Turn
-	_, err := ParseIngestSession(strings.NewReader(strings.Join(lines, "\n")+"\n"), "src/sess", 8192, &meta, func(t Turn) bool {
-		turns = append(turns, t)
-		return true
-	})
-	if err != nil {
-		t.Fatalf("ParseIngestSession: %v", err)
+	a := byKey["src/sess-a"]
+	if a == nil || len(a.Turns) != 3 {
+		t.Fatalf("sess-a: expected 3 turns, got %v", a)
 	}
-	if len(turns) != 3 {
-		t.Fatalf("expected 3 turns, got %d", len(turns))
-	}
-	for i, turn := range turns {
+	for i, turn := range a.Turns {
 		if turn.TurnIndex != i {
-			t.Errorf("turn[%d].TurnIndex=%d want %d", i, turn.TurnIndex, i)
+			t.Errorf("sess-a turn[%d].TurnIndex=%d want %d", i, turn.TurnIndex, i)
+		}
+	}
+	b := byKey["src/sess-b"]
+	if b == nil || len(b.Turns) != 2 {
+		t.Fatalf("sess-b: expected 2 turns, got %v", b)
+	}
+	for i, turn := range b.Turns {
+		if turn.TurnIndex != i {
+			t.Errorf("sess-b turn[%d].TurnIndex=%d want %d", i, turn.TurnIndex, i)
 		}
 	}
 }
@@ -357,24 +579,51 @@ func TestIngestMaxTurnLength(t *testing.T) {
 	lines := []string{
 		makeIngestRecord("src", "sess", "user", longText, "2026-06-01T10:00:00Z", nil),
 	}
+	acc := parseIngestLines(t, lines, 100)
 
-	var meta SessionMeta
-	var turns []Turn
-	_, err := ParseIngestSession(strings.NewReader(strings.Join(lines, "\n")+"\n"), "src/sess", 100, &meta, func(t Turn) bool {
-		turns = append(turns, t)
-		return true
-	})
-	if err != nil {
-		t.Fatalf("ParseIngestSession: %v", err)
+	sessions := acc.Sessions()
+	if len(sessions) != 1 || len(sessions[0].Turns) != 1 {
+		t.Fatalf("expected 1 session with 1 turn")
 	}
-	if len(turns) != 1 {
-		t.Fatalf("expected 1 turn, got %d", len(turns))
+	text := sessions[0].Turns[0].Text
+	if len(text) > 115 { // 100 + len(" [truncated]")
+		t.Errorf("text not truncated: len=%d", len(text))
 	}
-	if len(turns[0].Text) > 115 { // 100 + len(" [truncated]")
-		t.Errorf("text not truncated: len=%d", len(turns[0].Text))
+	if !strings.HasSuffix(text, " [truncated]") {
+		t.Errorf("truncation marker missing: %q", text)
 	}
-	if !strings.HasSuffix(turns[0].Text, " [truncated]") {
-		t.Errorf("truncation marker missing: %q", turns[0].Text)
+}
+
+// TestIngestTurnUUIDRawStableID verifies the uuid is the RAW stable_id value
+// (e.g. "hermes-cog:1") — no internal dedup-key prefix, no double source
+// prefix — and the bare content hash when stable_id is absent.
+func TestIngestTurnUUIDRawStableID(t *testing.T) {
+	lines := []string{
+		makeIngestRecord("hermes-cog", "sess", "user", "with stable id", "2026-06-01T10:00:00Z",
+			map[string]any{"refs": map[string]any{"stable_id": "hermes-cog:1", "message_id": 1}}),
+		makeIngestRecord("hermes-cog", "sess", "user", "without stable id", "2026-06-01T10:00:01Z", nil),
+	}
+	acc := parseIngestLines(t, lines, 8192)
+
+	sessions := acc.Sessions()
+	if len(sessions) != 1 || len(sessions[0].Turns) != 2 {
+		t.Fatalf("expected 1 session with 2 turns")
+	}
+	turns := sessions[0].Turns
+
+	if turns[0].UUID != "hermes-cog:1" {
+		t.Errorf("uuid=%q want raw stable_id %q", turns[0].UUID, "hermes-cog:1")
+	}
+	if strings.Contains(turns[0].UUID, "stable:") {
+		t.Errorf("internal dedup prefix leaked into uuid: %q", turns[0].UUID)
+	}
+
+	// No stable_id → 16-hex-char content hash, no namespace prefix.
+	if len(turns[1].UUID) != 16 {
+		t.Errorf("hash uuid length=%d want 16: %q", len(turns[1].UUID), turns[1].UUID)
+	}
+	if strings.Contains(turns[1].UUID, ":") {
+		t.Errorf("hash uuid contains prefix separator: %q", turns[1].UUID)
 	}
 }
 
@@ -448,15 +697,15 @@ func TestSearchTermANDIntegration(t *testing.T) {
 		query     string
 		wantCount int
 	}{
-		{"harness", 1},                          // single term
-		{"harness attestation", 1},              // AND: both present in turn u1
-		{"attestation", 2},                      // present in u1 + a1
-		{"attestation model", 1},                // AND: "attestation model" only in a1
-		{"harness operator", 0},                 // AND: no single turn has both
-		{`"harness attestation"`, 1},            // exact phrase match
-		{`"attestation policy"`, 1},             // phrase
-		{`"attestation policy" harness`, 1},     // phrase + term
-		{`"attestation policy" kubernetes`, 0},  // phrase + missing term
+		{"harness", 1},                         // single term
+		{"harness attestation", 1},             // AND: both present in turn u1
+		{"attestation", 2},                     // present in u1 + a1
+		{"attestation model", 1},               // AND: "attestation model" only in a1
+		{"harness operator", 0},                // AND: no single turn has both
+		{`"harness attestation"`, 1},           // exact phrase match
+		{`"attestation policy"`, 1},            // phrase
+		{`"attestation policy" harness`, 1},    // phrase + term
+		{`"attestation policy" kubernetes`, 0}, // phrase + missing term
 	}
 	for _, tc := range tests {
 		hits := idx.Search(tc.query, time.Time{}, time.Time{}, "", "", 0)
@@ -475,7 +724,7 @@ func TestParseSearchQuery(t *testing.T) {
 		{"", nil},
 		{"hello", []string{"hello"}},
 		{"foo bar", []string{"foo", "bar"}},
-		{"foo  bar", []string{"foo", "bar"}},   // extra whitespace
+		{"foo  bar", []string{"foo", "bar"}}, // extra whitespace
 		{`"foo bar"`, []string{"foo bar"}},
 		{`"foo bar" baz`, []string{"foo bar", "baz"}},
 		{`baz "foo bar"`, []string{"baz", "foo bar"}},
@@ -496,7 +745,7 @@ func TestParseSearchQuery(t *testing.T) {
 	}
 }
 
-// ─── Feature 3: UUID dedup on the CC path ────────────────────────────────────
+// ─── Feature 3: dedup ────────────────────────────────────────────────────────
 
 // TestCCParserUUIDDedup verifies that when a CC JSONL contains duplicate uuid
 // values (resumed/compacted sessions), only the first occurrence is indexed.
@@ -587,22 +836,17 @@ func TestIngestDedupByStableID(t *testing.T) {
 	}
 
 	lines := []string{
-		makeRecWithStableID("sess", "first occurrence", "stable-001"),
-		makeRecWithStableID("sess", "duplicate of stable-001", "stable-001"),
-		makeRecWithStableID("sess", "different record", "stable-002"),
+		makeRecWithStableID("sess", "first occurrence", "src:1"),
+		makeRecWithStableID("sess", "duplicate of src:1", "src:1"),
+		makeRecWithStableID("sess", "different record", "src:2"),
 	}
+	acc := parseIngestLines(t, lines, 8192)
 
-	var meta SessionMeta
-	var turns []Turn
-	_, err := ParseIngestSession(
-		strings.NewReader(strings.Join(lines, "\n")+"\n"),
-		"src/sess", 8192, &meta, func(t Turn) bool {
-			turns = append(turns, t)
-			return true
-		})
-	if err != nil {
-		t.Fatalf("ParseIngestSession: %v", err)
+	sessions := acc.Sessions()
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(sessions))
 	}
+	turns := sessions[0].Turns
 	if len(turns) != 2 {
 		t.Fatalf("expected 2 turns after stable_id dedup, got %d", len(turns))
 	}
@@ -619,24 +863,18 @@ func TestIngestDedupByContentHash(t *testing.T) {
 		makeIngestRecord("src", "sess", "user", "hello world", "2026-06-01T10:00:00Z", nil), // exact dup
 		makeIngestRecord("src", "sess", "user", "different text", "2026-06-01T10:00:00Z", nil),
 	}
+	acc := parseIngestLines(t, lines, 8192)
 
-	var meta SessionMeta
-	var turns []Turn
-	_, err := ParseIngestSession(
-		strings.NewReader(strings.Join(lines, "\n")+"\n"),
-		"src/sess", 8192, &meta, func(t Turn) bool {
-			turns = append(turns, t)
-			return true
-		})
-	if err != nil {
-		t.Fatalf("ParseIngestSession: %v", err)
+	sessions := acc.Sessions()
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(sessions))
 	}
-	if len(turns) != 2 {
-		t.Fatalf("expected 2 turns after content-hash dedup, got %d", len(turns))
+	if len(sessions[0].Turns) != 2 {
+		t.Fatalf("expected 2 turns after content-hash dedup, got %d", len(sessions[0].Turns))
 	}
 }
 
-// TestIngestSessionCollisonIsolation verifies that ingest sessions with the
+// TestIngestSessionCollisionIsolation verifies that ingest sessions with the
 // same session_id but different sources are kept separate in the index.
 func TestIngestSessionCollisionIsolation(t *testing.T) {
 	p, root := newTestProvider(t)
@@ -646,25 +884,18 @@ func TestIngestSessionCollisionIsolation(t *testing.T) {
 	ts := "2026-06-01T10:00:00Z"
 
 	// Two sources with the same session_id — must not collide.
-	writeIngestDir(t, ingestRoot, "source-a", rawSessID, []string{
+	writeIngestDir(t, ingestRoot, "source-a", "run1", []string{
 		makeIngestRecord("source-a", rawSessID, "user", "message from source-a", ts, nil),
 	})
-	writeIngestDir(t, ingestRoot, "source-b", rawSessID, []string{
+	writeIngestDir(t, ingestRoot, "source-b", "run1", []string{
 		makeIngestRecord("source-b", rawSessID, "user", "message from source-b", ts, nil),
 	})
 	writeObservatoryConfigFull(t, root, nil, []string{ingestRoot})
 
-	ctx := context.Background()
-	cfgAny, _ := p.LoadConfig(root)
-	liveAny, _ := p.FetchLive(ctx, cfgAny)
-	plan, _ := p.ComputePlan(cfgAny, liveAny, nil)
-	if plan.Summary.Creates != 2 {
-		t.Fatalf("expected 2 creates, got %d", plan.Summary.Creates)
+	creates, ls := reconcileOnce(t, p, root)
+	if creates != 2 {
+		t.Fatalf("expected 2 creates (one per source), got %d", creates)
 	}
-	_, _ = p.ApplyPlan(ctx, plan)
-
-	liveAny2, _ := p.FetchLive(ctx, cfgAny)
-	ls := liveAny2.(*liveState)
 
 	keyA := fmt.Sprintf("source-a/%s", rawSessID)
 	keyB := fmt.Sprintf("source-b/%s", rawSessID)

--- a/internal/conversations/ingest_features_test.go
+++ b/internal/conversations/ingest_features_test.go
@@ -1,0 +1,688 @@
+// ingest_features_test.go — table-driven tests for the three new features:
+//
+//  1. Normalized ingest source: schema validation/rejection, (source, session_id) keying
+//  2. Term-AND search with phrase quoting
+//  3. UUID dedup on the CC parser path; content-hash dedup on the ingest path
+package conversations
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+// makeIngestRecord builds one normalized ingest JSONL line.
+func makeIngestRecord(source, sessionID, role, text, ts string, extras map[string]any) string {
+	rec := map[string]any{
+		"schema":     "cogos.observatory.conversations/v0.1",
+		"source":     source,
+		"session_id": sessionID,
+		"role":       role,
+		"timestamp":  ts,
+		"text":       text,
+	}
+	for k, v := range extras {
+		rec[k] = v
+	}
+	b, _ := json.Marshal(rec)
+	return string(b)
+}
+
+// writeIngestDir creates <ingestRoot>/<source>/<filename>.jsonl and returns the path.
+func writeIngestDir(t *testing.T, ingestRoot, source, filename string, lines []string) string {
+	t.Helper()
+	dir := filepath.Join(ingestRoot, source)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir ingest dir: %v", err)
+	}
+	path := filepath.Join(dir, filename+".jsonl")
+	content := strings.Join(lines, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write ingest file: %v", err)
+	}
+	return path
+}
+
+// writeObservatoryConfigFull writes .cog/config/observatory.yaml with both
+// source_dirs and ingest_dirs. When srcDirs is nil, an empty temp dir is
+// used as source_dirs so the provider does not fall back to the default
+// ~/.claude/projects path. Pass explicit paths in srcDirs when needed.
+func writeObservatoryConfigFull(t *testing.T, root string, srcDirs, ingestDirs []string) {
+	t.Helper()
+	cfgDir := filepath.Join(root, ".cog", "config")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+
+	// When no source_dirs provided, use an empty temp dir so the provider
+	// does not fall back to defaultSourceDirs() and pick up real CC sessions.
+	if srcDirs == nil {
+		emptyDir := t.TempDir()
+		srcDirs = []string{emptyDir}
+	}
+
+	var lines []string
+	lines = append(lines, "source_dirs:")
+	for _, d := range srcDirs {
+		lines = append(lines, "  - "+d)
+	}
+
+	if len(ingestDirs) > 0 {
+		lines = append(lines, "ingest_dirs:")
+		for _, d := range ingestDirs {
+			lines = append(lines, "  - "+d)
+		}
+	}
+	lines = append(lines, "include_patterns:")
+	lines = append(lines, "  - \"*.jsonl\"")
+
+	content := strings.Join(lines, "\n") + "\n"
+	path := filepath.Join(cfgDir, "observatory.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write observatory.yaml: %v", err)
+	}
+}
+
+// ─── Feature 1: Normalized ingest source ─────────────────────────────────────
+
+// TestIngestSchemaValidation verifies that records with unknown schema values
+// are rejected and logged, while valid records are accepted.
+func TestIngestSchemaValidation(t *testing.T) {
+	cases := []struct {
+		name          string
+		schema        string
+		wantRejected  int
+		wantTurns     int
+	}{
+		{
+			name:         "valid schema accepted",
+			schema:       "cogos.observatory.conversations/v0.1",
+			wantRejected: 0,
+			wantTurns:    1,
+		},
+		{
+			name:         "unknown schema rejected",
+			schema:       "cogos.observatory.conversations/v0.0",
+			wantRejected: 1,
+			wantTurns:    0,
+		},
+		{
+			name:         "empty schema rejected",
+			schema:       "",
+			wantRejected: 1,
+			wantTurns:    0,
+		},
+		{
+			name:         "future schema rejected",
+			schema:       "cogos.observatory.conversations/v1.0",
+			wantRejected: 1,
+			wantTurns:    0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := map[string]any{
+				"schema":     tc.schema,
+				"source":     "test-source",
+				"session_id": "test-session",
+				"role":       "user",
+				"timestamp":  "2026-06-01T10:00:00Z",
+				"text":       "hello world",
+			}
+			b, _ := json.Marshal(rec)
+			line := string(b) + "\n"
+
+			var meta SessionMeta
+			var turns []Turn
+			rejected, err := ParseIngestSession(strings.NewReader(line), "test-source/test-session", 8192, &meta, func(t Turn) bool {
+				turns = append(turns, t)
+				return true
+			})
+			if err != nil {
+				t.Fatalf("ParseIngestSession: %v", err)
+			}
+			if rejected != tc.wantRejected {
+				t.Errorf("rejected=%d want %d", rejected, tc.wantRejected)
+			}
+			if len(turns) != tc.wantTurns {
+				t.Errorf("turns=%d want %d", len(turns), tc.wantTurns)
+			}
+		})
+	}
+}
+
+// TestIngestRequiredFields verifies that records missing required fields are
+// rejected (logged) without aborting the parse stream.
+func TestIngestRequiredFields(t *testing.T) {
+	ts := "2026-06-01T10:00:00Z"
+	base := map[string]any{
+		"schema":     "cogos.observatory.conversations/v0.1",
+		"source":     "test-src",
+		"session_id": "sess-1",
+		"role":       "user",
+		"timestamp":  ts,
+		"text":       "complete record",
+	}
+
+	cases := []struct {
+		name       string
+		dropField  string
+		wantTurns  int
+	}{
+		{"all fields present", "", 1},
+		{"missing source", "source", 0},
+		{"missing session_id", "session_id", 0},
+		{"missing role", "role", 0},
+		{"missing timestamp", "timestamp", 0},
+		{"missing text", "text", 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := make(map[string]any)
+			for k, v := range base {
+				rec[k] = v
+			}
+			if tc.dropField != "" {
+				delete(rec, tc.dropField)
+			}
+			b, _ := json.Marshal(rec)
+			line := string(b) + "\n"
+
+			var meta SessionMeta
+			var turns []Turn
+			_, err := ParseIngestSession(strings.NewReader(line), "test-src/sess-1", 8192, &meta, func(t Turn) bool {
+				turns = append(turns, t)
+				return true
+			})
+			if err != nil {
+				t.Fatalf("ParseIngestSession: %v", err)
+			}
+			if len(turns) != tc.wantTurns {
+				t.Errorf("turns=%d want %d (field=%s)", len(turns), tc.wantTurns, tc.dropField)
+			}
+		})
+	}
+}
+
+// TestIngestRoleValidation verifies that records with valid roles are accepted
+// and records with invalid roles are rejected.
+func TestIngestRoleValidation(t *testing.T) {
+	cases := []struct {
+		role      string
+		wantTurns int
+	}{
+		{"user", 1},
+		{"assistant", 1},
+		{"system", 1},
+		{"tool", 1},
+		{"observer", 0},
+		{"", 0},
+		{"ASSISTANT", 0}, // case-sensitive — schema specifies lowercase
+	}
+	for _, tc := range cases {
+		t.Run("role="+tc.role, func(t *testing.T) {
+			rec := map[string]any{
+				"schema":     "cogos.observatory.conversations/v0.1",
+				"source":     "src",
+				"session_id": "s1",
+				"role":       tc.role,
+				"timestamp":  "2026-06-01T10:00:00Z",
+				"text":       "test",
+			}
+			b, _ := json.Marshal(rec)
+			var meta SessionMeta
+			var turns []Turn
+			_, _ = ParseIngestSession(strings.NewReader(string(b)+"\n"), "src/s1", 8192, &meta, func(t Turn) bool {
+				turns = append(turns, t)
+				return true
+			})
+			if len(turns) != tc.wantTurns {
+				t.Errorf("role=%q: turns=%d want %d", tc.role, len(turns), tc.wantTurns)
+			}
+		})
+	}
+}
+
+// TestIngestSourceSessionIDKeying verifies that ingest sessions are keyed as
+// "<source>/<session_id>" in the index and that the Source field is populated
+// in the returned SessionMeta.
+func TestIngestSourceSessionIDKeying(t *testing.T) {
+	p, root := newTestProvider(t)
+	ingestRoot := t.TempDir()
+
+	source := "hermes-test"
+	sessionID := "20260601_100000_abc123"
+	indexKey := source + "/" + sessionID
+
+	lines := []string{
+		makeIngestRecord(source, sessionID, "user", "hello from hermes", "2026-06-01T10:00:00Z", nil),
+		makeIngestRecord(source, sessionID, "assistant", "hello back", "2026-06-01T10:00:01Z",
+			map[string]any{"session_title": "Hermes Test Session"}),
+	}
+	writeIngestDir(t, ingestRoot, source, sessionID, lines)
+	writeObservatoryConfigFull(t, root, nil, []string{ingestRoot})
+
+	ctx := context.Background()
+	cfgAny, err := p.LoadConfig(root)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	liveAny, _ := p.FetchLive(ctx, cfgAny)
+	plan, err := p.ComputePlan(cfgAny, liveAny, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if plan.Summary.Creates != 1 {
+		t.Fatalf("expected 1 create, got %d", plan.Summary.Creates)
+	}
+
+	results, err := p.ApplyPlan(ctx, plan)
+	if err != nil {
+		t.Fatalf("ApplyPlan: %v", err)
+	}
+	if len(results) != 1 || results[0].Status != "succeeded" {
+		t.Fatalf("expected 1 success, got: %v", results)
+	}
+
+	liveAny2, _ := p.FetchLive(ctx, cfgAny)
+	ls := liveAny2.(*liveState)
+
+	entry, ok := ls.Entries[indexKey]
+	if !ok {
+		t.Fatalf("expected session at key %q, got keys: %v", indexKey, liveStateKeys(ls))
+	}
+	if entry.Meta.Source != source {
+		t.Errorf("Source=%q want %q", entry.Meta.Source, source)
+	}
+	if entry.Meta.TurnCount != 2 {
+		t.Errorf("TurnCount=%d want 2", entry.Meta.TurnCount)
+	}
+	if entry.Meta.Title != "Hermes Test Session" {
+		t.Errorf("Title=%q want %q", entry.Meta.Title, "Hermes Test Session")
+	}
+
+	// Search should return the source in the hit.
+	p.mu.Lock()
+	idx := p.index
+	p.mu.Unlock()
+	hits := idx.Search("hermes", time.Time{}, time.Time{}, "", "", 10)
+	if len(hits) == 0 {
+		t.Fatal("expected search hits, got 0")
+	}
+	if hits[0].Source != source {
+		t.Errorf("hit.Source=%q want %q", hits[0].Source, source)
+	}
+}
+
+// TestIngestMonotonicTurnIndex verifies that monotonic turn_index is assigned
+// per (source, session_id) when the records do not supply turn_index.
+func TestIngestMonotonicTurnIndex(t *testing.T) {
+	lines := []string{
+		makeIngestRecord("src", "sess", "user", "first", "2026-06-01T10:00:00Z", nil),
+		makeIngestRecord("src", "sess", "assistant", "second", "2026-06-01T10:00:01Z", nil),
+		makeIngestRecord("src", "sess", "user", "third", "2026-06-01T10:00:02Z", nil),
+	}
+
+	var meta SessionMeta
+	var turns []Turn
+	_, err := ParseIngestSession(strings.NewReader(strings.Join(lines, "\n")+"\n"), "src/sess", 8192, &meta, func(t Turn) bool {
+		turns = append(turns, t)
+		return true
+	})
+	if err != nil {
+		t.Fatalf("ParseIngestSession: %v", err)
+	}
+	if len(turns) != 3 {
+		t.Fatalf("expected 3 turns, got %d", len(turns))
+	}
+	for i, turn := range turns {
+		if turn.TurnIndex != i {
+			t.Errorf("turn[%d].TurnIndex=%d want %d", i, turn.TurnIndex, i)
+		}
+	}
+}
+
+// TestIngestMaxTurnLength verifies that long text is truncated at max_turn_length.
+func TestIngestMaxTurnLength(t *testing.T) {
+	longText := strings.Repeat("x", 200)
+	lines := []string{
+		makeIngestRecord("src", "sess", "user", longText, "2026-06-01T10:00:00Z", nil),
+	}
+
+	var meta SessionMeta
+	var turns []Turn
+	_, err := ParseIngestSession(strings.NewReader(strings.Join(lines, "\n")+"\n"), "src/sess", 100, &meta, func(t Turn) bool {
+		turns = append(turns, t)
+		return true
+	})
+	if err != nil {
+		t.Fatalf("ParseIngestSession: %v", err)
+	}
+	if len(turns) != 1 {
+		t.Fatalf("expected 1 turn, got %d", len(turns))
+	}
+	if len(turns[0].Text) > 115 { // 100 + len(" [truncated]")
+		t.Errorf("text not truncated: len=%d", len(turns[0].Text))
+	}
+	if !strings.HasSuffix(turns[0].Text, " [truncated]") {
+		t.Errorf("truncation marker missing: %q", turns[0].Text)
+	}
+}
+
+// ─── Feature 2: Term-AND search ───────────────────────────────────────────────
+
+// TestSearchTermAND verifies that multi-term queries require ALL terms.
+func TestSearchTermAND(t *testing.T) {
+	cases := []struct {
+		name      string
+		query     string
+		wantMatch bool
+	}{
+		{"single term match", "harness", true},
+		{"single term no match", "kubernetes", false},
+		{"two terms both present", "harness attestation", true},
+		{"two terms first missing", "kubernetes attestation", false},
+		{"two terms second missing", "harness kubernetes", false},
+		{"two terms both missing", "kubernetes flannel", false},
+		{"three terms all present", "harness attestation policy", true},
+		{"three terms one missing", "harness attestation flannel", false},
+		{"phrase match exact", `"attestation policy"`, true},
+		{"phrase match partial word", `"attest"`, true},
+		{"phrase match not present", `"kubernetes attestation"`, false},
+		{"phrase plus term match", `"attestation policy" harness`, true},
+		{"phrase plus term missing term", `"attestation policy" kubernetes`, false},
+	}
+
+	// Seed text that contains: "harness attestation policy"
+	seedText := "The harness attestation policy defines the trust model."
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			terms := parseSearchQuery(tc.query)
+			got := matchesAllTerms(seedText, terms)
+			if got != tc.wantMatch {
+				t.Errorf("query=%q matchesAllTerms=%v want %v", tc.query, got, tc.wantMatch)
+			}
+		})
+	}
+}
+
+// TestSearchTermANDIntegration verifies term-AND search end-to-end through the
+// index layer, including that single-term behavior is backward-compatible.
+func TestSearchTermANDIntegration(t *testing.T) {
+	p, root := newTestProvider(t)
+	srcDir := t.TempDir()
+	const sid = "aaaabbbb-cccc-dddd-eeee-ffffaaaabbbb"
+
+	lines := []string{
+		makeUserRecord("u1", "", sid,
+			"what is the harness attestation policy?", "2026-06-01T10:00:00Z"),
+		makeAssistantRecord("a1", "u1", sid,
+			"The attestation model is defined in ADR-073.", "2026-06-01T10:01:00Z"),
+		makeUserRecord("u2", "a1", sid,
+			"tell me about operator identity", "2026-06-01T10:02:00Z"),
+	}
+	writeJSONLFixture(t, srcDir, sid, lines)
+	writeObservatoryConfig(t, root, []string{srcDir})
+
+	ctx := context.Background()
+	cfgAny, _ := p.LoadConfig(root)
+	liveAny, _ := p.FetchLive(ctx, cfgAny)
+	plan, _ := p.ComputePlan(cfgAny, liveAny, nil)
+	_, _ = p.ApplyPlan(ctx, plan)
+
+	p.mu.Lock()
+	idx := p.index
+	p.mu.Unlock()
+
+	tests := []struct {
+		query     string
+		wantCount int
+	}{
+		{"harness", 1},                          // single term
+		{"harness attestation", 1},              // AND: both present in turn u1
+		{"attestation", 2},                      // present in u1 + a1
+		{"attestation model", 1},                // AND: "attestation model" only in a1
+		{"harness operator", 0},                 // AND: no single turn has both
+		{`"harness attestation"`, 1},            // exact phrase match
+		{`"attestation policy"`, 1},             // phrase
+		{`"attestation policy" harness`, 1},     // phrase + term
+		{`"attestation policy" kubernetes`, 0},  // phrase + missing term
+	}
+	for _, tc := range tests {
+		hits := idx.Search(tc.query, time.Time{}, time.Time{}, "", "", 0)
+		if len(hits) != tc.wantCount {
+			t.Errorf("query=%q: got %d hits want %d", tc.query, len(hits), tc.wantCount)
+		}
+	}
+}
+
+// TestParseSearchQuery verifies the query tokenizer independently.
+func TestParseSearchQuery(t *testing.T) {
+	cases := []struct {
+		input string
+		want  []string
+	}{
+		{"", nil},
+		{"hello", []string{"hello"}},
+		{"foo bar", []string{"foo", "bar"}},
+		{"foo  bar", []string{"foo", "bar"}},   // extra whitespace
+		{`"foo bar"`, []string{"foo bar"}},
+		{`"foo bar" baz`, []string{"foo bar", "baz"}},
+		{`baz "foo bar"`, []string{"baz", "foo bar"}},
+		{`"a" "b c"`, []string{"a", "b c"}},
+		{`"unclosed`, []string{"unclosed"}}, // unclosed quote treated as literal
+	}
+	for _, tc := range cases {
+		got := parseSearchQuery(tc.input)
+		if len(got) != len(tc.want) {
+			t.Errorf("parseSearchQuery(%q) = %v want %v", tc.input, got, tc.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Errorf("parseSearchQuery(%q)[%d] = %q want %q", tc.input, i, got[i], tc.want[i])
+			}
+		}
+	}
+}
+
+// ─── Feature 3: UUID dedup on the CC path ────────────────────────────────────
+
+// TestCCParserUUIDDedup verifies that when a CC JSONL contains duplicate uuid
+// values (resumed/compacted sessions), only the first occurrence is indexed.
+func TestCCParserUUIDDedup(t *testing.T) {
+	sid := "dedup-session-uuid-test"
+	ts := "2026-06-01T10:00:00Z"
+
+	// Build a JSONL where "uuid-u1" appears twice — simulating a compacted
+	// append that re-inserts historical turns.
+	line1 := makeUserRecord("uuid-u1", "", sid, "original message", ts)
+	line2 := makeUserRecord("uuid-u1", "", sid, "duplicate of original", ts) // same uuid
+	line3 := makeUserRecord("uuid-u2", "uuid-u1", sid, "new message", ts)
+
+	jsonl := strings.Join([]string{line1, line2, line3}, "\n") + "\n"
+
+	var meta SessionMeta
+	var turns []Turn
+	err := ParseSession(strings.NewReader(jsonl), sid, 8192, &meta, func(t Turn) bool {
+		turns = append(turns, t)
+		return true
+	})
+	if err != nil {
+		t.Fatalf("ParseSession: %v", err)
+	}
+
+	// Expect 2 turns (line2 is a duplicate of line1 by uuid and should be skipped).
+	if len(turns) != 2 {
+		t.Fatalf("expected 2 turns after uuid dedup, got %d", len(turns))
+	}
+	// The first turn should be the original, not the duplicate.
+	if turns[0].Text != "original message" {
+		t.Errorf("first turn text=%q want %q", turns[0].Text, "original message")
+	}
+	// Turn indices should be 0, 1 (monotonic after dedup).
+	if turns[0].TurnIndex != 0 || turns[1].TurnIndex != 1 {
+		t.Errorf("turn indices after dedup: %d, %d; want 0, 1",
+			turns[0].TurnIndex, turns[1].TurnIndex)
+	}
+}
+
+// TestCCParserUUIDDedup_EmptyUUID verifies that records with empty uuid are
+// not cross-deduplicated against each other (they are distinct turns that
+// happen to lack a uuid).
+func TestCCParserUUIDDedup_EmptyUUID(t *testing.T) {
+	sid := "empty-uuid-session"
+	ts := "2026-06-01T10:00:00Z"
+
+	// Two records with no uuid — both should be indexed.
+	makeRecNoUUID := func(text string) string {
+		content, _ := json.Marshal([]map[string]string{{"type": "text", "text": text}})
+		msg, _ := json.Marshal(map[string]any{
+			"role":    "user",
+			"content": json.RawMessage(content),
+		})
+		rec := map[string]any{
+			"type":      "user",
+			"sessionId": sid,
+			"timestamp": ts,
+			"message":   json.RawMessage(msg),
+		}
+		b, _ := json.Marshal(rec)
+		return string(b)
+	}
+
+	line1 := makeRecNoUUID("turn one")
+	line2 := makeRecNoUUID("turn two")
+	jsonl := line1 + "\n" + line2 + "\n"
+
+	var meta SessionMeta
+	var turns []Turn
+	_ = ParseSession(strings.NewReader(jsonl), sid, 8192, &meta, func(t Turn) bool {
+		turns = append(turns, t)
+		return true
+	})
+
+	if len(turns) != 2 {
+		t.Fatalf("expected 2 turns (no uuid should not collapse), got %d", len(turns))
+	}
+}
+
+// TestIngestDedupByStableID verifies that ingest records with the same
+// refs.stable_id are deduplicated, retaining only the first occurrence.
+func TestIngestDedupByStableID(t *testing.T) {
+	makeRecWithStableID := func(sid, text, stableID string) string {
+		refs := map[string]any{"stable_id": stableID}
+		return makeIngestRecord("src", sid, "user", text, "2026-06-01T10:00:00Z",
+			map[string]any{"refs": refs})
+	}
+
+	lines := []string{
+		makeRecWithStableID("sess", "first occurrence", "stable-001"),
+		makeRecWithStableID("sess", "duplicate of stable-001", "stable-001"),
+		makeRecWithStableID("sess", "different record", "stable-002"),
+	}
+
+	var meta SessionMeta
+	var turns []Turn
+	_, err := ParseIngestSession(
+		strings.NewReader(strings.Join(lines, "\n")+"\n"),
+		"src/sess", 8192, &meta, func(t Turn) bool {
+			turns = append(turns, t)
+			return true
+		})
+	if err != nil {
+		t.Fatalf("ParseIngestSession: %v", err)
+	}
+	if len(turns) != 2 {
+		t.Fatalf("expected 2 turns after stable_id dedup, got %d", len(turns))
+	}
+	if turns[0].Text != "first occurrence" {
+		t.Errorf("first turn text=%q want %q", turns[0].Text, "first occurrence")
+	}
+}
+
+// TestIngestDedupByContentHash verifies that ingest records without a
+// refs.stable_id are deduplicated by content hash (role+timestamp+text).
+func TestIngestDedupByContentHash(t *testing.T) {
+	lines := []string{
+		makeIngestRecord("src", "sess", "user", "hello world", "2026-06-01T10:00:00Z", nil),
+		makeIngestRecord("src", "sess", "user", "hello world", "2026-06-01T10:00:00Z", nil), // exact dup
+		makeIngestRecord("src", "sess", "user", "different text", "2026-06-01T10:00:00Z", nil),
+	}
+
+	var meta SessionMeta
+	var turns []Turn
+	_, err := ParseIngestSession(
+		strings.NewReader(strings.Join(lines, "\n")+"\n"),
+		"src/sess", 8192, &meta, func(t Turn) bool {
+			turns = append(turns, t)
+			return true
+		})
+	if err != nil {
+		t.Fatalf("ParseIngestSession: %v", err)
+	}
+	if len(turns) != 2 {
+		t.Fatalf("expected 2 turns after content-hash dedup, got %d", len(turns))
+	}
+}
+
+// TestIngestSessionCollisonIsolation verifies that ingest sessions with the
+// same session_id but different sources are kept separate in the index.
+func TestIngestSessionCollisionIsolation(t *testing.T) {
+	p, root := newTestProvider(t)
+	ingestRoot := t.TempDir()
+
+	const rawSessID = "my-session"
+	ts := "2026-06-01T10:00:00Z"
+
+	// Two sources with the same session_id — must not collide.
+	writeIngestDir(t, ingestRoot, "source-a", rawSessID, []string{
+		makeIngestRecord("source-a", rawSessID, "user", "message from source-a", ts, nil),
+	})
+	writeIngestDir(t, ingestRoot, "source-b", rawSessID, []string{
+		makeIngestRecord("source-b", rawSessID, "user", "message from source-b", ts, nil),
+	})
+	writeObservatoryConfigFull(t, root, nil, []string{ingestRoot})
+
+	ctx := context.Background()
+	cfgAny, _ := p.LoadConfig(root)
+	liveAny, _ := p.FetchLive(ctx, cfgAny)
+	plan, _ := p.ComputePlan(cfgAny, liveAny, nil)
+	if plan.Summary.Creates != 2 {
+		t.Fatalf("expected 2 creates, got %d", plan.Summary.Creates)
+	}
+	_, _ = p.ApplyPlan(ctx, plan)
+
+	liveAny2, _ := p.FetchLive(ctx, cfgAny)
+	ls := liveAny2.(*liveState)
+
+	keyA := fmt.Sprintf("source-a/%s", rawSessID)
+	keyB := fmt.Sprintf("source-b/%s", rawSessID)
+
+	if _, ok := ls.Entries[keyA]; !ok {
+		t.Errorf("missing index key %q; have: %v", keyA, liveStateKeys(ls))
+	}
+	if _, ok := ls.Entries[keyB]; !ok {
+		t.Errorf("missing index key %q; have: %v", keyB, liveStateKeys(ls))
+	}
+}
+
+// ─── helper ──────────────────────────────────────────────────────────────────
+
+func liveStateKeys(ls *liveState) []string {
+	keys := make([]string, 0, len(ls.Entries))
+	for k := range ls.Entries {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/internal/conversations/ingest_parser.go
+++ b/internal/conversations/ingest_parser.go
@@ -4,9 +4,19 @@
 // Records with an unknown schema value are rejected and logged; the parser
 // never guesses at schema semantics.
 //
-// Dedup on the normalized path:
+// An ingest FILE is a transport artifact (one file per observer run) that may
+// contain records from MANY sessions interleaved — the schema carries
+// session_id per record precisely for this. The ingestAccumulator therefore
+// groups records by composite key "<source>/<session_id>" while consuming
+// files, and a session may SPAN files across observer runs (incremental runs
+// append later messages for the same session_id). Dedup spans files within a
+// session:
 //   - When refs contains a "stable_id" key: dedup by that value.
 //   - Otherwise: dedup by SHA-256 of "<role>\x00<timestamp>\x00<text>".
+//
+// Turn UUID is the raw stable_id value when present (e.g. "hermes-cog:1"),
+// else the content hash. Internal dedup-key namespacing never leaks into the
+// uuid.
 //
 // Monotonic turn_index is assigned per (source, session_id) when absent from
 // the record.
@@ -20,8 +30,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"strings"
-	"time"
 )
 
 // knownIngestSchemas is the set of schema values this parser speaks.
@@ -54,34 +62,63 @@ type ingestRecord struct {
 
 // ingestRefs is the optional refs object within an ingest record.
 type ingestRefs struct {
-	StableID any    `json:"stable_id,omitempty"` // stable per-record id for dedup
-	DB       string `json:"db,omitempty"`
-	MessageID any   `json:"message_id,omitempty"`
+	StableID  any    `json:"stable_id,omitempty"` // stable per-record id for dedup
+	DB        string `json:"db,omitempty"`
+	MessageID any    `json:"message_id,omitempty"`
 }
 
-// ParseIngestSession streams turns from a normalized ingest JSONL. r is the
-// open file (caller controls open/close). The indexKey is the composite
-// "<source>/<session_id>" used as the session key in the index.
-//
-// Behaviour:
-//   - Records with unknown schema → rejected, logged, counted in stats.
-//   - Records with unknown role  → rejected, logged.
-//   - Missing required fields (source, session_id, role, timestamp, text) → rejected, logged.
-//   - Duplicate records (by stable_id or content hash) → silently skipped.
-//   - turn_index absent           → assigned monotonically from 0.
-//   - text longer than maxTurnLen → truncated with " [truncated]" suffix.
-//
-// Returns the number of records rejected due to schema mismatch.
-func ParseIngestSession(r io.Reader, indexKey string, maxTurnLen int, meta *SessionMeta, callback func(Turn) bool) (rejectedSchemas int, err error) {
+// ingestSessionAccum collects the meta + turns for one (source, session_id)
+// while files are being consumed.
+type ingestSessionAccum struct {
+	Meta  SessionMeta
+	Turns []Turn
+
+	// seen holds internal dedup keys for this session. The map spans files:
+	// incremental observer runs may re-emit records already ingested from an
+	// earlier file.
+	seen map[string]struct{}
+}
+
+// ingestAccumulator consumes ingest JSONL files and groups records into
+// per-session accumulators keyed by "<source>/<session_id>".
+type ingestAccumulator struct {
+	maxTurnLen int
+
+	// sessions maps composite key → accumulator.
+	sessions map[string]*ingestSessionAccum
+
+	// order records first-seen order of session keys for deterministic output.
+	order []string
+
+	// RejectedSchemas counts records rejected for an unknown schema value.
+	RejectedSchemas int
+}
+
+// newIngestAccumulator returns an empty accumulator.
+func newIngestAccumulator(maxTurnLen int) *ingestAccumulator {
 	if maxTurnLen <= 0 {
 		maxTurnLen = defaultMaxTurnLen
 	}
+	return &ingestAccumulator{
+		maxTurnLen: maxTurnLen,
+		sessions:   make(map[string]*ingestSessionAccum),
+	}
+}
 
+// ConsumeFile streams one ingest JSONL from r, validating and routing each
+// record into its session accumulator. r is typically an os.File; it is NOT
+// closed — the caller controls open/close.
+//
+// Behaviour per record:
+//   - unknown schema → rejected, logged, counted in RejectedSchemas
+//   - missing required fields (source, session_id, role, timestamp, text) → rejected, logged
+//   - unknown role → rejected, logged
+//   - duplicate (by stable_id or content hash, within session) → silently skipped
+//   - turn_index absent → assigned monotonically per session
+//   - text longer than maxTurnLen → truncated with " [truncated]" suffix
+func (a *ingestAccumulator) ConsumeFile(r io.Reader) error {
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, maxScannerTokenSize), maxScannerTokenSize)
-
-	seen := make(map[string]struct{}) // dedup keys seen so far
-	turnIndex := 0
 
 	for scanner.Scan() {
 		line := scanner.Bytes()
@@ -97,125 +134,140 @@ func ParseIngestSession(r io.Reader, indexKey string, maxTurnLen int, meta *Sess
 
 		// Schema validation — reject and log unknown schemas.
 		if !knownIngestSchemas[rec.Schema] {
-			log.Printf("conversations/ingest: rejected record with unknown schema %q in session %s", rec.Schema, indexKey)
-			rejectedSchemas++
+			log.Printf("conversations/ingest: rejected record with unknown schema %q (source=%q session_id=%q)", rec.Schema, rec.Source, rec.SessionID)
+			a.RejectedSchemas++
 			continue
 		}
 
 		// Required field validation.
 		if rec.Source == "" || rec.SessionID == "" || rec.Role == "" || rec.Timestamp == "" || rec.Text == "" {
-			log.Printf("conversations/ingest: rejected record missing required fields in session %s (source=%q session_id=%q role=%q timestamp=%q text_len=%d)",
-				indexKey, rec.Source, rec.SessionID, rec.Role, rec.Timestamp, len(rec.Text))
+			log.Printf("conversations/ingest: rejected record missing required fields (source=%q session_id=%q role=%q timestamp=%q text_len=%d)",
+				rec.Source, rec.SessionID, rec.Role, rec.Timestamp, len(rec.Text))
 			continue
 		}
 
 		// Role validation.
 		role, roleOK := validIngestRoles[rec.Role]
 		if !roleOK {
-			log.Printf("conversations/ingest: rejected record with unknown role %q in session %s", rec.Role, indexKey)
+			log.Printf("conversations/ingest: rejected record with unknown role %q (source=%q session_id=%q)", rec.Role, rec.Source, rec.SessionID)
 			continue
 		}
 
-		// Dedup key.
-		dedupKey := ingestDedupKey(rec)
-		if _, dup := seen[dedupKey]; dup {
+		key := indexKeyForIngest(rec.Source, rec.SessionID)
+		sess, ok := a.sessions[key]
+		if !ok {
+			sess = &ingestSessionAccum{
+				Meta: SessionMeta{
+					SessionID: key,
+					Source:    rec.Source,
+				},
+				seen: make(map[string]struct{}),
+			}
+			a.sessions[key] = sess
+			a.order = append(a.order, key)
+		}
+
+		// Dedup within the session (spans files).
+		turnUUID, dedupKey := ingestRecordID(rec)
+		if _, dup := sess.seen[dedupKey]; dup {
 			continue
 		}
-		seen[dedupKey] = struct{}{}
+		sess.seen[dedupKey] = struct{}{}
 
 		// Assign monotonic turn_index when absent.
-		idx := turnIndex
+		idx := len(sess.Turns)
 		if rec.TurnIndex != nil {
 			idx = *rec.TurnIndex
 		}
 
 		// Truncate text.
 		text := rec.Text
-		if len(text) > maxTurnLen {
-			text = text[:maxTurnLen] + " [truncated]"
+		if len(text) > a.maxTurnLen {
+			text = text[:a.maxTurnLen] + " [truncated]"
 		}
 
 		ts := parseTimestamp(rec.Timestamp)
-		updateTimeBounds(meta, ts)
+		updateTimeBounds(&sess.Meta, ts)
 
-		// Session title from any record that carries one.
-		if rec.SessionTitle != "" && meta.Title == "" {
-			meta.Title = rec.SessionTitle
+		// Session title / identity propagate from any record that carries them.
+		if rec.SessionTitle != "" && sess.Meta.Title == "" {
+			sess.Meta.Title = rec.SessionTitle
 		}
-		// Identity from any record that carries one.
-		if rec.Identity != "" && meta.Identity == "" {
-			meta.Identity = rec.Identity
+		if rec.Identity != "" && sess.Meta.Identity == "" {
+			sess.Meta.Identity = rec.Identity
 		}
 
-		turn := Turn{
-			UUID:      dedupKey, // stable identifier within the index
-			SessionID: indexKey,
+		sess.Turns = append(sess.Turns, Turn{
+			UUID:      turnUUID,
+			SessionID: key,
 			TurnIndex: idx,
 			Role:      role,
 			Timestamp: ts,
 			Text:      text,
-		}
-
-		if !callback(turn) {
-			return rejectedSchemas, nil
-		}
-		turnIndex++
-		meta.TurnCount = turnIndex
+		})
+		sess.Meta.TurnCount = len(sess.Turns)
 	}
 
-	return rejectedSchemas, scanner.Err()
+	return scanner.Err()
 }
 
-// ingestDedupKey returns the dedup key for an ingest record.
+// Sessions returns the accumulated sessions in first-seen order.
+func (a *ingestAccumulator) Sessions() []*ingestSessionAccum {
+	out := make([]*ingestSessionAccum, 0, len(a.order))
+	for _, key := range a.order {
+		out = append(out, a.sessions[key])
+	}
+	return out
+}
+
+// ingestRecordID returns the turn UUID and the internal dedup key for an
+// ingest record.
 //
-// Priority:
-//  1. refs.stable_id (if present and non-empty after string conversion)
-//  2. SHA-256 of "<role>\x00<timestamp>\x00<text>"
-func ingestDedupKey(rec ingestRecord) string {
-	// Try to extract stable_id from refs.
-	if len(rec.Refs) > 0 {
-		var refs ingestRefs
-		if json.Unmarshal(rec.Refs, &refs) == nil && refs.StableID != nil {
-			var stableStr string
-			switch v := refs.StableID.(type) {
-			case string:
-				stableStr = v
-			case float64:
-				stableStr = fmt.Sprintf("%.0f", v)
-			default:
-				b, _ := json.Marshal(v)
-				stableStr = string(b)
-			}
-			if stableStr != "" {
-				return "stable:" + rec.Source + ":" + stableStr
-			}
-		}
+// UUID priority:
+//  1. refs.stable_id verbatim (observers emit "<source>:<message_id>",
+//     e.g. "hermes-cog:1") — never re-prefixed.
+//  2. First 16 hex chars of SHA-256("<role>\x00<timestamp>\x00<text>").
+//
+// The dedup key carries an internal namespace prefix ("s:" / "h:") so a
+// stable_id can never collide with a content hash, but that prefix never
+// appears in the UUID.
+func ingestRecordID(rec ingestRecord) (uuid string, dedupKey string) {
+	if stable := ingestStableID(rec); stable != "" {
+		return stable, "s:" + stable
 	}
 
-	// Fall back to content hash.
 	h := sha256.New()
 	h.Write([]byte(rec.Role))
 	h.Write([]byte{0})
 	h.Write([]byte(rec.Timestamp))
 	h.Write([]byte{0})
 	h.Write([]byte(rec.Text))
-	return "hash:" + hex.EncodeToString(h.Sum(nil))[:16]
+	sum := hex.EncodeToString(h.Sum(nil))[:16]
+	return sum, "h:" + sum
+}
+
+// ingestStableID extracts refs.stable_id as a string, or "" when absent.
+func ingestStableID(rec ingestRecord) string {
+	if len(rec.Refs) == 0 {
+		return ""
+	}
+	var refs ingestRefs
+	if json.Unmarshal(rec.Refs, &refs) != nil || refs.StableID == nil {
+		return ""
+	}
+	switch v := refs.StableID.(type) {
+	case string:
+		return v
+	case float64:
+		return fmt.Sprintf("%.0f", v)
+	default:
+		b, _ := json.Marshal(v)
+		return string(b)
+	}
 }
 
 // indexKeyForIngest builds the composite session key used in the index for
 // normalized ingest sessions: "<source>/<session_id>".
 func indexKeyForIngest(source, sessionID string) string {
 	return source + "/" + sessionID
-}
-
-// parseIngestTimestamp parses an ingest record timestamp. Accepts RFC3339 with
-// or without sub-second precision, and Python isoformat strings that use a
-// space separator instead of 'T'.
-func parseIngestTimestamp(s string) time.Time {
-	if s == "" {
-		return time.Time{}
-	}
-	// Normalise Python isoformat space separator to 'T'.
-	normalised := strings.Replace(s, " ", "T", 1)
-	return parseTimestamp(normalised)
 }

--- a/internal/conversations/ingest_parser.go
+++ b/internal/conversations/ingest_parser.go
@@ -1,0 +1,221 @@
+// ingest_parser.go — streaming parser for the normalized ingest surface.
+//
+// Handles records conforming to cogos.observatory.conversations/v0.1.
+// Records with an unknown schema value are rejected and logged; the parser
+// never guesses at schema semantics.
+//
+// Dedup on the normalized path:
+//   - When refs contains a "stable_id" key: dedup by that value.
+//   - Otherwise: dedup by SHA-256 of "<role>\x00<timestamp>\x00<text>".
+//
+// Monotonic turn_index is assigned per (source, session_id) when absent from
+// the record.
+package conversations
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"strings"
+	"time"
+)
+
+// knownIngestSchemas is the set of schema values this parser speaks.
+// Records declaring any other schema value are rejected.
+var knownIngestSchemas = map[string]bool{
+	"cogos.observatory.conversations/v0.1": true,
+}
+
+// validIngestRoles is the allowed set of role values per the schema contract.
+var validIngestRoles = map[string]Role{
+	"user":      RoleUser,
+	"assistant": RoleAssistant,
+	"tool":      RoleTool,
+	"system":    RoleSystem,
+}
+
+// ingestRecord is the decoded form of one line in a normalized ingest JSONL.
+type ingestRecord struct {
+	Schema       string          `json:"schema"`
+	Source       string          `json:"source"`
+	SessionID    string          `json:"session_id"`
+	SessionTitle string          `json:"session_title,omitempty"`
+	TurnIndex    *int            `json:"turn_index,omitempty"` // pointer so we can detect absence
+	Role         string          `json:"role"`
+	Timestamp    string          `json:"timestamp"`
+	Text         string          `json:"text"`
+	Identity     string          `json:"identity,omitempty"`
+	Refs         json.RawMessage `json:"refs,omitempty"`
+}
+
+// ingestRefs is the optional refs object within an ingest record.
+type ingestRefs struct {
+	StableID any    `json:"stable_id,omitempty"` // stable per-record id for dedup
+	DB       string `json:"db,omitempty"`
+	MessageID any   `json:"message_id,omitempty"`
+}
+
+// ParseIngestSession streams turns from a normalized ingest JSONL. r is the
+// open file (caller controls open/close). The indexKey is the composite
+// "<source>/<session_id>" used as the session key in the index.
+//
+// Behaviour:
+//   - Records with unknown schema → rejected, logged, counted in stats.
+//   - Records with unknown role  → rejected, logged.
+//   - Missing required fields (source, session_id, role, timestamp, text) → rejected, logged.
+//   - Duplicate records (by stable_id or content hash) → silently skipped.
+//   - turn_index absent           → assigned monotonically from 0.
+//   - text longer than maxTurnLen → truncated with " [truncated]" suffix.
+//
+// Returns the number of records rejected due to schema mismatch.
+func ParseIngestSession(r io.Reader, indexKey string, maxTurnLen int, meta *SessionMeta, callback func(Turn) bool) (rejectedSchemas int, err error) {
+	if maxTurnLen <= 0 {
+		maxTurnLen = defaultMaxTurnLen
+	}
+
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, maxScannerTokenSize), maxScannerTokenSize)
+
+	seen := make(map[string]struct{}) // dedup keys seen so far
+	turnIndex := 0
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var rec ingestRecord
+		if jsonErr := json.Unmarshal(line, &rec); jsonErr != nil {
+			// Skip unparseable lines gracefully.
+			continue
+		}
+
+		// Schema validation — reject and log unknown schemas.
+		if !knownIngestSchemas[rec.Schema] {
+			log.Printf("conversations/ingest: rejected record with unknown schema %q in session %s", rec.Schema, indexKey)
+			rejectedSchemas++
+			continue
+		}
+
+		// Required field validation.
+		if rec.Source == "" || rec.SessionID == "" || rec.Role == "" || rec.Timestamp == "" || rec.Text == "" {
+			log.Printf("conversations/ingest: rejected record missing required fields in session %s (source=%q session_id=%q role=%q timestamp=%q text_len=%d)",
+				indexKey, rec.Source, rec.SessionID, rec.Role, rec.Timestamp, len(rec.Text))
+			continue
+		}
+
+		// Role validation.
+		role, roleOK := validIngestRoles[rec.Role]
+		if !roleOK {
+			log.Printf("conversations/ingest: rejected record with unknown role %q in session %s", rec.Role, indexKey)
+			continue
+		}
+
+		// Dedup key.
+		dedupKey := ingestDedupKey(rec)
+		if _, dup := seen[dedupKey]; dup {
+			continue
+		}
+		seen[dedupKey] = struct{}{}
+
+		// Assign monotonic turn_index when absent.
+		idx := turnIndex
+		if rec.TurnIndex != nil {
+			idx = *rec.TurnIndex
+		}
+
+		// Truncate text.
+		text := rec.Text
+		if len(text) > maxTurnLen {
+			text = text[:maxTurnLen] + " [truncated]"
+		}
+
+		ts := parseTimestamp(rec.Timestamp)
+		updateTimeBounds(meta, ts)
+
+		// Session title from any record that carries one.
+		if rec.SessionTitle != "" && meta.Title == "" {
+			meta.Title = rec.SessionTitle
+		}
+		// Identity from any record that carries one.
+		if rec.Identity != "" && meta.Identity == "" {
+			meta.Identity = rec.Identity
+		}
+
+		turn := Turn{
+			UUID:      dedupKey, // stable identifier within the index
+			SessionID: indexKey,
+			TurnIndex: idx,
+			Role:      role,
+			Timestamp: ts,
+			Text:      text,
+		}
+
+		if !callback(turn) {
+			return rejectedSchemas, nil
+		}
+		turnIndex++
+		meta.TurnCount = turnIndex
+	}
+
+	return rejectedSchemas, scanner.Err()
+}
+
+// ingestDedupKey returns the dedup key for an ingest record.
+//
+// Priority:
+//  1. refs.stable_id (if present and non-empty after string conversion)
+//  2. SHA-256 of "<role>\x00<timestamp>\x00<text>"
+func ingestDedupKey(rec ingestRecord) string {
+	// Try to extract stable_id from refs.
+	if len(rec.Refs) > 0 {
+		var refs ingestRefs
+		if json.Unmarshal(rec.Refs, &refs) == nil && refs.StableID != nil {
+			var stableStr string
+			switch v := refs.StableID.(type) {
+			case string:
+				stableStr = v
+			case float64:
+				stableStr = fmt.Sprintf("%.0f", v)
+			default:
+				b, _ := json.Marshal(v)
+				stableStr = string(b)
+			}
+			if stableStr != "" {
+				return "stable:" + rec.Source + ":" + stableStr
+			}
+		}
+	}
+
+	// Fall back to content hash.
+	h := sha256.New()
+	h.Write([]byte(rec.Role))
+	h.Write([]byte{0})
+	h.Write([]byte(rec.Timestamp))
+	h.Write([]byte{0})
+	h.Write([]byte(rec.Text))
+	return "hash:" + hex.EncodeToString(h.Sum(nil))[:16]
+}
+
+// indexKeyForIngest builds the composite session key used in the index for
+// normalized ingest sessions: "<source>/<session_id>".
+func indexKeyForIngest(source, sessionID string) string {
+	return source + "/" + sessionID
+}
+
+// parseIngestTimestamp parses an ingest record timestamp. Accepts RFC3339 with
+// or without sub-second precision, and Python isoformat strings that use a
+// space separator instead of 'T'.
+func parseIngestTimestamp(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	// Normalise Python isoformat space separator to 'T'.
+	normalised := strings.Replace(s, " ", "T", 1)
+	return parseTimestamp(normalised)
+}

--- a/internal/conversations/mcp_tools.go
+++ b/internal/conversations/mcp_tools.go
@@ -94,6 +94,7 @@ func makeSearchConversationsHandler(p *Provider) mcp.ToolHandlerFor[searchConver
 			Excerpt      string `json:"excerpt"`
 			SessionTitle string `json:"session_title,omitempty"`
 			Identity     string `json:"identity,omitempty"`
+			Source       string `json:"source,omitempty"`
 		}
 		out := make([]hitOut, 0, len(hits))
 		for _, h := range hits {
@@ -110,6 +111,7 @@ func makeSearchConversationsHandler(p *Provider) mcp.ToolHandlerFor[searchConver
 				Excerpt:      h.Excerpt,
 				SessionTitle: h.SessionTitle,
 				Identity:     h.Identity,
+				Source:       h.Source,
 			})
 		}
 
@@ -209,6 +211,7 @@ func makeListConversationsHandler(p *Provider) mcp.ToolHandlerFor[listConversati
 
 		type sessionOut struct {
 			SessionID   string `json:"session_id"`
+			Source      string `json:"source,omitempty"`
 			Title       string `json:"title,omitempty"`
 			TurnCount   int    `json:"turn_count"`
 			FirstTurnAt string `json:"first_turn_at,omitempty"`
@@ -221,6 +224,7 @@ func makeListConversationsHandler(p *Provider) mcp.ToolHandlerFor[listConversati
 		for _, m := range metas {
 			so := sessionOut{
 				SessionID:  m.SessionID,
+				Source:     m.Source,
 				Title:      m.Title,
 				TurnCount:  m.TurnCount,
 				Identity:   m.Identity,

--- a/internal/conversations/parser.go
+++ b/internal/conversations/parser.go
@@ -78,6 +78,11 @@ type rawAITitle struct {
 // updating meta in place. r is typically an os.File; it is NOT closed.
 // The caller controls open/close. callback may return false to abort early.
 //
+// Dedup: turns with a duplicate uuid within the same session are silently
+// skipped. This handles resumed/compacted JSONL files where CC re-appends
+// historical turns that are already present, causing the same uuid to appear
+// at two different turn_indexes.
+//
 // ParseSession is purely functional: no global state, no side effects beyond
 // the callbacks. Tests can supply a strings.Reader fixture.
 func ParseSession(r io.Reader, sessionID string, maxTurnLen int, meta *SessionMeta, callback func(Turn) bool) error {
@@ -88,6 +93,7 @@ func ParseSession(r io.Reader, sessionID string, maxTurnLen int, meta *SessionMe
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, maxScannerTokenSize), maxScannerTokenSize)
 
+	seenUUIDs := make(map[string]struct{})
 	turnIndex := 0
 	for scanner.Scan() {
 		line := scanner.Bytes()
@@ -115,6 +121,13 @@ func ParseSession(r io.Reader, sessionID string, maxTurnLen int, meta *SessionMe
 			}
 
 		case "user":
+			// UUID dedup: skip turns whose uuid has already been seen in this session.
+			if rec.UUID != "" {
+				if _, dup := seenUUIDs[rec.UUID]; dup {
+					continue
+				}
+				seenUUIDs[rec.UUID] = struct{}{}
+			}
 			turn, ok := parseUserRecord(&rec, sessionID, turnIndex, maxTurnLen)
 			if !ok {
 				continue
@@ -127,6 +140,13 @@ func ParseSession(r io.Reader, sessionID string, maxTurnLen int, meta *SessionMe
 			meta.TurnCount = turnIndex
 
 		case "assistant":
+			// UUID dedup: skip turns whose uuid has already been seen in this session.
+			if rec.UUID != "" {
+				if _, dup := seenUUIDs[rec.UUID]; dup {
+					continue
+				}
+				seenUUIDs[rec.UUID] = struct{}{}
+			}
 			turn, ok := parseAssistantRecord(&rec, sessionID, turnIndex, maxTurnLen)
 			if !ok {
 				continue

--- a/internal/conversations/provider.go
+++ b/internal/conversations/provider.go
@@ -81,16 +81,23 @@ func (p *Provider) LoadConfig(root string) (any, error) {
 	}
 	p.mu.Unlock()
 
-	// Discover source JSONL files.
+	// Discover CC source JSONL files.
 	files, err := discoverSourceFiles(obs)
 	if err != nil {
 		return nil, fmt.Errorf("conversations: discover source files: %w", err)
 	}
 
+	// Discover normalized ingest sources.
+	ingestSources, err := discoverIngestSources(obs)
+	if err != nil {
+		return nil, fmt.Errorf("conversations: discover ingest sources: %w", err)
+	}
+
 	return &providerConfig{
-		Root:        root,
-		Observatory: obs,
-		SourceFiles: files,
+		Root:          root,
+		Observatory:   obs,
+		SourceFiles:   files,
+		IngestSources: ingestSources,
 	}, nil
 }
 
@@ -152,7 +159,16 @@ func (p *Provider) ComputePlan(config any, live any, _ *reconcile.State) (*recon
 		sourceSet[f.SessionID] = f
 	}
 
-	// Walk source files.
+	// Split live entries: CC sessions have Meta.Source == ""; normalized
+	// ingest sessions carry their observer source id.
+	ingestEntriesBySource := make(map[string][]IndexEntry)
+	for _, entry := range ls.Entries {
+		if entry.Meta.Source != "" {
+			ingestEntriesBySource[entry.Meta.Source] = append(ingestEntriesBySource[entry.Meta.Source], entry)
+		}
+	}
+
+	// ── CC source files ──────────────────────────────────────────────────────
 	for _, f := range cfg.SourceFiles {
 		existing, indexed := ls.Entries[f.SessionID]
 		switch {
@@ -162,11 +178,9 @@ func (p *Provider) ComputePlan(config any, live any, _ *reconcile.State) (*recon
 				ResourceType: "conversations",
 				Name:         f.SessionID,
 				Details: map[string]any{
-					"source_path":   f.Path,
-					"mtime":         f.Mtime.Format(time.RFC3339),
-					"size":          f.Size,
-					"is_ingest":     f.IsIngest,
-					"ingest_source": f.IngestSource,
+					"source_path": f.Path,
+					"mtime":       f.Mtime.Format(time.RFC3339),
+					"size":        f.Size,
 				},
 			})
 			plan.Summary.Creates++
@@ -177,14 +191,12 @@ func (p *Provider) ComputePlan(config any, live any, _ *reconcile.State) (*recon
 				ResourceType: "conversations",
 				Name:         f.SessionID,
 				Details: map[string]any{
-					"source_path":   f.Path,
-					"mtime":         f.Mtime.Format(time.RFC3339),
-					"size":          f.Size,
-					"prev_mtime":    existing.Meta.SourceMtime.Format(time.RFC3339),
-					"prev_size":     existing.Meta.SourceSize,
-					"prev_turns":    existing.Meta.TurnCount,
-					"is_ingest":     f.IsIngest,
-					"ingest_source": f.IngestSource,
+					"source_path": f.Path,
+					"mtime":       f.Mtime.Format(time.RFC3339),
+					"size":        f.Size,
+					"prev_mtime":  existing.Meta.SourceMtime.Format(time.RFC3339),
+					"prev_size":   existing.Meta.SourceSize,
+					"prev_turns":  existing.Meta.TurnCount,
 				},
 			})
 			plan.Summary.Updates++
@@ -203,9 +215,67 @@ func (p *Provider) ComputePlan(config any, live any, _ *reconcile.State) (*recon
 		}
 	}
 
-	// Sessions in index but no longer in source.
-	for sid := range ls.Entries {
-		if _, inSource := sourceSet[sid]; !inSource {
+	// ── Normalized ingest sources (one action per SOURCE, not per file) ──────
+	configuredIngest := make(map[string]struct{}, len(cfg.IngestSources))
+	for _, src := range cfg.IngestSources {
+		configuredIngest[src.Source] = struct{}{}
+		indexed := ingestEntriesBySource[src.Source]
+		details := map[string]any{
+			"is_ingest":    true,
+			"source_dir":   src.Dir,
+			"ingest_files": src.Files,
+			"total_size":   src.TotalSize,
+			"latest_mtime": src.LatestMtime.Format(time.RFC3339),
+		}
+
+		switch {
+		case len(indexed) == 0:
+			plan.Actions = append(plan.Actions, reconcile.Action{
+				Action:       reconcile.ActionCreate,
+				ResourceType: "conversations",
+				Name:         src.Source,
+				Details:      details,
+			})
+			plan.Summary.Creates++
+
+		case isIngestDrift(indexed, src):
+			details["prev_sessions"] = len(indexed)
+			plan.Actions = append(plan.Actions, reconcile.Action{
+				Action:       reconcile.ActionUpdate,
+				ResourceType: "conversations",
+				Name:         src.Source,
+				Details:      details,
+			})
+			plan.Summary.Updates++
+
+		default:
+			plan.Actions = append(plan.Actions, reconcile.Action{
+				Action:       reconcile.ActionSkip,
+				ResourceType: "conversations",
+				Name:         src.Source,
+				Details: map[string]any{
+					"reason":   "in sync",
+					"sessions": len(indexed),
+				},
+			})
+			plan.Summary.Skipped++
+		}
+	}
+
+	// ── Deletes ──────────────────────────────────────────────────────────────
+	// CC sessions in index but no longer in source; ingest sessions whose
+	// source is no longer configured. Stale sessions within a still-configured
+	// ingest source are pruned by ApplyPlan after re-parse.
+	for sid, entry := range ls.Entries {
+		var stale bool
+		if entry.Meta.Source == "" {
+			_, inSource := sourceSet[sid]
+			stale = !inSource
+		} else {
+			_, configured := configuredIngest[entry.Meta.Source]
+			stale = !configured
+		}
+		if stale {
 			plan.Actions = append(plan.Actions, reconcile.Action{
 				Action:       reconcile.ActionDelete,
 				ResourceType: "conversations",
@@ -271,6 +341,22 @@ func (p *Provider) ApplyPlan(ctx context.Context, plan *reconcile.Plan) ([]recon
 
 		switch action.Action {
 		case reconcile.ActionCreate, reconcile.ActionUpdate:
+			if isIngest, _ := action.Details["is_ingest"].(bool); isIngest {
+				// Normalized ingest: action.Name is the SOURCE; re-parse all
+				// of its files and rebuild every session of that source.
+				if applyErr := applyIngestSource(idx, action); applyErr != nil {
+					res.Status = reconcile.ApplyFailed
+					res.Error = fmt.Sprintf("index ingest source %s: %v", action.Name, applyErr)
+					results = append(results, res)
+					errs = append(errs, res.Error)
+					continue
+				}
+				res.Status = reconcile.ApplySucceeded
+				res.CreatedID = action.Name
+				results = append(results, res)
+				continue
+			}
+
 			sourcePath, _ := action.Details["source_path"].(string)
 			if sourcePath == "" {
 				res.Status = reconcile.ApplyFailed
@@ -279,16 +365,8 @@ func (p *Provider) ApplyPlan(ctx context.Context, plan *reconcile.Plan) ([]recon
 				errs = append(errs, res.Error)
 				continue
 			}
-			isIngest, _ := action.Details["is_ingest"].(bool)
-			ingestSource, _ := action.Details["ingest_source"].(string)
-			sf := sourceFileInfo{
-				Path:         sourcePath,
-				SessionID:    action.Name,
-				IsIngest:     isIngest,
-				IngestSource: ingestSource,
-			}
 
-			meta, turns, err := indexSession(sourcePath, action.Name, defaultMaxTurnLen, sf)
+			meta, turns, err := indexSession(sourcePath, action.Name, defaultMaxTurnLen)
 			if err != nil {
 				res.Status = reconcile.ApplyFailed
 				res.Error = fmt.Sprintf("index session %s: %v", action.Name, err)
@@ -509,13 +587,11 @@ func defaultIngestDirs(root string) []string {
 	return nil
 }
 
-// discoverSourceFiles scans SourceDirs (CC UUID JSONL) and IngestDirs
-// (normalized ingest surface) and returns the union as sourceFileInfo entries.
+// discoverSourceFiles scans SourceDirs and returns matching CC JSONL files.
 func discoverSourceFiles(obs ObservatoryConfig) ([]sourceFileInfo, error) {
 	var files []sourceFileInfo
 	seen := make(map[string]struct{})
 
-	// ── CC source_dirs path ──────────────────────────────────────────────────
 	for _, dir := range obs.SourceDirs {
 		expanded := expandHome(dir)
 		entries, err := os.ReadDir(expanded)
@@ -561,30 +637,18 @@ func discoverSourceFiles(obs ObservatoryConfig) ([]sourceFileInfo, error) {
 		}
 	}
 
-	// ── Normalized ingest path ───────────────────────────────────────────────
-	ingestFiles, err := discoverIngestFiles(obs)
-	if err != nil {
-		return nil, err
-	}
-	for _, f := range ingestFiles {
-		if _, dup := seen[f.Path]; dup {
-			continue
-		}
-		seen[f.Path] = struct{}{}
-		files = append(files, f)
-	}
-
 	sort.Slice(files, func(i, j int) bool {
 		return files[i].SessionID < files[j].SessionID
 	})
 	return files, nil
 }
 
-// discoverIngestFiles scans IngestDirs for <source>/*.jsonl files conforming
-// to the normalized ingest surface schema. Returns one sourceFileInfo per file
-// with IsIngest=true and SessionID keyed as "<source>/<filename_stem>".
-func discoverIngestFiles(obs ObservatoryConfig) ([]sourceFileInfo, error) {
-	var files []sourceFileInfo
+// discoverIngestSources scans IngestDirs for <source>/*.jsonl files and
+// returns one ingestSourceInfo per source directory, aggregating file list,
+// total size, and latest mtime. Sources appearing under multiple ingest roots
+// are merged into one entry.
+func discoverIngestSources(obs ObservatoryConfig) ([]ingestSourceInfo, error) {
+	bySource := make(map[string]*ingestSourceInfo)
 
 	for _, ingestRoot := range obs.IngestDirs {
 		expanded := expandHome(ingestRoot)
@@ -611,6 +675,12 @@ func discoverIngestFiles(obs ObservatoryConfig) ([]sourceFileInfo, error) {
 				return nil, fmt.Errorf("read ingest source dir %s: %w", sourceDir, err)
 			}
 
+			src, ok := bySource[sourceName]
+			if !ok {
+				src = &ingestSourceInfo{Source: sourceName, Dir: sourceDir}
+				bySource[sourceName] = src
+			}
+
 			for _, je := range jsonlEntries {
 				if je.IsDir() {
 					continue
@@ -619,27 +689,29 @@ func discoverIngestFiles(obs ObservatoryConfig) ([]sourceFileInfo, error) {
 				if !strings.HasSuffix(name, ".jsonl") {
 					continue
 				}
-				stem := strings.TrimSuffix(name, ".jsonl")
-				// Composite index key: "<source>/<filename_stem>".
-				indexKey := indexKeyForIngest(sourceName, stem)
-				absPath := filepath.Join(sourceDir, name)
-
 				fi, err := je.Info()
 				if err != nil {
 					continue
 				}
-				files = append(files, sourceFileInfo{
-					Path:         absPath,
-					SessionID:    indexKey,
-					Mtime:        fi.ModTime(),
-					Size:         fi.Size(),
-					IsIngest:     true,
-					IngestSource: sourceName,
-				})
+				src.Files = append(src.Files, filepath.Join(sourceDir, name))
+				src.TotalSize += fi.Size()
+				if fi.ModTime().After(src.LatestMtime) {
+					src.LatestMtime = fi.ModTime()
+				}
 			}
 		}
 	}
-	return files, nil
+
+	var out []ingestSourceInfo
+	for _, src := range bySource {
+		if len(src.Files) == 0 {
+			continue
+		}
+		sort.Strings(src.Files)
+		out = append(out, *src)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Source < out[j].Source })
+	return out, nil
 }
 
 // sessionIDFromFilename extracts the UUID from a filename like
@@ -702,11 +774,7 @@ func isDrift(meta SessionMeta, f sourceFileInfo) bool {
 
 // indexSession opens sourcePath, streams turns, and returns the resulting
 // SessionMeta and Turn slice. Does not hold the file open after return.
-//
-// When sf.IsIngest is true the normalized ingest parser (ingest_parser.go) is
-// used instead of the CC JSONL parser; sf.IngestSource is populated into the
-// returned SessionMeta.Source.
-func indexSession(sourcePath, sessionID string, maxTurnLen int, sf sourceFileInfo) (SessionMeta, []Turn, error) {
+func indexSession(sourcePath, sessionID string, maxTurnLen int) (SessionMeta, []Turn, error) {
 	fi, err := os.Stat(sourcePath)
 	if err != nil {
 		return SessionMeta{}, nil, fmt.Errorf("stat %s: %w", sourcePath, err)
@@ -720,7 +788,6 @@ func indexSession(sourcePath, sessionID string, maxTurnLen int, sf sourceFileInf
 
 	meta := SessionMeta{
 		SessionID:   sessionID,
-		Source:      sf.IngestSource,
 		SourcePath:  sourcePath,
 		IndexedAt:   time.Now().UTC(),
 		SourceMtime: fi.ModTime(),
@@ -728,22 +795,6 @@ func indexSession(sourcePath, sessionID string, maxTurnLen int, sf sourceFileInf
 	}
 
 	var turns []Turn
-
-	if sf.IsIngest {
-		rejected, parseErr := ParseIngestSession(f, sessionID, maxTurnLen, &meta, func(t Turn) bool {
-			turns = append(turns, t)
-			return true
-		})
-		if parseErr != nil {
-			return meta, turns, fmt.Errorf("parse ingest %s: %w", sourcePath, parseErr)
-		}
-		if rejected > 0 {
-			// Non-fatal: we already logged per-record rejections.
-			_ = rejected
-		}
-		return meta, turns, nil
-	}
-
 	err = ParseSession(f, sessionID, maxTurnLen, &meta, func(t Turn) bool {
 		turns = append(turns, t)
 		return true
@@ -753,4 +804,108 @@ func indexSession(sourcePath, sessionID string, maxTurnLen int, sf sourceFileInf
 	}
 
 	return meta, turns, nil
+}
+
+// isIngestDrift returns true when the indexed sessions of a source are stale
+// compared to the source's current file aggregate. All sessions of a source
+// share the same stored (SourceSize, SourceMtime) aggregate values from the
+// last apply, so checking one entry suffices; we check all defensively.
+func isIngestDrift(indexed []IndexEntry, src ingestSourceInfo) bool {
+	for _, entry := range indexed {
+		if entry.Meta.SourceSize != src.TotalSize {
+			return true
+		}
+		diff := entry.Meta.SourceMtime.Sub(src.LatestMtime)
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff > 2*time.Second {
+			return true
+		}
+	}
+	return false
+}
+
+// applyIngestSource re-parses every file of an ingest source (action.Name),
+// upserts each resulting session, and prunes index sessions of that source
+// that no longer appear in the parse result.
+func applyIngestSource(idx *Index, action reconcile.Action) error {
+	sourceDir, _ := action.Details["source_dir"].(string)
+	files := stringSliceDetail(action.Details["ingest_files"])
+	if len(files) == 0 {
+		return fmt.Errorf("no ingest_files in plan action")
+	}
+
+	// Aggregate stats for drift bookkeeping on each session meta.
+	var totalSize int64
+	var latestMtime time.Time
+	acc := newIngestAccumulator(defaultMaxTurnLen)
+	for _, path := range files {
+		fi, err := os.Stat(path)
+		if err != nil {
+			return fmt.Errorf("stat %s: %w", path, err)
+		}
+		totalSize += fi.Size()
+		if fi.ModTime().After(latestMtime) {
+			latestMtime = fi.ModTime()
+		}
+
+		f, err := os.Open(path)
+		if err != nil {
+			return fmt.Errorf("open %s: %w", path, err)
+		}
+		consumeErr := acc.ConsumeFile(f)
+		f.Close()
+		if consumeErr != nil {
+			return fmt.Errorf("parse %s: %w", path, consumeErr)
+		}
+	}
+
+	now := time.Now().UTC()
+	parsed := make(map[string]struct{})
+	for _, sess := range acc.Sessions() {
+		sess.Meta.SourcePath = sourceDir
+		sess.Meta.IndexedAt = now
+		sess.Meta.SourceMtime = latestMtime
+		sess.Meta.SourceSize = totalSize
+		if err := idx.UpsertSession(sess.Meta, sess.Turns); err != nil {
+			return fmt.Errorf("upsert session %s: %w", sess.Meta.SessionID, err)
+		}
+		parsed[sess.Meta.SessionID] = struct{}{}
+	}
+
+	// Prune sessions of this source that vanished from the parse result
+	// (observer files are append-only, so this is rare — defensive only).
+	for _, meta := range idx.ListSessions(time.Time{}, time.Time{}, "") {
+		if meta.Source != action.Name {
+			continue
+		}
+		if _, ok := parsed[meta.SessionID]; !ok {
+			if err := idx.DeleteSession(meta.SessionID); err != nil {
+				return fmt.Errorf("prune stale session %s: %w", meta.SessionID, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// stringSliceDetail coerces a plan-action detail value into []string.
+// Handles both the in-process []string form and the []any form a JSON
+// round-trip would produce.
+func stringSliceDetail(v any) []string {
+	switch t := v.(type) {
+	case []string:
+		return t
+	case []any:
+		out := make([]string, 0, len(t))
+		for _, e := range t {
+			if s, ok := e.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
 }

--- a/internal/conversations/provider.go
+++ b/internal/conversations/provider.go
@@ -162,9 +162,11 @@ func (p *Provider) ComputePlan(config any, live any, _ *reconcile.State) (*recon
 				ResourceType: "conversations",
 				Name:         f.SessionID,
 				Details: map[string]any{
-					"source_path": f.Path,
-					"mtime":       f.Mtime.Format(time.RFC3339),
-					"size":        f.Size,
+					"source_path":   f.Path,
+					"mtime":         f.Mtime.Format(time.RFC3339),
+					"size":          f.Size,
+					"is_ingest":     f.IsIngest,
+					"ingest_source": f.IngestSource,
 				},
 			})
 			plan.Summary.Creates++
@@ -181,6 +183,8 @@ func (p *Provider) ComputePlan(config any, live any, _ *reconcile.State) (*recon
 					"prev_mtime":    existing.Meta.SourceMtime.Format(time.RFC3339),
 					"prev_size":     existing.Meta.SourceSize,
 					"prev_turns":    existing.Meta.TurnCount,
+					"is_ingest":     f.IsIngest,
+					"ingest_source": f.IngestSource,
 				},
 			})
 			plan.Summary.Updates++
@@ -275,8 +279,16 @@ func (p *Provider) ApplyPlan(ctx context.Context, plan *reconcile.Plan) ([]recon
 				errs = append(errs, res.Error)
 				continue
 			}
+			isIngest, _ := action.Details["is_ingest"].(bool)
+			ingestSource, _ := action.Details["ingest_source"].(string)
+			sf := sourceFileInfo{
+				Path:         sourcePath,
+				SessionID:    action.Name,
+				IsIngest:     isIngest,
+				IngestSource: ingestSource,
+			}
 
-			meta, turns, err := indexSession(sourcePath, action.Name, defaultMaxTurnLen)
+			meta, turns, err := indexSession(sourcePath, action.Name, defaultMaxTurnLen, sf)
 			if err != nil {
 				res.Status = reconcile.ApplyFailed
 				res.Error = fmt.Sprintf("index session %s: %v", action.Name, err)
@@ -365,6 +377,7 @@ func (p *Provider) BuildState(_ any, live any, existing *reconcile.State) (*reco
 			LastRefreshed: now,
 			Attributes: map[string]any{
 				"source_path":   m.SourcePath,
+				"source":        m.Source,
 				"turn_count":    m.TurnCount,
 				"first_turn_at": m.FirstTurnAt.Format(time.RFC3339),
 				"last_turn_at":  m.LastTurnAt.Format(time.RFC3339),
@@ -457,6 +470,7 @@ func loadObservatoryConfig(root string) (ObservatoryConfig, error) {
 		if os.IsNotExist(err) {
 			// Default config.
 			obs.SourceDirs = defaultSourceDirs()
+			obs.IngestDirs = defaultIngestDirs(root)
 			obs.IncludePatterns = []string{"*.jsonl"}
 			obs.MaxTurnLength = defaultMaxTurnLen
 			return obs, nil
@@ -472,6 +486,9 @@ func loadObservatoryConfig(root string) (ObservatoryConfig, error) {
 	if len(obs.SourceDirs) == 0 {
 		obs.SourceDirs = defaultSourceDirs()
 	}
+	if len(obs.IngestDirs) == 0 {
+		obs.IngestDirs = defaultIngestDirs(root)
+	}
 	if len(obs.IncludePatterns) == 0 {
 		obs.IncludePatterns = []string{"*.jsonl"}
 	}
@@ -482,11 +499,23 @@ func loadObservatoryConfig(root string) (ObservatoryConfig, error) {
 	return obs, nil
 }
 
-// discoverSourceFiles scans SourceDirs and returns matching JSONL files.
+// defaultIngestDirs returns the default ingest root directory for the given
+// workspace root: <root>/.cog/observatory/ingest. Returns nil if absent.
+func defaultIngestDirs(root string) []string {
+	candidate := filepath.Join(root, ".cog", "observatory", "ingest")
+	if _, err := os.Stat(candidate); err == nil {
+		return []string{candidate}
+	}
+	return nil
+}
+
+// discoverSourceFiles scans SourceDirs (CC UUID JSONL) and IngestDirs
+// (normalized ingest surface) and returns the union as sourceFileInfo entries.
 func discoverSourceFiles(obs ObservatoryConfig) ([]sourceFileInfo, error) {
 	var files []sourceFileInfo
 	seen := make(map[string]struct{})
 
+	// ── CC source_dirs path ──────────────────────────────────────────────────
 	for _, dir := range obs.SourceDirs {
 		expanded := expandHome(dir)
 		entries, err := os.ReadDir(expanded)
@@ -532,9 +561,84 @@ func discoverSourceFiles(obs ObservatoryConfig) ([]sourceFileInfo, error) {
 		}
 	}
 
+	// ── Normalized ingest path ───────────────────────────────────────────────
+	ingestFiles, err := discoverIngestFiles(obs)
+	if err != nil {
+		return nil, err
+	}
+	for _, f := range ingestFiles {
+		if _, dup := seen[f.Path]; dup {
+			continue
+		}
+		seen[f.Path] = struct{}{}
+		files = append(files, f)
+	}
+
 	sort.Slice(files, func(i, j int) bool {
 		return files[i].SessionID < files[j].SessionID
 	})
+	return files, nil
+}
+
+// discoverIngestFiles scans IngestDirs for <source>/*.jsonl files conforming
+// to the normalized ingest surface schema. Returns one sourceFileInfo per file
+// with IsIngest=true and SessionID keyed as "<source>/<filename_stem>".
+func discoverIngestFiles(obs ObservatoryConfig) ([]sourceFileInfo, error) {
+	var files []sourceFileInfo
+
+	for _, ingestRoot := range obs.IngestDirs {
+		expanded := expandHome(ingestRoot)
+		sourceDirs, err := os.ReadDir(expanded)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("read ingest dir %s: %w", expanded, err)
+		}
+
+		for _, sourceEntry := range sourceDirs {
+			if !sourceEntry.IsDir() {
+				continue
+			}
+			sourceName := sourceEntry.Name()
+			sourceDir := filepath.Join(expanded, sourceName)
+
+			jsonlEntries, err := os.ReadDir(sourceDir)
+			if err != nil {
+				if os.IsNotExist(err) {
+					continue
+				}
+				return nil, fmt.Errorf("read ingest source dir %s: %w", sourceDir, err)
+			}
+
+			for _, je := range jsonlEntries {
+				if je.IsDir() {
+					continue
+				}
+				name := je.Name()
+				if !strings.HasSuffix(name, ".jsonl") {
+					continue
+				}
+				stem := strings.TrimSuffix(name, ".jsonl")
+				// Composite index key: "<source>/<filename_stem>".
+				indexKey := indexKeyForIngest(sourceName, stem)
+				absPath := filepath.Join(sourceDir, name)
+
+				fi, err := je.Info()
+				if err != nil {
+					continue
+				}
+				files = append(files, sourceFileInfo{
+					Path:         absPath,
+					SessionID:    indexKey,
+					Mtime:        fi.ModTime(),
+					Size:         fi.Size(),
+					IsIngest:     true,
+					IngestSource: sourceName,
+				})
+			}
+		}
+	}
 	return files, nil
 }
 
@@ -598,7 +702,11 @@ func isDrift(meta SessionMeta, f sourceFileInfo) bool {
 
 // indexSession opens sourcePath, streams turns, and returns the resulting
 // SessionMeta and Turn slice. Does not hold the file open after return.
-func indexSession(sourcePath, sessionID string, maxTurnLen int) (SessionMeta, []Turn, error) {
+//
+// When sf.IsIngest is true the normalized ingest parser (ingest_parser.go) is
+// used instead of the CC JSONL parser; sf.IngestSource is populated into the
+// returned SessionMeta.Source.
+func indexSession(sourcePath, sessionID string, maxTurnLen int, sf sourceFileInfo) (SessionMeta, []Turn, error) {
 	fi, err := os.Stat(sourcePath)
 	if err != nil {
 		return SessionMeta{}, nil, fmt.Errorf("stat %s: %w", sourcePath, err)
@@ -612,6 +720,7 @@ func indexSession(sourcePath, sessionID string, maxTurnLen int) (SessionMeta, []
 
 	meta := SessionMeta{
 		SessionID:   sessionID,
+		Source:      sf.IngestSource,
 		SourcePath:  sourcePath,
 		IndexedAt:   time.Now().UTC(),
 		SourceMtime: fi.ModTime(),
@@ -619,6 +728,22 @@ func indexSession(sourcePath, sessionID string, maxTurnLen int) (SessionMeta, []
 	}
 
 	var turns []Turn
+
+	if sf.IsIngest {
+		rejected, parseErr := ParseIngestSession(f, sessionID, maxTurnLen, &meta, func(t Turn) bool {
+			turns = append(turns, t)
+			return true
+		})
+		if parseErr != nil {
+			return meta, turns, fmt.Errorf("parse ingest %s: %w", sourcePath, parseErr)
+		}
+		if rejected > 0 {
+			// Non-fatal: we already logged per-record rejections.
+			_ = rejected
+		}
+		return meta, turns, nil
+	}
+
 	err = ParseSession(f, sessionID, maxTurnLen, &meta, func(t Turn) bool {
 		turns = append(turns, t)
 		return true

--- a/internal/conversations/types.go
+++ b/internal/conversations/types.go
@@ -169,23 +169,43 @@ type ObservatoryConfig struct {
 
 // providerConfig is the internal config bundle built by LoadConfig.
 type providerConfig struct {
-	Root        string
-	Observatory ObservatoryConfig
-	SourceFiles []sourceFileInfo // expanded from SourceDirs
+	Root          string
+	Observatory   ObservatoryConfig
+	SourceFiles   []sourceFileInfo   // CC UUID JSONLs expanded from SourceDirs
+	IngestSources []ingestSourceInfo // normalized ingest sources expanded from IngestDirs
 }
 
-// sourceFileInfo is metadata about one discovered source JSONL.
+// sourceFileInfo is metadata about one discovered Claude Code source JSONL.
 type sourceFileInfo struct {
 	Path      string
-	SessionID string    // index key: UUID for CC sessions; "<source>/<session_id>" for ingest sessions
+	SessionID string // derived from filename (UUID before .jsonl)
 	Mtime     time.Time
 	Size      int64
-	// IsIngest is true when this file was discovered via IngestDirs (normalized
-	// ingest surface) rather than SourceDirs (CC UUID JSONL path).
-	IsIngest bool
-	// IngestSource is the <source> component from the ingest path hierarchy
-	// (e.g. "hermes-darkstar"). Empty for CC source_dirs files.
-	IngestSource string
+}
+
+// ingestSourceInfo is the aggregate of one normalized ingest <source>
+// directory. An ingest FILE is a transport artifact (one per observer run);
+// records from many sessions are interleaved within a file and one session
+// may span several files. Planning therefore happens at SOURCE granularity:
+// the aggregate (TotalSize, LatestMtime) over all files is the drift signal,
+// and ApplyPlan re-parses every file of the source to rebuild its sessions.
+type ingestSourceInfo struct {
+	// Source is the observer-declared source id (directory name, e.g.
+	// "hermes-darkstar").
+	Source string
+
+	// Dir is the absolute path of the source directory.
+	Dir string
+
+	// Files are the absolute paths of the source's JSONL files, sorted by
+	// name (observer run files are timestamp-named → chronological order).
+	Files []string
+
+	// TotalSize is the sum of file sizes (drift detection).
+	TotalSize int64
+
+	// LatestMtime is the most recent file mtime (drift detection).
+	LatestMtime time.Time
 }
 
 // liveState is the result of FetchLive.

--- a/internal/conversations/types.go
+++ b/internal/conversations/types.go
@@ -10,12 +10,13 @@
 // raw JSONL.
 //
 // Package layout:
-//   - types.go      — shared model types (SessionMeta, Turn, IndexEntry, etc.)
-//   - parser.go     — streaming JSONL parser (bufio.Scanner; never os.ReadFile)
-//   - index.go      — in-memory full-text index backed by flat projection files
-//   - provider.go   — Reconcilable implementation
-//   - mcp_tools.go  — cog_search_conversations, cog_get_conversation_turn,
-//                     cog_list_conversations tool registrations
+//   - types.go         — shared model types (SessionMeta, Turn, IndexEntry, etc.)
+//   - parser.go        — streaming JSONL parser (bufio.Scanner; never os.ReadFile)
+//   - ingest_parser.go — normalized ingest surface parser (cogos.observatory.conversations/v0.1)
+//   - index.go         — in-memory full-text index backed by flat projection files
+//   - provider.go      — Reconcilable implementation
+//   - mcp_tools.go     — cog_search_conversations, cog_get_conversation_turn,
+//                        cog_list_conversations tool registrations
 package conversations
 
 import "time"
@@ -27,12 +28,22 @@ const (
 	RoleUser      Role = "user"
 	RoleAssistant Role = "assistant"
 	RoleSystem    Role = "system"
+	RoleTool      Role = "tool"
 )
 
 // SessionMeta carries per-session metadata without loading turn content.
 type SessionMeta struct {
-	// SessionID is the UUID from the JSONL file name.
+	// SessionID is the UUID from the JSONL file name (CC path) or the
+	// observer-declared session_id (normalized ingest path).
 	SessionID string `json:"session_id"`
+
+	// Source identifies the observer that produced this session. Empty for
+	// sessions ingested via the CC source_dirs path; set to the <source>
+	// component of the ingest path for normalized ingest records.
+	//
+	// The index keys normalized-ingest sessions as "<source>/<session_id>" to
+	// prevent collision with CC UUID session keys.
+	Source string `json:"source,omitempty"`
 
 	// SourcePath is the absolute path to the source JSONL.
 	SourcePath string `json:"source_path"`
@@ -96,15 +107,16 @@ type Turn struct {
 
 // SearchHit is one result returned by cog_search_conversations.
 type SearchHit struct {
-	SessionID  string    `json:"session_id"`
-	TurnIndex  int       `json:"turn_index"`
-	UUID       string    `json:"uuid"`
-	Timestamp  time.Time `json:"timestamp"`
-	Role       Role      `json:"role"`
-	Excerpt    string    `json:"excerpt"`    // ~300-char snippet containing the match
-	Context    string    `json:"context,omitempty"` // preceding/following text
-	SessionTitle string  `json:"session_title,omitempty"`
-	Identity   string    `json:"identity,omitempty"`
+	SessionID    string    `json:"session_id"`
+	TurnIndex    int       `json:"turn_index"`
+	UUID         string    `json:"uuid"`
+	Timestamp    time.Time `json:"timestamp"`
+	Role         Role      `json:"role"`
+	Excerpt      string    `json:"excerpt"`              // ~300-char snippet containing the match
+	Context      string    `json:"context,omitempty"`   // preceding/following text
+	SessionTitle string    `json:"session_title,omitempty"`
+	Identity     string    `json:"identity,omitempty"`
+	Source       string    `json:"source,omitempty"` // observer source id, empty for CC sessions
 }
 
 // IndexDepth describes how thoroughly a session is indexed.
@@ -125,9 +137,16 @@ type IndexEntry struct {
 // ObservatoryConfig is the deserialized form of .cog/config/observatory.yaml.
 // Uses yaml struct tags so gopkg.in/yaml.v3 can unmarshal it correctly.
 type ObservatoryConfig struct {
-	// SourceDirs is the list of JSONL source directories to scan.
+	// SourceDirs is the list of JSONL source directories to scan for
+	// Claude Code session files (UUID-named .jsonl).
 	// Defaults to ["~/.claude/projects/-Users-slowbro"].
 	SourceDirs []string `yaml:"source_dirs" json:"source_dirs,omitempty"`
+
+	// IngestDirs is the list of normalized ingest root directories. Each
+	// directory is expected to contain <source>/*.jsonl subdirectories whose
+	// records conform to cogos.observatory.conversations/v0.1.
+	// Defaults to ["<workspace>/.cog/observatory/ingest"].
+	IngestDirs []string `yaml:"ingest_dirs" json:"ingest_dirs,omitempty"`
 
 	// IncludePatterns are glob patterns relative to each SourceDir.
 	// Defaults to ["*.jsonl"].
@@ -158,9 +177,15 @@ type providerConfig struct {
 // sourceFileInfo is metadata about one discovered source JSONL.
 type sourceFileInfo struct {
 	Path      string
-	SessionID string    // derived from filename (UUID before .jsonl)
+	SessionID string    // index key: UUID for CC sessions; "<source>/<session_id>" for ingest sessions
 	Mtime     time.Time
 	Size      int64
+	// IsIngest is true when this file was discovered via IngestDirs (normalized
+	// ingest surface) rather than SourceDirs (CC UUID JSONL path).
+	IsIngest bool
+	// IngestSource is the <source> component from the ingest path hierarchy
+	// (e.g. "hermes-darkstar"). Empty for CC source_dirs files.
+	IngestSource string
 }
 
 // liveState is the result of FetchLive.


### PR DESCRIPTION
## Summary

Three features landing together on the conversations observatory:

**1. Normalized ingest source (`ingest_dirs`)**

New config key `ingest_dirs` in `observatory.yaml` (default: `<workspace>/.cog/observatory/ingest`). Scans `<ingest_dir>/<source>/*.jsonl`; parses records per schema `cogos.observatory.conversations/v0.1` (see schema spec: `cog://mem/working/2026-06-10-conversation-observatory-ingest-schema-v0.1.cog.md`). Required fields: `schema`, `source`, `session_id`, `role`, `timestamp`, `text`. Optional: `session_title`, `turn_index`, `identity`, `refs`. Records with unknown schema values are rejected and logged — never guessed. Sessions are keyed as `<source>/<session_id>` in the index, preventing collision with CC UUID session keys. `source` is exposed in session metadata returned by `cog_list_conversations` and `cog_search_conversations`. Monotonic `turn_index` is assigned per `(source, session_id)` when absent. `max_turn_length` truncation applies at ingest.

**2. Term-AND search with phrase quoting**

`cog_search_conversations` now splits queries on whitespace: a turn matches iff ALL terms are present (case-insensitive substring per term). A double-quoted substring is matched as an exact phrase. Single-term behavior is unchanged. Query examples: `harness attestation` (both words must appear), `"attestation policy" harness` (phrase + term).

**3. Turn dedup on ingest**

- **CC path**: `ParseSession` deduplicates turns by `uuid` within a session. Resumed/compacted JSONL files re-append historical turns; the same `uuid` can appear at two `turn_index` positions — the duplicate is now silently skipped.
- **Normalized path**: `ParseIngestSession` deduplicates by `refs.stable_id` when present, else by SHA-256 of `(role, timestamp, text)`.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/conversations/... -v` — all 27 tests pass
- [x] `go test -short -timeout 120s ./...` — full suite clean
- [x] Table-driven tests cover: schema validation/rejection, required-field validation, role validation, `(source, session_id)` collision isolation, monotonic turn_index, max_turn_length, term-AND search (unit + integration), phrase quoting, `parseSearchQuery` tokenizer, CC uuid dedup, ingest stable_id dedup, ingest content-hash dedup