### PR TITLE
fix(security): close path-traversal holes the #396 sweep missed

### DIFF
--- a/internal/engine/mcp_architecture.go
+++ b/internal/engine/mcp_architecture.go
@@ -282,6 +282,18 @@ func (m *MCPServer) toolArchitectureProject(ctx context.Context, req *mcp.CallTo
 	if in.Handle == "" || in.Target == "" {
 		return fallbackResult("handle and target are required", "")
 	}
+	// Contain the caller-supplied target: architecture_project.py writes to it,
+	// so reject any target that resolves outside the workspace root. The script
+	// runs with the kernel's CWD (the workspace), so a relative target resolves
+	// the same way here; we validate the resolved path and pass the caller's
+	// value unchanged for valid (contained) inputs.
+	resolvedTarget := filepath.Clean(in.Target)
+	if !filepath.IsAbs(resolvedTarget) {
+		resolvedTarget = filepath.Join(m.cfg.WorkspaceRoot, resolvedTarget)
+	}
+	if !pathWithin(m.cfg.WorkspaceRoot, resolvedTarget) {
+		return fallbackResult(fmt.Sprintf("target %q is outside the workspace root", in.Target), "")
+	}
 	args := []string{in.Handle, "--target=" + in.Target}
 	if len(in.Filter) > 0 {
 		filterJSON, err := json.Marshal(in.Filter)

--- a/internal/engine/mcp_stubs.go
+++ b/internal/engine/mcp_stubs.go
@@ -178,7 +178,13 @@ func pathToMemURI(workspaceRoot, path string) string {
 func searchMemoryGrep(workspaceRoot, query string, limit int, sector string) (map[string]any, error) {
 	memDir := filepath.Join(workspaceRoot, ".cog", "mem")
 	if sector != "" {
-		memDir = filepath.Join(memDir, sector)
+		// Caller-supplied sector becomes a path component; contain it so a value
+		// like "../../etc" can't walk the grep fallback outside the memory root.
+		contained, err := containedJoin(memDir, sector)
+		if err != nil {
+			return nil, fmt.Errorf("invalid sector %q: %w", sector, err)
+		}
+		memDir = contained
 	}
 
 	var results []map[string]any
@@ -458,7 +464,12 @@ func buildMemoryIndexFromDB(dbPath, workspaceRoot, sector string) (map[string]an
 func buildMemoryIndexFromFS(workspaceRoot, sector string) (map[string]any, error) {
 	memDir := filepath.Join(workspaceRoot, ".cog", "mem")
 	if sector != "" {
-		memDir = filepath.Join(memDir, sector)
+		// Contain the caller-supplied sector — see searchMemoryGrep.
+		contained, err := containedJoin(memDir, sector)
+		if err != nil {
+			return nil, fmt.Errorf("invalid sector %q: %w", sector, err)
+		}
+		memDir = contained
 	}
 
 	var docs []map[string]any

--- a/internal/engine/security_path_traversal_test.go
+++ b/internal/engine/security_path_traversal_test.go
@@ -1,0 +1,67 @@
+// security_path_traversal_test.go — regression coverage for the path-traversal
+// holes closed in the "security: close path-traversal holes #396 missed" change.
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFileForTest(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// TestSearchMemoryGrep_SectorContainment verifies the grep fallback rejects a
+// caller-supplied sector that escapes the memory root, while allowing a normal
+// sector.
+func TestSearchMemoryGrep_SectorContainment(t *testing.T) {
+	root := t.TempDir()
+	writeFileForTest(t, filepath.Join(root, ".cog", "mem", "semantic", "a.md"), "hello secret")
+	writeFileForTest(t, filepath.Join(root, "outside", "b.md"), "hello secret")
+
+	if _, err := searchMemoryGrep(root, "secret", 10, "semantic"); err != nil {
+		t.Fatalf("valid sector errored: %v", err)
+	}
+	for _, bad := range []string{"../../outside", "../outside", "../../../etc", "a/../../outside"} {
+		if _, err := searchMemoryGrep(root, "secret", 10, bad); err == nil {
+			t.Errorf("searchMemoryGrep sector %q: expected containment error, got nil", bad)
+		}
+	}
+}
+
+// TestBuildMemoryIndexFromFS_SectorContainment is the same guard on the index
+// fallback path.
+func TestBuildMemoryIndexFromFS_SectorContainment(t *testing.T) {
+	root := t.TempDir()
+	writeFileForTest(t, filepath.Join(root, ".cog", "mem", "episodic", "a.md"), "x")
+	writeFileForTest(t, filepath.Join(root, "outside", "b.md"), "x")
+
+	if _, err := buildMemoryIndexFromFS(root, "episodic"); err != nil {
+		t.Fatalf("valid sector errored: %v", err)
+	}
+	for _, bad := range []string{"../../outside", "../../../etc"} {
+		if _, err := buildMemoryIndexFromFS(root, bad); err == nil {
+			t.Errorf("buildMemoryIndexFromFS sector %q: expected containment error, got nil", bad)
+		}
+	}
+}
+
+func TestValidClaudeProjectName(t *testing.T) {
+	for _, ok := range []string{"my-project", "-Users-foo-bar", "abc123", "a.b-c"} {
+		if !validClaudeProjectName(ok) {
+			t.Errorf("validClaudeProjectName(%q) = false, want true", ok)
+		}
+	}
+	for _, bad := range []string{"..", "../x", "a/b", "../../tmp", "x/..", "/abs"} {
+		if validClaudeProjectName(bad) {
+			t.Errorf("validClaudeProjectName(%q) = true, want false", bad)
+		}
+	}
+}

--- a/internal/engine/serve_claude_code.go
+++ b/internal/engine/serve_claude_code.go
@@ -41,6 +41,14 @@ func claudeProjectsDir() string {
 	return filepath.Join(home, ".claude", "projects")
 }
 
+// validClaudeProjectName reports whether p is safe to use as a single path
+// component under claudeProjectsDir(): no parent refs and no separators, so it
+// cannot escape the projects directory. Shared by the sessions and spawn
+// handlers so both reject traversal identically.
+func validClaudeProjectName(p string) bool {
+	return !strings.Contains(p, "..") && !strings.ContainsRune(p, '/')
+}
+
 // ── route registration ───────────────────────────────────────────────────────
 
 // registerClaudeCodeRoutes wires the three /v1/claude-code/* routes onto mux.
@@ -133,7 +141,7 @@ func (s *Server) handleClaudeCodeSessions(w http.ResponseWriter, r *http.Request
 		return
 	}
 	// Sanitize: no path traversal.
-	if strings.Contains(project, "..") || strings.ContainsRune(project, '/') {
+	if !validClaudeProjectName(project) {
 		writeJSONError(w, http.StatusBadRequest, "invalid_param", "invalid project name")
 		return
 	}
@@ -317,6 +325,14 @@ func (s *Server) handleClaudeCodeSpawn(w http.ResponseWriter, r *http.Request) {
 	var req claudeCodeSpawnRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "bad_request", "invalid JSON body")
+		return
+	}
+	// Sanitize: req.Project becomes the spawned process's working directory
+	// (filepath.Join(claudeProjectsDir(), req.Project)); reject traversal so the
+	// CWD can't be steered outside ~/.claude/projects. Matches the guard in
+	// handleClaudeCodeSessions. Empty Project is allowed (no WorkDir derived).
+	if req.Project != "" && !validClaudeProjectName(req.Project) {
+		writeJSONError(w, http.StatusBadRequest, "invalid_param", "invalid project name")
 		return
 	}
 

--- a/internal/engine/serve_compat.go
+++ b/internal/engine/serve_compat.go
@@ -395,10 +395,12 @@ func (s *Server) handleMemoryRead(w http.ResponseWriter, r *http.Request) {
 		absPath = filepath.Join(s.cfg.WorkspaceRoot, ".cog", "mem", path)
 	}
 
-	// Security: ensure path is under .cog/mem/
+	// Security: ensure path is under .cog/mem/. Use pathWithin (not a bare
+	// HasPrefix) so a sibling like ".cog/mem-evil" — which textually starts with
+	// the mem root — does not pass the containment check.
 	memRoot := filepath.Join(s.cfg.WorkspaceRoot, ".cog", "mem")
 	cleanPath := filepath.Clean(absPath)
-	if !strings.HasPrefix(cleanPath, memRoot) {
+	if !pathWithin(memRoot, cleanPath) {
 		http.Error(w, "path outside memory root", http.StatusForbidden)
 		return
 	}


### PR DESCRIPTION
The 2026-06-25 deep audit (multi-agent, adversarially verified) found four caller-supplied-path sites on the loopback HTTP+MCP surface that #396 did not cover. All reuse the `pathWithin`/`containedJoin` helpers #396 established. **All are reject-only** — valid inputs are unaffected; only previously-exploitable inputs are now refused. Loopback-only by default (local-access hardening, not remote RCE), but `bind_addr: 0.0.0.0` deployments make them network-reachable.

| Site | Sev | Hole | Fix |
|------|-----|------|-----|
| `serve_compat.go:401` `handleMemoryRead` | HIGH | `strings.HasPrefix(cleanPath, memRoot)` w/o separator → `?path=../mem-sibling/secret.md` escapes (`mem-sibling` starts with `mem`) | `pathWithin(memRoot, cleanPath)` |
| `mcp_stubs.go:181/461` `searchMemoryGrep`/`buildMemoryIndexFromFS` | MED | `sector` `filepath.Join`'d unvalidated → `sector=../../etc` walks outside mem in the DB-absent fallback | `containedJoin(memDir, sector)` |
| `mcp_architecture.go:285` `toolArchitectureProject` | MED | `target` passed unvalidated as `--target=` to a python script that **writes** there | reject targets resolving outside workspace root |
| `serve_claude_code.go:361` `handleClaudeCodeSpawn` | LOW | `req.Project` (→ spawned WorkDir) had no traversal guard unlike sibling handler | shared `validClaudeProjectName` helper on both |

## Notes for review
- **Reject-only**: every change rejects inputs that were never legitimate; no valid-input behavior changes. The `mcp_architecture` one validates the *resolved* target but passes the caller's *original* value unchanged for contained inputs (the python runs with the kernel's CWD = workspace, so relative targets resolve identically).
- `validClaudeProjectName` allows the normal `-Users-foo-bar`-style project names; rejects `..` and `/`.

## Tests
`security_path_traversal_test.go`: sector-containment on both `mcp_stubs` fallback paths (valid sector passes, `../../outside` etc. rejected) + `validClaudeProjectName` table. `go vet` clean; the HIGH `serve_compat` fix reuses the already-tested `pathWithin`.

Found by the overnight deep audit; full report in `AUDIT-2026-06-25-deep.md` (S1–S4).