### PR TITLE
perf(reconcile): carry rendered projection in ApplyPlan instead of re-reading the corpus

### DIFF
--- a/internal/engine/decision_lineage_reconciler.go
+++ b/internal/engine/decision_lineage_reconciler.go
@@ -163,6 +163,9 @@ func (r *DecisionLineageReconciler) ComputePlan(config any, live any, state *rec
 				"path":           projPath,
 				"decision_count": len(decisions),
 				"kind":           string(ProjectionDecisionLineage),
+				// Carry the already-rendered projection so ApplyPlan writes it
+				// directly instead of re-loading + re-rendering the whole corpus.
+				"content": projected,
 			},
 		})
 		if action == reconcile.ActionCreate {
@@ -212,19 +215,24 @@ func (r *DecisionLineageReconciler) ApplyPlan(ctx context.Context, plan *reconci
 			continue
 		}
 
-		// Re-derive from the corpus (idempotency: generate from scratch).
-		// projPath = <root>/.cog/mem/semantic/lineage/projections/decision-lineage.md
-		// root is five dirs up from the projections dir.
-		root := deriveRootFromProjectionPath(projPath)
-		decisions, err := LoadDecisionCorpus(root)
-		if err != nil {
-			results = append(results, reconcile.Result{
-				Phase: "apply", Action: string(action.Action), Name: action.Name,
-				Status: reconcile.ApplyFailed, Error: fmt.Sprintf("reload corpus: %v", err),
-			})
-			continue
+		// Use the projection ComputePlan already rendered this cycle. Only fall
+		// back to re-loading + re-rendering the whole decision corpus (the
+		// redundant O(corpus) work FetchLive/ComputePlan already did) if a
+		// caller built the plan without content — e.g. a test or a hand-built
+		// plan. projPath = <root>/.cog/mem/semantic/lineage/projections/decision-lineage.md.
+		content, _ := action.Details["content"].(string)
+		if content == "" {
+			root := deriveRootFromProjectionPath(projPath)
+			decisions, derr := LoadDecisionCorpus(root)
+			if derr != nil {
+				results = append(results, reconcile.Result{
+					Phase: "apply", Action: string(action.Action), Name: action.Name,
+					Status: reconcile.ApplyFailed, Error: fmt.Sprintf("reload corpus: %v", derr),
+				})
+				continue
+			}
+			content = renderDecisionLineageProjection(ComputeManifold(decisions, r.now()))
 		}
-		content := renderDecisionLineageProjection(ComputeManifold(decisions, r.now()))
 
 		tmp := projPath + ".tmp"
 		if err := os.WriteFile(tmp, []byte(content), 0644); err != nil {
@@ -252,7 +260,8 @@ func (r *DecisionLineageReconciler) ApplyPlan(ctx context.Context, plan *reconci
 			Phase: "apply", Action: string(action.Action), Name: action.Name,
 			Status: reconcile.ApplySucceeded,
 		})
-		log.Printf("[decision-lineage-reconciler] wrote %s (%d decisions)", projPath, len(decisions))
+		decisionCount, _ := action.Details["decision_count"].(int)
+		log.Printf("[decision-lineage-reconciler] wrote %s (%d decisions)", projPath, decisionCount)
 	}
 
 	return results, nil

--- a/internal/engine/decision_lineage_reconciler_test.go
+++ b/internal/engine/decision_lineage_reconciler_test.go
@@ -300,3 +300,44 @@ func TestSpineCLIViews(t *testing.T) {
 		t.Error("accretion view missing header")
 	}
 }
+
+// TestDecisionLineageApplyPlan_UsesDetailsContent verifies ApplyPlan writes the
+// projection content carried in Action.Details verbatim, rather than re-loading
+// and re-rendering the decision corpus (the per-cycle redundancy this fix
+// removes). A sentinel that no corpus would produce proves the content path is
+// taken.
+func TestDecisionLineageApplyPlan_UsesDetailsContent(t *testing.T) {
+	dir := t.TempDir()
+	projDir := filepath.Join(dir, ".cog", "mem", "semantic", "lineage", "projections")
+	if err := os.MkdirAll(projDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	projPath := filepath.Join(projDir, string(ProjectionDecisionLineage)+".md")
+
+	rec := NewDecisionLineageReconciler()
+	const sentinel = "SENTINEL-PROJECTION-CONTENT\n"
+	plan := &reconcile.Plan{
+		Actions: []reconcile.Action{{
+			Action:       reconcile.ActionCreate,
+			ResourceType: rec.Type(),
+			Name:         string(ProjectionDecisionLineage),
+			Details: map[string]any{
+				"path":           projPath,
+				"decision_count": 0,
+				"content":        sentinel,
+			},
+		}},
+	}
+
+	if _, err := rec.ApplyPlan(context.Background(), plan); err != nil {
+		t.Fatalf("ApplyPlan: %v", err)
+	}
+
+	got, err := os.ReadFile(projPath)
+	if err != nil {
+		t.Fatalf("read projection: %v", err)
+	}
+	if string(got) != sentinel {
+		t.Errorf("ApplyPlan wrote %q, want the Details content verbatim (no corpus re-derive)", string(got))
+	}
+}

--- a/internal/engine/projection_reconciler.go
+++ b/internal/engine/projection_reconciler.go
@@ -320,9 +320,12 @@ func (r *ProjectionReconciler) ComputePlan(config any, live any, state *reconcil
 			ResourceType: r.Type(),
 			Name:         string(r.kind),
 			Details: map[string]any{
-				"path":        projPath,
-				"node_count":  len(nodes),
-				"kind":        string(r.kind),
+				"path":       projPath,
+				"node_count": len(nodes),
+				"kind":       string(r.kind),
+				// Carry the rendered projection so ApplyPlan writes it directly
+				// instead of re-reading + re-parsing the whole nodes corpus.
+				"content": projected,
 			},
 		})
 		if action == reconcile.ActionCreate {
@@ -377,43 +380,46 @@ func (r *ProjectionReconciler) ApplyPlan(ctx context.Context, plan *reconcile.Pl
 			continue
 		}
 
-		// Re-generate projection content (idempotency: generate from scratch).
-		// We need to reload nodes since ApplyPlan doesn't carry live state.
-		// The projection content was already computed in ComputePlan; we
-		// re-derive it here to satisfy the idempotency requirement.
-		nodesDir := filepath.Dir(filepath.Dir(projPath)) // projections/../ = lineage/
-		nodesDir = filepath.Join(nodesDir, "nodes")
+		// Use the projection ComputePlan already rendered this cycle. Only fall
+		// back to re-reading + re-parsing the whole nodes corpus (the redundant
+		// O(corpus) work FetchLive/ComputePlan already did) if a caller built
+		// the plan without content — e.g. a test or a hand-built plan.
+		content, _ := action.Details["content"].(string)
+		if content == "" {
+			nodesDir := filepath.Dir(filepath.Dir(projPath)) // projections/../ = lineage/
+			nodesDir = filepath.Join(nodesDir, "nodes")
 
-		entries, err := os.ReadDir(nodesDir)
-		if err != nil {
-			results = append(results, reconcile.Result{
-				Phase:  "apply",
-				Action: string(action.Action),
-				Name:   action.Name,
-				Status: reconcile.ApplyFailed,
-				Error:  fmt.Sprintf("reload nodes: %v", err),
-			})
-			continue
-		}
-
-		var nodes []LineageNode
-		for _, entry := range entries {
-			if !strings.HasSuffix(entry.Name(), ".cog.md") {
+			entries, derr := os.ReadDir(nodesDir)
+			if derr != nil {
+				results = append(results, reconcile.Result{
+					Phase:  "apply",
+					Action: string(action.Action),
+					Name:   action.Name,
+					Status: reconcile.ApplyFailed,
+					Error:  fmt.Sprintf("reload nodes: %v", derr),
+				})
 				continue
 			}
-			node, err := parseLineageNode(filepath.Join(nodesDir, entry.Name()))
-			if err == nil {
-				nodes = append(nodes, *node)
-			}
-		}
-		sort.Slice(nodes, func(i, j int) bool {
-			if nodes[i].Frontmatter.Tier != nodes[j].Frontmatter.Tier {
-				return nodes[i].Frontmatter.Tier < nodes[j].Frontmatter.Tier
-			}
-			return nodes[i].Frontmatter.ID < nodes[j].Frontmatter.ID
-		})
 
-		content := generateProjection(r.kind, nodes)
+			var nodes []LineageNode
+			for _, entry := range entries {
+				if !strings.HasSuffix(entry.Name(), ".cog.md") {
+					continue
+				}
+				node, perr := parseLineageNode(filepath.Join(nodesDir, entry.Name()))
+				if perr == nil {
+					nodes = append(nodes, *node)
+				}
+			}
+			sort.Slice(nodes, func(i, j int) bool {
+				if nodes[i].Frontmatter.Tier != nodes[j].Frontmatter.Tier {
+					return nodes[i].Frontmatter.Tier < nodes[j].Frontmatter.Tier
+				}
+				return nodes[i].Frontmatter.ID < nodes[j].Frontmatter.ID
+			})
+
+			content = generateProjection(r.kind, nodes)
+		}
 
 		// Atomic write: tmp + rename.
 		tmp := projPath + ".tmp"
@@ -451,7 +457,8 @@ func (r *ProjectionReconciler) ApplyPlan(ctx context.Context, plan *reconcile.Pl
 			Status: reconcile.ApplySucceeded,
 		})
 
-		log.Printf("[projection-reconciler] wrote %s (%d nodes)", projPath, len(nodes))
+		nodeCount, _ := action.Details["node_count"].(int)
+		log.Printf("[projection-reconciler] wrote %s (%d nodes)", projPath, nodeCount)
 	}
 
 	return results, nil


### PR DESCRIPTION
**REVIEW-REQUIRED — left open for your sign-off** (reconcile `ApplyPlan` data flow). Audit Q1 + Q2.

`ProjectionReconciler.ApplyPlan` (`projection_reconciler.go:387`) and `DecisionLineageReconciler.ApplyPlan` (`decision_lineage_reconciler.go:219`) both re-read + re-parse the **entire** nodes/decision corpus and re-render the projection — work `FetchLive` + `ComputePlan` already did earlier in the same reconcile cycle. The `Reconcilable.ApplyPlan(ctx, plan)` signature carries no live state, so the content was re-derived "for idempotency."

But the rendered string is deterministic given (corpus, clock tick), so carrying it forward preserves idempotency **without** the redundant O(corpus) disk scan + YAML parse. With 6 projection instances, a drifted cycle did up to **12 full corpus reads**; the `ProjectionWatcher` fsnotify also fires it on every node write.

## Fix
`ComputePlan` stores the already-rendered projection in `Action.Details["content"]`; `ApplyPlan` writes that directly. A defensive fallback re-derives **only** when `content` is absent (a hand-built / test plan). The atomic tmp+rename and the written bytes are unchanged; the per-action logs use the count already in `Details`.

## Scope / left out
Q3 (`site.go:324`, the same pattern for site CRDs) is **not** included — it touches the site **deploy** path (writes CNAME etc.), which is more consequential than writing an idempotent projection `.md`. Documented in the audit report for a separate, careful change.

## Test
`TestDecisionLineageApplyPlan_UsesDetailsContent`: ApplyPlan writes a sentinel carried in `Details` verbatim (proving no corpus re-derive). Existing full-cycle reconciler tests green under `-race`.

Same per-cycle-rescan elimination shape as #399. Audit ref: `AUDIT-2026-06-25-deep.md` (Q1/Q2).