### PR TITLE
Scrub residual private references from public docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,9 @@ autoresearch-foveated/
 .claude/
 agent-worktrees/
 cogos-worktrees/
+
+# Runtime/private spill — never publish (episodic sessions, blobs, OOB Hermes state)
+.cog/blobs/
+.cog/mem/episodic/
+.cog/mem/working/
+.hermes/

--- a/docs/MCP-SPEC.md
+++ b/docs/MCP-SPEC.md
@@ -144,12 +144,12 @@ This is useful for `.mcp.json` configurations that launch the server as a subpro
 
 ```json
 {
-  "uri": "cog://mem/semantic/architecture/cogos-v3-design-spec",
+  "uri": "cog://mem/semantic/architecture/example-design-spec",
   "resolved": true,
-  "filesystem_path": "$COG_WORKSPACE/.cog/mem/semantic/architecture/cogos-v3-design-spec.cog.md",
+  "filesystem_path": "$COG_WORKSPACE/.cog/mem/semantic/architecture/example-design-spec.cog.md",
   "metadata": {
     "type": "architecture",
-    "title": "CogOS v3 Design Specification",
+    "title": "Example Design Specification",
     "created": "2026-03-19T00:00:00Z",
     "modified": "2026-03-19T18:30:00Z",
     "status": "active",
@@ -168,7 +168,7 @@ This is useful for `.mcp.json` configurations that launch the server as a subpro
 
 ```
 Tool: cog_resolve_uri
-Input: { "uri": "cog://mem/episodic/2026-03-19/session-01" }
+Input: { "uri": "cog://mem/episodic/2026-03-19/example-session" }
 → Returns path, type, tags, timestamps for that session CogDoc.
 ```
 
@@ -219,14 +219,14 @@ Input: { "uri": "cog://mem/episodic/2026-03-19/session-01" }
   "query_sector": "all",
   "results": [
     {
-      "uri": "cog://mem/semantic/architecture/cogos-v3-design-spec",
+      "uri": "cog://mem/semantic/architecture/example-design-spec",
       "salience": 0.97,
       "sector": "semantic",
-      "title": "CogOS v3 Design Specification",
+      "title": "Example Design Specification",
       "last_accessed": "2026-03-19T18:30:00Z"
     },
     {
-      "uri": "cog://mem/episodic/2026-03-19/von-foerster-session",
+      "uri": "cog://mem/episodic/2026-03-19/example-design-session",
       "salience": 0.91,
       "sector": "episodic",
       "title": "Von Foerster Architecture Session",
@@ -298,7 +298,7 @@ Input: { "limit": 5, "min_score": 0.8, "sector": "semantic" }
       "tokens": 4500,
       "items": [
         {
-          "uri": "cog://mem/semantic/architecture/cogos-v3-design-spec",
+          "uri": "cog://mem/semantic/architecture/example-design-spec",
           "salience": 0.97,
           "tokens": 2800,
           "excerpt": "... trimmed content ..."
@@ -324,7 +324,7 @@ Input: { "limit": 5, "min_score": 0.8, "sector": "semantic" }
 
 ```
 Tool: cog_assemble_context
-Input: { "token_budget": 4000, "focus_uri": "cog://mem/semantic/architecture/cogos-v3-design-spec" }
+Input: { "token_budget": 4000, "focus_uri": "cog://mem/semantic/architecture/example-design-spec" }
 → Returns a compact context package biased toward the v3 design spec.
 ```
 
@@ -520,8 +520,8 @@ Input: {}
   "total_matches": 3,
   "results": [
     {
-      "uri": "cog://mem/semantic/architecture/cogos-v3-design-spec",
-      "title": "CogOS v3 Design Specification",
+      "uri": "cog://mem/semantic/architecture/example-design-spec",
+      "title": "Example Design Specification",
       "score": 0.94,
       "sector": "semantic",
       "tags": ["v3", "architecture"],
@@ -633,17 +633,17 @@ Input: { "format": "summary" }
 
 ```json
 {
-  "uri": "cog://mem/semantic/architecture/cogos-v3-design-spec",
-  "filesystem_path": "$COG_WORKSPACE/.cog/mem/semantic/architecture/cogos-v3-design-spec.cog.md",
+  "uri": "cog://mem/semantic/architecture/example-design-spec",
+  "filesystem_path": "$COG_WORKSPACE/.cog/mem/semantic/architecture/example-design-spec.cog.md",
   "frontmatter": {
-    "title": "CogOS v3 Design Specification",
+    "title": "Example Design Specification",
     "type": "architecture",
     "created": "2026-03-19",
     "tags": ["v3", "architecture"],
     "memory_sector": "semantic",
     "salience": "critical"
   },
-  "body": "# CogOS v3 Design Specification\n\n> **Origin:** Derived 2026-03-19...",
+  "body": "# Example Design Specification\n\n> **Origin:** Derived 2026-03-19...",
   "section": null,
   "tokens": 4500,
   "truncated": false
@@ -654,7 +654,7 @@ Input: { "format": "summary" }
 
 ```json
 {
-  "uri": "cog://mem/semantic/architecture/cogos-v3-design-spec#the-continuous-process",
+  "uri": "cog://mem/semantic/architecture/example-design-spec#the-continuous-process",
   "section": {
     "anchor": "the-continuous-process",
     "title": "The Continuous Process",
@@ -669,7 +669,7 @@ Input: { "format": "summary" }
 
 ```
 Tool: cog_read_cogdoc
-Input: { "uri": "cog://mem/semantic/architecture/cogos-v3-design-spec#two-axioms" }
+Input: { "uri": "cog://mem/semantic/architecture/example-design-spec#two-axioms" }
 → Returns just the "Two Axioms" section from the v3 design spec.
 ```
 
@@ -858,14 +858,14 @@ Input: {
   },
   "index": [
     {
-      "uri": "cog://mem/semantic/architecture/cogos-v3-design-spec",
+      "uri": "cog://mem/semantic/architecture/example-design-spec",
       "type": "architecture",
       "tags": ["v3", "architecture", "design-spec"]
     }
   ],
   "refs": {
-    "cog://mem/semantic/architecture/cogos-v3-design-spec": [
-      "cog://mem/semantic/project/cogos-v2-overview",
+    "cog://mem/semantic/architecture/example-design-spec": [
+      "cog://mem/semantic/project/example-overview",
       "cog://identity"
     ]
   }
@@ -916,7 +916,7 @@ MCP resources provide read-only, subscription-capable snapshots of runtime state
   "total_items": 847,
   "above_threshold": 23,
   "items": [
-    { "uri": "cog://mem/semantic/architecture/cogos-v3-design-spec", "salience": 0.97 }
+    { "uri": "cog://mem/semantic/architecture/example-design-spec", "salience": 0.97 }
   ]
 }
 ```
@@ -1243,7 +1243,7 @@ Start the full HTTP server on a random port, connect an SSE client, and verify t
 
 ## References
 
-- [CogOS v3 Design Specification](../../.cog/mem/semantic/architecture/cogos-v3-design-spec.cog.md) — The first-principles architecture this spec implements
+- [Example Design Specification](../../.cog/mem/semantic/architecture/example-design-spec.cog.md) — The first-principles architecture this spec implements
 - [CogOS v2 MCP Tools](../../services/cogos-api/README-MCP.md) — The 45-tool v2 server this replaces
 - [Official Go MCP SDK](https://github.com/modelcontextprotocol/go-sdk) — v1.4.1, maintained by MCP org + Google
 - [mark3labs/mcp-go](https://github.com/mark3labs/mcp-go) — Community Go MCP library (alternative)

--- a/docs/adrs/096-worktree-reconciler.md
+++ b/docs/adrs/096-worktree-reconciler.md
@@ -15,18 +15,18 @@
 On 2026-05-13 a wave of dispatch operations created five parallel worktrees in the `mod3` repository to implement a modality schema wave. As of 2026-05-17 those worktrees remain on disk:
 
 ```
-/Users/slowbro/workspaces/myrgic/mod3/.claude/worktrees/mod3-modality-rfc        [wave/2026-05-13-mod3/modality-rfc]
-/Users/slowbro/workspaces/myrgic/mod3/.claude/worktrees/mod3-modality-schemas    [worktree-mod3-modality-schemas]
-/Users/slowbro/workspaces/myrgic/mod3/.claude/worktrees/mod3-pipecat             [wave/2026-05-13-mod3/pipecat]
-/Users/slowbro/workspaces/myrgic/mod3/.claude/worktrees/mod3-sidecar-doc         [wave/2026-05-13-mod3/sidecar-doc]
-/Users/slowbro/workspaces/myrgic/mod3/.claude/worktrees/mod3-worker-cli          [wave/2026-05-13-mod3/worker-cli]
+/Users/dev/workspaces/myrgic/mod3/.claude/worktrees/mod3-modality-rfc        [wave/2026-05-13-mod3/modality-rfc]
+/Users/dev/workspaces/myrgic/mod3/.claude/worktrees/mod3-modality-schemas    [worktree-mod3-modality-schemas]
+/Users/dev/workspaces/myrgic/mod3/.claude/worktrees/mod3-pipecat             [wave/2026-05-13-mod3/pipecat]
+/Users/dev/workspaces/myrgic/mod3/.claude/worktrees/mod3-sidecar-doc         [wave/2026-05-13-mod3/sidecar-doc]
+/Users/dev/workspaces/myrgic/mod3/.claude/worktrees/mod3-worker-cli          [wave/2026-05-13-mod3/worker-cli]
 ```
 
 Each holds real unmerged commits against `main`. The `cogos` repository has two additional agent-locked worktrees from in-flight or completed dispatch sessions:
 
 ```
-/Users/slowbro/workspaces/myrgic/cogos/.claude/worktrees/agent-a5647032c84cb9e61  [worktree-agent-a5647032c84cb9e61] locked
-/Users/slowbro/workspaces/myrgic/cogos/.claude/worktrees/agent-a8c054cc717aa7cb4  [(detached HEAD)] locked
+/Users/dev/workspaces/myrgic/cogos/.claude/worktrees/agent-a5647032c84cb9e61  [worktree-agent-a5647032c84cb9e61] locked
+/Users/dev/workspaces/myrgic/cogos/.claude/worktrees/agent-a8c054cc717aa7cb4  [(detached HEAD)] locked
 ```
 
 The substrate cannot safely automate cleanup of any of these seven worktrees because **no ledger entry exists that binds them to the dispatch identities that created them**. The substrate has no way to answer:

--- a/docs/architecture/the-constellation.md
+++ b/docs/architecture/the-constellation.md
@@ -35,7 +35,7 @@ A node in the Constellation is anything the ledger can refer to by a stable iden
 
 - **Cogdocs** — `.cog.md` files under `.cog/mem/`, indexed in `constellation.db`. The oldest and most numerous population. Already production.
 - **Identities** — keyed by NodeID (SHA-256 of pubkey DER in the trust-node projection). Today's kernel tracks a subset via session records; the trust-node projection specifies the full node lifecycle.
-- **Channels** — first-class node type proposed by the channel-provider-interface RFC (`${COGOS_WORKSPACE:-$HOME/workspaces/cog}/.cog/mem/semantic/designs/channel-provider-interface.cog.md`). Storage: cogdocs under `.cog/mem/procedural/channels/`. Not yet implemented.
+- **Channels** — first-class node type proposed by the channel-provider-interface RFC. Storage: cogdocs under `.cog/mem/procedural/channels/`. Not yet implemented.
 - **Sessions** — currently tracked by kernel session records; not yet canonicalized as Constellation nodes. Candidate for promotion.
 - **Agents** — partially represented (identity cards in `cog://agents/`, session records). No canonical node form yet; would compose from identity + session populations.
 - **Peer nodes** — remote CogOS instances federated via the trust-node projection. Today only present in the `myrgic/constellation` reference implementation; not yet integrated into the kernel's memory-graph.
@@ -174,7 +174,7 @@ To avoid overclaiming: this doc unifies the **architecture**, not the **code**.
 
 Two concrete tracks follow from this framing.
 
-**Near-term (design landed, code pending).** The channel-provider RFC at `${COGOS_WORKSPACE:-$HOME/workspaces/cog}/.cog/mem/semantic/designs/channel-provider-interface.cog.md` is the first adoption of this framing at the code level. It treats channels as a new node population in the Constellation, with attendance as the edge type and an attention-EMA as the signal — exactly the shape this doc makes generic. Adopting the RFC and prototyping the first `audio`-kind provider (mod3) validates whether the unified framing holds under implementation pressure.
+**Near-term (design landed, code pending).** The channel-provider RFC is the first adoption of this framing at the code level. It treats channels as a new node population in the Constellation, with attendance as the edge type and an attention-EMA as the signal — exactly the shape this doc makes generic. Adopting the RFC and prototyping the first `audio`-kind provider (mod3) validates whether the unified framing holds under implementation pressure.
 
 **Medium-term (convergence).** The larger work is running the trust-node projection's semantics natively in the kernel over the same `constellation.db` the memory-graph uses. Concretely: promote the kernel's session-record surface into a first-class identity-node table (with the columns the trust-node projection specifies); wire the 5-second heartbeat loop into the kernel's process state; teach the memory-graph indexer to emit events into the same `events/{seq:08d}.json` ledger shape the trust-node projection already uses; keep the public `myrgic/constellation` repo as the specification the kernel implements. When that lands, "the Constellation" stops being an architectural claim layered over two implementations and becomes one running system. The bridge interface at `internal/engine/constellation_bridge.go` is the seam where that convergence will happen.
 


### PR DESCRIPTION
Wave-0 pre-flight for the architecture-corpus migration (Phase 2). Follow-up to #379, which scrubbed the structured-frontmatter `cog://` leaks. A re-audit found residue #379 missed.

## What this scrubs

**Real private slugs used as running examples** (`docs/MCP-SPEC.md`)
- `cog://mem/semantic/architecture/cogos-v3-design-spec` appeared 14x as the spec's running example (a real private substrate doc). Replaced with a generic `example-design-spec` slug throughout, including `filesystem_path` echoes and the See-Also link.
- Two episodic refs (`2026-03-19/von-foerster-session`, `2026-03-19/session-01`) to generic illustrative slugs.

**Hardcoded username in example output** (`docs/adrs/096-worktree-reconciler.md`)
- `/Users/slowbro/...` (7x) to `/Users/dev/...`. The reconciler example output leaked the real username and full private worktree layout.

**Resolvable private design-doc path** (`docs/architecture/the-constellation.md`)
- Dropped two `${COGOS_WORKSPACE}/.cog/mem/semantic/designs/channel-provider-interface.cog.md` paths; kept the named reference.

**Gitignore protection**
- `.cog/mem/episodic/`, `.cog/blobs/`, `.hermes/`, `.cog/mem/working/` were untracked but un-ignored, so a stray `git add -A` would have published episodic session records and OOB Hermes plans. Now ignored. Pre-existing tracked files unaffected.

No semantic change to any spec; all examples remain illustrative.

Generated with Claude Code