### PR TITLE
fix(engine): abort procmgr SIGKILL-escalation goroutine on shutdown

### DIFF
--- a/internal/engine/procmgr.go
+++ b/internal/engine/procmgr.go
@@ -173,8 +173,11 @@ type ProcessManager struct {
 	// Nil means no callbacks (results are just logged).
 	onComplete func(proc *ManagedProcess)
 
-	// Graceful shutdown signal.
-	shutdownCh chan struct{}
+	// Graceful shutdown signal. Closed once, when Shutdown() returns, so the
+	// per-kill SIGKILL-escalation goroutines abort instead of lingering past
+	// daemon teardown. shutdownOnce guards the close against repeat Shutdown calls.
+	shutdownCh   chan struct{}
+	shutdownOnce sync.Once
 }
 
 // ProcessManagerConfig configures the process manager.
@@ -358,7 +361,16 @@ func (pm *ProcessManager) Kill(id string) {
 	if proc.cmd != nil && proc.cmd.Process != nil {
 		_ = proc.cmd.Process.Signal(syscall.SIGTERM)
 		go func() {
-			time.Sleep(5 * time.Second)
+			// Wait out the grace period, but abort if the manager finishes
+			// shutting down first — otherwise this goroutine outlives the daemon
+			// by up to 5s firing a pointless SIGKILL at an already-reaped PID.
+			// shutdownCh closes only when Shutdown() returns (after its own grace
+			// window), so a normal kill still escalates here as before.
+			select {
+			case <-time.After(5 * time.Second):
+			case <-pm.shutdownCh:
+				return
+			}
 			// Liveness probe via signal 0 instead of reading proc.cmd.ProcessState:
 			// ProcessState is written by cmd.Wait() in another goroutine, so
 			// reading it here is a data race. Signal goes through os.Process'
@@ -523,6 +535,12 @@ func (pm *ProcessManager) Stats() ProcessStats {
 // Shutdown gracefully terminates all running processes.
 // Sends SIGTERM to all, waits up to timeout, then SIGKILL.
 func (pm *ProcessManager) Shutdown(timeout time.Duration) {
+	// Signal escalation goroutines to stop once we return (after the grace
+	// window below). During the window shutdownCh is still open, so in-flight
+	// SIGKILL escalations fire normally; only those still pending after teardown
+	// are aborted.
+	defer pm.shutdownOnce.Do(func() { close(pm.shutdownCh) })
+
 	pm.mu.RLock()
 	var running []string
 	for id, proc := range pm.processes {

--- a/internal/engine/procmgr_test.go
+++ b/internal/engine/procmgr_test.go
@@ -91,6 +91,24 @@ func TestReapHardCap(t *testing.T) {
 	}
 }
 
+// TestProcessManagerShutdownClosesChannel verifies Shutdown closes shutdownCh
+// (so kill-escalation goroutines can abort) and that a repeat Shutdown does not
+// panic on a double close (guarded by shutdownOnce).
+func TestProcessManagerShutdownClosesChannel(t *testing.T) {
+	pm := NewProcessManager(ProcessManagerConfig{})
+	pm.Shutdown(10 * time.Millisecond) // no running procs → returns immediately
+
+	select {
+	case <-pm.shutdownCh:
+		// closed as expected
+	default:
+		t.Fatal("shutdownCh not closed after Shutdown")
+	}
+
+	// Idempotent: a second Shutdown must not panic on a double close.
+	pm.Shutdown(10 * time.Millisecond)
+}
+
 // TestProcMgrConcurrentAccess drives Track/Finish/Remove/List/Stats/CanSpawn
 // from many goroutines so `go test -race` flags any unsynchronized field
 // access (e.g. reading proc.Status without proc.mu).


### PR DESCRIPTION
The audit's one SAFE-AUTOMERGE finding (`procmgr.go:360`, low).

The manual SIGTERM→SIGKILL escalation path (taken when `proc.cancel` is nil — the foreground streaming providers, which `Track` without a cancel func) spawned a goroutine that slept an **uninterruptible** `time.Sleep(5s)`. On daemon shutdown it outlived the daemon by up to that 5s, firing a pointless SIGKILL at an already-reaped PID. Harmless but untidy.

## Fix
Wire up the previously-unused `shutdownCh`:
- The escalation goroutine now `select`s on the 5s timer **or** `shutdownCh`.
- `Shutdown()` closes `shutdownCh` when it **returns** (deferred `sync.Once`) — i.e. *after* its own grace window.

So: a normal kill still escalates exactly as before; in-flight escalations during the shutdown grace window still fire; only goroutines still pending after teardown abort. No change to the kill semantics during normal operation.

## Test
`Shutdown` closes `shutdownCh`, and a repeat `Shutdown` doesn't panic (double-close guarded by `shutdownOnce`). Existing procmgr `-race` suite still green.