### PR TITLE
fix(engine): cap kernel log growth and stop procmgr map/goroutine leaks

### DIFF
--- a/internal/engine/log_capture.go
+++ b/internal/engine/log_capture.go
@@ -26,9 +26,19 @@ package engine
 
 import (
 	"context"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
+)
+
+// Kernel log rotation bounds for the JSONL sink. Exposed as vars so tests can
+// shrink them; COG_KERNEL_LOG_MAX_MB overrides the size cap at runtime. With the
+// defaults the sink is capped at roughly maxBackups+1 × 64 MB on disk.
+var (
+	kernelLogMaxBytes   int64 = 64 * 1024 * 1024 // rotate the active file past 64 MB
+	kernelLogMaxBackups       = 5                // keep 5 rotated copies (~384 MB total)
 )
 
 // DefaultKernelLogPath returns the default per-workspace path for the kernel
@@ -75,8 +85,9 @@ func (h *teeHandler) WithGroup(name string) slog.Handler {
 
 // newTeeHandler constructs a teeHandler that writes text to textSink and JSON
 // to jsonSink at the supplied level. Exported for tests; production callers
-// use upgradeLoggerWithFileSink.
-func newTeeHandler(textSink, jsonSink *os.File, level slog.Level) *teeHandler {
+// use upgradeLoggerWithFileSink. jsonSink is an io.Writer so production can pass
+// a rotatingWriter while tests pass a bytes.Buffer or *os.File.
+func newTeeHandler(textSink, jsonSink io.Writer, level slog.Level) *teeHandler {
 	opts := &slog.HandlerOptions{Level: level}
 	return &teeHandler{
 		text: slog.NewTextHandler(textSink, opts),
@@ -93,8 +104,10 @@ func newTeeHandler(textSink, jsonSink *os.File, level slog.Level) *teeHandler {
 // the file sink is logged as a Warn via the stderr-only fallback logger and
 // the function returns without altering the default logger.
 //
-// The file handle is intentionally never Close()'d; it lives for the kernel's
-// process lifetime. Exit flushes via the OS.
+// The sink is a size-rotating writer (see rotating_writer.go): the active file
+// is capped at kernelLogMaxBytes and rotated to <path>.1..N, so the sink no
+// longer grows without bound. The writer is intentionally never Close()'d; it
+// lives for the kernel's process lifetime and the OS flushes on exit.
 func upgradeLoggerWithFileSink(cfg *Config) {
 	if cfg == nil {
 		return
@@ -110,13 +123,14 @@ func upgradeLoggerWithFileSink(cfg *Config) {
 		path = DefaultKernelLogPath(cfg.WorkspaceRoot)
 	}
 
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		slog.Warn("kernel log: cannot create dir; continuing with stderr-only logger",
-			"path", path, "err", err)
-		return
+	maxBytes := kernelLogMaxBytes
+	if v := os.Getenv("COG_KERNEL_LOG_MAX_MB"); v != "" {
+		if mb, perr := strconv.ParseInt(v, 10, 64); perr == nil && mb > 0 {
+			maxBytes = mb * 1024 * 1024
+		}
 	}
 
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	w, err := newRotatingWriter(path, maxBytes, kernelLogMaxBackups)
 	if err != nil {
 		slog.Warn("kernel log: cannot open sink; continuing with stderr-only logger",
 			"path", path, "err", err)
@@ -124,7 +138,7 @@ func upgradeLoggerWithFileSink(cfg *Config) {
 	}
 	// Intentionally not closed — lives for kernel lifetime.
 
-	tee := newTeeHandler(os.Stderr, f, level)
+	tee := newTeeHandler(os.Stderr, w, level)
 	slog.SetDefault(slog.New(tee))
-	slog.Info("kernel log: file sink active", "path", path)
+	slog.Info("kernel log: file sink active", "path", path, "max_bytes", maxBytes, "max_backups", kernelLogMaxBackups)
 }

--- a/internal/engine/procmgr.go
+++ b/internal/engine/procmgr.go
@@ -19,11 +19,23 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"sort"
 	"sync"
 	"syscall"
 	"time"
 
 	"github.com/google/uuid"
+)
+
+// Retention bounds for finished processes. Without eviction the processes map
+// grew without bound: Finish marked background processes complete but never
+// deleted them, so every background dispatch leaked an entry for the kernel's
+// lifetime. Finished entries are kept briefly for observability (List/Stats)
+// then reaped; a hard cap backstops pathological bursts. Vars (not consts) so
+// tests can shrink them; production never reassigns them.
+var (
+	finishedRetention   = 15 * time.Minute
+	maxTrackedProcesses = 512
 )
 
 // ProcessKind classifies how a process is managed.
@@ -111,6 +123,34 @@ func (p *ManagedProcess) SetError(err error) {
 	}
 }
 
+// loadStatus returns Status under p.mu. Status is mutated under p.mu by
+// SetError/Finish/Kill, so every reader outside those methods must go through
+// here (or snapshot) rather than touching p.Status directly — otherwise the
+// read races the write. Immutable fields (ID, Kind, Source, Identity,
+// StartedAt, CallbackChannel) are set once in Track and safe to read directly.
+func (p *ManagedProcess) loadStatus() ProcessStatus {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.Status
+}
+
+// snapshot returns the mutable fields (Status, FinishedAt, Error) consistently
+// under p.mu. FinishedAt's pointee is written once in Finish and never mutated
+// after, so returning the pointer is safe.
+func (p *ManagedProcess) snapshot() (ProcessStatus, *time.Time, string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.Status, p.FinishedAt, p.Error
+}
+
+// terminal reports whether the process has reached a finished state, i.e. it is
+// no longer running. Read under p.mu.
+func (p *ManagedProcess) terminal() (bool, *time.Time) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.Status != ProcessRunning, p.FinishedAt
+}
+
 // ManagedProcessOpts configures tracking for a new process.
 type ManagedProcessOpts struct {
 	Kind            ProcessKind
@@ -186,6 +226,7 @@ func (pm *ProcessManager) Track(cmd *exec.Cmd, opts ManagedProcessOpts) *Managed
 	}
 
 	pm.processes[proc.ID] = proc
+	pm.reapLocked()
 
 	slog.Info("procmgr: tracked",
 		"id", proc.ID[:8],
@@ -197,11 +238,57 @@ func (pm *ProcessManager) Track(cmd *exec.Cmd, opts ManagedProcessOpts) *Managed
 	return proc
 }
 
-// Remove unregisters a process. Called when a foreground process completes.
+// reapLocked evicts finished processes so the map can't grow without bound.
+// Caller must hold pm.mu (write). Entries terminal longer than
+// finishedRetention are dropped; if the map is still over maxTrackedProcesses,
+// the oldest-finished entries are dropped until it fits. Running processes are
+// never evicted. Per-process state is read under proc.mu (lock order: pm.mu
+// then proc.mu, matching Finish).
+func (pm *ProcessManager) reapLocked() {
+	now := time.Now()
+	type finishedProc struct {
+		id string
+		at time.Time
+	}
+	var finished []finishedProc
+	for id, proc := range pm.processes {
+		done, at := proc.terminal()
+		if !done {
+			continue
+		}
+		when := now
+		if at != nil {
+			when = *at
+		}
+		if now.Sub(when) > finishedRetention {
+			delete(pm.processes, id)
+			continue
+		}
+		finished = append(finished, finishedProc{id: id, at: when})
+	}
+
+	if len(pm.processes) <= maxTrackedProcesses {
+		return
+	}
+	// Still over the hard cap after the age sweep — drop oldest-finished first.
+	sort.Slice(finished, func(i, j int) bool { return finished[i].at.Before(finished[j].at) })
+	for _, f := range finished {
+		if len(pm.processes) <= maxTrackedProcesses {
+			break
+		}
+		delete(pm.processes, f.id)
+	}
+}
+
+// Remove unregisters a process. Called when a foreground process completes or
+// when a background process fails to start. Deletes unconditionally — the
+// caller is asserting it no longer needs the entry tracked. (Normal background
+// completion goes through Finish, which retains the entry briefly for
+// observability before reapLocked evicts it.)
 func (pm *ProcessManager) Remove(id string) {
 	pm.mu.Lock()
 	proc, ok := pm.processes[id]
-	if ok && proc.Kind == ProcessForeground {
+	if ok {
 		delete(pm.processes, id)
 	}
 	pm.mu.Unlock()
@@ -225,6 +312,9 @@ func (pm *ProcessManager) Finish(id string) {
 		proc.FinishedAt = &now
 		proc.mu.Unlock()
 		callback = pm.onComplete
+		// Evict stale finished entries now that we've added one. The just-
+		// finished proc is within finishedRetention, so it survives this sweep.
+		pm.reapLocked()
 	}
 	pm.mu.Unlock()
 
@@ -237,7 +327,7 @@ func (pm *ProcessManager) Finish(id string) {
 		slog.Info("procmgr: finished",
 			"id", id[:8],
 			"kind", proc.Kind,
-			"status", proc.Status,
+			"status", proc.loadStatus(),
 			"duration", time.Since(proc.StartedAt).Round(time.Millisecond),
 		)
 	}
@@ -269,7 +359,12 @@ func (pm *ProcessManager) Kill(id string) {
 		_ = proc.cmd.Process.Signal(syscall.SIGTERM)
 		go func() {
 			time.Sleep(5 * time.Second)
-			if proc.cmd.ProcessState == nil || !proc.cmd.ProcessState.Exited() {
+			// Liveness probe via signal 0 instead of reading proc.cmd.ProcessState:
+			// ProcessState is written by cmd.Wait() in another goroutine, so
+			// reading it here is a data race. Signal goes through os.Process'
+			// own synchronization and returns an error once the process has been
+			// reaped, so a nil error means "still alive → escalate to SIGKILL".
+			if err := proc.cmd.Process.Signal(syscall.Signal(0)); err == nil {
 				slog.Warn("procmgr: SIGKILL escalation", "id", id[:8])
 				_ = proc.cmd.Process.Signal(os.Kill)
 			}
@@ -283,11 +378,10 @@ func (pm *ProcessManager) KillBySource(source string) int {
 	pm.mu.RLock()
 	var targets []string
 	for id, proc := range pm.processes {
-		if proc.Source == source && proc.Status == ProcessRunning {
+		// Source/Kind are immutable; Status is read under proc.mu.
+		if proc.Source == source && proc.Kind == ProcessForeground && proc.loadStatus() == ProcessRunning {
 			// Only kill foreground processes. Background processes survive.
-			if proc.Kind == ProcessForeground {
-				targets = append(targets, id)
-			}
+			targets = append(targets, id)
 		}
 	}
 	pm.mu.RUnlock()
@@ -304,7 +398,8 @@ func (pm *ProcessManager) KillByIdentity(identity string) int {
 	pm.mu.RLock()
 	var targets []string
 	for id, proc := range pm.processes {
-		if proc.Identity == identity && proc.Status == ProcessRunning && proc.Kind == ProcessForeground {
+		// Identity/Kind are immutable; Status is read under proc.mu.
+		if proc.Identity == identity && proc.Kind == ProcessForeground && proc.loadStatus() == ProcessRunning {
 			targets = append(targets, id)
 		}
 	}
@@ -324,7 +419,7 @@ func (pm *ProcessManager) CanSpawn(identity string) error {
 	running := 0
 	identityRunning := 0
 	for _, proc := range pm.processes {
-		if proc.Status == ProcessRunning {
+		if proc.loadStatus() == ProcessRunning {
 			running++
 			if proc.Identity == identity {
 				identityRunning++
@@ -364,20 +459,21 @@ func (pm *ProcessManager) List() []ProcessSummary {
 
 	result := make([]ProcessSummary, 0, len(pm.processes))
 	for _, proc := range pm.processes {
+		status, finishedAt, errStr := proc.snapshot()
 		duration := time.Since(proc.StartedAt)
-		if proc.FinishedAt != nil {
-			duration = proc.FinishedAt.Sub(proc.StartedAt)
+		if finishedAt != nil {
+			duration = finishedAt.Sub(proc.StartedAt)
 		}
 		result = append(result, ProcessSummary{
 			ID:              proc.ID[:8],
 			Kind:            proc.Kind.String(),
-			Status:          proc.Status.String(),
+			Status:          status.String(),
 			Source:          proc.Source,
 			Identity:        truncID(proc.Identity),
 			StartedAt:       proc.StartedAt.Format(time.RFC3339),
 			Duration:        duration.Round(time.Millisecond).String(),
 			CallbackChannel: proc.CallbackChannel,
-			Error:           proc.Error,
+			Error:           errStr,
 		})
 	}
 	return result
@@ -404,7 +500,7 @@ func (pm *ProcessManager) Stats() ProcessStats {
 		BySource: make(map[string]int),
 	}
 	for _, proc := range pm.processes {
-		switch proc.Status {
+		switch proc.loadStatus() {
 		case ProcessRunning:
 			stats.Running++
 		case ProcessCompleted:
@@ -430,7 +526,7 @@ func (pm *ProcessManager) Shutdown(timeout time.Duration) {
 	pm.mu.RLock()
 	var running []string
 	for id, proc := range pm.processes {
-		if proc.Status == ProcessRunning {
+		if proc.loadStatus() == ProcessRunning {
 			running = append(running, id)
 		}
 	}
@@ -461,7 +557,7 @@ func (pm *ProcessManager) Shutdown(timeout time.Duration) {
 			pm.mu.RLock()
 			stillRunning := 0
 			for _, proc := range pm.processes {
-				if proc.Status == ProcessRunning {
+				if proc.loadStatus() == ProcessRunning {
 					stillRunning++
 				}
 			}

--- a/internal/engine/procmgr_test.go
+++ b/internal/engine/procmgr_test.go
@@ -126,3 +126,56 @@ func TestProcMgrConcurrentAccess(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// TestProcMgrKillVsReaders is the targeted regression for the proc.Status data
+// race: Kill writes proc.Status under proc.mu while List/Stats/KillBy* read it.
+// Before the loadStatus/snapshot fix, `go test -race` flagged this interleaving.
+// We register processes whose cmd was never started (cmd.Process == nil) so
+// Kill's escalation goroutine is skipped and no real signals are sent — only
+// the bookkeeping (and its locking) is exercised.
+func TestProcMgrKillVsReaders(t *testing.T) {
+	pm := NewProcessManager(ProcessManagerConfig{MaxGlobal: 100000})
+
+	ids := make([]string, 0, 256)
+	for i := 0; i < 256; i++ {
+		p := pm.Track(exec.Command("true"), ManagedProcessOpts{
+			Kind:     ProcessForeground,
+			Source:   "sess-a",
+			Identity: "node-1",
+		})
+		ids = append(ids, p.ID)
+	}
+
+	var wg sync.WaitGroup
+	// Killers mutate Status under proc.mu.
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func(off int) {
+			defer wg.Done()
+			for i := off; i < len(ids); i += 8 {
+				pm.Kill(ids[i])
+			}
+		}(g)
+	}
+	// Source/identity sweeps also flip status via Kill on matching procs.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			_ = pm.KillBySource("sess-a")
+			_ = pm.KillByIdentity("node-1")
+		}
+	}()
+	// Readers race the killers.
+	for g := 0; g < 6; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 300; i++ {
+				_ = pm.List()
+				_ = pm.Stats()
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/engine/procmgr_test.go
+++ b/internal/engine/procmgr_test.go
@@ -1,0 +1,128 @@
+// procmgr_test.go — map-eviction + concurrency coverage for ProcessManager.
+//
+// The eviction tests pin the manager to a fake (never-started) *exec.Cmd so no
+// real subprocess is spawned; only the bookkeeping is exercised. The
+// concurrency test is meant to run under `go test -race`.
+package engine
+
+import (
+	"os/exec"
+	"sync"
+	"testing"
+	"time"
+)
+
+// trackFake registers a process without starting a real subprocess.
+func trackFake(pm *ProcessManager, kind ProcessKind) *ManagedProcess {
+	return pm.Track(exec.Command("true"), ManagedProcessOpts{Kind: kind, Source: "test"})
+}
+
+// TestFinishEvictsAgedBackgroundEntries is the regression test for the leak:
+// background processes used to stay in the map forever after Finish.
+func TestFinishEvictsAgedBackgroundEntries(t *testing.T) {
+	oldRetention := finishedRetention
+	finishedRetention = 0 // any finished entry is immediately past retention
+	defer func() { finishedRetention = oldRetention }()
+
+	pm := NewProcessManager(ProcessManagerConfig{})
+
+	// A finished background process from a prior cycle...
+	old := trackFake(pm, ProcessBackground)
+	pm.Finish(old.ID) // marks terminal; reapLocked runs but `old` is the newest
+
+	// ...is evicted when the next Finish triggers a reap (retention == 0 means
+	// the previously-finished `old` is now strictly older than retention).
+	next := trackFake(pm, ProcessBackground)
+	pm.Finish(next.ID)
+
+	pm.mu.RLock()
+	_, oldPresent := pm.processes[old.ID]
+	total := len(pm.processes)
+	pm.mu.RUnlock()
+
+	if oldPresent {
+		t.Errorf("aged finished background entry %s was not evicted", old.ID[:8])
+	}
+	if total > 1 {
+		t.Errorf("map retained %d entries, want <= 1 (only the just-finished one)", total)
+	}
+}
+
+// TestRemoveDeletesBackgroundEntry covers the failed-start path, where Remove is
+// called on a background process and must drop it (it used to only delete
+// foreground kinds, leaking the entry).
+func TestRemoveDeletesBackgroundEntry(t *testing.T) {
+	pm := NewProcessManager(ProcessManagerConfig{})
+	proc := trackFake(pm, ProcessBackground)
+
+	pm.Remove(proc.ID)
+
+	pm.mu.RLock()
+	_, present := pm.processes[proc.ID]
+	pm.mu.RUnlock()
+	if present {
+		t.Errorf("background entry %s not removed", proc.ID[:8])
+	}
+}
+
+// TestReapHardCap verifies the hard cap drops oldest-finished entries even when
+// they are within the retention window.
+func TestReapHardCap(t *testing.T) {
+	oldCap := maxTrackedProcesses
+	oldRetention := finishedRetention
+	maxTrackedProcesses = 10
+	finishedRetention = time.Hour // age sweep keeps everything; only the cap bites
+	defer func() {
+		maxTrackedProcesses = oldCap
+		finishedRetention = oldRetention
+	}()
+
+	pm := NewProcessManager(ProcessManagerConfig{MaxGlobal: 1000})
+	for i := 0; i < 50; i++ {
+		p := trackFake(pm, ProcessBackground)
+		pm.Finish(p.ID)
+	}
+
+	pm.mu.RLock()
+	total := len(pm.processes)
+	pm.mu.RUnlock()
+	if total > maxTrackedProcesses {
+		t.Errorf("map has %d entries, want <= hard cap %d", total, maxTrackedProcesses)
+	}
+}
+
+// TestProcMgrConcurrentAccess drives Track/Finish/Remove/List/Stats/CanSpawn
+// from many goroutines so `go test -race` flags any unsynchronized field
+// access (e.g. reading proc.Status without proc.mu).
+func TestProcMgrConcurrentAccess(t *testing.T) {
+	pm := NewProcessManager(ProcessManagerConfig{MaxGlobal: 100000})
+
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 100; i++ {
+				p := trackFake(pm, ProcessBackground)
+				if i%2 == 0 {
+					pm.Finish(p.ID)
+				} else {
+					pm.Remove(p.ID)
+				}
+			}
+		}()
+	}
+	// Concurrent readers.
+	for g := 0; g < 4; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				_ = pm.List()
+				_ = pm.Stats()
+				_ = pm.CanSpawn("node-x")
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/engine/rotating_writer.go
+++ b/internal/engine/rotating_writer.go
@@ -1,0 +1,144 @@
+// rotating_writer.go — size-capped, concurrency-safe io.Writer for kernel logs.
+//
+// The kernel slog JSON sink (see log_capture.go) was opened O_APPEND and left
+// open for the process lifetime with no rotation, so kernel.log.jsonl grew
+// without bound (observed at ~446 MB on a long-lived kernel). slog may call a
+// handler's Handle — and therefore Write — from multiple goroutines, so the
+// writer mutex-serializes every Write and the rotation it triggers.
+//
+// Rotation scheme: when a write would push the active file past maxBytes, the
+// active file is renamed to "<path>.1", existing "<path>.N" backups shift up by
+// one, and anything beyond maxBackups is deleted. "<path>.1" is always the
+// newest backup. This mirrors the rename-and-prune convention already used by
+// bus_session.go's events.jsonl rotation and config_write.go's rotateBackups,
+// so we add no new dependency.
+//
+// IMPORTANT: this writer is itself the slog sink, so it must NEVER call slog
+// (Warn/Info/etc.) — that would re-enter Write under the held mutex. Rotation
+// faults are reported straight to os.Stderr.
+package engine
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// rotatingWriter is an io.WriteCloser that caps a file at maxBytes and keeps up
+// to maxBackups rotated copies. Safe for concurrent Write/Close.
+type rotatingWriter struct {
+	mu         sync.Mutex
+	path       string
+	maxBytes   int64
+	maxBackups int
+	f          *os.File
+	size       int64
+}
+
+// newRotatingWriter opens (or creates, O_APPEND) path and returns a writer that
+// rotates once the file would exceed maxBytes, retaining maxBackups copies.
+// maxBytes <= 0 disables rotation (the writer becomes a plain appender);
+// maxBackups < 1 is clamped to 1 so at least one rotated copy is kept.
+func newRotatingWriter(path string, maxBytes int64, maxBackups int) (*rotatingWriter, error) {
+	if maxBackups < 1 {
+		maxBackups = 1
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, err
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	var size int64
+	if fi, statErr := f.Stat(); statErr == nil {
+		size = fi.Size()
+	}
+	return &rotatingWriter{
+		path:       path,
+		maxBytes:   maxBytes,
+		maxBackups: maxBackups,
+		f:          f,
+		size:       size,
+	}, nil
+}
+
+// Write implements io.Writer. It rotates before writing when the current file
+// is non-empty and the incoming bytes would push it past maxBytes, so a single
+// record never straddles a rotation boundary.
+func (w *rotatingWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.maxBytes > 0 && w.size > 0 && w.size+int64(len(p)) > w.maxBytes {
+		if err := w.rotateLocked(); err != nil {
+			// Never drop the log line over a rotation fault — keep appending to
+			// the current (possibly over-size) file. Report once to stderr;
+			// must not use slog here (this writer IS the slog sink).
+			fmt.Fprintf(os.Stderr, "kernel log: rotation failed, continuing on %s: %v\n", w.path, err)
+		}
+	}
+
+	n, err := w.f.Write(p)
+	w.size += int64(n)
+	return n, err
+}
+
+// rotateLocked renames the active file to "<path>.1", shifting older backups up
+// and pruning beyond maxBackups, then opens a fresh active file. Caller holds mu.
+func (w *rotatingWriter) rotateLocked() error {
+	// Close the active handle so the rename releases it cleanly (matters on
+	// Windows, where an open file cannot be renamed).
+	_ = w.f.Close()
+
+	// Shift existing backups upward: <path>.(N-1) -> <path>.N, dropping the
+	// oldest. Descending order avoids clobbering a not-yet-moved backup.
+	for i := w.maxBackups - 1; i >= 1; i-- {
+		src := fmt.Sprintf("%s.%d", w.path, i)
+		if _, statErr := os.Stat(src); statErr != nil {
+			continue
+		}
+		dst := fmt.Sprintf("%s.%d", w.path, i+1)
+		_ = os.Remove(dst)
+		_ = os.Rename(src, dst)
+	}
+
+	// Move the active file to the newest backup slot. If the rename fails the
+	// file is left in place; reopening O_APPEND below means we resume on it
+	// rather than losing the handle.
+	newest := w.path + ".1"
+	_ = os.Remove(newest)
+	if err := os.Rename(w.path, newest); err != nil {
+		f, openErr := os.OpenFile(w.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+		if openErr != nil {
+			return fmt.Errorf("rotate rename %s: %w (reopen also failed: %v)", w.path, err, openErr)
+		}
+		w.f = f
+		if fi, statErr := f.Stat(); statErr == nil {
+			w.size = fi.Size()
+		}
+		return fmt.Errorf("rotate rename %s: %w", w.path, err)
+	}
+
+	f, err := os.OpenFile(w.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("rotate reopen %s: %w", w.path, err)
+	}
+	w.f = f
+	w.size = 0
+	return nil
+}
+
+// Close closes the active file handle. Production never calls this (the sink
+// lives for the kernel lifetime); it exists for tests and graceful teardown.
+func (w *rotatingWriter) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.f == nil {
+		return nil
+	}
+	err := w.f.Close()
+	w.f = nil
+	return err
+}

--- a/internal/engine/rotating_writer_test.go
+++ b/internal/engine/rotating_writer_test.go
@@ -1,0 +1,96 @@
+// rotating_writer_test.go — size-rotation + concurrency for the kernel log sink.
+package engine
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestRotatingWriterRotatesAndPrunes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kernel.log.jsonl")
+
+	// 100-byte cap, keep 2 backups. Each Write is 60 bytes, so the 2nd write
+	// (60+60 > 100) rotates, and so on.
+	w, err := newRotatingWriter(path, 100, 2)
+	if err != nil {
+		t.Fatalf("newRotatingWriter: %v", err)
+	}
+	defer w.Close()
+
+	line := make([]byte, 60)
+	for i := range line {
+		line[i] = 'x'
+	}
+	for i := 0; i < 6; i++ {
+		if _, err := w.Write(line); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+	}
+
+	// Active file must be at or below the cap (last write started a fresh file).
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat active: %v", err)
+	}
+	if fi.Size() > 100 {
+		t.Errorf("active file %d bytes, want <= 100", fi.Size())
+	}
+
+	// At most maxBackups rotated copies survive; .3 must have been pruned.
+	if _, err := os.Stat(path + ".1"); err != nil {
+		t.Errorf("expected backup .1 to exist: %v", err)
+	}
+	if _, err := os.Stat(path + ".2"); err != nil {
+		t.Errorf("expected backup .2 to exist: %v", err)
+	}
+	if _, err := os.Stat(path + ".3"); !os.IsNotExist(err) {
+		t.Errorf("backup .3 should have been pruned, stat err=%v", err)
+	}
+}
+
+func TestRotatingWriterDisabledWhenMaxBytesZero(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "k.log")
+	w, err := newRotatingWriter(path, 0, 3) // 0 disables rotation
+	if err != nil {
+		t.Fatalf("newRotatingWriter: %v", err)
+	}
+	defer w.Close()
+
+	for i := 0; i < 50; i++ {
+		if _, err := w.Write([]byte("some log line\n")); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	if _, err := os.Stat(path + ".1"); !os.IsNotExist(err) {
+		t.Errorf("rotation must be disabled, but .1 exists")
+	}
+}
+
+// TestRotatingWriterConcurrent exercises the mutex under -race: slog may call
+// Handle (and therefore Write) from multiple goroutines.
+func TestRotatingWriterConcurrent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "concurrent.log")
+	w, err := newRotatingWriter(path, 4096, 3)
+	if err != nil {
+		t.Fatalf("newRotatingWriter: %v", err)
+	}
+	defer w.Close()
+
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				_, _ = w.Write([]byte(fmt.Sprintf("g=%d i=%d payload-padding-padding\n", g, i)))
+			}
+		}(g)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Second cluster from the codebase audit (`AUDIT-2026-06-24.md`): **resource leaks**. Security cluster shipped in #396.

## What grows / leaks

**1. `kernel.log.jsonl` grew without bound.** The kernel slog JSON sink (`log_capture.go`) was opened `O_APPEND` and left open for the process lifetime with no rotation. On a long-lived kernel it reached ~446 MB.

**2. `ProcessManager` leaked map entries.** `Finish()` marked background processes complete but never deleted them, so every background `claude` dispatch leaked a `*ManagedProcess` for the kernel's lifetime. `Remove()` only deleted `ProcessForeground` kinds, so the failed-start path leaked too.

**3. `ProcessManager` data races.** `proc.Status` is written under `proc.mu` (Kill/Finish/SetError) but read under only `pm.mu` in `List`/`Stats`/`CanSpawn`/`KillBySource`/`KillByIdentity`/`Shutdown`. The kill-escalation goroutine read `proc.cmd.ProcessState`, which `cmd.Wait()` writes from another goroutine. Both are `-race`-flaggable.

## Fixes

- **`rotating_writer.go`** (new): concurrency-safe, size-rotating `io.Writer`. slog may call `Handle` (→ `Write`) from multiple goroutines, so every write is mutex-serialized. Rotation renames active → `<path>.1`, shifts older backups up, prunes beyond `maxBackups`. Reports faults to stderr (never via slog, which would re-enter). No new dependency. Sink capped at 64 MB active + 5 backups (`COG_KERNEL_LOG_MAX_MB` override).
- **`procmgr.go`**:
  - `reapLocked()` (age retention 15m + hard cap 512), called from `Track`/`Finish`.
  - `Remove()` deletes unconditionally (fixes failed-start background leak).
  - All `proc.Status` reads routed through `loadStatus()`/`snapshot()` under `proc.mu`. Lock order globally `pm.mu → proc.mu`.
  - Kill goroutine uses a `Signal(0)` liveness probe instead of the racy `ProcessState` read.

## Scope notes / deferred
- **Service-log rotation** (`local_runner.go`) not included: the child writes via an inherited fd, so a kernel-side writer can't intercept it (needs reopen-on-signal or a pipe).
- **`bus_session.go` AppendEvent lock** deferred to its own PR: contention concern on a hash-chained ledger, not a leak; `events.jsonl` already rotates at 64 MB.

## Tests
- `rotating_writer_test.go`: rotation + prune, disabled-when-zero, concurrent under `-race`.
- `procmgr_test.go`: leak regression, failed-start `Remove`, hard cap, `-race` concurrency.

Pre-existing unrelated local failure: `TestBuildRouterRegistersMLXSupervisedType` does live auto-discovery of LM Studio on :1234 (fails locally, passes in CI).