### PR TITLE
perf(service): cache ServiceProvider.Health() behind a short TTL

### DIFF
--- a/service_provider.go
+++ b/service_provider.go
@@ -61,7 +61,21 @@ type ServiceProvider struct {
 	mu      sync.Mutex
 	root    string
 	runtime *DockerClient
+
+	// Health() result cache. computeHealth issues a Docker Ping + one
+	// ContainerList per declared service; Health() is called on every
+	// /v1/infer, every autonomic tick, and after every reconcile cycle, so the
+	// live probe is memoized for serviceHealthTTL. Guarded by mu.
+	cachedHealth ResourceStatus
+	healthAt     time.Time
+	healthValid  bool
 }
+
+// serviceHealthTTL bounds how stale a cached Health() result may be. Service
+// liveness changes are picked up within this window (and at the latest by the
+// next ~30s reconcile cycle), which is well inside the Reconcilable contract's
+// "Health() must be near-zero-cost" expectation.
+const serviceHealthTTL = 15 * time.Second
 
 func init() {
 	RegisterProvider("service", &ServiceProvider{})
@@ -701,8 +715,32 @@ func (s *ServiceProvider) BuildState(config any, live any, existing *ReconcileSt
 
 // ─── Health ─────────────────────────────────────────────────────────────────────
 
-// Health returns the three-axis status of the service subsystem.
+// Health returns the three-axis status of the service subsystem, served from a
+// short-TTL cache so the live Docker probe runs at most once per
+// serviceHealthTTL no matter how many callers hit it.
 func (s *ServiceProvider) Health() ResourceStatus {
+	s.mu.Lock()
+	if s.healthValid && time.Since(s.healthAt) < serviceHealthTTL {
+		h := s.cachedHealth
+		s.mu.Unlock()
+		return h
+	}
+	s.mu.Unlock()
+
+	h := s.computeHealth()
+
+	s.mu.Lock()
+	s.cachedHealth = h
+	s.healthAt = time.Now()
+	s.healthValid = true
+	s.mu.Unlock()
+	return h
+}
+
+// computeHealth performs the live probe: a Docker Ping plus a per-service
+// container/PID-liveness check. Called by Health() at most once per
+// serviceHealthTTL.
+func (s *ServiceProvider) computeHealth() ResourceStatus {
 	s.mu.Lock()
 	root := s.root
 	s.mu.Unlock()

--- a/service_provider_test.go
+++ b/service_provider_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// TestServiceProviderHealthCache verifies Health() serves a fresh cached result
+// without recomputing (the expensive Docker probe), and recomputes once the
+// cache is older than serviceHealthTTL.
+func TestServiceProviderHealthCache(t *testing.T) {
+	// Non-empty root with no services dir → computeHealth short-circuits to
+	// Healthy without touching Docker, so the test is hermetic.
+	s := &ServiceProvider{root: t.TempDir()}
+
+	sentinel := ResourceStatus{Sync: SyncStatusOutOfSync, Health: HealthDegraded, Message: "cached-sentinel"}
+
+	// Prime a fresh cache: Health() must return it verbatim, no recompute.
+	s.mu.Lock()
+	s.cachedHealth = sentinel
+	s.healthAt = time.Now()
+	s.healthValid = true
+	s.mu.Unlock()
+	if h := s.Health(); h.Message != "cached-sentinel" {
+		t.Errorf("fresh cache: Health().Message=%q, want %q (cache hit, no recompute)", h.Message, "cached-sentinel")
+	}
+
+	// Expire the cache: Health() must recompute (empty workspace → Healthy),
+	// replacing the sentinel.
+	s.mu.Lock()
+	s.healthAt = time.Now().Add(-2 * serviceHealthTTL)
+	s.mu.Unlock()
+	if h := s.Health(); h.Message == "cached-sentinel" {
+		t.Error("expired cache: Health() returned the stale sentinel; want a recompute")
+	}
+}


### PR DESCRIPTION
**REVIEW-REQUIRED — left open for your sign-off** (touches service-health reporting). Audit Q4 (`service_provider.go:720`, medium).

`ServiceProvider.Health()` issues a Docker Ping + one `ContainerList` **per declared service** on every call, with no caching. `Health()` is on hot paths — every `POST /v1/infer` (foveated `buildHealthBlock`), every autonomic tick, and after every reconcile cycle — so a workspace with N docker-mode services pays **1+N Docker API round-trips per inference request**. The Reconcilable contract wants `Health()` near-zero-cost (cf. `IdentityProvider`/`RBACProvider`, which return cached status).

## Fix
Memoize the live probe for `serviceHealthTTL` (15s): `Health()` returns the cached `ResourceStatus` when fresh, else recomputes (existing probe, now `computeHealth`) and refreshes the cache. Service liveness changes are still picked up within the TTL and at the latest by the next ~30s reconcile cycle.

## Test
`TestServiceProviderHealthCache`: a fresh cache is returned without recompute; an expired cache recomputes. Hermetic (empty workspace → no Docker).

Audit ref: `AUDIT-2026-06-25-deep.md` (Q4).