### PR TITLE
docs: remove internal references from public ADRs/RFCs

### DIFF
--- a/docs/adrs/094-lineage-observatory.md
+++ b/docs/adrs/094-lineage-observatory.md
@@ -14,8 +14,8 @@
 CogOS accumulates research insights across multiple intellectual lineage threads —
 connections between established science (Spencer-Brown, Maturana/Varela, Pattee,
 Rosen, Friston, von Foerster, L. Kauffman) and the working theoretical claims
-of the SRC/CogOS framework. These connections live in `~/workspaces/cog/.cog/mem/semantic/`
-as individual cogdocs, but there is no coherent mechanism for:
+of the broader research framework. These connections live in the substrate's
+semantic memory sector as individual cogdocs, but there is no coherent mechanism for:
 
 1. **Maintaining tier labels** (Tier 1 = established science → Tier 4 = speculative cosmological claims)
 2. **Tracking public exposure risk** for each node before external communication
@@ -132,7 +132,7 @@ When a corpus document contains a factual error:
 2. If the source document (outside lineage/) needs patching, patch in-place with the same frontmatter flag.
 3. The ProjectionReconciler will pick up the correction on the next reconcile cycle.
 
-**Canonical correction (2026-05-16):** ΔF = 0.7316 nats (NOT ln(2) = 0.6931) for the FEP cost at the eigenform operating point. τ₁ = ln(2) is correct and refers to the eigenform threshold radius — a distinct quantity. Correction sweep found no documents incorrectly conflating these values; the `self-reference-cost-synthesis.cog.md` canonical document is correct.
+**Canonical correction (2026-05-16):** A correction sweep validated the canonical values in the lineage node corpus for the FEP cost at the eigenform operating point. No documents were found incorrectly conflating the distinct quantities involved. The canonical node document is correct.
 
 ### §7 — What this ADR does NOT do
 

--- a/docs/adrs/097-memory-projection-reconciler.md
+++ b/docs/adrs/097-memory-projection-reconciler.md
@@ -28,7 +28,7 @@ CogOS operators maintain two structurally distinct memory surfaces:
 - Cross-session, cross-workspace coherent — the substrate-canonical memory layer
 - Section-aware reads via `cog_memory_toc` / `--section` for large documents
 
-As of 2026-05-17, the operator's Claude Code memories at `~/.claude/projects/-Users-slowbro/memory/` contain dozens of active records — feedback memories, session summaries, project state, user profile — none of which appear as cogdocs in `.cog/mem/`. The substrate's kernel cannot search these memories using `cog_memory_search`. Conversely, the substrate's cogdocs at `cog://mem/semantic/insights/` (a corpus of hundreds of research documents) are not visible to in-session Claude Code reads, which rely on MEMORY.md for context.
+As of 2026-05-17, the operator's Claude Code memories at `~/.claude/projects/*/memory/` contain dozens of active records — feedback memories, session summaries, project state, user profile — none of which appear as cogdocs in `.cog/mem/`. The substrate's kernel cannot search these memories using `cog_memory_search`. Conversely, the substrate's cogdocs in the semantic sector (a corpus of hundreds of research documents) are not visible to in-session Claude Code reads, which rely on MEMORY.md for context.
 
 The two surfaces drift apart by construction. Every Claude Code memory written after the last manual sync widens the gap. Without a reconciliation mechanism, the operator's memory infrastructure bifurcates: operator-personal knowledge in one surface, substrate-indexed knowledge in another, with no automated path between them.
 
@@ -292,7 +292,7 @@ The Claude Code memory filename encodes the slug but not the semantic category. 
 
 - Existing Claude Code memories that have never been projected classify as `claude-code-only-needs-projection` with an empty ledger. This is the legitimate starting state: the empty ledger means no prior projection state exists; all memories classify as needing a first projection. This is not an error condition; it is the expected first-run state (same reasoning as ADR-096 §7).
 - Substrate cogdocs that are not memory projections and do not carry `projection.target: claude-code` are unaffected by this Reconcilable. The reconciler only manages cogdocs it created or that have opted in via projection frontmatter.
-- The reconciler does not touch `cog://mem/semantic/lineage/` (managed by `ProjectionReconciler` per ADR-094) or any cogdoc managed by another Reconcilable. Domain isolation is enforced by the `projection.origin` frontmatter field.
+- The reconciler does not touch the lineage sector (managed by `ProjectionReconciler` per ADR-094) or any cogdoc managed by another Reconcilable. Domain isolation is enforced by the `projection.origin` frontmatter field.
 
 ## Implementation
 
@@ -319,7 +319,7 @@ A `MemoryProjectionReconciler` prototype MUST be able to classify each memory pa
 | Both files exist; one modified since last hash | `paired-drift` |
 | Both files exist; both modified since last hash | `conflict-both-modified` |
 
-With an empty ledger, all operator-personal Claude Code memories at `~/.claude/projects/-Users-slowbro/memory/` classify as `claude-code-only-needs-projection` and all substrate cogdocs with `projection.target: claude-code` (if any) classify as `substrate-only-needs-projection`. This is the correct and expected starting classification — it is the first-run state.
+With an empty ledger, all operator-personal Claude Code memories at `~/.claude/projects/*/memory/` classify as `claude-code-only-needs-projection` and all substrate cogdocs with `projection.target: claude-code` (if any) classify as `substrate-only-needs-projection`. This is the correct and expected starting classification — it is the first-run state.
 
 Integration test cases to add:
 
@@ -344,4 +344,4 @@ Integration test cases to add:
 
 4. **Index ownership when both surfaces grow independently.** If the operator writes new Claude Code memories and new substrate cogdocs between ticks, both MEMORY.md and the substrate index grow independently. The reconciler's index merge (§3, Index reconciliation) adds new entries from each side to the other. This additive-only merge means duplicate-topic entries may accumulate if the operator creates parallel documents on both sides without pairing them. A future ADR should define a deduplication policy for the merged index.
 
-5. **Migration of existing operator-personal memories.** This ADR specifies the projection contract, not a migration plan. Projecting the operator's existing Claude Code memories (`~/.claude/projects/-Users-slowbro/memory/`) into substrate cogdocs is an operator-decided operation: the reconciler will classify all existing memories as `claude-code-only-needs-projection` on first run and will project them outward on the next apply cycle. Whether the operator wants this to happen automatically or wants to review and approve projections before they land in the substrate is a configuration decision outside this ADR's scope. A `dry-run` mode for the first apply cycle (producing a classification report without writing any cogdocs) is recommended as implementation guidance but not specified as a contract here.
+5. **Migration of existing operator-personal memories.** This ADR specifies the projection contract, not a migration plan. Projecting the operator's existing Claude Code memories (`~/.claude/projects/*/memory/`) into substrate cogdocs is an operator-decided operation: the reconciler will classify all existing memories as `claude-code-only-needs-projection` on first run and will project them outward on the next apply cycle. Whether the operator wants this to happen automatically or wants to review and approve projections before they land in the substrate is a configuration decision outside this ADR's scope. A `dry-run` mode for the first apply cycle (producing a classification report without writing any cogdocs) is recommended as implementation guidance but not specified as a contract here.

--- a/docs/adrs/098-skill-projection-reconciler.md
+++ b/docs/adrs/098-skill-projection-reconciler.md
@@ -39,7 +39,7 @@ The workspace-wins override is silent: if `~/.claude/skills/my-skill/SKILL.md` a
 
 ### Why this is the worst provenance offender in the projection audit
 
-The three-field provenance audit (see `feedback_projection_provenance_three_field_minimality.md`, surfaced in ADR-097 §8) graded existing projection mechanisms against the three-field test:
+The three-field provenance audit (surfaced in ADR-097 §8) graded existing projection mechanisms against the three-field test:
 
 | Mechanism | `projection.source-path` | `projection.origin` | `projection.last-hash` | Grade |
 |---|---|---|---|---|
@@ -138,7 +138,7 @@ Per ADR-092 §3, `ApplyPlan` is idempotent: writing the same projection content 
 
 ### §3 — Three-field provenance contract on projected artifacts
 
-Every skill projection written by this reconciler carries the minimum three-field provenance contract (per `feedback_projection_provenance_three_field_minimality.md`):
+Every skill projection written by this reconciler carries the minimum three-field provenance contract (per the three-field provenance minimality memo; internal reference omitted):
 
 ```yaml
 ---

--- a/docs/adrs/099-node-identity-layering.md
+++ b/docs/adrs/099-node-identity-layering.md
@@ -1,14 +1,19 @@
-# ADR-099: Node Identity Layering — Three-Layer Clarification and Canonical Path Forward
+---
+type: adr
+id: ADR-099
+title: "ADR-099: Node Identity Layering — Three-Layer Clarification and Canonical Path Forward"
+status: accepted
+created: 2026-05-18
+refs: "ADR-062, ADR-073"
+---
 
-**Status:** Accepted  
-**Date:** 2026-05-18  
-**Context:** Wave 6b audit surfaced two `NodeIdentity` implementations using different cryptographic schemes. This ADR investigates, names each layer, documents its scope, and specifies the canonical path forward.
+# ADR-099: Node Identity Layering — Three-Layer Clarification and Canonical Path Forward
 
 ---
 
 ## Problem statement
 
-A Wave 6b audit (see `project_substrate_implementation_state_2026-05-18.md`) reported a "node-identity schism" between two implementations:
+A Wave 6b audit reported a "node-identity schism" between two implementations:
 
 - `cog/.cog/node_identity.go` — Ed25519, with `NodeID = sha256(public_key_bytes + role + genesis_timestamp)` prefix `"sha256:"`
 - `constellation/identity.go` — ECDSA P-256, with `NodeID = hex(sha256(DER(pubkey)))`
@@ -31,7 +36,7 @@ The proposed resolution was to retire the former in favour of the latter, since 
 
 ### Layer 2 — Workspace operational identity (`cog/.cog/node_identity.go`)
 
-- **Package:** `package main` inside `~/workspaces/cog/.cog/` (the cog workspace CLI — NOT part of the cogos kernel repo)
+- **Package:** `package main` inside the cog workspace CLI (NOT part of the cogos kernel repo)
 - **Crypto:** Ed25519 (via `crypto.go:EnsureKeypair`)
 - **NodeID derivation:** `"sha256:" + hex(sha256(pubkey_bytes + role_bytes + genesis_timestamp_bytes))`
 - **Purpose:** Workspace-scoped stable identity for the cog workspace CLI (`serve.go`, `registration.go`, `cmd_signal.go`). Seeds the ledger genesis event and is referenced in workspace signals.
@@ -62,13 +67,13 @@ The audit characterised Layer 2 as a "drift" from Layer 1. The characterisation 
 | Crypto | ECDSA P-256 | Ed25519 | None |
 | Imported by cogos kernel? | No | No | Yes (cmd_node.go) |
 
-No code currently bridges Layer 1 and Layer 2. The cogos kernel does not import `github.com/myrgic/constellation`. The cog workspace CLI does not import `github.com/myrgic/constellation` either (it is a separate binary in `~/workspaces/cog/.cog/`).
+No code currently bridges Layer 1 and Layer 2. The cogos kernel does not import `github.com/myrgic/constellation`. The cog workspace CLI does not import `github.com/myrgic/constellation` either (it is a separate binary).
 
 ---
 
 ## The canonical path forward (decided)
 
-The design spec (`project_cogos_identity_as_crd.md`, Layer definitions) specifies:
+The three-layer identity design spec (Layer definitions) specifies:
 
 > L1 — Node: `kind: Node` (already exists), ECDSA P-256, NodeID = hex(SHA-256(DER(pubkey))), git-backed hash-chained ledger
 
@@ -122,8 +127,8 @@ When Layer 2 retirement is attempted, the migration procedure is:
 
 ## References
 
-- `project_cogos_identity_as_crd.md` — three-layer identity model (L1/L2/L3)
-- `project_substrate_implementation_state_2026-05-18.md` — audit that surfaced the gap
+- Three-layer identity model (L1/L2/L3) — (internal reference omitted)
+- Wave 6b implementation-state audit that surfaced the gap — (internal reference omitted)
 - `constellation/identity.go` — L1 canonical implementation
 - `cog/.cog/node_identity.go` — L2 workspace operational implementation
 - ADR-062 — Recursive Node Architecture (L3 node registration)

--- a/docs/adrs/100-substrate-library-extraction.md
+++ b/docs/adrs/100-substrate-library-extraction.md
@@ -1,61 +1,56 @@
 ---
-cog:
-  version: "1.0.0"
-  type: adr
-  id: ADR-100
-  layer: spec
-
+type: adr
+id: ADR-100
+layer: spec
 title: "ADR-100: Substrate Library Extraction From Current Package Structure"
 created: 2026-05-19
 status: accepted
 tags: [adr, substrate, kernel, library-extraction, decomposition, supersedes-085]
 author: chaz
 refs:
-  - uri: cog://rfc/034
-    rel: implements
+  - rel: implements
     description: >
       The categorical cut; substrate-vs-kernel boundary; library extraction
-      is RFC-034 Phase 2. This ADR specifies the decomposition that Phase 2
-      executes. RFC-034 §13 named "ADR-085 advances to accepted" as the
-      implementation gate; this ADR supersedes that gate.
-  - uri: cog://adr/085
-    rel: supersedes
+      is the Phase 2 substrate-kernel split RFC. This ADR specifies the
+      decomposition that Phase 2 executes. That RFC's §13 named "ADR-085
+      advances to accepted" as the implementation gate; this ADR supersedes
+      that gate. (internal reference omitted)
+  - rel: supersedes
     description: >
       ADR-085 prescribed a per-provider decomposition into
       internal/providers/<name>/ subpackages. The actual architecture went to
       internal/engine/ as the primary dispatch core (250+ files). This ADR
       captures the current state and specifies the substrate-extraction path
-      forward from where the code actually is.
-  - uri: cog://rfc/035
-    rel: composes-with
+      forward from where the code actually is. (internal reference omitted)
+  - rel: composes-with
     description: >
       RFC-035 BlockClass — specifies the CogBlock/EventEnvelope unification
       (block.go:11-45 + ledger.go:23+ merge into a single ledger-entry type).
       The unified CogBlock is the canonical substrate atom. RFC-035 must land
       before Step 2 of the migration (pkg/substrate/block/ stabilization).
-  - uri: cog://rfc/036
-    rel: composes-with
+      (internal reference omitted)
+  - rel: composes-with
     description: >
       RFC-036 WorkspaceClass — specifies Workspace as a Binding Pattern
       instance. The WorkspaceClaim schema lives in the substrate library;
       the WorkspaceReconciler lives in the kernel. Step 3 coordinates with
-      RFC-036's schema landing.
-  - uri: cog://rfc/037
-    rel: composes-with
+      RFC-036's schema landing. (internal reference omitted)
+  - rel: composes-with
     description: >
       RFC-037 ChannelClass — specifies Channel as a Binding Pattern instance.
       Channel schema (channel_config.go, channel_types.go) moves to substrate;
       routing logic stays kernel. Step 3 coordinates with RFC-037.
-  - uri: cog://adr/091
-    rel: composes-with
+      (internal reference omitted)
+  - rel: composes-with
+    target: "[ADR-091](091-substrate-as-named-architectural-layer.md)"
     description: >
       ADR-091 named the Substrate/Kernel/Module trichotomy and established
       that pkg/cogblock, pkg/reconcile, pkg/uri, pkg/bep, pkg/cogfield are
       already separately-versioned Go modules. ADR-100 operationalizes
       ADR-091's trichotomy as a concrete migration plan from the current
       package state.
-  - uri: cog://adr/092
-    rel: composes-with
+  - rel: composes-with
+    target: "[ADR-092](092-substrate-contracts-and-concurrency.md)"
     description: >
       ADR-092 specified the ledger-writer concurrency contract and boot-order
       semantics. The substrate library migration must preserve the
@@ -191,17 +186,17 @@ kernel. Apply this check to any ambiguous case before filing a PR.
 
 ### Step 0: Mark ADR-085 `superseded`
 
-Update `~/workspaces/cog/.cog/adr/085-cogos-subpackage-decomposition.cog.md`
-frontmatter: `status: superseded`. Add forward-reference to ADR-100.
-Update RFC-034 §13 gate reference from "ADR-085 advances to accepted" to
-"ADR-100 advances to accepted."
+Update the ADR-085 document frontmatter: `status: superseded`. Add
+forward-reference to ADR-100. Update the substrate-kernel split RFC §13 gate
+reference from "ADR-085 advances to accepted" to "ADR-100 advances to
+accepted."
 
 This is a documentation-only change. No code moves. Gate: doc references
 consistent.
 
 ### Step 1: Create `pkg/substrate/` as empty Go module
 
-Create `~/workspaces/myrgic/cogos/pkg/substrate/go.mod` with module path
+Create `pkg/substrate/go.mod` with module path
 `github.com/myrgic/cogos/pkg/substrate`. Add to `go.work`. No code yet — just
 the module scaffold with a `doc.go` naming the layer.
 
@@ -324,10 +319,10 @@ Step 6 is a clean cut rather than a heroic refactor.
 
 | Document | Relationship |
 |---|---|
-| RFC-034 (Substrate-Kernel Categorical Split) | Parent RFC; this ADR is its decomposition prerequisite |
-| RFC-035 (BlockClass) | Unification prerequisite for Step 4; must ratify before Step 4 begins |
-| RFC-036 (WorkspaceClass) | Coordinates with Step 3 WorkspaceClaim schema extraction |
-| RFC-037 (ChannelClass) | Coordinates with Step 3 Channel schema extraction |
+| Substrate-Kernel Categorical Split RFC (internal reference omitted) | Parent RFC; this ADR is its decomposition prerequisite |
+| BlockClass RFC (internal reference omitted) | Unification prerequisite for Step 4; must ratify before Step 4 begins |
+| WorkspaceClass RFC (internal reference omitted) | Coordinates with Step 3 WorkspaceClaim schema extraction |
+| ChannelClass RFC (internal reference omitted) | Coordinates with Step 3 Channel schema extraction |
 | ADR-085 (superseded) | Historical record of the decomposition plan that diverged; this ADR is its replacement |
-| ADR-091 (Substrate as Named Architectural Layer) | Establishes the trichotomy; names the forcing functions that gate Step 6 |
-| ADR-092 (Substrate Contracts and Concurrency) | Specifies the ledger-writer contract that Step 4 must satisfy |
+| [ADR-091 (Substrate as Named Architectural Layer)](091-substrate-as-named-architectural-layer.md) | Establishes the trichotomy; names the forcing functions that gate Step 6 |
+| [ADR-092 (Substrate Contracts and Concurrency)](092-substrate-contracts-and-concurrency.md) | Specifies the ledger-writer contract that Step 4 must satisfy |

--- a/docs/adrs/101-testkernel-in-process-boot-harness.md
+++ b/docs/adrs/101-testkernel-in-process-boot-harness.md
@@ -1,38 +1,35 @@
 ---
-cog:
-  version: "1.0.0"
-  type: adr
-  id: ADR-101
-  layer: spec
-
+type: adr
+id: ADR-101
+layer: spec
 title: "ADR-101: testkernel — In-Process Boot Harness for Daemon-Level Integration Testing"
 created: 2026-05-19
 status: accepted
 tags: [adr, kernel, testing, testkernel, reconcile, mcp, integration-testing]
 author: chaz
 refs:
-  - uri: cog://adr/092
-    rel: composes-with
+  - rel: composes-with
+    target: "[ADR-092](092-substrate-contracts-and-concurrency.md)"
     description: >
       ADR-092 specifies the Reconcilable contract (LoadConfig → FetchLive →
       ComputePlan → ApplyPlan → BuildState → WriteState) and the single-writer
       concurrency invariant. testkernel must not break either.
-  - uri: cog://adr/095
-    rel: composes-with
+  - rel: composes-with
+    target: "[ADR-095](095-daemon-reconcile-loop-driver.md)"
     description: >
       ADR-095 specifies ReconcileDaemon — the running loop that testkernel
       wraps. The Trigger/WaitForReconcile API in testkernel aligns with
       ReconcileDaemon.Trigger. PollInterval=0 semantics are specified here.
-  - uri: cog://adr/091
-    rel: composes-with
+  - rel: composes-with
+    target: "[ADR-091](091-substrate-as-named-architectural-layer.md)"
     description: >
       ADR-091 named the Substrate/Kernel/Module trichotomy. testkernel lives
       at the Kernel layer: it wraps the running engine, not the substrate
       libraries. Downstream modules (constellation, mod3) that need to
       integration-test against a real kernel instance access it through
       testkernel's exported API.
-  - uri: cog://adr/100
-    rel: composes-with
+  - rel: composes-with
+    target: "[ADR-100](100-substrate-library-extraction.md)"
     description: >
       ADR-100 is extracting the substrate library from internal/engine/. The
       testkernel package shape must be stable against that extraction: it depends
@@ -622,8 +619,7 @@ func TestIdentityProvider_MCPRoundTrip(t *testing.T) {
 
 The package is named `testkernel`. This is a plain descriptive name for a test
 helper that boots a kernel. No Eigen, EigSight, HyperCycle, or other
-research-vocabulary terms appear in this package name or its API per the
-standing rule on substrate naming (`feedback_substrate_naming_forward_direction.md`).
-The API surface uses Go-idiomatic names: `Boot`, `Stop`, `CallTool`,
-`TriggerReconcile`, `WaitForReconcile`. None of these encode framework
-terminology.
+research-vocabulary terms appear in this package name or its API — the standing
+rule on substrate naming prohibits them. The API surface uses Go-idiomatic names:
+`Boot`, `Stop`, `CallTool`, `TriggerReconcile`, `WaitForReconcile`. None of these
+encode framework terminology.

--- a/docs/rfc-drafts/mod3-bus-sessions-subscription.md
+++ b/docs/rfc-drafts/mod3-bus-sessions-subscription.md
@@ -1,9 +1,13 @@
-# RFC Draft: mod3 subscribes to bus_sessions for cross-session voice presence
+---
+type: rfc-draft
+title: "mod3 subscribes to bus_sessions for cross-session voice presence"
+status: draft
+closes: "myrgic/cogos#156"
+depends_on: "myrgic/cogos#154"
+scope: "Design only — no implementation in this document"
+---
 
-**Status:** Draft — awaiting review and RFC number assignment  
-**Closes:** myrgic/cogos#156  
-**Depends on:** myrgic/cogos#154 (bus_sessions read path must be live before this data path is useful)  
-**Scope:** Design only — no implementation in this document
+# RFC Draft: mod3 subscribes to bus_sessions for cross-session voice presence
 
 ---
 

--- a/docs/rfc-drafts/workspace-node-relationship.md
+++ b/docs/rfc-drafts/workspace-node-relationship.md
@@ -1,9 +1,13 @@
-# RFC Draft: workspace ⟷ node relationship (N:M)
+---
+type: rfc-draft
+title: "workspace ⟷ node relationship (N:M)"
+status: draft
+closes: "myrgic/cogos#160"
+companion: "myrgic/cogos#161"
+scope: "Design only — no implementation in this document"
+---
 
-**Status:** Draft — awaiting review and RFC number assignment
-**Closes:** myrgic/cogos#160
-**Companion:** myrgic/cogos#161 (mechanical on-disk demonstration)
-**Scope:** Design only — no implementation in this document
+# RFC Draft: workspace ⟷ node relationship (N:M)
 
 ---
 

--- a/docs/rfcs/0002-public-corpus-migration.md
+++ b/docs/rfcs/0002-public-corpus-migration.md
@@ -11,7 +11,7 @@
 
 ## Summary
 
-There is a substantial private design corpus — 89 ADRs and 25 RFCs in `~/workspaces/cog/.cog/` — that predates this repository's first public RFC and that the public source code already cites by ID. None of those documents have been ported to the public repo. Twenty-two ADRs and three RFCs are referenced from `.go`, `.md`, and `.yaml` files in this tree and resolve to nothing.
+There is a substantial private design corpus — 89 ADRs and 25 RFCs — that predates this repository's first public RFC and that the public source code already cites by ID. None of those documents have been ported to the public repo. Twenty-two ADRs and three RFCs are referenced from `.go`, `.md`, and `.yaml` files in this tree and resolve to nothing.
 
 This RFC is the canonical mirror-workflow doc. It does three things:
 
@@ -38,8 +38,8 @@ The forcing function created by PR #141 — "the first public RFC" — is the ri
 
 | Corpus | Location | Files | Status breakdown |
 |---|---|---|---|
-| Private ADRs | `~/workspaces/cog/.cog/adr/` | 89 | accepted: 56, proposed: 29, superseded: 4 |
-| Private RFCs | `~/workspaces/cog/.cog/conf/spec/rfc/` | 25 | draft: 25 (all) |
+| Private ADRs | private substrate workspace | 89 | accepted: 56, proposed: 29, superseded: 4 |
+| Private RFCs | private substrate workspace | 25 | draft: 25 (all) |
 | Public ADRs (today) | `docs/adrs/` (does not exist) | 0 | — |
 | Public RFCs (today) | `docs/rfcs/` (PR #141 creates) | 0 → 1 | RFC-0001 draft |
 
@@ -114,7 +114,7 @@ status: draft         # draft | accepted | superseded | rejected
 created: 2026-05-01
 authors: [chazmaniandinkle]
 mirrors:              # OPTIONAL; required only when this is a port
-  - source: cog://rfc/006
+  - source: cog://example/rfc/006
     rel: primary-source
     private_status: draft
     note: |
@@ -283,7 +283,7 @@ The third role of this document. Once Wave 0 lands, this section governs new des
 ### Mirroring a private precursor (Wave 1/2/3 work)
 
 1. **Confirm wave.** Wave 1 is bulk migration. Wave 3 is on-demand: only port a document when something new cites it.
-2. **Read the private source** (`~/workspaces/cog/.cog/adr/NNN-...cog.md` or RFC). Note the private status at this snapshot.
+2. **Read the private source** (ADR or RFC from the private substrate corpus). Note the private status at this snapshot.
 3. **Allocate the next public ID.**
 4. **Copy and adapt.** Public document is a derivative, not a verbatim copy. Adaptations:
    - Strip iteration history sections (Discussion Log, Simmer criteria, anything labeled "private" or that references private memory cogdocs).
@@ -470,7 +470,7 @@ A starting point for sub-wave PRs. Not run in CI; a one-shot the porting maintai
 """Skeleton: read a private ADR/RFC, emit a draft public mirror."""
 import re, sys, pathlib
 
-PRIVATE_ROOT = pathlib.Path("~/workspaces/cog/.cog").expanduser()
+PRIVATE_ROOT = pathlib.Path("~/.cog").expanduser()  # adjust to your private substrate path
 PUBLIC_ROOT = pathlib.Path(".")  # run from repo root
 
 def port(private_id: str, public_id: str, kind: str):
@@ -529,9 +529,9 @@ Use it as a draft-emitter; the maintainer hand-edits before opening the PR.
 ## References
 
 - [PR #141](https://github.com/cogos-dev/cogos/pull/141): RFC-0001, the first public RFC, drafted under the assumption no prior corpus existed; this RFC is the corrective.
-- Private RFC-006 (`cog://rfc/006`): Public-Class ADR Corpus and Mirror Workflow. The substrate ancestor of this RFC. Most decisions here adapt RFC-006's frontmatter and lifecycle conventions to the public corpus's realities.
-- Private RFC-004 (`cog://rfc/004`): ADR In-Review Status and Reshape Workflow. The private workflow doc CONTRIBUTING.md currently cites; replaced for public purposes by RFC-0002.
-- Private RFC-005 (`cog://rfc/005`): ADR Implementation-Tracking Frontmatter. A candidate for future public adoption (Open Question 3).
-- Private ADR-027 (`cog://adr/027`): RFC Process Adoption. Defines the private RFC lifecycle this RFC mirrors.
-- Private ADR-085 (`cog://adr/085`): CogOS Kernel Subpackage Decomposition. The load-bearing source for PR #141; will be ported as a public ADR in Wave 1c.
+- Private RFC-006: Public-Class ADR Corpus and Mirror Workflow. The substrate ancestor of this RFC. Most decisions here adapt RFC-006's frontmatter and lifecycle conventions to the public corpus's realities. (internal reference omitted)
+- Private RFC-004: ADR In-Review Status and Reshape Workflow. The private workflow doc CONTRIBUTING.md currently cites; replaced for public purposes by RFC-0002. (internal reference omitted)
+- Private RFC-005: ADR Implementation-Tracking Frontmatter. A candidate for future public adoption (Open Question 3). (internal reference omitted)
+- Private ADR-027: RFC Process Adoption. Defines the private RFC lifecycle this RFC mirrors. (internal reference omitted)
+- Private ADR-085: CogOS Kernel Subpackage Decomposition. The load-bearing source for PR #141; will be ported as a public ADR in Wave 1c. (internal reference omitted)
 - [CONTRIBUTING.md](../../CONTRIBUTING.md): currently cites private RFC-004; needs amendment as part of Wave 0.

--- a/docs/rfcs/0003-cogblock-topology-refinements.md
+++ b/docs/rfcs/0003-cogblock-topology-refinements.md
@@ -194,7 +194,7 @@ No Go code changes in this refinement. The theorem candidate does not gate imple
 
 - Issue #208
 - Kauffman (2009) §V, "Reflexivity and Eigenform"; eigenform lineage (von Foerster 1981, Spencer-Brown 1969); Lambek's lemma; ADR-059
-- Council cogdocs: `cog://mem/semantic/council/2026-05-05/` (private; verbatim not reproduced here)
+- Council cogdocs: 2026-05-05 deliberation record (private; verbatim not reproduced here)
 
 ---
 

--- a/docs/rfcs/0005-cog-fork-session.md
+++ b/docs/rfcs/0005-cog-fork-session.md
@@ -35,10 +35,10 @@ The substrate already provides the primitives this RFC assembles:
 A fork event is therefore a small addition: a new `session.fork` CogBlock Kind, a body
 declaring the parent hash and overlay manifest, and downstream consumers interpreting it.
 
-The SRC reading: the session's state-at-T, observed from its own perspective, hashes to
-a canonical reference — `φ(s*) = s*` applied to sessions. A fork is publishing a marker
-that says "this point is now reference-able." The substrate needs no separate fork-table
-or snapshot store; the ledger is already hash-chained.
+The session's state-at-T, observed from its own perspective, hashes to a canonical
+reference. A fork is publishing a marker that says "this point is now reference-able."
+The substrate needs no separate fork-table or snapshot store; the ledger is already
+hash-chained.
 
 ## `session.fork` CogBlock Kind
 

--- a/docs/rfcs/0007-dispatch-provider-override.md
+++ b/docs/rfcs/0007-dispatch-provider-override.md
@@ -6,7 +6,7 @@
 | Author   | @chazmaniandinkle                                                                              |
 | Tracking | [#TBD](https://github.com/myrgic/cogos/issues/) (Layer 2 + 3 follow-ups)                       |
 | Target   | `v0.7.0` (Layer 1, this RFC) · later releases (Layers 2 + 3)                                   |
-| Relates  | [RFC-0006 vLLM provider](0006-vllm-pagedattention-provider.md), `cog://rfc/027` (bus peering)  |
+| Relates  | [RFC-0006 vLLM provider](0006-vllm-pagedattention-provider.md), bus peering RFC (internal reference omitted) |
 
 ## Summary
 

--- a/docs/rfcs/0008-inference-control-plane.md
+++ b/docs/rfcs/0008-inference-control-plane.md
@@ -54,11 +54,11 @@ Per RFC-034 (Observer-as-Reconciler vocabulary): an **Observer** is a Reconcilab
 
 Concretely: the `NodeStateObserver` is a Reconcilable instance (per RFC-034's Reconcilable Binding Pattern) with:
 - Read-only external authority over runtime processes and endpoints
-- An `ApplyPlan` that writes observation results to `cog://mem/semantic/observations/node-state/`
+- An `ApplyPlan` that writes observation results to `{workspace}/.cog/mem/semantic/observations/node-state/`
 - A reconcile interval (default 30s) driven by the standard Reconcilable scheduler
 
 This framing unifies Observatory with the rest of the substrate's reconciler hierarchy: the
-Observatory endpoint at `cog://mem/semantic/observations/node-state/` is written by the
+Observatory endpoint at `{workspace}/.cog/mem/semantic/observations/node-state/` is written by the
 NodeStateObserver instance, readable by the router at zero-copy cost.
 
 A Registry knows what providers are configured. A Reconciler knows what providers *should* be running and can restart them. An Observer (Reconcilable instance) knows what providers *are* running right now and writes that view to an Observatory endpoint. The router reads the endpoint; it does not poll the observer directly.
@@ -79,7 +79,7 @@ This RFC introduces the Observatory endpoint concept and the Observer-as-Reconci
 
 The **NodeStateObserver** is a Reconcilable instance (per RFC-034's Observer-as-Reconciler
 pattern) that probes inference runtime state on the local node and writes its observations
-to the **NodeStateObservatory** substrate endpoint at `cog://mem/semantic/observations/node-state/`.
+to the **NodeStateObservatory** substrate endpoint at `{workspace}/.cog/mem/semantic/observations/node-state/`.
 
 The distinction matters:
 - **NodeStateObserver** = the Reconcilable instance doing the probing. It has read-only
@@ -93,7 +93,7 @@ The distinction matters:
 
 - **Observer package**: `internal/observatory`
 - **Observer interface**: `NodeStateObserver` (Reconcilable; per RFC-034)
-- **Observatory endpoint**: `cog://mem/semantic/observations/node-state/`
+- **Observatory endpoint**: `{workspace}/.cog/mem/semantic/observations/node-state/`
 - **Scope**: local node only. Cross-node inference federation is future scope (§10).
 - **Source of truth**: direct process probes, HTTP health checks, `sysctl`/`vm_stat` for memory pressure, `diskutil`/`lsblk` for storage tier classification.
 
@@ -625,7 +625,7 @@ Remote endpoints (Anthropic API, OpenAI API, desktop machine at 192.168.x.x).
 
 The following are explicitly on the roadmap but out of scope for this RFC:
 
-**Cross-node inference federation**: extending the Observatory to observe InferenceChannels on peer nodes in a constellation. Today the Observatory is node-local. A multi-node extension would require the bus-peering layer (`cog://rfc/027`) and a distributed view-merge protocol. This is a natural follow-on once the local Observatory is stable.
+**Cross-node inference federation**: extending the Observatory to observe InferenceChannels on peer nodes in a constellation. Today the Observatory is node-local. A multi-node extension would require the bus-peering layer (bus-peering RFC; internal reference omitted) and a distributed view-merge protocol. This is a natural follow-on once the local Observatory is stable.
 
 **Predictive model preloading**: using access-pattern history from the Observatory's cold-start log to predict which model will be needed next and issue a background warm-up. The Observatory already records `LastInferenceAt` per model; a scheduler could use this to preload during idle periods.
 
@@ -640,4 +640,4 @@ The following are explicitly NOT in this RFC:
 - **vLLM block-API integration**. RFC-0006 covers the vLLM provider with PagedAttention block access. RFC-0008 classifies a vLLM channel as `cog-native` with `block_primitive: pagedattention`; the block-API wiring is RFC-0006's scope.
 - **ADR formalizing Observatory as a substrate primitive**. RFC-0008 introduces the term; the ADR is follow-on work.
 - **Layer 2 and Layer 3 of RFC-0007** (agent-card provider preference; router-aware autonomic loop). Those layers build on top of the provider resolution work; the Observatory feeds into Layer 3 when it lands.
-- **Bus-peering / cross-node events**. `cog://rfc/027` covers bus peering. Observatory events are node-local until that RFC's scope is resolved.
+- **Bus-peering / cross-node events**. The bus-peering RFC (internal reference omitted) covers bus peering. Observatory events are node-local until that RFC's scope is resolved.

--- a/docs/rfcs/0009-consolidated-mcp-transport.md
+++ b/docs/rfcs/0009-consolidated-mcp-transport.md
@@ -7,7 +7,7 @@
 | Created  | 2026-05-18                                                                                             |
 | Accepted | 2026-05-27 — direction accepted by operator; open questions (§6) resolve during implementation         |
 | Tracking | TBD                                                                                                    |
-| Relates  | [ADR-091](../adrs/091-substrate-as-named-architectural-layer.md), [ADR-092](../adrs/092-substrate-contracts-and-concurrency.md), [ADR-095](../adrs/095-daemon-reconcile-loop-driver.md), [ADR-096](../adrs/096-worktree-reconciler.md), [ADR-097](../adrs/097-memory-projection-reconciler.md), [ADR-098](../adrs/098-skill-projection-reconciler.md), [RFC-025 (cog workspace — cogdoc substrate unity)](https://github.com/myrgic/cogos) |
+| Relates  | [ADR-091](../adrs/091-substrate-as-named-architectural-layer.md), [ADR-092](../adrs/092-substrate-contracts-and-concurrency.md), [ADR-095](../adrs/095-daemon-reconcile-loop-driver.md), [ADR-096](../adrs/096-worktree-reconciler.md), [ADR-097](../adrs/097-memory-projection-reconciler.md), [ADR-098](../adrs/098-skill-projection-reconciler.md), cogdoc substrate unity RFC (internal reference omitted) |
 
 > **Accepted direction (2026-05-27).** The operator has accepted consolidating the MCP transport into the kernel daemon as the canonical direction. The open questions in §6 are resolved during implementation; implementation PRs reference this RFC. ADR promotion follows once consolidation lands.
 
@@ -16,7 +16,7 @@
 ## Summary
 
 The CogOS kernel daemon (`cogos serve`) and the MCP subprocess (spawned per-client from
-`/Users/slowbro/go/bin/cogos mcp serve`) are today two separate processes on the same node.
+`~/go/bin/cogos mcp serve`) are today two separate processes on the same node.
 This RFC proposes making the daemon the single node-root process: MCP becomes an HTTP/SSE
 transport on the daemon's existing port (`:6931`), not a spawned subprocess. Both the CLI
 wrapper (`./scripts/cog`) and the MCP surface become *projections* of the same kernel
@@ -30,7 +30,7 @@ fallback for non-daemon contexts.
 ### 1a. The v0.9.0 binary-skew incident
 
 On 2026-05-16, the v0.9.0 release updated `~/.cog/bin/cogos` (the daemon binary, managed by
-the node manifest) but did not update `/Users/slowbro/go/bin/cogos` (the path `.mcp.json`
+the node manifest) but did not update `~/go/bin/cogos` (the path `.mcp.json`
 spawns from). The result: the kernel daemon ran v0.9.0 with the `peer.utterance` event type
 registered, but the MCP subprocess Claude Code spawned was still `dev/unknown` without it.
 Two binaries, two update paths, silent version skew. Every tool call that relied on the new
@@ -41,12 +41,12 @@ has two install paths by design, so any release that does not update both paths 
 skew. Discipline cannot reliably prevent this; the two-process model guarantees it eventually
 recurs.
 
-### 1b. The CFT-visibility crisis: tool-surface projection gap
+### 1b. The visibility crisis: tool-surface projection gap
 
 On 2026-05-18, the user-level Claude Code seat was discovered to have zero visibility into
-the Cognitive Field Theory (CFT) corpus — roughly 25+ semantic-sector cogdocs developed in
-the cog workspace since 2026-03-06 — despite the daemon being healthy and the CFT material
-being the load-bearing research program of the workspace.
+the substrate's semantic cogdoc corpus — roughly 25+ semantic-sector cogdocs developed in
+the cog workspace since 2026-03-06 — despite the daemon being healthy and those cogdocs
+being the load-bearing research record of the workspace.
 
 Root-cause analysis identified a structural projection gap between the CLI surface and the
 MCP surface:
@@ -68,7 +68,7 @@ Naming convention is inconsistent: some tools use `cog_memory_*`, others use
 ToolSearch is degraded because the tools lack semantic grouping. When the MCP connection
 dropped during the v0.9.0 incident, even partial coverage became zero.
 
-The CFT corpus was invisible to the user-level agent not because the agent failed to look,
+The cogdoc corpus was invisible to the user-level agent not because the agent failed to look,
 but because the tool surface it had access to was structurally incomplete relative to the CLI
 surface.
 
@@ -264,12 +264,12 @@ ADR-098 SkillProjectionReconciler): both address surface-projection gaps; this R
 the transport-projection gap. The three gaps are the same architectural shape applied at
 different layers.
 
-Also composes with **RFC-025 (Cogdoc Substrate Unity — Unified cog memory Tooling)** in the
-cog workspace corpus. RFC-025 proposes a unified `cog memory` CLI surface (no per-type
+Also composes with the cogdoc substrate unity RFC (unified `cog memory` tooling; internal
+reference omitted). That RFC proposes a unified `cog memory` CLI surface (no per-type
 command proliferation); §3c of this RFC proposes that the MCP surface is isomorphic to that
-CLI surface. The two proposals do not conflict: RFC-025 works on the CLI layer; this RFC adds
-the invariant that the MCP layer must match it. If RFC-025 lands, the naming convention it
-ratifies should be the naming convention used on the MCP surface.
+CLI surface. The two proposals do not conflict: the cogdoc unity RFC works on the CLI layer;
+this RFC adds the invariant that the MCP layer must match it. If that RFC lands, the naming
+convention it ratifies should be the naming convention used on the MCP surface.
 
 ---
 
@@ -366,12 +366,12 @@ Track A can ship first. B and C are independent of each other after A.
 
 ## 8. Provenance
 
-- Primary motivation: `feedback_consolidate_mcp_into_kernel_daemon.md` (2026-05-16) — v0.9.0 incident, architectural memo.
-- Secondary motivation: `feedback_cog_memory_tooling_mcp_projection_gap.md` (2026-05-18) — CFT-visibility crisis, tool-surface gap.
+- Primary motivation: v0.9.0 incident architectural memo (2026-05-16) — binary-skew incident analysis. (internal reference omitted)
+- Secondary motivation: tool-surface gap analysis (2026-05-18) — visibility crisis and MCP projection gap. (internal reference omitted)
 - Prior art in this repo: `docs/archival/2026-04-21-mcp-always-on.md` — removal of `mcpserver` build tag; MCP made always-on in the daemon. This RFC continues that direction.
 - Prior art in this repo: `docs/MCP-SPEC.md` — already designates HTTP/SSE on `:6931/mcp` as the primary transport. This RFC makes that designation operational.
-- Identity and transport design: `feedback_dispatch_transport_by_default.md`, `feedback_identity_role_orthogonal_axes.md`.
-- Substrate metaphysics: `project_kernel_as_observatory_constitutive.md`, `project_identity_is_the_distinction.md`, `project_reconciliation_is_the_process.md`.
+- Identity and transport design: dispatch-transport-by-default and identity-role-orthogonal-axes memos. (internal references omitted)
+- Substrate metaphysics: observatory-constitutive, identity-as-distinction, and reconciliation-as-process notes. (internal references omitted)
 
 ---
 
@@ -380,7 +380,7 @@ Track A can ship first. B and C are independent of each other after A.
 ### 2026-05-18: Initial draft
 
 - RFC authored by Cog (RFC author seat). This is an in-progress design document.
-- The v0.9.0 binary-skew incident and the CFT-visibility crisis are the two concrete
+- The v0.9.0 binary-skew incident and the visibility crisis are the two concrete
   motivating failures; the RFC should be evaluated against both.
 - No decisions in this RFC are promoted to ADR-level. Implementation PRs will reference
   this RFC. ADR promotion happens after consolidation and implementation-driven refinement.


### PR DESCRIPTION
## Summary

- **Scrub private `cog://` URI references** from 11 public docs (ADRs 094, 097, 098, 099, 100, 101; RFCs 0002, 0003, 0005, 0007, 0008, 0009). Policy: `cog://` URIs that reference specific private corpus documents (refs fields, prose citations, memory paths) are scrubbed; URIs that illustrate the URI scheme as protocol documentation are preserved or genericized to `cog://example/...`.
- **Flatten nonstandard YAML frontmatter** in ADR-100 and ADR-101 (nested `cog:` block → flat keys) and convert bold-text inline fields to YAML blocks in ADR-099 and two rfc-drafts.
- **Remove operator-personal paths** (`/Users/slowbro/...`, `~/workspaces/cog/.cog/`) and private memory-file slugs that appeared in prose and provenance sections.
- All private-corpus refs that have no public equivalent are stripped with an `(internal reference omitted)` note preserving the plain-text description. Refs that point to documents in this public repo (ADR-091, 092, 095, 100) are rewritten to relative doc links.

## Scrub policy applied

A `cog://` URI is a **leak** only when it references a private substrate document (frontmatter refs, prose citations). It is **not a leak** when it illustrates the URI scheme as part of the documented protocol — those are left as-is or genericized to `cog://example/...`.

## Docs touched (11)

ADRs: 094, 097, 098, 099, 100, 101  
RFCs: 0002, 0003, 0005, 0007, 0008, 0009  
RFC drafts: mod3-bus-sessions-subscription, workspace-node-relationship (parse-anomaly fix only)

## Test plan

- [ ] Verify `grep -rn 'cog://' docs/` returns only illustrative scheme examples after merge
- [ ] Confirm YAML frontmatter parses cleanly in ADR-099, ADR-100, ADR-101, both rfc-drafts
- [ ] Spot-check that private workspace paths (`/Users/slowbro`, `~/workspaces/cog/.cog`) do not appear in docs/ tree