### PR TITLE
fix(conversations): recognize user-draft role; quarantine unsent drafts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 #   make e2e      - Run e2e test in a container
 #   make e2e-local - Run e2e test locally
 
-VERSION := 0.16.1
+VERSION := 0.16.2
 BUILD_TIME := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -s -w -X github.com/myrgic/cogos/internal/engine.BuildTime=$(BUILD_TIME) -X github.com/myrgic/cogos/internal/engine.Version=$(VERSION)
 BUILD_TAGS := fts5

--- a/internal/conversations/ingest_parser.go
+++ b/internal/conversations/ingest_parser.go
@@ -40,10 +40,11 @@ var knownIngestSchemas = map[string]bool{
 
 // validIngestRoles is the allowed set of role values per the schema contract.
 var validIngestRoles = map[string]Role{
-	"user":      RoleUser,
-	"assistant": RoleAssistant,
-	"tool":      RoleTool,
-	"system":    RoleSystem,
+	"user":       RoleUser,
+	"assistant":  RoleAssistant,
+	"tool":       RoleTool,
+	"system":     RoleSystem,
+	"user-draft": RoleUserDraft,
 }
 
 // ingestRecord is the decoded form of one line in a normalized ingest JSONL.
@@ -164,6 +165,29 @@ func (a *ingestAccumulator) ConsumeFile(r io.Reader) error {
 		role, roleOK := validIngestRoles[rec.Role]
 		if !roleOK {
 			log.Printf("conversations/ingest: rejected record with unknown role %q (source=%q session_id=%q)", rec.Role, rec.Source, rec.SessionID)
+			continue
+		}
+
+		// Draft roles are recognized but are NOT conversation turns: an unsent
+		// composer draft is not something the user actually said, so it must
+		// never become a session.turn. Route it to the quarantine surface with
+		// provenance and count it toward coverage, so the source reaches a
+		// fully-accounted, converged state instead of re-surfacing the same
+		// records — logging a rejection for each — on every reconcile cycle.
+		if role == RoleUserDraft {
+			if a.Quarantine != nil {
+				prov := QuarantineProvenance{
+					Reason:    QuarantineReasonDraftRole,
+					Component: "session.turn",
+				}
+				if qErr := a.Quarantine.WriteRecord(rec.Source, json.RawMessage(line), prov); qErr != nil {
+					log.Printf("conversations/ingest: quarantine write error: %v", qErr)
+				}
+			}
+			if a.Coverage != nil {
+				a.Coverage.RecordQuarantined(rec.Source, "session.turn")
+			}
+			a.Quarantined++
 			continue
 		}
 

--- a/internal/conversations/quarantine.go
+++ b/internal/conversations/quarantine.go
@@ -39,6 +39,11 @@ const (
 	// QuarantineReasonOntologyMismatch is used when a record declares an
 	// (ontology id, major version) for which no L1 instance is loaded.
 	QuarantineReasonOntologyMismatch QuarantineReason = "ontology_mismatch"
+
+	// QuarantineReasonDraftRole is used when a record carries a recognized draft
+	// role (e.g. "user-draft"): an unsent composer draft that is not a
+	// conversation turn, and so is preserved in quarantine rather than ingested.
+	QuarantineReasonDraftRole QuarantineReason = "draft_role"
 )
 
 // QuarantineProvenance is the provenance block appended to quarantined records.

--- a/internal/conversations/types.go
+++ b/internal/conversations/types.go
@@ -29,6 +29,13 @@ const (
 	RoleAssistant Role = "assistant"
 	RoleSystem    Role = "system"
 	RoleTool      Role = "tool"
+
+	// RoleUserDraft marks an unsent composer draft captured by an observer
+	// (e.g. claude-ai-web). A draft is not a turn the user actually sent, so it
+	// is recognized — to keep it off the unknown-role rejection path — but is
+	// never ingested as a session.turn; the ingest parser routes draft roles to
+	// quarantine instead.
+	RoleUserDraft Role = "user-draft"
 )
 
 // SessionMeta carries per-session metadata without loading turn content.


### PR DESCRIPTION
## Problem

Unsent composer drafts captured by the `claude-ai-web` observer carry role `user-draft`. The conversations ingest schema recognized only `user`/`assistant`/`tool`/`system`, so every reconcile cycle re-rejected all draft records — one log line each — and held the `conversations` provider permanently `Degraded`. The provider never reached a converged, idle state, so it re-parsed every ingest source on each cycle. On a live node this manifested as sustained kernel CPU and a multi-hundred-MB `serve.log`.

## Fix

Recognize `user-draft` as a known role (`RoleUserDraft`) and route such records to the existing quarantine surface (`reason: draft_role`) with coverage accounting, rather than ingesting them as `session.turn`s — an unsent draft is not a turn the user actually sent. Quarantine is the convergence-safe terminal already used by the unmapped-component path, so:

- the source becomes fully accounted → provider converges → reconcile goes idle;
- the drafts are preserved in quarantine, not dropped;
- no per-record rejection logging.

## Release

Bumps `VERSION` → `0.16.2`. This release also carries the previously-merged per-source coverage cache (skip re-parse on unchanged sources); together they remove the re-parse-every-cycle CPU draw.

## Test

`go test ./internal/conversations/` passes. Verified live on a node: the `conversations` provider went `Degraded → Healthy`, the 8 affected draft records moved to `quarantine.jsonl` with `reason: draft_role`, and rejection-spam stopped.