### PR TITLE
feat(embed): OpenAI /v1/embeddings instead of Ollama-native API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 #   make e2e      - Run e2e test in a container
 #   make e2e-local - Run e2e test locally
 
-VERSION := 0.16.5
+VERSION := 0.16.6
 BUILD_TIME := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -s -w -X github.com/myrgic/cogos/internal/engine.BuildTime=$(BUILD_TIME) -X github.com/myrgic/cogos/internal/engine.Version=$(VERSION)
 BUILD_TAGS := fts5

--- a/decompose_store.go
+++ b/decompose_store.go
@@ -1,6 +1,6 @@
 // decompose_store.go — Wave 3: Embedding generation and CogDoc storage
 //
-// embedResults() calls Ollama's native /api/embed endpoint to generate
+// embedResults() calls an OpenAI-compatible /v1/embeddings endpoint to generate
 // vector embeddings for each decomposition tier. Best-effort: if the
 // embed endpoint is unreachable, logs a warning and continues.
 //
@@ -44,26 +44,29 @@ func documentPrefix(model string) string {
 
 // === C1+C2: Embedding Generation ===
 
-// ollamaEmbedRequest is the request body for Ollama's /api/embed endpoint.
-type ollamaEmbedRequest struct {
+// openAIEmbedRequest is the request body for POST /v1/embeddings — the
+// OpenAI-compatible embeddings surface (LM Studio, Ollama's /v1 endpoint, vLLM).
+type openAIEmbedRequest struct {
 	Model string `json:"model"`
 	Input string `json:"input"`
 }
 
-// ollamaEmbedResponse is the response from Ollama's /api/embed endpoint.
-type ollamaEmbedResponse struct {
-	Embeddings [][]float32 `json:"embeddings"`
+// openAIEmbedResponse is the response from POST /v1/embeddings (OpenAI-compatible).
+type openAIEmbedResponse struct {
+	Data []struct {
+		Embedding []float32 `json:"embedding"`
+	} `json:"data"`
 }
 
-// embedFromOllama calls Ollama's native embed endpoint for a single text.
-// `model` is the Ollama model tag (e.g. "bge-m3:latest", "nomic-embed-text");
-// pass "" to use defaultEmbedModel. Returns the full embedding vector — native
-// dimensionality depends on the model (768 for nomic, 1024 for bge-m3).
+// embedFromOllama embeds a single text via an OpenAI-compatible /v1/embeddings
+// server. `model` is the served model id; pass "" to use defaultEmbedModel.
+// Returns the FULL embedding vector unchanged — the caller (embedResults) does
+// the per-tier Matryoshka truncation via truncateVec.
 func embedFromOllama(ctx context.Context, ollamaURL, model, text string) ([]float32, error) {
 	if model == "" {
 		model = defaultEmbedModel
 	}
-	reqBody := ollamaEmbedRequest{
+	reqBody := openAIEmbedRequest{
 		Model: model,
 		Input: text,
 	}
@@ -72,7 +75,7 @@ func embedFromOllama(ctx context.Context, ollamaURL, model, text string) ([]floa
 		return nil, fmt.Errorf("marshal embed request: %w", err)
 	}
 
-	url := ollamaURL + "/api/embed"
+	url := ollamaURL + "/v1/embeddings"
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(bodyBytes))
 	if err != nil {
 		return nil, fmt.Errorf("create embed request: %w", err)
@@ -91,16 +94,16 @@ func embedFromOllama(ctx context.Context, ollamaURL, model, text string) ([]floa
 		return nil, fmt.Errorf("embed server returned %d: %s", resp.StatusCode, string(body))
 	}
 
-	var embedResp ollamaEmbedResponse
+	var embedResp openAIEmbedResponse
 	if err := json.NewDecoder(resp.Body).Decode(&embedResp); err != nil {
 		return nil, fmt.Errorf("decode embed response: %w", err)
 	}
 
-	if len(embedResp.Embeddings) == 0 {
+	if len(embedResp.Data) == 0 || len(embedResp.Data[0].Embedding) == 0 {
 		return nil, fmt.Errorf("embed server returned no embeddings")
 	}
 
-	return embedResp.Embeddings[0], nil
+	return embedResp.Data[0].Embedding, nil
 }
 
 // truncateVec returns the first n elements of a vector (Matryoshka truncation).

--- a/internal/engine/trm_context.go
+++ b/internal/engine/trm_context.go
@@ -1,7 +1,7 @@
 // trm_context.go — TRM integration into the context assembly pipeline.
 //
 // Provides:
-//   - OllamaEmbed: embed a query via the local Ollama /api/embeddings endpoint
+//   - OllamaEmbed: embed a query via an OpenAI-compatible /v1/embeddings endpoint
 //   - trmScoreDocs: score CogDoc candidates using MambaTRM + embedding index
 //   - loadTRMAtStartup: one-shot loader called from main.go
 //
@@ -19,8 +19,8 @@ import (
 	"log/slog"
 	"math"
 	"net/http"
-	"sort"
 	"os"
+	"sort"
 	"strings"
 	"time"
 )
@@ -41,23 +41,30 @@ func queryPrefix(model string) string {
 	return ""
 }
 
-// ollamaEmbedRequest is the request body for POST /api/embeddings.
-type ollamaEmbedRequest struct {
-	Model  string `json:"model"`
-	Prompt string `json:"prompt"`
+// openAIEmbedRequest is the request body for POST /v1/embeddings — the
+// OpenAI-compatible embeddings surface served by LM Studio, Ollama's /v1
+// endpoint, vLLM, etc. (Replaces the former Ollama-native /api/embeddings.)
+type openAIEmbedRequest struct {
+	Model string `json:"model"`
+	Input string `json:"input"`
 }
 
-// ollamaEmbedResponse is the response from POST /api/embeddings.
-type ollamaEmbedResponse struct {
-	Embedding []float64 `json:"embedding"`
+// openAIEmbedResponse is the response from POST /v1/embeddings (OpenAI-compatible).
+type openAIEmbedResponse struct {
+	Data []struct {
+		Embedding []float64 `json:"embedding"`
+	} `json:"data"`
 }
 
-// OllamaEmbed calls Ollama to embed a query string. Native dimensionality
-// depends on the model (768 for nomic-embed-text, 1024 for bge-m3, etc.).
+// OllamaEmbed calls an OpenAI-compatible /v1/embeddings server to embed a query
+// string. Native dimensionality depends on the model (768 for nomic-embed-text,
+// 1024 for bge-m3, etc.); the result is Matryoshka-truncated to the index dim.
 //
 // The endpoint and model come from cfg; defaults are localhost:11434 and
-// defaultEmbedModel (bge-m3:latest). The task-specific query prefix is
-// applied only for prefix-aware models — see queryPrefix.
+// defaultEmbedModel (bge-m3:latest). The task-specific query prefix is applied
+// only for prefix-aware models — see queryPrefix. (The cfg keys are still named
+// OllamaEmbed* for config compatibility; the endpoint is now any
+// OpenAI-compatible embeddings server.)
 func OllamaEmbed(ctx context.Context, cfg *Config, query string) ([]float32, error) {
 	endpoint := cfg.OllamaEmbedEndpoint
 	if endpoint == "" {
@@ -68,9 +75,9 @@ func OllamaEmbed(ctx context.Context, cfg *Config, query string) ([]float32, err
 		model = defaultEmbedModel
 	}
 
-	reqBody, err := json.Marshal(ollamaEmbedRequest{
-		Model:  model,
-		Prompt: queryPrefix(model) + query,
+	reqBody, err := json.Marshal(openAIEmbedRequest{
+		Model: model,
+		Input: queryPrefix(model) + query,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("marshal embed request: %w", err)
@@ -79,7 +86,7 @@ func OllamaEmbed(ctx context.Context, cfg *Config, query string) ([]float32, err
 	httpCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(httpCtx, http.MethodPost, endpoint+"/api/embeddings", bytes.NewReader(reqBody))
+	req, err := http.NewRequestWithContext(httpCtx, http.MethodPost, endpoint+"/v1/embeddings", bytes.NewReader(reqBody))
 	if err != nil {
 		return nil, fmt.Errorf("create embed request: %w", err)
 	}
@@ -96,19 +103,25 @@ func OllamaEmbed(ctx context.Context, cfg *Config, query string) ([]float32, err
 		return nil, fmt.Errorf("ollama embed: status %d: %s", resp.StatusCode, string(body))
 	}
 
-	var embedResp ollamaEmbedResponse
+	var embedResp openAIEmbedResponse
 	if err := json.NewDecoder(resp.Body).Decode(&embedResp); err != nil {
 		return nil, fmt.Errorf("decode embed response: %w", err)
 	}
+	if len(embedResp.Data) == 0 || len(embedResp.Data[0].Embedding) == 0 {
+		return nil, fmt.Errorf("embed server returned no embeddings")
+	}
+	embedding := embedResp.Data[0].Embedding
 
 	// Convert float64 to float32, truncating to EMBED_DIM (Matryoshka).
-	dim := len(embedResp.Embedding)
+	// PRESERVED: the on-disk index is 384-dim, so the query must be truncated to
+	// match. Do not remove without re-exporting the index at the full dimension.
+	dim := len(embedding)
 	if dim > 384 {
 		dim = 384 // Matryoshka truncation to match index
 	}
 	vec := make([]float32, dim)
 	for i := 0; i < dim; i++ {
-		vec[i] = float32(embedResp.Embedding[i])
+		vec[i] = float32(embedding[i])
 	}
 
 	// L2-normalize for cosine similarity.

--- a/pkg/cogdoc_review/similarity.go
+++ b/pkg/cogdoc_review/similarity.go
@@ -40,23 +40,26 @@ import (
 )
 
 const (
-	defaultEmbedModel    = "bge-m3:latest"
-	matryoshkaDim        = 384
-	pipelineVersion      = "v0.1.0"
+	defaultEmbedModel = "bge-m3:latest"
+	matryoshkaDim     = 384
+	pipelineVersion   = "v0.1.0"
 )
 
-// --- Ollama embed (slim copy; no import of internal/engine) ---
+// --- OpenAI-compatible /v1/embeddings (slim copy; no import of internal/engine) ---
 
-type ollamaEmbedRequest struct {
-	Model  string `json:"model"`
-	Prompt string `json:"prompt"`
+type openAIEmbedRequest struct {
+	Model string `json:"model"`
+	Input string `json:"input"`
 }
 
-type ollamaEmbedResponse struct {
-	Embedding []float64 `json:"embedding"`
+type openAIEmbedResponse struct {
+	Data []struct {
+		Embedding []float64 `json:"embedding"`
+	} `json:"data"`
 }
 
-// embedQuery embeds a query string via Ollama and returns a unit-normalized
+// embedQuery embeds a query string via an OpenAI-compatible /v1/embeddings
+// server (LM Studio, Ollama's /v1 endpoint, vLLM) and returns a unit-normalized
 // float32 vector truncated to matryoshkaDim (384).
 func embedQuery(ctx context.Context, ollamaEndpoint, model, query string) ([]float32, error) {
 	if ollamaEndpoint == "" {
@@ -66,9 +69,9 @@ func embedQuery(ctx context.Context, ollamaEndpoint, model, query string) ([]flo
 		model = defaultEmbedModel
 	}
 
-	reqBody, err := json.Marshal(ollamaEmbedRequest{
-		Model:  model,
-		Prompt: query, // bge-m3 does not use task prefixes
+	reqBody, err := json.Marshal(openAIEmbedRequest{
+		Model: model,
+		Input: query, // bge-m3 does not use task prefixes
 	})
 	if err != nil {
 		return nil, fmt.Errorf("marshal embed request: %w", err)
@@ -78,7 +81,7 @@ func embedQuery(ctx context.Context, ollamaEndpoint, model, query string) ([]flo
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(httpCtx, http.MethodPost,
-		ollamaEndpoint+"/api/embeddings", bytes.NewReader(reqBody))
+		ollamaEndpoint+"/v1/embeddings", bytes.NewReader(reqBody))
 	if err != nil {
 		return nil, fmt.Errorf("build embed request: %w", err)
 	}
@@ -95,18 +98,22 @@ func embedQuery(ctx context.Context, ollamaEndpoint, model, query string) ([]flo
 		return nil, fmt.Errorf("ollama embed: status %d: %s", resp.StatusCode, string(body))
 	}
 
-	var embedResp ollamaEmbedResponse
+	var embedResp openAIEmbedResponse
 	if err := json.NewDecoder(resp.Body).Decode(&embedResp); err != nil {
 		return nil, fmt.Errorf("decode embed response: %w", err)
 	}
+	if len(embedResp.Data) == 0 || len(embedResp.Data[0].Embedding) == 0 {
+		return nil, fmt.Errorf("embed server returned no embeddings")
+	}
+	embedding := embedResp.Data[0].Embedding
 
-	dim := len(embedResp.Embedding)
+	dim := len(embedding)
 	if dim > matryoshkaDim {
 		dim = matryoshkaDim
 	}
 	vec := make([]float32, dim)
 	for i := 0; i < dim; i++ {
-		vec[i] = float32(embedResp.Embedding[i])
+		vec[i] = float32(embedding[i])
 	}
 	return l2Normalize(vec), nil
 }


### PR DESCRIPTION
Switch all three embedding clients from Ollama's native API to the OpenAI-compatible `/v1/embeddings` surface, so the kernel can use LM Studio (or any OpenAI-compatible server) for embeddings — enabling consolidation onto a single local model interface.

## Changes
- `internal/engine/trm_context.go` (`OllamaEmbed`): `/api/embeddings` → `/v1/embeddings`; request `{model,input}`, response `data[0].embedding`. **Preserves** the 384-dim Matryoshka truncation + L2 normalization (the on-disk index is 384-dim).
- `decompose_store.go` (`embedFromOllama`): `/api/embed` → `/v1/embeddings`; returns the full vector unchanged (caller truncates per-tier via `truncateVec`).
- `pkg/cogdoc_review/similarity.go` (`embedQuery`): `/api/embeddings` → `/v1/embeddings`; preserves the `matryoshkaDim` (384) truncation + L2 norm.

Endpoint + model stay config-driven (the `OllamaEmbed*` keys are retained for config compatibility; the endpoint is now any OpenAI-compatible server). Ollama also serves `/v1/embeddings`, so this works against both backends during the transition.

## Verification
- `go build ./...`, `go vet`, and `go test` (internal/engine, root, pkg/cogdoc_review) all green.
- Live-verified against both LM Studio (:1234) and Ollama (:11434) `/v1/embeddings` (1024-dim bge-m3).
- Adversarial review: Opus (all lenses PASS, live-verified) + gemma-26b (PASS). An earlier revision that wrongly removed the 384-dim truncation was caught and corrected by the Opus index-integrity lens.