### PR TITLE
fix(engine): return 501 before parsing chat body when no router is configured

### DIFF
--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -778,6 +778,20 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 	defer span.End()
 	r = r.WithContext(ctx)
 
+	// Check for a configured router before spending cycles on body parsing so
+	// that a nil router always yields 501 regardless of the request body.
+	if s.router == nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotImplemented)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]string{
+				"type":    "not_implemented",
+				"message": "no inference router configured; run with a providers.yaml",
+			},
+		})
+		return
+	}
+
 	body, err := io.ReadAll(io.LimitReader(r.Body, 4<<20)) // 4 MB limit
 	if err != nil {
 		http.Error(w, "read body: "+err.Error(), http.StatusBadRequest)
@@ -828,18 +842,6 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 
 	// Notify the process of the incoming interaction.
 	s.process.Send(NewGateEventFromBlock(block, "user.message", query))
-
-	if s.router == nil {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNotImplemented)
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"error": map[string]string{
-				"type":    "not_implemented",
-				"message": "no inference router configured; run with a providers.yaml",
-			},
-		})
-		return
-	}
 
 	// Assemble foveated context — engine owns the full window.
 	// It decomposes client messages, scores them alongside CogDocs,


### PR DESCRIPTION
## Summary

- Moves the `s.router == nil` guard to the top of `handleChat`, ahead of `io.ReadAll` / `json.Unmarshal`.
- Previously a nil/empty request body (e.g. a bare `POST /v1/chat/completions` with no body) would hit the JSON parser first and return 400 — before reaching the 501 branch.
- Removes the now-unreachable duplicate nil-check that was placed lower in the function.
- Behavior for the router-present path is unchanged.

This unblocks the nightly-integration workflow; `TestIntegrationFullLifecycle/chat_returns_501` (build tag `integration`) now passes on main. Closes #373.

## Test plan

- [x] `go test -tags integration -run TestIntegrationFullLifecycle ./internal/engine/` — all subtests pass
- [x] `go test -short ./...` — full suite clean
- [x] `go vet ./internal/engine/` — no issues