### PR TITLE
fix(component): report Healthy when LoadRegistry is unwired (daemon)

### DIFF
--- a/internal/providers/component/component_provider.go
+++ b/internal/providers/component/component_provider.go
@@ -393,10 +393,15 @@ func (c *ComponentProvider) Health() reconcile.ResourceStatus {
 	}
 
 	if LoadRegistry == nil {
-		return reconcile.ResourceStatus{
-			Sync: reconcile.SyncStatusUnknown, Health: reconcile.HealthDegraded, Operation: reconcile.OperationIdle,
-			Message: "component registry loader not wired",
-		}
+		// Daemon context: LoadRegistry is wired only through the cog CLI DI
+		// seams, so in the daemon binary this provider is intentionally inert —
+		// LoadConfig returns nil and the reconcile cycle reports "in sync" with
+		// nothing to observe (see LoadConfig/FetchLive/ComputePlan above). Health
+		// must mirror that benign state: reporting Degraded here pins the
+		// autonomic engine on a standing degraded=1 and drives a needless LLM
+		// self-heal escalation every cycle for a provider that has nothing to
+		// reconcile in this context.
+		return reconcile.NewResourceStatus(reconcile.SyncStatusSynced, reconcile.HealthHealthy)
 	}
 
 	reg, err := LoadRegistry(root)

--- a/internal/providers/component/health_test.go
+++ b/internal/providers/component/health_test.go
@@ -1,0 +1,37 @@
+package component
+
+import (
+	"testing"
+
+	"github.com/myrgic/cogos/pkg/substrate/reconcile"
+)
+
+// TestHealthNilLoadRegistryIsHealthy verifies that the component provider reports
+// a benign Synced/Healthy status when LoadRegistry is nil.
+//
+// In the daemon binary LoadRegistry is intentionally nil (it is wired only
+// through the cog CLI DI seams), so the provider is inert: LoadConfig returns
+// nil and the reconcile cycle reports "in sync" with nothing to observe. Health
+// must mirror that state. Previously Health returned Degraded/Unknown here,
+// which pinned the autonomic engine on a standing degraded=1 and triggered a
+// needless LLM self-heal escalation on every reconcile cycle.
+func TestHealthNilLoadRegistryIsHealthy(t *testing.T) {
+	orig := LoadRegistry
+	LoadRegistry = nil
+	t.Cleanup(func() { LoadRegistry = orig })
+
+	c := &ComponentProvider{}
+	// LoadConfig sets the provider root; with LoadRegistry nil it returns
+	// (nil, nil), the same no-op path the daemon takes.
+	if _, err := c.LoadConfig(t.TempDir()); err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+
+	st := c.Health()
+	if st.Health != reconcile.HealthHealthy {
+		t.Errorf("Health = %v, want Healthy (inert provider in daemon context)", st.Health)
+	}
+	if st.Sync != reconcile.SyncStatusSynced {
+		t.Errorf("Sync = %v, want Synced", st.Sync)
+	}
+}


### PR DESCRIPTION
## Problem

In the **daemon** binary, the component provider's `LoadRegistry` is intentionally `nil` — it is wired only through the cog CLI DI seams. Every other method handles that nil state as a benign no-op: `LoadConfig` returns `nil`, and `FetchLive`/`ComputePlan`/`BuildState` short-circuit so the reconcile cycle reports **"in sync, nothing to observe."**

`Health()` was the lone exception: for the same nil state it returned `Health=Degraded, Sync=Unknown ("component registry loader not wired")`. So in the daemon the `component` provider is **permanently Degraded** — not because anything is wrong, but because `Health()` didn't mirror the rest of the provider.

On a live node this standing `degraded=1` makes the autonomic engine escalate to an LLM self-heal cycle on (nearly) every reconcile tick, for a provider that has nothing to reconcile in this context.

## Fix

`Health()` now returns `Synced/Healthy` when `LoadRegistry == nil`, consistent with `LoadConfig`/`FetchLive`/`ComputePlan`. One-line behavioral change; the real reconcile/plan paths are unchanged.

## Test

Adds `health_test.go`: with `LoadRegistry` nil (daemon context), `Health()` returns `Healthy`/`Synced`. (The `component` package had no tests previously.)