### PR TITLE
perf(conversations): incremental append-aware parse for CC sessions

### DIFF
--- a/internal/conversations/incremental_test.go
+++ b/internal/conversations/incremental_test.go
@@ -1,0 +1,540 @@
+package conversations
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/myrgic/cogos/pkg/substrate/reconcile"
+)
+
+// userRecordLine builds one type="user" JSONL record line (with trailing \n)
+// using the same shape the real Claude Code session files use.
+func userRecordLine(t *testing.T, sessionID, uuid, text, ts string) string {
+	t.Helper()
+	content, _ := json.Marshal([]map[string]string{{"type": "text", "text": text}})
+	msg, _ := json.Marshal(map[string]any{"role": "user", "content": json.RawMessage(content)})
+	rec := map[string]any{
+		"type":       "user",
+		"uuid":       uuid,
+		"parentUuid": "",
+		"sessionId":  sessionID,
+		"timestamp":  ts,
+		"message":    json.RawMessage(msg),
+		"userType":   "external",
+		"entrypoint": "cli",
+	}
+	b, _ := json.Marshal(rec)
+	return string(b) + "\n"
+}
+
+// writeJSONL writes content to a temp file and returns its path + sourceFileInfo.
+func writeJSONL(t *testing.T, dir, name, content string) (string, sourceFileInfo) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return path, sourceFileInfo{
+		Path:      path,
+		SessionID: strings.TrimSuffix(name, ".jsonl"),
+		Mtime:     fi.ModTime(),
+		Size:      fi.Size(),
+	}
+}
+
+// TestComputeFilePrefixHash verifies the prefix hash is stable under append,
+// changes under a head edit, and gracefully hashes files smaller than the
+// window.
+func TestComputeFilePrefixHash(t *testing.T) {
+	dir := t.TempDir()
+
+	// Small file (< window): whole file hashed, must be deterministic.
+	small := filepath.Join(dir, "small.txt")
+	if err := os.WriteFile(small, []byte("hello world"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h1, err := computeFilePrefixHash(small, prefixHashWindow)
+	if err != nil {
+		t.Fatalf("hash small: %v", err)
+	}
+	h1b, _ := computeFilePrefixHash(small, prefixHashWindow)
+	if h1 != h1b {
+		t.Fatalf("hash not deterministic: %q vs %q", h1, h1b)
+	}
+
+	// Build a file larger than the window so appends never touch the hashed head.
+	head := strings.Repeat("A", int(prefixHashWindow)+1024)
+	big := filepath.Join(dir, "big.txt")
+	if err := os.WriteFile(big, []byte(head), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	hBefore, err := computeFilePrefixHash(big, prefixHashWindow)
+	if err != nil {
+		t.Fatalf("hash big: %v", err)
+	}
+
+	// Append beyond the window: prefix hash must be unchanged.
+	f, _ := os.OpenFile(big, os.O_APPEND|os.O_WRONLY, 0o644)
+	_, _ = f.WriteString(strings.Repeat("B", 4096))
+	f.Close()
+	hAfterAppend, _ := computeFilePrefixHash(big, prefixHashWindow)
+	if hAfterAppend != hBefore {
+		t.Errorf("append changed prefix hash: %q -> %q", hBefore, hAfterAppend)
+	}
+
+	// Rewrite the first byte: prefix hash must change.
+	data, _ := os.ReadFile(big)
+	data[0] = 'Z'
+	if err := os.WriteFile(big, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	hAfterEdit, _ := computeFilePrefixHash(big, prefixHashWindow)
+	if hAfterEdit == hBefore {
+		t.Error("head edit did not change prefix hash")
+	}
+}
+
+// TestIsDriftAppendOnlyClassification exercises the four drift outcomes:
+// no-drift, append-only, truncation, and head-rewrite.
+func TestIsDriftAppendOnlyClassification(t *testing.T) {
+	dir := t.TempDir()
+	sid := "11111111-1111-1111-1111-111111111111"
+
+	// Initial content larger than the prefix window so appends stay clear of it.
+	head := strings.Repeat("x", int(prefixHashWindow)+512)
+	line0 := head + "\n"
+	path, _ := writeJSONL(t, dir, sid+".jsonl", line0)
+
+	prefix, err := computeFilePrefixHash(path, prefixHashWindow)
+	if err != nil {
+		t.Fatalf("prefix hash: %v", err)
+	}
+	fi, _ := os.Stat(path)
+	meta := SessionMeta{
+		SessionID:            sid,
+		SourcePath:           path,
+		SourceSize:           fi.Size(),
+		SourceMtime:          fi.ModTime(),
+		LastParsedByteOffset: fi.Size(),
+		LastParsedTurnIndex:  1,
+		PrefixSha256:         prefix,
+	}
+
+	// (a) No drift: identical size + mtime.
+	if d := isDrift(meta, sourceFileInfo{Path: path, Size: fi.Size(), Mtime: fi.ModTime()}); d.Drifted {
+		t.Errorf("expected no drift, got %+v", d)
+	}
+
+	// (b) Append-only: grow the file beyond the window, prefix unchanged.
+	f, _ := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	_, _ = f.WriteString(strings.Repeat("y", 2048) + "\n")
+	f.Close()
+	fiGrown, _ := os.Stat(path)
+	dGrown := isDrift(meta, sourceFileInfo{Path: path, Size: fiGrown.Size(), Mtime: fiGrown.ModTime().Add(3 * time.Second)})
+	if !dGrown.Drifted || !dGrown.IsAppendOnly {
+		t.Errorf("expected append-only drift, got %+v", dGrown)
+	}
+
+	// (c) Truncation: size smaller than indexed → not append-only.
+	dTrunc := isDrift(meta, sourceFileInfo{Path: path, Size: meta.SourceSize - 10, Mtime: fi.ModTime().Add(3 * time.Second)})
+	if !dTrunc.Drifted || dTrunc.IsAppendOnly {
+		t.Errorf("expected full-reparse drift on truncation, got %+v", dTrunc)
+	}
+
+	// (d) Head rewrite: same growth but stored prefix hash no longer matches.
+	metaStale := meta
+	metaStale.PrefixSha256 = "deadbeef"
+	dRewrite := isDrift(metaStale, sourceFileInfo{Path: path, Size: fiGrown.Size(), Mtime: fiGrown.ModTime().Add(3 * time.Second)})
+	if !dRewrite.Drifted || dRewrite.IsAppendOnly {
+		t.Errorf("expected full-reparse drift on head rewrite, got %+v", dRewrite)
+	}
+
+	// (e) No cursor: append-only growth but no recorded offset/hash → full reparse.
+	metaNoCursor := meta
+	metaNoCursor.LastParsedByteOffset = 0
+	metaNoCursor.PrefixSha256 = ""
+	dNoCursor := isDrift(metaNoCursor, sourceFileInfo{Path: path, Size: fiGrown.Size(), Mtime: fiGrown.ModTime().Add(3 * time.Second)})
+	if !dNoCursor.Drifted || dNoCursor.IsAppendOnly {
+		t.Errorf("expected full-reparse drift without a cursor, got %+v", dNoCursor)
+	}
+}
+
+// TestParseSessionIncrementalTail proves that, seeked to a cursor, the
+// incremental parser emits only the appended records, numbers them from the
+// supplied start index, and reports correct absolute offsets.
+func TestParseSessionIncrementalTail(t *testing.T) {
+	dir := t.TempDir()
+	sid := "22222222-2222-2222-2222-222222222222"
+
+	l0 := userRecordLine(t, sid, "u0", "first turn", "2026-05-01T10:00:00Z")
+	l1 := userRecordLine(t, sid, "u1", "second turn", "2026-05-01T10:01:00Z")
+	path, _ := writeJSONL(t, dir, sid+".jsonl", l0+l1)
+
+	// Full parse to establish the cursor.
+	fullMeta, fullTurns, err := indexSession(path, sid, 8192)
+	if err != nil {
+		t.Fatalf("indexSession: %v", err)
+	}
+	if len(fullTurns) != 2 {
+		t.Fatalf("expected 2 turns from full parse, got %d", len(fullTurns))
+	}
+	if fullMeta.LastParsedTurnIndex != 2 {
+		t.Fatalf("cursor turn index = %d, want 2", fullMeta.LastParsedTurnIndex)
+	}
+	if fullMeta.LastParsedByteOffset != int64(len(l0)+len(l1)) {
+		t.Fatalf("cursor byte offset = %d, want %d", fullMeta.LastParsedByteOffset, len(l0)+len(l1))
+	}
+
+	// Append two more records.
+	l2 := userRecordLine(t, sid, "u2", "third turn", "2026-05-01T10:02:00Z")
+	l3 := userRecordLine(t, sid, "u3", "fourth turn", "2026-05-01T10:03:00Z")
+	f, _ := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	_, _ = f.WriteString(l2 + l3)
+	f.Close()
+
+	incMeta, merged, newCount, err := indexSessionIncremental(path, sid, fullMeta, fullTurns, 8192)
+	if err != nil {
+		t.Fatalf("indexSessionIncremental: %v", err)
+	}
+	if newCount != 2 {
+		t.Fatalf("expected 2 new turns, got %d", newCount)
+	}
+	if len(merged) != 4 {
+		t.Fatalf("expected 4 merged turns, got %d", len(merged))
+	}
+	// New turns must be numbered 2 and 3 and carry the appended text.
+	if merged[2].TurnIndex != 2 || merged[2].UUID != "u2" {
+		t.Errorf("turn[2] = idx %d uuid %q, want 2/u2", merged[2].TurnIndex, merged[2].UUID)
+	}
+	if merged[3].TurnIndex != 3 || merged[3].UUID != "u3" {
+		t.Errorf("turn[3] = idx %d uuid %q, want 3/u3", merged[3].TurnIndex, merged[3].UUID)
+	}
+	// Cursor advances to end-of-file and to the new turn count.
+	fi, _ := os.Stat(path)
+	if incMeta.LastParsedByteOffset != fi.Size() {
+		t.Errorf("cursor offset = %d, want EOF %d", incMeta.LastParsedByteOffset, fi.Size())
+	}
+	if incMeta.LastParsedTurnIndex != 4 || incMeta.TurnCount != 4 {
+		t.Errorf("cursor turn index/count = %d/%d, want 4/4", incMeta.LastParsedTurnIndex, incMeta.TurnCount)
+	}
+}
+
+// TestIncrementalDedupAgainstExisting verifies that re-appended historical
+// records (same UUID) in the tail are deduplicated against the existing turn
+// set, not re-emitted as duplicate turns.
+func TestIncrementalDedupAgainstExisting(t *testing.T) {
+	dir := t.TempDir()
+	sid := "33333333-3333-3333-3333-333333333333"
+
+	l0 := userRecordLine(t, sid, "d0", "alpha", "2026-05-01T10:00:00Z")
+	path, _ := writeJSONL(t, dir, sid+".jsonl", l0)
+	fullMeta, fullTurns, err := indexSession(path, sid, 8192)
+	if err != nil {
+		t.Fatalf("indexSession: %v", err)
+	}
+
+	// Append a NEW record plus a re-appended copy of the already-indexed d0.
+	l1 := userRecordLine(t, sid, "d1", "beta", "2026-05-01T10:01:00Z")
+	dupD0 := userRecordLine(t, sid, "d0", "alpha", "2026-05-01T10:00:00Z")
+	f, _ := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	_, _ = f.WriteString(l1 + dupD0)
+	f.Close()
+
+	_, merged, newCount, err := indexSessionIncremental(path, sid, fullMeta, fullTurns, 8192)
+	if err != nil {
+		t.Fatalf("indexSessionIncremental: %v", err)
+	}
+	if newCount != 1 {
+		t.Fatalf("expected 1 new turn (d0 deduped), got %d", newCount)
+	}
+	if len(merged) != 2 {
+		t.Fatalf("expected 2 merged turns, got %d", len(merged))
+	}
+	uuids := map[string]int{}
+	for _, tn := range merged {
+		uuids[tn.UUID]++
+	}
+	if uuids["d0"] != 1 {
+		t.Errorf("d0 appears %d times, want exactly 1 (dedup failed)", uuids["d0"])
+	}
+}
+
+// TestIncrementalNewlinelessTailNotCommitted verifies the tail-line safety
+// rule: a complete record written WITHOUT its trailing newline is still parsed
+// (its turn is captured immediately) but the durable cursor is NOT advanced
+// past it. A second pass after the newline arrives re-reads the line and dedups
+// it by UUID, so it is never double-counted.
+func TestIncrementalNewlinelessTailNotCommitted(t *testing.T) {
+	dir := t.TempDir()
+	sid := "44444444-4444-4444-4444-444444444444"
+
+	l0 := userRecordLine(t, sid, "p0", "complete", "2026-05-01T10:00:00Z")
+	path, _ := writeJSONL(t, dir, sid+".jsonl", l0)
+	fullMeta, fullTurns, err := indexSession(path, sid, 8192)
+	if err != nil {
+		t.Fatalf("indexSession: %v", err)
+	}
+
+	// Append a COMPLETE record but WITHOUT its trailing newline.
+	l1 := userRecordLine(t, sid, "p1", "newlineless", "2026-05-01T10:01:00Z")
+	noNewline := strings.TrimSuffix(l1, "\n")
+	f, _ := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	_, _ = f.WriteString(noNewline)
+	f.Close()
+
+	incMeta, merged, newCount, err := indexSessionIncremental(path, sid, fullMeta, fullTurns, 8192)
+	if err != nil {
+		t.Fatalf("indexSessionIncremental: %v", err)
+	}
+	// The complete record is captured immediately.
+	if newCount != 1 {
+		t.Fatalf("newlineless complete record should yield 1 new turn, got %d", newCount)
+	}
+	if len(merged) != 2 || merged[1].UUID != "p1" {
+		t.Fatalf("expected p1 captured as turn 1, got %d turns", len(merged))
+	}
+	// But the durable cursor must NOT have advanced past the uncommitted line.
+	if incMeta.LastParsedByteOffset != fullMeta.LastParsedByteOffset {
+		t.Errorf("cursor advanced over newlineless line: %d (was %d)", incMeta.LastParsedByteOffset, fullMeta.LastParsedByteOffset)
+	}
+
+	// Complete the record with its newline; re-parse must NOT double-count p1.
+	f, _ = os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	_, _ = f.WriteString("\n")
+	f.Close()
+
+	incMeta2, merged2, newCount2, err := indexSessionIncremental(path, sid, incMeta, merged, 8192)
+	if err != nil {
+		t.Fatalf("indexSessionIncremental (completion): %v", err)
+	}
+	if newCount2 != 0 {
+		t.Fatalf("re-read of committed record should yield 0 new turns (deduped), got %d", newCount2)
+	}
+	if len(merged2) != 2 {
+		t.Fatalf("turn count must stay 2 after re-read, got %d", len(merged2))
+	}
+	// Now the cursor advances to EOF since the line is newline-terminated.
+	fi, _ := os.Stat(path)
+	if incMeta2.LastParsedByteOffset != fi.Size() {
+		t.Errorf("cursor = %d after completion, want EOF %d", incMeta2.LastParsedByteOffset, fi.Size())
+	}
+}
+
+// TestIncrementalGenuinelyPartialTail verifies that a tail line which is NOT
+// valid JSON (a true mid-write fragment) is never emitted and never advances
+// the cursor; once the rest of the record arrives it parses correctly.
+func TestIncrementalGenuinelyPartialTail(t *testing.T) {
+	dir := t.TempDir()
+	sid := "4a4a4a4a-4a4a-4a4a-4a4a-4a4a4a4a4a4a"
+
+	l0 := userRecordLine(t, sid, "g0", "complete", "2026-05-01T10:00:00Z")
+	path, _ := writeJSONL(t, dir, sid+".jsonl", l0)
+	fullMeta, fullTurns, err := indexSession(path, sid, 8192)
+	if err != nil {
+		t.Fatalf("indexSession: %v", err)
+	}
+
+	// Append the FIRST HALF of a record (invalid JSON fragment).
+	l1 := userRecordLine(t, sid, "g1", "the second turn text here", "2026-05-01T10:01:00Z")
+	half := l1[:len(l1)/2]
+	f, _ := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	_, _ = f.WriteString(half)
+	f.Close()
+
+	incMeta, merged, newCount, err := indexSessionIncremental(path, sid, fullMeta, fullTurns, 8192)
+	if err != nil {
+		t.Fatalf("indexSessionIncremental: %v", err)
+	}
+	if newCount != 0 {
+		t.Fatalf("invalid-JSON fragment must yield 0 turns, got %d", newCount)
+	}
+	if incMeta.LastParsedByteOffset != fullMeta.LastParsedByteOffset {
+		t.Errorf("cursor advanced over invalid fragment: %d (was %d)", incMeta.LastParsedByteOffset, fullMeta.LastParsedByteOffset)
+	}
+
+	// Write the remaining half plus newline; now the record is complete.
+	f, _ = os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	_, _ = f.WriteString(l1[len(l1)/2:])
+	f.Close()
+
+	_, merged2, newCount2, err := indexSessionIncremental(path, sid, incMeta, merged, 8192)
+	if err != nil {
+		t.Fatalf("indexSessionIncremental (completion): %v", err)
+	}
+	if newCount2 != 1 {
+		t.Fatalf("completed record should yield 1 new turn, got %d", newCount2)
+	}
+	if len(merged2) != 2 || merged2[1].UUID != "g1" {
+		t.Errorf("expected g1 as turn 1, got %d turns", len(merged2))
+	}
+}
+
+// TestConvergenceNoDriftWhenIdle is the regression guard for the bug this fix
+// targets: once a session is fully indexed (cursor seeded), an unchanged file
+// must report NO drift so the reconcile loop converges to zero changes.
+func TestConvergenceNoDriftWhenIdle(t *testing.T) {
+	dir := t.TempDir()
+	sid := "55555555-5555-5555-5555-555555555555"
+	l0 := userRecordLine(t, sid, "c0", "only turn", "2026-05-01T10:00:00Z")
+	path, src := writeJSONL(t, dir, sid+".jsonl", l0)
+
+	meta, _, err := indexSession(path, sid, 8192)
+	if err != nil {
+		t.Fatalf("indexSession: %v", err)
+	}
+	// The just-indexed file is unchanged; isDrift must say so across repeats.
+	for i := 0; i < 3; i++ {
+		if d := isDrift(meta, src); d.Drifted {
+			t.Fatalf("idle cycle %d reported drift %+v; reconcile would never converge", i, d)
+		}
+	}
+}
+
+// TestFullReparseFallbackOnRewrite proves the safety net: when a file's head is
+// rewritten (not a pure append), the drift classifier refuses the incremental
+// path and a full re-parse rebuilds the turn set correctly.
+func TestFullReparseFallbackOnRewrite(t *testing.T) {
+	dir := t.TempDir()
+	sid := "66666666-6666-6666-6666-666666666666"
+
+	l0 := userRecordLine(t, sid, "r0", "original first", "2026-05-01T10:00:00Z")
+	l1 := userRecordLine(t, sid, "r1", "original second", "2026-05-01T10:01:00Z")
+	path, _ := writeJSONL(t, dir, sid+".jsonl", l0+l1)
+	fullMeta, _, err := indexSession(path, sid, 8192)
+	if err != nil {
+		t.Fatalf("indexSession: %v", err)
+	}
+
+	// Rewrite the file entirely (compaction): different head, different UUIDs,
+	// larger overall so size grows but the prefix hash will not match.
+	n0 := userRecordLine(t, sid, "n0", "rewritten alpha", "2026-05-01T11:00:00Z")
+	n1 := userRecordLine(t, sid, "n1", "rewritten beta", "2026-05-01T11:01:00Z")
+	n2 := userRecordLine(t, sid, "n2", "rewritten gamma", "2026-05-01T11:02:00Z")
+	if err := os.WriteFile(path, []byte(n0+n1+n2), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fi, _ := os.Stat(path)
+	d := isDrift(fullMeta, sourceFileInfo{Path: path, Size: fi.Size(), Mtime: fi.ModTime().Add(5 * time.Second)})
+	if !d.Drifted {
+		t.Fatal("expected drift after rewrite")
+	}
+	if d.IsAppendOnly {
+		t.Fatal("rewrite misclassified as append-only — would corrupt the turn set")
+	}
+
+	// The fallback path (indexSession) rebuilds from scratch with the new turns.
+	newMeta, newTurns, err := indexSession(path, sid, 8192)
+	if err != nil {
+		t.Fatalf("full re-parse: %v", err)
+	}
+	if len(newTurns) != 3 {
+		t.Fatalf("expected 3 turns after rewrite, got %d", len(newTurns))
+	}
+	if newMeta.TurnCount != 3 {
+		t.Errorf("meta turn count = %d, want 3", newMeta.TurnCount)
+	}
+	for i, want := range []string{"n0", "n1", "n2"} {
+		if newTurns[i].UUID != want {
+			t.Errorf("turn[%d] uuid = %q, want %q", i, newTurns[i].UUID, want)
+		}
+	}
+}
+
+// TestReconcileAppendOnlyEndToEnd drives the full reconcile cycle through the
+// public provider methods to prove: (1) a grown source yields an UPDATE action
+// flagged is_append_only=true, (2) ApplyPlan parses only the appended tail and
+// merges it (correct total turn count), and (3) a subsequent unchanged cycle
+// converges to zero create/update actions (the bug this fix targets).
+func TestReconcileAppendOnlyEndToEnd(t *testing.T) {
+	p, root := newTestProvider(t)
+	srcDir := t.TempDir()
+	sid := "77777777-7777-7777-7777-777777777777"
+	ctx := context.Background()
+
+	// Cycle 1: initial index (one turn) → create.
+	l0 := userRecordLine(t, sid, "e0", "first", "2026-05-01T10:00:00Z")
+	path := filepath.Join(srcDir, sid+".jsonl")
+	if err := os.WriteFile(path, []byte(l0), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeObservatoryConfig(t, root, []string{srcDir})
+
+	cfgAny, _ := p.LoadConfig(root)
+	liveAny, _ := p.FetchLive(ctx, cfgAny)
+	plan1, _ := p.ComputePlan(cfgAny, liveAny, nil)
+	if plan1.Summary.Creates != 1 {
+		t.Fatalf("cycle1: expected 1 create, got %d", plan1.Summary.Creates)
+	}
+	if _, err := p.ApplyPlan(ctx, plan1); err != nil {
+		t.Fatalf("cycle1 ApplyPlan: %v", err)
+	}
+
+	// Cycle 2: append two turns → update flagged append-only.
+	l1 := userRecordLine(t, sid, "e1", "second", "2026-05-01T10:01:00Z")
+	l2 := userRecordLine(t, sid, "e2", "third", "2026-05-01T10:02:00Z")
+	f, _ := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	_, _ = f.WriteString(l1 + l2)
+	f.Close()
+
+	cfgAny, _ = p.LoadConfig(root)
+	liveAny, _ = p.FetchLive(ctx, cfgAny)
+	plan2, _ := p.ComputePlan(cfgAny, liveAny, nil)
+	if plan2.Summary.Updates != 1 {
+		t.Fatalf("cycle2: expected 1 update, got %d", plan2.Summary.Updates)
+	}
+	var sawAppendOnly bool
+	for _, a := range plan2.Actions {
+		if a.Action == reconcile.ActionUpdate {
+			if ao, _ := a.Details["is_append_only"].(bool); ao {
+				sawAppendOnly = true
+			}
+		}
+	}
+	if !sawAppendOnly {
+		t.Fatal("cycle2: update action was not classified is_append_only")
+	}
+	if _, err := p.ApplyPlan(ctx, plan2); err != nil {
+		t.Fatalf("cycle2 ApplyPlan: %v", err)
+	}
+
+	// Confirm the merged session has all 3 turns with correct indexes.
+	liveAny, _ = p.FetchLive(ctx, cfgAny)
+	ls := liveAny.(*liveState)
+	entry, ok := ls.Entries[sid]
+	if !ok {
+		t.Fatal("session missing from index after cycle2")
+	}
+	if entry.Meta.TurnCount != 3 {
+		t.Fatalf("expected 3 turns after append, got %d", entry.Meta.TurnCount)
+	}
+	_, turns, _ := p.index.GetTurns(sid)
+	if len(turns) != 3 {
+		t.Fatalf("expected 3 indexed turns, got %d", len(turns))
+	}
+	for i, want := range []string{"e0", "e1", "e2"} {
+		if turns[i].UUID != want || turns[i].TurnIndex != i {
+			t.Errorf("turn[%d] = uuid %q idx %d, want %s/%d", i, turns[i].UUID, turns[i].TurnIndex, want, i)
+		}
+	}
+
+	// Cycle 3: no changes → convergence. No create/update; only skip.
+	cfgAny, _ = p.LoadConfig(root)
+	liveAny, _ = p.FetchLive(ctx, cfgAny)
+	plan3, _ := p.ComputePlan(cfgAny, liveAny, nil)
+	if plan3.Summary.Creates != 0 || plan3.Summary.Updates != 0 || plan3.Summary.Deletes != 0 {
+		t.Fatalf("cycle3 did not converge: creates=%d updates=%d deletes=%d skipped=%d",
+			plan3.Summary.Creates, plan3.Summary.Updates, plan3.Summary.Deletes, plan3.Summary.Skipped)
+	}
+	if plan3.Summary.Skipped != 1 {
+		t.Fatalf("cycle3: expected 1 skip, got %d", plan3.Summary.Skipped)
+	}
+}

--- a/internal/conversations/index.go
+++ b/internal/conversations/index.go
@@ -160,6 +160,23 @@ func (idx *Index) ListSessions(since, until time.Time, identity string) []Sessio
 	return out
 }
 
+// GetTurns returns a copy of the indexed turn slice for a session (in
+// turn-index order) plus its meta and a presence flag. The returned slice is a
+// fresh copy safe to mutate/append without holding the index lock — the
+// incremental parse path appends new turns onto it before re-upserting.
+func (idx *Index) GetTurns(sessionID string) (SessionMeta, []Turn, bool) {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	meta, ok := idx.sessions[sessionID]
+	if !ok {
+		return SessionMeta{}, nil, false
+	}
+	src := idx.turns[sessionID]
+	cp := make([]Turn, len(src))
+	copy(cp, src)
+	return meta, cp, true
+}
+
 // GetTurn returns the Turn at turnIndex within session, or false.
 func (idx *Index) GetTurn(sessionID string, turnIndex int) (Turn, bool) {
 	idx.mu.RLock()

--- a/internal/conversations/parser.go
+++ b/internal/conversations/parser.go
@@ -40,33 +40,33 @@ var systemReminderRE = regexp.MustCompile(`(?s)<system-reminder>.*?</system-remi
 // rawRecord is the outermost envelope of every JSONL line.
 // We decode into this first and then dispatch on Type.
 type rawRecord struct {
-	Type       string          `json:"type"`
-	UUID       string          `json:"uuid"`
-	ParentUUID string          `json:"parentUuid"`
-	SessionID  string          `json:"sessionId"`
-	Timestamp  string          `json:"timestamp"`
-	Message    json.RawMessage `json:"message"`
-	Content    string          `json:"content"` // system records use content string
-	UserType   string          `json:"userType"`
-	Entrypoint string          `json:"entrypoint"`
-	IsSidechain bool           `json:"isSidechain"`
-	Level      string          `json:"level"`
+	Type        string          `json:"type"`
+	UUID        string          `json:"uuid"`
+	ParentUUID  string          `json:"parentUuid"`
+	SessionID   string          `json:"sessionId"`
+	Timestamp   string          `json:"timestamp"`
+	Message     json.RawMessage `json:"message"`
+	Content     string          `json:"content"` // system records use content string
+	UserType    string          `json:"userType"`
+	Entrypoint  string          `json:"entrypoint"`
+	IsSidechain bool            `json:"isSidechain"`
+	Level       string          `json:"level"`
 }
 
 // rawMessage is message.* within a user or assistant record.
 type rawMessage struct {
-	Role    string             `json:"role"`
-	Model   string             `json:"model"`
-	Content json.RawMessage    `json:"content"`
+	Role    string          `json:"role"`
+	Model   string          `json:"model"`
+	Content json.RawMessage `json:"content"`
 }
 
 // rawContentBlock is one element of message.content when it is an array.
 type rawContentBlock struct {
-	Type      string          `json:"type"`
-	Text      string          `json:"text"`
-	Thinking  string          `json:"thinking"`
-	Input     json.RawMessage `json:"input,omitempty"`    // tool_use
-	Content   json.RawMessage `json:"content,omitempty"`  // tool_result nested
+	Type     string          `json:"type"`
+	Text     string          `json:"text"`
+	Thinking string          `json:"thinking"`
+	Input    json.RawMessage `json:"input,omitempty"`   // tool_use
+	Content  json.RawMessage `json:"content,omitempty"` // tool_result nested
 }
 
 // rawAITitle is the ai-title record type.
@@ -161,6 +161,155 @@ func ParseSession(r io.Reader, sessionID string, maxTurnLen int, meta *SessionMe
 	}
 
 	return scanner.Err()
+}
+
+// ParseSessionIncremental parses only the records found at or after the
+// reader's current position, assigning turn indexes starting at startTurnIndex.
+// It is the append-only counterpart to ParseSession: the caller seeks the
+// underlying file to meta.LastParsedByteOffset before calling, so only the
+// freshly-appended tail is scanned. Each emitted Turn is passed to callback;
+// callback may return false to abort early.
+//
+// startOffset is the absolute file offset the reader is positioned at (i.e.
+// meta.LastParsedByteOffset). The returned committedOffset is the absolute
+// offset just past the last NEWLINE-TERMINATED line consumed — the caller
+// persists it as the new cursor so the next cycle resumes there.
+//
+// Tail-line handling: a final line WITHOUT a trailing newline may be either a
+// complete record the writer has not yet newline-terminated, or a half-written
+// record. We parse it (so a complete record's turn is not delayed a cycle) but
+// do NOT advance committedOffset past it. The cursor therefore stays at the
+// start of that line, so the next cycle re-reads it; UUID dedup makes the
+// re-read idempotent, and a genuinely partial line simply fails to parse and
+// emits nothing. This guarantees no record is ever skipped or double-counted.
+//
+// Unlike ParseSession this uses bufio.Reader.ReadBytes so per-line byte
+// accounting is exact (bufio.Scanner buffers ahead and cannot report line
+// boundaries). The parsing/dedup/field-extraction rules are otherwise
+// identical to ParseSession.
+//
+// seenUUIDs may be supplied by the caller (UUIDs already present in the
+// session) so that re-appended historical records — common in resumed or
+// compacted JSONL — are deduplicated against the existing turn set, not just
+// within this tail. Pass nil for an empty set.
+func ParseSessionIncremental(r io.Reader, sessionID string, startTurnIndex int, startOffset int64, maxTurnLen int, meta *SessionMeta, seenUUIDs map[string]struct{}, callback func(turn Turn) bool) (committedOffset int64, err error) {
+	if maxTurnLen <= 0 {
+		maxTurnLen = 8192
+	}
+	if seenUUIDs == nil {
+		seenUUIDs = make(map[string]struct{})
+	}
+
+	br := bufio.NewReaderSize(r, 1024*1024)
+	turnIndex := startTurnIndex
+	committedOffset = startOffset
+	var consumed int64 // bytes consumed from the reader since startOffset
+
+	for {
+		line, readErr := br.ReadBytes('\n')
+		consumed += int64(len(line))
+		hasNewline := len(line) > 0 && line[len(line)-1] == '\n'
+		trimmed := trimLineEnd(line)
+
+		if len(trimmed) != 0 {
+			cont := consumeIncrementalRecord(trimmed, sessionID, &turnIndex, maxTurnLen, meta, seenUUIDs, callback)
+			// Advance the durable cursor only past newline-terminated lines.
+			// A trailing newline-less line is parsed (above) but its offset is
+			// withheld so the next cycle safely re-reads it.
+			if hasNewline {
+				committedOffset = startOffset + consumed
+			}
+			if !cont {
+				return committedOffset, nil
+			}
+		} else if hasNewline {
+			// Blank/whitespace-only line that is newline-terminated: nothing to
+			// emit, but the cursor still advances past it.
+			committedOffset = startOffset + consumed
+		}
+
+		if readErr != nil {
+			if readErr == io.EOF {
+				return committedOffset, nil
+			}
+			return committedOffset, readErr
+		}
+	}
+}
+
+// consumeIncrementalRecord decodes one JSONL line and, when it yields a Turn,
+// invokes callback. Returns false when the callback asks to abort. turnIndex is
+// advanced in place on a successful emit. This mirrors the per-record switch in
+// ParseSession exactly.
+func consumeIncrementalRecord(line []byte, sessionID string, turnIndex *int, maxTurnLen int, meta *SessionMeta, seenUUIDs map[string]struct{}, callback func(Turn) bool) bool {
+	var rec rawRecord
+	if err := json.Unmarshal(line, &rec); err != nil {
+		// Skip unparseable lines — consistent with ParseSession.
+		return true
+	}
+
+	if rec.Entrypoint != "" && meta.Entrypoint == "" {
+		meta.Entrypoint = rec.Entrypoint
+	}
+
+	switch rec.Type {
+	case "ai-title":
+		var t rawAITitle
+		if err := json.Unmarshal(line, &t); err == nil && t.Title != "" {
+			meta.Title = t.Title
+		}
+
+	case "user":
+		if rec.UUID != "" {
+			if _, dup := seenUUIDs[rec.UUID]; dup {
+				return true
+			}
+			seenUUIDs[rec.UUID] = struct{}{}
+		}
+		turn, ok := parseUserRecord(&rec, sessionID, *turnIndex, maxTurnLen)
+		if !ok {
+			return true
+		}
+		updateTimeBounds(meta, turn.Timestamp)
+		if !callback(turn) {
+			return false
+		}
+		*turnIndex++
+		meta.TurnCount = *turnIndex
+
+	case "assistant":
+		if rec.UUID != "" {
+			if _, dup := seenUUIDs[rec.UUID]; dup {
+				return true
+			}
+			seenUUIDs[rec.UUID] = struct{}{}
+		}
+		turn, ok := parseAssistantRecord(&rec, sessionID, *turnIndex, maxTurnLen)
+		if !ok {
+			return true
+		}
+		updateTimeBounds(meta, turn.Timestamp)
+		if !callback(turn) {
+			return false
+		}
+		*turnIndex++
+		meta.TurnCount = *turnIndex
+	}
+	return true
+}
+
+// trimLineEnd strips a trailing \n and optional \r from a raw line read by
+// bufio.Reader.ReadBytes, returning the record bytes. It does not allocate
+// when there is nothing to trim.
+func trimLineEnd(line []byte) []byte {
+	n := len(line)
+	if n > 0 && line[n-1] == '\n' {
+		n--
+		if n > 0 && line[n-1] == '\r' {
+			n--
+		}
+	}
+	return line[:n]
 }
 
 // parseUserRecord extracts a Turn from a type="user" raw record.

--- a/internal/conversations/provider.go
+++ b/internal/conversations/provider.go
@@ -3,18 +3,22 @@
 // Implements pkg/reconcile.Reconcilable with resource type "conversations".
 //
 // Method summary:
-//   Type()        — "conversations"
-//   LoadConfig()  — scan source dirs for JSONL files; load .cog/config/observatory.yaml
-//   FetchLive()   — load index from .cog/state/conversations/_meta.json
-//   ComputePlan() — diff source files vs index entries; plan create/update/delete/skip
-//   ApplyPlan()   — stream-parse new/changed sessions into the index
-//   BuildState()  — construct Terraform-style state from live index entries
-//   Health()      — Healthy/Degraded/OutOfSync based on index drift and errors
+//
+//	Type()        — "conversations"
+//	LoadConfig()  — scan source dirs for JSONL files; load .cog/config/observatory.yaml
+//	FetchLive()   — load index from .cog/state/conversations/_meta.json
+//	ComputePlan() — diff source files vs index entries; plan create/update/delete/skip
+//	ApplyPlan()   — stream-parse new/changed sessions into the index
+//	BuildState()  — construct Terraform-style state from live index entries
+//	Health()      — Healthy/Degraded/OutOfSync based on index drift and errors
 package conversations
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -26,6 +30,13 @@ import (
 	"github.com/myrgic/cogos/pkg/substrate/reconcile"
 	"gopkg.in/yaml.v3"
 )
+
+// prefixHashWindow is the number of leading bytes of a source JSONL hashed to
+// detect truncation / in-place rewrite. A growing append-only file keeps this
+// prefix byte-identical; any edit to the head (compaction, resume-rewrite)
+// changes it and forces a full re-parse. 64 KiB comfortably covers many CC
+// session header + first-turns records.
+const prefixHashWindow int64 = 64 * 1024
 
 // Provider implements reconcile.Reconcilable for the Conversations Observatory.
 type Provider struct {
@@ -249,6 +260,10 @@ func (p *Provider) ComputePlan(config any, live any, _ *reconcile.State) (*recon
 	// ── CC source files ──────────────────────────────────────────────────────
 	for _, f := range cfg.SourceFiles {
 		existing, indexed := ls.Entries[f.SessionID]
+		var drift driftResult
+		if indexed {
+			drift = isDrift(existing.Meta, f)
+		}
 		switch {
 		case !indexed:
 			plan.Actions = append(plan.Actions, reconcile.Action{
@@ -263,18 +278,19 @@ func (p *Provider) ComputePlan(config any, live any, _ *reconcile.State) (*recon
 			})
 			plan.Summary.Creates++
 
-		case isDrift(existing.Meta, f):
+		case drift.Drifted:
 			plan.Actions = append(plan.Actions, reconcile.Action{
 				Action:       reconcile.ActionUpdate,
 				ResourceType: "conversations",
 				Name:         f.SessionID,
 				Details: map[string]any{
-					"source_path": f.Path,
-					"mtime":       f.Mtime.Format(time.RFC3339),
-					"size":        f.Size,
-					"prev_mtime":  existing.Meta.SourceMtime.Format(time.RFC3339),
-					"prev_size":   existing.Meta.SourceSize,
-					"prev_turns":  existing.Meta.TurnCount,
+					"source_path":    f.Path,
+					"mtime":          f.Mtime.Format(time.RFC3339),
+					"size":           f.Size,
+					"prev_mtime":     existing.Meta.SourceMtime.Format(time.RFC3339),
+					"prev_size":      existing.Meta.SourceSize,
+					"prev_turns":     existing.Meta.TurnCount,
+					"is_append_only": drift.IsAppendOnly,
 				},
 			})
 			plan.Summary.Updates++
@@ -507,7 +523,38 @@ func (p *Provider) ApplyPlan(ctx context.Context, plan *reconcile.Plan) ([]recon
 				continue
 			}
 
-			meta, turns, err := indexSession(sourcePath, action.Name, defaultMaxTurnLen)
+			// Append-only fast path: when ComputePlan classified this update as a
+			// pure append (file grew, head prefix unchanged) and a usable cursor
+			// is on record, parse only the appended tail instead of re-reading
+			// the whole file from byte 0. Falls back to a full re-parse on any
+			// inconsistency (no cursor, parse error) so correctness never depends
+			// on the cursor being right.
+			var (
+				meta  SessionMeta
+				turns []Turn
+				err   error
+			)
+			appendOnly, _ := action.Details["is_append_only"].(bool)
+			if action.Action == reconcile.ActionUpdate && appendOnly {
+				prevMeta, existingTurns, ok := idx.GetTurns(action.Name)
+				if ok && prevMeta.LastParsedByteOffset > 0 && prevMeta.PrefixSha256 != "" {
+					m, merged, _, incErr := indexSessionIncremental(sourcePath, action.Name, prevMeta, existingTurns, defaultMaxTurnLen)
+					if incErr == nil {
+						meta, turns = m, merged
+					} else {
+						// Incremental parse failed (e.g. file rewritten between
+						// plan and apply). Fall back to a safe full re-parse.
+						errs = append(errs, fmt.Sprintf("incremental %s fell back to full: %v", action.Name, incErr))
+						meta, turns, err = indexSession(sourcePath, action.Name, defaultMaxTurnLen)
+					}
+				} else {
+					// Flagged append-only but no usable cursor in the index
+					// (cold start, pre-cursor meta) — full re-parse seeds it.
+					meta, turns, err = indexSession(sourcePath, action.Name, defaultMaxTurnLen)
+				}
+			} else {
+				meta, turns, err = indexSession(sourcePath, action.Name, defaultMaxTurnLen)
+			}
 			if err != nil {
 				res.Status = reconcile.ApplyFailed
 				res.Error = fmt.Sprintf("index session %s: %v", action.Name, err)
@@ -632,9 +679,10 @@ func (p *Provider) BuildState(_ any, live any, existing *reconcile.State) (*reco
 // ─── Health ───────────────────────────────────────────────────────────────────
 
 // Health returns three-axis status:
-//   Sync      — Synced when last plan had no non-skip actions
-//   Health    — Degraded when ApplyPlan had errors; Healthy otherwise
-//   Operation — Syncing while ApplyPlan is running
+//
+//	Sync      — Synced when last plan had no non-skip actions
+//	Health    — Degraded when ApplyPlan had errors; Healthy otherwise
+//	Operation — Syncing while ApplyPlan is running
 func (p *Provider) Health() reconcile.ResourceStatus {
 	p.mu.Lock()
 	summary := p.lastPlanSummary
@@ -904,26 +952,96 @@ func expandHome(path string) string {
 	return filepath.Join(home, path[1:])
 }
 
-// isDrift returns true when the indexed meta is stale compared to f.
-// Primary signal: size change (definitive — any content change changes size).
-// Secondary signal: mtime difference > 1s (guards against same-size rewrites).
+// driftResult is the outcome of a CC source drift check.
+type driftResult struct {
+	// Drifted is true when the indexed meta is stale compared to the source.
+	Drifted bool
+	// IsAppendOnly is true when the only change is appended content: the file
+	// grew and its hashed prefix is byte-identical to the last-indexed prefix.
+	// Only meaningful when Drifted is true. When false on a drifted source, the
+	// caller must full re-parse (truncation/rewrite or no usable cursor).
+	IsAppendOnly bool
+}
+
+// isDrift reports whether the indexed meta is stale compared to f, and if so
+// whether the change is a pure append (so the caller can parse only the tail).
 //
-// mtime is compared with 2-second tolerance to guard against filesystem mtime
-// resolution differences between `os.ReadDir` calls on fast-write filesystems
-// (e.g. Linux tmpfs in CI runners). A 1-byte change always changes size, so
-// the 2s tolerance only matters for truly same-size content changes (rare in
-// practice for session JSONLs, which grow monotonically).
-func isDrift(meta SessionMeta, f sourceFileInfo) bool {
-	// Size change is the definitive fast path.
-	if meta.SourceSize != f.Size {
-		return true
+// Drift detection (unchanged semantics):
+//   - size change is the definitive fast path
+//   - mtime difference > 2s (filesystem-granularity tolerance) for same-size
+//     rewrites
+//
+// Append-only classification (new):
+//   - the file must have GROWN (f.Size > meta.SourceSize), and
+//   - a valid cursor must exist (meta.PrefixSha256 set, meta.LastParsedByteOffset
+//     <= f.Size), and
+//   - the freshly-hashed prefix must equal meta.PrefixSha256.
+//
+// The hashed window is bounded by the LAST-PARSED offset, never the current
+// file size, so the hashed region only ever covers bytes that were already
+// present at index time. Appends land strictly after that offset and therefore
+// can never perturb the hash — without this bound, a small file (< window)
+// would re-hash the appended bytes and spuriously look like a rewrite.
+//
+// Any prefix-hash mismatch, size decrease, or missing cursor classifies the
+// drift as NOT append-only → full re-parse. A prefix hash that cannot be
+// computed (I/O error) is treated conservatively as not-append-only.
+func isDrift(meta SessionMeta, f sourceFileInfo) driftResult {
+	sizeChanged := meta.SourceSize != f.Size
+	mtimeDiff := meta.SourceMtime.Sub(f.Mtime)
+	if mtimeDiff < 0 {
+		mtimeDiff = -mtimeDiff
 	}
-	// mtime with 2s tolerance for filesystem-level mtime granularity jitter.
-	diff := meta.SourceMtime.Sub(f.Mtime)
-	if diff < 0 {
-		diff = -diff
+	mtimeChanged := mtimeDiff > 2*time.Second
+
+	if !sizeChanged && !mtimeChanged {
+		return driftResult{Drifted: false}
 	}
-	return diff > 2*time.Second
+
+	// Drifted. Decide whether it is a safe append.
+	grew := f.Size > meta.SourceSize
+	hasCursor := meta.PrefixSha256 != "" &&
+		meta.LastParsedByteOffset > 0 &&
+		meta.LastParsedByteOffset <= f.Size
+	if !grew || !hasCursor {
+		return driftResult{Drifted: true, IsAppendOnly: false}
+	}
+
+	prefix, err := computeFilePrefixHash(f.Path, prefixHashLen(meta.LastParsedByteOffset))
+	if err != nil || prefix != meta.PrefixSha256 {
+		// I/O error or rewrite of the head → fall back to full re-parse.
+		return driftResult{Drifted: true, IsAppendOnly: false}
+	}
+	return driftResult{Drifted: true, IsAppendOnly: true}
+}
+
+// prefixHashLen returns the number of leading bytes to hash for a source whose
+// last-parsed offset is offset: the prefix window, clamped so it never exceeds
+// the bytes that were already indexed. Hashing only already-seen bytes makes
+// the hash invariant under append.
+func prefixHashLen(offset int64) int64 {
+	if offset < prefixHashWindow {
+		return offset
+	}
+	return prefixHashWindow
+}
+
+// computeFilePrefixHash returns the hex-encoded SHA-256 of up to prefixSize
+// leading bytes of the file at path. Files shorter than prefixSize are hashed
+// in full. The hash is over the raw bytes, so it is stable across reads of an
+// unchanged prefix and changes the moment any leading byte changes.
+func computeFilePrefixHash(path string, prefixSize int64) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.CopyN(h, f, prefixSize); err != nil && err != io.EOF {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // indexSession opens sourcePath, streams turns, and returns the resulting
@@ -948,8 +1066,14 @@ func indexSession(sourcePath, sessionID string, maxTurnLen int) (SessionMeta, []
 		SourceSize:  fi.Size(),
 	}
 
+	// Drive the full parse through the incremental parser from offset 0 so the
+	// cursor convention (committed offset = past the last NEWLINE-TERMINATED
+	// line) is identical on both paths. This keeps a trailing newline-less
+	// (possibly partial) final record from being committed, so a later append
+	// that completes it is parsed correctly. Turn extraction is byte-identical
+	// to ParseSession — both share parseUserRecord/parseAssistantRecord.
 	var turns []Turn
-	err = ParseSession(f, sessionID, maxTurnLen, &meta, func(t Turn) bool {
+	committed, err := ParseSessionIncremental(f, sessionID, 0, 0, maxTurnLen, &meta, nil, func(t Turn) bool {
 		turns = append(turns, t)
 		return true
 	})
@@ -957,7 +1081,92 @@ func indexSession(sourcePath, sessionID string, maxTurnLen int) (SessionMeta, []
 		return meta, turns, fmt.Errorf("parse %s: %w", sourcePath, err)
 	}
 
+	// Seed the incremental-parse cursor so the next reconcile cycle can parse
+	// only the appended tail. PrefixSha256 captures the file head (bounded by
+	// the committed offset) for truncation/rewrite detection.
+	meta.LastParsedByteOffset = committed
+	meta.LastParsedTurnIndex = len(turns)
+	if prefix, hErr := computeFilePrefixHash(sourcePath, prefixHashLen(committed)); hErr == nil {
+		meta.PrefixSha256 = prefix
+	}
+
 	return meta, turns, nil
+}
+
+// indexSessionIncremental seeks to the cursor recorded in prev and parses only
+// the appended tail of sourcePath, merging the new turns onto existingTurns. It
+// returns the updated meta, the merged turn slice, and the number of new turns
+// emitted. The caller must have already classified the source as append-only
+// (grew + prefix match) via isDrift.
+//
+// existingTurns is the session's current indexed turn slice; new turns are
+// appended after deduplicating by UUID against it, preserving the FTS-relevant
+// invariant that no two turns in a session share a UUID.
+func indexSessionIncremental(sourcePath, sessionID string, prev SessionMeta, existingTurns []Turn, maxTurnLen int) (SessionMeta, []Turn, int, error) {
+	fi, err := os.Stat(sourcePath)
+	if err != nil {
+		return SessionMeta{}, nil, 0, fmt.Errorf("stat %s: %w", sourcePath, err)
+	}
+
+	f, err := os.Open(sourcePath)
+	if err != nil {
+		return SessionMeta{}, nil, 0, fmt.Errorf("open %s: %w", sourcePath, err)
+	}
+	defer f.Close()
+
+	if _, err := f.Seek(prev.LastParsedByteOffset, io.SeekStart); err != nil {
+		return SessionMeta{}, nil, 0, fmt.Errorf("seek %s: %w", sourcePath, err)
+	}
+
+	// Carry forward the existing meta and refresh drift/index bookkeeping.
+	meta := prev
+	meta.SourcePath = sourcePath
+	meta.IndexedAt = time.Now().UTC()
+	meta.SourceMtime = fi.ModTime()
+	meta.SourceSize = fi.Size()
+
+	// Seed seenUUIDs with the UUIDs already indexed so re-appended historical
+	// records (resume/compaction) are deduplicated against the full session,
+	// not merely within this tail.
+	seen := make(map[string]struct{}, len(existingTurns))
+	for _, t := range existingTurns {
+		if t.UUID != "" {
+			seen[t.UUID] = struct{}{}
+		}
+	}
+
+	merged := existingTurns
+	startIdx := prev.LastParsedTurnIndex
+	if startIdx <= 0 {
+		// Defensive: a missing/zero turn-index cursor on a session that already
+		// has turns would renumber the tail from 0 and collide. Resume from the
+		// existing count instead.
+		startIdx = len(existingTurns)
+	}
+
+	committed, err := ParseSessionIncremental(f, sessionID, startIdx, prev.LastParsedByteOffset, maxTurnLen, &meta, seen,
+		func(t Turn) bool {
+			merged = append(merged, t)
+			return true
+		})
+	if err != nil {
+		return meta, merged, 0, fmt.Errorf("incremental parse %s: %w", sourcePath, err)
+	}
+
+	newCount := len(merged) - len(existingTurns)
+
+	// Advance the cursor to the committed offset (past the last newline-
+	// terminated line; it stays at prev.LastParsedByteOffset when the tail held
+	// only a partially-written final line, so that line is re-read next cycle
+	// and deduped by UUID).
+	meta.LastParsedByteOffset = committed
+	meta.LastParsedTurnIndex = len(merged)
+	meta.TurnCount = len(merged)
+	if prefix, hErr := computeFilePrefixHash(sourcePath, prefixHashLen(committed)); hErr == nil {
+		meta.PrefixSha256 = prefix
+	}
+
+	return meta, merged, newCount, nil
 }
 
 // isIngestDrift returns true when the indexed sessions of a source are stale

--- a/internal/conversations/types.go
+++ b/internal/conversations/types.go
@@ -16,7 +16,7 @@
 //   - index.go         — in-memory full-text index backed by flat projection files
 //   - provider.go      — Reconcilable implementation
 //   - mcp_tools.go     — cog_search_conversations, cog_get_conversation_turn,
-//                        cog_list_conversations tool registrations
+//     cog_list_conversations tool registrations
 package conversations
 
 import "time"
@@ -70,6 +70,27 @@ type SessionMeta struct {
 
 	// SourceSize records the source file size at index time (drift detection).
 	SourceSize int64 `json:"source_size"`
+
+	// ── Incremental-parse cursor (CC source_dirs path only) ──────────────────
+	// These fields let the reconcile loop parse only the appended tail of a
+	// monotonically-growing session JSONL instead of re-reading from byte 0
+	// every cycle. They are populated by both the full-parse and incremental
+	// parse paths. Ingest sessions (Source != "") do not use these.
+
+	// LastParsedByteOffset is the byte offset at the end of the last record
+	// successfully consumed from the source file. The incremental parser seeks
+	// here before scanning the tail. Zero means "no cursor — full parse".
+	LastParsedByteOffset int64 `json:"last_parsed_byte_offset,omitempty"`
+
+	// LastParsedTurnIndex is the turn_index that will be assigned to the NEXT
+	// emitted turn (i.e. one past the highest indexed turn_index). The
+	// incremental parser starts numbering from here.
+	LastParsedTurnIndex int `json:"last_parsed_turn_index,omitempty"`
+
+	// PrefixSha256 is the hex-encoded SHA-256 of the first prefixHashWindow
+	// bytes of the source file at last successful index time. A mismatch on a
+	// later cycle signals a rewrite/truncation and forces a full re-parse.
+	PrefixSha256 string `json:"prefix_sha256,omitempty"`
 
 	// Identity is the operator identity extracted from the JSONL (e.g. "slowbro").
 	// Populated from userType/sessionId/cwd fields present in the records.
@@ -131,8 +152,8 @@ type SearchHit struct {
 	UUID         string    `json:"uuid"`
 	Timestamp    time.Time `json:"timestamp"`
 	Role         Role      `json:"role"`
-	Excerpt      string    `json:"excerpt"`              // ~300-char snippet containing the match
-	Context      string    `json:"context,omitempty"`   // preceding/following text
+	Excerpt      string    `json:"excerpt"`           // ~300-char snippet containing the match
+	Context      string    `json:"context,omitempty"` // preceding/following text
 	SessionTitle string    `json:"session_title,omitempty"`
 	Identity     string    `json:"identity,omitempty"`
 	Source       string    `json:"source,omitempty"` // observer source id, empty for CC sessions
@@ -142,9 +163,9 @@ type SearchHit struct {
 type IndexDepth string
 
 const (
-	DepthFull          IndexDepth = "full"           // all turns parsed and indexed
-	DepthMetaOnly      IndexDepth = "meta_only"      // meta parsed, turns not
-	DepthNotProjected  IndexDepth = "not_projected"  // file seen, not yet indexed
+	DepthFull         IndexDepth = "full"          // all turns parsed and indexed
+	DepthMetaOnly     IndexDepth = "meta_only"     // meta parsed, turns not
+	DepthNotProjected IndexDepth = "not_projected" // file seen, not yet indexed
 )
 
 // IndexEntry describes one session's projection status.


### PR DESCRIPTION
## Problem

The Conversations Observatory reconcile cycle never converged: every 30s it re-read and re-parsed each growing Claude Code session JSONL from byte 0. A live/active session (mtime+size changing each cycle) forever triggered `ActionUpdate → full ParseSession → UpsertSession → drift again`, holding the provider permanently `OutOfSync` at ~900–1100ms/cycle. On a live node this is the dominant steady-state CPU draw (heaviest of ~23 providers) — independent of the user-draft loop fixed in #386.

## Fix

A per-source incremental cursor so append-only growth parses only the appended tail:

- `SessionMeta` gains `LastParsedByteOffset` / `LastParsedTurnIndex` / `PrefixSha256` (persisted in `_meta.json`; CC `source_dirs` path only).
- `isDrift` now returns `{Drifted, IsAppendOnly}`. A drift is append-only only when the file grew, a usable cursor exists, and the hashed head prefix is byte-identical. Size decrease or prefix mismatch (truncation/compaction/rewrite) forces a full re-parse. The hashed window is bounded by the last-parsed offset so appends never perturb it.
- `ParseSessionIncremental` parses from a seeked offset with exact per-line byte accounting; a trailing newline-less line is parsed but its offset withheld (re-read + UUID-deduped next cycle); a genuinely partial fragment never emits.
- `ApplyPlan` takes the incremental path for append-only updates and **falls back to a full re-parse on any inconsistency** — correctness never depends on the cursor being right.

## Result

Append-only sessions parse only new turns (~3–10× faster cycles); an idle source reports no drift so creates/updates drop to 0 (convergence restored). Ingest sources untouched; FTS integrity preserved (UUID-stable, dedup applied).

## Tests

11 new tests in `incremental_test.go`: prefix-hash stability-under-append / change-under-head-edit; the four drift classifications (idle/append/truncate/rewrite); tail parsing offsets+indexes; dedup against existing turns; newline-less and genuinely-partial tail handling; idle-convergence regression guard; full-reparse fallback on rewrite; and an end-to-end reconcile proving append → `is_append_only` update → convergence. Pre-existing drift tests still pass. Green under `-race`.

> Perf change to hot reconcile code — requesting review before merge. No version bump here (decoupled from the in-flight v0.16.2 release).