### PR TITLE
test(router): make BuildRouter MLX test hermetic via WithoutAutoDiscovery

### DIFF
--- a/internal/engine/provider_mlx_supervised_test.go
+++ b/internal/engine/provider_mlx_supervised_test.go
@@ -465,7 +465,10 @@ routing:
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
-	router, err := BuildRouter(cfg)
+	// WithoutAutoDiscovery keeps the test hermetic: otherwise BuildRouter live-
+	// probes LM Studio on :1234 and, when one is running on the host, registers
+	// "lmstudio" ahead of the configured mlx-gemma, breaking FirstLocalProvider.
+	router, err := BuildRouter(cfg, WithoutAutoDiscovery())
 	if err != nil {
 		t.Fatalf("BuildRouter: %v", err)
 	}

--- a/internal/engine/router.go
+++ b/internal/engine/router.go
@@ -470,8 +470,11 @@ func BuildRouter(cfg *Config, opts ...BuildRouterOption) (Router, error) {
 		slog.Info("router: registered", "name", name, "model", pc.Model)
 	}
 
-	// Auto-discover OpenAI-compatible servers on well-known ports.
-	autoDiscoverOpenAICompat(router, pcfg)
+	// Auto-discover OpenAI-compatible servers on well-known ports. Skippable so
+	// tests don't pick up whatever LLM server happens to be live on the host.
+	if !bro.noAutoDiscover {
+		autoDiscoverOpenAICompat(router, pcfg)
+	}
 
 	// Start the background availability maintainer when a lifecycle context is
 	// provided (the long-running daemon). Short-lived callers omit it and rely
@@ -484,8 +487,9 @@ func BuildRouter(cfg *Config, opts ...BuildRouterOption) (Router, error) {
 }
 
 type buildRouterOpts struct {
-	procMgr *ProcessManager
-	ctx     context.Context
+	procMgr        *ProcessManager
+	ctx            context.Context
+	noAutoDiscover bool
 }
 
 // BuildRouterOption configures BuildRouter.
@@ -494,6 +498,14 @@ type BuildRouterOption func(*buildRouterOpts)
 // WithProcessManager provides a ProcessManager for providers that spawn subprocesses.
 func WithProcessManager(pm *ProcessManager) BuildRouterOption {
 	return func(o *buildRouterOpts) { o.procMgr = pm }
+}
+
+// WithoutAutoDiscovery disables the live probe of well-known OpenAI-compatible
+// backends (LM Studio :1234, etc.). Production leaves auto-discovery on; tests
+// pass this so router construction is hermetic and does not depend on whatever
+// local LLM servers happen to be running on the host.
+func WithoutAutoDiscovery() BuildRouterOption {
+	return func(o *buildRouterOpts) { o.noAutoDiscover = true }
 }
 
 // WithRouterContext ties the router's background availability maintainer to


### PR DESCRIPTION
## Problem
`TestBuildRouterRegistersMLXSupervisedType` (`internal/engine/provider_mlx_supervised_test.go`) fails on any host running LM Studio on :1234. `BuildRouter` live-probes well-known OpenAI-compat backends (`autoDiscoverOpenAICompat`) and registers a reachable `lmstudio` provider, so `FirstLocalProvider()` returns `lmstudio` instead of the configured `mlx-gemma`. It passes in CI only because no LM Studio runs there — a classic non-hermetic test (surfaced repeatedly during the audit-fix work since this dev box runs LM Studio).

## Fix
Add an opt-in `WithoutAutoDiscovery()` `BuildRouterOption` that skips the live probe, and use it in the test.

- **Production unchanged**: auto-discovery stays on by default; only the test opts out.
- **Additive**: new option alongside the existing `WithProcessManager`/`WithRouterContext`.

## Verification
With LM Studio live on :1234 (the exact condition that broke it), the test now passes 3/3. `go vet` clean, full `MLXSupervised|Router` suite green, gofmt clean.