### PR TITLE
fix(conversations): cache per-source coverage; skip re-parse on unchanged sources

### DIFF
--- a/internal/conversations/coverage.go
+++ b/internal/conversations/coverage.go
@@ -116,6 +116,24 @@ func (t *CoverageTracker) All() map[string]SourceCoverage {
 	return out
 }
 
+// SetSource wholesale-replaces the stored coverage for source with a deep copy
+// of sc. Any existing coverage for source is discarded. Used to restore cached
+// coverage for an unchanged source without re-parsing it. Thread-safe.
+func (t *CoverageTracker) SetSource(source string, sc SourceCoverage) {
+	// Deep-copy the unmapped component counts so the caller's map (and the
+	// stored copy) cannot alias, mirroring All().
+	sc2 := sc
+	if sc.UnmappedComponentCounts != nil {
+		sc2.UnmappedComponentCounts = make(map[string]int, len(sc.UnmappedComponentCounts))
+		for k, v := range sc.UnmappedComponentCounts {
+			sc2.UnmappedComponentCounts[k] = v
+		}
+	}
+	t.mu.Lock()
+	t.sources[source] = &sc2
+	t.mu.Unlock()
+}
+
 // Reset clears all counters (used between reconcile runs if desired).
 func (t *CoverageTracker) Reset() {
 	t.mu.Lock()

--- a/internal/conversations/coverage_cache_test.go
+++ b/internal/conversations/coverage_cache_test.go
@@ -1,0 +1,267 @@
+// coverage_cache_test.go — regression test for the per-source coverage cache.
+//
+// The conversations Reconcilable previously re-parsed the entire ingest corpus
+// on every reconcile cycle (including ActionSkip sources) purely to recompute
+// coverage. That pinned multiple CPU cores at the ~30s reconcile cadence. The
+// fix caches per-source coverage and serves it on ActionSkip without parsing,
+// since ActionSkip is itself the drift-free signal.
+//
+// This test asserts that an unchanged ingest source across two cycles is served
+// from cache on the second cycle WITHOUT re-parsing, and that the cached numbers
+// equal a from-scratch parse of the same input.
+package conversations
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeHermesOntologyDir writes a minimal L1 + L2 ontology into <ontDir> that the
+// provider's LoadConfig will read. role='tool' is classified degenerate so the
+// coverage numbers are non-trivial (mapped + degenerate + intended all exercised).
+func writeHermesOntologyDir(t *testing.T, ontDir string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(ontDir, "mappings"), 0o755); err != nil {
+		t.Fatalf("mkdir ontology: %v", err)
+	}
+	ontL1 := `ontology: cogos.ontology/v1
+id: cogos.conversations
+version: 1.0.0
+entities:
+  session:
+    description: One session.
+    keys: [source, session_id]
+components:
+  session.turn:
+    description: A turn.
+    fields: { role: string, text: string, timestamp: rfc3339 }
+    required: [role, text, timestamp]
+relations: {}
+`
+	if err := os.WriteFile(filepath.Join(ontDir, "cogos.conversations.v1.yaml"), []byte(ontL1), 0o644); err != nil {
+		t.Fatalf("write L1: %v", err)
+	}
+	ontL2 := `mapping:
+  id: hermes-statedb.v1
+  version: 1.0.0
+  sources:
+    - hermes-darkstar
+    - hermes-cog
+  ontology: "cogos.conversations@^1"
+rules:
+  - id: text_user
+    source_condition: "role = 'user' AND content IS NOT NULL AND content != ''"
+    target_class: session.turn
+    quality: intended
+  - id: text_assistant_with_prose
+    source_condition: "role = 'assistant' AND content IS NOT NULL AND content != ''"
+    target_class: session.turn
+    quality: intended
+  - id: text_tool_degenerate
+    source_condition: "role = 'tool' AND content IS NOT NULL AND content != ''"
+    target_class: session.turn
+    quality: degenerate
+`
+	if err := os.WriteFile(filepath.Join(ontDir, "mappings", "hermes-statedb.v1.yaml"), []byte(ontL2), 0o644); err != nil {
+		t.Fatalf("write L2: %v", err)
+	}
+}
+
+// writeCacheTestConfig writes an observatory.yaml pointing at an empty source
+// dir (so the default ~/.claude path is not scanned), the given ingest root, and
+// the given ontology dir.
+func writeCacheTestConfig(t *testing.T, root, ingestRoot, ontDir string) {
+	t.Helper()
+	cfgDir := filepath.Join(root, ".cog", "config")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	cfgContent := fmt.Sprintf(`source_dirs:
+  - %s
+ingest_dirs:
+  - %s
+ontology_dir: %s
+include_patterns:
+  - "*.jsonl"
+`, t.TempDir(), ingestRoot, ontDir)
+	if err := os.WriteFile(filepath.Join(cfgDir, "observatory.yaml"), []byte(cfgContent), 0o644); err != nil {
+		t.Fatalf("write observatory.yaml: %v", err)
+	}
+}
+
+// fromScratchCoverage parses the given ingest lines through a fresh accumulator
+// with the given ontology and returns the resulting per-source coverage. This is
+// the ground-truth a cached value must match.
+func fromScratchCoverage(t *testing.T, lines []string, lo *LoadedOntology) map[string]SourceCoverage {
+	t.Helper()
+	cov := NewCoverageTracker()
+	a := newIngestAccumulator(defaultMaxTurnLen)
+	a.Ontology = lo
+	a.Coverage = cov
+	if err := a.ConsumeFile(strings.NewReader(strings.Join(lines, "\n") + "\n")); err != nil {
+		t.Fatalf("from-scratch ConsumeFile: %v", err)
+	}
+	return cov.All()
+}
+
+// TestCoverageCache_SkipServesFromCacheWithoutReparse asserts the hot-loop fix:
+// across two reconcile cycles over an UNCHANGED ingest source, the second cycle
+// serves coverage from the cache and does NOT re-parse the source files.
+//
+// Re-parse detection is hermetic and unambiguous: after cycle 1 primes the cache,
+// the source file is made unreadable (chmod 0000) WITHOUT altering its size or
+// mtime, so ComputePlan still emits ActionSkip. If cycle 2 attempted a re-parse it
+// would fail to open the file (recorded as a non-fatal coverage error and yielding
+// empty coverage). A cache hit avoids the open entirely, so coverage stays correct
+// and no error is recorded.
+func TestCoverageCache_SkipServesFromCacheWithoutReparse(t *testing.T) {
+	p, root := newTestProvider(t)
+	ingestRoot := t.TempDir()
+
+	ontDir := filepath.Join(root, ".cog", "observatory", "ontology")
+	writeHermesOntologyDir(t, ontDir)
+
+	// 4 user + 3 assistant (intended) + 2 tool (degenerate) = 9 mapped, 2 degenerate.
+	source := "hermes-darkstar"
+	ts := "2026-06-10T00:00:00Z"
+	var lines []string
+	for i := 1; i <= 4; i++ {
+		lines = append(lines, makeIngestRecord(source, "sess-1", "user",
+			fmt.Sprintf("user msg %d", i), ts,
+			map[string]any{"refs": map[string]any{"stable_id": fmt.Sprintf("%s:%d", source, i)}}))
+	}
+	for i := 5; i <= 7; i++ {
+		lines = append(lines, makeIngestRecord(source, "sess-1", "assistant",
+			fmt.Sprintf("asst reply %d", i), ts,
+			map[string]any{"refs": map[string]any{"stable_id": fmt.Sprintf("%s:%d", source, i)}}))
+	}
+	for i := 8; i <= 9; i++ {
+		lines = append(lines, makeIngestRecord(source, "sess-1", "tool",
+			fmt.Sprintf(`{"result":"r%d"}`, i), ts,
+			map[string]any{"refs": map[string]any{"stable_id": fmt.Sprintf("%s:%d", source, i)}}))
+	}
+	ingestFile := writeIngestDir(t, ingestRoot, source, "20260610T000000Z-run1", lines)
+
+	writeCacheTestConfig(t, root, ingestRoot, ontDir)
+
+	// ── Cycle 1: full reconcile parses the source and primes the cache. ──
+	reconcileOnce(t, p, root)
+	cov1 := p.Coverage()
+	sc1 := cov1[source]
+	if sc1.Mapped != 9 {
+		t.Fatalf("cycle 1 Mapped: want 9, got %d", sc1.Mapped)
+	}
+	if sc1.Degenerate != 2 {
+		t.Fatalf("cycle 1 Degenerate: want 2, got %d", sc1.Degenerate)
+	}
+
+	// Sanity: cache is warm for the source after cycle 1.
+	p.mu.Lock()
+	_, warm := p.coverageCache[source]
+	p.mu.Unlock()
+	if !warm {
+		t.Fatalf("coverageCache not primed for %q after cycle 1", source)
+	}
+
+	// ── Make the source unreadable WITHOUT changing size/mtime. ──
+	// chmod 0000 leaves stat() metadata (size, mtime) intact, so ComputePlan
+	// still classifies the source as ActionSkip; only an actual open() would
+	// fail. This is the re-parse tripwire.
+	if err := os.Chmod(ingestFile, 0o000); err != nil {
+		t.Fatalf("chmod source unreadable: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(ingestFile, 0o644) })
+
+	// Confirm an open really would fail now (guards against running as root).
+	if f, err := os.Open(ingestFile); err == nil {
+		_ = f.Close()
+		t.Skip("source file still readable after chmod 0000 (likely running as root); re-parse tripwire unavailable")
+	}
+
+	// ── Cycle 2: source unchanged → ActionSkip → must serve from cache. ──
+	reconcileOnce(t, p, root)
+
+	// No errors must have been recorded. A re-parse attempt would have appended
+	// a non-fatal "coverage-only pass" error from the failed open().
+	p.mu.Lock()
+	cycle2Errs := append([]string(nil), p.lastErrors...)
+	p.mu.Unlock()
+	if len(cycle2Errs) != 0 {
+		t.Fatalf("cycle 2 recorded errors (indicates a re-parse was attempted): %v", cycle2Errs)
+	}
+
+	cov2 := p.Coverage()
+	sc2 := cov2[source]
+
+	// Coverage served from cache must be byte-for-byte equal to cycle 1.
+	if sc2.Mapped != sc1.Mapped || sc2.Degenerate != sc1.Degenerate || sc2.Quarantined != sc1.Quarantined {
+		t.Fatalf("cached coverage drifted: cycle1=%+v cycle2=%+v", sc1, sc2)
+	}
+
+	// And it must equal a from-scratch parse of the same input (correctness, not
+	// just stability).
+	want := fromScratchCoverage(t, lines, p.Ontology())[source]
+	if sc2.Mapped != want.Mapped || sc2.Degenerate != want.Degenerate || sc2.Quarantined != want.Quarantined {
+		t.Fatalf("cached coverage != from-scratch parse: cached=%+v scratch=%+v", sc2, want)
+	}
+}
+
+// TestCoverageCache_RemovedSourceIsPruned asserts the dead-eviction fix:
+// when an ingest source that was cached in coverageCache is absent from the
+// plan on the next cycle (i.e. the source directory was removed from the
+// observatory config), its cache entry must be gone after ApplyPlan completes.
+//
+// Before the fix, the ActionDelete branch did `delete(p.coverageCache,
+// action.Name)` where action.Name is a SESSION id, not a SOURCE name, so the
+// delete never matched and the stale entry leaked forever. The fix prunes by
+// diffing coverageCache keys against the set of sources that emitted any
+// create/update/skip action this cycle.
+func TestCoverageCache_RemovedSourceIsPruned(t *testing.T) {
+	p, root := newTestProvider(t)
+	ingestRoot := t.TempDir()
+
+	ontDir := filepath.Join(root, ".cog", "observatory", "ontology")
+	writeHermesOntologyDir(t, ontDir)
+
+	source := "hermes-darkstar"
+	ts := "2026-06-10T00:00:00Z"
+	var lines []string
+	for i := 1; i <= 3; i++ {
+		lines = append(lines, makeIngestRecord(source, "sess-1", "user",
+			fmt.Sprintf("msg %d", i), ts,
+			map[string]any{"refs": map[string]any{"stable_id": fmt.Sprintf("%s:%d", source, i)}}))
+	}
+	writeIngestDir(t, ingestRoot, source, "run1", lines)
+	writeCacheTestConfig(t, root, ingestRoot, ontDir)
+
+	// ── Cycle 1: source is created + cache is primed. ──
+	reconcileOnce(t, p, root)
+
+	p.mu.Lock()
+	_, warm := p.coverageCache[source]
+	p.mu.Unlock()
+	if !warm {
+		t.Fatalf("coverageCache not primed for %q after cycle 1", source)
+	}
+
+	// ── Remove the ingest source from the config so cycle 2 has no ingest. ──
+	// Point ingest_dirs at a fresh empty directory (no source sub-directories),
+	// so ComputePlan emits ActionDelete for the now-stale index sessions and
+	// emits NO create/update/skip for the source — making it absent from
+	// liveSources and triggering the prune path.
+	emptyIngest := t.TempDir()
+	writeCacheTestConfig(t, root, emptyIngest, ontDir)
+
+	// ── Cycle 2: source is gone → cache entry must be pruned. ──
+	reconcileOnce(t, p, root)
+
+	p.mu.Lock()
+	_, stillWarm := p.coverageCache[source]
+	p.mu.Unlock()
+	if stillWarm {
+		t.Fatalf("coverageCache still contains %q after source was removed — eviction is broken", source)
+	}
+}

--- a/internal/conversations/provider.go
+++ b/internal/conversations/provider.go
@@ -50,14 +50,21 @@ type Provider struct {
 
 	// coverage accumulates per-source coverage metrics across reconcile runs.
 	coverage *CoverageTracker
+
+	// coverageCache holds the last computed coverage per ingest source so that
+	// unchanged (ActionSkip) sources can be served from cache instead of being
+	// re-parsed every reconcile cycle. Guarded by p.mu. ActionSkip is itself the
+	// drift-free signal, so a cached entry is valid whenever present.
+	coverageCache map[string]SourceCoverage
 }
 
 // NewProvider constructs a ConversationsProvider. The root workspace path
 // is set by LoadConfig. Tests may call LoadConfig directly with a temp dir.
 func NewProvider() *Provider {
 	return &Provider{
-		operation: reconcile.OperationIdle,
-		coverage:  NewCoverageTracker(),
+		operation:     reconcile.OperationIdle,
+		coverage:      NewCoverageTracker(),
+		coverageCache: make(map[string]SourceCoverage),
 	}
 }
 
@@ -145,6 +152,9 @@ func (p *Provider) LoadConfig(root string) (any, error) {
 	p.quarantine = NewQuarantineWriter(quarantineDir)
 	if p.coverage == nil {
 		p.coverage = NewCoverageTracker()
+	}
+	if p.coverageCache == nil {
+		p.coverageCache = make(map[string]SourceCoverage)
 	}
 	p.mu.Unlock()
 
@@ -411,15 +421,41 @@ func (p *Provider) ApplyPlan(ctx context.Context, plan *reconcile.Plan) ([]recon
 
 	var results []reconcile.Result
 	var errs []string
+	// liveSources collects ingest source names present this cycle, used to
+	// prune coverageCache for removed sources after the action loop.
+	liveSources := make(map[string]struct{})
 
 	for _, action := range plan.Actions {
 		if action.Action == reconcile.ActionSkip {
-			// For skipped ingest sources, re-accumulate coverage without
-			// touching the index (the data hasn't changed, but we need counts).
-			if isIngest, _ := action.Details["is_ingest"].(bool); isIngest && cov != nil {
-				if covErr := accumulateCoverage(action, ont, cov); covErr != nil {
-					// Non-fatal: log but don't fail the action.
-					errs = append(errs, fmt.Sprintf("coverage-only pass for %s: %v", action.Name, covErr))
+			// For skipped ingest sources the data has NOT drifted (ActionSkip is
+			// itself the drift-free signal — ComputePlan already verified the
+			// index matches the source). Serve coverage from cache to avoid a
+			// full re-parse of every file each cycle (the CPU hot-loop fix).
+			if isIngest, _ := action.Details["is_ingest"].(bool); isIngest {
+				// Always record the source as live, even when cov is nil, so the
+				// prune pass below never evicts a source that is still configured.
+				liveSources[action.Name] = struct{}{}
+				if cov != nil {
+					p.mu.Lock()
+					cached, warm := p.coverageCache[action.Name]
+					p.mu.Unlock()
+
+					if warm {
+						// Cache hit: restore without parsing.
+						cov.SetSource(action.Name, cached)
+					} else {
+						// Cold cache (e.g. first cycle after a restart): fall back to
+						// a one-time coverage-only parse, then prime the cache.
+						if covErr := accumulateCoverage(action, ont, cov); covErr != nil {
+							// Non-fatal: log but don't fail the action.
+							errs = append(errs, fmt.Sprintf("coverage-only pass for %s: %v", action.Name, covErr))
+						} else {
+							snap := cov.All()[action.Name]
+							p.mu.Lock()
+							p.coverageCache[action.Name] = snap
+							p.mu.Unlock()
+						}
+					}
 				}
 			}
 			continue
@@ -436,12 +472,25 @@ func (p *Provider) ApplyPlan(ctx context.Context, plan *reconcile.Plan) ([]recon
 			if isIngest, _ := action.Details["is_ingest"].(bool); isIngest {
 				// Normalized ingest: action.Name is the SOURCE; re-parse all
 				// of its files and rebuild every session of that source.
+				// Record the source as live before parsing so a transient parse
+				// error does not drop it from liveSources and cause a spurious
+				// cache eviction on the same cycle.
+				liveSources[action.Name] = struct{}{}
 				if applyErr := applyIngestSource(idx, action, ont, qw, cov); applyErr != nil {
 					res.Status = reconcile.ApplyFailed
 					res.Error = fmt.Sprintf("index ingest source %s: %v", action.Name, applyErr)
 					results = append(results, res)
 					errs = append(errs, res.Error)
 					continue
+				}
+				// applyIngestSource parsed + populated cov for this source;
+				// snapshot it into the cache so subsequent skip cycles can
+				// serve it without re-parsing.
+				if cov != nil {
+					snap := cov.All()[action.Name]
+					p.mu.Lock()
+					p.coverageCache[action.Name] = snap
+					p.mu.Unlock()
 				}
 				res.Status = reconcile.ApplySucceeded
 				res.CreatedID = action.Name
@@ -496,6 +545,13 @@ func (p *Provider) ApplyPlan(ctx context.Context, plan *reconcile.Plan) ([]recon
 	}
 
 	p.mu.Lock()
+	// Removed ingest sources emit no create/update/skip action this cycle, so
+	// any cache key absent from liveSources is a source that is gone.
+	for src := range p.coverageCache {
+		if _, ok := liveSources[src]; !ok {
+			delete(p.coverageCache, src)
+		}
+	}
 	p.lastErrors = errs
 	p.mu.Unlock()
 


### PR DESCRIPTION
## Problem

The conversations Reconcilable provider re-parsed the entire conversation corpus on every reconcile cycle (~30s), pinning ~3 CPU cores (host load 17 on 12 cores). `ApplyPlan` calls `cov.Reset()` then rebuilds coverage by re-parsing every ingest source each cycle — including `ActionSkip` (unchanged) sources via `accumulateCoverage` -> full `ConsumeFile` parse. With 11 ingest sources (one a 639-conversation export), that is a full-corpus re-parse twice a minute regardless of whether anything changed.

## Fix

Cache per-source coverage; serve unchanged sources from cache instead of re-parsing.

- `coverage.go`: add `CoverageTracker.SetSource(source, sc)` (deep-copy, wholesale replace).
- `provider.go` `ApplyPlan`: on `ActionSkip` ingest sources, restore coverage from `coverageCache` with no parse; a cold cache (e.g. first cycle after restart) falls back to a one-time coverage-only parse then primes the cache; create/update snapshot fresh coverage after `applyIngestSource`; a post-loop prune evicts cache entries for removed sources. `cov.Reset()` stays, so `cov.All()` still reflects the full current corpus each cycle.

`ActionSkip` is itself the drift-free signal (ComputePlan already verified the index matches the source), so a cached entry is valid whenever present. Coverage via `provider.Coverage()` / `GET /v1/observatory/coverage` is unchanged for an unchanged corpus.

## Verification

- New hermetic tests: `TestCoverageCache_SkipServesFromCacheWithoutReparse` (chmod 0000 the source so a re-parse would fail-open; asserts cycle 2 serves from cache with no error and coverage equals a from-scratch parse) and `TestCoverageCache_RemovedSourceIsPruned`.
- `go build -tags fts5` (CGO), `go vet`, and `go test -race` all pass.
- Adversarial review confirmed the warm-skip path performs no file I/O and the cache is race-free (`p.mu` guards all access, never held across a parse).

## Known limitation (separate follow-up)

The cache keys on source presence, not ontology version. An in-place edit to the L1/L2 ontology while source files stay byte-unchanged would serve coverage computed under the old ontology until those files change or the daemon restarts. Tracked separately for ontology-aware cache invalidation.
