### PR TITLE
ci(release): drop darwin-amd64 from the release matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,11 +47,13 @@ jobs:
             runner: macos-14
             cgo: '1'
             tags: 'fts5'
-          - goos: darwin
-            goarch: amd64
-            runner: macos-13
-            cgo: '1'
-            tags: 'fts5'
+          # darwin-amd64 (Intel Mac) intentionally dropped from releases: GitHub's
+          # macos-13 runners chronically sit queued for hours, wedging the whole
+          # release (the release job needs the full build matrix) — this cancelled
+          # v0.16.1 after 24h and stalled v0.16.2. Release targets are arm64 Mac +
+          # linux. Re-add this entry when an Intel-Mac target / reliable runner is
+          # needed. (The Makefile `all` target still cross-builds darwin-amd64 for
+          # local use.)
           # Windows: CGO_ENABLED=0 matches the Makefile (avoids tree-sitter's
           # CGO path). FTS5 is unavailable in this build; Windows is not a
           # kernel-daemon target, so dark-search does not apply to it.


### PR DESCRIPTION
The `release` job `needs` the full build matrix, but GitHub's **macos-13 runners chronically sit queued for hours** — so the `darwin-amd64` (Intel Mac) build wedges every release. This **cancelled v0.16.1 after 24h** and has **stalled v0.16.2** (CI + 5/6 platform builds passed; darwin-amd64 queued indefinitely; the release never fires).

Drop `darwin-amd64` from the release matrix. Release targets become **arm64 Mac + linux (+ windows)** — which match where the kernel actually runs (Apple Silicon + linux k8s). The Makefile `all` target still cross-builds `darwin-amd64` for anyone who needs a local Intel binary; re-add the matrix entry when there's a real Intel-Mac target or a reliable runner.

Reversible one-entry change.