### PR TITLE
feat(conversations): ontology-as-class enforcement — load L0/L1/L2, quarantine, coverage metric (v0.2 groundwork)

### DIFF
--- a/cmd/cogos/z_conversations_wire_test.go
+++ b/cmd/cogos/z_conversations_wire_test.go
@@ -61,9 +61,11 @@ func TestConversationsResolverDelegatesToProvider(t *testing.T) {
 		t.Fatalf("want unknown-param error through the wired resolver, got: %v", err)
 	}
 
-	// Reserved-param rejection likewise.
-	_, err = r.ResolveURI(ctx, "cog:conversations?component=tool.call")
-	if err == nil || !strings.Contains(err.Error(), "reserved") {
-		t.Fatalf("want reserved-param error through the wired resolver, got: %v", err)
+	// component= is now an active param (v0.2 ontology-as-class enforcement);
+	// it should resolve without a "reserved" error (the empty index returns
+	// an empty slice, not an error).
+	_, err = r.ResolveURI(ctx, "cog:conversations?component=session.turn")
+	if err != nil {
+		t.Fatalf("component= param should be accepted (v0.2 active), got: %v", err)
 	}
 }

--- a/internal/conversations/coverage.go
+++ b/internal/conversations/coverage.go
@@ -1,0 +1,135 @@
+// coverage.go — per-source coverage metric for the ontology enforcement layer.
+//
+// Coverage is the v0.2 "Prometheus move": unmapped-component count per source
+// is itself a metric. This file defines the types and accumulates counters
+// during ingest; the provider exposes them via the /v1/observatory/coverage
+// HTTP route and via provider.Coverage().
+//
+// Coverage shape per spec (§v0.2 coverage metric):
+//   { mapped, degenerate?, quarantined, unmapped_component_counts }
+//
+// "Mapped" = records successfully emitted as a known L1 component.
+// "Degenerate" = records emitted under the wrong component class (per L2
+//   quality: degenerate flag, e.g. role=tool rows mapped to session.turn).
+// "Quarantined" = records routed to the quarantine surface.
+// "Unmapped component counts" = per-source component-class counts for
+//   components that no mapping speaks.
+package conversations
+
+import "sync"
+
+// SourceCoverage holds the coverage metric for one ingest source.
+type SourceCoverage struct {
+	// Mapped is the count of records successfully emitted as a known L1 component.
+	Mapped int `json:"mapped"`
+
+	// Degenerate is the count of records emitted under the wrong L1 class
+	// (quality: degenerate in L2 mapping).
+	Degenerate int `json:"degenerate,omitempty"`
+
+	// Quarantined is the count of records routed to the quarantine surface
+	// because no L2 mapping speaks their component class.
+	Quarantined int `json:"quarantined"`
+
+	// UnmappedComponentCounts is a per-component-class count of records that
+	// were quarantined. The key is the source-declared or inferred component
+	// identifier (e.g. "tool_result", "attachment", "system/turn_duration").
+	UnmappedComponentCounts map[string]int `json:"unmapped_component_counts,omitempty"`
+
+	// OntologyRef is the L1 version that was enforced (e.g. "cogos.conversations@1.0.0").
+	OntologyRef string `json:"ontology_ref,omitempty"`
+
+	// MappingRef is the L2 mapping version used (e.g. "claude-code-jsonl@1.0.0").
+	MappingRef string `json:"mapping_ref,omitempty"`
+}
+
+// CoverageTracker accumulates coverage counters across ingest runs.
+// Thread-safe via an internal mutex.
+type CoverageTracker struct {
+	mu      sync.Mutex
+	sources map[string]*SourceCoverage
+}
+
+// NewCoverageTracker returns an empty tracker.
+func NewCoverageTracker() *CoverageTracker {
+	return &CoverageTracker{
+		sources: make(map[string]*SourceCoverage),
+	}
+}
+
+// RecordMapped increments the mapped counter for source.
+func (t *CoverageTracker) RecordMapped(source string) {
+	t.mu.Lock()
+	t.getOrCreate(source).Mapped++
+	t.mu.Unlock()
+}
+
+// RecordDegenerate increments the degenerate counter for source.
+func (t *CoverageTracker) RecordDegenerate(source string) {
+	t.mu.Lock()
+	sc := t.getOrCreate(source)
+	sc.Degenerate++
+	sc.Mapped++ // degenerate records ARE emitted, so they count toward mapped too
+	t.mu.Unlock()
+}
+
+// RecordQuarantined increments quarantined and the unmapped-component count
+// for the given component class.
+func (t *CoverageTracker) RecordQuarantined(source, component string) {
+	t.mu.Lock()
+	sc := t.getOrCreate(source)
+	sc.Quarantined++
+	if sc.UnmappedComponentCounts == nil {
+		sc.UnmappedComponentCounts = make(map[string]int)
+	}
+	sc.UnmappedComponentCounts[component]++
+	t.mu.Unlock()
+}
+
+// SetRefs records the ontology and mapping version refs for a source.
+// Safe to call multiple times; last write wins (refs are stable within a run).
+func (t *CoverageTracker) SetRefs(source, ontologyRef, mappingRef string) {
+	t.mu.Lock()
+	sc := t.getOrCreate(source)
+	sc.OntologyRef = ontologyRef
+	sc.MappingRef = mappingRef
+	t.mu.Unlock()
+}
+
+// All returns a snapshot of all source coverage records. The returned map
+// is a copy — safe to read without holding the lock.
+func (t *CoverageTracker) All() map[string]SourceCoverage {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make(map[string]SourceCoverage, len(t.sources))
+	for src, sc := range t.sources {
+		// Deep-copy the unmapped component counts map.
+		sc2 := *sc
+		if sc.UnmappedComponentCounts != nil {
+			sc2.UnmappedComponentCounts = make(map[string]int, len(sc.UnmappedComponentCounts))
+			for k, v := range sc.UnmappedComponentCounts {
+				sc2.UnmappedComponentCounts[k] = v
+			}
+		}
+		out[src] = sc2
+	}
+	return out
+}
+
+// Reset clears all counters (used between reconcile runs if desired).
+func (t *CoverageTracker) Reset() {
+	t.mu.Lock()
+	t.sources = make(map[string]*SourceCoverage)
+	t.mu.Unlock()
+}
+
+// getOrCreate returns the SourceCoverage for source, creating it if absent.
+// Must be called with t.mu held.
+func (t *CoverageTracker) getOrCreate(source string) *SourceCoverage {
+	sc, ok := t.sources[source]
+	if !ok {
+		sc = &SourceCoverage{}
+		t.sources[source] = sc
+	}
+	return sc
+}

--- a/internal/conversations/coverage_route.go
+++ b/internal/conversations/coverage_route.go
@@ -1,0 +1,61 @@
+// coverage_route.go — HTTP handler for GET /v1/observatory/coverage.
+//
+// Returns per-source coverage metrics for the ontology enforcement layer.
+// Smallest honest surface: one GET endpoint, JSON response.
+//
+// Response shape:
+//
+//	{
+//	  "ontology_ref": "cogos.conversations@1.0.0",
+//	  "sources": {
+//	    "hermes-darkstar": {
+//	      "mapped": 12453,
+//	      "degenerate": 16547,
+//	      "quarantined": 0,
+//	      "unmapped_component_counts": {},
+//	      "ontology_ref": "cogos.conversations@1.0.0",
+//	      "mapping_ref": "hermes-statedb.v1@1.0.0"
+//	    }
+//	  }
+//	}
+//
+// Note: v0.1 records are all session.turn. Sources with no loaded mapping
+// will have quarantined > 0 and empty mapped.
+package conversations
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// CoverageHTTPHandler returns an http.Handler that serves
+// GET /v1/observatory/coverage.
+// p may be nil — returns {"error": "provider not wired"} in that case.
+func CoverageHTTPHandler(p *Provider) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if p == nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"error": "conversations provider not wired",
+			})
+			return
+		}
+
+		cov := p.Coverage()
+		ont := p.Ontology()
+
+		ontRef := ""
+		if ont != nil {
+			ontRef = ont.OntologyRef
+		}
+
+		resp := map[string]any{
+			"ontology_ref": ontRef,
+			"sources":      cov,
+			"note":         "v0.1 records are all session.turn; v0.2 introduces additional component classes",
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+}

--- a/internal/conversations/coverage_test.go
+++ b/internal/conversations/coverage_test.go
@@ -9,9 +9,14 @@
 //   6. Reset() clears all counters
 //   7. Multiple sources tracked independently
 //   8. Full ingest cycle: mixed mapped/quarantined records → coverage totals
+//   9. (Bug 1 regression) RecordDegenerate called for role='tool' hermes records
+//  10. (Bug 2 regression) Coverage stable across two identical reconcile cycles
 package conversations
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -175,5 +180,260 @@ func TestCoverageFromIngest_MixedSourcesFullCycle(t *testing.T) {
 		// Only known-source sessions make it through; unknown-source is quarantined.
 		// All 5 known-source records have same content → only 1 after dedup.
 		t.Logf("sessions: %d (dedup collapses identical records)", len(sessions))
+	}
+}
+
+// ─── Bug regression tests ─────────────────────────────────────────────────────
+
+// makeHermesOntology creates a LoadedOntology that mirrors the hermes-statedb
+// mapping spec: hermes-darkstar and hermes-cog are mapped sources, role='tool'
+// records are classified as degenerate (text_tool_degenerate rule).
+func makeHermesOntology(t *testing.T) *LoadedOntology {
+	t.Helper()
+	dir := t.TempDir()
+
+	l1 := `ontology: cogos.ontology/v1
+id: cogos.conversations
+version: 1.0.0
+entities:
+  session:
+    description: One conversation session.
+    keys: [source, session_id]
+components:
+  session.turn:
+    description: A conversation turn.
+    fields: { role: string, text: string, timestamp: rfc3339 }
+    required: [role, text, timestamp]
+relations: {}
+`
+	if err := os.WriteFile(filepath.Join(dir, "cogos.conversations.v1.yaml"), []byte(l1), 0o644); err != nil {
+		t.Fatalf("write L1: %v", err)
+	}
+
+	mappingsDir := filepath.Join(dir, "mappings")
+	if err := os.Mkdir(mappingsDir, 0o755); err != nil {
+		t.Fatalf("mkdir mappings: %v", err)
+	}
+
+	// Minimal hermes-statedb mapping: intended rules for user/assistant, plus
+	// the degenerate rule for tool rows — mirroring the production spec.
+	m2 := `mapping:
+  id: hermes-statedb.v1
+  version: 1.0.0
+  sources:
+    - hermes-darkstar
+    - hermes-cog
+  ontology: "cogos.conversations@^1"
+rules:
+  - id: text_user
+    source_condition: "role = 'user' AND content IS NOT NULL AND content != ''"
+    target_class: session.turn
+    quality: intended
+  - id: text_assistant_with_prose
+    source_condition: "role = 'assistant' AND content IS NOT NULL AND content != ''"
+    target_class: session.turn
+    quality: intended
+  - id: text_tool_degenerate
+    source_condition: "role = 'tool' AND content IS NOT NULL AND content != ''"
+    target_class: session.turn
+    quality: degenerate
+`
+	if err := os.WriteFile(filepath.Join(mappingsDir, "hermes-statedb.v1.yaml"), []byte(m2), 0o644); err != nil {
+		t.Fatalf("write L2: %v", err)
+	}
+
+	lo, err := LoadOntologyDir(dir)
+	if err != nil {
+		t.Fatalf("LoadOntologyDir: %v", err)
+	}
+	return lo
+}
+
+// TestCoverageRecordDegenerateWiredForToolRole is the Bug 1 regression.
+// Verifies that role='tool' records from a hermes source increment Degenerate
+// (not just Mapped) in the coverage tracker, per the text_tool_degenerate rule
+// in the hermes-statedb.v1 L2 mapping spec.
+func TestCoverageRecordDegenerateWiredForToolRole(t *testing.T) {
+	lo := makeHermesOntology(t)
+	cov := NewCoverageTracker()
+
+	acc := newIngestAccumulator(defaultMaxTurnLen)
+	acc.Ontology = lo
+	acc.Coverage = cov
+
+	ts := "2026-06-10T00:00:00Z"
+	source := "hermes-darkstar"
+
+	lines := []string{
+		// 3 intended (user + assistant)
+		makeIngestRecord(source, "s1", "user", "user message", ts,
+			map[string]any{"refs": map[string]any{"stable_id": source + ":1"}}),
+		makeIngestRecord(source, "s1", "assistant", "assistant reply", ts,
+			map[string]any{"refs": map[string]any{"stable_id": source + ":2"}}),
+		makeIngestRecord(source, "s1", "user", "follow-up", ts,
+			map[string]any{"refs": map[string]any{"stable_id": source + ":3"}}),
+		// 2 degenerate (tool rows mapped to session.turn)
+		makeIngestRecord(source, "s1", "tool", `{"result":"ok"}`, ts,
+			map[string]any{"refs": map[string]any{"stable_id": source + ":4"}}),
+		makeIngestRecord(source, "s1", "tool", `{"result":"err"}`, ts,
+			map[string]any{"refs": map[string]any{"stable_id": source + ":5"}}),
+	}
+
+	if err := acc.ConsumeFile(strings.NewReader(strings.Join(lines, "\n") + "\n")); err != nil {
+		t.Fatalf("ConsumeFile: %v", err)
+	}
+
+	m := cov.All()
+	sc := m[source]
+
+	// Degenerate must be > 0 — RecordDegenerate is wired for role='tool'.
+	if sc.Degenerate == 0 {
+		t.Errorf("Degenerate: want > 0 (role='tool' records must trigger RecordDegenerate), got 0")
+	}
+	if sc.Degenerate != 2 {
+		t.Errorf("Degenerate: want 2, got %d", sc.Degenerate)
+	}
+	// Degenerate records are also counted as mapped (per RecordDegenerate contract).
+	if sc.Mapped != 5 {
+		t.Errorf("Mapped: want 5 (3 intended + 2 degenerate), got %d", sc.Mapped)
+	}
+	// Quarantined must be 0 — all records are from a mapped source.
+	if sc.Quarantined != 0 {
+		t.Errorf("Quarantined: want 0, got %d", sc.Quarantined)
+	}
+}
+
+// TestCoverageStableAcrossReconcileCycles is the Bug 2 regression.
+// Verifies that running two identical reconcile cycles over the same input
+// produces identical coverage counts.  Previously, coverage accumulated
+// without reset across cycles, causing counts to double on each cycle.
+func TestCoverageStableAcrossReconcileCycles(t *testing.T) {
+	p, root := newTestProvider(t)
+	ingestRoot := t.TempDir()
+
+	// Load the hermes ontology so degenerate classification fires.
+	lo := makeHermesOntology(t)
+	ontDir := filepath.Join(root, ".cog", "observatory", "ontology")
+	if err := os.MkdirAll(filepath.Join(ontDir, "mappings"), 0o755); err != nil {
+		t.Fatalf("mkdir ontology: %v", err)
+	}
+	// Write L1 + L2 into the workspace ontology dir so LoadConfig picks them up.
+	l1Src := filepath.Join(t.TempDir(), "l1.yaml")
+	_ = lo // already in memory; write a minimal fixture that LoadOntologyDir will read
+
+	// Build the full ontology dir the provider will read from.
+	ontL1 := `ontology: cogos.ontology/v1
+id: cogos.conversations
+version: 1.0.0
+entities:
+  session:
+    description: One session.
+    keys: [source, session_id]
+components:
+  session.turn:
+    description: A turn.
+    fields: { role: string, text: string, timestamp: rfc3339 }
+    required: [role, text, timestamp]
+relations: {}
+`
+	_ = l1Src
+	if err := os.WriteFile(filepath.Join(ontDir, "cogos.conversations.v1.yaml"), []byte(ontL1), 0o644); err != nil {
+		t.Fatalf("write L1 to ontdir: %v", err)
+	}
+	ontL2 := `mapping:
+  id: hermes-statedb.v1
+  version: 1.0.0
+  sources:
+    - hermes-darkstar
+    - hermes-cog
+  ontology: "cogos.conversations@^1"
+rules:
+  - id: text_user
+    source_condition: "role = 'user' AND content IS NOT NULL AND content != ''"
+    target_class: session.turn
+    quality: intended
+  - id: text_assistant_with_prose
+    source_condition: "role = 'assistant' AND content IS NOT NULL AND content != ''"
+    target_class: session.turn
+    quality: intended
+  - id: text_tool_degenerate
+    source_condition: "role = 'tool' AND content IS NOT NULL AND content != ''"
+    target_class: session.turn
+    quality: degenerate
+`
+	if err := os.WriteFile(filepath.Join(ontDir, "mappings", "hermes-statedb.v1.yaml"), []byte(ontL2), 0o644); err != nil {
+		t.Fatalf("write L2 to ontdir: %v", err)
+	}
+
+	// Write test ingest data: 4 user, 3 assistant, 2 tool records.
+	source := "hermes-darkstar"
+	ts := "2026-06-10T00:00:00Z"
+	var lines []string
+	for i := 1; i <= 4; i++ {
+		lines = append(lines, makeIngestRecord(source, "sess-1", "user",
+			fmt.Sprintf("user msg %d", i), ts,
+			map[string]any{"refs": map[string]any{"stable_id": fmt.Sprintf("%s:%d", source, i)}}))
+	}
+	for i := 5; i <= 7; i++ {
+		lines = append(lines, makeIngestRecord(source, "sess-1", "assistant",
+			fmt.Sprintf("asst reply %d", i), ts,
+			map[string]any{"refs": map[string]any{"stable_id": fmt.Sprintf("%s:%d", source, i)}}))
+	}
+	for i := 8; i <= 9; i++ {
+		lines = append(lines, makeIngestRecord(source, "sess-1", "tool",
+			fmt.Sprintf(`{"result":"r%d"}`, i), ts,
+			map[string]any{"refs": map[string]any{"stable_id": fmt.Sprintf("%s:%d", source, i)}}))
+	}
+	writeIngestDir(t, ingestRoot, source, "20260610T000000Z-run1", lines)
+
+	// Point the observatory config at our ingest dir and ontology dir.
+	cfgDir := filepath.Join(root, ".cog", "config")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	cfgContent := fmt.Sprintf(`source_dirs:
+  - %s
+ingest_dirs:
+  - %s
+ontology_dir: %s
+include_patterns:
+  - "*.jsonl"
+`, t.TempDir(), ingestRoot, ontDir)
+	if err := os.WriteFile(filepath.Join(cfgDir, "observatory.yaml"), []byte(cfgContent), 0o644); err != nil {
+		t.Fatalf("write observatory.yaml: %v", err)
+	}
+
+	// First reconcile cycle.
+	reconcileOnce(t, p, root)
+	cov1 := p.Coverage()
+
+	// Second reconcile cycle — identical input, no drift, all sources skip.
+	reconcileOnce(t, p, root)
+	cov2 := p.Coverage()
+
+	// Counts must be identical across cycles (Bug 2: was doubling each cycle).
+	sc1 := cov1[source]
+	sc2 := cov2[source]
+
+	if sc1.Mapped != sc2.Mapped {
+		t.Errorf("Mapped not stable: cycle1=%d cycle2=%d (expected equal)", sc1.Mapped, sc2.Mapped)
+	}
+	if sc1.Degenerate != sc2.Degenerate {
+		t.Errorf("Degenerate not stable: cycle1=%d cycle2=%d (expected equal)", sc1.Degenerate, sc2.Degenerate)
+	}
+	if sc1.Quarantined != sc2.Quarantined {
+		t.Errorf("Quarantined not stable: cycle1=%d cycle2=%d (expected equal)", sc1.Quarantined, sc2.Quarantined)
+	}
+
+	// Bug 1 check: degenerate must be > 0 (2 tool records).
+	if sc1.Degenerate == 0 {
+		t.Errorf("Degenerate: want > 0 (role='tool' records), got 0 in cycle 1")
+	}
+	if sc1.Degenerate != 2 {
+		t.Errorf("Degenerate: want 2, got %d in cycle 1", sc1.Degenerate)
+	}
+	// Mapped = intended (7) + degenerate (2) = 9.
+	if sc1.Mapped != 9 {
+		t.Errorf("Mapped: want 9 (7 intended + 2 degenerate), got %d in cycle 1", sc1.Mapped)
 	}
 }

--- a/internal/conversations/coverage_test.go
+++ b/internal/conversations/coverage_test.go
@@ -1,0 +1,179 @@
+// coverage_test.go — tests for the per-source coverage tracker.
+//
+// Covers:
+//   1. RecordMapped increments mapped counter
+//   2. RecordDegenerate increments both degenerate and mapped
+//   3. RecordQuarantined increments quarantined and unmapped component counts
+//   4. SetRefs persists ontology/mapping refs
+//   5. All() returns a copy (mutation-safe)
+//   6. Reset() clears all counters
+//   7. Multiple sources tracked independently
+//   8. Full ingest cycle: mixed mapped/quarantined records → coverage totals
+package conversations
+
+import (
+	"strings"
+	"testing"
+)
+
+// ─── CoverageTracker unit tests ───────────────────────────────────────────────
+
+func TestCoverageTracker_RecordMapped(t *testing.T) {
+	ct := NewCoverageTracker()
+	ct.RecordMapped("src1")
+	ct.RecordMapped("src1")
+	ct.RecordMapped("src1")
+
+	m := ct.All()
+	if m["src1"].Mapped != 3 {
+		t.Errorf("mapped: want 3, got %d", m["src1"].Mapped)
+	}
+	if m["src1"].Quarantined != 0 {
+		t.Errorf("quarantined: want 0, got %d", m["src1"].Quarantined)
+	}
+}
+
+func TestCoverageTracker_RecordDegenerate(t *testing.T) {
+	ct := NewCoverageTracker()
+	ct.RecordDegenerate("src1")
+
+	m := ct.All()
+	if m["src1"].Mapped != 1 {
+		t.Errorf("mapped: want 1 (degenerate counts as mapped), got %d", m["src1"].Mapped)
+	}
+	if m["src1"].Degenerate != 1 {
+		t.Errorf("degenerate: want 1, got %d", m["src1"].Degenerate)
+	}
+}
+
+func TestCoverageTracker_RecordQuarantined(t *testing.T) {
+	ct := NewCoverageTracker()
+	ct.RecordQuarantined("src1", "tool_result")
+	ct.RecordQuarantined("src1", "tool_result")
+	ct.RecordQuarantined("src1", "image")
+
+	m := ct.All()
+	sc := m["src1"]
+	if sc.Quarantined != 3 {
+		t.Errorf("quarantined: want 3, got %d", sc.Quarantined)
+	}
+	if sc.UnmappedComponentCounts["tool_result"] != 2 {
+		t.Errorf("tool_result count: want 2, got %d", sc.UnmappedComponentCounts["tool_result"])
+	}
+	if sc.UnmappedComponentCounts["image"] != 1 {
+		t.Errorf("image count: want 1, got %d", sc.UnmappedComponentCounts["image"])
+	}
+}
+
+func TestCoverageTracker_SetRefs(t *testing.T) {
+	ct := NewCoverageTracker()
+	ct.SetRefs("src1", "cogos.conversations@1.0.0", "claude-code-jsonl@1.0.0")
+
+	m := ct.All()
+	sc := m["src1"]
+	if sc.OntologyRef != "cogos.conversations@1.0.0" {
+		t.Errorf("ontology_ref: want cogos.conversations@1.0.0, got %q", sc.OntologyRef)
+	}
+	if sc.MappingRef != "claude-code-jsonl@1.0.0" {
+		t.Errorf("mapping_ref: want claude-code-jsonl@1.0.0, got %q", sc.MappingRef)
+	}
+}
+
+func TestCoverageTracker_AllReturnsCopy(t *testing.T) {
+	ct := NewCoverageTracker()
+	ct.RecordMapped("src1")
+
+	m1 := ct.All()
+	// Mutate the returned copy — should not affect the tracker.
+	sc := m1["src1"]
+	sc.Mapped = 999
+	m1["src1"] = sc
+
+	m2 := ct.All()
+	if m2["src1"].Mapped != 1 {
+		t.Errorf("All() mutation leaked: want 1, got %d", m2["src1"].Mapped)
+	}
+}
+
+func TestCoverageTracker_Reset(t *testing.T) {
+	ct := NewCoverageTracker()
+	ct.RecordMapped("src1")
+	ct.RecordMapped("src2")
+	ct.Reset()
+
+	m := ct.All()
+	if len(m) != 0 {
+		t.Errorf("after Reset: want 0 sources, got %d", len(m))
+	}
+}
+
+func TestCoverageTracker_MultipleSources(t *testing.T) {
+	ct := NewCoverageTracker()
+	ct.RecordMapped("hermes-darkstar")
+	ct.RecordMapped("hermes-darkstar")
+	ct.RecordQuarantined("claude-code-jsonl", "tool_result")
+	ct.SetRefs("hermes-darkstar", "cogos.conversations@1.0.0", "hermes-statedb.v1@1.0.0")
+	ct.SetRefs("claude-code-jsonl", "cogos.conversations@1.0.0", "claude-code-jsonl@1.0.0")
+
+	m := ct.All()
+	if len(m) != 2 {
+		t.Errorf("expected 2 sources, got %d", len(m))
+	}
+	if m["hermes-darkstar"].Mapped != 2 {
+		t.Errorf("hermes-darkstar mapped: want 2, got %d", m["hermes-darkstar"].Mapped)
+	}
+	if m["claude-code-jsonl"].Quarantined != 1 {
+		t.Errorf("claude-code-jsonl quarantined: want 1, got %d", m["claude-code-jsonl"].Quarantined)
+	}
+}
+
+// ─── Full ingest cycle: mixed mapped/quarantined → coverage totals ─────────────
+
+func TestCoverageFromIngest_MixedSourcesFullCycle(t *testing.T) {
+	lo, _ := makeTestOntology(t)
+	cov := NewCoverageTracker()
+
+	acc := newIngestAccumulator(defaultMaxTurnLen)
+	acc.Ontology = lo
+	acc.Coverage = cov
+	// No quarantine writer needed for this test (nil is safe — just won't write files).
+
+	var lines []string
+	// 5 records from known-source (should be mapped)
+	for i := 0; i < 5; i++ {
+		lines = append(lines, makeIngestRecord("known-source", "s1", "user", "msg", "2026-06-10T00:00:00Z", nil))
+	}
+	// 3 records from unknown-source (should be quarantined)
+	for i := 0; i < 3; i++ {
+		lines = append(lines, makeIngestRecord("unknown-source", "s2", "assistant", "reply", "2026-06-10T00:00:00Z", nil))
+	}
+
+	if err := acc.ConsumeFile(strings.NewReader(strings.Join(lines, "\n") + "\n")); err != nil {
+		t.Fatalf("ConsumeFile: %v", err)
+	}
+
+	m := cov.All()
+
+	if m["known-source"].Mapped != 5 {
+		t.Errorf("known-source mapped: want 5, got %d", m["known-source"].Mapped)
+	}
+	if m["known-source"].Quarantined != 0 {
+		t.Errorf("known-source quarantined: want 0, got %d", m["known-source"].Quarantined)
+	}
+
+	if m["unknown-source"].Quarantined != 3 {
+		t.Errorf("unknown-source quarantined: want 3, got %d", m["unknown-source"].Quarantined)
+	}
+	if m["unknown-source"].Mapped != 0 {
+		t.Errorf("unknown-source mapped: want 0, got %d", m["unknown-source"].Mapped)
+	}
+
+	// Dedup: 5 known-source msgs all have same content hash → actually only 1 unique
+	// (dedup by content hash since no stable_id). Check that sessions reflect this.
+	sessions := acc.Sessions()
+	if len(sessions) != 1 {
+		// Only known-source sessions make it through; unknown-source is quarantined.
+		// All 5 known-source records have same content → only 1 after dedup.
+		t.Logf("sessions: %d (dedup collapses identical records)", len(sessions))
+	}
+}

--- a/internal/conversations/ingest_parser.go
+++ b/internal/conversations/ingest_parser.go
@@ -202,8 +202,15 @@ func (a *ingestAccumulator) ConsumeFile(r io.Reader) error {
 			}
 
 			// Mapping present — record coverage.
+			// Check whether this record matches a degenerate rule in the L2
+			// mapping (e.g. role='tool' rows in hermes-statedb mapped to
+			// session.turn instead of tool.result per text_tool_degenerate).
 			if a.Coverage != nil {
-				a.Coverage.RecordMapped(rec.Source)
+				if a.Ontology.IsDegenerateRecord(rec.Source, rec.Role) {
+					a.Coverage.RecordDegenerate(rec.Source)
+				} else {
+					a.Coverage.RecordMapped(rec.Source)
+				}
 				a.Coverage.SetRefs(rec.Source, ontRef, mappingRef)
 			}
 		}

--- a/internal/conversations/ingest_parser.go
+++ b/internal/conversations/ingest_parser.go
@@ -92,6 +92,20 @@ type ingestAccumulator struct {
 
 	// RejectedSchemas counts records rejected for an unknown schema value.
 	RejectedSchemas int
+
+	// Quarantined counts records routed to the quarantine surface.
+	Quarantined int
+
+	// Ontology is the loaded L1+L2 ontology set. When non-nil, records whose
+	// component class no mapping speaks are quarantined instead of dropped.
+	Ontology *LoadedOntology
+
+	// Quarantine is the quarantine writer. When non-nil, quarantined records
+	// are appended to <workspace>/.cog/observatory/quarantine/<source>/.
+	Quarantine *QuarantineWriter
+
+	// Coverage accumulates per-source coverage metrics.
+	Coverage *CoverageTracker
 }
 
 // newIngestAccumulator returns an empty accumulator.
@@ -153,6 +167,48 @@ func (a *ingestAccumulator) ConsumeFile(r io.Reader) error {
 			continue
 		}
 
+		// ── v0.2 ontology enforcement ────────────────────────────────────────
+		// v0.1 records are all session.turn — the schema only carries role +
+		// text, which maps cleanly to session.turn. When a loaded mapping is
+		// present we set the component class and L3 version tags; when no
+		// mapping exists for this source, we quarantine with provenance.
+		componentClass := "session.turn" // v0.1 invariant
+		ontRef := ""
+		mappingRef := ""
+
+		if a.Ontology != nil && a.Ontology.L1 != nil {
+			ontRef = a.Ontology.OntologyRef
+			mappingRef = a.Ontology.MappingVersionRef(rec.Source)
+
+			if mappingRef == "" {
+				// No mapping speaks this source — quarantine with provenance.
+				if a.Quarantine != nil {
+					prov := QuarantineProvenance{
+						Reason:      QuarantineReasonUnmappedComponent,
+						Component:   componentClass,
+						OntologyRef: ontRef,
+						MappingRef:  "",
+					}
+					if qErr := a.Quarantine.WriteRecord(rec.Source, json.RawMessage(line), prov); qErr != nil {
+						log.Printf("conversations/ingest: quarantine write error: %v", qErr)
+					}
+				}
+				if a.Coverage != nil {
+					a.Coverage.RecordQuarantined(rec.Source, componentClass)
+					a.Coverage.SetRefs(rec.Source, ontRef, "")
+				}
+				a.Quarantined++
+				continue
+			}
+
+			// Mapping present — record coverage.
+			if a.Coverage != nil {
+				a.Coverage.RecordMapped(rec.Source)
+				a.Coverage.SetRefs(rec.Source, ontRef, mappingRef)
+			}
+		}
+		// ─────────────────────────────────────────────────────────────────────
+
 		key := indexKeyForIngest(rec.Source, rec.SessionID)
 		sess, ok := a.sessions[key]
 		if !ok {
@@ -198,12 +254,15 @@ func (a *ingestAccumulator) ConsumeFile(r io.Reader) error {
 		}
 
 		sess.Turns = append(sess.Turns, Turn{
-			UUID:      turnUUID,
-			SessionID: key,
-			TurnIndex: idx,
-			Role:      role,
-			Timestamp: ts,
-			Text:      text,
+			UUID:            turnUUID,
+			SessionID:       key,
+			TurnIndex:       idx,
+			Role:            role,
+			Timestamp:       ts,
+			Text:            text,
+			Component:       componentClass,
+			OntologyVersion: ontRef,
+			MappingVersion:  mappingRef,
 		})
 		sess.Meta.TurnCount = len(sess.Turns)
 	}

--- a/internal/conversations/mcp_tools.go
+++ b/internal/conversations/mcp_tools.go
@@ -128,6 +128,7 @@ func makeSearchConversationsHandler(p *Provider, maxBytes int) mcp.ToolHandlerFo
 
 		p.mu.Lock()
 		idx := p.index
+		ont := p.ontology
 		p.mu.Unlock()
 		if idx == nil {
 			return convErrorResult("index not yet initialised — run cog reconcile conversations first"), nil, nil
@@ -142,7 +143,7 @@ func makeSearchConversationsHandler(p *Provider, maxBytes int) mcp.ToolHandlerFo
 				return convErrorResult(ErrURIMixedParams.Error()), nil, nil
 			}
 
-			slice, err := ResolveConversationURI(input.URI, idx)
+			slice, err := ResolveConversationURIWithOntology(input.URI, idx, ont)
 			if err != nil {
 				return convErrorResult(fmt.Sprintf("resolve uri %q: %v", input.URI, err)), nil, nil
 			}
@@ -243,6 +244,7 @@ func makeGetConversationTurnHandler(p *Provider, maxBytes int) mcp.ToolHandlerFo
 
 		p.mu.Lock()
 		idx := p.index
+		ont := p.ontology
 		p.mu.Unlock()
 		if idx == nil {
 			return convErrorResult("index not yet initialised — run cog reconcile conversations first"), nil, nil
@@ -255,7 +257,7 @@ func makeGetConversationTurnHandler(p *Provider, maxBytes int) mcp.ToolHandlerFo
 				return convErrorResult(ErrURIMixedParams.Error()), nil, nil
 			}
 
-			slice, err := ResolveConversationURI(input.URI, idx)
+			slice, err := ResolveConversationURIWithOntology(input.URI, idx, ont)
 			if err != nil {
 				return convErrorResult(fmt.Sprintf("resolve uri %q: %v", input.URI, err)), nil, nil
 			}

--- a/internal/conversations/ontology.go
+++ b/internal/conversations/ontology.go
@@ -134,14 +134,40 @@ func ParseL1Ontology(data []byte) (*OntologyDoc, error) {
 type MappingDoc struct {
 	Mapping MappingMeta `yaml:"mapping"`
 
-	// Rules is the list of declared mapping rules.
+	// Rules is the list of declared mapping rules (top-level, as in
+	// claude-code-jsonl.v1.yaml).
 	Rules []MappingRule `yaml:"rules,omitempty"`
+
+	// CurrentMapping carries mapping metadata and rules nested under a
+	// current_mapping: key (as in hermes-statedb.v1.yaml).
+	// When Rules is empty, EffectiveRules() returns CurrentMapping.Rules.
+	CurrentMapping *CurrentMappingSection `yaml:"current_mapping,omitempty"`
 
 	// Unmapped is the list of explicitly unmapped source components.
 	Unmapped []UnmappedEntry `yaml:"unmapped,omitempty"`
 
 	// CoverageBaseline carries the day-one metric snapshot.
 	CoverageBaseline *CoverageBaseline `yaml:"coverage_baseline,omitempty"`
+}
+
+// CurrentMappingSection represents the nested current_mapping: block used by
+// the hermes-statedb mapping spec.
+type CurrentMappingSection struct {
+	Description string        `yaml:"description,omitempty"`
+	Rules       []MappingRule `yaml:"rules,omitempty"`
+}
+
+// EffectiveRules returns the mapping rules regardless of whether they are
+// declared at the top level (Rules) or nested under current_mapping (Rules is
+// empty and CurrentMapping.Rules is non-empty).
+func (md *MappingDoc) EffectiveRules() []MappingRule {
+	if len(md.Rules) > 0 {
+		return md.Rules
+	}
+	if md.CurrentMapping != nil {
+		return md.CurrentMapping.Rules
+	}
+	return nil
 }
 
 // MappingMeta carries the mapping header fields.
@@ -344,7 +370,7 @@ func LoadOntologyDir(ontologyDir string) (*LoadedOntology, error) {
 		}
 
 		// Accumulate mapped L1 component names from declared rules.
-		for _, rule := range mdoc.Rules {
+		for _, rule := range mdoc.EffectiveRules() {
 			// claude-code-jsonl rules use emit.component; hermes uses target_class.
 			if emitMap, ok := rule.Emit["component"].(string); ok && emitMap != "" {
 				lo.MappedComponents[emitMap] = struct{}{}
@@ -427,4 +453,36 @@ func (lo *LoadedOntology) MappingVersionRef(source string) string {
 		return ""
 	}
 	return md.Mapping.ID + "@" + md.Mapping.Version
+}
+
+// IsDegenerateRecord reports whether a record from source with the given role
+// matches a degenerate mapping rule in the L2 spec.
+//
+// A rule is degenerate when MappingRule.Quality == "degenerate".  Role
+// matching is derived from the rule's SourceCondition: we look for the pattern
+// role = '<role>' anywhere in the condition string (case-sensitive, single
+// quotes, exact role value).  This covers all current mapping rules whose
+// degenerate classification is role-keyed (e.g. hermes-statedb text_tool_degenerate:
+// source_condition = "role = 'tool' AND content IS NOT NULL AND content != ''").
+//
+// Returns false when no mapping is loaded for source, or when no degenerate
+// rule matches the given role.
+func (lo *LoadedOntology) IsDegenerateRecord(source, role string) bool {
+	if lo == nil {
+		return false
+	}
+	md, ok := lo.L2[source]
+	if !ok {
+		return false
+	}
+	needle := "role = '" + role + "'"
+	for _, rule := range md.EffectiveRules() {
+		if rule.Quality != "degenerate" {
+			continue
+		}
+		if strings.Contains(rule.SourceCondition, needle) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/conversations/ontology.go
+++ b/internal/conversations/ontology.go
@@ -1,0 +1,430 @@
+// ontology.go — L0/L1/L2 ontology loading and enforcement.
+//
+// Build order (per spec 2026-06-10):
+//   L0: cogos.ontology/v1 — the meta-grammar; ONLY thing we hard-code knowledge of.
+//   L1: cogos.conversations@1.0.0 — component class declarations.
+//   L2: mappings/*.v1.yaml — per-source mapping rules with coverage_baseline.
+//
+// The observatory loads L0/L1/L2 at provider LoadConfig from
+// <workspace>/.cog/observatory/ontology/ (configurable via ontology_dir).
+//
+// Enforcement contract (from L0 § enforcement):
+//   - Records declaring an unknown (ontology id, major version) are rejected,
+//     logged, counted.
+//   - Components no L2 mapping speaks are quarantined with provenance (never
+//     guessed, never dropped).
+//   - Unmapped-component count per source is a metric.
+//   - L3 records carry the (ontology, mapping) versions that produced them.
+package conversations
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ─── L0 constants ─────────────────────────────────────────────────────────────
+
+// l0GrammarVersion is the ONLY L0 grammar version this codebase speaks.
+// Reject any L1 that declares a different ontology: value.
+const l0GrammarVersion = "cogos.ontology/v1"
+
+// ─── L1 types ────────────────────────────────────────────────────────────────
+
+// OntologyDoc is the parsed form of an L1 YAML file conforming to the L0
+// grammar (cogos.ontology/v1).
+type OntologyDoc struct {
+	// Ontology is the L0 grammar version claim ("cogos.ontology/v1").
+	Ontology string `yaml:"ontology"`
+
+	// ID is the dotted ontology identifier (e.g. "cogos.conversations").
+	ID string `yaml:"id"`
+
+	// Version is the semver of this L1 instance (e.g. "1.0.0").
+	Version string `yaml:"version"`
+
+	// Entities maps entity name → EntityDecl.
+	Entities map[string]EntityDecl `yaml:"entities"`
+
+	// Components maps component name → ComponentDecl.
+	Components map[string]ComponentDecl `yaml:"components"`
+
+	// Relations maps relation name → RelationDecl.
+	Relations map[string]RelationDecl `yaml:"relations"`
+}
+
+// EntityDecl is a session-grade container declaration.
+type EntityDecl struct {
+	Description string   `yaml:"description"`
+	Keys        []string `yaml:"keys"`
+}
+
+// ComponentDecl is a component class declaration.
+type ComponentDecl struct {
+	Description string            `yaml:"description"`
+	Fields      map[string]string `yaml:"fields"`
+	Required    []string          `yaml:"required"`
+	Relations   map[string]string `yaml:"relations"`
+	Policy      *ComponentPolicy  `yaml:"policy,omitempty"`
+}
+
+// ComponentPolicy carries indexing/visibility policy for a component class.
+type ComponentPolicy struct {
+	Index        *bool  `yaml:"index,omitempty"`
+	DefaultViews string `yaml:"default_views,omitempty"`
+}
+
+// RelationDecl is a relation declaration.
+type RelationDecl struct {
+	Description string `yaml:"description"`
+	From        string `yaml:"from"`
+	To          string `yaml:"to"`
+	Cardinality string `yaml:"cardinality"`
+}
+
+// majorVersion extracts the major version number from a semver string like
+// "1.0.0". Returns 0 on parse failure; the caller can treat 0 as unknown.
+func majorVersion(semver string) int {
+	if semver == "" {
+		return 0
+	}
+	parts := strings.SplitN(semver, ".", 3)
+	n := 0
+	for _, c := range parts[0] {
+		if c < '0' || c > '9' {
+			return 0
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n
+}
+
+// ParseL1Ontology parses and validates an L1 YAML document. Returns an error
+// if:
+//   - the file does not parse as valid YAML
+//   - the ontology: field declares an L0 grammar version we don't recognise
+//   - required top-level fields (id, version) are absent
+func ParseL1Ontology(data []byte) (*OntologyDoc, error) {
+	var doc OntologyDoc
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("ontology: yaml parse: %w", err)
+	}
+
+	// Reject unknown L0 grammar versions.
+	if doc.Ontology != l0GrammarVersion {
+		return nil, fmt.Errorf("ontology: unknown L0 grammar version %q (only %q is supported)", doc.Ontology, l0GrammarVersion)
+	}
+
+	if doc.ID == "" {
+		return nil, fmt.Errorf("ontology: missing required field 'id'")
+	}
+	if doc.Version == "" {
+		return nil, fmt.Errorf("ontology: missing required field 'version'")
+	}
+
+	return &doc, nil
+}
+
+// ─── L2 types ─────────────────────────────────────────────────────────────────
+
+// MappingDoc is the parsed form of an L2 mapping YAML file.
+type MappingDoc struct {
+	Mapping MappingMeta `yaml:"mapping"`
+
+	// Rules is the list of declared mapping rules.
+	Rules []MappingRule `yaml:"rules,omitempty"`
+
+	// Unmapped is the list of explicitly unmapped source components.
+	Unmapped []UnmappedEntry `yaml:"unmapped,omitempty"`
+
+	// CoverageBaseline carries the day-one metric snapshot.
+	CoverageBaseline *CoverageBaseline `yaml:"coverage_baseline,omitempty"`
+}
+
+// MappingMeta carries the mapping header fields.
+type MappingMeta struct {
+	ID         string `yaml:"id"`
+	Version    string `yaml:"version"`
+	Source     string `yaml:"source,omitempty"`
+	Sources    []string `yaml:"sources,omitempty"`
+	Ontology   string `yaml:"ontology"` // e.g. "cogos.conversations@^1"
+	Status     string `yaml:"status,omitempty"`
+	ParserRef  string `yaml:"parser_ref,omitempty"`
+	Created    string `yaml:"created,omitempty"`
+	Observer   string `yaml:"observer,omitempty"`
+	IngestSchema string `yaml:"ingest_schema,omitempty"`
+	RecordIdentity string `yaml:"record_identity,omitempty"`
+}
+
+// MappingRule is one declared mapping rule inside an L2 mapping.
+type MappingRule struct {
+	ID    string `yaml:"id"`
+	Match struct {
+		RecordType  string   `yaml:"record_type,omitempty"`
+		Condition   string   `yaml:"condition,omitempty"`
+		ContentPath string   `yaml:"content_path,omitempty"`
+		BlockTypes  []string `yaml:"block_types,omitempty"`
+	} `yaml:"match,omitempty"`
+	Emit  map[string]any `yaml:"emit,omitempty"`
+	Notes string         `yaml:"notes,omitempty"`
+
+	// For hermes-statedb rules, which use these fields directly.
+	SourceCondition string   `yaml:"source_condition,omitempty"`
+	TargetClass     string   `yaml:"target_class,omitempty"`
+	FieldMap        map[string]string `yaml:"field_map,omitempty"`
+	Quality         string   `yaml:"quality,omitempty"`
+}
+
+// UnmappedEntry describes a source component that the mapping explicitly
+// declares as unmapped (but does not silently drop — it is quarantine-bound).
+type UnmappedEntry struct {
+	ID              string `yaml:"id"`
+	JSONLLocation   string `yaml:"jsonl_location,omitempty"`
+	CorpusCount     string `yaml:"corpus_count,omitempty"`
+	ParserBehavior  string `yaml:"parser_behavior,omitempty"`
+	TargetL1Class   string `yaml:"target_l1_class,omitempty"`
+	V2Note          string `yaml:"v2_note,omitempty"`
+	SourceColumns   []string `yaml:"source_columns,omitempty"`
+	Description     string `yaml:"description,omitempty"`
+	RowScope        string `yaml:"row_scope,omitempty"`
+	SourceCondition string `yaml:"source_condition,omitempty"`
+	Quality         string `yaml:"quality,omitempty"`
+}
+
+// CoverageBaseline carries the baseline metrics from the mapping file.
+type CoverageBaseline struct {
+	SnapshotDate    string `yaml:"snapshot_date,omitempty"`
+	SourcesMeasured []string `yaml:"sources_measured,omitempty"`
+	Corpus          *struct {
+		Files       int    `yaml:"files,omitempty"`
+		Records     int    `yaml:"records,omitempty"`
+		Bytes       int64  `yaml:"bytes,omitempty"`
+		SampledDate string `yaml:"sampled_date,omitempty"`
+	} `yaml:"corpus,omitempty"`
+}
+
+// ─── Loaded ontology set ─────────────────────────────────────────────────────
+
+// LoadedOntology is the in-memory representation of a loaded L1+L2 set.
+type LoadedOntology struct {
+	// L1 is the parsed ontology document.
+	L1 *OntologyDoc
+
+	// L2 maps source-id → mapping document. Source-id matches the observer
+	// source declaration in ingest records (e.g. "claude-code-jsonl",
+	// "hermes-darkstar", "hermes-cog").
+	L2 map[string]*MappingDoc
+
+	// MappedComponents is the union of L1 component names that any loaded
+	// L2 mapping maps to. Used for quarantine gating.
+	MappedComponents map[string]struct{}
+
+	// OntologyRef is the canonical version reference for L3 tagging:
+	// "<id>@<version>", e.g. "cogos.conversations@1.0.0".
+	OntologyRef string
+}
+
+// ParseMappingDoc parses and validates an L2 YAML mapping document.
+func ParseMappingDoc(data []byte) (*MappingDoc, error) {
+	var doc MappingDoc
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("mapping: yaml parse: %w", err)
+	}
+	if doc.Mapping.ID == "" {
+		return nil, fmt.Errorf("mapping: missing required field mapping.id")
+	}
+	if doc.Mapping.Ontology == "" {
+		return nil, fmt.Errorf("mapping: missing required field mapping.ontology")
+	}
+	return &doc, nil
+}
+
+// LoadOntologyDir loads L1 + L2 YAML files from ontologyDir:
+//   - <ontologyDir>/*.yaml (not under mappings/) is treated as an L1 instance
+//     if it declares ontology: cogos.ontology/v1 and has a non-"meta_schema" top key.
+//   - <ontologyDir>/mappings/*.yaml are treated as L2 mapping docs.
+//
+// Non-YAML files are silently skipped. Missing ontologyDir is not an error
+// (returns nil with empty maps). An L1 file failing L0 grammar validation
+// returns an error.
+//
+// Source routing for L2: a mapping doc that declares mapping.source is keyed
+// under that source id; a mapping doc with mapping.sources (list) is keyed
+// under each. The hermes-statedb mapping declares sources: [hermes-darkstar,
+// hermes-cog], so both sources share the same mapping doc.
+func LoadOntologyDir(ontologyDir string) (*LoadedOntology, error) {
+	if _, err := os.Stat(ontologyDir); os.IsNotExist(err) {
+		// Absent dir is OK — enforcement just won't fire.
+		return &LoadedOntology{
+			L2:               make(map[string]*MappingDoc),
+			MappedComponents: make(map[string]struct{}),
+		}, nil
+	}
+
+	lo := &LoadedOntology{
+		L2:               make(map[string]*MappingDoc),
+		MappedComponents: make(map[string]struct{}),
+	}
+
+	// ── Load L1 instances from the root of ontologyDir ───────────────────────
+	entries, err := os.ReadDir(ontologyDir)
+	if err != nil {
+		return nil, fmt.Errorf("ontology: read dir %s: %w", ontologyDir, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		path := filepath.Join(ontologyDir, e.Name())
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil, fmt.Errorf("ontology: read %s: %w", path, readErr)
+		}
+
+		// Quick check: does this YAML start with an 'ontology:' or 'meta_schema:' key?
+		// We only parse files that look like L1 instances (have 'ontology:' field).
+		var peek map[string]any
+		if peekErr := yaml.Unmarshal(data, &peek); peekErr != nil {
+			continue // skip non-YAML or unparseable files
+		}
+		if _, hasMeta := peek["meta_schema"]; hasMeta {
+			continue // this is the L0 meta-schema itself, not an L1 instance
+		}
+		if _, hasOntology := peek["ontology"]; !hasOntology {
+			continue // not an L1 ontology instance
+		}
+
+		doc, parseErr := ParseL1Ontology(data)
+		if parseErr != nil {
+			return nil, fmt.Errorf("ontology: parse L1 %s: %w", e.Name(), parseErr)
+		}
+		// Last one wins if multiple L1 files exist (unexpected, but handle cleanly).
+		lo.L1 = doc
+		lo.OntologyRef = doc.ID + "@" + doc.Version
+	}
+
+	// ── Load L2 mappings from <ontologyDir>/mappings/ ─────────────────────────
+	mappingsDir := filepath.Join(ontologyDir, "mappings")
+	mappingEntries, err := os.ReadDir(mappingsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// No mappings dir is OK.
+			return lo, nil
+		}
+		return nil, fmt.Errorf("ontology: read mappings dir %s: %w", mappingsDir, err)
+	}
+	for _, e := range mappingEntries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		path := filepath.Join(mappingsDir, e.Name())
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil, fmt.Errorf("ontology: read mapping %s: %w", path, readErr)
+		}
+		mdoc, parseErr := ParseMappingDoc(data)
+		if parseErr != nil {
+			return nil, fmt.Errorf("ontology: parse L2 %s: %w", e.Name(), parseErr)
+		}
+
+		// Index by source id(s).
+		sources := mdoc.Mapping.Sources
+		if mdoc.Mapping.Source != "" {
+			sources = append(sources, mdoc.Mapping.Source)
+		}
+		// Fallback: use mapping.id as source key.
+		if len(sources) == 0 {
+			sources = []string{mdoc.Mapping.ID}
+		}
+		for _, src := range sources {
+			lo.L2[src] = mdoc
+		}
+
+		// Accumulate mapped L1 component names from declared rules.
+		for _, rule := range mdoc.Rules {
+			// claude-code-jsonl rules use emit.component; hermes uses target_class.
+			if emitMap, ok := rule.Emit["component"].(string); ok && emitMap != "" {
+				lo.MappedComponents[emitMap] = struct{}{}
+			}
+			if rule.TargetClass != "" {
+				lo.MappedComponents[rule.TargetClass] = struct{}{}
+			}
+		}
+	}
+
+	// Always include session.turn in MappedComponents since both mappings emit it.
+	lo.MappedComponents["session.turn"] = struct{}{}
+
+	return lo, nil
+}
+
+// L3Tag is the version tagging appended to newly-ingested records per the L3
+// spec: each record carries the (ontology, mapping) versions that produced it
+// so re-mapping under a new version is always possible.
+type L3Tag struct {
+	// Ontology is the L1 version reference, e.g. "cogos.conversations@1.0.0".
+	Ontology string `json:"ontology,omitempty"`
+	// Mapping is the L2 mapping id + version, e.g. "claude-code-jsonl@1.0.0".
+	Mapping string `json:"mapping,omitempty"`
+}
+
+// OntologyVersionCheck validates that a requested ontology= URI param value
+// matches the loaded L1's (id, major version). Returns an error with an
+// explicit mismatch message when they don't match.
+func (lo *LoadedOntology) OntologyVersionCheck(requested string) error {
+	if lo == nil || lo.L1 == nil {
+		return fmt.Errorf("no ontology loaded; cannot validate ontology=%q", requested)
+	}
+	// requested may be "cogos.conversations@1.0.0" or "cogos.conversations@^1".
+	// We validate id match and major-version compatibility.
+	id, ver, _ := strings.Cut(requested, "@")
+	if id != lo.L1.ID {
+		return fmt.Errorf("ontology mismatch: requested %q but loaded ontology is %q", requested, lo.OntologyRef)
+	}
+	if ver == "" {
+		return nil // no version constraint — id match is sufficient
+	}
+	// Strip caret prefix for semver range (e.g. "^1").
+	ver = strings.TrimPrefix(ver, "^")
+	reqMajor := majorVersion(ver)
+	loadedMajor := majorVersion(lo.L1.Version)
+	if reqMajor != 0 && reqMajor != loadedMajor {
+		return fmt.Errorf("ontology major version mismatch: requested major %d but loaded %s is major %d",
+			reqMajor, lo.OntologyRef, loadedMajor)
+	}
+	return nil
+}
+
+// ComponentClass validates that a requested component= URI param value names
+// a known L1 component class. Returns an error when unknown.
+func (lo *LoadedOntology) ComponentClass(requested string) error {
+	if lo == nil || lo.L1 == nil {
+		return fmt.Errorf("no ontology loaded; cannot validate component=%q", requested)
+	}
+	if _, ok := lo.L1.Components[requested]; !ok {
+		known := make([]string, 0, len(lo.L1.Components))
+		for k := range lo.L1.Components {
+			known = append(known, k)
+		}
+		sortStrings(known)
+		return fmt.Errorf("unknown component class %q; known classes: %s",
+			requested, strings.Join(known, ", "))
+	}
+	return nil
+}
+
+// MappingVersionRef returns the "<id>@<version>" string for the L2 mapping
+// associated with the given source, or "" when no mapping is loaded.
+func (lo *LoadedOntology) MappingVersionRef(source string) string {
+	if lo == nil {
+		return ""
+	}
+	md, ok := lo.L2[source]
+	if !ok {
+		return ""
+	}
+	return md.Mapping.ID + "@" + md.Mapping.Version
+}

--- a/internal/conversations/ontology_test.go
+++ b/internal/conversations/ontology_test.go
@@ -286,7 +286,7 @@ func TestLoadOntologyDir_MissingDir_NoError(t *testing.T) {
 		t.Errorf("expected nil error for missing dir, got %v", err)
 	}
 	if lo == nil {
-		t.Error("expected non-nil LoadedOntology even for missing dir")
+		t.Fatal("expected non-nil LoadedOntology even for missing dir")
 	}
 	if lo.L1 != nil {
 		t.Error("expected nil L1 for missing dir")

--- a/internal/conversations/ontology_test.go
+++ b/internal/conversations/ontology_test.go
@@ -1,0 +1,479 @@
+// ontology_test.go — table-driven tests for L0/L1/L2 parse and enforcement.
+//
+// Covers:
+//   1. L0 grammar version validation (accept known, reject unknown)
+//   2. L1 required field validation
+//   3. L2 mapping parse
+//   4. LoadOntologyDir from a temp fixture dir
+//   5. OntologyVersionCheck (id+major mismatch)
+//   6. ComponentClass lookup (known/unknown)
+//   7. majorVersion helper
+//   8. component= URI param now accepted (not reserved error)
+//   9. ontology= URI param now accepted (not reserved error)
+package conversations
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// ─── L0/L1 parse tests ───────────────────────────────────────────────────────
+
+func TestParseL1Ontology_ValidDocument(t *testing.T) {
+	yaml := `
+ontology: cogos.ontology/v1
+id: cogos.conversations
+version: 1.0.0
+entities:
+  session:
+    description: One conversation stream.
+    keys: [source, session_id]
+components:
+  session.turn:
+    description: A conversational turn.
+    fields: { role: "string", text: string }
+    required: [role, text]
+relations:
+  in_session:
+    description: Component belongs to session.
+    from: "*"
+    to: session
+    cardinality: "N:1"
+`
+	doc, err := ParseL1Ontology([]byte(yaml))
+	if err != nil {
+		t.Fatalf("ParseL1Ontology: unexpected error: %v", err)
+	}
+	if doc.ID != "cogos.conversations" {
+		t.Errorf("id: want cogos.conversations, got %q", doc.ID)
+	}
+	if doc.Version != "1.0.0" {
+		t.Errorf("version: want 1.0.0, got %q", doc.Version)
+	}
+	if _, ok := doc.Components["session.turn"]; !ok {
+		t.Error("expected session.turn component")
+	}
+}
+
+func TestParseL1Ontology_UnknownL0Grammar(t *testing.T) {
+	cases := []struct {
+		name    string
+		ontLine string
+	}{
+		{"wrong version", `ontology: cogos.ontology/v2`},
+		{"unknown grammar", `ontology: some.other.grammar/v1`},
+		{"missing ontology key", `id: foo\nversion: 1.0.0`},
+		{"empty ontology", `ontology: ""\nid: foo\nversion: 1.0.0`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			yaml := tc.ontLine + "\nid: test\nversion: 1.0.0\n"
+			_, err := ParseL1Ontology([]byte(yaml))
+			if err == nil {
+				t.Errorf("expected error for L0 grammar %q, got nil", tc.ontLine)
+			}
+		})
+	}
+}
+
+func TestParseL1Ontology_MissingRequiredFields(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+	}{
+		{
+			"missing id",
+			"ontology: cogos.ontology/v1\nversion: 1.0.0\n",
+		},
+		{
+			"missing version",
+			"ontology: cogos.ontology/v1\nid: cogos.conversations\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseL1Ontology([]byte(tc.yaml))
+			if err == nil {
+				t.Errorf("%s: expected error, got nil", tc.name)
+			}
+		})
+	}
+}
+
+func TestParseL1Ontology_InvalidYAML(t *testing.T) {
+	_, err := ParseL1Ontology([]byte("{not valid yaml: ["))
+	if err == nil {
+		t.Error("expected error for invalid YAML, got nil")
+	}
+}
+
+// ─── L2 mapping parse tests ──────────────────────────────────────────────────
+
+func TestParseMappingDoc_Valid(t *testing.T) {
+	yaml := `
+mapping:
+  id: claude-code-jsonl
+  version: 1.0.0
+  source: claude-code-jsonl
+  ontology: "cogos.conversations@^1"
+rules:
+  - id: user-text-to-turn
+    emit:
+      component: session.turn
+unmapped:
+  - id: tool-result-blocks
+    target_l1_class: tool.result
+`
+	doc, err := ParseMappingDoc([]byte(yaml))
+	if err != nil {
+		t.Fatalf("ParseMappingDoc: %v", err)
+	}
+	if doc.Mapping.ID != "claude-code-jsonl" {
+		t.Errorf("mapping id: want claude-code-jsonl, got %q", doc.Mapping.ID)
+	}
+	if len(doc.Rules) != 1 {
+		t.Errorf("rules: want 1, got %d", len(doc.Rules))
+	}
+	if len(doc.Unmapped) != 1 {
+		t.Errorf("unmapped: want 1, got %d", len(doc.Unmapped))
+	}
+}
+
+func TestParseMappingDoc_MissingID(t *testing.T) {
+	yaml := `
+mapping:
+  version: 1.0.0
+  ontology: "cogos.conversations@^1"
+`
+	_, err := ParseMappingDoc([]byte(yaml))
+	if err == nil {
+		t.Error("expected error for missing mapping.id, got nil")
+	}
+}
+
+func TestParseMappingDoc_MissingOntology(t *testing.T) {
+	yaml := `
+mapping:
+  id: test-mapping
+  version: 1.0.0
+`
+	_, err := ParseMappingDoc([]byte(yaml))
+	if err == nil {
+		t.Error("expected error for missing mapping.ontology, got nil")
+	}
+}
+
+// ─── LoadOntologyDir tests ────────────────────────────────────────────────────
+
+// writeOntologyFixtures sets up a minimal ontology dir with an L1 and two
+// L2 mappings in the temp directory.
+func writeOntologyFixtures(t *testing.T, dir string) {
+	t.Helper()
+
+	l1 := `ontology: cogos.ontology/v1
+id: cogos.conversations
+version: 1.0.0
+entities:
+  session:
+    description: One conversation stream.
+    keys: [source, session_id]
+components:
+  session.turn:
+    description: A conversational turn.
+    fields: { role: string, text: string, timestamp: rfc3339 }
+    required: [role, text, timestamp]
+    relations: { in_session: session }
+  tool.call:
+    description: A tool invocation.
+    fields: { name: string, timestamp: rfc3339 }
+    required: [name, timestamp]
+relations:
+  in_session:
+    description: Component belongs to session.
+    from: "*"
+    to: session
+    cardinality: "N:1"
+`
+	if err := os.WriteFile(filepath.Join(dir, "cogos.conversations.v1.yaml"), []byte(l1), 0o644); err != nil {
+		t.Fatalf("write L1: %v", err)
+	}
+
+	// L0 meta-schema (should be skipped, not parsed as L1).
+	l0 := `meta_schema: cogos.ontology/v1
+version: 1.0.0
+grammar:
+  entity:
+    fields:
+      description: string
+`
+	if err := os.WriteFile(filepath.Join(dir, "cogos.ontology.v1.yaml"), []byte(l0), 0o644); err != nil {
+		t.Fatalf("write L0: %v", err)
+	}
+
+	mappingsDir := filepath.Join(dir, "mappings")
+	if err := os.Mkdir(mappingsDir, 0o755); err != nil {
+		t.Fatalf("mkdir mappings: %v", err)
+	}
+
+	cc := `mapping:
+  id: claude-code-jsonl
+  version: 1.0.0
+  source: claude-code-jsonl
+  ontology: "cogos.conversations@^1"
+rules:
+  - id: user-text
+    emit:
+      component: session.turn
+`
+	if err := os.WriteFile(filepath.Join(mappingsDir, "claude-code-jsonl.v1.yaml"), []byte(cc), 0o644); err != nil {
+		t.Fatalf("write CC mapping: %v", err)
+	}
+
+	hermes := `mapping:
+  id: hermes-statedb.v1
+  version: 1.0.0
+  sources:
+    - hermes-darkstar
+    - hermes-cog
+  ontology: "cogos.conversations@^1"
+rules:
+  - id: text-user
+    target_class: session.turn
+`
+	if err := os.WriteFile(filepath.Join(mappingsDir, "hermes-statedb.v1.yaml"), []byte(hermes), 0o644); err != nil {
+		t.Fatalf("write Hermes mapping: %v", err)
+	}
+}
+
+func TestLoadOntologyDir_LoadsL1AndL2(t *testing.T) {
+	dir := t.TempDir()
+	writeOntologyFixtures(t, dir)
+
+	lo, err := LoadOntologyDir(dir)
+	if err != nil {
+		t.Fatalf("LoadOntologyDir: %v", err)
+	}
+	if lo.L1 == nil {
+		t.Fatal("expected L1 to be loaded")
+	}
+	if lo.L1.ID != "cogos.conversations" {
+		t.Errorf("L1.ID: want cogos.conversations, got %q", lo.L1.ID)
+	}
+	if lo.OntologyRef != "cogos.conversations@1.0.0" {
+		t.Errorf("OntologyRef: want cogos.conversations@1.0.0, got %q", lo.OntologyRef)
+	}
+
+	// L2 should have 3 source entries: claude-code-jsonl, hermes-darkstar, hermes-cog
+	if _, ok := lo.L2["claude-code-jsonl"]; !ok {
+		t.Error("expected claude-code-jsonl in L2")
+	}
+	if _, ok := lo.L2["hermes-darkstar"]; !ok {
+		t.Error("expected hermes-darkstar in L2")
+	}
+	if _, ok := lo.L2["hermes-cog"]; !ok {
+		t.Error("expected hermes-cog in L2")
+	}
+	// MappedComponents should include session.turn
+	if _, ok := lo.MappedComponents["session.turn"]; !ok {
+		t.Error("expected session.turn in MappedComponents")
+	}
+}
+
+func TestLoadOntologyDir_MissingDir_NoError(t *testing.T) {
+	lo, err := LoadOntologyDir("/nonexistent/path/that/does/not/exist")
+	if err != nil {
+		t.Errorf("expected nil error for missing dir, got %v", err)
+	}
+	if lo == nil {
+		t.Error("expected non-nil LoadedOntology even for missing dir")
+	}
+	if lo.L1 != nil {
+		t.Error("expected nil L1 for missing dir")
+	}
+}
+
+func TestLoadOntologyDir_InvalidL1_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	// Write an L1 file with an unknown L0 grammar version.
+	bad := `ontology: cogos.ontology/v99
+id: bad
+version: 1.0.0
+`
+	if err := os.WriteFile(filepath.Join(dir, "bad.yaml"), []byte(bad), 0o644); err != nil {
+		t.Fatalf("write bad L1: %v", err)
+	}
+	_, err := LoadOntologyDir(dir)
+	if err == nil {
+		t.Error("expected error for invalid L1 grammar, got nil")
+	}
+}
+
+// ─── OntologyVersionCheck tests ──────────────────────────────────────────────
+
+func TestOntologyVersionCheck(t *testing.T) {
+	lo := &LoadedOntology{
+		L1: &OntologyDoc{
+			ID:      "cogos.conversations",
+			Version: "1.0.0",
+		},
+		OntologyRef: "cogos.conversations@1.0.0",
+	}
+
+	cases := []struct {
+		requested string
+		wantErr   bool
+	}{
+		{"cogos.conversations@1.0.0", false},
+		{"cogos.conversations@^1", false},
+		{"cogos.conversations@1", false},
+		{"cogos.conversations", false},             // no version = id match only
+		{"cogos.conversations@2.0.0", true},        // major mismatch
+		{"cogos.conversations@^2", true},           // major mismatch (caret)
+		{"cogos.other@1.0.0", true},                // id mismatch
+		{"something.totally.different@1.0.0", true},
+	}
+
+	for _, tc := range cases {
+		err := lo.OntologyVersionCheck(tc.requested)
+		if tc.wantErr && err == nil {
+			t.Errorf("OntologyVersionCheck(%q): expected error, got nil", tc.requested)
+		}
+		if !tc.wantErr && err != nil {
+			t.Errorf("OntologyVersionCheck(%q): unexpected error: %v", tc.requested, err)
+		}
+	}
+}
+
+func TestOntologyVersionCheck_NilOntology(t *testing.T) {
+	var lo *LoadedOntology
+	err := lo.OntologyVersionCheck("cogos.conversations@1.0.0")
+	if err == nil {
+		t.Error("expected error for nil ontology, got nil")
+	}
+}
+
+// ─── ComponentClass tests ─────────────────────────────────────────────────────
+
+func TestComponentClass(t *testing.T) {
+	lo := &LoadedOntology{
+		L1: &OntologyDoc{
+			Components: map[string]ComponentDecl{
+				"session.turn": {},
+				"tool.call":    {},
+				"tool.result":  {},
+			},
+		},
+	}
+
+	cases := []struct {
+		class   string
+		wantErr bool
+	}{
+		{"session.turn", false},
+		{"tool.call", false},
+		{"tool.result", false},
+		{"unknown.class", true},
+		{"", true},
+	}
+	for _, tc := range cases {
+		err := lo.ComponentClass(tc.class)
+		if tc.wantErr && err == nil {
+			t.Errorf("ComponentClass(%q): expected error, got nil", tc.class)
+		}
+		if !tc.wantErr && err != nil {
+			t.Errorf("ComponentClass(%q): unexpected error: %v", tc.class, err)
+		}
+	}
+}
+
+// ─── majorVersion helper tests ────────────────────────────────────────────────
+
+func TestMajorVersion(t *testing.T) {
+	cases := []struct {
+		semver string
+		want   int
+	}{
+		{"1.0.0", 1},
+		{"2.3.4", 2},
+		{"10.0.0", 10},
+		{"0.1.0", 0},
+		{"", 0},
+		{"v1.0.0", 0},  // 'v' prefix is not numeric → returns 0
+		{"1", 1},
+		{"abc", 0},
+	}
+	for _, tc := range cases {
+		got := majorVersion(tc.semver)
+		if got != tc.want {
+			t.Errorf("majorVersion(%q) = %d, want %d", tc.semver, got, tc.want)
+		}
+	}
+}
+
+// ─── URI param activation tests (component= and ontology= no longer reserved) ─
+
+func TestURIParams_ComponentAndOntologyActivated(t *testing.T) {
+	// These should no longer return ErrURIReservedParam — they are active params.
+	cases := []struct {
+		name string
+		uri  string
+	}{
+		{
+			"component= accepted",
+			"cog:conversations?component=session.turn",
+		},
+		{
+			"ontology= accepted",
+			"cog:conversations?ontology=cogos.conversations@1.0.0",
+		},
+		{
+			"both accepted",
+			"cog:conversations?component=session.turn&ontology=cogos.conversations@1.0.0",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			uq, err := ParseConversationURI(tc.uri)
+			if err != nil {
+				t.Errorf("ParseConversationURI(%q): unexpected error: %v", tc.uri, err)
+				return
+			}
+			_ = uq
+		})
+	}
+}
+
+func TestURIParam_ComponentValue(t *testing.T) {
+	uq, err := ParseConversationURI("cog:conversations?component=session.turn")
+	if err != nil {
+		t.Fatalf("ParseConversationURI: %v", err)
+	}
+	if uq.ComponentClass != "session.turn" {
+		t.Errorf("ComponentClass: want session.turn, got %q", uq.ComponentClass)
+	}
+}
+
+func TestURIParam_OntologyValue(t *testing.T) {
+	uq, err := ParseConversationURI("cog:conversations?ontology=cogos.conversations@1.0.0")
+	if err != nil {
+		t.Fatalf("ParseConversationURI: %v", err)
+	}
+	if uq.OntologyVersion != "cogos.conversations@1.0.0" {
+		t.Errorf("OntologyVersion: want cogos.conversations@1.0.0, got %q", uq.OntologyVersion)
+	}
+}
+
+func TestURIParam_ComponentEmptyValue_Error(t *testing.T) {
+	_, err := ParseConversationURI("cog:conversations?component=")
+	if err == nil {
+		t.Error("expected error for empty component= value, got nil")
+	}
+}
+
+func TestURIParam_OntologyEmptyValue_Error(t *testing.T) {
+	_, err := ParseConversationURI("cog:conversations?ontology=")
+	if err == nil {
+		t.Error("expected error for empty ontology= value, got nil")
+	}
+}

--- a/internal/conversations/provider.go
+++ b/internal/conversations/provider.go
@@ -40,6 +40,16 @@ type Provider struct {
 	lastPlanSummary reconcile.Summary
 	lastErrors      []string
 	operation       reconcile.OperationPhase
+
+	// ontology is the loaded L1+L2 ontology set. nil when enforcement is
+	// disabled (ontology_dir not set or absent from the workspace).
+	ontology *LoadedOntology
+
+	// quarantine is the writer for quarantined records.
+	quarantine *QuarantineWriter
+
+	// coverage accumulates per-source coverage metrics across reconcile runs.
+	coverage *CoverageTracker
 }
 
 // NewProvider constructs a ConversationsProvider. The root workspace path
@@ -47,7 +57,27 @@ type Provider struct {
 func NewProvider() *Provider {
 	return &Provider{
 		operation: reconcile.OperationIdle,
+		coverage:  NewCoverageTracker(),
 	}
+}
+
+// Coverage returns a snapshot of the current per-source coverage metrics.
+// The returned map is a copy and safe to read without holding the provider lock.
+func (p *Provider) Coverage() map[string]SourceCoverage {
+	p.mu.Lock()
+	cov := p.coverage
+	p.mu.Unlock()
+	if cov == nil {
+		return make(map[string]SourceCoverage)
+	}
+	return cov.All()
+}
+
+// Ontology returns the loaded ontology (may be nil when enforcement is disabled).
+func (p *Provider) Ontology() *LoadedOntology {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.ontology
 }
 
 // Type returns the resource type identifier.
@@ -60,19 +90,20 @@ func (p *Provider) Type() string { return "conversations" }
 func (p *Provider) ResolveURI(uri string) (*ResolvedSlice, error) {
 	p.mu.Lock()
 	idx := p.index
+	ont := p.ontology
 	p.mu.Unlock()
 
 	if idx == nil {
 		return nil, fmt.Errorf("conversations index not initialised — run cog reconcile conversations first")
 	}
-	return ResolveConversationURI(uri, idx)
+	return ResolveConversationURIWithOntology(uri, idx, ont)
 }
 
 // ─── LoadConfig ──────────────────────────────────────────────────────────────
 
 // LoadConfig reads .cog/config/observatory.yaml (if present), discovers JSONL
-// source files in each configured SourceDir, and initialises the index if not
-// already loaded.
+// source files in each configured SourceDir, initialises the index if not
+// already loaded, and loads the ontology from the ontology_dir when present.
 func (p *Provider) LoadConfig(root string) (any, error) {
 	p.mu.Lock()
 	p.root = root
@@ -96,6 +127,27 @@ func (p *Provider) LoadConfig(root string) (any, error) {
 	}
 	p.mu.Unlock()
 
+	// Load ontology + mappings from ontology_dir (always attempt; missing dir is ok).
+	ontologyDir := obs.OntologyDir
+	if ontologyDir == "" {
+		ontologyDir = defaultOntologyDir(root)
+	}
+	lo, ontErr := LoadOntologyDir(expandHome(ontologyDir))
+	if ontErr != nil {
+		return nil, fmt.Errorf("conversations: load ontology: %w", ontErr)
+	}
+
+	// Set up quarantine writer and coverage tracker.
+	quarantineDir := filepath.Join(root, QuarantineDir)
+
+	p.mu.Lock()
+	p.ontology = lo
+	p.quarantine = NewQuarantineWriter(quarantineDir)
+	if p.coverage == nil {
+		p.coverage = NewCoverageTracker()
+	}
+	p.mu.Unlock()
+
 	// Discover CC source JSONL files.
 	files, err := discoverSourceFiles(obs)
 	if err != nil {
@@ -113,6 +165,7 @@ func (p *Provider) LoadConfig(root string) (any, error) {
 		Observatory:   obs,
 		SourceFiles:   files,
 		IngestSources: ingestSources,
+		Ontology:      lo,
 	}, nil
 }
 
@@ -329,6 +382,9 @@ func (p *Provider) ApplyPlan(ctx context.Context, plan *reconcile.Plan) ([]recon
 	p.mu.Lock()
 	p.operation = reconcile.OperationSyncing
 	idx := p.index
+	ont := p.ontology
+	qw := p.quarantine
+	cov := p.coverage
 	p.mu.Unlock()
 	defer func() {
 		p.mu.Lock()
@@ -359,7 +415,7 @@ func (p *Provider) ApplyPlan(ctx context.Context, plan *reconcile.Plan) ([]recon
 			if isIngest, _ := action.Details["is_ingest"].(bool); isIngest {
 				// Normalized ingest: action.Name is the SOURCE; re-parse all
 				// of its files and rebuild every session of that source.
-				if applyErr := applyIngestSource(idx, action); applyErr != nil {
+				if applyErr := applyIngestSource(idx, action, ont, qw, cov); applyErr != nil {
 					res.Status = reconcile.ApplyFailed
 					res.Error = fmt.Sprintf("index ingest source %s: %v", action.Name, applyErr)
 					results = append(results, res)
@@ -532,6 +588,12 @@ func (p *Provider) Health() reconcile.ResourceStatus {
 // ─── Internal helpers ─────────────────────────────────────────────────────────
 
 const defaultMaxTurnLen = 8192
+
+// defaultOntologyDir returns the default ontology directory for the given
+// workspace root: <root>/.cog/observatory/ontology. Returns "" if absent.
+func defaultOntologyDir(root string) string {
+	return filepath.Join(root, ".cog", "observatory", "ontology")
+}
 
 // defaultSourceDirs returns the default JSONL source directories to scan.
 // Prefers ~/.claude/projects/-Users-slowbro; falls back gracefully.
@@ -844,7 +906,10 @@ func isIngestDrift(indexed []IndexEntry, src ingestSourceInfo) bool {
 // applyIngestSource re-parses every file of an ingest source (action.Name),
 // upserts each resulting session, and prunes index sessions of that source
 // that no longer appear in the parse result.
-func applyIngestSource(idx *Index, action reconcile.Action) error {
+//
+// ont, qw, cov may be nil; when non-nil, ontology enforcement, quarantine
+// routing, and coverage tracking are applied during ConsumeFile.
+func applyIngestSource(idx *Index, action reconcile.Action, ont *LoadedOntology, qw *QuarantineWriter, cov *CoverageTracker) error {
 	sourceDir, _ := action.Details["source_dir"].(string)
 	files := stringSliceDetail(action.Details["ingest_files"])
 	if len(files) == 0 {
@@ -855,6 +920,9 @@ func applyIngestSource(idx *Index, action reconcile.Action) error {
 	var totalSize int64
 	var latestMtime time.Time
 	acc := newIngestAccumulator(defaultMaxTurnLen)
+	acc.Ontology = ont
+	acc.Quarantine = qw
+	acc.Coverage = cov
 	for _, path := range files {
 		fi, err := os.Stat(path)
 		if err != nil {

--- a/internal/conversations/provider.go
+++ b/internal/conversations/provider.go
@@ -317,13 +317,18 @@ func (p *Provider) ComputePlan(config any, live any, _ *reconcile.State) (*recon
 			plan.Summary.Updates++
 
 		default:
+			// Include is_ingest + ingest_files in skip actions so that
+			// ApplyPlan can re-accumulate coverage for unchanged sources
+			// (coverage must be recomputed every cycle, not accumulated).
 			plan.Actions = append(plan.Actions, reconcile.Action{
 				Action:       reconcile.ActionSkip,
 				ResourceType: "conversations",
 				Name:         src.Source,
 				Details: map[string]any{
-					"reason":   "in sync",
-					"sessions": len(indexed),
+					"reason":       "in sync",
+					"sessions":     len(indexed),
+					"is_ingest":    true,
+					"ingest_files": src.Files,
 				},
 			})
 			plan.Summary.Skipped++
@@ -396,11 +401,27 @@ func (p *Provider) ApplyPlan(ctx context.Context, plan *reconcile.Plan) ([]recon
 		return nil, fmt.Errorf("conversations: index not initialised (LoadConfig not called)")
 	}
 
+	// Reset coverage at the start of each reconcile cycle so counts reflect
+	// the current corpus state rather than accumulating across cycles.
+	// Skipped ingest sources are re-accumulated via a coverage-only parse pass
+	// immediately below so all sources appear in the output regardless of drift.
+	if cov != nil {
+		cov.Reset()
+	}
+
 	var results []reconcile.Result
 	var errs []string
 
 	for _, action := range plan.Actions {
 		if action.Action == reconcile.ActionSkip {
+			// For skipped ingest sources, re-accumulate coverage without
+			// touching the index (the data hasn't changed, but we need counts).
+			if isIngest, _ := action.Details["is_ingest"].(bool); isIngest && cov != nil {
+				if covErr := accumulateCoverage(action, ont, cov); covErr != nil {
+					// Non-fatal: log but don't fail the action.
+					errs = append(errs, fmt.Sprintf("coverage-only pass for %s: %v", action.Name, covErr))
+				}
+			}
 			continue
 		}
 
@@ -970,6 +991,39 @@ func applyIngestSource(idx *Index, action reconcile.Action, ont *LoadedOntology,
 		}
 	}
 
+	return nil
+}
+
+// accumulateCoverage parses the ingest files for the given action's source and
+// accumulates coverage metrics into cov without touching the index.  Used on
+// ActionSkip to ensure coverage is recomputed every cycle even when the source
+// data has not changed.
+//
+// ont may be nil (returns without error when nil — no coverage to accumulate).
+func accumulateCoverage(action reconcile.Action, ont *LoadedOntology, cov *CoverageTracker) error {
+	if ont == nil || cov == nil {
+		return nil
+	}
+	files := stringSliceDetail(action.Details["ingest_files"])
+	if len(files) == 0 {
+		return nil
+	}
+	acc := newIngestAccumulator(defaultMaxTurnLen)
+	acc.Ontology = ont
+	acc.Coverage = cov
+	// Quarantine is intentionally nil — we are not writing quarantine records,
+	// only re-counting coverage metrics.
+	for _, path := range files {
+		f, err := os.Open(path)
+		if err != nil {
+			return fmt.Errorf("open %s: %w", path, err)
+		}
+		consumeErr := acc.ConsumeFile(f)
+		f.Close()
+		if consumeErr != nil {
+			return fmt.Errorf("parse %s: %w", path, consumeErr)
+		}
+	}
 	return nil
 }
 

--- a/internal/conversations/quarantine.go
+++ b/internal/conversations/quarantine.go
@@ -1,0 +1,139 @@
+// quarantine.go — quarantine surface for unmapped/unknown ingest components.
+//
+// Per L0 enforcement invariants:
+//   - Records/components that no loaded mapping speaks are quarantined with
+//     provenance (never guessed, never silently dropped).
+//   - Quarantine files land under <workspace>/.cog/observatory/quarantine/<source>/.
+//   - Each quarantine record is a JSON line with the original record plus a
+//     _quarantine provenance block.
+//
+// Quarantine is append-only. The observatory never reads quarantine files back
+// into the index — they are a forensic/diagnostic surface only.
+package conversations
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// QuarantineDir is the default subdirectory under the workspace for quarantine
+// output: <workspace>/.cog/observatory/quarantine.
+const QuarantineDir = ".cog/observatory/quarantine"
+
+// QuarantineReason describes why a record was quarantined.
+type QuarantineReason string
+
+const (
+	// QuarantineReasonUnmappedComponent is used when the component class
+	// inferred for this record does not appear in any loaded L2 mapping.
+	QuarantineReasonUnmappedComponent QuarantineReason = "unmapped_component"
+
+	// QuarantineReasonUnknownSchema is used when an ingest record declares
+	// an unknown schema version.
+	QuarantineReasonUnknownSchema QuarantineReason = "unknown_schema"
+
+	// QuarantineReasonOntologyMismatch is used when a record declares an
+	// (ontology id, major version) for which no L1 instance is loaded.
+	QuarantineReasonOntologyMismatch QuarantineReason = "ontology_mismatch"
+)
+
+// QuarantineProvenance is the provenance block appended to quarantined records.
+type QuarantineProvenance struct {
+	// Reason is the quarantine reason code.
+	Reason QuarantineReason `json:"reason"`
+
+	// Component is the source-declared or inferred component identifier
+	// (e.g. "tool_result", "attachment", "system").
+	Component string `json:"component,omitempty"`
+
+	// OntologyRef is the loaded ontology version reference at the time
+	// of quarantine, e.g. "cogos.conversations@1.0.0".
+	OntologyRef string `json:"ontology_ref,omitempty"`
+
+	// MappingRef is the loaded mapping version reference for the source,
+	// e.g. "claude-code-jsonl@1.0.0".
+	MappingRef string `json:"mapping_ref,omitempty"`
+
+	// QuarantinedAt is the RFC3339 timestamp of when the record was quarantined.
+	QuarantinedAt string `json:"quarantined_at"`
+}
+
+// quarantineRecord is the JSON line written to the quarantine file.
+type quarantineRecord struct {
+	// Original is the raw record bytes preserved verbatim.
+	Original json.RawMessage `json:"original"`
+
+	// Quarantine is the provenance block.
+	Quarantine QuarantineProvenance `json:"_quarantine"`
+}
+
+// QuarantineWriter writes quarantined records to the per-source quarantine
+// directory. Thread-safe via an internal mutex.
+type QuarantineWriter struct {
+	mu         sync.Mutex
+	quarantine string // <workspace>/.cog/observatory/quarantine
+}
+
+// NewQuarantineWriter creates a writer backed by quarantineDir.
+// quarantineDir is typically <workspace>/.cog/observatory/quarantine.
+func NewQuarantineWriter(quarantineDir string) *QuarantineWriter {
+	return &QuarantineWriter{quarantine: quarantineDir}
+}
+
+// WriteRecord appends one quarantined record to
+// <quarantineDir>/<source>/quarantine.jsonl.
+// The file is created and the directory is mkdir'd if absent.
+// Returns an error only for I/O failures; callers may log and continue.
+func (q *QuarantineWriter) WriteRecord(source string, original json.RawMessage, prov QuarantineProvenance) error {
+	prov.QuarantinedAt = time.Now().UTC().Format(time.RFC3339)
+
+	qr := quarantineRecord{
+		Original:   original,
+		Quarantine: prov,
+	}
+	line, err := json.Marshal(qr)
+	if err != nil {
+		return fmt.Errorf("quarantine: marshal record: %w", err)
+	}
+	line = append(line, '\n')
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	dir := filepath.Join(q.quarantine, sanitizeSourceName(source))
+	if mkdirErr := os.MkdirAll(dir, 0o755); mkdirErr != nil {
+		return fmt.Errorf("quarantine: mkdir %s: %w", dir, mkdirErr)
+	}
+
+	path := filepath.Join(dir, "quarantine.jsonl")
+	f, openErr := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if openErr != nil {
+		return fmt.Errorf("quarantine: open %s: %w", path, openErr)
+	}
+	defer f.Close()
+
+	if _, writeErr := f.Write(line); writeErr != nil {
+		return fmt.Errorf("quarantine: write %s: %w", path, writeErr)
+	}
+	return nil
+}
+
+// sanitizeSourceName replaces characters that are not safe in directory names.
+// Only forward-slashes and null bytes are replaced; other characters are kept
+// as-is since source names are typically simple identifiers.
+func sanitizeSourceName(name string) string {
+	out := make([]byte, 0, len(name))
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		if c == '/' || c == 0 {
+			out = append(out, '_')
+		} else {
+			out = append(out, c)
+		}
+	}
+	return string(out)
+}

--- a/internal/conversations/quarantine_test.go
+++ b/internal/conversations/quarantine_test.go
@@ -1,0 +1,303 @@
+// quarantine_test.go — tests for quarantine-with-provenance behaviour.
+//
+// Covers:
+//   1. QuarantineWriter writes a valid JSONL file with provenance
+//   2. Multiple writes append (not overwrite)
+//   3. Source name sanitization
+//   4. Ingest accumulator routes unmapped-source records to quarantine
+//   5. Quarantine counts are reflected in coverage tracker
+package conversations
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ─── QuarantineWriter unit tests ─────────────────────────────────────────────
+
+func TestQuarantineWriter_WritesRecord(t *testing.T) {
+	qDir := t.TempDir()
+	qw := NewQuarantineWriter(qDir)
+
+	original := json.RawMessage(`{"schema":"cogos.observatory.conversations/v0.1","source":"test-source","session_id":"s1","role":"user","timestamp":"2026-06-10T00:00:00Z","text":"hello"}`) //nolint:lll
+	prov := QuarantineProvenance{
+		Reason:      QuarantineReasonUnmappedComponent,
+		Component:   "session.turn",
+		OntologyRef: "cogos.conversations@1.0.0",
+		MappingRef:  "",
+	}
+
+	if err := qw.WriteRecord("test-source", original, prov); err != nil {
+		t.Fatalf("WriteRecord: %v", err)
+	}
+
+	// Verify the file exists and is valid JSONL.
+	path := filepath.Join(qDir, "test-source", "quarantine.jsonl")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read quarantine file: %v", err)
+	}
+
+	var rec quarantineRecord
+	if jsonErr := json.Unmarshal(data[:len(data)-1], &rec); jsonErr != nil { // trim trailing \n
+		t.Fatalf("unmarshal quarantine record: %v", jsonErr)
+	}
+
+	if rec.Quarantine.Reason != QuarantineReasonUnmappedComponent {
+		t.Errorf("reason: want %v, got %v", QuarantineReasonUnmappedComponent, rec.Quarantine.Reason)
+	}
+	if rec.Quarantine.OntologyRef != "cogos.conversations@1.0.0" {
+		t.Errorf("ontology_ref: want cogos.conversations@1.0.0, got %q", rec.Quarantine.OntologyRef)
+	}
+	if rec.Quarantine.QuarantinedAt == "" {
+		t.Error("quarantined_at should be non-empty")
+	}
+}
+
+func TestQuarantineWriter_AppendsBetweenCalls(t *testing.T) {
+	qDir := t.TempDir()
+	qw := NewQuarantineWriter(qDir)
+
+	original := json.RawMessage(`{"schema":"cogos.observatory.conversations/v0.1","source":"src","session_id":"s1","role":"user","timestamp":"2026-06-10T00:00:00Z","text":"msg1"}`)
+	prov := QuarantineProvenance{Reason: QuarantineReasonUnmappedComponent, Component: "session.turn"}
+
+	for i := 0; i < 3; i++ {
+		if err := qw.WriteRecord("src", original, prov); err != nil {
+			t.Fatalf("WriteRecord %d: %v", i, err)
+		}
+	}
+
+	path := filepath.Join(qDir, "src", "quarantine.jsonl")
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+
+	count := 0
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		if strings.TrimSpace(scanner.Text()) != "" {
+			count++
+		}
+	}
+	if count != 3 {
+		t.Errorf("expected 3 lines, got %d", count)
+	}
+}
+
+func TestQuarantineWriter_SourceNameSanitization(t *testing.T) {
+	qDir := t.TempDir()
+	qw := NewQuarantineWriter(qDir)
+
+	original := json.RawMessage(`{"schema":"cogos.observatory.conversations/v0.1","source":"src/sub","session_id":"s1","role":"user","timestamp":"2026-06-10T00:00:00Z","text":"x"}`)
+	prov := QuarantineProvenance{Reason: QuarantineReasonUnmappedComponent, Component: "session.turn"}
+
+	if err := qw.WriteRecord("src/sub", original, prov); err != nil {
+		t.Fatalf("WriteRecord: %v", err)
+	}
+
+	// Should create "src_sub" not "src/sub" (which would create a nested dir).
+	path := filepath.Join(qDir, "src_sub", "quarantine.jsonl")
+	if _, statErr := os.Stat(path); statErr != nil {
+		t.Errorf("sanitized path %s not found: %v", path, statErr)
+	}
+}
+
+// ─── Ingest accumulator quarantine routing tests ─────────────────────────────
+
+// makeTestOntology creates a minimal LoadedOntology with session.turn mapped
+// for source "known-source" but NOT for "unknown-source".
+func makeTestOntology(t *testing.T) (*LoadedOntology, string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	// Write L1.
+	l1 := `ontology: cogos.ontology/v1
+id: cogos.conversations
+version: 1.0.0
+entities:
+  session:
+    description: One session.
+    keys: [source, session_id]
+components:
+  session.turn:
+    description: A turn.
+    fields: { role: string, text: string, timestamp: rfc3339 }
+    required: [role, text, timestamp]
+relations: {}
+`
+	if err := os.WriteFile(filepath.Join(dir, "cogos.conversations.v1.yaml"), []byte(l1), 0o644); err != nil {
+		t.Fatalf("write L1: %v", err)
+	}
+
+	mappingsDir := filepath.Join(dir, "mappings")
+	if err := os.Mkdir(mappingsDir, 0o755); err != nil {
+		t.Fatalf("mkdir mappings: %v", err)
+	}
+
+	// L2 mapping only for "known-source".
+	m2 := `mapping:
+  id: test-mapping
+  version: 1.0.0
+  source: known-source
+  ontology: "cogos.conversations@^1"
+rules:
+  - id: user-text
+    emit:
+      component: session.turn
+`
+	if err := os.WriteFile(filepath.Join(mappingsDir, "test-mapping.v1.yaml"), []byte(m2), 0o644); err != nil {
+		t.Fatalf("write L2: %v", err)
+	}
+
+	lo, err := LoadOntologyDir(dir)
+	if err != nil {
+		t.Fatalf("LoadOntologyDir: %v", err)
+	}
+	return lo, dir
+}
+
+func TestIngestAccumulator_QuarantinesUnknownSource(t *testing.T) {
+	lo, _ := makeTestOntology(t)
+	qDir := t.TempDir()
+	qw := NewQuarantineWriter(qDir)
+	cov := NewCoverageTracker()
+
+	acc := newIngestAccumulator(defaultMaxTurnLen)
+	acc.Ontology = lo
+	acc.Quarantine = qw
+	acc.Coverage = cov
+
+	// Record from "unknown-source" — no mapping exists, should be quarantined.
+	record := makeQRecord("unknown-source", "s1", "user", "hello unknown")
+	if err := acc.ConsumeFile(strings.NewReader(record + "\n")); err != nil {
+		t.Fatalf("ConsumeFile: %v", err)
+	}
+
+	// Accumulator should have 0 sessions (record was quarantined, not indexed).
+	if len(acc.Sessions()) != 0 {
+		t.Errorf("expected 0 sessions (quarantined), got %d", len(acc.Sessions()))
+	}
+	if acc.Quarantined != 1 {
+		t.Errorf("Quarantined: want 1, got %d", acc.Quarantined)
+	}
+
+	// Coverage should show quarantined.
+	covMap := cov.All()
+	sc, ok := covMap["unknown-source"]
+	if !ok {
+		t.Fatal("expected coverage entry for unknown-source")
+	}
+	if sc.Quarantined != 1 {
+		t.Errorf("coverage quarantined: want 1, got %d", sc.Quarantined)
+	}
+	if sc.Mapped != 0 {
+		t.Errorf("coverage mapped: want 0, got %d", sc.Mapped)
+	}
+
+	// Quarantine file should exist.
+	qPath := filepath.Join(qDir, "unknown-source", "quarantine.jsonl")
+	if _, err := os.Stat(qPath); err != nil {
+		t.Errorf("quarantine file not created: %v", err)
+	}
+}
+
+func TestIngestAccumulator_IndexesKnownSource(t *testing.T) {
+	lo, _ := makeTestOntology(t)
+	qDir := t.TempDir()
+	qw := NewQuarantineWriter(qDir)
+	cov := NewCoverageTracker()
+
+	acc := newIngestAccumulator(defaultMaxTurnLen)
+	acc.Ontology = lo
+	acc.Quarantine = qw
+	acc.Coverage = cov
+
+	// Record from "known-source" — mapping exists, should be indexed.
+	record := makeQRecord("known-source", "s1", "user", "hello known")
+	if err := acc.ConsumeFile(strings.NewReader(record + "\n")); err != nil {
+		t.Fatalf("ConsumeFile: %v", err)
+	}
+
+	if len(acc.Sessions()) != 1 {
+		t.Errorf("expected 1 session, got %d", len(acc.Sessions()))
+	}
+	if acc.Quarantined != 0 {
+		t.Errorf("Quarantined: want 0, got %d", acc.Quarantined)
+	}
+
+	// Coverage: mapped=1, quarantined=0.
+	covMap := cov.All()
+	sc, ok := covMap["known-source"]
+	if !ok {
+		t.Fatal("expected coverage entry for known-source")
+	}
+	if sc.Mapped != 1 {
+		t.Errorf("mapped: want 1, got %d", sc.Mapped)
+	}
+	if sc.Quarantined != 0 {
+		t.Errorf("quarantined: want 0, got %d", sc.Quarantined)
+	}
+}
+
+func TestIngestAccumulator_L3Tags(t *testing.T) {
+	lo, _ := makeTestOntology(t)
+	acc := newIngestAccumulator(defaultMaxTurnLen)
+	acc.Ontology = lo
+
+	record := makeQRecord("known-source", "s1", "user", "text with L3 tags")
+	if err := acc.ConsumeFile(strings.NewReader(record + "\n")); err != nil {
+		t.Fatalf("ConsumeFile: %v", err)
+	}
+
+	sessions := acc.Sessions()
+	if len(sessions) != 1 || len(sessions[0].Turns) != 1 {
+		t.Fatalf("expected 1 session with 1 turn, got %d sessions", len(sessions))
+	}
+	turn := sessions[0].Turns[0]
+
+	if turn.Component != "session.turn" {
+		t.Errorf("Component: want session.turn, got %q", turn.Component)
+	}
+	if turn.OntologyVersion != "cogos.conversations@1.0.0" {
+		t.Errorf("OntologyVersion: want cogos.conversations@1.0.0, got %q", turn.OntologyVersion)
+	}
+	if !strings.Contains(turn.MappingVersion, "test-mapping") {
+		t.Errorf("MappingVersion should contain 'test-mapping', got %q", turn.MappingVersion)
+	}
+}
+
+func TestIngestAccumulator_NoOntology_IndexesNormally(t *testing.T) {
+	// Without ontology, all records are indexed with empty L3 tags.
+	acc := newIngestAccumulator(defaultMaxTurnLen)
+	// acc.Ontology is nil
+
+	record := makeQRecord("any-source", "s1", "user", "normal ingest")
+	if err := acc.ConsumeFile(strings.NewReader(record + "\n")); err != nil {
+		t.Fatalf("ConsumeFile: %v", err)
+	}
+
+	sessions := acc.Sessions()
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(sessions))
+	}
+	turn := sessions[0].Turns[0]
+	if turn.Component != "session.turn" {
+		// v0.1 invariant: component defaults to session.turn
+		t.Errorf("Component: want session.turn (v0.1 default), got %q", turn.Component)
+	}
+	if turn.OntologyVersion != "" {
+		t.Errorf("OntologyVersion: want empty (no ontology loaded), got %q", turn.OntologyVersion)
+	}
+}
+
+// makeQRecord is a quarantine-test-local helper so we don't conflict with
+// ingest_features_test.go's makeIngestRecord (which has a different signature).
+func makeQRecord(source, sessionID, role, text string) string {
+	return makeIngestRecord(source, sessionID, role, text, "2026-06-10T00:00:00Z", nil)
+}

--- a/internal/conversations/types.go
+++ b/internal/conversations/types.go
@@ -103,6 +103,18 @@ type Turn struct {
 
 	// ParentUUID links this turn to its parent in the conversation tree.
 	ParentUUID string `json:"parent_uuid,omitempty"`
+
+	// Component is the L1 component class for this record (e.g. "session.turn").
+	// Set on newly-ingested L3 records; empty for records ingested before v0.2.
+	Component string `json:"component,omitempty"`
+
+	// OntologyVersion is the L1 ontology reference used when this record was
+	// indexed (e.g. "cogos.conversations@1.0.0"). Empty for pre-v0.2 records.
+	OntologyVersion string `json:"ontology_version,omitempty"`
+
+	// MappingVersion is the L2 mapping reference used when this record was
+	// indexed (e.g. "claude-code-jsonl@1.0.0"). Empty for pre-v0.2 records.
+	MappingVersion string `json:"mapping_version,omitempty"`
 }
 
 // SearchHit is one result returned by cog_search_conversations.
@@ -165,6 +177,11 @@ type ObservatoryConfig struct {
 
 	// Identity tags to apply to all sessions from this config.
 	DefaultIdentity string `yaml:"default_identity" json:"default_identity,omitempty"`
+
+	// OntologyDir is the directory containing L1 + L2 ontology YAML files.
+	// Defaults to <workspace>/.cog/observatory/ontology when present.
+	// Set to an empty string to disable ontology enforcement entirely.
+	OntologyDir string `yaml:"ontology_dir" json:"ontology_dir,omitempty"`
 }
 
 // providerConfig is the internal config bundle built by LoadConfig.
@@ -173,6 +190,7 @@ type providerConfig struct {
 	Observatory   ObservatoryConfig
 	SourceFiles   []sourceFileInfo   // CC UUID JSONLs expanded from SourceDirs
 	IngestSources []ingestSourceInfo // normalized ingest sources expanded from IngestDirs
+	Ontology      *LoadedOntology    // nil when ontology enforcement is disabled
 }
 
 // sourceFileInfo is metadata about one discovered Claude Code source JSONL.

--- a/internal/conversations/uri_resolver.go
+++ b/internal/conversations/uri_resolver.go
@@ -46,8 +46,10 @@ import (
 	"time"
 )
 
-// ErrURIReservedParam is returned when a caller passes a reserved query param
-// (component= or ontology=) that is not yet supported.
+// ErrURIReservedParam is retained for backward compatibility. It is no longer
+// returned by the parser — component= and ontology= are now active params.
+// Callers that import this error for equality checks will see no behaviour
+// change since the parser never returns it from v0.2 onwards.
 var ErrURIReservedParam = errors.New("reserved param: not yet supported")
 
 // ErrURIUnknownParam is returned for any unrecognised query parameter.
@@ -93,6 +95,16 @@ type URIQuery struct {
 
 	// Fragment addressing.
 	Fragment *FragmentSpec
+
+	// v0.2 ontology-as-class params (activated in v0.2 groundwork).
+	// ComponentClass filters records by L1 component class.
+	// Only records whose Turn.Component matches are returned.
+	// Note: v0.1 records are all session.turn — say so in responses.
+	ComponentClass string // component=<class>; empty = all classes
+
+	// OntologyVersion is the requested L1 version for validation.
+	// The resolver rejects mismatches with an explicit error.
+	OntologyVersion string // ontology=<id>@<version>; empty = no validation
 }
 
 // FragmentSpec describes the resolved fragment form.
@@ -138,6 +150,13 @@ type ResolvedTurn struct {
 
 	// Source is the observer source id (empty for CC sessions).
 	Source string `json:"source,omitempty"`
+
+	// v0.2 L3 version tags — populated on records indexed with ontology
+	// enforcement enabled. Empty for records indexed before v0.2.
+	// Component is always "session.turn" for v0.1 records.
+	Component       string `json:"component,omitempty"`
+	OntologyVersion string `json:"ontology_version,omitempty"`
+	MappingVersion  string `json:"mapping_version,omitempty"`
 }
 
 // ParseConversationURI parses and validates a cog:conversations URI.
@@ -203,15 +222,12 @@ func parseConversationQueryParams(queryStr string, uq *URIQuery) error {
 		return nil
 	}
 
-	// Known params — processed below.
+	// Known params — all processed below (component= and ontology= now active).
 	known := map[string]bool{
 		"q": true, "role": true, "since": true, "until": true,
 		"limit": true, "offset": true, "order": true,
 		"res": true, "fields": true,
-	}
-	// Reserved params — must produce explicit error, not be silently ignored.
-	reserved := map[string]bool{
-		"component": true, "ontology": true,
+		"component": true, "ontology": true, // v0.2 activated
 	}
 
 	for _, pair := range strings.Split(queryStr, "&") {
@@ -221,9 +237,6 @@ func parseConversationQueryParams(queryStr string, uq *URIQuery) error {
 		k, v, _ := strings.Cut(pair, "=")
 		k = strings.TrimSpace(k)
 
-		if reserved[k] {
-			return fmt.Errorf("%w: %q (planned for v0.2 ontology-as-class)", ErrURIReservedParam, k)
-		}
 		if !known[k] {
 			return fmt.Errorf("%w: %q", ErrURIUnknownParam, k)
 		}
@@ -278,6 +291,19 @@ func parseConversationQueryParams(queryStr string, uq *URIQuery) error {
 			}
 		case "fields":
 			uq.Fields = strings.Split(v, ",")
+		case "component":
+			// component= filters by L1 component class.
+			// Validation against the loaded ontology happens at resolve time.
+			if v == "" {
+				return fmt.Errorf("invalid component= value: must be a non-empty component class name")
+			}
+			uq.ComponentClass = v
+		case "ontology":
+			// ontology= is validated against the loaded L1 at resolve time.
+			if v == "" {
+				return fmt.Errorf("invalid ontology= value: must be a non-empty version reference")
+			}
+			uq.OntologyVersion = v
 		}
 	}
 	return nil
@@ -359,11 +385,45 @@ func (uq *URIQuery) isBounded() bool {
 // ResolveConversationURI resolves a cog:conversations URI against the given
 // index and returns the resulting slice. ErrUnknownAuthority is returned for
 // cross-workspace authority forms.
+//
+// Deprecated: use ResolveConversationURIWithOntology when ontology enforcement
+// is available. This variant passes nil ontology (component= and ontology= params
+// accepted in the URI but not validated).
 func ResolveConversationURI(raw string, idx *Index) (*ResolvedSlice, error) {
+	return ResolveConversationURIWithOntology(raw, idx, nil)
+}
+
+// ResolveConversationURIWithOntology resolves a cog:conversations URI against
+// the given index, optionally validating component= and ontology= URI params
+// against the loaded ontology. lo may be nil — when nil, the params are parsed
+// but not validated against a loaded L1 (component= filters by string match
+// only; ontology= is accepted and recorded but not verified).
+func ResolveConversationURIWithOntology(raw string, idx *Index, lo *LoadedOntology) (*ResolvedSlice, error) {
 	uq, err := ParseConversationURI(raw)
 	if err != nil {
 		return nil, err
 	}
+
+	// v0.2 ontology= validation: if an ontology version is requested, verify
+	// it matches the loaded L1. Explicit mismatch → error.
+	if uq.OntologyVersion != "" {
+		if lo == nil || lo.L1 == nil {
+			return nil, fmt.Errorf("ontology=%q requested but no ontology is loaded; "+
+				"set ontology_dir in observatory config", uq.OntologyVersion)
+		}
+		if err := lo.OntologyVersionCheck(uq.OntologyVersion); err != nil {
+			return nil, err
+		}
+	}
+
+	// v0.2 component= validation: if a component class is requested and an
+	// ontology is loaded, verify the class exists in the L1.
+	if uq.ComponentClass != "" && lo != nil && lo.L1 != nil {
+		if err := lo.ComponentClass(uq.ComponentClass); err != nil {
+			return nil, err
+		}
+	}
+
 	return resolveQuery(raw, uq, idx)
 }
 
@@ -457,6 +517,20 @@ func resolveQuery(rawURI string, uq *URIQuery, idx *Index) (*ResolvedSlice, erro
 					continue
 				}
 			}
+			// v0.2 component= filter: filter records that carry a component
+			// class. Records ingested before v0.2 have an empty Component
+			// field and are included when component= is set (the filter is
+			// applied as a best-effort: if the field is unpopulated, it is
+			// treated as session.turn per v0.1 invariant).
+			if uq.ComponentClass != "" {
+				effectiveClass := t.Component
+				if effectiveClass == "" {
+					effectiveClass = "session.turn" // v0.1 invariant
+				}
+				if effectiveClass != uq.ComponentClass {
+					continue
+				}
+			}
 			allTurns = append(allTurns, t)
 		}
 	}
@@ -503,6 +577,12 @@ func resolveQuery(rawURI string, uq *URIQuery, idx *Index) (*ResolvedSlice, erro
 			rt.Text = abstractText(t.Text)
 		case ResPointer:
 			// No text — refs+metadata only.
+		}
+		// v0.2 L3 tags: carry component/ontology/mapping versions when present.
+		if t.Component != "" {
+			rt.Component = t.Component
+			rt.OntologyVersion = t.OntologyVersion
+			rt.MappingVersion = t.MappingVersion
 		}
 		resolved = append(resolved, rt)
 	}

--- a/internal/conversations/uri_resolver_test.go
+++ b/internal/conversations/uri_resolver_test.go
@@ -314,18 +314,20 @@ func TestParseConversationURI_QueryParams(t *testing.T) {
 	}
 }
 
-// ─── Reserved param tests ─────────────────────────────────────────────────────
+// ─── component= and ontology= are now active (not reserved) ─────────────────
+//
+// v0.2 groundwork activated these params. The old "reserved" check was removed
+// so these tests now verify that the params parse without error.
 
 func TestParseConversationURI_ReservedParams(t *testing.T) {
-	for _, reserved := range []string{"component", "ontology"} {
-		t.Run("reserved="+reserved, func(t *testing.T) {
-			uri := fmt.Sprintf("cog:conversations?%s=foo", reserved)
+	// component= and ontology= were previously reserved but are now active params
+	// as of v0.2 ontology-as-class enforcement. Verify they no longer error.
+	for _, param := range []string{"component", "ontology"} {
+		t.Run("now-active="+param, func(t *testing.T) {
+			uri := fmt.Sprintf("cog:conversations?%s=foo", param)
 			_, err := ParseConversationURI(uri)
-			if err == nil {
-				t.Fatalf("want error for reserved param %q, got nil", reserved)
-			}
-			if !strings.Contains(err.Error(), "reserved") {
-				t.Errorf("error should mention 'reserved', got %q", err.Error())
+			if err != nil {
+				t.Errorf("param %q should be accepted (v0.2 active), got error: %v", param, err)
 			}
 		})
 	}

--- a/internal/engine/providers_register.go
+++ b/internal/engine/providers_register.go
@@ -22,6 +22,8 @@
 // binaries (which register stub providers directly) are not affected.
 package engine
 
+import "net/http"
+
 // RegisterProviders is called once at daemon boot to populate the
 // pkg/reconcile provider registry. Set by cmd/cogos/providers_wire.go.
 // Nil means "no additional providers to register" (e.g. in tests).
@@ -46,3 +48,10 @@ var RegisterMCPExtensions func(srv *MCPServer)
 // Nil means the session-register path proceeds without identity binding
 // (naked-by-default: safe, correct, no functional change for existing callers).
 var WireHarnessBackend func(s *Server)
+
+// RegisterHTTPExtensions is called once during NewServer after the built-in
+// routes are registered. Extensions receive the *Server and *http.ServeMux so
+// they can call s.route() to register additional HTTP endpoints (e.g. the
+// observatory coverage route). Set by cmd/cogos extension init() functions.
+// Nil means no additional routes are registered.
+var RegisterHTTPExtensions func(s *Server, mux *http.ServeMux)

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -237,6 +237,11 @@ func NewServer(cfg *Config, nucleus *Nucleus, process *Process) *Server {
 	// ACP-client surface: list/browse Claude Code projects+sessions, spawn subprocess.
 	s.registerClaudeCodeRoutes(mux)
 
+	// Extension HTTP routes (e.g. observatory coverage).
+	if RegisterHTTPExtensions != nil {
+		RegisterHTTPExtensions(s, mux)
+	}
+
 	// Cluster / BEP transport status (Phase 2 S2). Dark by default: when
 	// cluster.enabled=false the handler returns {"enabled":false} and no
 	// engine state is inspected. The route is always registered so the

--- a/internal/engine/serve_manifest.go
+++ b/internal/engine/serve_manifest.go
@@ -61,6 +61,12 @@ func (s *Server) route(mux *http.ServeMux, pattern string, handler http.HandlerF
 	s.recordRoute(pattern)
 }
 
+// Route is the exported variant of route for use by RegisterHTTPExtensions
+// callbacks (which live outside the engine package).
+func (s *Server) Route(mux *http.ServeMux, pattern string, handler http.HandlerFunc) {
+	s.route(mux, pattern, handler)
+}
+
 // routeH is like route but takes an http.Handler (used for /mcp which is
 // backed by the streamable HTTP handler from the MCP library).
 func (s *Server) routeH(mux *http.ServeMux, pattern string, handler http.Handler) {

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -40,6 +40,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -238,6 +239,16 @@ func RegisterConversations(provider *conversations.Provider) {
 
 	// Wire conversations URI resolver.
 	engine.SetConversationsResolver(&conversationsURIResolver{p: provider})
+
+	// Wire GET /v1/observatory/coverage (v0.2 coverage metric surface).
+	prevHTTP := engine.RegisterHTTPExtensions
+	engine.RegisterHTTPExtensions = func(s *engine.Server, mux *http.ServeMux) {
+		if prevHTTP != nil {
+			prevHTTP(s, mux)
+		}
+		s.Route(mux, "GET /v1/observatory/coverage",
+			conversations.CoverageHTTPHandler(provider))
+	}
 }
 
 // conversationsURIResolver adapts conversations.Provider to


### PR DESCRIPTION
## Summary

- **Ontology loader** (`ontology.go`): `LoadOntologyDir` reads L1 component-class declarations and per-source L2 mapping YAMLs from `<workspace>/.cog/observatory/ontology/`. `ParseL1Ontology` rejects files that declare an unknown L0 grammar version (only `cogos.ontology/v1` is accepted). Exposes `OntologyVersionCheck` and `ComponentClass` for param validation.
- **Quarantine writer** (`quarantine.go`): `QuarantineWriter` appends records that have no mapping to `<workspace>/.cog/observatory/quarantine/<source>/quarantine.jsonl` with full provenance (reason, component, ontology_ref, mapping_ref, quarantined_at). Records are never silently dropped.
- **Coverage tracker** (`coverage.go`, `coverage_route.go`): per-source `{mapped, degenerate, quarantined, unmapped_component_counts}` counters; `GET /v1/observatory/coverage` exposed via the `RegisterHTTPExtensions` daemon hook.
- **Ingest enforcement** (`ingest_parser.go`): when an ontology is loaded, records from unmapped sources are quarantined; records from known sources are indexed and their `Turn` records carry `component`, `ontology_version`, `mapping_version` L3 provenance tags.
- **URI resolver** (`uri_resolver.go`): `component=` and `ontology=` URI params are now active. `component=` filters resolved turns by class (v0.1 records treated as `session.turn`). `ontology=` validates against the loaded L1 major version and rejects mismatches explicitly.
- **Engine hook** (`providers_register.go`, `serve.go`, `serve_manifest.go`): `RegisterHTTPExtensions func(*Server, *http.ServeMux)` hook-variable; exported `Server.Route()` wrapper for extension registration; `/v1/observatory/coverage` classified as `observability` in the manifest family table.
- **Daemon wiring** (`z_conversations_wire.go`): chains `CoverageHTTPHandler` behind `RegisterHTTPExtensions` using the same pattern as `RegisterMCPExtensions`. Daemon-only; legacy root-package main is unaffected.

## Test plan

- [ ] `go test -short ./internal/conversations/...` — new `ontology_test.go`, `quarantine_test.go`, `coverage_test.go` plus updated `uri_resolver_test.go` all pass
- [ ] `go test -short ./cmd/cogos/...` — updated `z_conversations_wire_test.go` verifies `component=` is accepted through the live wired resolver
- [ ] `go test -short ./...` — full suite green
- [ ] `go vet ./...` — clean
- [ ] CI e2e MCP probe must pass (no new MCP tools added; existing tool output paths unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)