### PR TITLE
fix(reconcile): kill GetProvider deadlock + stop disabled-pipeline per-cycle work

### DIFF
--- a/internal/engine/decision_lineage_reconciler.go
+++ b/internal/engine/decision_lineage_reconciler.go
@@ -124,8 +124,14 @@ func (r *DecisionLineageReconciler) ComputePlan(config any, live any, state *rec
 	if config == nil {
 		return &reconcile.Plan{ResourceType: r.Type()}, nil
 	}
-	cfg := config.(*DecisionLineageConfig)
-	decisions := live.([]Decision)
+	cfg, ok := config.(*DecisionLineageConfig)
+	if !ok {
+		return nil, fmt.Errorf("decision-lineage ComputePlan: unexpected config type %T", config)
+	}
+	decisions, ok := live.([]Decision)
+	if !ok {
+		return nil, fmt.Errorf("decision-lineage ComputePlan: unexpected live type %T", live)
+	}
 
 	manifold := ComputeManifold(decisions, r.now())
 	projected := renderDecisionLineageProjection(manifold)
@@ -258,8 +264,14 @@ func (r *DecisionLineageReconciler) BuildState(config any, live any, existing *r
 	if config == nil {
 		return reconcile.NewState(r.Type()), nil
 	}
-	cfg := config.(*DecisionLineageConfig)
-	decisions := live.([]Decision)
+	cfg, ok := config.(*DecisionLineageConfig)
+	if !ok {
+		return nil, fmt.Errorf("decision-lineage BuildState: unexpected config type %T", config)
+	}
+	decisions, ok := live.([]Decision)
+	if !ok {
+		return nil, fmt.Errorf("decision-lineage BuildState: unexpected live type %T", live)
+	}
 
 	state := reconcile.NewState(r.Type())
 	if existing != nil {

--- a/internal/engine/decision_lineage_reconciler_test.go
+++ b/internal/engine/decision_lineage_reconciler_test.go
@@ -240,6 +240,22 @@ func TestDecisionLineageReconciler_Registered(t *testing.T) {
 	}
 }
 
+// TestDecisionLineageReconciler_WrongLiveType verifies ComputePlan and
+// BuildState return an error (not panic) when a non-daemon caller passes a live
+// value of the wrong type. Previously the unchecked `live.([]Decision)`
+// assertion panicked, which would crash the whole daemon.
+func TestDecisionLineageReconciler_WrongLiveType(t *testing.T) {
+	rec := NewDecisionLineageReconciler()
+	cfg := &DecisionLineageConfig{ProjectionDir: t.TempDir()}
+
+	if _, err := rec.ComputePlan(cfg, "not-decisions", nil); err == nil {
+		t.Error("ComputePlan with wrong live type: expected error, got nil")
+	}
+	if _, err := rec.BuildState(cfg, 42, nil); err == nil {
+		t.Error("BuildState with wrong live type: expected error, got nil")
+	}
+}
+
 func TestRootDerivation(t *testing.T) {
 	// Round-trip: a corpus dir and a projection path must both derive the root.
 	root := "/tmp/ws"

--- a/internal/engine/reconcile_daemon.go
+++ b/internal/engine/reconcile_daemon.go
@@ -445,7 +445,15 @@ func (d *ReconcileDaemon) runOneCycle(ctx context.Context, providerType string) 
 
 	// Step 3: Load persisted state.
 	stateStart := time.Now()
-	state, _ := reconcile.LoadState(d.cfg.WorkspaceRoot, providerType)
+	state, stateErr := reconcile.LoadState(d.cfg.WorkspaceRoot, providerType)
+	if stateErr != nil {
+		// LoadState maps a missing file to (nil, nil); a non-nil error here is
+		// corruption or a permission/read fault. Surface it instead of silently
+		// resetting lineage serials, mirroring the WriteState warning below.
+		// Continue with the nil state — providers already handle a nil state.
+		slog.Warn("reconcile-daemon: LoadState failed; continuing with empty state",
+			"provider", providerType, "err", stateErr)
+	}
 	stateMs = time.Since(stateStart).Milliseconds()
 
 	// Step 4: ComputePlan — pure function, deterministic.

--- a/pkg/cogdoc_review/reconciler.go
+++ b/pkg/cogdoc_review/reconciler.go
@@ -141,6 +141,15 @@ func (r *CogdocReviewReconciler) FetchLive(ctx context.Context, config any) (any
 		return nil, fmt.Errorf("cogdoc_review FetchLive: expected *CogdocReviewClass, got %T", config)
 	}
 
+	// When the pipeline is disabled, skip the O(corpus) WalkDir+YAML parse and
+	// the Ollama HTTP probe entirely. ComputePlan short-circuits on !Enabled and
+	// only reads CorpusSize/OllamaReachable for plan metadata, so a zero-value
+	// liveState is sufficient. Without this guard a disabled reconciler still
+	// walked the whole corpus and made a 3s Ollama probe on every ~30s tick.
+	if !class.Enabled {
+		return &liveState{}, nil
+	}
+
 	corpus, err := walkCorpus(r.WorkspaceRoot, class.CorpusPaths)
 	if err != nil {
 		return nil, fmt.Errorf("walk corpus: %w", err)

--- a/pkg/cogdoc_review/reconciler_test.go
+++ b/pkg/cogdoc_review/reconciler_test.go
@@ -189,6 +189,40 @@ func TestComputePlan_Disabled(t *testing.T) {
 	}
 }
 
+// TestFetchLive_DisabledSkipsCorpusWalk verifies the Enabled guard: a disabled
+// pipeline must NOT walk the corpus (the per-cycle O(corpus) cost + Ollama
+// probe we eliminated). corpus_size in the plan metadata reflects whether the
+// walk ran: 0 when disabled (walk skipped), >0 when enabled over the same docs.
+func TestFetchLive_DisabledSkipsCorpusWalk(t *testing.T) {
+	dir := makeWorkspace(t)
+	writeCogdoc(t, dir, ".cog/mem/semantic/insights/a.cog.md", "a-1", "A", true)
+	writeCogdoc(t, dir, ".cog/mem/semantic/insights/b.cog.md", "b-1", "B", false)
+	r := cogdoc_review.NewCogdocReviewReconciler(dir)
+	ctx := context.Background()
+
+	corpusSize := func(t *testing.T, enabled bool) int {
+		t.Helper()
+		class := &reconcile.CogdocReviewClass{Enabled: enabled}
+		lv, err := r.FetchLive(ctx, class)
+		if err != nil {
+			t.Fatalf("FetchLive(enabled=%v): %v", enabled, err)
+		}
+		plan, err := r.ComputePlan(class, lv, nil)
+		if err != nil {
+			t.Fatalf("ComputePlan(enabled=%v): %v", enabled, err)
+		}
+		cs, _ := plan.Metadata["corpus_size"].(int)
+		return cs
+	}
+
+	if cs := corpusSize(t, false); cs != 0 {
+		t.Errorf("disabled corpus_size = %d, want 0 (corpus walk should be skipped)", cs)
+	}
+	if cs := corpusSize(t, true); cs == 0 {
+		t.Errorf("enabled corpus_size = 0, want > 0 (corpus walk should run over the 2 docs)")
+	}
+}
+
 // TestComputePlan_EmptyCorpus verifies plan on an empty corpus.
 func TestComputePlan_EmptyCorpus(t *testing.T) {
 	dir := makeWorkspace(t)

--- a/pkg/substrate/reconcile/registry.go
+++ b/pkg/substrate/reconcile/registry.go
@@ -37,7 +37,17 @@ func GetProvider(name string) (Reconcilable, error) {
 	defer providersMu.RUnlock()
 	p, ok := providers[name]
 	if !ok {
-		return nil, fmt.Errorf("unknown resource type: %s (registered: %v)", name, ListProviders())
+		// Build the name list inline rather than calling ListProviders(): that
+		// would take a second RLock, and sync.RWMutex is not reentrant — once a
+		// writer (config-reload RegisterProvider/UpsertProvider) is blocked
+		// waiting, Go's RWMutex stops admitting new readers, so the re-RLock
+		// would deadlock this goroutine permanently.
+		names := make([]string, 0, len(providers))
+		for n := range providers {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		return nil, fmt.Errorf("unknown resource type: %s (registered: %v)", name, names)
 	}
 	return p, nil
 }

--- a/pkg/substrate/reconcile/registry_test.go
+++ b/pkg/substrate/reconcile/registry_test.go
@@ -2,7 +2,10 @@ package reconcile
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
+	"time"
 )
 
 // mockProvider implements Reconcilable for testing.
@@ -42,6 +45,49 @@ func TestGetProviderUnknown(t *testing.T) {
 	_, err := GetProvider("nonexistent")
 	if err == nil {
 		t.Error("expected error for unknown provider")
+	}
+}
+
+// TestGetProviderUnknownNoDeadlockUnderWriter is the regression for the
+// recursive-RLock deadlock. GetProvider's error path used to call
+// ListProviders(), taking a second RLock; sync.RWMutex is not reentrant, so a
+// writer (config reload) pending between the two locks deadlocked the reader
+// permanently. Here many error-path readers race a stream of writers. With the
+// bug this hangs; we bound completion with an explicit deadline so a regression
+// fails fast instead of relying on the package-level test timeout.
+func TestGetProviderUnknownNoDeadlockUnderWriter(t *testing.T) {
+	ResetProviders()
+	defer ResetProviders()
+
+	done := make(chan struct{})
+	go func() {
+		var wg sync.WaitGroup
+		for w := 0; w < 4; w++ {
+			wg.Add(1)
+			go func(w int) {
+				defer wg.Done()
+				for i := 0; i < 500; i++ {
+					UpsertProvider(fmt.Sprintf("p-%d-%d", w, i), &mockProvider{name: "x"})
+				}
+			}(w)
+		}
+		for r := 0; r < 8; r++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for i := 0; i < 500; i++ {
+					_, _ = GetProvider("nonexistent")
+				}
+			}()
+		}
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("GetProvider error path deadlocked under concurrent writers (recursive RLock regression)")
 	}
 }
 


### PR DESCRIPTION
Third cluster from the codebase audit (`AUDIT-2026-06-24.md`): **reconcile-contract**, low-risk subset. Security shipped in #396, resource leaks in #397.

This PR takes the four findings that are unambiguous correctness/efficiency fixes with **no change to reconcile semantics**. The contract-semantics items from the same cluster are deferred to review-required follow-ups (see below) since they touch worktree/ledger state and provider state machines.

## Fixes

**1. `reconcile.GetProvider` recursive-RLock deadlock** — `pkg/substrate/reconcile/registry.go`
The unknown-name error path called `ListProviders()`, which takes a second `RLock`. `sync.RWMutex` is not reentrant: once a writer (config-reload `RegisterProvider`/`UpsertProvider`) is blocked waiting, Go's RWMutex stops admitting new readers, so the re-`RLock` deadlocks the calling goroutine permanently. Fixed by building the name list inline under the already-held lock. Regression test verified to hang against the buggy code.

**2. `cogdoc_review.FetchLive` unguarded by `Enabled`** — `pkg/cogdoc_review/reconciler.go`
A disabled pipeline still did an O(corpus) `WalkDir`+YAML parse and a 3s Ollama HTTP probe on every ~30s tick. `ComputePlan` already short-circuits on `!Enabled` (reading only `CorpusSize`/`OllamaReachable` for metadata), so `FetchLive` now returns a zero-value `liveState` when disabled. Directly relevant to the original "kernel eating CPU" report.

**3. `reconcile_daemon` swallowed LoadState errors** — `internal/engine/reconcile_daemon.go`
`state, _ := reconcile.LoadState(...)` hid JSON corruption / permission faults and silently reset lineage serials. Now captured and `slog.Warn`ed on the non-`IsNotExist` error (LoadState maps a missing file to `(nil, nil)`), mirroring the existing `WriteState` warning. Error behavior is otherwise unchanged (continue with nil state).

**4. `decision_lineage` unchecked type assertions** — `internal/engine/decision_lineage_reconciler.go`
`ComputePlan`/`BuildState` did `config.(*DecisionLineageConfig)` / `live.([]Decision)` without comma-ok, so a non-daemon caller (test/CLI) passing the wrong type panicked and crashed the daemon. Now returns an error, mirroring `WorktreeReconciler.ComputePlan`.

## Deferred to review-required follow-ups (touch reconcile/worktree contract)
- **WorktreeReconciler stays HealthDegraded after alarm acknowledged** (`worktree_reconciler.go:648`) — high value (re-degrades + LLM-escalates every ~30s, burning API budget) but mutates worktree-reconcile alarm semantics.
- **EvalProvider.ComputePlan destructive write** (`eval/provider_impl.go:487`) — `ComputePlan` (contractually pure) clears a sidecar file; fix threads triggers through `FetchLive`/live state.
- **MLXSupervisedProvider never converges during model load** (`provider_mlx_supervised.go:236`) — needs a starting-state/cooldown in the provider state machine.
- **Per-cycle subprocess batching** (`local_runner.go` `ps`, `pin/pin.go` `git`) — perf, needs argv-match-semantics-preserving refactor.

## Tests
- `registry_test.go`: deadlock regression under concurrent writers (bounded deadline; confirmed it fails against the buggy code).
- `reconciler_test.go`: disabled pipeline skips the corpus walk (corpus_size 0 vs >0).
- `decision_lineage_reconciler_test.go`: wrong-live-type returns error, not panic.

`go test -race` green for all touched packages. (Pre-existing unrelated local failure `TestBuildRouterRegistersMLXSupervisedType` — live LM Studio auto-discovery — passes in CI.)