### PR TITLE
chore: bump version to 0.16.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 #   make e2e      - Run e2e test in a container
 #   make e2e-local - Run e2e test locally
 
-VERSION := 0.16.4
+VERSION := 0.16.5
 BUILD_TIME := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -s -w -X github.com/myrgic/cogos/internal/engine.BuildTime=$(BUILD_TIME) -X github.com/myrgic/cogos/internal/engine.Version=$(VERSION)
 BUILD_TAGS := fts5


### PR DESCRIPTION
Ships the self-update feature (#410). Tag v0.16.5 follows on merge; this is the version that must be bootstrap-installed once, after which 'cogos self-update' / auto-apply take over.