### PR TITLE
perf(worktree): cache per-session ledger scans in ReadWorktreeEvents

### DIFF
--- a/internal/engine/worktree_ledger_cache_test.go
+++ b/internal/engine/worktree_ledger_cache_test.go
@@ -1,0 +1,154 @@
+// worktree_ledger_cache_test.go — covers the per-file scan cache in
+// FilesystemLedgerReader.ReadWorktreeEvents. The reconcile cycle calls this
+// every ~30s; the cache must re-parse only files whose size/mtime changed.
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// writeLedgerEvent appends one worktree.* EventEnvelope line to
+// <ws>/.cog/ledger/<session>/events.jsonl, creating the dir on demand.
+func writeLedgerEvent(t *testing.T, ws, session string, kind CogBlockKind, data map[string]any) {
+	t.Helper()
+	dir := filepath.Join(ws, ".cog", "ledger", session)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir ledger session: %v", err)
+	}
+	env := EventEnvelope{HashedPayload: EventPayload{
+		Type:      string(kind),
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		SessionID: session,
+		Data:      data,
+	}}
+	line, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+	f, err := os.OpenFile(filepath.Join(dir, "events.jsonl"), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("open events.jsonl: %v", err)
+	}
+	defer f.Close()
+	if _, err := f.Write(append(line, '\n')); err != nil {
+		t.Fatalf("write event: %v", err)
+	}
+}
+
+func TestReadWorktreeEvents_CachesUnchangedFiles(t *testing.T) {
+	// Wrap the scan function so we can count actual (cache-miss) parses.
+	var parses int32
+	orig := scanWorktreeEventsFile
+	scanWorktreeEventsFile = func(path, repoRoot string) ([]WorktreeLedgerEvent, error) {
+		atomic.AddInt32(&parses, 1)
+		return orig(path, repoRoot)
+	}
+	defer func() { scanWorktreeEventsFile = orig }()
+
+	ws := t.TempDir()
+	repoRoot := "/repo/root"
+	writeLedgerEvent(t, ws, "sessA", BlockWorktreeCreated, map[string]any{
+		"worktree_id":   "wt-1",
+		"repo_root":     repoRoot,
+		"worktree_path": "/repo/root/.wt/wt-1",
+		"branch":        "feature",
+	})
+
+	r := NewFilesystemLedgerReader(ws)
+	ctx := context.Background()
+
+	// First read parses sessA once and returns the created event.
+	ev1, err := r.ReadWorktreeEvents(ctx, repoRoot)
+	if err != nil {
+		t.Fatalf("read 1: %v", err)
+	}
+	if len(ev1) != 1 {
+		t.Fatalf("read 1: got %d events, want 1", len(ev1))
+	}
+	if n := atomic.LoadInt32(&parses); n != 1 {
+		t.Fatalf("read 1: parses=%d, want 1", n)
+	}
+
+	// Second read: file unchanged → cache hit, no new parse.
+	ev2, err := r.ReadWorktreeEvents(ctx, repoRoot)
+	if err != nil {
+		t.Fatalf("read 2: %v", err)
+	}
+	if len(ev2) != 1 {
+		t.Fatalf("read 2: got %d events, want 1", len(ev2))
+	}
+	if n := atomic.LoadInt32(&parses); n != 1 {
+		t.Fatalf("read 2 should be a cache hit: parses=%d, want still 1", n)
+	}
+
+	// Append a second event: size grows → cache invalidated → re-parse, 2 events.
+	writeLedgerEvent(t, ws, "sessA", BlockWorktreeTerminal, map[string]any{
+		"worktree_id": "wt-1",
+		"reason":      "merged",
+	})
+	ev3, err := r.ReadWorktreeEvents(ctx, repoRoot)
+	if err != nil {
+		t.Fatalf("read 3: %v", err)
+	}
+	if len(ev3) != 2 {
+		t.Fatalf("read 3: got %d events, want 2", len(ev3))
+	}
+	if n := atomic.LoadInt32(&parses); n != 2 {
+		t.Fatalf("read 3 should re-parse the grown file: parses=%d, want 2", n)
+	}
+
+	// Remove the session dir: the cache entry is evicted, zero events returned.
+	if err := os.RemoveAll(filepath.Join(ws, ".cog", "ledger", "sessA")); err != nil {
+		t.Fatalf("remove session: %v", err)
+	}
+	ev4, err := r.ReadWorktreeEvents(ctx, repoRoot)
+	if err != nil {
+		t.Fatalf("read 4: %v", err)
+	}
+	if len(ev4) != 0 {
+		t.Fatalf("read 4: got %d events, want 0 after deletion", len(ev4))
+	}
+
+	r.mu.Lock()
+	_, stillCached := r.scanCache[filepath.Join(ws, ".cog", "ledger", "sessA", "events.jsonl")]
+	r.mu.Unlock()
+	if stillCached {
+		t.Error("deleted session ledger was not evicted from the scan cache")
+	}
+}
+
+// TestReadWorktreeEvents_RepoRootKeyedCache ensures a different repoRoot filter
+// does not serve another root's cached events.
+func TestReadWorktreeEvents_RepoRootKeyedCache(t *testing.T) {
+	ws := t.TempDir()
+	writeLedgerEvent(t, ws, "sessA", BlockWorktreeCreated, map[string]any{
+		"worktree_id":   "wt-1",
+		"repo_root":     "/repo/alpha",
+		"worktree_path": "/repo/alpha/.wt/wt-1",
+	})
+	r := NewFilesystemLedgerReader(ws)
+	ctx := context.Background()
+
+	alpha, err := r.ReadWorktreeEvents(ctx, "/repo/alpha")
+	if err != nil {
+		t.Fatalf("alpha: %v", err)
+	}
+	if len(alpha) != 1 {
+		t.Fatalf("alpha: got %d, want 1", len(alpha))
+	}
+	// Different repoRoot must not reuse alpha's cached events (created events are
+	// repo_root-filtered).
+	beta, err := r.ReadWorktreeEvents(ctx, "/repo/beta")
+	if err != nil {
+		t.Fatalf("beta: %v", err)
+	}
+	if len(beta) != 0 {
+		t.Fatalf("beta: got %d events, want 0 (alpha's event must not leak across repoRoot)", len(beta))
+	}
+}

--- a/internal/engine/worktree_spawn.go
+++ b/internal/engine/worktree_spawn.go
@@ -19,6 +19,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -144,6 +145,27 @@ func realGitAdd(ctx context.Context, repoRoot, worktreePath, branch, base string
 // `worktree.*` events. Production implementation.
 type FilesystemLedgerReader struct {
 	WorkspaceRoot string
+
+	// scanCache memoizes the parsed worktree events of each per-session
+	// events.jsonl, keyed by file path. The WorktreeReconciler runs LoadConfig
+	// (→ ReadWorktreeEvents) on every ~30s reconcile cycle; without this cache
+	// that re-reads and JSON-parses the entire ledger (hundreds of MB / hundreds
+	// of thousands of lines across thousands of session dirs) every tick just to
+	// extract a handful of worktree events. Ledger files are append-only, so a
+	// changed size+mtime reliably signals new content; unchanged files reuse
+	// their parsed events. Guarded by mu (LoadConfig can be called concurrently
+	// by the reconcile daemon and the autonomic ticker).
+	mu        sync.Mutex
+	scanCache map[string]worktreeScanEntry
+}
+
+// worktreeScanEntry is one cached file scan. repoRoot is part of the validity
+// key because scanWorktreeEventsFile filters by it.
+type worktreeScanEntry struct {
+	repoRoot string
+	size     int64
+	modTime  time.Time
+	events   []WorktreeLedgerEvent
 }
 
 func NewFilesystemLedgerReader(workspaceRoot string) *FilesystemLedgerReader {
@@ -163,7 +185,14 @@ func (r *FilesystemLedgerReader) ReadWorktreeEvents(ctx context.Context, repoRoo
 		return nil, err
 	}
 
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.scanCache == nil {
+		r.scanCache = make(map[string]worktreeScanEntry)
+	}
+
 	var events []WorktreeLedgerEvent
+	seen := make(map[string]struct{}, len(sessionDirs))
 	for _, d := range sessionDirs {
 		select {
 		case <-ctx.Done():
@@ -171,13 +200,44 @@ func (r *FilesystemLedgerReader) ReadWorktreeEvents(ctx context.Context, repoRoo
 		default:
 		}
 		eventsFile := filepath.Join(ledgerDir, d, "events.jsonl")
+		fi, statErr := os.Stat(eventsFile)
+		if statErr != nil {
+			// Missing/unreadable per-session ledger; skip (and let the eviction
+			// pass below drop any stale cache entry for it).
+			continue
+		}
+		seen[eventsFile] = struct{}{}
+
+		// Cache hit: same repoRoot filter and unchanged size+mtime → reuse the
+		// previously parsed events instead of re-reading and re-parsing.
+		if c, ok := r.scanCache[eventsFile]; ok && c.repoRoot == repoRoot && c.size == fi.Size() && c.modTime.Equal(fi.ModTime()) {
+			events = append(events, c.events...)
+			continue
+		}
+
 		evs, err := scanWorktreeEventsFile(eventsFile, repoRoot)
 		if err != nil {
 			// Skip unreadable per-session ledgers; do not fail the whole tick.
+			// Drop any stale cache entry so a transient error doesn't pin it.
+			delete(r.scanCache, eventsFile)
 			continue
+		}
+		r.scanCache[eventsFile] = worktreeScanEntry{
+			repoRoot: repoRoot,
+			size:     fi.Size(),
+			modTime:  fi.ModTime(),
+			events:   evs,
 		}
 		events = append(events, evs...)
 	}
+
+	// Evict cache entries for session ledgers that disappeared this tick.
+	for k := range r.scanCache {
+		if _, ok := seen[k]; !ok {
+			delete(r.scanCache, k)
+		}
+	}
+
 	return events, nil
 }
 
@@ -230,7 +290,10 @@ func readDirIfExists(dir string) ([]string, error) {
 	return names, nil
 }
 
-func scanWorktreeEventsFile(path, repoRoot string) ([]WorktreeLedgerEvent, error) {
+// scanWorktreeEventsFile reads one per-session events.jsonl and projects the
+// worktree.* events matching repoRoot. It is a var so the scan cache test can
+// wrap it to count actual (cache-miss) parses; production keeps the default.
+var scanWorktreeEventsFile = func(path, repoRoot string) ([]WorktreeLedgerEvent, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## The live CPU symptom

While verifying the audit fixes, the running kernel showed the **worktree reconciler over its 500ms cycle budget at ~2.5s every ~30s tick**, continuously (a sustained ~8% of one core), logged as:

```
reconcile: provider anomaly  provider=worktree-reconciler  reasons=[over_budget]
  cycle_ms=2542  fetch_ms=15  over_budget_cycles=360  degraded_cycles=0
```

`fetch_ms` is tiny, so the cost is **not** `FetchLive`. The root cause is `WorktreeReconciler.LoadConfig`, which the daemon runs every cycle and which calls `FilesystemLedgerReader.ReadWorktreeEvents`. That function lists **every** `.cog/ledger/<session>/` directory and fully reads + JSON-parses each `events.jsonl` to extract a handful of `worktree.*` events.

On this workspace the ledger is **445 MB across 677 files / ~513k events / 3,657 session dirs** — re-read and re-parsed every 30s. This is the literal "cogos is eating my CPU" symptom and it grows unbounded with history.

This is **not** the acknowledged-alarm re-degrade bug from the audit (no alarms are firing; `degraded_cycles=0`). It is a per-cycle full-ledger rescan.

## Fix

Ledger files are append-only, so cache each session file's parsed worktree events in `FilesystemLedgerReader`, keyed by `path + repoRoot`, invalidated on `size`/`mtime` change. Steady state re-parses only files that actually grew (usually none) and otherwise just `stat`s them. Deleted session ledgers are evicted. Guarded by a mutex (`LoadConfig` can run concurrently from the reconcile daemon and the autonomic ticker).

**Semantically transparent**: identical events returned, only the read path is memoized. No change to reconcile decisions, no mutation of ledger or worktree state.

### Measured against the live 445 MB ledger
```
COLD scan: 2.563s (513,340 events)  →  WARM (cached): 10ms (513,340 events)   ~246x
```

## Tests
`worktree_ledger_cache_test.go`: cache-hit on unchanged file (asserts no re-parse via a parse counter), re-parse on append, eviction on delete, and `repoRoot`-keyed isolation (one repo's cached events never leak to another root's query). `scanWorktreeEventsFile` becomes a `var` seam for the parse counter, mirroring the existing `psLookup` seam.

## Note on merge
Flagging for your review before merge since this touches the ledger read path you asked me not to change blind — even though it's read-side caching with no semantic or state change. It is the highest-value remaining item (the live CPU cause) but the most sensitive, so I'm leaving the merge to you.

This is also a specific instance of the audit's systemic finding that reconcile providers re-scan full corpora/ledgers per cycle; the same caching shape applies to the deferred `pin`/`ps` per-cycle-subprocess items.