### PR TITLE
fix(engine): byte-cap all MCP tool outputs with explicit truncation markers

### DIFF
--- a/cmd/cogos/z_conversations_wire.go
+++ b/cmd/cogos/z_conversations_wire.go
@@ -69,7 +69,7 @@ func init() {
 		if prev != nil {
 			prev(srv)
 		}
-		conversations.RegisterConversationTools(srv.Server(), srv.TrackTool, daemonConversationsProvider)
+		conversations.RegisterConversationTools(srv.Server(), srv.TrackTool, daemonConversationsProvider, srv.MaxToolOutputBytes())
 	}
 
 	// Wire the cog:conversations URI resolver behind GET /v1/uri/resolve.

--- a/internal/conversations/mcp_tools.go
+++ b/internal/conversations/mcp_tools.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+	"unicode/utf8"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -36,13 +37,21 @@ type ToolTracker func(*mcp.Tool) *mcp.Tool
 func identityTracker(t *mcp.Tool) *mcp.Tool { return t }
 
 // RegisterConversationTools registers the three conversation MCP tools on the
-// given server. provider may be nil — tools return "not configured" in that case.
-// tracker is MCPServer.TrackTool; pass nil to skip manifest tracking (tests).
-func RegisterConversationTools(server *mcp.Server, tracker ToolTracker, provider *Provider) {
+// given server. provider may be nil — tools return "not configured" in that
+// case. tracker is MCPServer.TrackTool; pass nil to skip manifest tracking
+// (tests). maxBytes caps the byte length of any text response; pass 0 to use
+// the default (32 KiB) — set at registration time because the handlers are
+// closures that capture it.
+func RegisterConversationTools(server *mcp.Server, tracker ToolTracker, provider *Provider, maxBytes int) {
 	if tracker == nil {
 		tracker = identityTracker
 	}
-
+	if maxBytes <= 0 {
+		maxBytes = defaultConvMaxBytes
+	}
+	if maxBytes < minConvMaxBytes {
+		maxBytes = minConvMaxBytes
+	}
 	mcp.AddTool(server, tracker(&mcp.Tool{
 		Name: "cog_search_conversations",
 		Description: "Full-text search over indexed operator conversation history. " +
@@ -51,7 +60,7 @@ func RegisterConversationTools(server *mcp.Server, tracker ToolTracker, provider
 			"use limit to cap results (default 20). " +
 			"Alternatively, pass uri=cog:conversations/… to dereference a query-aware URI directly " +
 			"(RFC-query-aware-conversation-uris R1-R6); mixing uri with other params is an error.",
-	}), makeSearchConversationsHandler(provider))
+	}), makeSearchConversationsHandler(provider, maxBytes))
 
 	mcp.AddTool(server, tracker(&mcp.Tool{
 		Name: "cog_get_conversation_turn",
@@ -59,7 +68,7 @@ func RegisterConversationTools(server *mcp.Server, tracker ToolTracker, provider
 			"Use after cog_search_conversations to drill into a specific hit. " +
 			"Alternatively, pass uri=cog:conversations/<source>/<session>#id-<uuid> or " +
 			"#turn-N to address a turn via URI (RFC-query-aware-conversation-uris).",
-	}), makeGetConversationTurnHandler(provider))
+	}), makeGetConversationTurnHandler(provider, maxBytes))
 
 	mcp.AddTool(server, tracker(&mcp.Tool{
 		Name: "cog_list_conversations",
@@ -67,7 +76,29 @@ func RegisterConversationTools(server *mcp.Server, tracker ToolTracker, provider
 			"(title, turn count, time bounds, identity, entrypoint). " +
 			"Optional since/until (RFC3339) and identity filters. " +
 			"Returns most-recent sessions first.",
-	}), makeListConversationsHandler(provider))
+	}), makeListConversationsHandler(provider, maxBytes))
+}
+
+const (
+	defaultConvMaxBytes = 32 * 1024 // 32 KiB — mirrors engine.DefaultMaxToolOutputBytes
+	minConvMaxBytes     = 4 * 1024  // 4 KiB floor
+)
+
+// capConvOutput trims s to at most maxBytes at a UTF-8 boundary and appends
+// the truncation marker. Mirrors engine.capToolOutput without creating a
+// cross-package dependency.
+func capConvOutput(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	cut := maxBytes
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + fmt.Sprintf(
+		"\n[output truncated: returned %d of %d bytes; narrow with offset/limit/filters, or dereference cog:conversations/... where applicable]",
+		cut, len(s),
+	)
 }
 
 // ─── cog_search_conversations ────────────────────────────────────────────────
@@ -89,7 +120,7 @@ type searchConversationsInput struct {
 	Limit     int    `json:"limit,omitempty"`
 }
 
-func makeSearchConversationsHandler(p *Provider) mcp.ToolHandlerFor[searchConversationsInput, map[string]any] {
+func makeSearchConversationsHandler(p *Provider, maxBytes int) mcp.ToolHandlerFor[searchConversationsInput, map[string]any] {
 	return func(ctx context.Context, req *mcp.CallToolRequest, input searchConversationsInput) (*mcp.CallToolResult, map[string]any, error) {
 		if p == nil {
 			return convErrorResult("conversations provider not wired"), nil, nil
@@ -182,8 +213,9 @@ func makeSearchConversationsHandler(p *Provider) mcp.ToolHandlerFor[searchConver
 			"hits":  out,
 		}
 		b, _ := json.MarshalIndent(resp, "", "  ")
+		text := capConvOutput(string(b), maxBytes)
 		return &mcp.CallToolResult{
-			Content: []mcp.Content{&mcp.TextContent{Text: string(b)}},
+			Content: []mcp.Content{&mcp.TextContent{Text: text}},
 		}, resp, nil
 	}
 }
@@ -203,7 +235,7 @@ type getConversationTurnInput struct {
 	TurnIndex int    `json:"turn_index,omitempty"`
 }
 
-func makeGetConversationTurnHandler(p *Provider) mcp.ToolHandlerFor[getConversationTurnInput, map[string]any] {
+func makeGetConversationTurnHandler(p *Provider, maxBytes int) mcp.ToolHandlerFor[getConversationTurnInput, map[string]any] {
 	return func(ctx context.Context, req *mcp.CallToolRequest, input getConversationTurnInput) (*mcp.CallToolResult, map[string]any, error) {
 		if p == nil {
 			return convErrorResult("conversations provider not wired"), nil, nil
@@ -261,8 +293,9 @@ func makeGetConversationTurnHandler(p *Provider) mcp.ToolHandlerFor[getConversat
 			"is_tool_call": turn.IsToolCall,
 		}
 		b, _ := json.MarshalIndent(resp, "", "  ")
+		text := capConvOutput(string(b), maxBytes)
 		return &mcp.CallToolResult{
-			Content: []mcp.Content{&mcp.TextContent{Text: string(b)}},
+			Content: []mcp.Content{&mcp.TextContent{Text: text}},
 		}, resp, nil
 	}
 }
@@ -276,7 +309,7 @@ type listConversationsInput struct {
 	Limit    int    `json:"limit,omitempty"`
 }
 
-func makeListConversationsHandler(p *Provider) mcp.ToolHandlerFor[listConversationsInput, map[string]any] {
+func makeListConversationsHandler(p *Provider, maxBytes int) mcp.ToolHandlerFor[listConversationsInput, map[string]any] {
 	return func(ctx context.Context, req *mcp.CallToolRequest, input listConversationsInput) (*mcp.CallToolResult, map[string]any, error) {
 		if p == nil {
 			return convErrorResult("conversations provider not wired"), nil, nil
@@ -338,8 +371,9 @@ func makeListConversationsHandler(p *Provider) mcp.ToolHandlerFor[listConversati
 			"count":    len(out),
 		}
 		b, _ := json.MarshalIndent(resp, "", "  ")
+		text := capConvOutput(string(b), maxBytes)
 		return &mcp.CallToolResult{
-			Content: []mcp.Content{&mcp.TextContent{Text: string(b)}},
+			Content: []mcp.Content{&mcp.TextContent{Text: text}},
 		}, resp, nil
 	}
 }

--- a/internal/engine/config.go
+++ b/internal/engine/config.go
@@ -172,6 +172,14 @@ type Config struct {
 	// Configurable via identity_naked_default: true in kernel.yaml.
 	IdentityNakedDefault bool
 
+	// MaxToolOutputBytes caps the byte length of any cog_* MCP tool text
+	// response before it is sent to the agent. Responses that exceed the cap
+	// are truncated at a UTF-8 rune boundary and annotated with an explicit
+	// truncation marker. 0 means use DefaultMaxToolOutputBytes (32 KiB).
+	// A hard floor of MinToolOutputBytes (4 KiB) prevents absurdly low values.
+	// Configurable via max_tool_output_bytes in kernel.yaml.
+	MaxToolOutputBytes int
+
 	// CoreInference is the node's declared N-tier inference contract.
 	// Loaded from .cog/config/core-inference.yaml; falls back to
 	// inference.DefaultCoreInferenceConfig() if the file is absent.
@@ -208,6 +216,11 @@ type kernelConfigSection struct {
 	// When empty, LoadConfig uses workspaceRoot/.cog/config/core-inference.yaml.
 	// Reserved for future use — not yet wired into the loader.
 	CoreInferencePath string `yaml:"core_inference_path,omitempty"`
+
+	// MaxToolOutputBytes caps MCP tool response text at this many bytes.
+	// 0 means use DefaultMaxToolOutputBytes (32 KiB).
+	// Floor: MinToolOutputBytes (4 KiB).
+	MaxToolOutputBytes int `yaml:"max_tool_output_bytes,omitempty"`
 }
 
 // kernelConfig is the on-disk YAML shape of .cog/config/kernel.yaml.
@@ -363,6 +376,9 @@ func applyKernelSection(cfg *Config, s kernelConfigSection) {
 	}
 	if s.Mod3URL != "" {
 		cfg.Mod3URL = s.Mod3URL
+	}
+	if s.MaxToolOutputBytes != 0 {
+		cfg.MaxToolOutputBytes = s.MaxToolOutputBytes
 	}
 }
 

--- a/internal/engine/mcp_architecture.go
+++ b/internal/engine/mcp_architecture.go
@@ -170,9 +170,9 @@ func (m *MCPServer) execArchitectureTool(ctx context.Context, scriptName string,
 	var parsed any
 	if err := json.Unmarshal(out, &parsed); err != nil {
 		// Some tools may emit non-JSON (e.g., list --format=table); return raw.
-		return marshalResult(map[string]any{"output": string(out)})
+		return m.cappedMarshal(map[string]any{"output": string(out)})
 	}
-	return marshalResult(parsed)
+	return m.cappedMarshal(parsed)
 }
 
 // ─── Tool handlers ───────────────────────────────────────────────────────────

--- a/internal/engine/mcp_output_cap.go
+++ b/internal/engine/mcp_output_cap.go
@@ -25,7 +25,9 @@
 package engine
 
 import (
+	"bufio"
 	"fmt"
+	"io"
 	"unicode/utf8"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -40,6 +42,12 @@ const (
 	// MinToolOutputBytes is the hard floor for max_tool_output_bytes.
 	// Below this the cap becomes so aggressive that tools are useless.
 	MinToolOutputBytes = 4 * 1024 // 4 KiB
+
+	// grepLineKeep is the per-line retention budget for cog_grep_files.
+	// Matches the old bufio.Scanner default token size so match coverage is
+	// unchanged for lines that previously worked, while lines beyond it are
+	// now truncated-and-drained instead of silently aborting the scan.
+	grepLineKeep = 64 * 1024 // 64 KiB
 )
 
 // capToolOutput truncates s to at most maxBytes, cutting at the last valid
@@ -145,4 +153,71 @@ func (m *MCPServer) MaxToolOutputBytes() int {
 		return DefaultMaxToolOutputBytes
 	}
 	return m.cfg.EffectiveMaxToolOutputBytes()
+}
+
+// readLineCapped reads one line from r (terminated by '\n' or EOF), retaining
+// at most keep bytes of line content (excluding the trailing newline). Unlike
+// bufio.Scanner, it can NEVER fail because a line is longer than a buffer —
+// over-long lines are truncated, not errored. This is the fix for the
+// "bufio.Scanner: token too long" cliff on minified one-line blobs.
+//
+// When drain is true the remainder of an over-long line is consumed so the
+// reader is positioned at the start of the next line (needed when the caller
+// wants subsequent lines, e.g. grep output parsing). When drain is false the
+// function returns as soon as keep bytes have been retained, leaving the rest
+// of the line unread — cog_read_file uses this so it never reads more than
+// ~maxBytes+ε from disk regardless of file size.
+//
+// Returns:
+//
+//	line     — up to keep bytes of line content, no trailing '\n'
+//	overflow — true when the line content was longer than keep
+//	err      — io.EOF only when no bytes remained at the start of the call;
+//	           any other error is a real read failure.
+func readLineCapped(r *bufio.Reader, keep int, drain bool) (line []byte, overflow bool, err error) {
+	first := true
+	for {
+		chunk, rerr := r.ReadSlice('\n')
+		if len(chunk) == 0 && rerr == io.EOF {
+			if first {
+				return nil, false, io.EOF
+			}
+			// EOF after accumulating a final unterminated line.
+			return line, overflow, nil
+		}
+		first = false
+
+		content := chunk
+		complete := rerr == nil // found the '\n'
+		if complete {
+			content = content[:len(content)-1] // strip '\n'
+		}
+
+		if len(line) < keep {
+			take := content
+			if len(line)+len(take) > keep {
+				take = take[:keep-len(line)]
+				overflow = true
+			}
+			// append copies — chunk is only valid until the next ReadSlice.
+			line = append(line, take...)
+		} else if len(content) > 0 {
+			overflow = true
+		}
+
+		switch {
+		case complete:
+			return line, overflow, nil
+		case rerr == bufio.ErrBufferFull:
+			if overflow && !drain {
+				// Caller doesn't need the rest of this line; stop reading.
+				return line, overflow, nil
+			}
+			continue
+		case rerr == io.EOF:
+			return line, overflow, nil
+		default:
+			return line, overflow, rerr
+		}
+	}
 }

--- a/internal/engine/mcp_output_cap.go
+++ b/internal/engine/mcp_output_cap.go
@@ -63,8 +63,21 @@ const (
 // Returns (possibly truncated string, true) when truncation occurred; returns
 // (s, false) when s fits within maxBytes.
 func capToolOutput(s string, maxBytes int) (string, bool) {
+	return capToolOutputWithTotal(s, maxBytes, int64(len(s)))
+}
+
+// capToolOutputWithTotal is capToolOutput with an externally-known total
+// source size. When a reader is BOUNDED (e.g. cog_read_file stops at the cap
+// rather than slurping a 5GB file), len(s) understates the source: a marker
+// saying "returned 32768 of 32774 bytes" on a 5MB file misleads the caller
+// into thinking 6 bytes are missing. Pass the os.Stat size (or other true
+// total) so the denominator tells the truth.
+func capToolOutputWithTotal(s string, maxBytes int, totalBytes int64) (string, bool) {
 	if maxBytes <= 0 {
 		maxBytes = DefaultMaxToolOutputBytes
+	}
+	if totalBytes < int64(len(s)) {
+		totalBytes = int64(len(s))
 	}
 	if len(s) <= maxBytes {
 		return s, false
@@ -78,7 +91,7 @@ func capToolOutput(s string, maxBytes int) (string, bool) {
 
 	marker := fmt.Sprintf(
 		"\n[output truncated: returned %d of %d bytes; narrow with offset/limit/filters, or dereference cog:conversations/... where applicable]",
-		cut, len(s),
+		cut, totalBytes,
 	)
 	return s[:cut] + marker, true
 }

--- a/internal/engine/mcp_output_cap.go
+++ b/internal/engine/mcp_output_cap.go
@@ -1,0 +1,148 @@
+// mcp_output_cap.go — byte-level output capping for MCP tool responses.
+//
+// Problem (2026-06-04 diagnosis): cog_* MCP tool responses are capped only
+// by item/line counts, not by byte size. A single 500-line read of a minified
+// JS bundle or a large JSONL ledger can return multiple megabytes, bloating
+// agent context windows beyond recovery.
+//
+// Fix: capToolOutput trims any string to maxBytes at a UTF-8 rune boundary
+// and appends an explicit truncation marker so the agent knows it received
+// partial output and how to obtain the rest.
+//
+// Cap defaults by tool class:
+//
+//	Read-file / grep / cogdoc class  — DefaultReadToolOutputBytes  (32 KiB)
+//	List / search / event class      — DefaultListToolOutputBytes  (32 KiB)
+//
+// Both classes share the same DefaultMaxToolOutputBytes default; a single
+// config knob (max_tool_output_bytes in kernel.yaml) adjusts both.
+// The floor is MinToolOutputBytes (4 KiB) — absurdly low values produce
+// truncation so aggressive the tool becomes useless.
+//
+// Usage:
+//
+//	s, truncated := capToolOutput(s, m.cfg.EffectiveMaxToolOutputBytes())
+package engine
+
+import (
+	"fmt"
+	"unicode/utf8"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const (
+	// DefaultMaxToolOutputBytes is the default byte cap applied to all
+	// cog_* MCP tool text outputs. 32 KiB is large enough to carry any
+	// reasonable single-tool response while preventing megabyte blowout.
+	DefaultMaxToolOutputBytes = 32 * 1024 // 32 KiB
+
+	// MinToolOutputBytes is the hard floor for max_tool_output_bytes.
+	// Below this the cap becomes so aggressive that tools are useless.
+	MinToolOutputBytes = 4 * 1024 // 4 KiB
+)
+
+// capToolOutput truncates s to at most maxBytes, cutting at the last valid
+// UTF-8 rune boundary at or before the limit. When truncation occurs it
+// appends a marker that states:
+//   - the total byte length of the original string
+//   - how many bytes were returned
+//   - guidance on how to narrow the call
+//
+// The marker itself is never counted against maxBytes, so the caller always
+// receives exactly min(len(s), maxBytes) bytes of payload plus the marker.
+//
+// Returns (possibly truncated string, true) when truncation occurred; returns
+// (s, false) when s fits within maxBytes.
+func capToolOutput(s string, maxBytes int) (string, bool) {
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxToolOutputBytes
+	}
+	if len(s) <= maxBytes {
+		return s, false
+	}
+
+	// Walk back from maxBytes until we're on a valid UTF-8 boundary.
+	cut := maxBytes
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+
+	marker := fmt.Sprintf(
+		"\n[output truncated: returned %d of %d bytes; narrow with offset/limit/filters, or dereference cog:conversations/... where applicable]",
+		cut, len(s),
+	)
+	return s[:cut] + marker, true
+}
+
+// EffectiveMaxToolOutputBytes returns the configured byte cap, applying the
+// hard floor so it can never be set absurdly low.
+func (c *Config) EffectiveMaxToolOutputBytes() int {
+	if c == nil {
+		return DefaultMaxToolOutputBytes
+	}
+	v := c.MaxToolOutputBytes
+	if v <= 0 {
+		return DefaultMaxToolOutputBytes
+	}
+	if v < MinToolOutputBytes {
+		return MinToolOutputBytes
+	}
+	return v
+}
+
+// capMarshalResult marshals data to JSON, then caps the resulting string at
+// maxBytes. It is the drop-in replacement for marshalResult in handlers where
+// we want byte-level output control.
+func capMarshalResult(data any, maxBytes int) (*mcp.CallToolResult, any, error) {
+	r, metadata, err := marshalResult(data)
+	if err != nil || r == nil {
+		return r, metadata, err
+	}
+	if len(r.Content) == 0 {
+		return r, metadata, nil
+	}
+	tc, ok := r.Content[0].(*mcp.TextContent)
+	if !ok {
+		return r, metadata, nil
+	}
+	capped, _ := capToolOutput(tc.Text, maxBytes)
+	tc.Text = capped
+	return r, metadata, nil
+}
+
+// capResult applies the configured byte cap to the already-built CallToolResult.
+// Returns r unmodified when r is nil or has no text content.
+func capResult(r *mcp.CallToolResult, metadata any, err error, maxBytes int) (*mcp.CallToolResult, any, error) {
+	if err != nil || r == nil || len(r.Content) == 0 {
+		return r, metadata, err
+	}
+	tc, ok := r.Content[0].(*mcp.TextContent)
+	if !ok {
+		return r, metadata, err
+	}
+	capped, _ := capToolOutput(tc.Text, maxBytes)
+	tc.Text = capped
+	return r, metadata, nil
+}
+
+// cappedMarshal is a convenience method on MCPServer that calls marshalResult
+// and applies the configured byte cap. Use this in all handlers that produce
+// potentially large textual output.
+func (m *MCPServer) cappedMarshal(data any) (*mcp.CallToolResult, any, error) {
+	maxBytes := DefaultMaxToolOutputBytes
+	if m.cfg != nil {
+		maxBytes = m.cfg.EffectiveMaxToolOutputBytes()
+	}
+	return capMarshalResult(data, maxBytes)
+}
+
+// MaxToolOutputBytes returns the effective byte cap for MCP tool outputs.
+// Exposed so extension-registration callsites (e.g. z_conversations_mcp.go)
+// can forward the cap to external RegisterXxx helpers.
+func (m *MCPServer) MaxToolOutputBytes() int {
+	if m.cfg == nil {
+		return DefaultMaxToolOutputBytes
+	}
+	return m.cfg.EffectiveMaxToolOutputBytes()
+}

--- a/internal/engine/mcp_output_cap_test.go
+++ b/internal/engine/mcp_output_cap_test.go
@@ -509,3 +509,16 @@ func TestCappedMarshal_AppliesCap(t *testing.T) {
 // Ensure imports are used.
 var _ = os.Stat
 var _ = mcp.NewServer
+
+func TestCapToolOutputWithTotal_TrueDenominator(t *testing.T) {
+	// A bounded reader hands us only ~cap bytes of a much larger source; the
+	// marker must report the true source size, not the bytes read.
+	s := strings.Repeat("A", 40_000)
+	out, truncated := capToolOutputWithTotal(s, 32768, 5_000_009)
+	if !truncated {
+		t.Fatal("expected truncation")
+	}
+	if !strings.Contains(out, "of 5000009 bytes") {
+		t.Fatalf("marker denominator should be true total; got marker tail: %q", out[len(out)-160:])
+	}
+}

--- a/internal/engine/mcp_output_cap_test.go
+++ b/internal/engine/mcp_output_cap_test.go
@@ -1,0 +1,334 @@
+// mcp_output_cap_test.go — unit tests for the MCP tool output byte cap.
+//
+// Coverage:
+//   - capToolOutput: truncation at the cap boundary, UTF-8 rune boundary
+//     safety, no-op when within cap, marker format, full-size reported.
+//   - Config.EffectiveMaxToolOutputBytes: floor enforcement, default, custom.
+//   - toolReadFile: byte cap applied when file content exceeds the cap,
+//     minified-one-line-blob case, truncated flag set correctly.
+//   - toolGrepFiles: byte cap applied to match result JSON.
+//   - cappedMarshal: cap applied to marshalResult output.
+//   - Config knob respected: setting max_tool_output_bytes changes the cap.
+package engine
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// ─── capToolOutput tests ─────────────────────────────────────────────────────
+
+func TestCapToolOutput_NoTruncation(t *testing.T) {
+	t.Parallel()
+	s := "hello world"
+	got, truncated := capToolOutput(s, 100)
+	if truncated {
+		t.Error("expected no truncation for small string")
+	}
+	if got != s {
+		t.Errorf("got %q; want %q", got, s)
+	}
+}
+
+func TestCapToolOutput_TruncatesAtCap(t *testing.T) {
+	t.Parallel()
+	s := strings.Repeat("a", 1000)
+	got, truncated := capToolOutput(s, 500)
+	if !truncated {
+		t.Error("expected truncation")
+	}
+	// Payload part should be exactly 500 bytes (all ASCII, so rune boundary = byte boundary).
+	payload := strings.SplitN(got, "\n[output truncated:", 2)[0]
+	if len(payload) != 500 {
+		t.Errorf("payload len = %d; want 500", len(payload))
+	}
+}
+
+func TestCapToolOutput_MarkerFormat(t *testing.T) {
+	t.Parallel()
+	s := strings.Repeat("x", 1000)
+	got, _ := capToolOutput(s, 100)
+	if !strings.Contains(got, "[output truncated: returned 100 of 1000 bytes") {
+		t.Errorf("marker missing or wrong format: %q", got)
+	}
+	if !strings.Contains(got, "narrow with offset/limit/filters") {
+		t.Errorf("marker missing narrowing guidance: %q", got)
+	}
+	if !strings.Contains(got, "cog:conversations/") {
+		t.Errorf("marker missing deref hint: %q", got)
+	}
+}
+
+func TestCapToolOutput_UTF8Boundary(t *testing.T) {
+	t.Parallel()
+	// Build a string with multi-byte runes. Use the 3-byte rune U+4E16 (世).
+	rune3 := "世" // 3 bytes: 0xE4, 0xB8, 0x96
+	// Repeat to fill >10 bytes, then cap at a point mid-rune.
+	s := strings.Repeat(rune3, 5) // 15 bytes
+	for cutPoint := 1; cutPoint < len(s); cutPoint++ {
+		got, _ := capToolOutput(s, cutPoint)
+		// The payload (before the marker) must be valid UTF-8.
+		payload := strings.SplitN(got, "\n[output truncated:", 2)[0]
+		if !utf8.ValidString(payload) {
+			t.Errorf("capToolOutput(s, %d): payload is not valid UTF-8", cutPoint)
+		}
+	}
+}
+
+func TestCapToolOutput_ZeroMaxUsesDefault(t *testing.T) {
+	t.Parallel()
+	s := strings.Repeat("a", DefaultMaxToolOutputBytes+1)
+	got, truncated := capToolOutput(s, 0)
+	if !truncated {
+		t.Error("expected truncation when maxBytes=0 and string exceeds default")
+	}
+	payload := strings.SplitN(got, "\n[output truncated:", 2)[0]
+	if len(payload) != DefaultMaxToolOutputBytes {
+		t.Errorf("payload len = %d; want %d", len(payload), DefaultMaxToolOutputBytes)
+	}
+}
+
+func TestCapToolOutput_ExactlyAtCap(t *testing.T) {
+	t.Parallel()
+	s := strings.Repeat("b", 100)
+	got, truncated := capToolOutput(s, 100)
+	if truncated {
+		t.Error("expected no truncation when string is exactly at cap")
+	}
+	if got != s {
+		t.Error("string modified when it should be unchanged")
+	}
+}
+
+// ─── Config.EffectiveMaxToolOutputBytes tests ────────────────────────────────
+
+func TestEffectiveMaxToolOutputBytes_Default(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{}
+	got := cfg.EffectiveMaxToolOutputBytes()
+	if got != DefaultMaxToolOutputBytes {
+		t.Errorf("got %d; want %d (default)", got, DefaultMaxToolOutputBytes)
+	}
+}
+
+func TestEffectiveMaxToolOutputBytes_CustomValue(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{MaxToolOutputBytes: 65536}
+	got := cfg.EffectiveMaxToolOutputBytes()
+	if got != 65536 {
+		t.Errorf("got %d; want 65536", got)
+	}
+}
+
+func TestEffectiveMaxToolOutputBytes_FloorEnforced(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{MaxToolOutputBytes: 100} // below MinToolOutputBytes
+	got := cfg.EffectiveMaxToolOutputBytes()
+	if got != MinToolOutputBytes {
+		t.Errorf("got %d; want %d (floor)", got, MinToolOutputBytes)
+	}
+}
+
+func TestEffectiveMaxToolOutputBytes_NilConfig(t *testing.T) {
+	t.Parallel()
+	var cfg *Config
+	got := cfg.EffectiveMaxToolOutputBytes()
+	if got != DefaultMaxToolOutputBytes {
+		t.Errorf("got %d; want %d (nil config default)", got, DefaultMaxToolOutputBytes)
+	}
+}
+
+// ─── toolReadFile byte-cap tests ─────────────────────────────────────────────
+
+func TestToolReadFile_ByteCapApplied(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	// Set a very small cap so we can verify truncation with a small test file.
+	cfg.MaxToolOutputBytes = MinToolOutputBytes // 4 KiB
+	process := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	server := NewMCPServer(cfg, makeNucleus("Cog", "tester"), process)
+
+	// Write a file large enough to exceed the 4 KiB cap.
+	// Each line is "   N\t<80 chars>\n" ≈ 90 bytes. 50 lines ≈ 4.5 KiB > 4 KiB.
+	var lines []string
+	for i := 0; i < 50; i++ {
+		lines = append(lines, strings.Repeat("x", 80))
+	}
+	path := filepath.Join(root, "big.txt")
+	writeTestFile(t, path, strings.Join(lines, "\n")+"\n")
+
+	result, _, err := server.toolReadFile(context.Background(), nil, readFileInput{Path: path})
+	if err != nil {
+		t.Fatalf("toolReadFile: %v", err)
+	}
+
+	var decoded map[string]any
+	decodeMCPJSON(t, result, &decoded)
+
+	// The output should be truncated.
+	content, _ := decoded["content"].(string)
+	if !strings.Contains(content, "[output truncated:") {
+		peek := content
+		if len(peek) > 200 {
+			peek = peek[:200]
+		}
+		t.Errorf("expected truncation marker in content; got %q", peek)
+	}
+	truncated, _ := decoded["truncated"].(bool)
+	if !truncated {
+		t.Error("expected truncated=true in result")
+	}
+}
+
+func TestToolReadFile_MinifiedOneLineBlobCapped(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	// 32 KiB cap. Write a single minified line of 200 KiB.
+	cfg.MaxToolOutputBytes = DefaultMaxToolOutputBytes
+	process := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	server := NewMCPServer(cfg, makeNucleus("Cog", "tester"), process)
+
+	// Minified file: one giant line (200 KiB).
+	bigLine := strings.Repeat("a", 200*1024)
+	path := filepath.Join(root, "minified.js")
+	writeTestFile(t, path, bigLine)
+
+	result, _, err := server.toolReadFile(context.Background(), nil, readFileInput{Path: path})
+	if err != nil {
+		t.Fatalf("toolReadFile on minified blob: %v", err)
+	}
+
+	// The full JSON response must not exceed a reasonable multiple of the cap.
+	// (JSON encoding adds some overhead for the struct, but the content field
+	// itself must not be 200 KiB.)
+	text := result.Content[0].(*mcp.TextContent).Text
+	if len(text) > 2*DefaultMaxToolOutputBytes {
+		t.Errorf("response too large: %d bytes (cap=%d); minified-blob not capped",
+			len(text), DefaultMaxToolOutputBytes)
+	}
+	var decoded map[string]any
+	decodeMCPJSON(t, result, &decoded)
+	truncated, _ := decoded["truncated"].(bool)
+	if !truncated {
+		t.Error("expected truncated=true for 200 KiB minified blob with 32 KiB cap")
+	}
+}
+
+func TestToolReadFile_SmallFileNotCapped(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	process := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	server := NewMCPServer(cfg, makeNucleus("Cog", "tester"), process)
+
+	path := filepath.Join(root, "small.go")
+	writeTestFile(t, path, "package engine\n\nfunc Foo() {}\n")
+
+	result, _, err := server.toolReadFile(context.Background(), nil, readFileInput{Path: path})
+	if err != nil {
+		t.Fatalf("toolReadFile: %v", err)
+	}
+
+	var decoded map[string]any
+	decodeMCPJSON(t, result, &decoded)
+	content, _ := decoded["content"].(string)
+	if strings.Contains(content, "[output truncated:") {
+		t.Error("small file should not have truncation marker")
+	}
+}
+
+// ─── toolGrepFiles byte-cap test ─────────────────────────────────────────────
+
+func TestToolGrepFiles_ByteCapApplied(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	cfg.MaxToolOutputBytes = MinToolOutputBytes // 4 KiB cap
+	process := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	server := NewMCPServer(cfg, makeNucleus("Cog", "tester"), process)
+
+	// Write many files each with a matching long line so JSON output bloats.
+	for i := 0; i < 30; i++ {
+		path := filepath.Join(root, fmt.Sprintf("file%02d.txt", i))
+		writeTestFile(t, path, "MATCH: "+strings.Repeat("y", 300)+"\n")
+	}
+
+	result, _, err := server.toolGrepFiles(context.Background(), nil, grepFilesInput{
+		Pattern:    "MATCH",
+		Path:       root,
+		MaxResults: 100,
+	})
+	if err != nil {
+		t.Fatalf("toolGrepFiles: %v", err)
+	}
+
+	text := result.Content[0].(*mcp.TextContent).Text
+	if len(text) > 2*MinToolOutputBytes+500 { // allow some marker overhead
+		t.Errorf("grep output too large: %d bytes (cap=%d)", len(text), MinToolOutputBytes)
+	}
+	if !strings.Contains(text, "[output truncated:") {
+		t.Errorf("expected truncation marker in grep output")
+	}
+}
+
+// ─── Config knob integration test ────────────────────────────────────────────
+
+func TestConfigKnob_MaxToolOutputBytes(t *testing.T) {
+	t.Parallel()
+	// Verify that a config with max_tool_output_bytes set changes the effective cap.
+	cfg := &Config{MaxToolOutputBytes: 8192}
+	if got := cfg.EffectiveMaxToolOutputBytes(); got != 8192 {
+		t.Errorf("EffectiveMaxToolOutputBytes = %d; want 8192", got)
+	}
+	// Verify floor: value below MinToolOutputBytes is clamped.
+	cfg2 := &Config{MaxToolOutputBytes: 1024}
+	if got := cfg2.EffectiveMaxToolOutputBytes(); got != MinToolOutputBytes {
+		t.Errorf("EffectiveMaxToolOutputBytes = %d; want %d (floor)", got, MinToolOutputBytes)
+	}
+}
+
+// ─── cappedMarshal tests ──────────────────────────────────────────────────────
+
+func TestCappedMarshal_AppliesCap(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	// Use MinToolOutputBytes (4 KiB) so the floor doesn't kick in;
+	// our test payload of ~6 KiB JSON exceeds this cap.
+	cfg.MaxToolOutputBytes = MinToolOutputBytes
+	process := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	server := NewMCPServer(cfg, makeNucleus("Cog", "tester"), process)
+
+	// Build data whose JSON exceeds MinToolOutputBytes (4 KiB).
+	// JSON: {"content":"zzz...5000z"} ≈ 5014 bytes > 4096.
+	data := map[string]any{
+		"content": strings.Repeat("z", 5000),
+	}
+	result, _, err := server.cappedMarshal(data)
+	if err != nil {
+		t.Fatalf("cappedMarshal: %v", err)
+	}
+	text := result.Content[0].(*mcp.TextContent).Text
+	if !strings.Contains(text, "[output truncated:") {
+		peek := text
+		if len(peek) > 200 {
+			peek = peek[:200]
+		}
+		t.Errorf("expected truncation marker, got: %q", peek)
+	}
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+// Ensure imports are used.
+var _ = os.Stat
+var _ = mcp.NewServer

--- a/internal/engine/mcp_output_cap_test.go
+++ b/internal/engine/mcp_output_cap_test.go
@@ -12,8 +12,10 @@
 package engine
 
 import (
+	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -192,13 +194,15 @@ func TestToolReadFile_MinifiedOneLineBlobCapped(t *testing.T) {
 	t.Parallel()
 	root := makeWorkspace(t)
 	cfg := makeConfig(t, root)
-	// 32 KiB cap. Write a single minified line of 200 KiB.
+	// 32 KiB cap. Single minified line of 5,000,009 bytes — strictly larger
+	// than ANY internal read buffer (mirrors the /tmp/caps-sandbox/blob.json
+	// e2e fixture). This is the exact case that previously returned
+	// "bufio.Scanner: token too long" instead of capped content.
 	cfg.MaxToolOutputBytes = DefaultMaxToolOutputBytes
 	process := NewProcess(cfg, makeNucleus("Cog", "tester"))
 	server := NewMCPServer(cfg, makeNucleus("Cog", "tester"), process)
 
-	// Minified file: one giant line (200 KiB).
-	bigLine := strings.Repeat("a", 200*1024)
+	bigLine := strings.Repeat("A", 5_000_009)
 	path := filepath.Join(root, "minified.js")
 	writeTestFile(t, path, bigLine)
 
@@ -207,10 +211,12 @@ func TestToolReadFile_MinifiedOneLineBlobCapped(t *testing.T) {
 		t.Fatalf("toolReadFile on minified blob: %v", err)
 	}
 
-	// The full JSON response must not exceed a reasonable multiple of the cap.
-	// (JSON encoding adds some overhead for the struct, but the content field
-	// itself must not be 200 KiB.)
 	text := result.Content[0].(*mcp.TextContent).Text
+	// MUST be capped content, never a scanner error.
+	if strings.Contains(text, "token too long") {
+		t.Fatalf("scanner cliff still present: %q", text)
+	}
+	// The full JSON response must not exceed a reasonable multiple of the cap.
 	if len(text) > 2*DefaultMaxToolOutputBytes {
 		t.Errorf("response too large: %d bytes (cap=%d); minified-blob not capped",
 			len(text), DefaultMaxToolOutputBytes)
@@ -219,7 +225,178 @@ func TestToolReadFile_MinifiedOneLineBlobCapped(t *testing.T) {
 	decodeMCPJSON(t, result, &decoded)
 	truncated, _ := decoded["truncated"].(bool)
 	if !truncated {
-		t.Error("expected truncated=true for 200 KiB minified blob with 32 KiB cap")
+		t.Error("expected truncated=true for 5 MB minified blob with 32 KiB cap")
+	}
+	content, _ := decoded["content"].(string)
+	if !strings.Contains(content, "[output truncated:") {
+		t.Error("expected explicit truncation marker in content")
+	}
+	// file_size_bytes reports the true source size (the marker's Y counts
+	// the rendered buffer, which stops at cap+ε by design).
+	if size, ok := decoded["file_size_bytes"].(float64); !ok || int64(size) != 5_000_009 {
+		t.Errorf("file_size_bytes = %v; want 5000009", decoded["file_size_bytes"])
+	}
+	// The mid-line cut must be flagged so the agent knows line numbering
+	// beyond the truncation point was not scanned.
+	if note, _ := decoded["note"].(string); !strings.Contains(note, "cut mid-line") {
+		t.Errorf("note = %q; want mid-line cut explanation", note)
+	}
+}
+
+func TestToolReadFile_OffsetSkipsOverLongLines(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	process := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	server := NewMCPServer(cfg, makeNucleus("Cog", "tester"), process)
+
+	// Line 1 is a 300 KiB blob (over the 64 KiB read buffer); line 2 is
+	// short. offset=1 must skip the blob without erroring and return line 2
+	// with the correct line number.
+	contents := strings.Repeat("z", 300*1024) + "\n" + "short line two\n"
+	path := filepath.Join(root, "mixed.txt")
+	writeTestFile(t, path, contents)
+
+	result, _, err := server.toolReadFile(context.Background(), nil, readFileInput{Path: path, Offset: 1})
+	if err != nil {
+		t.Fatalf("toolReadFile with offset over long line: %v", err)
+	}
+	var decoded map[string]any
+	decodeMCPJSON(t, result, &decoded)
+	content, _ := decoded["content"].(string)
+	if !strings.Contains(content, "   2\tshort line two") {
+		t.Errorf("expected line 2 with correct numbering; got %q", content)
+	}
+}
+
+func TestToolReadFile_RelativePathResolvesAgainstWorkspaceRoot(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	process := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	server := NewMCPServer(cfg, makeNucleus("Cog", "tester"), process)
+
+	writeTestFile(t, filepath.Join(root, "rel.txt"), "relative content\n")
+
+	result, _, err := server.toolReadFile(context.Background(), nil, readFileInput{Path: "rel.txt"})
+	if err != nil {
+		t.Fatalf("toolReadFile relative path: %v", err)
+	}
+	var decoded map[string]any
+	decodeMCPJSON(t, result, &decoded)
+	content, _ := decoded["content"].(string)
+	if !strings.Contains(content, "relative content") {
+		t.Errorf("relative path did not resolve against workspace root; got %q", content)
+	}
+}
+
+// ─── readLineCapped tests ────────────────────────────────────────────────────
+
+func TestReadLineCapped(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		input    string
+		keep     int
+		wantLine string
+		wantOver bool
+	}{
+		{name: "short line", input: "hello\n", keep: 100, wantLine: "hello"},
+		{name: "exact keep", input: "abcde\n", keep: 5, wantLine: "abcde"},
+		{name: "over keep", input: "abcdef\n", keep: 5, wantLine: "abcde", wantOver: true},
+		{name: "no trailing newline", input: "tail", keep: 100, wantLine: "tail"},
+		{name: "empty line", input: "\n", keep: 100, wantLine: ""},
+		{name: "keep zero skip", input: "anything here\n", keep: 0, wantLine: "", wantOver: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := bufio.NewReaderSize(strings.NewReader(tc.input), 16)
+			line, over, err := readLineCapped(r, tc.keep, true)
+			if err != nil {
+				t.Fatalf("readLineCapped: %v", err)
+			}
+			if string(line) != tc.wantLine {
+				t.Errorf("line = %q; want %q", line, tc.wantLine)
+			}
+			if over != tc.wantOver {
+				t.Errorf("overflow = %v; want %v", over, tc.wantOver)
+			}
+		})
+	}
+}
+
+func TestReadLineCapped_LongLineSmallBuffer(t *testing.T) {
+	t.Parallel()
+	// A 1 MB line through a 64-byte buffer: must never error, retain keep
+	// bytes, and (drain=true) leave the reader at the start of the next line.
+	long := strings.Repeat("x", 1024*1024)
+	r := bufio.NewReaderSize(strings.NewReader(long+"\nnext\n"), 64)
+
+	line, over, err := readLineCapped(r, 100, true)
+	if err != nil {
+		t.Fatalf("readLineCapped on 1MB line: %v", err)
+	}
+	if len(line) != 100 || !over {
+		t.Errorf("len=%d over=%v; want 100/true", len(line), over)
+	}
+
+	next, over2, err := readLineCapped(r, 100, true)
+	if err != nil {
+		t.Fatalf("second line: %v", err)
+	}
+	if string(next) != "next" || over2 {
+		t.Errorf("next = %q over=%v; want \"next\"/false", next, over2)
+	}
+
+	if _, _, err := readLineCapped(r, 100, true); err != io.EOF {
+		t.Errorf("expected io.EOF at end, got %v", err)
+	}
+}
+
+func TestReadLineCapped_NoDrainStopsEarly(t *testing.T) {
+	t.Parallel()
+	// drain=false: after retaining keep bytes the rest of the line stays
+	// unread — cog_read_file's guarantee that at most cap+ε is read from disk.
+	long := strings.Repeat("y", 1024*1024)
+	sr := strings.NewReader(long)
+	r := bufio.NewReaderSize(sr, 64)
+
+	line, over, err := readLineCapped(r, 100, false)
+	if err != nil {
+		t.Fatalf("readLineCapped: %v", err)
+	}
+	if len(line) != 100 || !over {
+		t.Errorf("len=%d over=%v; want 100/true", len(line), over)
+	}
+	// Almost all of the 1 MB must remain unread in the source.
+	if sr.Len() < 1024*1024-1024 {
+		t.Errorf("reader consumed too much: %d bytes remain (want ~1MB)", sr.Len())
+	}
+}
+
+func TestToolGrepFiles_LongLineDoesNotAbortScan(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	process := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	server := NewMCPServer(cfg, makeNucleus("Cog", "tester"), process)
+
+	// One file: 200 KiB first line (over the old 64 KiB scanner limit),
+	// then a matching short line AFTER it. The old scanner silently stopped
+	// at the long line and missed the later match.
+	path := filepath.Join(root, "longline.txt")
+	writeTestFile(t, path, strings.Repeat("f", 200*1024)+"\nNEEDLE here\n")
+
+	result, _, err := server.toolGrepFiles(context.Background(), nil, grepFilesInput{
+		Pattern: "NEEDLE",
+		Path:    root,
+	})
+	if err != nil {
+		t.Fatalf("toolGrepFiles: %v", err)
+	}
+	text := result.Content[0].(*mcp.TextContent).Text
+	if !strings.Contains(text, "NEEDLE here") {
+		t.Errorf("match after long line was missed: %s", text)
 	}
 }
 

--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -2483,9 +2483,16 @@ func (m *MCPServer) toolReadFile(ctx context.Context, req *mcp.CallToolRequest, 
 		workspaceRoot = m.cfg.WorkspaceRoot
 	}
 
+	// Bare relative paths resolve against the workspace root, not the kernel
+	// process CWD — "blob.json" means "<workspace>/blob.json" to a caller.
+	inputPath := input.Path
+	if !filepath.IsAbs(inputPath) && workspaceRoot != "" {
+		inputPath = filepath.Join(workspaceRoot, inputPath)
+	}
+
 	// Workspace jail: reject paths that are not under the workspace root.
 	// We resolve both to absolute paths so symlink traversal can't escape.
-	abs, err := filepath.Abs(input.Path)
+	abs, err := filepath.Abs(inputPath)
 	if err != nil {
 		return textResult(fmt.Sprintf("invalid path: %v", err))
 	}
@@ -2530,52 +2537,79 @@ func (m *MCPServer) toolReadFile(ctx context.Context, req *mcp.CallToolRequest, 
 		maxBytes = m.cfg.EffectiveMaxToolOutputBytes()
 	}
 
-	scanner := bufio.NewScanner(f)
-	// Expand the scanner buffer so individual lines up to 1 MiB don't fail
-	// with "token too long" — we rely on the byte cap below to prevent
-	// megabyte blowout instead.
-	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	// Chunked line reading via readLineCapped — unlike bufio.Scanner this can
+	// NEVER fail with "token too long" on arbitrarily long lines (the
+	// minified-one-line-blob case from the 2026-06-04 diagnosis). It also
+	// never reads more than ~maxBytes+ε from disk: once the output budget is
+	// exhausted mid-line, the rest of the file is left unread.
+	reader := bufio.NewReaderSize(f, 64*1024)
 	var buf bytes.Buffer
 	lineNo := 0
 	linesWritten := 0
 	truncated := false
+	overflowed := false // a single line exceeded the remaining byte budget
 
-	for scanner.Scan() {
-		lineNo++
-		if lineNo <= offset {
+readLoop:
+	for {
+		// Skip offset lines — must be fully drained to find line boundaries,
+		// but nothing is retained.
+		if lineNo < offset {
+			_, _, rerr := readLineCapped(reader, 0, true)
+			if rerr == io.EOF {
+				break readLoop
+			}
+			if rerr != nil {
+				return textResult(fmt.Sprintf("read error: %v", rerr))
+			}
+			lineNo++
 			continue
 		}
-		if linesWritten >= limit {
-			// Peek to see if there's more.
-			if scanner.Scan() {
+		if linesWritten >= limit || buf.Len() >= maxBytes {
+			// Bounds hit — peek one byte to detect remaining content.
+			if _, rerr := reader.ReadByte(); rerr == nil {
 				truncated = true
 			}
-			break
+			break readLoop
 		}
-		fmt.Fprintf(&buf, "%4d\t%s\n", lineNo, scanner.Text())
+		remaining := maxBytes - buf.Len()
+		line, overflow, rerr := readLineCapped(reader, remaining, false)
+		if rerr == io.EOF {
+			break readLoop
+		}
+		if rerr != nil {
+			return textResult(fmt.Sprintf("read error: %v", rerr))
+		}
+		lineNo++
+		fmt.Fprintf(&buf, "%4d\t%s\n", lineNo, line)
+		if overflow {
+			// The line was cut at the byte budget and its tail was left
+			// unread — stop here; line numbering beyond this point is unknown.
+			truncated = true
+			overflowed = true
+			break readLoop
+		}
 		linesWritten++
-		// Byte cap: stop accumulating once we exceed the output cap.
-		// This is the primary guard against minified-blob blowout.
-		if buf.Len() >= maxBytes {
-			if scanner.Scan() {
-				truncated = true
-			}
-			break
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return textResult(fmt.Sprintf("read error: %v", err))
 	}
 
 	content, byteTruncated := capToolOutput(buf.String(), maxBytes)
 	if byteTruncated {
 		truncated = true
 	}
-	return marshalResult(map[string]any{
+	resp := map[string]any{
 		"content":   content,
 		"lines":     linesWritten,
 		"truncated": truncated,
-	})
+	}
+	if fi, statErr := f.Stat(); statErr == nil {
+		resp["file_size_bytes"] = fi.Size()
+	}
+	if overflowed {
+		resp["note"] = fmt.Sprintf(
+			"line %d exceeded the %d-byte output cap and was cut mid-line; the rest of the file was not scanned, so line numbering beyond this point is unknown — use offset/limit to page",
+			lineNo, maxBytes,
+		)
+	}
+	return marshalResult(resp)
 }
 
 // toolGrepFiles implements cog_grep_files. Runs ripgrep (rg) when available,
@@ -2593,13 +2627,17 @@ func (m *MCPServer) toolGrepFiles(ctx context.Context, req *mcp.CallToolRequest,
 		workspaceRoot = m.cfg.WorkspaceRoot
 	}
 
-	// Resolve search path.
+	// Resolve search path. Bare relative paths resolve against the workspace
+	// root, not the kernel process CWD.
 	searchPath := input.Path
 	if searchPath == "" {
 		searchPath = workspaceRoot
 	}
 	if searchPath == "" {
 		searchPath = "."
+	}
+	if !filepath.IsAbs(searchPath) && workspaceRoot != "" {
+		searchPath = filepath.Join(workspaceRoot, searchPath)
 	}
 
 	absSearch, err := filepath.Abs(searchPath)
@@ -2653,9 +2691,20 @@ func (m *MCPServer) toolGrepFiles(ctx context.Context, req *mcp.CallToolRequest,
 		}
 		cmd := exec.CommandContext(ctx, rgPath, args...)
 		out, _ := cmd.Output() // exit 1 means no match, not an error we care about
-		scanner := bufio.NewScanner(bytes.NewReader(out))
-		for scanner.Scan() {
-			line := scanner.Text()
+		// readLineCapped instead of bufio.Scanner: a single match on a
+		// minified multi-megabyte line must not abort (or silently stop)
+		// output parsing. Over-long lines are retained up to grepLineKeep
+		// and drained; the response-level byte cap bounds the final JSON.
+		reader := bufio.NewReaderSize(bytes.NewReader(out), 64*1024)
+		for {
+			lineBytes, _, rerr := readLineCapped(reader, grepLineKeep, true)
+			if rerr == io.EOF {
+				break
+			}
+			if rerr != nil {
+				return textResult(fmt.Sprintf("read rg output: %v", rerr))
+			}
+			line := string(lineBytes)
 			// rg --no-heading format: path:linenum:text
 			parts := strings.SplitN(line, ":", 3)
 			if len(parts) < 3 {
@@ -2701,11 +2750,22 @@ func (m *MCPServer) toolGrepFiles(ctx context.Context, req *mcp.CallToolRequest,
 				return nil
 			}
 			defer f.Close()
-			scanner := bufio.NewScanner(f)
+			// readLineCapped instead of bufio.Scanner: a >64 KiB line used
+			// to silently stop the scan of the rest of the file. Over-long
+			// lines are matched against their first grepLineKeep bytes and
+			// fully drained so subsequent lines are still scanned.
+			reader := bufio.NewReaderSize(f, 64*1024)
 			lineNo := 0
-			for scanner.Scan() {
+			for {
+				lineBytes, _, rerr := readLineCapped(reader, grepLineKeep, true)
+				if rerr == io.EOF {
+					break
+				}
+				if rerr != nil {
+					return nil // unreadable file — skip, like open errors
+				}
 				lineNo++
-				if re.MatchString(scanner.Text()) {
+				if re.Match(lineBytes) {
 					if len(matches) >= maxResults {
 						truncated = true
 						return io.EOF
@@ -2719,7 +2779,7 @@ func (m *MCPServer) toolGrepFiles(ctx context.Context, req *mcp.CallToolRequest,
 					matches = append(matches, matchEntry{
 						Path: relPath,
 						Line: lineNo,
-						Text: scanner.Text(),
+						Text: string(lineBytes),
 					})
 				}
 			}

--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -969,7 +969,11 @@ func (m *MCPServer) toolAssembleContext(ctx context.Context, req *mcp.CallToolRe
 		return textResult(fmt.Sprintf("context assembly failed: %v", err))
 	}
 
-	return marshalResult(assembled)
+	maxBytes := DefaultMaxToolOutputBytes
+	if m.cfg != nil {
+		maxBytes = m.cfg.EffectiveMaxToolOutputBytes()
+	}
+	return capMarshalResult(assembled, maxBytes)
 }
 
 func (m *MCPServer) toolCheckCoherence(ctx context.Context, req *mcp.CallToolRequest, input checkCoherenceInput) (*mcp.CallToolResult, any, error) {
@@ -978,7 +982,11 @@ func (m *MCPServer) toolCheckCoherence(ctx context.Context, req *mcp.CallToolReq
 		return fallbackResult(fmt.Sprintf("coherence check failed: %v", err),
 			"./scripts/cog coherence check")
 	}
-	return marshalResult(report)
+	maxBytes := DefaultMaxToolOutputBytes
+	if m.cfg != nil {
+		maxBytes = m.cfg.EffectiveMaxToolOutputBytes()
+	}
+	return capMarshalResult(report, maxBytes)
 }
 
 func (m *MCPServer) toolGetState(ctx context.Context, req *mcp.CallToolRequest, input getStateInput) (*mcp.CallToolResult, any, error) {
@@ -1059,7 +1067,11 @@ func (m *MCPServer) toolSearchMemory(ctx context.Context, req *mcp.CallToolReque
 		return fallbackResult(fmt.Sprintf("search failed: %v", err),
 			fmt.Sprintf("./scripts/cog memory search %q", input.Query))
 	}
-	return marshalResult(results)
+	maxBytes := DefaultMaxToolOutputBytes
+	if m.cfg != nil {
+		maxBytes = m.cfg.EffectiveMaxToolOutputBytes()
+	}
+	return capMarshalResult(results, maxBytes)
 }
 
 // toolGetNucleus — no longer registered as an MCP tool; used by the internal tool loop (tool_loop.go).
@@ -1110,17 +1122,22 @@ func (m *MCPServer) toolReadCogdoc(ctx context.Context, req *mcp.CallToolRequest
 		result.SchemaHint = fmt.Sprintf("This CogDoc is missing a description field. If you can summarize it in one sentence, include it in your next response as: COGDOC_PATCH: %s | description: your summary here", uri)
 	}
 
+	maxBytes := DefaultMaxToolOutputBytes
+	if m.cfg != nil {
+		maxBytes = m.cfg.EffectiveMaxToolOutputBytes()
+	}
+
 	// If fragment specified, extract section
 	if res.Fragment != "" {
 		section := extractSection(content, res.Fragment)
 		if section != "" {
 			result.Fragment = res.Fragment
 			result.Content = section
-			return marshalResult(result)
+			return capMarshalResult(result, maxBytes)
 		}
 	}
 
-	return marshalResult(result)
+	return capMarshalResult(result, maxBytes)
 }
 
 func (m *MCPServer) toolPatchFrontmatter(ctx context.Context, req *mcp.CallToolRequest, input patchFrontmatterInput) (*mcp.CallToolResult, any, error) {
@@ -1535,7 +1552,7 @@ func (m *MCPServer) toolReadLedger(ctx context.Context, req *mcp.CallToolRequest
 		return fallbackResult(fmt.Sprintf("read ledger failed: %v", err),
 			"ls .cog/ledger/ && cat .cog/ledger/<session_id>/events.jsonl")
 	}
-	return marshalResult(result)
+	return m.cappedMarshal(result)
 }
 
 func (m *MCPServer) toolReadEvents(ctx context.Context, req *mcp.CallToolRequest, input readEventsInput) (*mcp.CallToolResult, any, error) {
@@ -1566,7 +1583,7 @@ func (m *MCPServer) toolReadEvents(ctx context.Context, req *mcp.CallToolRequest
 		return fallbackResult(fmt.Sprintf("read events failed: %v", err),
 			"ls .cog/ledger/ && cat .cog/ledger/*/events.jsonl")
 	}
-	return marshalResult(result)
+	return m.cappedMarshal(result)
 }
 
 func (m *MCPServer) toolTailEvents(ctx context.Context, req *mcp.CallToolRequest, input tailEventsInput) (*mcp.CallToolResult, any, error) {
@@ -1638,7 +1655,7 @@ func (m *MCPServer) toolTailEvents(ctx context.Context, req *mcp.CallToolRequest
 	for _, env := range replay {
 		events = append(events, envelopeToLedgerEvent(env))
 		if len(events) >= maxEvents {
-			return marshalResult(map[string]any{
+			return m.cappedMarshal(map[string]any{
 				"count":          len(events),
 				"events":         events,
 				"stopped_reason": "max_events",
@@ -1676,7 +1693,7 @@ tailLoop:
 		stopped = "max_events"
 	}
 
-	return marshalResult(map[string]any{
+	return m.cappedMarshal(map[string]any{
 		"count":          len(events),
 		"events":         events,
 		"stopped_reason": stopped,
@@ -1852,7 +1869,7 @@ func (m *MCPServer) toolTailKernelLog(ctx context.Context, req *mcp.CallToolRequ
 			fmt.Sprintf("tail -n 100 %s | jq -c .", path),
 		)
 	}
-	return marshalResult(result)
+	return m.cappedMarshal(result)
 }
 
 // intToStr renders an int as a string for BuildKernelLogQueryFromValues.
@@ -1888,7 +1905,7 @@ func (m *MCPServer) toolGetAgentState(ctx context.Context, req *mcp.CallToolRequ
 	if err != nil {
 		return agentErrorResult(err, "curl http://localhost:6931/v1/agents/primary")
 	}
-	return marshalResult(snap)
+	return m.cappedMarshal(snap)
 }
 
 // toolTriggerAgentLoop implements cog_trigger_agent_loop — manually
@@ -1933,7 +1950,7 @@ func (m *MCPServer) toolDispatchToHarness(ctx context.Context, req *mcp.CallTool
 	if err != nil {
 		return agentErrorResult(err, "curl -X POST http://localhost:6931/v1/agents/primary/dispatch -d @body.json")
 	}
-	return marshalResult(result)
+	return m.cappedMarshal(result)
 }
 
 // agentErrorResult translates AgentControllerError into the MCP fallback
@@ -2017,7 +2034,7 @@ func (m *MCPServer) toolRenderPeerAwarenessPacket(ctx context.Context, req *mcp.
 		return fallbackResult(fmt.Sprintf("render failed: %v", err),
 			"curl 'http://localhost:6931/v1/peer-awareness?sid=<sid>'")
 	}
-	return marshalResult(result)
+	return m.cappedMarshal(result)
 }
 
 // toolReadToolCalls is the MCP handler for cog_read_tool_calls. It parses the
@@ -2054,7 +2071,7 @@ func (m *MCPServer) toolReadToolCalls(ctx context.Context, req *mcp.CallToolRequ
 		return fallbackResult(fmt.Sprintf("query failed: %v", err),
 			"grep '\"type\":\"tool\\.' .cog/ledger/*/events.jsonl")
 	}
-	return marshalResult(result)
+	return m.cappedMarshal(result)
 }
 
 // toolTailToolCalls returns a snapshot of the most recent tool-call rows for
@@ -2100,7 +2117,7 @@ func (m *MCPServer) toolTailToolCalls(ctx context.Context, req *mcp.CallToolRequ
 			"tail -f .cog/ledger/*/events.jsonl | grep '\"type\":\"tool\\.'")
 	}
 	stopped := "snapshot"
-	return marshalResult(map[string]any{
+	return m.cappedMarshal(map[string]any{
 		"count":          result.Count,
 		"events":         result.Calls,
 		"stopped_reason": stopped,
@@ -2160,7 +2177,7 @@ func (m *MCPServer) toolReadConversation(ctx context.Context, req *mcp.CallToolR
 		return fallbackResult(fmt.Sprintf("query failed: %v", err),
 			fmt.Sprintf("jq -c . .cog/run/turns/%s.jsonl", sessionID))
 	}
-	return marshalResult(res)
+	return m.cappedMarshal(res)
 }
 
 // ── Config Mutation API ──────────────────────────────────────────────────────
@@ -2249,7 +2266,7 @@ func (m *MCPServer) toolSearchTraces(ctx context.Context, req *mcp.CallToolReque
 			"ls .cog/run/*.jsonl && jq -c . .cog/run/<name>.jsonl | head",
 		)
 	}
-	return marshalResult(res)
+	return m.cappedMarshal(res)
 }
 
 // buildTraceQueryFromInput validates the MCP input shape and normalizes it
@@ -2508,7 +2525,16 @@ func (m *MCPServer) toolReadFile(ctx context.Context, req *mcp.CallToolRequest, 
 		offset = 0
 	}
 
+	maxBytes := DefaultMaxToolOutputBytes
+	if m.cfg != nil {
+		maxBytes = m.cfg.EffectiveMaxToolOutputBytes()
+	}
+
 	scanner := bufio.NewScanner(f)
+	// Expand the scanner buffer so individual lines up to 1 MiB don't fail
+	// with "token too long" — we rely on the byte cap below to prevent
+	// megabyte blowout instead.
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	var buf bytes.Buffer
 	lineNo := 0
 	linesWritten := 0
@@ -2528,13 +2554,25 @@ func (m *MCPServer) toolReadFile(ctx context.Context, req *mcp.CallToolRequest, 
 		}
 		fmt.Fprintf(&buf, "%4d\t%s\n", lineNo, scanner.Text())
 		linesWritten++
+		// Byte cap: stop accumulating once we exceed the output cap.
+		// This is the primary guard against minified-blob blowout.
+		if buf.Len() >= maxBytes {
+			if scanner.Scan() {
+				truncated = true
+			}
+			break
+		}
 	}
 	if err := scanner.Err(); err != nil {
 		return textResult(fmt.Sprintf("read error: %v", err))
 	}
 
+	content, byteTruncated := capToolOutput(buf.String(), maxBytes)
+	if byteTruncated {
+		truncated = true
+	}
 	return marshalResult(map[string]any{
-		"content":   buf.String(),
+		"content":   content,
 		"lines":     linesWritten,
 		"truncated": truncated,
 	})
@@ -2692,10 +2730,14 @@ func (m *MCPServer) toolGrepFiles(ctx context.Context, req *mcp.CallToolRequest,
 		}
 	}
 
-	return marshalResult(map[string]any{
+	maxBytes := DefaultMaxToolOutputBytes
+	if m.cfg != nil {
+		maxBytes = m.cfg.EffectiveMaxToolOutputBytes()
+	}
+	return capMarshalResult(map[string]any{
 		"matches":   matches,
 		"truncated": truncated,
-	})
+	}, maxBytes)
 }
 
 // extractSection pulls a section from markdown by heading anchor.

--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -2591,7 +2591,17 @@ readLoop:
 		linesWritten++
 	}
 
-	content, byteTruncated := capToolOutput(buf.String(), maxBytes)
+	// Use the true file size as the marker denominator: the reader above is
+	// bounded, so len(buf) understates a large file by design.
+	totalBytes := int64(buf.Len())
+	var fileSize int64 = -1
+	if fi, statErr := f.Stat(); statErr == nil {
+		fileSize = fi.Size()
+		if fi.Size() > totalBytes {
+			totalBytes = fi.Size()
+		}
+	}
+	content, byteTruncated := capToolOutputWithTotal(buf.String(), maxBytes, totalBytes)
 	if byteTruncated {
 		truncated = true
 	}
@@ -2600,8 +2610,8 @@ readLoop:
 		"lines":     linesWritten,
 		"truncated": truncated,
 	}
-	if fi, statErr := f.Stat(); statErr == nil {
-		resp["file_size_bytes"] = fi.Size()
+	if fileSize >= 0 {
+		resp["file_size_bytes"] = fileSize
 	}
 	if overflowed {
 		resp["note"] = fmt.Sprintf(

--- a/z_conversations_mcp.go
+++ b/z_conversations_mcp.go
@@ -25,6 +25,6 @@ func init() {
 		if prev != nil {
 			prev(srv)
 		}
-		conversations.RegisterConversationTools(srv.Server(), srv.TrackTool, conversationsProviderInstance)
+		conversations.RegisterConversationTools(srv.Server(), srv.TrackTool, conversationsProviderInstance, srv.MaxToolOutputBytes())
 	}
 }


### PR DESCRIPTION
## Summary

**Diagnosis (2026-06-04, session `hermes-darkstar/20260604_162547_67278862`):**
> *toolReadFile caps 500 lines with no byte cap — a one-line minified blob can be megabytes.*
> The same issue was enumerated across every content-bearing cog_* handler: item/line counts without byte floors allowed multi-megabyte responses to enter agent context windows.

This PR lands the fix that was diagnosed then but never shipped.

## What changed

### Commit 1: byte-cap mechanism + all handlers
- `internal/engine/mcp_output_cap.go`: `capToolOutput(s, maxBytes) (string, bool)` — trims at UTF-8 rune boundary, appends explicit marker stating size and narrowing guidance. Never silent.
- `Config.MaxToolOutputBytes` + `EffectiveMaxToolOutputBytes()` — kernel.yaml knob `max_tool_output_bytes`, default 32 KiB, hard floor 4 KiB.
- `cappedMarshal` / `capMarshalResult` applied across 21 handlers (table below).

### Commit 2: scanner-cliff fix (from real-data e2e review)
The first commit's `bufio.Scanner` with a 1 MiB buffer still ERRORED (`token too long`) on a 5,000,009-byte single-line file — the exact diagnosed case. Replaced with `readLineCapped(r, keep, drain)`:
- Chunked `ReadSlice` loop — over-long lines are **truncated, never errored**, with any buffer size.
- `cog_read_file` uses `drain=false`: at most **~maxBytes+ε is read from disk** regardless of file size (strictly better than reading 5 MB to discard it).
- Response now includes `file_size_bytes` (true source size; the marker's byte counts refer to the rendered buffer) and a `note` when a line is cut mid-line — line numbering beyond the cut is not scanned, paging via offset/limit.
- `cog_grep_files` had the same cliff in **silent** form: both scanner sites (rg-output parse, Go-fallback walk) silently stopped at >64 KiB lines, dropping all later matches. Both now use `readLineCapped` (64 KiB per-line retention, full drain) so subsequent matches are still found.
- Cheap fix while in there: bare relative paths (`blob.json`) in `cog_read_file`/`cog_grep_files` now resolve against the workspace root instead of kernel CWD.

### Handlers capped (21 tools)

| Handler | File | Notes |
|---|---|---|
| `cog_read_file` | mcp_server.go | Chunked capped reader; never reads more than cap+ε; `file_size_bytes` + mid-line `note` |
| `cog_grep_files` | mcp_server.go | Capped line reader at both scanner sites + response-level cap |
| `cog_read_cogdoc` | mcp_server.go | Cap on full-doc and fragment paths |
| `cog_search_memory` | mcp_server.go | |
| `cog_check_coherence` | mcp_server.go | |
| `cog_assemble_context` | mcp_server.go | |
| `cog_read_ledger` | mcp_server.go | |
| `cog_read_events` | mcp_server.go | |
| `cog_tail_events` | mcp_server.go | Both early-return (max_events) and final return |
| `cog_tail_kernel_log` | mcp_server.go | |
| `cog_read_conversation` | mcp_server.go | |
| `cog_read_tool_calls` | mcp_server.go | |
| `cog_tail_tool_calls` | mcp_server.go | |
| `cog_get_agent_state` | mcp_server.go | |
| `cog_dispatch_to_harness` | mcp_server.go | |
| `cog_search_traces` | mcp_server.go | |
| `cog_render_peer_awareness_packet` | mcp_server.go | |
| All 8 `cog_architecture_*` tools | mcp_architecture.go | Via shared `execArchitectureTool` |
| `cog_search_conversations` | conversations/mcp_tools.go | `maxBytes` threaded through `RegisterConversationTools` |
| `cog_get_conversation_turn` | conversations/mcp_tools.go | |
| `cog_list_conversations` | conversations/mcp_tools.go | |

## e2e verification (real sandbox kernel)

Built this branch, served `--workspace /tmp/caps-sandbox --port 7034`, MCP streamable HTTP initialize → `tools/call cog_read_file` on `/private/tmp/caps-sandbox/blob.json` (single 5,000,008-byte line):

- Response: **33,284 bytes** (was: `read error: bufio.Scanner: token too long`)
- Content: 32 KiB of payload ending with
  `[output truncated: returned 32768 of 32774 bytes; narrow with offset/limit/filters, or dereference cog:conversations/... where applicable]`
- Plus `"file_size_bytes":5000008`, `"truncated":true`, and
  `"note":"line 1 exceeded the 32768-byte output cap and was cut mid-line; the rest of the file was not scanned, so line numbering beyond this point is unknown — use offset/limit to page"`

## macOS path notes (from e2e review)

- **`/tmp/...` rejected as outside root**: could **not reproduce** on this build booted with `--workspace /tmp/caps-sandbox` — the containment code resolves symlinks on both sides and `/tmp/caps-sandbox/blob.json` reads fine. That containment logic **predates this PR** (commit `2641475`). One residual pre-existing edge: when the target file does *not* exist under a symlinked root, `EvalSymlinks(abs)` fails and the unresolved path is compared against the resolved root, yielding a misleading "outside workspace root" instead of "not found". Left as-is (out of scope).
- **Bare relative path rejected**: pre-existing (`filepath.Abs` resolved against kernel CWD). Fixed here since it was a two-line change; covered by test.

## Config

```yaml
# kernel.yaml (optional; default 32768 / 32 KiB; floor 4096 / 4 KiB)
max_tool_output_bytes: 32768
```

## Test plan

- [x] `go build ./...` + `go vet` clean
- [x] `go test ./internal/... -short -timeout 120s` all pass
- [x] New: 5 MB one-line blob (exceeds any internal buffer) → capped + marker, **no error**
- [x] New: `readLineCapped` table-driven (boundaries, EOF, drain/no-drain, 1 MB line through 64-byte buffer)
- [x] New: offset-skip over a 300 KiB line; grep match after a 200 KiB line no longer dropped; relative-path resolution
- [x] Real-kernel e2e on sandbox fixture (above)
- [ ] Do not merge — review first