### PR TITLE
chore: bump version to 0.16.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 #   make e2e      - Run e2e test in a container
 #   make e2e-local - Run e2e test locally
 
-VERSION := 0.16.2
+VERSION := 0.16.3
 BUILD_TIME := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -s -w -X github.com/myrgic/cogos/internal/engine.BuildTime=$(BUILD_TIME) -X github.com/myrgic/cogos/internal/engine.Version=$(VERSION)
 BUILD_TAGS := fts5


### PR DESCRIPTION
Cuts **v0.16.3**, shipping the accumulated work since v0.16.2 (whose release wedged on the macos-13 runner, now fixed in #394):

- #386 conversations: quarantine unsent `user-draft` records
- #388 component: report Healthy when `LoadRegistry` is unwired
- #389 reconcile: per-phase timing
- #391 reconcile: per-provider convergence self-reporter
- #392 conversations: skip FetchLive reload when index unchanged (~950ms→~3ms)
- #393 projection-compiler: cache cogblock.py parse by content hash (~1.5s→~few ms)
- #394 ci(release): drop darwin-amd64 (unblocks releases)

After merge: tag `v0.16.3` to fire the (now-unblocked) release.