### PR TITLE
Wave 1 — harness: accepted-ADR conformance

### DIFF
--- a/internal/engine/agent_dispatch.go
+++ b/internal/engine/agent_dispatch.go
@@ -101,6 +101,17 @@ type DispatchRequest struct {
 	// let the model emit a reasoning trace before answering.
 	Thinking *bool
 
+	// Temperature overrides the sampling temperature for this dispatch. nil
+	// keeps the harness default (0.1). Per ADR-066 §models-always-swappable:
+	// inference parameters must be caller-overridable, not hardcoded.
+	Temperature *float64
+
+	// MaxTokens overrides the completion token ceiling for this dispatch.
+	// 0 (the zero value) keeps the harness default (localHarnessExecuteMaxToks=1024).
+	// Per ADR-066 §models-always-swappable: callers must be able to widen
+	// or narrow the window without a harness change.
+	MaxTokens int
+
 	// Identity propagates OIDC-shaped caller claims for trace metadata.
 	// Optional; see DispatchIdentity for forward-compat notes.
 	Identity DispatchIdentity

--- a/internal/engine/agent_dispatch.go
+++ b/internal/engine/agent_dispatch.go
@@ -155,6 +155,10 @@ type DispatchResult struct {
 	// the difference between "ran on the legacy e4b/26b path" and "ran on
 	// the named provider X." Per RFC-0007 Layer 1.
 	ProviderUsed string `json:"provider_used,omitempty"`
+	// Degraded is true when the model returned no final text and the slot fell
+	// back to summarizeToolTranscript. Success is still true — the tool loop
+	// completed — but the output contract (ADR-eigen output-contract) was not met.
+	Degraded bool `json:"degraded,omitempty"`
 }
 
 // ResolvedProvider is the materialized backend a ProviderResolver returns

--- a/internal/engine/dashboard_inlet.go
+++ b/internal/engine/dashboard_inlet.go
@@ -443,7 +443,7 @@ func engineRespondExecutor(ctx context.Context, arguments string) (string, error
 func respondToolDefinition() ToolDefinition {
 	return ToolDefinition{
 		Name:        engineRespondToolName,
-		Description: "Send a response to the user in the current dashboard conversation. Use this after you have observed a user_message event and want to reply. The message is published on bus_dashboard_response for the Mod³ dashboard to render. Call at most once per user turn; use wait if no reply is warranted.",
+		Description: "Send a response to the user in the current dashboard conversation. Use this after you have observed a user_message event and want to reply. The message is published on bus_dashboard_response for the Mod³ dashboard to render. Call at most once per user turn; skip respond entirely if no reply is needed. A second call within the same turn is rejected.",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{

--- a/internal/engine/harness_text_sanitize.go
+++ b/internal/engine/harness_text_sanitize.go
@@ -1,0 +1,84 @@
+// harness_text_sanitize.go — strip model-format control tokens out of harness
+// output before it becomes substrate-visible Content.
+//
+// Background (2026-06-28): the gemma-4-26b MLX build served by LM Studio is
+// rendered with an OpenAI "harmony" chat template. gemma was not trained on the
+// harmony special tokens, so on the turn after a tool result it emits them as
+// *literal text* — and, because its tokenizer has no real token for them, in a
+// corrupted form: `<|channel>thought\n<channel|>PONG` rather than the canonical
+// `<|channel|>final<|message|>PONG`. Those markers must never reach Content or
+// the dashboard. The clean fix is template-side (give LM Studio a gemma-native
+// template); stripControlTokens is the defensive, backend-agnostic guard so the
+// kernel stays robust to any harmony-templated local backend.
+package engine
+
+import (
+	"regexp"
+	"strings"
+)
+
+// harmonyTokenRe matches harmony channel control tokens in three shapes:
+//
+//   - well-formed:  <|channel|> <|message|> <|start|> <|end|> <|return|> <|"|>
+//   - missing tail: <|channel>   (opens "<|", closes ">")
+//   - missing head: <channel|>   (opens "<", closes "|>")
+//
+// The first arm matches any short pipe-delimited token (catches well-formed
+// harmony/ChatML markers and the corrupted quote token `<|"|>`); the second arm
+// is restricted to the harmony keyword vocabulary so ordinary `<x>`-style markup
+// in real content is never disturbed.
+var harmonyTokenRe = regexp.MustCompile(
+	`<\|[^<>|]{0,32}\|>` +
+		`|<\|?(?:start|end|message|channel|constrain|return|call|refusal)\|?>`,
+)
+
+// harmonyChannelLineRe matches a line that is nothing but a harmony channel or
+// role name left dangling once its surrounding tokens were removed (e.g. the
+// bare `thought` in `<|channel>thought<channel|>...`).
+var harmonyChannelLineRe = regexp.MustCompile(
+	`(?i)^(?:analysis|commentary|final|thought|assistant|developer|system|user)$`,
+)
+
+// stripControlTokens removes harmony/control-token noise from model output.
+// Clean text (the overwhelming common case) is returned unchanged via the fast
+// path — only strings that actually contain harmony delimiters are rewritten.
+//
+// Strategy: replace every control token with a newline so adjacent channel
+// names and message bodies land on separate lines, then drop empty lines and
+// dangling channel/role names. When a standalone `final` channel marker
+// survives, only the text after the last one is kept (harmony places the
+// user-visible answer in the `final` channel, after any `analysis`/`commentary`).
+func stripControlTokens(s string) string {
+	// Fast path: no harmony delimiters at all → nothing to strip.
+	if !strings.Contains(s, "<|") && !strings.Contains(s, "|>") {
+		return s
+	}
+
+	cleaned := harmonyTokenRe.ReplaceAllString(s, "\n")
+	lines := strings.Split(cleaned, "\n")
+
+	// If the final channel marker survived as its own line, the user-visible
+	// answer is everything after the LAST one; discard preceding channels.
+	lastFinal := -1
+	for i, ln := range lines {
+		if strings.EqualFold(strings.TrimSpace(ln), "final") {
+			lastFinal = i
+		}
+	}
+	if lastFinal >= 0 && lastFinal+1 < len(lines) {
+		lines = lines[lastFinal+1:]
+	}
+
+	kept := make([]string, 0, len(lines))
+	for _, ln := range lines {
+		trimmed := strings.TrimSpace(ln)
+		if trimmed == "" {
+			continue
+		}
+		if harmonyChannelLineRe.MatchString(trimmed) {
+			continue // dangling channel/role name, not content
+		}
+		kept = append(kept, trimmed)
+	}
+	return strings.TrimSpace(strings.Join(kept, "\n"))
+}

--- a/internal/engine/local_agent_harness.go
+++ b/internal/engine/local_agent_harness.go
@@ -795,8 +795,9 @@ func (c *LocalHarnessController) executeCycleTaskWithPrompt(ctx context.Context,
 	}
 	resp, clientCalls, transcript, err := c.completeWithToolLoop(ctx, provider, req, registry)
 	// Structured loop-exit sentinels (ADR-031, ADR-052): surface partial content
-	// rather than propagating as a hard error. The cycle record will reflect the
-	// sentinel reason via the caller (runCycle records err.Error() in Reason).
+	// rather than propagating as a hard error. The sentinel is logged below; this
+	// function then returns the partial content with a nil error, so the autonomic
+	// cycle proceeds as a soft success (the sentinel reason is not propagated up).
 	if err != nil && !errors.Is(err, ErrToolLoopMaxTurns) && !errors.Is(err, ErrToolLoopNoProgress) {
 		return "", err
 	}

--- a/internal/engine/local_agent_harness.go
+++ b/internal/engine/local_agent_harness.go
@@ -2,11 +2,14 @@ package engine
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1381,19 +1384,47 @@ func (c *LocalHarnessController) dispatchSlot(parent context.Context, provider P
 	}
 	counting := &countingProvider{Provider: provider}
 
+	// ADR-066 §models-always-swappable: temperature and max_tokens must be
+	// caller-overridable. Default to the harness constants when not set.
 	temp := 0.1
+	if req.Temperature != nil {
+		temp = *req.Temperature
+	}
+	maxToks := localHarnessExecuteMaxToks
+	if req.MaxTokens > 0 {
+		maxToks = req.MaxTokens
+	}
+
+	// ADR-066 §KV-Cache-Branching: RequestID must be content-stable so that
+	// identical fan-out slots share a KV-cache prefix. Hash (systemPrompt +
+	// task + sorted tool names); append idx only for per-slot log uniqueness —
+	// the prefix up to the dash is cache-relevant and identical across slots.
+	tools := registry.Definitions()
+	toolNames := make([]string, len(tools))
+	for i, t := range tools {
+		toolNames[i] = t.Name
+	}
+	sort.Strings(toolNames)
+	h := sha256.New()
+	h.Write([]byte(systemPrompt))
+	h.Write([]byte(req.Task))
+	for _, n := range toolNames {
+		h.Write([]byte(n))
+	}
+	contentKey := hex.EncodeToString(h.Sum(nil))[:16]
+
 	compReq := &CompletionRequest{
 		SystemPrompt: systemPrompt,
 		Messages: []ProviderMessage{
 			{Role: "user", Content: strings.TrimSpace(req.Task)},
 		},
-		Tools:         registry.Definitions(),
+		Tools:         tools,
 		ToolChoice:    "auto",
-		MaxTokens:     localHarnessExecuteMaxToks,
+		MaxTokens:     maxToks,
 		Temperature:   &temp,
 		ModelOverride: model,
 		Metadata: RequestMetadata{
-			RequestID:      fmt.Sprintf("local-harness-dispatch-%d-%d", time.Now().UnixNano(), idx),
+			RequestID:      fmt.Sprintf("local-harness-dispatch-%s-%d", contentKey, idx),
 			PreferLocal:    true,
 			PreferProvider: req.Provider,
 			Source:         "local-harness-dispatch",

--- a/internal/engine/local_agent_harness.go
+++ b/internal/engine/local_agent_harness.go
@@ -136,17 +136,10 @@ const (
 	localHarnessExecuteMaxToks = 1024
 )
 
-const localHarnessAssessPrompt = `You are the resident local CogOS maintenance agent.
-Operate only through local inference and the kernel's local tools.
-Decide whether a maintenance pass is warranted right now.
-Return only one compact JSON object with these keys:
-{"action":"sleep|observe|consolidate|repair|propose|escalate","reason":"short string","urgency":0..1,"target":"short string","task":"short concrete next step"}
-Prefer "sleep" unless the observation names a concrete task worth doing now.`
-
-const localHarnessExecutePrompt = `You are the resident local CogOS maintenance agent.
-Stay local-only. Use the provided kernel tools when they materially improve the answer.
-Prefer inspection and diagnosis over mutation. Finish with a concise plain-text result.
-
+// harnessURIBlock is the canonical CogDoc URI reference injected into every
+// harness prompt. Defined once here to prevent drift across prompts (ADR-066
+// pointer-discipline: single authoritative source for URI format guidance).
+const harnessURIBlock = `
 CogDoc URIs use the bare form cog:<type>/<path>. Valid types:
   mem, adr, role, skill, agent, spec, status, ledger, crystal,
   kernel, canonical, config, ontology, work, handoff, artifact, docs, hooks
@@ -158,6 +151,18 @@ Cross-workspace refs use authority form: cog://other-workspace/mem/...
 Invalid: cog://adrs/..., cog://docs/... with raw fs paths.
 If cog_search_memory returns a bus event path (".cog/.state/buses/.../events.jsonl#N"),
 that is a chat log entry, not a readable CogDoc — do not try to read it.`
+
+const localHarnessAssessPrompt = `You are the resident local CogOS maintenance agent.
+Operate only through local inference and the kernel's local tools.
+Decide whether a maintenance pass is warranted right now.
+Return only one compact JSON object with these keys:
+{"action":"sleep|observe|consolidate|repair|propose|escalate","reason":"short string","urgency":0..1,"target":"short string","task":"short concrete next step"}
+Prefer "sleep" unless the observation names a concrete task worth doing now.`
+
+const localHarnessExecutePrompt = `You are the resident local CogOS maintenance agent.
+Stay local-only. Use the provided kernel tools when they materially improve the answer.
+Prefer inspection and diagnosis over mutation. Finish with a concise plain-text result.
+` + harnessURIBlock
 
 // localHarnessChatPrompt is the system prompt used during the execute phase
 // when pending dashboard user messages are present. It replaces the maintenance
@@ -182,21 +187,11 @@ Rules:
 - You may use other kernel tools (cog_search_memory, cog_read_cogdoc, etc.) before
   calling respond if they would help you answer accurately. Keep it brief.
 - If you are uncertain, say so plainly. Do not invent facts about the workspace.
-
-CogDoc URIs use the bare form cog:<type>/<path>. Types: mem, adr, role, skill, agent,
-spec, status, ledger, crystal, kernel, canonical, config, ontology, work, handoff, artifact, docs, hooks.
-Cross-workspace refs: cog://other-workspace/mem/...`
+` + harnessURIBlock
 
 const localHarnessDispatchPrompt = `You are the resident local CogOS harness.
 Stay local-only. Use only the provided kernel tools. Be concise and finish with a direct answer.
-
-CogDoc URIs use the bare form cog:<type>/<path>. Valid types:
-  mem, adr, role, skill, agent, spec, status, ledger, crystal,
-  kernel, canonical, config, ontology, work, handoff, artifact, docs, hooks
-Example: cog:adr/077 (ADRs resolve by numeric prefix).
-Cross-workspace refs use authority form: cog://other-workspace/mem/...
-If cog_search_memory returns ".cog/.state/buses/.../events.jsonl#N", that's a chat log entry,
-not a readable CogDoc — do not try to read it.
+` + harnessURIBlock + `
 
 Output contract (ADR-eigen output-contract, RFC-027 alignment layer): after any
 tool calls, finish with a plain-text answer — or call respond exactly once with

--- a/internal/engine/local_agent_harness.go
+++ b/internal/engine/local_agent_harness.go
@@ -14,7 +14,31 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/myrgic/cogos/trace"
 )
+
+// dispatchCycleIDKey is the context key that carries the cycle-trace ID minted
+// by DispatchToHarness. All trace events emitted within a single dispatch
+// invocation (including per-tool events in the tool loop) share this ID, so
+// bus consumers can correlate them. Follows the pattern in dashboard_inlet.go.
+// ADR-083 (bus cycle-trace path, not OTel), ADR-033, ADR-072.
+type dispatchCycleIDKey struct{}
+
+// withDispatchCycleID attaches a cycle-trace ID to the context.
+func withDispatchCycleID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, dispatchCycleIDKey{}, id)
+}
+
+// dispatchCycleIDFromCtx returns the cycle-trace ID stored in the context, or
+// an empty string when none is present (tool-loop calls outside a dispatch).
+func dispatchCycleIDFromCtx(ctx context.Context) string {
+	if v, ok := ctx.Value(dispatchCycleIDKey{}).(string); ok {
+		return v
+	}
+	return ""
+}
 
 // defaultHarnessScopeName is the scope used when no scope is requested.
 // Callers that don't specify a scope get exactly the tool set they always have.
@@ -1372,6 +1396,26 @@ func (c *LocalHarnessController) DispatchToHarness(ctx context.Context, req Disp
 		batch.Notes = append(batch.Notes, note)
 	}
 
+	// ADR-083 (bus cycle-trace), ADR-033, ADR-072: mint one cycle-trace ID per
+	// DispatchToHarness invocation so that all tool-dispatch events from every
+	// fan-out slot, plus the batch-level start/end ledger entries, share a
+	// correlating ID. Consumers on the kernel bus reconstruct a full dispatch
+	// audit trail by filtering on this ID.
+	cycleID := uuid.NewString()
+	ctx = withDispatchCycleID(ctx, cycleID)
+
+	// Emit dispatch-start ledger entry (ADR-033, ADR-072).
+	_ = EmitLedgerEvent(c.cfg, map[string]any{
+		"type":   "harness.dispatch.start",
+		"source": "local-harness",
+		"payload": map[string]any{
+			"cycle_id": cycleID,
+			"n":        req.N,
+			"task":     truncateDigest(req.Task),
+			"provider": req.Provider,
+		},
+	})
+
 	start := time.Now()
 	var wg sync.WaitGroup
 	for i := 0; i < req.N; i++ {
@@ -1383,6 +1427,18 @@ func (c *LocalHarnessController) DispatchToHarness(ctx context.Context, req Disp
 	}
 	wg.Wait()
 	batch.TotalDurationSec = time.Since(start).Seconds()
+
+	// Emit dispatch-end ledger entry (ADR-033, ADR-072).
+	_ = EmitLedgerEvent(c.cfg, map[string]any{
+		"type":   "harness.dispatch.end",
+		"source": "local-harness",
+		"payload": map[string]any{
+			"cycle_id":         cycleID,
+			"n":                req.N,
+			"total_duration_s": batch.TotalDurationSec,
+		},
+	})
+
 	return batch, nil
 }
 
@@ -1452,6 +1508,32 @@ func (c *LocalHarnessController) dispatchSlot(parent context.Context, provider P
 	resp, clientCalls, transcript, err := c.completeWithToolLoop(slotCtx, counting, compReq, registry)
 	res.DurationSec = time.Since(start).Seconds()
 	res.Turns = counting.CompleteCalls()
+
+	// ADR-083 (bus cycle-trace, not OTel), ADR-033, ADR-072: emit one
+	// KindToolDispatch cycle-trace event per tool call so bus consumers
+	// (dashboard, audit log) can see every tool invoked during this dispatch.
+	// The cycleID injected by DispatchToHarness correlates all events from one
+	// cog_dispatch_to_harness invocation.
+	cycleID := dispatchCycleIDFromCtx(parent)
+	for _, tc := range transcript {
+		var toolErr error
+		if tc.Rejected {
+			toolErr = fmt.Errorf("%s", tc.RejectReason)
+		}
+		var argsRaw json.RawMessage
+		if tc.Arguments != "" {
+			argsRaw = json.RawMessage(tc.Arguments)
+		}
+		emitTrace(trace.NewToolDispatch(
+			TraceIdentity(),
+			cycleID,
+			tc.Name,
+			argsRaw,
+			time.Duration(tc.DurationMs)*time.Millisecond,
+			toolErr,
+		))
+	}
+
 	for _, tc := range transcript {
 		entry := DispatchToolCallSummary{
 			Name:         tc.Name,

--- a/internal/engine/local_agent_harness.go
+++ b/internal/engine/local_agent_harness.go
@@ -172,7 +172,12 @@ CogDoc URIs use the bare form cog:<type>/<path>. Valid types:
 Example: cog:adr/077 (ADRs resolve by numeric prefix).
 Cross-workspace refs use authority form: cog://other-workspace/mem/...
 If cog_search_memory returns ".cog/.state/buses/.../events.jsonl#N", that's a chat log entry,
-not a readable CogDoc — do not try to read it.`
+not a readable CogDoc — do not try to read it.
+
+Output contract (ADR-eigen output-contract, RFC-027 alignment layer): after any
+tool calls, finish with a plain-text answer — or call respond exactly once with
+the answer. Do NOT narrate tool use, emit role/channel markers, or output special
+tokens such as <|...|> or respond{...} scaffolding.`
 
 type localHarnessAssessment struct {
 	Action  string  `json:"action"`
@@ -1458,9 +1463,18 @@ func (c *LocalHarnessController) dispatchSlot(parent context.Context, provider P
 		return res
 	}
 	res.Success = true
-	res.Content = strings.TrimSpace(resp.Content)
+	// Strip harmony/control-token leakage before the content becomes
+	// substrate-visible. ADR-eigen (output-contract) + RFC-027 (alignment layer).
+	res.Content = stripControlTokens(strings.TrimSpace(resp.Content))
 	if res.Content == "" && len(transcript) > 0 {
+		// Model returned no final text; fall back to a transcript summary.
+		// Surface Degraded so callers know the output contract was not met.
 		res.Content = summarizeToolTranscript(transcript)
+		res.Degraded = true
+		slog.Warn("local harness dispatch: model returned no final text; degraded to transcript summary",
+			"request_id", compReq.Metadata.RequestID,
+			"tool_calls", len(transcript),
+		)
 	}
 	// slotNote carries per-slot warnings (e.g. legacy "26b route unavailable,
 	// degraded to e4b") that the caller may need to surface per-result. These

--- a/internal/engine/local_agent_harness.go
+++ b/internal/engine/local_agent_harness.go
@@ -775,13 +775,25 @@ func (c *LocalHarnessController) executeCycleTaskWithPrompt(ctx context.Context,
 		},
 	}
 	resp, clientCalls, transcript, err := c.completeWithToolLoop(ctx, provider, req, registry)
-	if err != nil {
+	// Structured loop-exit sentinels (ADR-031, ADR-052): surface partial content
+	// rather than propagating as a hard error. The cycle record will reflect the
+	// sentinel reason via the caller (runCycle records err.Error() in Reason).
+	if err != nil && !errors.Is(err, ErrToolLoopMaxTurns) && !errors.Is(err, ErrToolLoopNoProgress) {
 		return "", err
+	}
+	if err != nil {
+		slog.Warn("local harness cycle: structured loop exit",
+			"sentinel", err.Error(),
+			"tool_calls", len(transcript),
+		)
 	}
 	if len(clientCalls) > 0 {
 		slog.Warn("local harness produced unsupported client tool calls", "count", len(clientCalls))
 	}
-	content := strings.TrimSpace(resp.Content)
+	var content string
+	if resp != nil {
+		content = strings.TrimSpace(resp.Content)
+	}
 	if content == "" && len(transcript) > 0 {
 		content = summarizeToolTranscript(transcript)
 	}
@@ -1455,6 +1467,28 @@ func (c *LocalHarnessController) dispatchSlot(parent context.Context, provider P
 		res.Error = fmt.Sprintf("unsupported client tool calls returned: %d", len(clientCalls))
 	}
 	if err != nil {
+		// Structured loop-exit sentinels (ADR-031, ADR-052): ErrToolLoopMaxTurns
+		// and ErrToolLoopNoProgress carry a partial response and transcript; mark
+		// the slot as Degraded rather than a hard failure so the partial content
+		// is still surfaced to the caller. Hard errors (provider failure, timeout)
+		// fall through to the existing failure path below.
+		if errors.Is(err, ErrToolLoopMaxTurns) || errors.Is(err, ErrToolLoopNoProgress) {
+			res.Success = true
+			res.Degraded = true
+			res.Error = err.Error()
+			if resp != nil {
+				res.Content = stripControlTokens(strings.TrimSpace(resp.Content))
+			}
+			if res.Content == "" && len(transcript) > 0 {
+				res.Content = summarizeToolTranscript(transcript)
+			}
+			slog.Warn("local harness dispatch: structured loop exit",
+				"sentinel", err.Error(),
+				"request_id", compReq.Metadata.RequestID,
+				"tool_calls", len(transcript),
+			)
+			return res
+		}
 		if slotCtx.Err() == context.DeadlineExceeded {
 			res.Error = "timeout"
 		} else {

--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -1704,12 +1704,19 @@ tailLoop:
 }
 
 // toolGetIndex — no longer registered as an MCP tool; used by the internal tool loop (tool_loop.go).
+// Output is capped per ADR-066 pointer-discipline: the index can cover thousands of CogDocs,
+// so we apply the configured byte cap to prevent context blowout. Callers needing deeper
+// inspection should dereference specific cog: URIs via cog_read_cogdoc.
 func (m *MCPServer) toolGetIndex(ctx context.Context, req *mcp.CallToolRequest, input getIndexInput) (*mcp.CallToolResult, any, error) {
 	index, err := BuildMemoryIndex(m.cfg.WorkspaceRoot, input.Sector)
 	if err != nil {
 		return textResult(fmt.Sprintf("index build failed: %v", err))
 	}
-	return marshalResult(index)
+	maxBytes := DefaultMaxToolOutputBytes
+	if m.cfg != nil {
+		maxBytes = m.cfg.EffectiveMaxToolOutputBytes()
+	}
+	return capMarshalResult(index, maxBytes)
 }
 
 func (m *MCPServer) toolIngest(ctx context.Context, req *mcp.CallToolRequest, input ingestInput) (*mcp.CallToolResult, any, error) {

--- a/internal/engine/tool_loop.go
+++ b/internal/engine/tool_loop.go
@@ -94,8 +94,9 @@ func NewKernelToolRegistry(mcpSrv *MCPServer) *KernelToolRegistry {
 			executor:    makeExecutor(mcpSrv, mcpSrv.toolResolveURI, resolveURIInput{}),
 		},
 		{
+			// ADR-045: description kept in sync with MCP registration in mcp_server.go.
 			name:        "cog_search_memory",
-			description: "Search the CogDoc memory corpus. Returns ranked results.",
+			description: "Full-text and semantic search over the CogDoc memory corpus. Returns ranked results with salience scores. Fallback: ./scripts/cog memory search \"query\"",
 			schema: mergeSchemas(
 				objectSchema("query", "Search query string"),
 				optionalSchema("limit", "number", "Max results (default 10)"),
@@ -104,8 +105,9 @@ func NewKernelToolRegistry(mcpSrv *MCPServer) *KernelToolRegistry {
 			executor: makeExecutor(mcpSrv, mcpSrv.toolSearchMemory, searchMemoryInput{}),
 		},
 		{
+			// ADR-045: description kept in sync with MCP registration in mcp_server.go.
 			name:        "cog_read_cogdoc",
-			description: "Read a CogDoc by URI. Returns content with parsed frontmatter and schema hints.",
+			description: "Read a CogDoc by URI or path. Resolves cog: URIs automatically. Returns full content with parsed frontmatter and optional section extraction via #fragment. Fallback: ./scripts/cog memory read <path>",
 			schema: mergeSchemas(
 				objectSchema("uri", "A cog: URI pointing to the CogDoc"),
 				optionalSchema("section", "string", "Section name to extract"),
@@ -160,8 +162,9 @@ func NewKernelToolRegistry(mcpSrv *MCPServer) *KernelToolRegistry {
 			executor: makeExecutor(mcpSrv, mcpSrv.toolQueryField, queryFieldInput{}),
 		},
 		{
+			// ADR-045: description kept in sync with MCP registration in mcp_server.go.
 			name:        "cog_check_coherence",
-			description: "Run workspace coherence validation",
+			description: "Run coherence validation against the workspace. Checks URI resolution, frontmatter validity, and reference integrity. Fallback: ./scripts/cog coherence check",
 			schema:      mergeSchemas(optionalSchema("scope", "string", "structural/navigational/canonical")),
 			executor:    makeExecutor(mcpSrv, mcpSrv.toolCheckCoherence, checkCoherenceInput{}),
 		},

--- a/internal/engine/tool_loop.go
+++ b/internal/engine/tool_loop.go
@@ -25,6 +25,34 @@ import (
 
 const maxToolLoopIterations = 10
 
+// noProgressRepeatLimit is the number of consecutive identical tool-call
+// signatures that trigger an early exit with ErrToolLoopNoProgress (ADR-031).
+const noProgressRepeatLimit = 3
+
+// ErrToolLoopMaxTurns is returned by RunToolLoopWithTranscript when the loop
+// reaches maxToolLoopIterations without the model emitting a final text
+// response. Callers (dispatchSlot, executeCycleTaskWithPrompt) check for this
+// sentinel to mark results as max-turns-exceeded rather than silent success.
+// (ADR-031 autonomic/fail-fast)
+var ErrToolLoopMaxTurns = &toolLoopSentinel{code: "max_turns", msg: "tool loop exceeded max iterations"}
+
+// ErrToolLoopNoProgress is returned when the loop detects the model repeating
+// the same tool call (name + args) for noProgressRepeatLimit consecutive
+// iterations. Autonomic, no model call — the loop breaks immediately.
+// (ADR-031 autonomic/fail-fast)
+var ErrToolLoopNoProgress = &toolLoopSentinel{code: "no_progress", msg: "tool loop detected no-progress: identical tool call repeated"}
+
+// toolLoopSentinel is the typed sentinel for structured loop-exit signals.
+// Exported as *toolLoopSentinel so callers can errors.Is against the package
+// vars; never constructed outside this file.
+type toolLoopSentinel struct {
+	code string
+	msg  string
+}
+
+func (e *toolLoopSentinel) Error() string { return e.msg }
+func (e *toolLoopSentinel) Code() string  { return e.code }
+
 // KernelToolRegistry holds the kernel's tool definitions and executors.
 // Populated at startup from the MCP server's tool set.
 type KernelToolRegistry struct {
@@ -402,6 +430,12 @@ func RunToolLoopWithTranscript(
 	var clientToolCalls []ToolCall
 	var transcript []ToolCallRecord
 
+	// No-progress tracking (ADR-031): record the last tool-call signature
+	// (tool-name + raw arguments) and count consecutive repeats. A run of
+	// noProgressRepeatLimit identical calls is treated as a stuck loop.
+	var lastToolSig string
+	var noProgressCount int
+
 	for i := 0; i < maxToolLoopIterations; i++ {
 		resp.ToolCalls = normalizeToolCallIDs(provider.Name(), i+1, resp.ToolCalls)
 		if len(resp.ToolCalls) == 0 {
@@ -493,6 +527,28 @@ func RunToolLoopWithTranscript(
 			return resp, clientToolCalls, transcript, nil
 		}
 
+		// No-progress guard (ADR-031): build a signature from the first kernel
+		// call's name+args. If the model keeps issuing the same call
+		// noProgressRepeatLimit times in a row, break autonomically without a
+		// model call rather than letting the loop spin to maxToolLoopIterations.
+		if len(kernelCalls) > 0 {
+			sig := kernelCalls[0].Name + "\x00" + kernelCalls[0].Arguments
+			if sig == lastToolSig {
+				noProgressCount++
+				if noProgressCount >= noProgressRepeatLimit {
+					slog.Warn("tool_loop: no-progress break",
+						"tool", kernelCalls[0].Name,
+						"repeat", noProgressCount,
+						"iteration", i+1,
+					)
+					return resp, clientToolCalls, transcript, ErrToolLoopNoProgress
+				}
+			} else {
+				lastToolSig = sig
+				noProgressCount = 1
+			}
+		}
+
 		// Execute kernel tools and add results.
 		for _, tc := range kernelCalls {
 			slog.Info("tool_loop: executing kernel tool",
@@ -529,6 +585,22 @@ func RunToolLoopWithTranscript(
 			})
 		}
 
+		// Respond hard-break (ADR-052 TERMINATE-as-break): if the model invoked
+		// the "respond" tool and it succeeded (ok:true in the result JSON), the
+		// turn is complete — break immediately rather than re-calling the model.
+		// Gate B in dashboard_inlet.go may return ok:false for a duplicate call;
+		// in that case we still break (the turn was already answered) to prevent
+		// the loop continuing after a denied respond invocation.
+		for _, tc := range kernelCalls {
+			if tc.Name == engineRespondToolName {
+				slog.Info("tool_loop: respond tool invoked — hard break (ADR-052)",
+					"tool", tc.Name,
+					"iteration", i+1,
+				)
+				return resp, clientToolCalls, transcript, nil
+			}
+		}
+
 		// If there are also client tool calls, we need to stop and let the client handle them.
 		if len(clientToolCalls) > 0 {
 			// Return a synthetic response that includes both the text and pending client calls.
@@ -549,8 +621,11 @@ func RunToolLoopWithTranscript(
 		)
 	}
 
+	// Max-turns structured exit (ADR-031): return ErrToolLoopMaxTurns so
+	// dispatchSlot / executeCycleTaskWithPrompt can mark the result as
+	// max-turns-exceeded rather than silently treating it as success.
 	slog.Warn("tool_loop: max iterations reached", "max", maxToolLoopIterations)
-	return resp, clientToolCalls, transcript, nil
+	return resp, clientToolCalls, transcript, ErrToolLoopMaxTurns
 }
 
 // normalizeToolCallIDs assigns stable IDs to any tool calls that arrived


### PR DESCRIPTION
## Wave 1 — local agent harness: accepted-ADR conformance

Curated multi-commit series (one commit per concern). Grounds: design-constraints cogdoc `cog://mem/semantic/architecture/harness-redesign-constraints`, derived from a 30-agent review (24 verified findings) + a 5-cluster architecture-research pass (48 constraints).

This wave lands ONLY accepted-ADR conformance (zero draft-RFC risk). Wave 2 (RFC-016/018/020/027 + identity-embedding G4) is deferred pending further corpus research.

### Commits
- 507df4f None. go build ./... clean, go vet ./internal/engine/ clean, go test ./internal/engine/ -run Dispatch passed (0.842s).\n- 4bc1570 none (partial: none)\n- e67f25a The respond hard-break fires after all kernelCalls are iterated, so if a batch includes both respond and other kernel tools, all are executed before the break. This is intentional (the respond result is already published) but means side-effects from non-respond tools in the same batch are not blocked. No ADR guidance conflicts with this — it is the minimal correct change. (partial: Gate-B (dashboard_inlet.go) currently returns ok:false for duplicate respond calls with a JSON result string, not a Go error. The loop-exit sentinel path handles this correctly (breaks regardless of ok value in result JSON) but a future ADR may want the ok:false path to also set a sticky per-turn flag visible to the harness for audit. Deferred as out of scope for this concern.)\n- fa0b97a No OTel was introduced (ADR-083 compliant). The trace.NewToolDispatch events are emitted post-hoc from the transcript collected by dispatchSlot rather than inline in RunToolLoopWithTranscript, so real-time mid-loop streaming is not supported — events land as a batch after the slot completes. This is acceptable for the current observability goal (audit trail) but would need inline emission (tool_loop.go changes) if sub-millisecond latency on the bus stream matters. RunToolLoop/RunToolLoopWithTranscript signatures are unchanged; no callers outside local_agent_harness.go use the dispatch path. (partial: Inline per-tool emission mid-loop (before the tool result is sent back to the model) would require threading cycleID into RunToolLoopWithTranscript via a context value or added parameter. Deferred because: (a) the batch-post approach satisfies the ADR requirement for audit trail visibility, (b) changing RunToolLoopWithTranscript's public interface or adding context reads inside tool_loop.go would affect other call sites (autonomic cycle via executeCycleTaskWithPrompt) and is a separate concern. The dispatchCycleIDFromCtx helper is already in place — extending tool_loop.go to read it would be a one-liner addition when that coverage is needed.)\n- 407cc86 tool-surface drift + unbounded output (CogDoc-URI-block-triplicated, dual-description-sets, respond-phantom-wait-param, cog_get_index-unbounded-output) (partial: Full unification of KernelToolRegistry descriptions with MCP-registered descriptions via snapshotToolDefinitions (ADR-045 complete single-source). Only the three most-drifted tools were reconciled by hand. The remaining ~10 tool descriptions in tool_loop.go still have abbreviated versions. A follow-up pass could auto-derive the tool_loop.go descriptions from the MCP registrations at construction time, eliminating the dual-description problem entirely.)

### ADRs honored
ADR-066 (foveation/KV-branching, params+RequestID), ADR-eigen (output contract), RFC-027 (alignment layer), ADR-031 (autonomic/fail-fast), ADR-052 (TERMINATE-break), ADR-083/033/072 (cycle-trace + event-layer + always-on ledger; OTel deliberately NOT used), ADR-045 (single canonical tool source).

### Merge
Recommend `--merge` (curated series, one commit per concern stays bisectable), not squash — per myrgic merge-strategy rule 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
