### PR TITLE
fix(engine): atomic bus registry write + correct rotation cache-reset order

### DIFF
--- a/internal/engine/bus_session.go
+++ b/internal/engine/bus_session.go
@@ -231,6 +231,12 @@ func (m *BusSessionManager) LoadRegistry() []BusRegistryEntry {
 }
 
 // saveRegistry writes the bus registry to disk. Caller must hold m.mu.
+//
+// The write is atomic (tmp + rename): a plain truncate-before-write left
+// registry.json empty if the process was killed mid-write, and loadRegistry
+// swallows the resulting parse error and returns an empty registry — dropping
+// all bus-to-session metadata until sessions re-register. Same pattern as
+// WriteState / saveSignalField.
 func (m *BusSessionManager) saveRegistry(entries []BusRegistryEntry) error {
 	if err := os.MkdirAll(m.BusesDir(), 0755); err != nil {
 		return err
@@ -239,7 +245,15 @@ func (m *BusSessionManager) saveRegistry(entries []BusRegistryEntry) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(m.RegistryPath(), data, 0644)
+	tmp := m.RegistryPath() + ".tmp"
+	if err := os.WriteFile(tmp, data, 0644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, m.RegistryPath()); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
 }
 
 // AppendEvent appends a new BusBlock to a bus's event chain.
@@ -313,13 +327,18 @@ func (m *BusSessionManager) AppendEvent(busID, eventType, from string, payload m
 		ts := time.Now().UTC().Format("2006-01-02T150405Z")
 		archivePath := filepath.Join(m.BusesDir(), busID, "events."+ts+".jsonl")
 		if renameErr := os.Rename(eventsFile, archivePath); renameErr == nil {
-			// Create a fresh empty events.jsonl for subsequent appends.
+			// Create a fresh empty events.jsonl for subsequent appends. Only
+			// reset the seq/hash cache once the new file actually exists — if
+			// Create fails (e.g. disk full) the events.jsonl is now absent, and
+			// zeroing the cache would make a concurrent ReadEvents see an empty
+			// bus until the next append's EnsureBus recreates the file.
 			if nf, createErr := os.Create(eventsFile); createErr == nil {
 				nf.Close()
+				m.lastSeq[busID] = 0
+				m.lastHash[busID] = ""
+			} else {
+				slog.Warn("bus: size-rotation create failed, retaining seq cache", "err", createErr, "bus_id", busID)
 			}
-			// Reset cache: new file starts at seq 0.
-			m.lastSeq[busID] = 0
-			m.lastHash[busID] = ""
 		} else {
 			slog.Warn("bus: size-rotation rename failed", "err", renameErr, "bus_id", busID)
 		}

--- a/internal/engine/bus_session_test.go
+++ b/internal/engine/bus_session_test.go
@@ -549,3 +549,25 @@ func TestBusSessionEventHandlerDispatch(t *testing.T) {
 		// ok — handler was properly removed
 	}
 }
+
+// TestSaveRegistryAtomic verifies the registry write goes through a temp file
+// and rename (no truncate-before-write window), leaves no .tmp behind, and
+// round-trips through loadRegistry.
+func TestSaveRegistryAtomic(t *testing.T) {
+	root := t.TempDir()
+	mgr := NewBusSessionManager(root)
+
+	entries := []BusRegistryEntry{{BusID: "bus_test", State: "active", LastEventSeq: 3}}
+	if err := mgr.saveRegistry(entries); err != nil {
+		t.Fatalf("saveRegistry: %v", err)
+	}
+
+	if _, err := os.Stat(mgr.RegistryPath() + ".tmp"); !os.IsNotExist(err) {
+		t.Errorf("temp file left behind after atomic write: stat err=%v", err)
+	}
+
+	got := mgr.loadRegistry()
+	if len(got) != 1 || got[0].BusID != "bus_test" || got[0].LastEventSeq != 3 {
+		t.Errorf("loadRegistry = %+v, want one bus_test entry with seq=3", got)
+	}
+}


### PR DESCRIPTION
Two `bus_session` robustness fixes from the 2026-06-25 deep audit.

## A1 (`bus_session.go:232`) — non-atomic registry write
`saveRegistry` used `os.WriteFile` (truncate-before-write). A SIGKILL/crash between truncate and write leaves `registry.json` empty; `loadRegistry` swallows the parse error and returns an empty registry, dropping bus-to-session metadata until sessions re-register.

**Fix:** tmp + rename — the same atomic pattern already used by `WriteState` and `saveSignalField`.

(The audit verifier downgraded the impact: bus event logs are authoritative and bus re-registration is automatic on the next request, so the prior blast radius was *transient* peripheral-context loss, not permanent data loss. But the atomic write is the correct posture.)

## A2 (`bus_session.go:317`) — rotation cache-reset ordering
During size-rotation the seq/hash cache was reset to zero **unconditionally** after the rename, even if the `os.Create` of the fresh `events.jsonl` failed — leaving the cache zeroed with no file present, so a concurrent `ReadEvents` saw an empty bus until the next append recreated it.

**Fix:** reset the cache only inside the create-succeeded branch; on create failure, warn and retain the cache.

## Test
`TestSaveRegistryAtomic`: round-trips through `loadRegistry` and leaves no `.tmp` behind. Existing bus suite green.

Audit ref: `AUDIT-2026-06-25-deep.md` (A1/A2).