### PR TITLE
feat(reconcile): self-report per-provider reconcile anomalies

### DIFF
--- a/internal/engine/convergence_tracker.go
+++ b/internal/engine/convergence_tracker.go
@@ -1,0 +1,189 @@
+// convergence_tracker.go — per-provider reconcile anomaly self-reporting.
+//
+// The reconcile daemon runs every provider's cycle on each tick. This tracker
+// watches the resulting stream and self-reports providers that are misbehaving,
+// so a problem surfaces as a kernel WARN (and a queryable snapshot) instead of
+// requiring an operator to notice elevated CPU and hand-trace the logs.
+//
+// Two clean signals, covering the two failure classes seen in practice:
+//
+//   - Cost over budget: a provider whose reconcile cycle exceeds CycleBudget for
+//     OverBudgetCycles consecutive ticks. Catches a provider "eating CPU" — e.g.
+//     a FetchLive that reloads its whole index from disk every cycle.
+//   - Persistent degraded: a provider reporting Degraded health for
+//     DegradedCycles consecutive ticks. Catches a provider stuck unhealthy — e.g.
+//     a misreported Health() that pins the autonomic engine on a standing
+//     degraded=1.
+//
+// "Has changes for N cycles" is deliberately NOT a signal: an actively-used
+// provider (e.g. conversations indexing a live session) legitimately changes
+// every cycle, so it would false-positive constantly.
+//
+// Snapshot() exposes the current per-provider status. It is both the operator/
+// agent-queryable surface and a test oracle: an integration test can run the
+// daemon for N ticks and assert the runtime expression — no provider flagged, or
+// a deliberately-broken provider flagged — testing observed behaviour, not just
+// code paths.
+package engine
+
+import (
+	"log/slog"
+	"sort"
+	"sync"
+	"time"
+)
+
+// ConvergenceConfig tunes the anomaly thresholds. Zero values fall back to
+// withDefaults().
+type ConvergenceConfig struct {
+	// CycleBudget: a cycle slower than this counts as over budget.
+	CycleBudget time.Duration
+	// OverBudgetCycles: consecutive over-budget ticks before flagging.
+	OverBudgetCycles int
+	// DegradedCycles: consecutive Degraded-health ticks before flagging.
+	DegradedCycles int
+	// ReWarnEvery: while still flagged, re-emit the WARN every N ticks so a
+	// standing anomaly stays visible without spamming every tick.
+	ReWarnEvery int
+}
+
+func (c ConvergenceConfig) withDefaults() ConvergenceConfig {
+	if c.CycleBudget <= 0 {
+		c.CycleBudget = 500 * time.Millisecond
+	}
+	if c.OverBudgetCycles <= 0 {
+		c.OverBudgetCycles = 3
+	}
+	if c.DegradedCycles <= 0 {
+		c.DegradedCycles = 3
+	}
+	if c.ReWarnEvery <= 0 {
+		c.ReWarnEvery = 20
+	}
+	return c
+}
+
+// ProviderConvergence is a queryable snapshot of one provider's recent reconcile
+// behaviour.
+type ProviderConvergence struct {
+	Provider         string   `json:"provider"`
+	LastCycleMs      int64    `json:"last_cycle_ms"`
+	LastFetchMs      int64    `json:"last_fetch_ms"`
+	OverBudgetCycles int      `json:"over_budget_cycles"`
+	DegradedCycles   int      `json:"degraded_cycles"`
+	Flagged          bool     `json:"flagged"`
+	Reasons          []string `json:"reasons,omitempty"`
+}
+
+type provConvState struct {
+	lastCycleMs     int64
+	lastFetchMs     int64
+	overBudget      int
+	degraded        int
+	flagged         bool
+	cyclesSinceWarn int
+}
+
+func (s *provConvState) reasons(cfg ConvergenceConfig) []string {
+	var r []string
+	if s.overBudget >= cfg.OverBudgetCycles {
+		r = append(r, "over_budget")
+	}
+	if s.degraded >= cfg.DegradedCycles {
+		r = append(r, "degraded")
+	}
+	return r
+}
+
+// convergenceTracker accumulates per-provider reconcile-cycle outcomes and emits
+// a WARN when a provider crosses (or remains past) an anomaly threshold.
+// Thread-safe.
+type convergenceTracker struct {
+	cfg ConvergenceConfig
+	mu  sync.Mutex
+	st  map[string]*provConvState
+}
+
+func newConvergenceTracker(cfg ConvergenceConfig) *convergenceTracker {
+	return &convergenceTracker{
+		cfg: cfg.withDefaults(),
+		st:  make(map[string]*provConvState),
+	}
+}
+
+// Observe records the outcome of one provider reconcile cycle. cycleMs is the
+// full cycle duration; fetchMs is the FetchLive phase (the usual dominant cost);
+// degraded is whether the provider reported Degraded health this cycle.
+func (t *convergenceTracker) Observe(provider string, cycleMs, fetchMs int64, degraded bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	s := t.st[provider]
+	if s == nil {
+		s = &provConvState{}
+		t.st[provider] = s
+	}
+	s.lastCycleMs = cycleMs
+	s.lastFetchMs = fetchMs
+
+	if cycleMs > t.cfg.CycleBudget.Milliseconds() {
+		s.overBudget++
+	} else {
+		s.overBudget = 0
+	}
+	if degraded {
+		s.degraded++
+	} else {
+		s.degraded = 0
+	}
+
+	reasons := s.reasons(t.cfg)
+	if len(reasons) > 0 {
+		// Anomalous: warn on the transition into anomaly, then periodically.
+		if !s.flagged || s.cyclesSinceWarn >= t.cfg.ReWarnEvery {
+			slog.Warn("reconcile: provider anomaly",
+				"provider", provider,
+				"reasons", reasons,
+				"cycle_ms", cycleMs,
+				"fetch_ms", fetchMs,
+				"over_budget_cycles", s.overBudget,
+				"degraded_cycles", s.degraded,
+				"cycle_budget_ms", t.cfg.CycleBudget.Milliseconds(),
+			)
+			s.cyclesSinceWarn = 0
+		} else {
+			s.cyclesSinceWarn++
+		}
+		s.flagged = true
+		return
+	}
+
+	// Healthy this cycle: clear and announce recovery once.
+	if s.flagged {
+		slog.Info("reconcile: provider anomaly cleared", "provider", provider)
+	}
+	s.flagged = false
+	s.cyclesSinceWarn = 0
+}
+
+// Snapshot returns the current per-provider convergence status, sorted by
+// provider name for stable output. Safe to call concurrently.
+func (t *convergenceTracker) Snapshot() []ProviderConvergence {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	out := make([]ProviderConvergence, 0, len(t.st))
+	for name, s := range t.st {
+		out = append(out, ProviderConvergence{
+			Provider:         name,
+			LastCycleMs:      s.lastCycleMs,
+			LastFetchMs:      s.lastFetchMs,
+			OverBudgetCycles: s.overBudget,
+			DegradedCycles:   s.degraded,
+			Flagged:          s.flagged,
+			Reasons:          s.reasons(t.cfg),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Provider < out[j].Provider })
+	return out
+}

--- a/internal/engine/convergence_tracker_test.go
+++ b/internal/engine/convergence_tracker_test.go
@@ -1,0 +1,100 @@
+package engine
+
+import (
+	"testing"
+	"time"
+)
+
+func findConv(snap []ProviderConvergence, name string) (ProviderConvergence, bool) {
+	for _, s := range snap {
+		if s.Provider == name {
+			return s, true
+		}
+	}
+	return ProviderConvergence{}, false
+}
+
+func hasReason(s ProviderConvergence, reason string) bool {
+	for _, r := range s.Reasons {
+		if r == reason {
+			return true
+		}
+	}
+	return false
+}
+
+func TestConvergenceTracker_FlagsOverBudgetAfterThreshold(t *testing.T) {
+	tr := newConvergenceTracker(ConvergenceConfig{
+		CycleBudget:      100 * time.Millisecond,
+		OverBudgetCycles: 3,
+	})
+	// Two over-budget cycles: not yet flagged (threshold is 3).
+	tr.Observe("slow", 500, 480, false)
+	tr.Observe("slow", 500, 480, false)
+	if s, _ := findConv(tr.Snapshot(), "slow"); s.Flagged {
+		t.Fatalf("flagged after 2 cycles, want not flagged: %+v", s)
+	}
+	// Third over-budget cycle: flagged with the over_budget reason.
+	tr.Observe("slow", 500, 480, false)
+	s, ok := findConv(tr.Snapshot(), "slow")
+	if !ok || !s.Flagged || !hasReason(s, "over_budget") {
+		t.Fatalf("want flagged over_budget after 3 cycles, got %+v", s)
+	}
+	if s.LastFetchMs != 480 {
+		t.Errorf("LastFetchMs = %d, want 480 (dominant phase surfaced)", s.LastFetchMs)
+	}
+	// A cycle back under budget clears the flag.
+	tr.Observe("slow", 50, 40, false)
+	if s, _ := findConv(tr.Snapshot(), "slow"); s.Flagged {
+		t.Errorf("flag should clear when back under budget, got %+v", s)
+	}
+}
+
+func TestConvergenceTracker_FlagsPersistentDegraded(t *testing.T) {
+	tr := newConvergenceTracker(ConvergenceConfig{DegradedCycles: 3})
+	for i := 0; i < 3; i++ {
+		tr.Observe("component", 5, 0, true) // fast, but degraded health
+	}
+	s, ok := findConv(tr.Snapshot(), "component")
+	if !ok || !s.Flagged || !hasReason(s, "degraded") {
+		t.Fatalf("want flagged degraded after 3 cycles, got %+v", s)
+	}
+	// A healthy cycle clears it.
+	tr.Observe("component", 5, 0, false)
+	if s, _ := findConv(tr.Snapshot(), "component"); s.Flagged {
+		t.Errorf("flag should clear when healthy, got %+v", s)
+	}
+}
+
+func TestConvergenceTracker_HealthyFastProviderNeverFlags(t *testing.T) {
+	tr := newConvergenceTracker(ConvergenceConfig{
+		CycleBudget:      100 * time.Millisecond,
+		OverBudgetCycles: 3,
+		DegradedCycles:   3,
+	})
+	// An actively-changing provider that stays fast and healthy must never flag,
+	// even over many cycles — "has changes" is intentionally not a signal.
+	for i := 0; i < 25; i++ {
+		tr.Observe("conversations", 40, 20, false)
+	}
+	if s, _ := findConv(tr.Snapshot(), "conversations"); s.Flagged {
+		t.Errorf("fast healthy provider flagged, want never: %+v", s)
+	}
+}
+
+// TestReconcileDaemon_ConvergenceSurface exercises the public snapshot the way an
+// operator/agent (or a CI assertion) would: drive the daemon's tracker with
+// numbers matching the real conversations regression (~950ms FetchLive) and
+// assert it is surfaced as a flagged over_budget provider.
+func TestReconcileDaemon_ConvergenceSurface(t *testing.T) {
+	d := NewReconcileDaemon(ReconcileDaemonConfig{
+		Convergence: ConvergenceConfig{CycleBudget: 100 * time.Millisecond, OverBudgetCycles: 2},
+	})
+	d.health.Observe("conversations", 950, 920, false)
+	d.health.Observe("conversations", 1000, 960, false)
+
+	s, ok := findConv(d.ProviderConvergence(), "conversations")
+	if !ok || !s.Flagged || !hasReason(s, "over_budget") {
+		t.Fatalf("daemon should surface the slow provider via ProviderConvergence(), got %+v", d.ProviderConvergence())
+	}
+}

--- a/internal/engine/reconcile_daemon.go
+++ b/internal/engine/reconcile_daemon.go
@@ -72,6 +72,10 @@ type ReconcileDaemonConfig struct {
 	// providers). When nil, the daemon uses reconcile.ListProviders() as before.
 	// Production code leaves this nil; only testkernel sets it.
 	Providers []reconcile.Reconcilable
+
+	// Convergence tunes the per-provider anomaly thresholds (cost-over-budget
+	// and persistent-degraded). Zero values fall back to sensible defaults.
+	Convergence ConvergenceConfig
 }
 
 func (c *ReconcileDaemonConfig) withDefaults() ReconcileDaemonConfig {
@@ -105,6 +109,10 @@ type ReconcileDaemon struct {
 	triggerMu sync.Mutex
 	triggered map[string]struct{}
 	triggerCh chan struct{} // notifies the loop that triggers are queued
+
+	// health self-reports per-provider reconcile anomalies (slow cycles,
+	// persistent degraded health) as WARNs and a queryable snapshot.
+	health *convergenceTracker
 }
 
 // NewReconcileDaemon creates a ReconcileDaemon with the given config.
@@ -115,7 +123,23 @@ func NewReconcileDaemon(cfg ReconcileDaemonConfig) *ReconcileDaemon {
 		state:     ReconcileDaemonStarting,
 		triggered: make(map[string]struct{}),
 		triggerCh: make(chan struct{}, 1),
+		health:    newConvergenceTracker(cfg.Convergence),
 	}
+}
+
+// ProviderConvergence returns the current per-provider reconcile anomaly
+// snapshot (cost-over-budget / persistent-degraded). It is the queryable surface
+// for operators and agents, and a test oracle: assert on observed runtime
+// behaviour after running the daemon, not just on code paths.
+func (d *ReconcileDaemon) ProviderConvergence() []ProviderConvergence {
+	return d.health.Snapshot()
+}
+
+// observeConvergence feeds one completed cycle's cost and a fresh Health() read
+// (for the degraded axis) to the anomaly tracker.
+func (d *ReconcileDaemon) observeConvergence(providerType string, provider reconcile.Reconcilable, cycleMs, fetchMs int64) {
+	degraded := provider.Health().Health == reconcile.HealthDegraded
+	d.health.Observe(providerType, cycleMs, fetchMs, degraded)
 }
 
 // State returns the current lifecycle state of the daemon.
@@ -467,6 +491,7 @@ func (d *ReconcileDaemon) runOneCycle(ctx context.Context, providerType string) 
 			"plan_ms", planMs,
 			"duration_ms", dur.Milliseconds(),
 		)
+		d.observeConvergence(providerType, provider, dur.Milliseconds(), fetchMs)
 		return nil
 	}
 
@@ -533,6 +558,8 @@ func (d *ReconcileDaemon) runOneCycle(ctx context.Context, providerType string) 
 		"write_ms", writeMs,
 		"duration_ms", dur.Milliseconds(),
 	)
+
+	d.observeConvergence(providerType, provider, dur.Milliseconds(), fetchMs)
 
 	if applyFailed > 0 {
 		return fmt.Errorf("provider %s: %d action(s) failed during apply", providerType, applyFailed)


### PR DESCRIPTION
Follow-on to #389 (per-phase timing). With per-phase cost now recorded, *watch the stream* and self-report misbehaving providers — so a problem surfaces as a kernel WARN + a queryable snapshot instead of an operator noticing CPU and hand-tracing logs.

## Signals (two clean ones)

- **Cost over budget** — cycle slower than `CycleBudget` for `OverBudgetCycles` consecutive ticks. Catches a provider *eating CPU* (e.g. the conversations `FetchLive` full-index-reload, ~950ms/cycle).
- **Persistent degraded** — `Degraded` health for `DegradedCycles` consecutive ticks. Catches a provider *stuck unhealthy* (e.g. the component `Health()` misreport fixed in #388).

`HasChanges for N cycles` is deliberately **not** a signal: an actively-used provider (conversations indexing a live session) legitimately changes every cycle and would false-positive constantly.

Together these two would have **auto-surfaced both of this week's bugs** (conversations slow; component degraded) instead of requiring manual diagnosis.

## Surface = test oracle

`ReconcileDaemon.ProviderConvergence()` returns the per-provider snapshot. It's the operator/agent-queryable surface **and** a CI test oracle: assert observed runtime behaviour, not just code paths. `convergence_tracker_test.go` asserts the real ~950ms conversations regression *would* be flagged and a fast/healthy provider never is.

## Next (separate PRs)
- Emit the same signals as OTel **metrics** (the kernel already has a meter provider) → dashboards/alerts.
- A `cog_reconcile_stats` MCP tool over `ProviderConvergence()` so an agent can ask "what's expensive / not converging?".
- **Trace-based CI assertions** — run the daemon against a fixture corpus and assert no provider flags / phase budgets hold (your idea: test the runtime expression, catch regressions that don't match a code pattern).

No version bump (decoupled from the in-flight release).