### PR TITLE
chore: bump version to 0.16.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 #   make e2e      - Run e2e test in a container
 #   make e2e-local - Run e2e test locally
 
-VERSION := 0.15.0
+VERSION := 0.16.0
 BUILD_TIME := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -s -w -X github.com/myrgic/cogos/internal/engine.BuildTime=$(BUILD_TIME) -X github.com/myrgic/cogos/internal/engine.Version=$(VERSION)
 BUILD_TAGS := fts5


### PR DESCRIPTION
Version bump for the 2026-06-10 release: observatory ingest v0.1, URI resolver (ratified RFC), byte caps, ontology enforcement, e2e MCP probe, daemon wiring test, nightly integration CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)