### PR TITLE
fix(engine): keep rotating log writer's handle valid after a failed reopen

### DIFF
--- a/internal/engine/rotating_writer.go
+++ b/internal/engine/rotating_writer.go
@@ -80,6 +80,22 @@ func (w *rotatingWriter) Write(p []byte) (int, error) {
 		}
 	}
 
+	// rotateLocked guarantees w.f is either a valid handle or nil — never a
+	// closed handle. If it could not reopen the sink (e.g. disk full mid-
+	// rotation), try once to (re)open here so logging self-heals when the
+	// condition clears, and surface a real error rather than EBADF-dropping the
+	// record onto a closed/nil descriptor.
+	if w.f == nil {
+		f, err := os.OpenFile(w.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+		if err != nil {
+			return 0, fmt.Errorf("kernel log sink unavailable: %w", err)
+		}
+		w.f = f
+		if fi, statErr := f.Stat(); statErr == nil {
+			w.size = fi.Size()
+		}
+	}
+
 	n, err := w.f.Write(p)
 	w.size += int64(n)
 	return n, err
@@ -87,10 +103,20 @@ func (w *rotatingWriter) Write(p []byte) (int, error) {
 
 // rotateLocked renames the active file to "<path>.1", shifting older backups up
 // and pruning beyond maxBackups, then opens a fresh active file. Caller holds mu.
+//
+// Invariant on return: w.f is either a valid open handle OR nil — never the
+// closed handle. The earlier version returned with w.f still pointing at the
+// handle closed below whenever the post-rename reopen failed, so every
+// subsequent Write hit EBADF and silently dropped the record. Write() now
+// self-heals from a nil w.f.
 func (w *rotatingWriter) rotateLocked() error {
 	// Close the active handle so the rename releases it cleanly (matters on
-	// Windows, where an open file cannot be renamed).
-	_ = w.f.Close()
+	// Windows, where an open file cannot be renamed). Drop the reference so a
+	// later early return can't leave a closed handle visible to Write.
+	if w.f != nil {
+		_ = w.f.Close()
+	}
+	w.f = nil
 
 	// Shift existing backups upward: <path>.(N-1) -> <path>.N, dropping the
 	// oldest. Descending order avoids clobbering a not-yet-moved backup.
@@ -105,27 +131,31 @@ func (w *rotatingWriter) rotateLocked() error {
 	}
 
 	// Move the active file to the newest backup slot. If the rename fails the
-	// file is left in place; reopening O_APPEND below means we resume on it
-	// rather than losing the handle.
+	// original is left in place and the reopen below resumes on it (O_APPEND).
 	newest := w.path + ".1"
 	_ = os.Remove(newest)
-	if err := os.Rename(w.path, newest); err != nil {
-		f, openErr := os.OpenFile(w.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
-		if openErr != nil {
-			return fmt.Errorf("rotate rename %s: %w (reopen also failed: %v)", w.path, err, openErr)
+	renameErr := os.Rename(w.path, newest)
+
+	// Open a fresh active handle. On rename success this creates a new empty
+	// file; on rename failure O_APPEND resumes the still-present original.
+	f, openErr := os.OpenFile(w.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if openErr != nil {
+		// Could not reopen (e.g. disk full after a successful rename). Leave
+		// w.f == nil; Write self-heals on a later call when the condition clears.
+		if renameErr != nil {
+			return fmt.Errorf("rotate %s: rename failed (%v) and reopen failed: %w", w.path, renameErr, openErr)
 		}
-		w.f = f
+		return fmt.Errorf("rotate %s: reopen after rename failed: %w", w.path, openErr)
+	}
+	w.f = f
+	if renameErr != nil {
+		// Resumed on the un-renamed original — preserve its size so the cap is
+		// still honored.
 		if fi, statErr := f.Stat(); statErr == nil {
 			w.size = fi.Size()
 		}
-		return fmt.Errorf("rotate rename %s: %w", w.path, err)
+		return fmt.Errorf("rotate rename %s: %w", w.path, renameErr)
 	}
-
-	f, err := os.OpenFile(w.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
-	if err != nil {
-		return fmt.Errorf("rotate reopen %s: %w", w.path, err)
-	}
-	w.f = f
 	w.size = 0
 	return nil
 }

--- a/internal/engine/rotating_writer_test.go
+++ b/internal/engine/rotating_writer_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -93,4 +94,72 @@ func TestRotatingWriterConcurrent(t *testing.T) {
 		}(g)
 	}
 	wg.Wait()
+}
+
+// TestRotatingWriterWriteAfterClose covers the Write self-heal path: if the
+// active handle is gone (here via Close, but in production via a failed
+// post-rotation reopen that leaves w.f nil), Write must reopen rather than
+// panic on a nil/closed handle or silently drop the record.
+func TestRotatingWriterWriteAfterClose(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "k.log")
+	w, err := newRotatingWriter(path, 1<<30, 2) // rotation effectively off
+	if err != nil {
+		t.Fatalf("newRotatingWriter: %v", err)
+	}
+	if err := w.Close(); err != nil { // w.f -> nil
+		t.Fatalf("Close: %v", err)
+	}
+
+	n, err := w.Write([]byte("recovered\n"))
+	if err != nil {
+		t.Fatalf("Write after Close: %v", err)
+	}
+	if n == 0 {
+		t.Fatal("Write reported 0 bytes after self-heal")
+	}
+	_ = w.Close()
+	b, _ := os.ReadFile(path)
+	if !strings.Contains(string(b), "recovered") {
+		t.Errorf("self-healed write not persisted; file=%q", string(b))
+	}
+}
+
+// TestRotatingWriterRotateWithNilHandle reproduces the post-failed-rotation
+// state — handle closed, w.f nil, size over the cap — and asserts the next
+// Write neither panics on the nil w.f.Close() in rotateLocked nor drops the
+// record. This is the regression for the closed-handle bug.
+func TestRotatingWriterRotateWithNilHandle(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "k.log")
+	w, err := newRotatingWriter(path, 100, 2)
+	if err != nil {
+		t.Fatalf("newRotatingWriter: %v", err)
+	}
+
+	// Force the exact state a failed reopen leaves behind.
+	w.mu.Lock()
+	_ = w.f.Close()
+	w.f = nil
+	w.size = 1000 // > maxBytes, so the next Write triggers rotateLocked
+	w.mu.Unlock()
+
+	n, err := w.Write([]byte("after-nil\n")) // must not panic on nil w.f.Close()
+	if err != nil {
+		t.Fatalf("Write with nil handle: %v", err)
+	}
+	if n == 0 {
+		t.Fatal("Write reported 0 bytes")
+	}
+	_ = w.Close()
+
+	found := false
+	for _, p := range []string{path, path + ".1"} {
+		if b, _ := os.ReadFile(p); strings.Contains(string(b), "after-nil") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("write after nil handle not found on disk")
+	}
 }


### PR DESCRIPTION
Regression in #397 (the kernel log rotation), found by the 2026-06-25 deep audit (R1 HIGH `rotating_writer.go:124`, R2 LOW `:113` — same root cause).

## Bug
`rotateLocked()` closes the active handle up front (needed so the rename releases it on Windows), then on **either** failure branch returns with `w.f` still pointing at that **closed** handle:
- rename succeeds but the post-rename `O_CREATE` reopen fails (disk full — rename is metadata-only and can succeed where create can't);
- rename fails AND the recovery reopen also fails.

After that, every `Write` does `w.f.Write(p)` on the closed fd → `EBADF` → the kernel JSON log record is **silently dropped** while the process reports healthy. `w.size` never advances (n=0), so rotation retriggers on every subsequent write.

## Fix
- `rotateLocked` now guarantees `w.f` is **either a valid handle or nil** on return — never the closed one — and guards the `w.f.Close()` against a nil handle so a second rotation attempt can't panic.
- `Write` self-heals from a nil handle: it reopens the sink (logging resumes once a disk-full condition clears) and returns a real error instead of EBADF-dropping onto a dead descriptor.

No happy-path behavior change — only the error/recovery path. This is purely hardening of code I shipped in #397.

## Tests
`rotating_writer_test.go`: Write-after-Close self-heal; and a forced post-failed-rotation state (closed handle + nil `w.f` + size over cap) that must not panic and must persist the record.

Found by the overnight deep audit; see `AUDIT-2026-06-25-deep.md` (R1/R2).