### PR TITLE
perf(projection-compiler): cache cogblock.py parse by source content hash

### DIFF
--- a/internal/engine/projection_compiler.go
+++ b/internal/engine/projection_compiler.go
@@ -90,6 +90,12 @@ type CompilerConfig struct {
 
 // sourceCogdoc is the parsed in-memory representation of one reflective
 // cogdoc returned by FetchLive.
+//
+// IMMUTABLE after parseCogdoc returns: FetchLive caches and shares the same
+// *sourceCogdoc pointer across reconcile cycles (see parseCache), so downstream
+// consumers (ComputePlan, extractBlocks, ApplyPlan, BuildState) MUST treat it —
+// and its Frontmatter map and Blocks slice — as read-only. Mutating it would
+// corrupt the cached entry for every subsequent cycle.
 type sourceCogdoc struct {
 	// Path is the absolute filesystem path of the source cogdoc.
 	Path string
@@ -208,6 +214,20 @@ type ProjectionCompiler struct {
 	// lastEventCount is the number of events emitted in the most recent
 	// ApplyPlan run (new + changed + pointer).
 	lastEventCount int
+
+	// parseCache memoizes parseCogdoc results keyed on the source file's content
+	// hash, so FetchLive only re-spawns cogblock.py (a python subprocess — the
+	// dominant FetchLive cost) for files whose content actually changed. Guarded
+	// by mu. ComputePlan/ApplyPlan treat the *sourceCogdoc as read-only, so
+	// sharing the cached pointer across cycles is safe.
+	parseCache map[string]cachedCogdoc
+}
+
+// cachedCogdoc pairs a parsed source cogdoc with the content hash of the file
+// it was parsed from, for the projection-compiler FetchLive parse cache.
+type cachedCogdoc struct {
+	hash string
+	doc  *sourceCogdoc
 }
 
 // NewProjectionCompiler constructs a compiler in Progressing/Unknown health.
@@ -280,16 +300,44 @@ func (c *ProjectionCompiler) FetchLive(ctx context.Context, config any) (any, er
 	}
 
 	out := make([]*sourceCogdoc, 0, len(paths))
+	seen := make(map[string]struct{}, len(paths))
 	for _, p := range paths {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		default:
 		}
+		seen[p] = struct{}{}
+
+		// Change-detection by content hash: only re-spawn cogblock.py (the
+		// dominant cost) when the source bytes changed since we last parsed it.
+		// Reading a small .cog.md to hash it is far cheaper than the python
+		// subprocess it guards. A read failure falls through to a parse attempt
+		// (parseCogdoc surfaces its own error), preserving prior behaviour.
+		h, haveHash := "", false
+		if data, readErr := os.ReadFile(p); readErr == nil {
+			h, haveHash = sha256Hex(string(data)), true
+			c.mu.Lock()
+			cached, hit := c.parseCache[p]
+			c.mu.Unlock()
+			if hit && cached.hash == h {
+				out = append(out, cached.doc)
+				continue
+			}
+		}
+
 		doc, err := parseCogdoc(ctx, cfg.CogblockPath, p)
 		if err != nil {
 			slog.Warn("projection-compiler: parse failed", "path", p, "err", err)
 			continue
+		}
+		if haveHash {
+			c.mu.Lock()
+			if c.parseCache == nil {
+				c.parseCache = make(map[string]cachedCogdoc)
+			}
+			c.parseCache[p] = cachedCogdoc{hash: h, doc: doc}
+			c.mu.Unlock()
 		}
 		out = append(out, doc)
 	}
@@ -299,6 +347,12 @@ func (c *ProjectionCompiler) FetchLive(ctx context.Context, config any) (any, er
 
 	c.mu.Lock()
 	c.lastSourceCount = len(out)
+	// Evict cache entries for sources that no longer exist (deleted/renamed).
+	for p := range c.parseCache {
+		if _, ok := seen[p]; !ok {
+			delete(c.parseCache, p)
+		}
+	}
 	c.mu.Unlock()
 
 	return out, nil

--- a/internal/engine/projection_compiler_test.go
+++ b/internal/engine/projection_compiler_test.go
@@ -445,3 +445,62 @@ func TestProjectionCompiler_HealthInitiallyProgressing(t *testing.T) {
 		t.Errorf("initial Health = %q, want %q", got, reconcile.HealthProgressing)
 	}
 }
+
+// TestProjectionCompiler_FetchLiveParseCache verifies FetchLive memoizes the
+// (expensive) cogblock.py parse: an unchanged source is served from cache (same
+// *sourceCogdoc pointer, no python re-spawn), and a changed source is re-parsed
+// (new pointer). This is the fix for the ~1.5s/cycle FetchLive cost from
+// re-spawning python for every source on every reconcile cycle.
+func TestProjectionCompiler_FetchLiveParseCache(t *testing.T) {
+	skipIfNoPython(t)
+	root := stageRoot(t)
+	c := NewProjectionCompiler()
+
+	// Copy a fixture cogdoc into a writable source we can mutate.
+	orig, err := os.ReadFile(fixturePath(t, "2026-05-19-chaz-substrate-physics-sequence.cog.md"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	srcPath := filepath.Join(root, ".cog", "mem", "reflective", "cache_test.cog.md")
+	if err := os.WriteFile(srcPath, orig, 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	cfgAny, err := c.LoadConfig(root)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	cfg := cfgAny.(*CompilerConfig)
+	cfg.SourceFiles = []string{srcPath}
+	ctx := context.Background()
+
+	docs1 := mustFetchOne(t, c, ctx, cfg)
+
+	// Unchanged → cache hit → identical pointer (no re-parse).
+	docs2 := mustFetchOne(t, c, ctx, cfg)
+	if docs2[0] != docs1[0] {
+		t.Errorf("unchanged source re-parsed; want cache hit (same *sourceCogdoc pointer)")
+	}
+
+	// Changed → cache miss → re-parsed → new pointer.
+	if err := os.WriteFile(srcPath, append(append([]byte{}, orig...), "\n\n## Coda\n\nappended.\n"...), 0o644); err != nil {
+		t.Fatalf("modify source: %v", err)
+	}
+	docs3 := mustFetchOne(t, c, ctx, cfg)
+	if docs3[0] == docs1[0] {
+		t.Errorf("changed source served from stale cache; want re-parse (new pointer)")
+	}
+}
+
+func mustFetchOne(t *testing.T, c *ProjectionCompiler, ctx context.Context, cfg *CompilerConfig) []*sourceCogdoc {
+	t.Helper()
+	live, err := c.FetchLive(ctx, cfg)
+	if err != nil {
+		t.Fatalf("FetchLive: %v", err)
+	}
+	docs := live.([]*sourceCogdoc)
+	if len(docs) != 1 {
+		t.Fatalf("want 1 doc, got %d", len(docs))
+	}
+	return docs
+}


### PR DESCRIPTION
## Problem

`projection-compiler.FetchLive` ran `python3 cogblock.py parse <path>` — one subprocess per source cogdoc — on **every** reconcile cycle (~1.5s with the current corpus, on both the reconcile daemon and the autonomic ticker). The convergence self-reporter (#391) flagged it as the next over-budget provider after the conversations `FetchLive` fix (#392). Sources rarely change, so the parse is almost always redundant.

## Fix

Memoize parse results in a per-source cache keyed on the file's **content hash**: FetchLive reads each `.cog.md` (cheap), and only re-spawns `cogblock.py` when the bytes changed since the last parse. Unchanged sources reuse the cached `*sourceCogdoc`. Cache entries for deleted/renamed sources are evicted. `parseCache` is `mu`-guarded; the lock is released around the subprocess.

## Correctness

The cached `*sourceCogdoc` is shared across cycles, so the safety hinge is that it's read-only downstream. An adversarial review confirmed every consumer (`ComputePlan`, `extractBlocks`, `ApplyPlan`, `BuildState`) reads — none mutate the doc, its `Frontmatter` map, or its `Blocks` slice — and all `parseCache` access is mu-guarded with the lock dropped around the python call (no crash race, the documented daemon+ticker concurrent-FetchLive hazard handled). A type-level `IMMUTABLE` comment guards against a future doc-mutating refactor.

## Tests

`TestProjectionCompiler_FetchLiveParseCache`: unchanged source → cache hit (same `*sourceCogdoc` pointer, no re-parse); changed source → re-parse (new pointer). All existing projection-compiler acceptance tests pass.

No version bump (decoupled from the in-flight release).