### PR TITLE
fix(security): contain caller-supplied paths on the HTTP+MCP surface

### DIFF
--- a/internal/engine/bus_session.go
+++ b/internal/engine/bus_session.go
@@ -153,6 +153,9 @@ func computeBusBlockHash(block *BusBlock) string {
 // EnsureBus creates the bus directory + events.jsonl if they don't exist.
 // Safe to call multiple times.
 func (m *BusSessionManager) EnsureBus(busID string) error {
+	if !validPathComponent(busID) {
+		return fmt.Errorf("invalid bus_id %q", busID)
+	}
 	busDir := filepath.Join(m.BusesDir(), busID)
 	if err := os.MkdirAll(busDir, 0755); err != nil {
 		return fmt.Errorf("create bus dir: %w", err)
@@ -415,6 +418,9 @@ func (m *BusSessionManager) updateRegistrySeqLocked(busID string, seq int, ts st
 // ReadEvents reads all events from a bus. De-dups by seq (file may have
 // duplicates from crash recovery).
 func (m *BusSessionManager) ReadEvents(busID string) ([]BusBlock, error) {
+	if !validPathComponent(busID) {
+		return nil, fmt.Errorf("invalid bus_id %q", busID)
+	}
 	eventsFile := m.EventsPath(busID)
 	f, err := os.Open(eventsFile)
 	if err != nil {

--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -1352,7 +1352,10 @@ func slugFromPath(path string) string {
 // WriteCogDoc writes a CogDoc to the memory filesystem with proper frontmatter.
 // This is the internal API used by the ingestion pipeline.
 func WriteCogDoc(workspaceRoot string, path string, opts CogDocWriteOpts) (string, error) {
-	fullPath := filepath.Join(workspaceRoot, ".cog", "mem", path)
+	fullPath, perr := containedJoin(filepath.Join(workspaceRoot, ".cog", "mem"), path)
+	if perr != nil {
+		return "", fmt.Errorf("write cogdoc: %w", perr)
+	}
 
 	// Ensure directory exists
 	dir := filepath.Dir(fullPath)

--- a/internal/engine/memory_sections.go
+++ b/internal/engine/memory_sections.go
@@ -215,28 +215,41 @@ func splitFrontmatter(content string) (fmText, body string, hasFM bool) {
 // path. Handles memory-relative paths (`.cog/mem/...`), workspace-relative
 // paths, absolute paths, and memory-bare paths (e.g. `semantic/foo.md`).
 // Mirrors legacy memory.go:resolveDocPath:769.
-func resolveMemoryDocPath(path, cogRoot string) string {
+func resolveMemoryDocPath(path, cogRoot string) (string, error) {
+	// This resolver feeds both reads (cog_memory_toc) and writes
+	// (cog_memory_index) from caller-supplied paths, so an unconstrained path is
+	// an arbitrary-filesystem primitive on the MCP surface. Reject absolute input
+	// and contain every resolution branch within the workspace root (the function
+	// legitimately reaches workspace-relative files like .cog/ontology, so the
+	// boundary is cogRoot, not .cog/mem).
 	if filepath.IsAbs(path) {
-		return path
+		return "", fmt.Errorf("memory doc path %q: absolute paths not permitted", path)
 	}
+
 	memoryDir := filepath.Join(cogRoot, ".cog", "mem")
-	if strings.Contains(path, "/.cog/mem/") {
+	var candidate string
+	switch {
+	case strings.Contains(path, "/.cog/mem/"):
 		parts := strings.SplitN(path, "/.cog/mem/", 2)
-		if len(parts) == 2 {
-			return filepath.Join(memoryDir, parts[1])
+		candidate = filepath.Join(memoryDir, parts[1])
+	case strings.HasPrefix(path, ".cog/mem/"):
+		candidate = filepath.Join(memoryDir, strings.TrimPrefix(path, ".cog/mem/"))
+	default:
+		// Try workspace-relative first (some paths like
+		// `.cog/ontology/crystal.cog.md` live outside `.cog/mem/`), else
+		// fall back to memory-relative.
+		wsPath := filepath.Join(cogRoot, path)
+		if _, err := os.Stat(wsPath); err == nil {
+			candidate = wsPath
+		} else {
+			candidate = filepath.Join(memoryDir, path)
 		}
 	}
-	if after, ok := strings.CutPrefix(path, ".cog/mem/"); ok {
-		return filepath.Join(memoryDir, after)
+
+	if !pathWithin(cogRoot, candidate) {
+		return "", fmt.Errorf("memory doc path %q escapes workspace", path)
 	}
-	// Try as workspace-relative first (mirrors legacy: some paths like
-	// `.cog/ontology/crystal.cog.md` live outside `.cog/mem/`).
-	wsPath := filepath.Join(cogRoot, path)
-	if _, err := os.Stat(wsPath); err == nil {
-		return wsPath
-	}
-	// Fall back to memory-relative.
-	return filepath.Join(memoryDir, path)
+	return filepath.Clean(candidate), nil
 }
 
 // readCogDocContentV3 is the side-effect-free read used by MemoryTOC and
@@ -245,7 +258,10 @@ func resolveMemoryDocPath(path, cogRoot string) string {
 // The v3-specific suffix avoids clashing with any future kernel-wide
 // read helper.
 func readCogDocContentV3(cogRoot, path string) (string, error) {
-	fullPath := resolveMemoryDocPath(path, cogRoot)
+	fullPath, perr := resolveMemoryDocPath(path, cogRoot)
+	if perr != nil {
+		return "", perr
+	}
 	data, err := os.ReadFile(fullPath)
 	if err != nil {
 		return "", fmt.Errorf("file not found: %s", path)
@@ -465,7 +481,10 @@ func MemoryIndex(cogRoot, path string, dryRun bool) (string, error) {
 
 	newContent := "---\n" + newFM + "---\n" + body
 
-	fullPath := resolveMemoryDocPath(path, cogRoot)
+	fullPath, perr := resolveMemoryDocPath(path, cogRoot)
+	if perr != nil {
+		return "", perr
+	}
 	if err := atomicWriteMemoryFile(fullPath, []byte(newContent), 0644); err != nil {
 		return "", fmt.Errorf("failed to write: %w", err)
 	}

--- a/internal/engine/memory_sections_test.go
+++ b/internal/engine/memory_sections_test.go
@@ -237,16 +237,28 @@ func TestResolveMemoryDocPath_Variants(t *testing.T) {
 	}
 
 	cases := []struct {
-		name string
-		in   string
-		want string
+		name    string
+		in      string
+		want    string
+		wantErr bool
 	}{
-		{"absolute", "/some/absolute/path.md", "/some/absolute/path.md"},
-		{"dotcog-mem-prefix", ".cog/mem/semantic/foo.md", filepath.Join(memDir, "semantic/foo.md")},
-		{"bare-memory-relative", "semantic/insights/foo.cog.md", filepath.Join(memDir, "semantic/insights/foo.cog.md")},
+		// Absolute input is now rejected (was an arbitrary-FS pass-through).
+		{"absolute-rejected", "/some/absolute/path.md", "", true},
+		{"dotcog-mem-prefix", ".cog/mem/semantic/foo.md", filepath.Join(memDir, "semantic/foo.md"), false},
+		{"bare-memory-relative", "semantic/insights/foo.cog.md", filepath.Join(memDir, "semantic/insights/foo.cog.md"), false},
 	}
 	for _, tc := range cases {
-		got := resolveMemoryDocPath(tc.in, root)
+		got, err := resolveMemoryDocPath(tc.in, root)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("%s: got %q, want error", tc.name, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", tc.name, err)
+			continue
+		}
 		if got != tc.want {
 			t.Errorf("%s: got %q; want %q", tc.name, got, tc.want)
 		}
@@ -264,7 +276,10 @@ func TestResolveMemoryDocPath_WorkspaceRelativePreferred(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(root, ".cog", "ontology", "crystal.cog.md"), []byte("# Crystal\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	got := resolveMemoryDocPath(".cog/ontology/crystal.cog.md", root)
+	got, err := resolveMemoryDocPath(".cog/ontology/crystal.cog.md", root)
+	if err != nil {
+		t.Fatal(err)
+	}
 	want := filepath.Join(root, ".cog", "ontology", "crystal.cog.md")
 	if got != want {
 		t.Errorf("got %q; want %q", got, want)

--- a/internal/engine/path_safety.go
+++ b/internal/engine/path_safety.go
@@ -1,0 +1,50 @@
+// path_safety.go — containment helpers for caller-supplied path input.
+//
+// The kernel's HTTP + MCP surface treats callers as "trusted local", but every
+// place that builds a filesystem path from caller input (cogdoc paths, cog: URI
+// components, bus ids) is still an arbitrary-read/write surface if the input can
+// escape its intended base via "../" or an absolute path. These helpers give one
+// consistent guard for those sites.
+package engine
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// pathWithin reports whether full (after cleaning) is base itself or strictly
+// inside base. The trailing-separator suffix means a sibling like "<base>-evil"
+// does NOT count as within "<base>". This is a LEXICAL check — it does not
+// resolve symlinks, so it assumes no attacker-plantable symlink already exists
+// under base (planting one requires a prior write primitive, i.e. second-order).
+func pathWithin(base, full string) bool {
+	cb := filepath.Clean(base)
+	cf := filepath.Clean(full)
+	return cf == cb || strings.HasPrefix(cf, cb+string(filepath.Separator))
+}
+
+// containedJoin joins base with the untrusted relative component rel and returns
+// the cleaned result only if it stays within base — defeating "../" traversal
+// (absolute input is absorbed by Join and stays contained). base is trusted; rel
+// is caller input. Lexical containment only — see pathWithin.
+func containedJoin(base, rel string) (string, error) {
+	full := filepath.Join(base, rel)
+	if !pathWithin(base, full) {
+		return "", fmt.Errorf("path %q escapes base %q", rel, base)
+	}
+	return filepath.Clean(full), nil
+}
+
+// validPathComponent reports whether s is safe to use as a single path segment
+// (e.g. a bus id that becomes a directory name): non-empty, not "."/"..", and
+// containing no separators, parent refs, or null bytes.
+func validPathComponent(s string) bool {
+	if s == "" || s == "." || s == ".." {
+		return false
+	}
+	if strings.ContainsAny(s, "/\\\x00") {
+		return false
+	}
+	return !strings.Contains(s, "..")
+}

--- a/internal/engine/path_safety_test.go
+++ b/internal/engine/path_safety_test.go
@@ -1,0 +1,69 @@
+package engine
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestContainedJoin(t *testing.T) {
+	base := filepath.FromSlash("/ws/.cog/mem")
+
+	ok := map[string]string{
+		"semantic/foo.cog.md": "/ws/.cog/mem/semantic/foo.cog.md",
+		"foo.cog.md":          "/ws/.cog/mem/foo.cog.md",
+		"a/../b.md":           "/ws/.cog/mem/b.md",       // resolves within base
+		"":                    "/ws/.cog/mem",            // empty rel = base
+		"/etc/passwd":         "/ws/.cog/mem/etc/passwd", // absolute input is absorbed/contained by Join, not an escape
+	}
+	for rel, want := range ok {
+		got, err := containedJoin(base, rel)
+		if err != nil {
+			t.Errorf("containedJoin(base, %q) unexpected err: %v", rel, err)
+			continue
+		}
+		if got != filepath.FromSlash(want) {
+			t.Errorf("containedJoin(base, %q) = %q, want %q", rel, got, want)
+		}
+	}
+
+	for _, rel := range []string{"../config/kernel.yaml", "../../etc/passwd", "a/../../escape"} {
+		if got, err := containedJoin(base, rel); err == nil {
+			t.Errorf("containedJoin(base, %q) = %q, want escape error", rel, got)
+		}
+	}
+}
+
+func TestValidPathComponent(t *testing.T) {
+	for _, s := range []string{"bus_dashboard_chat", "bus_traces", "abc123", "a-b_c.d"} {
+		if !validPathComponent(s) {
+			t.Errorf("validPathComponent(%q) = false, want true", s)
+		}
+	}
+	for _, s := range []string{"", ".", "..", "../config", "a/b", "a\\b", "..\\x", "x/..", string([]byte{0})} {
+		if validPathComponent(s) {
+			t.Errorf("validPathComponent(%q) = true, want false", s)
+		}
+	}
+}
+
+// TestResolveMemoryDocPath_Containment covers the cog_memory_index/cog_memory_toc
+// gap the adversarial review found: absolute pass-through + unfiltered "..".
+func TestResolveMemoryDocPath_Containment(t *testing.T) {
+	root := t.TempDir()
+
+	if got, err := resolveMemoryDocPath("/etc/passwd", root); err == nil {
+		t.Errorf("absolute path resolved to %q, want error", got)
+	}
+	for _, p := range []string{"../../../etc/passwd", ".cog/mem/../../../etc/shadow"} {
+		if got, err := resolveMemoryDocPath(p, root); err == nil {
+			t.Errorf("resolveMemoryDocPath(%q) = %q, want escape error", p, got)
+		}
+	}
+	got, err := resolveMemoryDocPath("semantic/foo.cog.md", root)
+	if err != nil {
+		t.Fatalf("legit path errored: %v", err)
+	}
+	if !pathWithin(filepath.Join(root, ".cog", "mem"), got) {
+		t.Errorf("legit path = %q, want within .cog/mem", got)
+	}
+}

--- a/internal/engine/uri.go
+++ b/internal/engine/uri.go
@@ -266,6 +266,12 @@ func ResolveURI(workspaceRoot, uri string) (*URIResolution, error) {
 
 // resolveProjection applies a Projection to produce an absolute filesystem path.
 func resolveProjection(workspaceRoot string, proj *Projection, uriPath string) (string, error) {
+	// Reject path traversal in the untrusted URI component before it reaches the
+	// filepath.Join sites below (direct/directory/glob all interpolate uriPath).
+	if strings.Contains(uriPath, "..") || filepath.IsAbs(uriPath) {
+		return "", fmt.Errorf("cog uri path %q: traversal not permitted", uriPath)
+	}
+
 	// Compute base directory.
 	var base string
 	if proj.ExtBase != "" {


### PR DESCRIPTION
From the codebase audit (`AUDIT-2026-06-24.md`) — the highest-severity real cluster.

## Problem

The kernel's HTTP/MCP surface on `:6931` treats callers as trusted-local, but three sites built filesystem paths from caller input via `filepath.Join` with **no containment check**, each an arbitrary read/write surface via `../` traversal:

- **`WriteCogDoc` / `cog_write_cogdoc`** (`mcp_server.go`) — a `path` could escape `.cog/mem`, including into the transition-hooks dir → **code execution on next kernel restart** (`transition_hooks.go` runs `sh -c` on workspace-declared hooks). Containing the write breaks that RCE chain.
- **`resolveProjection` cog: URIs** (`uri.go`) — direct/directory/glob interpolate the URI path, so `mem/../../config/kernel.yaml` could **read/patch any file** via `/v1/resolve`, `cog_read_cogdoc`, `cog_patch_frontmatter`.
- **`bus_id` as a path component** (`bus_session.go` `EnsureBus`/`ReadEvents`) — `bus_id=../../x` from `POST /v1/bus/*` could mkdir+write a JSONL anywhere under the workspace.

## Fix

New `path_safety.go`:
- `containedJoin(base, rel)` — `filepath.Clean` + base-prefix check (absolute input is absorbed by `Join` and stays contained, not an escape).
- `validPathComponent(s)` — single-segment ids: rejects separators, parent-refs, nul.

Applied the matching guard at each site. Mirrors the containment your `MemoryWrite`-style sites already use. `path_safety_test.go` covers `../` rejection and the absolute-path-containment nuance.

> Security-critical — under adversarial review (bypass / completeness / no-broken-legit-paths) in parallel; will fold in any gap before merge. No version bump.