### PR TITLE
fix(eval): make ComputePlan pure by draining dispatch triggers in FetchLive

### DIFF
--- a/internal/eval/provider.go
+++ b/internal/eval/provider.go
@@ -419,6 +419,11 @@ type EvalLiveState struct {
 	Scorecards map[string]*Scorecard `json:"scorecards"`
 	// FetchedAt is the ISO-8601 timestamp when this snapshot was taken.
 	FetchedAt string `json:"fetched_at"`
+	// DispatchTriggers maps experiment ID → force, drained from the
+	// eval-dispatch-triggers.json sidecar during FetchLive (the read-and-clear
+	// happens there, not in ComputePlan, so ComputePlan stays pure — each
+	// trigger is consumed exactly when it is observed into live state).
+	DispatchTriggers map[string]bool `json:"dispatch_triggers,omitempty"`
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/eval/provider_impl.go
+++ b/internal/eval/provider_impl.go
@@ -251,12 +251,23 @@ func splitFrontmatter(text string) (map[string]interface{}, error) {
 // FetchLive reads all completed trial records from bus_tournament.
 // Re-materializes scorecards inline per reconcile cycle (all-time, per design memo Q2).
 func (e *EvalProvider) FetchLive(ctx context.Context, config any) (any, error) {
+	// Drain the cog_run_experiment sidecar here (the observation step), once per
+	// cycle, so ComputePlan can stay pure. Doing the read-and-clear in
+	// ComputePlan meant a discarded/re-run plan could silently consume a
+	// user-initiated trigger. (The remaining concurrent-FetchLive window between
+	// the reconcile daemon and the autonomic ticker is the separate C1 issue.)
+	var dispatchTriggers map[string]bool
+	if e.root != "" {
+		dispatchTriggers = readAndClearDispatchTriggers(e.root)
+	}
+
 	if e.busReader == nil {
 		// No reader wired — return empty live state (FetchLive degrades gracefully)
 		return &EvalLiveState{
-			Trials:     []TrialRecord{},
-			Scorecards: map[string]*Scorecard{},
-			FetchedAt:  nowISO(),
+			Trials:           []TrialRecord{},
+			Scorecards:       map[string]*Scorecard{},
+			FetchedAt:        nowISO(),
+			DispatchTriggers: dispatchTriggers,
 		}, nil
 	}
 
@@ -264,9 +275,10 @@ func (e *EvalProvider) FetchLive(ctx context.Context, config any) (any, error) {
 	if err != nil {
 		// Degrade gracefully — kernel may not be reachable during tests
 		return &EvalLiveState{
-			Trials:     []TrialRecord{},
-			Scorecards: map[string]*Scorecard{},
-			FetchedAt:  nowISO(),
+			Trials:           []TrialRecord{},
+			Scorecards:       map[string]*Scorecard{},
+			FetchedAt:        nowISO(),
+			DispatchTriggers: dispatchTriggers,
 		}, nil
 	}
 	if events == nil {
@@ -300,9 +312,10 @@ func (e *EvalProvider) FetchLive(ctx context.Context, config any) (any, error) {
 	}
 
 	return &EvalLiveState{
-		Trials:     trials,
-		Scorecards: scorecards,
-		FetchedAt:  nowISO(),
+		Trials:           trials,
+		Scorecards:       scorecards,
+		FetchedAt:        nowISO(),
+		DispatchTriggers: dispatchTriggers,
 	}, nil
 }
 
@@ -480,15 +493,13 @@ func (e *EvalProvider) ComputePlan(config any, live any, state *reconcile.State)
 		}
 	}
 
-	// Merge in triggers from the sidecar file written by cog_run_experiment.
-	// This bridges the MCP-tool invocation → reconcile-cycle gap. The file is
-	// cleared by readAndClearDispatchTriggers so each trigger fires exactly once.
-	if e.root != "" {
-		for expID, force := range readAndClearDispatchTriggers(e.root) {
-			dispatchTriggers[expID] = true
-			if force {
-				forcedExperiments[expID] = true
-			}
+	// Merge in triggers observed (and drained) by FetchLive from the
+	// cog_run_experiment sidecar. ComputePlan only reads them now — the
+	// destructive clear lives in FetchLive — so this stays a pure function.
+	for expID, force := range ls.DispatchTriggers {
+		dispatchTriggers[expID] = true
+		if force {
+			forcedExperiments[expID] = true
 		}
 	}
 

--- a/internal/eval/provider_test.go
+++ b/internal/eval/provider_test.go
@@ -1157,7 +1157,17 @@ func TestComputePlan_DispatchTriggerFromFile(t *testing.T) {
 		},
 		BaselinePins: map[string]string{},
 	}
-	ls := &EvalLiveState{Scorecards: map[string]*Scorecard{}}
+	// FetchLive drains the trigger sidecar into the live state (the read-and-
+	// clear moved here from ComputePlan to keep ComputePlan pure); ComputePlan
+	// then reads the trigger from live.
+	liveAny, err := p.FetchLive(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("FetchLive: %v", err)
+	}
+	ls := liveAny.(*EvalLiveState)
+	if _, ok := ls.DispatchTriggers["exp-001"]; !ok {
+		t.Fatalf("FetchLive did not drain the trigger into live state: %+v", ls.DispatchTriggers)
+	}
 
 	plan, err := p.ComputePlan(cfg, ls, nil)
 	if err != nil {
@@ -1168,6 +1178,11 @@ func TestComputePlan_DispatchTriggerFromFile(t *testing.T) {
 	actions := filterNonSkip(plan.Actions)
 	if len(actions) == 0 {
 		t.Errorf("expected non-skip action when trigger is set, got all skips: %v", actionSummary(plan.Actions))
+	}
+
+	// And the sidecar must be drained — a second FetchLive sees no trigger.
+	if t2 := readAndClearDispatchTriggers(dir); len(t2) != 0 {
+		t.Errorf("trigger not cleared by FetchLive: %v", t2)
 	}
 }
 


### PR DESCRIPTION
**REVIEW-REQUIRED — left open for your sign-off** (reconcile-contract change in the eval provider's data flow).

Found during the overnight work (not in the audit's list, but the same reconcile-purity class). `EvalProvider.ComputePlan` called `readAndClearDispatchTriggers(e.root)`, which **destructively clears** the `eval-dispatch-triggers.json` sidecar. `ComputePlan` is contractually **pure** — the reconcile daemon may call it and discard the plan, and a concurrent daemon+ticker call can both clear — so a user-initiated `cog_run_experiment` trigger could be silently dropped.

## Fix
Move the read-and-clear into `FetchLive` (the observation step, once per cycle) and carry the result in `EvalLiveState.DispatchTriggers`. `ComputePlan` now only **reads** `ls.DispatchTriggers`, so it is pure: re-running it on the same live state yields the same plan and consumes nothing. Triggers are drained on all `FetchLive` return paths (including graceful-degrade), so a trigger still fires when the tournament bus is unreachable.

## Scope note
The remaining concurrent-`FetchLive` window (reconcile daemon vs autonomic ticker) is the separate **C1** root-cause issue (`autonomic_ticker.go:344`), tracked in `AUDIT-2026-06-25-deep.md`. This change makes `ComputePlan` pure; C1 closes the cross-goroutine apply race.

## Test
The dispatch-trigger test now drives the real flow: `FetchLive` drains the sidecar into live state, `ComputePlan` produces the non-skip action, and the sidecar is confirmed cleared.