### PR TITLE
chore: bump version to 0.16.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 #   make e2e      - Run e2e test in a container
 #   make e2e-local - Run e2e test locally
 
-VERSION := 0.16.3
+VERSION := 0.16.4
 BUILD_TIME := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -s -w -X github.com/myrgic/cogos/internal/engine.BuildTime=$(BUILD_TIME) -X github.com/myrgic/cogos/internal/engine.Version=$(VERSION)
 BUILD_TAGS := fts5


### PR DESCRIPTION
Cuts a release of the overnight audit-remediation batch (#396–#408). Tag `v0.16.4` follows once this merges; release notes auto-generate from PR titles since v0.16.3 per the changelog policy.