### PR TITLE
test(daemon): close gap C — extract wiring to internal/providers/all, add TestDaemonWiring

### DIFF
--- a/cmd/cogos/providers_wire.go
+++ b/cmd/cogos/providers_wire.go
@@ -1,239 +1,31 @@
-// providers_wire.go — wires Reconcilable provider registration, workspace
-// context, and MCP tool extensions into the kernel daemon at boot.
+// providers_wire.go — thin caller that applies all production provider and
+// MCP-extension registrations into the kernel daemon at boot.
 //
-// A named import of internal/providers/daemon triggers that package's init(),
-// which registers all 10 production providers ("agent", "component", "discord",
-// "eval", "identity", "mcp-tools", "openclaw-agents", "openclaw-cron",
-// "openclaw-gateway", "service") with pkg/reconcile before engine.Main()
-// starts the HTTP server.
+// The logic formerly in this file has been extracted to
+// internal/providers/all so it is importable by test helpers outside this
+// package main.  This file keeps the package-level vars (daemonEvalProvider,
+// daemonHarnessRegistry) that are referenced by binary-assembly tests in
+// this directory, and its init() delegates to all.Register.
 //
-// The identity provider (Wave 6b) registers a daemon-side stub via
-// internal/providers/daemon. The full plan/apply implementation lives in
-// workspace-root identity_wiring.go (cog CLI binary).
-//
-// engine.RegisterProviders is set here so the registration call happens inside
-// runServe() (after the logger is up) rather than in a file-level init() that
-// might fire before tracing/logging infrastructure is ready.
-//
-// engine.SetProvidersWorkspace is set here so that after LoadConfig resolves
-// cfg.WorkspaceRoot, the daemon-side providers receive the workspace path and
-// can perform real filesystem Health() checks rather than reporting
-// "workspace not yet configured".
-//
-// engine.RegisterMCPExtensions wires the four eval MCP tools
-// (cog_run_experiment, cog_list_experiments, cog_get_experiment_status,
-// cog_pin_baseline) onto the kernel's MCP server so they are accessible
-// from both the cog CLI binary and the daemon.
-//
-// workspace.LoadConfig and workspace.GitRoot are wired here so that
-// internal/workspace.ResolveWorkspace() can resolve the active workspace
-// from ~/.cog/node/global.yaml and from the enclosing git repository, in
-// addition to the COG_ROOT environment variable. Without this wiring the
-// daemon binary skips tiers 2-4 of the resolution algorithm silently.
-// Previously this wiring lived only in cog.go:init() (the CLI binary).
+// See internal/providers/all/all.go for the full wiring description.
 package main
 
 import (
-	"bytes"
-	"context"
-	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
-
-	"github.com/myrgic/cogos/internal/engine"
 	"github.com/myrgic/cogos/internal/eval"
-	"github.com/myrgic/cogos/internal/providers/component"
-	"github.com/myrgic/cogos/internal/providers/daemon"
-	_ "github.com/myrgic/cogos/internal/providers/site" // registers "site" with pkg/reconcile
-	"github.com/myrgic/cogos/internal/workspace"
+	"github.com/myrgic/cogos/internal/providers/all"
 	subidentity "github.com/myrgic/cogos/pkg/substrate/identity"
-	"gopkg.in/yaml.v3"
 )
 
-// daemonGlobalConfig is the minimal shape of ~/.cog/node/global.yaml that
-// workspace resolution requires. Only the two fields used by
-// workspace.ConfigProvider are declared; other keys round-trip cleanly via
-// yaml.v3's default behaviour.
-//
-// ADR-085 rule 7: duplicate small helpers rather than exporting them from
-// the root CLI package.
-type daemonGlobalConfig struct {
-	CurrentWorkspace string                           `yaml:"current-workspace,omitempty"`
-	Workspaces       map[string]*daemonWorkspaceEntry `yaml:"workspaces,omitempty"`
-}
-
-type daemonWorkspaceEntry struct {
-	Path string `yaml:"path"`
-}
-
-func (c *daemonGlobalConfig) CurrentWorkspaceValue() string { return c.CurrentWorkspace }
-func (c *daemonGlobalConfig) WorkspacePath(name string) (string, bool) {
-	e, ok := c.Workspaces[name]
-	if !ok || e == nil {
-		return "", false
-	}
-	return e.Path, ok
-}
-
-// daemonConfigProvider wraps *daemonGlobalConfig to implement workspace.ConfigProvider.
-type daemonConfigProvider struct{ cfg *daemonGlobalConfig }
-
-func (p daemonConfigProvider) CurrentWorkspace() string { return p.cfg.CurrentWorkspace }
-func (p daemonConfigProvider) WorkspacePath(name string) (string, bool) {
-	return p.cfg.WorkspacePath(name)
-}
-
-// loadDaemonGlobalConfig reads ~/.cog/node/global.yaml, falling back to
-// ~/.cog/config (the legacy path used before issue #161). Returns an empty
-// config on ENOENT so the daemon starts even on a fresh node.
-//
-// Local duplicate of cog.go's loadGlobalConfig / globalConfigPath per
-// ADR-085 rule 7.
-func loadDaemonGlobalConfig() (workspace.ConfigProvider, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return daemonConfigProvider{cfg: &daemonGlobalConfig{
-			Workspaces: make(map[string]*daemonWorkspaceEntry),
-		}}, nil
-	}
-	newPath := filepath.Join(home, ".cog", "node", "global.yaml")
-	oldPath := filepath.Join(home, ".cog", "config")
-
-	path := newPath
-	if _, statErr := os.Stat(newPath); os.IsNotExist(statErr) {
-		if _, statErr2 := os.Stat(oldPath); statErr2 == nil {
-			path = oldPath
-		}
-	}
-
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return daemonConfigProvider{cfg: &daemonGlobalConfig{
-				Workspaces: make(map[string]*daemonWorkspaceEntry),
-			}}, nil
-		}
-		return nil, fmt.Errorf("daemon: read global config: %w", err)
-	}
-
-	var cfg daemonGlobalConfig
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("daemon: parse global config: %w", err)
-	}
-	if cfg.Workspaces == nil {
-		cfg.Workspaces = make(map[string]*daemonWorkspaceEntry)
-	}
-	return daemonConfigProvider{cfg: &cfg}, nil
-}
-
-// daemonGitRoot returns the top-level git repository containing the process
-// working directory. Local duplicate of cog.go's gitRoot per ADR-085 rule 7.
-func daemonGitRoot() (string, error) {
-	var out bytes.Buffer
-	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
-	cmd.Stdout = &out
-	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("not a git repository")
-	}
-	return strings.TrimSpace(out.String()), nil
-}
-
-// uriRegistryLocatorAdapter adapts engine.ResolveWorkspacePath to satisfy the
-// pin.WorkspaceLocator interface. This avoids exporting the engine's unexported
-// uriResolver type while still allowing the pin provider to consult the global
-// workspace registry for target path resolution.
-type uriRegistryLocatorAdapter struct{}
-
-func (a *uriRegistryLocatorAdapter) LocateWorkspace(ctx context.Context, name string) (string, error) {
-	return engine.ResolveWorkspacePath(ctx, name)
-}
-
-// daemonEvalProvider is the daemon-side EvalProvider instance passed to the
-// eval MCP tools. The daemon does not run plan/apply; it only exposes the
-// four read/trigger tools whose state effects (trigger files, baseline pins)
-// are read by the CLI's reconcile loop.
+// daemonEvalProvider is the daemon-side EvalProvider instance. The daemon does
+// not run plan/apply; it only exposes the four read/trigger eval MCP tools
+// whose state effects are read by the CLI's reconcile loop.
 var daemonEvalProvider = eval.New(nil, nil)
 
+// daemonHarnessRegistry is the in-memory RBAC harness-binding store.
+// It satisfies engine.HarnessAttacher so cog_register_session can create
+// HarnessBindingCRDs for sessions that supply a "subject" field.
+var daemonHarnessRegistry = subidentity.NewHarnessRegistry()
+
 func init() {
-	// Wire workspace.LoadConfig and workspace.GitRoot so that
-	// internal/workspace.ResolveWorkspace() can resolve workspaces via the
-	// global registry (~/.cog/node/global.yaml) and via git root detection,
-	// in addition to the COG_ROOT env var that always works unconditionally.
-	//
-	// These DI seams were previously only wired in cog.go:init() (the CLI
-	// binary). Moving them here closes the gap for the daemon binary.
-	workspace.LoadConfig = func() (workspace.ConfigProvider, error) {
-		return loadDaemonGlobalConfig()
-	}
-	workspace.GitRoot = daemonGitRoot
-
-	// The named import of internal/providers/daemon above already triggered
-	// daemon.init() (and component.init() via daemon's blank import), which
-	// called reconcile.RegisterProvider for all 10 providers (including the
-	// Wave 6b identity stub). engine.RegisterProviders is set to a no-op rather
-	// than left nil so runServe() logs "providers registered" when it calls the hook.
-	engine.RegisterProviders = func() {
-		// providers already registered by internal/providers/daemon init()
-
-		// ProjectionCompiler (ADR-projection-compiler-primitive, ratified 2026-05-22):
-		// depth-axis Reconcilable that compiles reflective cogdocs at
-		// cog://mem/reflective/ into structured events. Uses filesystem-backed
-		// defaults; idempotent — UpsertProvider semantics make repeated calls safe.
-		engine.RegisterProjectionCompiler()
-	}
-
-	// Wire workspace context into daemon-side providers. runServe() calls this
-	// after LoadConfig resolves cfg.WorkspaceRoot. Until then, workspaceRoot
-	// is "" and Health() returns "workspace not yet configured" — acceptable
-	// because no Health() is called until the autonomic ticker or foveated
-	// handler fires.
-	engine.SetProvidersWorkspace = func(workspaceRoot string) {
-		daemon.SetWorkspaceRoot(workspaceRoot)
-		component.SetWorkspaceRoot(workspaceRoot)
-		// WorktreeReconciler (ADR-096, accepted 2026-05-22): the substrate-
-		// canonical Reconcilable for git worktree lifecycle. v0 registers one
-		// instance per workspace root using filesystem-backed ledger adapters.
-		// Multi-repo registration is ADR-096 Open Question 4 territory.
-		// UpsertProvider is idempotent — safe to call on every workspace
-		// resolution.
-		if workspaceRoot != "" {
-			engine.RegisterWorktreeReconciler(workspaceRoot, nil, nil, nil)
-		}
-		// Wire URIRegistry into the pin provider's WorkspaceLocator so FetchLive
-		// can consult the global workspace registry for target path resolution
-		// (two-step chain: registry → sibling-dir fallback). Safe to call every
-		// time SetProvidersWorkspace fires — SetPinWorkspaceLocator is idempotent.
-		daemon.SetPinWorkspaceLocator(&uriRegistryLocatorAdapter{})
-		// Prime the daemon EvalProvider root so its MCP tools can resolve
-		// the workspace-relative state files (eval-dispatch-triggers.json,
-		// eval-baselines.json). LoadConfig is idempotent — safe to call here.
-		if workspaceRoot != "" {
-			_, _ = daemonEvalProvider.LoadConfig(workspaceRoot)
-		}
-	}
-
-	// Wire the four eval MCP tools onto the kernel's MCP server. The daemon
-	// EvalProvider is minimal (no dispatcher/emitter) — the tools read/write
-	// the sidecar state files that the CLI's reconcile loop consumes.
-	// The root path is set lazily: cog_run_experiment calls LoadConfig, which
-	// sets e.root before writeDispatchTrigger uses it. For a fully configured
-	// workspace, the tools work end-to-end; for a fresh smoke workspace they
-	// return a "not configured" error that still exercises the code path.
-	engine.RegisterMCPExtensions = func(srv *engine.MCPServer) {
-		eval.RegisterEvalTools(srv.Server(), daemonEvalProvider)
-	}
-
-	// G0(b): wire the RBAC harness-binding layer so cog_register_session can
-	// create HarnessBindingCRDs when a "subject" field is supplied.
-	// The daemon binary uses HarnessRegistry from pkg/substrate/identity —
-	// a minimal in-memory implementation of the HarnessAttacher interface.
-	// The full RBACProvider (with reconcile-cycle integration) lives in the
-	// CLI binary's root package; the daemon-side shim satisfies the same
-	// interface with a lighter footprint appropriate to the daemon's role.
-	daemonHarnessRegistry := subidentity.NewHarnessRegistry()
-	engine.WireHarnessBackend = func(s *engine.Server) {
-		s.SetHarnessBackend(daemonHarnessRegistry)
-	}
+	all.Register(daemonEvalProvider, daemonHarnessRegistry)
 }

--- a/cmd/cogos/z_conversations_wire.go
+++ b/cmd/cogos/z_conversations_wire.go
@@ -1,79 +1,34 @@
-// z_conversations_wire.go — wires the Conversations Observatory into the
-// kernel daemon.
+// z_conversations_wire.go — thin caller that wires the Conversations
+// Observatory into the kernel daemon.
 //
-// Prefixed "z_" so this init() runs after providers_wire.go (p < z), ensuring
-// we chain on top of the eval-tools RegisterMCPExtensions set there.
+// Prefixed "z_" so this init() runs after providers_wire.go (p < z),
+// ensuring we chain on top of the eval-tools RegisterMCPExtensions set there.
 //
-// The daemon does not run plan/apply for the conversations provider
-// (that is the cog CLI's job via the workspace-root reconcile loop).
-// However the daemon DOES need the MCP tools registered so agents can
-// call cog_search_conversations from within a daemon-mediated session.
+// The logic formerly in this file has been extracted to
+// internal/providers/all.RegisterConversations so it is importable by test
+// helpers outside this package main.  This file keeps daemonConversationsProvider
+// as a package-level var because it is referenced directly by the binary-assembly
+// regression test in z_conversations_wire_test.go.
 //
-// The conversations provider singleton is shared between the reconcile
-// registration (wired here) and the MCP tool handlers. The provider's
-// LoadConfig is called lazily the first time the MCP tools are invoked
-// (or when engine.SetProvidersWorkspace fires), so the daemon starts
-// cleanly even before a workspace is configured.
+// PLACEMENT NOTE (preserved from original):
+//   This wiring MUST live in cmd/cogos (the kernel daemon binary), not in
+//   the repo-root package main.  The root package is the legacy cog CLI
+//   monolith mid-decomposition; it never boots engine.Server, so any
+//   SetConversationsResolver call placed there never runs in the daemon and
+//   /v1/uri/resolve answers "resolver not wired".
 package main
 
 import (
-	"context"
-
 	"github.com/myrgic/cogos/internal/conversations"
-	"github.com/myrgic/cogos/internal/engine"
-	"github.com/myrgic/cogos/pkg/substrate/reconcile"
+	"github.com/myrgic/cogos/internal/providers/all"
 )
 
+// daemonConversationsProvider is the shared provider singleton for both the
+// reconcile registration and the MCP tool handlers.  The existing
+// binary-assembly test (z_conversations_wire_test.go) reaches this var
+// directly; keep it here rather than in internal/providers/all.
 var daemonConversationsProvider = conversations.NewProvider()
 
-// daemonURIResolver adapts the conversations provider to the
-// engine.ConversationsResolver interface backing GET /v1/uri/resolve.
-//
-// Placement matters: this wiring MUST live in cmd/cogos (the kernel daemon
-// binary), not in the repo-root package main. The root package is the legacy
-// cog CLI monolith mid-decomposition; it never boots engine.Server, so any
-// SetConversationsResolver call placed there never runs in the daemon and
-// /v1/uri/resolve answers "resolver not wired" — the exact bug this comment
-// guards against (caught by real-data e2e review of PR #370).
-type daemonURIResolver struct {
-	p *conversations.Provider
-}
-
-func (r *daemonURIResolver) ResolveURI(_ context.Context, uri string) (any, error) {
-	return r.p.ResolveURI(uri)
-}
-
 func init() {
-	// Register the conversations provider with the reconcile registry so the
-	// daemon's proprioception Health() block includes it.
-	reconcile.RegisterProvider("conversations", daemonConversationsProvider)
-
-	// Wire workspace root injection — called by SetProvidersWorkspace after
-	// LoadConfig resolves cfg.WorkspaceRoot. Triggers index initialisation.
-	prevSetWorkspace := engine.SetProvidersWorkspace
-	engine.SetProvidersWorkspace = func(workspaceRoot string) {
-		if prevSetWorkspace != nil {
-			prevSetWorkspace(workspaceRoot)
-		}
-		if workspaceRoot != "" {
-			// Initialise the index against the resolved workspace root.
-			// Errors are non-fatal — the provider degrades gracefully.
-			_, _ = daemonConversationsProvider.LoadConfig(workspaceRoot)
-		}
-	}
-
-	// Chain conversations MCP tools after the eval tools registered by
-	// providers_wire.go (p < z ensures providers_wire.go init() ran first).
-	prev := engine.RegisterMCPExtensions
-	engine.RegisterMCPExtensions = func(srv *engine.MCPServer) {
-		if prev != nil {
-			prev(srv)
-		}
-		conversations.RegisterConversationTools(srv.Server(), srv.TrackTool, daemonConversationsProvider, srv.MaxToolOutputBytes())
-	}
-
-	// Wire the cog:conversations URI resolver behind GET /v1/uri/resolve.
-	// Shares the same provider singleton as the MCP tools so both surfaces
-	// see the same live index.
-	engine.SetConversationsResolver(&daemonURIResolver{p: daemonConversationsProvider})
+	all.RegisterConversations(daemonConversationsProvider)
 }

--- a/cmd/cogos/z_daemon_wiring_test.go
+++ b/cmd/cogos/z_daemon_wiring_test.go
@@ -1,0 +1,122 @@
+// z_daemon_wiring_test.go — binary-assembly regression guard for the full
+// cmd/cogos provider and MCP-extension wiring.
+//
+// Context (ADR-101 test-gap C):
+//
+//	PR #370 shipped a dead daemon route: the conversations URI resolver was
+//	placed in the repo-root package main (never linked into cmd/cogos), so
+//	42 green unit tests passed while GET /v1/uri/resolve answered "not wired"
+//	on a live kernel.  z_conversations_wire_test.go guards the resolver seam.
+//
+//	Gap C is the generalisation: zero tests verified that cmd/cogos as a whole
+//	assembles the expected MCP surface.  A future change could drop an import
+//	or an init() call and all existing tests would still pass.
+//
+// This test closes gap C by booting a kernel via internal/testkernel with the
+// PRODUCTION registration set (exactly the init() chain that runs in the
+// daemon binary) and asserting over the live MCP wire protocol:
+//
+//  1. The golden tool set (one representative per wired subsystem) is present.
+//  2. The conversations URI resolver seam is populated (engine-level check).
+//  3. The harness-backend wiring hook is set (engine-level check).
+//
+// Running inside package main ensures this binary's init() chain — the exact
+// wiring the daemon boots with — has executed by the time the test runs.
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/myrgic/cogos/internal/engine"
+	"github.com/myrgic/cogos/internal/testkernel"
+)
+
+// goldenTools is the minimal set of MCP tool names that must be present on
+// the live daemon surface.  One tool per wired subsystem, matching the e2e
+// probe in scripts/e2e-test.sh (Phase 3b section).
+//
+// Adding a tool here intentionally: the set is deliberately small so that
+// normal tool-name churn doesn't require constant test updates.  The goal is
+// to detect a dropped registration chain, not to enumerate every tool.
+var goldenTools = []string{
+	"cog_get_state",           // core kernel MCP (mcp_server.go)
+	"cog_search_memory",       // core kernel MCP (mcp_server.go)
+	"cog_search_conversations", // conversations layer (z_conversations_wire.go)
+	"cog_list_sessions",       // session tools (mcp_sessions.go)
+	"cog_read_cogdoc",         // core kernel MCP (mcp_server.go)
+}
+
+// TestDaemonWiring boots the kernel daemon with the production registration
+// set and asserts the golden MCP surface over the live wire protocol.
+//
+// This test is the binary-assembly guard for cmd/cogos as a whole.  It
+// complements the seam-level checks in z_conversations_wire_test.go by
+// exercising the full MCP surface rather than a single engine variable.
+func TestDaemonWiring(t *testing.T) {
+	if testing.Short() {
+		t.Skip("TestDaemonWiring: skipped in -short mode (boots a live kernel)")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Boot with the production registration set.  init() in providers_wire.go
+	// and z_conversations_wire.go has already fired by the time this line runs;
+	// engine.RegisterMCPExtensions holds the full eval+conversations chain.
+	k, err := testkernel.Boot(ctx, t)
+	if err != nil {
+		t.Fatalf("testkernel.Boot: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := k.Stop(); err != nil {
+			t.Errorf("testkernel.Stop: %v", err)
+		}
+	})
+
+	// ── 1. Golden tool set ────────────────────────────────────────────────────
+
+	tools, err := k.ListTools(ctx, t)
+	if err != nil {
+		t.Fatalf("k.ListTools: %v", err)
+	}
+
+	// Build a presence map for O(1) lookup.
+	toolSet := make(map[string]struct{}, len(tools))
+	for _, name := range tools {
+		toolSet[name] = struct{}{}
+	}
+
+	for _, want := range goldenTools {
+		if _, ok := toolSet[want]; !ok {
+			t.Errorf("golden tool missing from live MCP surface: %q\n"+
+				"  hint: check that the registration chain in cmd/cogos "+
+				"(providers_wire.go / z_conversations_wire.go) was not broken\n"+
+				"  registered tools: %v", want, tools)
+		}
+	}
+
+	// ── 2. Conversations resolver seam ────────────────────────────────────────
+	// init() in z_conversations_wire.go must have called
+	// engine.SetConversationsResolver; if it didn't, GET /v1/uri/resolve will
+	// answer "resolver not wired" on a live kernel.
+
+	if r := engine.WiredConversationsResolver(); r == nil {
+		t.Error("engine conversations resolver is nil after cmd/cogos init — " +
+			"RegisterConversations wiring is missing from the daemon binary " +
+			"(it must reach engine.SetConversationsResolver via z_conversations_wire.go)")
+	}
+
+	// ── 3. Harness-backend wiring hook ────────────────────────────────────────
+	// init() in providers_wire.go must have set engine.WireHarnessBackend so
+	// that cog_register_session can create HarnessBindingCRDs for sessions that
+	// supply a "subject" field.  A nil hook means the harness layer is dark and
+	// RBAC session binding silently does nothing.
+
+	if engine.WireHarnessBackend == nil {
+		t.Error("engine.WireHarnessBackend is nil after cmd/cogos init — " +
+			"the harness-backend wiring hook is missing from the daemon binary " +
+			"(it must be set in providers_wire.go or all.Register)")
+	}
+}

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -1,0 +1,251 @@
+// Package all wires all production provider and MCP-extension registrations
+// used by the kernel daemon (cmd/cogos).
+//
+// Motivation (ADR-101 test-gap C):
+//
+//	Before this package existed the wiring lived exclusively in cmd/cogos
+//	(a package main, not importable by test helpers outside that directory).
+//	Extracting it here allows testkernel-based tests to apply the same
+//	production registration set that the daemon boots with, closing the
+//	"cmd/cogos assembly" gap where a dropped registration goes undetected
+//	until a live kernel is interrogated.
+//
+// Design rules:
+//   - No package-level init().  The two functions below are pure setters;
+//     callers (cmd/cogos init() blocks) decide when to invoke them.
+//   - No package-level state beyond the helpers shared by the two functions.
+//     The eval provider and harness registry are owned by the caller and
+//     passed in; conversations provider is similarly owned by the caller.
+//   - cmd/cogos stays as the owner of package-level provider vars so that
+//     the existing cmd/cogos test (z_conversations_wire_test.go) can reach
+//     them without indirection.
+//
+// Usage in cmd/cogos:
+//
+//	// providers_wire.go init():
+//	all.Register(daemonEvalProvider, daemonHarnessRegistry)
+//
+//	// z_conversations_wire.go init():
+//	all.RegisterConversations(daemonConversationsProvider)
+//
+// Usage in tests:
+//
+//	// Reset engine globals, apply production wiring, boot kernel.
+//	all.Register(eval.New(nil, nil), subidentity.NewHarnessRegistry())
+//	all.RegisterConversations(conversations.NewProvider())
+//	k, _ := testkernel.Boot(ctx, t)
+package all
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/myrgic/cogos/internal/conversations"
+	"github.com/myrgic/cogos/internal/engine"
+	"github.com/myrgic/cogos/internal/eval"
+	"github.com/myrgic/cogos/internal/providers/component"
+	"github.com/myrgic/cogos/internal/providers/daemon"
+	_ "github.com/myrgic/cogos/internal/providers/site" // registers "site" with pkg/reconcile
+	"github.com/myrgic/cogos/internal/workspace"
+	subidentity "github.com/myrgic/cogos/pkg/substrate/identity"
+	"github.com/myrgic/cogos/pkg/substrate/reconcile"
+	"gopkg.in/yaml.v3"
+)
+
+// ── workspace helpers (duplicated from cmd/cogos per ADR-085 rule 7) ─────────
+
+// globalConfig is the minimal shape of ~/.cog/node/global.yaml used by
+// workspace resolution.
+type globalConfig struct {
+	CurrentWorkspace string                    `yaml:"current-workspace,omitempty"`
+	Workspaces       map[string]*workspaceEntry `yaml:"workspaces,omitempty"`
+}
+
+type workspaceEntry struct {
+	Path string `yaml:"path"`
+}
+
+type configProvider struct{ cfg *globalConfig }
+
+func (p configProvider) CurrentWorkspace() string { return p.cfg.CurrentWorkspace }
+func (p configProvider) WorkspacePath(name string) (string, bool) {
+	e, ok := p.cfg.Workspaces[name]
+	if !ok || e == nil {
+		return "", false
+	}
+	return e.Path, ok
+}
+
+// loadGlobalConfig reads ~/.cog/node/global.yaml with the legacy fallback.
+// Returns empty config on ENOENT.
+func loadGlobalConfig() (workspace.ConfigProvider, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return configProvider{cfg: &globalConfig{Workspaces: make(map[string]*workspaceEntry)}}, nil
+	}
+	newPath := filepath.Join(home, ".cog", "node", "global.yaml")
+	oldPath := filepath.Join(home, ".cog", "config")
+
+	path := newPath
+	if _, statErr := os.Stat(newPath); os.IsNotExist(statErr) {
+		if _, statErr2 := os.Stat(oldPath); statErr2 == nil {
+			path = oldPath
+		}
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return configProvider{cfg: &globalConfig{Workspaces: make(map[string]*workspaceEntry)}}, nil
+		}
+		return nil, fmt.Errorf("providers/all: read global config: %w", err)
+	}
+
+	var cfg globalConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("providers/all: parse global config: %w", err)
+	}
+	if cfg.Workspaces == nil {
+		cfg.Workspaces = make(map[string]*workspaceEntry)
+	}
+	return configProvider{cfg: &cfg}, nil
+}
+
+// gitRoot returns the top-level git repository containing the process
+// working directory.
+func gitRoot() (string, error) {
+	var out bytes.Buffer
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("not a git repository")
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+// uriRegistryLocator adapts engine.ResolveWorkspacePath to the pin.WorkspaceLocator
+// interface without exporting engine's internal resolver type.
+type uriRegistryLocator struct{}
+
+func (a *uriRegistryLocator) LocateWorkspace(ctx context.Context, name string) (string, error) {
+	return engine.ResolveWorkspacePath(ctx, name)
+}
+
+// ── Registration ──────────────────────────────────────────────────────────────
+
+// Register sets the four engine hook variables that the kernel daemon uses
+// at boot:
+//
+//   - engine.RegisterProviders — reconcile provider registry + ProjectionCompiler
+//   - engine.SetProvidersWorkspace — workspace root injection into providers
+//   - engine.RegisterMCPExtensions — eval MCP tools (initial chain)
+//   - engine.WireHarnessBackend — RBAC harness-binding layer
+//
+// Also wires workspace.LoadConfig and workspace.GitRoot so that
+// workspace.ResolveWorkspace() can resolve via the global registry and git root
+// detection in addition to COG_ROOT.
+//
+// Register replaces (not chains) any previously set values for these four
+// hooks. Call RegisterConversations after Register to add the conversations
+// layer on top.
+//
+// Callers own evalProvider and harnessRegistry. Pass eval.New(nil, nil) and
+// subidentity.NewHarnessRegistry() for production defaults.
+func Register(evalProvider *eval.EvalProvider, harnessRegistry *subidentity.HarnessRegistry) {
+	// Wire workspace resolution DI seams.
+	workspace.LoadConfig = func() (workspace.ConfigProvider, error) {
+		return loadGlobalConfig()
+	}
+	workspace.GitRoot = gitRoot
+
+	// The named import of internal/providers/daemon above triggered daemon.init()
+	// (and component.init() via daemon's blank import), registering all 10
+	// production providers with pkg/reconcile.
+	engine.RegisterProviders = func() {
+		// providers already registered by internal/providers/daemon init()
+		engine.RegisterProjectionCompiler()
+	}
+
+	engine.SetProvidersWorkspace = func(workspaceRoot string) {
+		daemon.SetWorkspaceRoot(workspaceRoot)
+		component.SetWorkspaceRoot(workspaceRoot)
+		if workspaceRoot != "" {
+			engine.RegisterWorktreeReconciler(workspaceRoot, nil, nil, nil)
+		}
+		daemon.SetPinWorkspaceLocator(&uriRegistryLocator{})
+		if workspaceRoot != "" && evalProvider != nil {
+			_, _ = evalProvider.LoadConfig(workspaceRoot)
+		}
+	}
+
+	engine.RegisterMCPExtensions = func(srv *engine.MCPServer) {
+		if evalProvider != nil {
+			eval.RegisterEvalTools(srv.Server(), evalProvider)
+		}
+	}
+
+	engine.WireHarnessBackend = func(s *engine.Server) {
+		if harnessRegistry != nil {
+			s.SetHarnessBackend(harnessRegistry)
+		}
+	}
+}
+
+// RegisterConversations chains the conversations layer onto the already-set
+// engine.RegisterMCPExtensions hook and calls engine.SetConversationsResolver.
+//
+// Must be called AFTER Register (or after any other code that sets
+// engine.RegisterMCPExtensions) so the chain is: eval tools → conversations
+// tools, matching the init() ordering in cmd/cogos ("p" before "z").
+//
+// Also registers the conversations provider with pkg/reconcile so the daemon's
+// proprioception Health() block includes it, and wires workspace root injection
+// so the provider's index is initialised on engine.SetProvidersWorkspace.
+//
+// provider must be non-nil; pass conversations.NewProvider() for production.
+func RegisterConversations(provider *conversations.Provider) {
+	if provider == nil {
+		return
+	}
+
+	// Register provider with reconcile registry.
+	reconcile.RegisterProvider("conversations", provider)
+
+	// Chain workspace root injection.
+	prevSetWorkspace := engine.SetProvidersWorkspace
+	engine.SetProvidersWorkspace = func(workspaceRoot string) {
+		if prevSetWorkspace != nil {
+			prevSetWorkspace(workspaceRoot)
+		}
+		if workspaceRoot != "" {
+			_, _ = provider.LoadConfig(workspaceRoot)
+		}
+	}
+
+	// Chain MCP extension registration.
+	prev := engine.RegisterMCPExtensions
+	engine.RegisterMCPExtensions = func(srv *engine.MCPServer) {
+		if prev != nil {
+			prev(srv)
+		}
+		conversations.RegisterConversationTools(srv.Server(), srv.TrackTool, provider, srv.MaxToolOutputBytes())
+	}
+
+	// Wire conversations URI resolver.
+	engine.SetConversationsResolver(&conversationsURIResolver{p: provider})
+}
+
+// conversationsURIResolver adapts conversations.Provider to
+// engine.ConversationsResolver.
+type conversationsURIResolver struct {
+	p *conversations.Provider
+}
+
+func (r *conversationsURIResolver) ResolveURI(_ context.Context, uri string) (any, error) {
+	return r.p.ResolveURI(uri)
+}

--- a/internal/testkernel/testkernel.go
+++ b/internal/testkernel/testkernel.go
@@ -4,8 +4,9 @@
 // ADR-101 Phase 1: thin wrapper over engine.Boot.
 // ADR-101 Phase 2: WithIsolatedRegistry injects an explicit provider list so
 // tests can exercise real plan/apply without touching the global registry.
-// Phase 3 will add CallTool/HTTPClient; Phase 4 will add goroutine-leak
-// detection.
+// ADR-101 Phase 3: ListTools queries the live MCP surface via the wire
+// protocol, enabling binary-assembly tests. CallTool is the Phase-3b follow-up.
+// Phase 4 will add goroutine-leak detection.
 //
 // Typical usage:
 //
@@ -31,10 +32,14 @@ package testkernel
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -108,6 +113,120 @@ func (k *Kernel) ReconcileDaemon() *engine.ReconcileDaemon {
 // Safe to call multiple times.
 func (k *Kernel) Stop() error {
 	return k.kernel.Stop()
+}
+
+// ListTools performs an MCP initialize→notifications/initialized→tools/list
+// sequence over HTTP and returns the sorted list of tool names registered on
+// this kernel's MCP server.
+//
+// This is a Phase-3 helper that exercises the actual MCP wire protocol rather
+// than going through internal Go types, so it catches registration gaps that
+// only show up on the live surface (the category-C gap that motivated ADR-101).
+//
+// CallTool is the natural follow-up (ADR-101 Phase 3b); this minimal addition
+// provides the assertion surface needed for TestDaemonWiring without wiring
+// the full call path.
+func (k *Kernel) ListTools(ctx context.Context, t *testing.T) ([]string, error) {
+	t.Helper()
+
+	mcpURL := k.endpoint + "/mcp"
+	client := &http.Client{Timeout: 10 * time.Second}
+
+	doPost := func(body string, extraHeaders map[string]string) ([]byte, http.Header, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, mcpURL, strings.NewReader(body))
+		if err != nil {
+			return nil, nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json, text/event-stream")
+		for k, v := range extraHeaders {
+			req.Header.Set(k, v)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, nil, err
+		}
+		defer resp.Body.Close()
+		b, err := io.ReadAll(resp.Body)
+		return b, resp.Header, err
+	}
+
+	// Step 1: initialize — acquire session ID.
+	initBody := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"testkernel","version":"1"}}}`
+	_, initHeaders, err := doPost(initBody, nil)
+	if err != nil {
+		return nil, fmt.Errorf("ListTools: initialize: %w", err)
+	}
+	sessionID := initHeaders.Get("Mcp-Session-Id")
+
+	// Step 2: notifications/initialized (fire-and-forget).
+	_, _, _ = doPost(`{"jsonrpc":"2.0","method":"notifications/initialized"}`,
+		map[string]string{"Mcp-Session-Id": sessionID})
+
+	// Step 3: tools/list.
+	listBody := `{"jsonrpc":"2.0","id":2,"method":"tools/list"}`
+	listResp, _, err := doPost(listBody, map[string]string{"Mcp-Session-Id": sessionID})
+	if err != nil {
+		return nil, fmt.Errorf("ListTools: tools/list: %w", err)
+	}
+
+	// The MCP Streamable HTTP transport may wrap the JSON-RPC response as an
+	// SSE event (Content-Type: text/event-stream):
+	//
+	//   event: message\ndata: {...}\n\n
+	//
+	// Strip SSE framing so we parse the raw JSON-RPC payload regardless of
+	// whether the server chose SSE or plain JSON encoding.
+	jsonPayload := extractSSEData(listResp)
+
+	// Parse the JSON-RPC response.
+	var rpc struct {
+		Result struct {
+			Tools []struct {
+				Name string `json:"name"`
+			} `json:"tools"`
+		} `json:"result"`
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(jsonPayload, &rpc); err != nil {
+		return nil, fmt.Errorf("ListTools: decode response: %w (body: %s)", err, listResp)
+	}
+	if rpc.Error != nil {
+		return nil, fmt.Errorf("ListTools: JSON-RPC error: %s", rpc.Error.Message)
+	}
+
+	names := make([]string, 0, len(rpc.Result.Tools))
+	for _, tool := range rpc.Result.Tools {
+		names = append(names, tool.Name)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// extractSSEData returns the JSON payload from an SSE-framed body.
+// If the body begins with "event:" or "data:" lines, it extracts and
+// concatenates all "data: ..." lines.  If the body looks like plain JSON
+// (starts with '{') it is returned unchanged.  This lets ListTools work
+// whether the server chose SSE or plain JSON encoding.
+func extractSSEData(body []byte) []byte {
+	trimmed := strings.TrimSpace(string(body))
+	if strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") {
+		return body // already plain JSON
+	}
+	// SSE: scan for "data: ..." lines and concatenate.
+	var dataLines []string
+	for _, line := range strings.Split(trimmed, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if strings.HasPrefix(line, "data: ") {
+			dataLines = append(dataLines, strings.TrimPrefix(line, "data: "))
+		}
+	}
+	if len(dataLines) == 0 {
+		return body // can't parse; return original for error reporting
+	}
+	return []byte(strings.Join(dataLines, ""))
 }
 
 // Boot starts a kernel in-process with the given options.


### PR DESCRIPTION
## Summary

- Extracts all production provider and MCP-extension registration logic from `cmd/cogos/providers_wire.go` and `z_conversations_wire.go` into `internal/providers/all` — a proper importable package. The two `cmd/cogos` files become thin one-liners that call `all.Register` / `all.RegisterConversations`. Behavior-identical refactor; daemon binary unchanged.
- Adds `testkernel.Kernel.ListTools` (Phase 3 per ADR-101): exercises the real MCP wire protocol (initialize → notifications/initialized → tools/list) over HTTP, returning sorted tool names. SSE framing stripped automatically. Documented as Phase 3; CallTool is 3b follow-up.
- Adds `cmd/cogos/z_daemon_wiring_test.go` with `TestDaemonWiring`: boots via testkernel with the production `init()` chain already fired, then asserts the e2e-probe golden tool set (`cog_get_state`, `cog_search_memory`, `cog_search_conversations`, `cog_list_sessions`, `cog_read_cogdoc`) is present on the live MCP surface, and that both engine seams (`WiredConversationsResolver`, `WireHarnessBackend`) are populated.

Closes test-gap C from the post-PR-370 audit. A dropped `init()` call or a misplaced registration will now fail at `go test ./cmd/cogos` rather than at runtime on a live kernel.

## Test plan

- [x] `go test -short ./cmd/cogos/... ./internal/testkernel/... ./internal/providers/all/...` — all pass
- [x] `go test -run TestDaemonWiring ./cmd/cogos/...` — PASS (boots live kernel, asserts tool list)
- [x] `go test -short ./internal/...` — all pass (18 packages)
- [x] `go test -short .` (root package) — PASS
- [x] e2e script `scripts/e2e-test.sh` — 22/22 PASS including MCP transport probe (Phase 3b golden tools)
- [x] `go vet ./cmd/cogos/... ./internal/testkernel/... ./internal/providers/all/...` — clean