### PR TITLE
fix(worktree): stop acknowledged alarms pinning Degraded; remove LoadConfig init race

### DIFF
--- a/internal/engine/worktree_reconciler.go
+++ b/internal/engine/worktree_reconciler.go
@@ -200,6 +200,23 @@ type WorktreeReconciler struct {
 // via init(); the reconciler will use defaults wired in LoadConfig once the
 // workspace root is known.
 func NewWorktreeReconciler(repoRoot string, reader LedgerReader, writer LedgerWriter, git GitAdapter) *WorktreeReconciler {
+	// Default the adapters here rather than lazily in LoadConfig. The reconcile
+	// daemon and the autonomic ticker both call LoadConfig on the same instance
+	// concurrently; the lazy nil-check-then-assign there was an unsynchronized
+	// write to these interface fields (a data race, torn-read risk). Doing it
+	// once at construction means the fields are never written at runtime, so all
+	// later reads (including FetchLive's GitAdapter use) are race-free.
+	// Production registers with nil adapters (internal/providers/all), so this is
+	// the live path, not just a convenience for callers that pass their own.
+	if reader == nil {
+		reader = NewFilesystemLedgerReader(repoRoot)
+	}
+	if writer == nil {
+		writer = NewFilesystemLedgerWriter(repoRoot)
+	}
+	if git == nil {
+		git = NewCLIGitAdapter()
+	}
 	return &WorktreeReconciler{
 		RepoRoot:     repoRoot,
 		LedgerReader: reader,
@@ -235,16 +252,9 @@ type worktreeConfig struct {
 // LoadConfig reads all worktree.* ledger events for this RepoRoot and derives
 // the declared worktree set. Read-only; idempotent.
 func (r *WorktreeReconciler) LoadConfig(workspaceRoot string) (any, error) {
-	if r.LedgerReader == nil {
-		// v0 fallback: workspace-root-scoped FilesystemLedgerReader.
-		r.LedgerReader = NewFilesystemLedgerReader(workspaceRoot)
-	}
-	if r.LedgerWriter == nil {
-		r.LedgerWriter = NewFilesystemLedgerWriter(workspaceRoot)
-	}
-	if r.GitAdapter == nil {
-		r.GitAdapter = NewCLIGitAdapter()
-	}
+	// Adapters are defaulted in NewWorktreeReconciler (never written at runtime)
+	// so concurrent LoadConfig calls from the daemon and autonomic ticker can't
+	// race on these fields.
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -646,6 +656,15 @@ func (r *WorktreeReconciler) ApplyPlan(ctx context.Context, plan *reconcile.Plan
 		}
 	}
 	for _, a := range plan.Actions {
+		// Only an actively-firing alarm (ActionUpdate) degrades health. An
+		// already-acknowledged alarm becomes an ActionSkip that still carries its
+		// classification in Details; counting that here pinned HealthDegraded
+		// forever, which kept the autonomic ticker's needsHeal true and re-ran a
+		// full heal cycle for this provider every tick (and continuously
+		// triggered the daemon-vs-ticker concurrent-apply race).
+		if a.Action == reconcile.ActionSkip {
+			continue
+		}
 		if cls, _ := a.Details["classification"].(string); isAlarmClassification(cls) {
 			anyAlarm = true
 		}

--- a/internal/engine/worktree_reconciler_register.go
+++ b/internal/engine/worktree_reconciler_register.go
@@ -18,8 +18,9 @@ import (
 
 // RegisterWorktreeReconciler registers a WorktreeReconciler instance for the
 // given repo root with the global reconcile registry. Adapters may be nil;
-// LoadConfig will fill them with the filesystem-backed defaults on first
-// invocation.
+// NewWorktreeReconciler fills them with the filesystem-backed defaults at
+// construction (so the fields are never written at runtime — see the data-race
+// note there).
 //
 // Safe to call multiple times for the same repo root (uses UpsertProvider).
 func RegisterWorktreeReconciler(repoRoot string, reader LedgerReader, writer LedgerWriter, git GitAdapter) *WorktreeReconciler {

--- a/internal/engine/worktree_reconciler_test.go
+++ b/internal/engine/worktree_reconciler_test.go
@@ -281,6 +281,10 @@ func TestWorktreeReconcilerAlarmIdempotent(t *testing.T) {
 	if got := ledger.emitCountByKind(BlockWorktreeAlarm); got != 1 {
 		t.Fatalf("cycle 1: alarm events=%d want 1", got)
 	}
+	// An actively-firing alarm (ActionUpdate) should mark the provider Degraded.
+	if h := r.Health(); h.Health != reconcile.HealthDegraded {
+		t.Errorf("cycle 1: health=%v want Degraded (alarm actively firing)", h.Health)
+	}
 
 	// Cycles 2–4: prior alarm in ledger → skip, no re-emit.
 	for i := 2; i <= 4; i++ {
@@ -294,6 +298,29 @@ func TestWorktreeReconcilerAlarmIdempotent(t *testing.T) {
 	}
 	if got := ledger.emitCountByKind(BlockWorktreeAlarm); got != 1 {
 		t.Errorf("after 4 cycles: alarm events=%d want 1 (idempotent — no re-emit)", got)
+	}
+	// C2 regression: once the alarm is acknowledged (ActionSkip), health must
+	// return to Healthy. Before the fix it stayed Degraded forever, which kept
+	// the autonomic ticker re-healing this provider on every tick.
+	if h := r.Health(); h.Health == reconcile.HealthDegraded || h.Sync == reconcile.SyncStatusOutOfSync {
+		t.Errorf("after acknowledged alarm: health=%v sync=%v want Healthy/Synced (C2)", h.Health, h.Sync)
+	}
+}
+
+// TestNewWorktreeReconciler_DefaultsNilAdapters covers C3: adapters passed nil
+// (the production registration path) are defaulted at construction, so LoadConfig
+// never writes these fields at runtime and concurrent daemon/ticker LoadConfig
+// calls can't race on them.
+func TestNewWorktreeReconciler_DefaultsNilAdapters(t *testing.T) {
+	r := NewWorktreeReconciler("/repo/root", nil, nil, nil)
+	if r.LedgerReader == nil {
+		t.Error("LedgerReader nil; want defaulted")
+	}
+	if r.LedgerWriter == nil {
+		t.Error("LedgerWriter nil; want defaulted")
+	}
+	if r.GitAdapter == nil {
+		t.Error("GitAdapter nil; want defaulted")
 	}
 }
 


### PR DESCRIPTION
**REVIEW-REQUIRED — left open for your sign-off** (touches worktree reconcile health/init semantics; the audit asked to review the concurrency cluster together).

Two related worktree-reconciler defects from the 2026-06-25 deep audit.

## C2 (HIGH, `worktree_reconciler.go:648`) — perpetual Degraded after acknowledgement
`ApplyPlan`'s health loop counted **any** action whose `Details["classification"]` is an alarm type — including the `ActionSkip` that `ComputePlan` emits for an already-acknowledged alarm (it dedupes the ledger emit but leaves the classification in Details). So once any worktree alarm fired, the provider stayed `HealthDegraded` on **every** subsequent cycle, which kept the autonomic ticker's `needsHeal` true and re-ran a full heal cycle for this provider every tick. That continuous heal is the **steady-state trigger** for the daemon-vs-ticker concurrent-apply hazard (C1).

**Fix:** skip `ActionSkip` actions in the health check — only actively-firing (`ActionUpdate`) alarms degrade health.

## C3 (`worktree_reconciler.go:238`) — data race on lazy adapter init
`LoadConfig` did a nil-check-then-assign on `LedgerReader`/`LedgerWriter`/`GitAdapter`. The daemon and the autonomic ticker call `LoadConfig` on the same instance concurrently, racing those interface-field writes (torn-read risk → possible nil-deref panic in `FetchLive`).

**Fix:** default the adapters in `NewWorktreeReconciler` so the fields are never written at runtime; remove the lazy init. Production registers with nil adapters, so this is the live path. Also removes a latent bug where the ticker's `LoadConfig("")` could mis-init adapters with a cwd-relative root if it ran first.

## Interaction with C1 (not in this PR)
C1 (`autonomic_ticker.go:344` — route `healDegradedProviders` through the daemon's `Trigger` so there's one apply path) is the **root** concurrency fix and is left for a separate, carefully-reviewed change. C2 and C3 are independent strict improvements: C2 removes the continuous trigger; C3 closes the field race. Neither conflicts with a later C1. Per the audit's caution, I did **not** assume C2+C3 fully resolve the concurrency — C1 is still needed for the duplicate-apply-path elimination.

## Tests
The alarm-idempotent test now asserts `Degraded` while the alarm fires, then `Healthy` after acknowledgement (the C2 regression — fails without the guard). New constructor test asserts nil adapters are defaulted (C3). `-race` suite green.

Audit ref: `AUDIT-2026-06-25-deep.md` (C2/C3).