### PR TITLE
feat(mcp): porcelain/plumbing tool surface — lean eager set fronting a deferred catalog

### DIFF
--- a/internal/engine/mcp_architecture.go
+++ b/internal/engine/mcp_architecture.go
@@ -48,8 +48,8 @@ type architectureResolveInput struct {
 }
 
 type architectureReadInput struct {
-	Handle           string `json:"handle" jsonschema:"the handle to read"`
-	FrontmatterOnly  bool   `json:"frontmatter_only,omitempty" jsonschema:"return only frontmatter (faster), not full blocks"`
+	Handle          string `json:"handle" jsonschema:"the handle to read"`
+	FrontmatterOnly bool   `json:"frontmatter_only,omitempty" jsonschema:"return only frontmatter (faster), not full blocks"`
 }
 
 type architectureListInput struct {
@@ -74,9 +74,9 @@ type architectureAuditInput struct {
 }
 
 type architectureWriteInput struct {
-	Slug   string                 `json:"slug" jsonschema:"canonical slug; must match tree.frontmatter.slug"`
-	Tree   map[string]any         `json:"tree" jsonschema:"the parsed tree to write (output of architecture_propose or architecture_read)"`
-	Author string                 `json:"author" jsonschema:"identity slug of author"`
+	Slug   string         `json:"slug" jsonschema:"canonical slug; must match tree.frontmatter.slug"`
+	Tree   map[string]any `json:"tree" jsonschema:"the parsed tree to write (output of architecture_propose or architecture_read)"`
+	Author string         `json:"author" jsonschema:"identity slug of author"`
 }
 
 type architectureProposeInput struct {
@@ -97,47 +97,48 @@ type architectureProjectInput struct {
 // ─── Registration ────────────────────────────────────────────────────────────
 
 // registerArchitectureTools registers all 8 architecture skill tools.
-// Called from MCPServer.registerTools.
+// Called from MCPServer.registerTools. All plumbing (deferred) — reachable
+// via cog_tool_search + cog_tool_invoke, not the porcelain preload set.
 func (m *MCPServer) registerArchitectureTools() {
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_architecture_resolve",
 		Description: "Resolve any handle (canonical URI, alias, slug, legacy numeric URI, wiki-link) to canonical URI + on-disk path. From the architecture skill plugin per ADR-architecture-memory-canonical-form-and-projection.",
-	}), withToolObserver(m, "cog_architecture_resolve", m.toolArchitectureResolve))
+	}, withToolObserver(m, "cog_architecture_resolve", m.toolArchitectureResolve))
 
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_architecture_read",
 		Description: "Read an architecture document by handle. Returns parsed CogBlock tree, or frontmatter-only for fast lookups.",
-	}), withToolObserver(m, "cog_architecture_read", m.toolArchitectureRead))
+	}, withToolObserver(m, "cog_architecture_read", m.toolArchitectureRead))
 
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_architecture_list",
 		Description: "Enumerate architecture documents with optional filters (kind, status, tag, scope, limit). Returns JSON array of doc stubs.",
-	}), withToolObserver(m, "cog_architecture_list", m.toolArchitectureList))
+	}, withToolObserver(m, "cog_architecture_list", m.toolArchitectureList))
 
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_architecture_search",
 		Description: "Ranked full-text + frontmatter search across the architecture corpus. Scoring: title=10x, tags=5x, body=1x; 2x for accepted status; -1 for superseded/retired.",
-	}), withToolObserver(m, "cog_architecture_search", m.toolArchitectureSearch))
+	}, withToolObserver(m, "cog_architecture_search", m.toolArchitectureSearch))
 
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_architecture_audit",
 		Description: "Run the projection-time audit gate on a document. 8 checks (schema, slug, roundtrip, PII, restricted-tags, distinctions, salience, refs). public_ready=true activates strict gates that block projection on PII or restricted tags.",
-	}), withToolObserver(m, "cog_architecture_audit", m.toolArchitectureAudit))
+	}, withToolObserver(m, "cog_architecture_audit", m.toolArchitectureAudit))
 
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_architecture_write",
 		Description: "Write or update an architecture document at its canonical path. Validates schema, slug consistency, and roundtrip-clean before atomic rename. Returns canonical URI + action (created|updated).",
-	}), withToolObserver(m, "cog_architecture_write", m.toolArchitectureWrite))
+	}, withToolObserver(m, "cog_architecture_write", m.toolArchitectureWrite))
 
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_architecture_propose",
 		Description: "Generate an ADR or RFC draft tree with stub sections and pre-populated frontmatter. Does NOT write to disk; returns the tree for review + subsequent cog_architecture_write.",
-	}), withToolObserver(m, "cog_architecture_propose", m.toolArchitecturePropose))
+	}, withToolObserver(m, "cog_architecture_propose", m.toolArchitecturePropose))
 
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_architecture_project",
 		Description: "Project a canonical architecture document to a target workspace. Composes resolve + audit + scrub + write. public_ready=true blocks projection on PII or restricted-tag findings before any target write.",
-	}), withToolObserver(m, "cog_architecture_project", m.toolArchitectureProject))
+	}, withToolObserver(m, "cog_architecture_project", m.toolArchitectureProject))
 }
 
 // ─── Shared helper ───────────────────────────────────────────────────────────

--- a/internal/engine/mcp_fork_session.go
+++ b/internal/engine/mcp_fork_session.go
@@ -36,9 +36,10 @@ func (m *MCPServer) SetForkRegistry(fr *ForkRegistry) {
 // ─── tool registration ────────────────────────────────────────────────────────
 
 // registerForkSessionTool installs the cog_fork_session MCP tool.
-// Called from registerSessionTools() in mcp_sessions.go.
+// Called from registerSessionTools() in mcp_sessions.go. Deferred/plumbing —
+// a rare RFC-0005 primitive, not part of the porcelain preload set.
 func (m *MCPServer) registerForkSessionTool() {
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name: "cog_fork_session",
 		Description: "Fork an existing session at a specific ledger state, " +
 			"producing a child session with an optional layer overlay. " +
@@ -49,7 +50,7 @@ func (m *MCPServer) registerForkSessionTool() {
 			"(caller-supplied or auto-minted as fork-<parent>-<hex>). " +
 			"Returns: child_session_id, fork_block_hash, fork_point, pinned_until. " +
 			"Cross-workspace forks return 501 Not Implemented (reserved for v1).",
-	}), withToolObserver(m, "cog_fork_session", m.toolForkSession))
+	}, withToolObserver(m, "cog_fork_session", m.toolForkSession))
 }
 
 // ─── input / output types ────────────────────────────────────────────────────

--- a/internal/engine/mcp_modality_proxy.go
+++ b/internal/engine/mcp_modality_proxy.go
@@ -129,9 +129,10 @@ func (m *MCPServer) getModalityProxy() *modalityProxy {
 
 // registerMod3Tools installs the 7 mod3_* MCP tools. Called from
 // MCPServer.registerTools after the cog_* tools so the tool index stays
-// stable at the front.
+// stable at the front. All mod3_* tools are plumbing (deferred) — reachable
+// via cog_tool_search + cog_tool_invoke, not the porcelain preload set.
 func (m *MCPServer) registerMod3Tools() {
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name: "mod3_speak",
 		Description: "Synthesize text to speech via mod3's queue-aware /v1/speak " +
 			"endpoint. Required: text. Optional: session_id, voice, speed, " +
@@ -147,33 +148,33 @@ func (m *MCPServer) registerMod3Tools() {
 			"overlapping audio, no local afplay spawned by the kernel. " +
 			"Fallback: curl -X POST http://localhost:7860/v1/speak " +
 			"-H 'Content-Type: application/json' -d '{\"text\":\"...\"}'",
-	}), withToolObserver(m, "mod3_speak", m.toolMod3Speak))
+	}, withToolObserver(m, "mod3_speak", m.toolMod3Speak))
 
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name: "mod3_stop",
 		Description: "Stop current mod3 speech and/or cancel queued jobs. " +
 			"Optional: session_id, job_id (cancel one specific job). Empty " +
 			"cancels current playback and clears the queue. Returns mod3's " +
 			"barge-in interruption context. Fallback: curl -X POST " +
 			"http://localhost:7860/v1/stop",
-	}), withToolObserver(m, "mod3_stop", m.toolMod3Stop))
+	}, withToolObserver(m, "mod3_stop", m.toolMod3Stop))
 
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name: "mod3_voices",
 		Description: "List available mod3 voices, optionally scoped to a " +
 			"session. Optional: session_id. Returns the voice catalogue mod3 " +
 			"exposes (id, name, language, gender metadata per voice). " +
 			"Fallback: mod3 API endpoint /v1/voices (local port 7860)",
-	}), withToolObserver(m, "mod3_voices", m.toolMod3Voices))
+	}, withToolObserver(m, "mod3_voices", m.toolMod3Voices))
 
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name: "mod3_status",
 		Description: "Probe mod3's /health endpoint. Returns the raw health " +
 			"payload (model_loaded, engine info, queue_depth, etc). 502 if " +
 			"mod3 is unreachable. Fallback: mod3 API endpoint /health (local port 7860)",
-	}), withToolObserver(m, "mod3_status", m.toolMod3Status))
+	}, withToolObserver(m, "mod3_status", m.toolMod3Status))
 
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name: "mod3_register_session",
 		Description: "Register a channel-participant session. Routes through " +
 			"the kernel's /v1/channel-sessions/register endpoint so " +
@@ -186,26 +187,26 @@ func (m *MCPServer) registerMod3Tools() {
 			"mod3} block: kernel identity record + mod3's full " +
 			"SessionRegisterResponse (assigned_voice, voice_conflict, " +
 			"output_device, queue_depth).",
-	}), withToolObserver(m, "mod3_register_session", m.toolMod3RegisterSession))
+	}, withToolObserver(m, "mod3_register_session", m.toolMod3RegisterSession))
 
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name: "mod3_deregister_session",
 		Description: "Deregister a channel-participant session. Routes " +
 			"through the kernel's /v1/channel-sessions/{id}/deregister " +
 			"endpoint so the kernel drops its identity record in sync with " +
 			"mod3. Required: session_id. Returns mod3's deregister " +
 			"acknowledgment (released_voice, dropped_jobs).",
-	}), withToolObserver(m, "mod3_deregister_session", m.toolMod3DeregisterSession))
+	}, withToolObserver(m, "mod3_deregister_session", m.toolMod3DeregisterSession))
 
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name: "mod3_list_sessions",
 		Description: "List channel-participant sessions via the kernel's " +
 			"/v1/channel-sessions endpoint. Returns a merged {kernel, mod3} " +
 			"block: kernel identity records + mod3's live per-channel state " +
 			"(voice_pool, voice_holders, serializer policy).",
-	}), withToolObserver(m, "mod3_list_sessions", m.toolMod3ListSessions))
+	}, withToolObserver(m, "mod3_list_sessions", m.toolMod3ListSessions))
 
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name: "mod3_tail_logs",
 		Description: "Tail recent structured chat-flow events from mod3's " +
 			"in-memory ring buffer (up to 5000 events, DEBUG-level). " +
@@ -216,7 +217,7 @@ func (m *MCPServer) registerMod3Tools() {
 			"since (ISO timestamp or relative like 5m), " +
 			"limit (default 50, max 500). " +
 			"Fallback: curl 'http://localhost:7860/v1/logs/chat-flow?limit=20'",
-	}), withToolObserver(m, "mod3_tail_logs", m.toolMod3TailLogs))
+	}, withToolObserver(m, "mod3_tail_logs", m.toolMod3TailLogs))
 }
 
 // ─── input / output types ────────────────────────────────────────────────────
@@ -524,10 +525,10 @@ func buildSynthesizeBody(in mod3SpeakInput) map[string]any {
 	return body
 }
 
-// checkSessionSubscriber asks mod3 whether ``sessionID`` has at least one
+// checkSessionSubscriber asks mod3 whether “sessionID“ has at least one
 // active dashboard WebSocket subscriber for audio playback. Returns
-// ``(subscribed, nil)`` on success, ``(false, err)`` on transport failure.
-// ``(false, nil)`` — the default when the proxy has no check configured —
+// “(subscribed, nil)“ on success, “(false, err)“ on transport failure.
+// “(false, nil)“ — the default when the proxy has no check configured —
 // also suppresses the routing path, so legacy callers see the exact same
 // afplay behavior as before.
 //

--- a/internal/engine/mcp_modality_proxy.go
+++ b/internal/engine/mcp_modality_proxy.go
@@ -525,10 +525,10 @@ func buildSynthesizeBody(in mod3SpeakInput) map[string]any {
 	return body
 }
 
-// checkSessionSubscriber asks mod3 whether “sessionID“ has at least one
+// checkSessionSubscriber asks mod3 whether `sessionID` has at least one
 // active dashboard WebSocket subscriber for audio playback. Returns
-// “(subscribed, nil)“ on success, “(false, err)“ on transport failure.
-// “(false, nil)“ — the default when the proxy has no check configured —
+// `(subscribed, nil)` on success, `(false, err)` on transport failure.
+// `(false, nil)` — the default when the proxy has no check configured —
 // also suppresses the routing path, so legacy callers see the exact same
 // afplay behavior as before.
 //

--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -168,6 +168,12 @@ func NewMCPServerWithAgentController(cfg *Config, nucleus *Nucleus, process *Pro
 	m.registerTools()
 	m.registerResources()
 
+	// Backfill InputSchema onto eager toolMeta entries (see trackTool's doc
+	// comment: mcp.AddTool's schema inference never writes back onto the
+	// original *mcp.Tool pointer, so this queries the live server the same
+	// way snapshotToolDefinitions does, immediately below).
+	m.backfillEagerSchemas()
+
 	// Snapshot the registered tool list as kernel-side ToolDefinitions so the
 	// chat path can auto-advertise the kernel's MCP tool surface to the
 	// inference provider when the request targets the kernel-agent route

--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -68,10 +68,19 @@ type MCPServer struct {
 	channelSessionBackend channelSessionBackend
 
 	// toolMeta is the manifest-introspection registry for MCP tools.
-	// Populated by trackTool at registration time (see serve_manifest.go);
-	// read by handleManifest. Frozen after registerTools returns, so
-	// lock-free reads are safe.
+	// Populated by trackTool/trackToolDeferred at registration time (see
+	// serve_manifest.go); read by handleManifest. Frozen after registerTools
+	// returns, so lock-free reads are safe.
 	toolMeta []mcpToolMeta
+
+	// deferredHandlers is the plumbing catalog (porcelain/plumbing tool
+	// surface, workflow wkweyu50g): tools registered via trackToolDeferred
+	// instead of mcp.AddTool, keyed by tool name. These never appear in
+	// tools/list; they are reachable only through cog_tool_search (discover)
+	// and cog_tool_invoke (dispatch). Populated during registerTools() and
+	// frozen afterwards — lock-free reads are safe post-construction, same
+	// contract as toolMeta.
+	deferredHandlers map[string]deferredToolHandler
 
 	// toolDefs is the cached snapshot of MCP tools as kernel-side
 	// [ToolDefinition] values, suitable for direct injection onto a
@@ -157,12 +166,13 @@ func NewMCPServerWithAgentController(cfg *Config, nucleus *Nucleus, process *Pro
 	}, nil)
 
 	m := &MCPServer{
-		server:          server,
-		cfg:             cfg,
-		nucleus:         nucleus,
-		process:         process,
-		cogdocSvc:       NewCogDocService(cfg, process),
-		agentController: ctrl,
+		server:           server,
+		cfg:              cfg,
+		nucleus:          nucleus,
+		process:          process,
+		cogdocSvc:        NewCogDocService(cfg, process),
+		agentController:  ctrl,
+		deferredHandlers: make(map[string]deferredToolHandler),
 	}
 
 	m.registerTools()
@@ -248,11 +258,28 @@ func (m *MCPServer) Server() *mcp.Server {
 // Design: tools are actions with side effects or non-trivial computation.
 // Read-only state queries will migrate to MCP Resources in Phase 2.
 //
-// Every handler is wrapped with withToolObserver so an invocation emits a
-// paired tool.call + tool.result event to the hash-chained ledger. This
-// closes Agent F gap #6 and activates the gate.go:94 recognizer that has
-// been waiting for a producer.
+// Porcelain/plumbing tool surface (workflow wkweyu50g, tier-then-trim
+// mechanism doc cog:mem/semantic/architecture/mcp-tool-surface-tier-then-trim
+// #Mechanism, RESOLVED): only the ~13-tool porcelain set below is registered
+// via mcp.AddTool (trackTool) — the set that appears in tools/list and is
+// eagerly visible to every harness. Everything else (the plumbing) routes
+// through trackToolDeferred into m.deferredHandlers instead, reachable only
+// via cog_tool_search (discover) and cog_tool_invoke (dispatch). This is a
+// server-autonomous mechanism: the kernel cannot ask Claude Code (or any
+// other harness) to defer-load specific MCP tools, so it shrinks its own
+// advertised schema surface instead of relying on client cooperation.
+//
+// Every eager handler is wrapped with withToolObserver so an invocation
+// emits a paired tool.call + tool.result event to the hash-chained ledger.
+// This closes Agent F gap #6 and activates the gate.go:94 recognizer that
+// has been waiting for a producer. Deferred (plumbing) handlers keep their
+// original withToolObserver wrapping too — trackToolDeferred's In type
+// parameter is inferred from the wrapped handler's signature, so converting
+// a registration site from trackTool/mcp.AddTool to trackToolDeferred does
+// not change what runs, only how it's reached.
 func (m *MCPServer) registerTools() {
+	// ── Porcelain (eager, mcp.AddTool) ──────────────────────────────────────
+
 	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name:        "cog_search_memory",
 		Description: "Full-text and semantic search over the CogDoc memory corpus. Returns ranked results with salience scores. Fallback: ./scripts/cog memory search \"query\"",
@@ -269,11 +296,6 @@ func (m *MCPServer) registerTools() {
 	}), withToolObserver(m, "cog_write_cogdoc", m.toolWriteCogdoc))
 
 	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
-		Name:        "cog_patch_frontmatter",
-		Description: "Merge description, tags, or type patches into a CogDoc frontmatter block.",
-	}), withToolObserver(m, "cog_patch_frontmatter", m.toolPatchFrontmatter))
-
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name:        "cog_check_coherence",
 		Description: "Run coherence validation against the workspace. Checks URI resolution, frontmatter validity, and reference integrity. Fallback: ./scripts/cog coherence check",
 	}), withToolObserver(m, "cog_check_coherence", m.toolCheckCoherence))
@@ -284,16 +306,34 @@ func (m *MCPServer) registerTools() {
 	}), withToolObserver(m, "cog_get_state", m.toolGetState))
 
 	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+		Name:        "cog_dispatch_to_harness",
+		Description: "Phase 2 transport: dispatch a task into the kernel-interior agent harness with structured return, optional concurrency (n=1..4), named tool scope, per-call tool narrowing, optional system-prompt override, and pluggable model routing (default: LM Studio via provider=\"lmstudio-darkstar\", resident gemma-4-26b at 127.0.0.1:1234). Synchronous: blocks until every slot completes, errors, or hits its per-slot timeout (default 30s, max 120s). Returns one DispatchResult per slot with content (the agent's final respond text), tool-call digests, duration, and turn count. Use this for the foveal->peripheral handoff — offload validation, rewriting, modality matching to the resident swarm instead of paying with Anthropic tokens. Named scopes (RFC-016): \"consolidation\" (default, 11 substrate tools: memory/field/coherence/identity; respond excluded from base), \"consolidation_with_respond\" (+ respond), \"consolidation_no_respond\" (no respond), \"audit\" (consolidation + cog_read_file + cog_grep_files), \"search\" (cog_resolve_uri/cog_search_memory/cog_query_field), \"observe\" (consolidation reads, no emit), \"emit\" (cog_emit_event only). Unknown scope names error immediately. Backward-compat note: cog_trigger_agent_loop still wakes the singleton with no payload; this tool is the new payload-bearing path.",
+	}), m.toolDispatchToHarness)
+
+	// Kernel-native session/handoff tools (mcp_sessions.go). The porcelain
+	// subset (register/list/heartbeat/end/list_handoffs/claim_handoff) is
+	// registered eagerly inside registerSessionTools; the rest
+	// (offer_handoff, complete_handoff, fork_session) is deferred there too.
+	m.registerSessionTools()
+
+	// ── Plumbing (deferred, trackToolDeferred) ──────────────────────────────
+
+	trackToolDeferred(m, &mcp.Tool{
+		Name:        "cog_patch_frontmatter",
+		Description: "Merge description, tags, or type patches into a CogDoc frontmatter block.",
+	}, withToolObserver(m, "cog_patch_frontmatter", m.toolPatchFrontmatter))
+
+	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_query_field",
 		Description: "Query the attentional field — the salience-scored map of all tracked CogDocs. Returns top-N items, optionally filtered by sector. Shows what the kernel considers most relevant right now.",
-	}), withToolObserver(m, "cog_query_field", m.toolQueryField))
+	}, withToolObserver(m, "cog_query_field", m.toolQueryField))
 
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_assemble_context",
 		Description: "Build a context package for a given token budget with an explicit focus topic. Use this for intentional context assembly (subtasks, specific investigations). The automatic foveated-context hook handles ambient context on every prompt.",
-	}), withToolObserver(m, "cog_assemble_context", m.toolAssembleContext))
+	}, withToolObserver(m, "cog_assemble_context", m.toolAssembleContext))
 
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name: "cog_emit_event",
 		Description: "Emit a typed event to the workspace ledger. " +
 			"Events: attention.boost (uri + weight), session.marker (label), " +
@@ -301,96 +341,91 @@ func (m *MCPServer) registerTools() {
 			"peer.utterance (from + to + content + turn; both sessions must be registered). " +
 			"Optional from_session: records the emitting session as event source; required for peer.utterance and must match payload.from. " +
 			"Fallback: events are JSONL in .cog/ledger/",
-	}), withToolObserver(m, "cog_emit_event", m.toolEmitEvent))
+	}, withToolObserver(m, "cog_emit_event", m.toolEmitEvent))
 
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_read_ledger",
 		Description: "Read the hash-chained event ledger. Filter by session_id, event_type (exact or 'prefix.*' wildcard), after_seq (requires session_id), since_timestamp (RFC3339), or limit (default 100, max 1000). Set verify_chain=true to recompute hashes and validate prior_hash links. Fallback: cat .cog/ledger/<session_id>/events.jsonl",
-	}), m.toolReadLedger)
+	}, m.toolReadLedger)
 
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_read_events",
 		Description: "Query recent kernel events for observability. Returns historical events from the ledger without chain verification (use cog_read_ledger for audit). Filters: session_id, event_type (exact or 'attention.*' wildcard), source ('kernel-v3' / 'mcp-client'), since/until (RFC3339 or duration shorthand like '5m'), limit (default 100, max 1000), order ('desc' newest-first default, 'asc' oldest-first). Fallback: ls .cog/ledger/ && cat .cog/ledger/*/events.jsonl",
-	}), m.toolReadEvents)
+	}, m.toolReadEvents)
 
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_tail_events",
 		Description: "Tail kernel events as they are appended to the ledger, like 'tail -f'. Blocks until max_events or max_duration reached. Same filters as cog_read_events plus since= for replay before going live. Bounded by max_events (default 100, max 1000) and max_duration (default 60s, max 10m). Fallback: kernel API streaming endpoint /v1/events/stream (local port 6931)",
-	}), m.toolTailEvents)
+	}, m.toolTailEvents)
 
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_ingest",
 		Description: "Ingest external material into CogOS knowledge. Deterministic decomposition — no LLM calls. Supports URLs, conversations, documents. Applies membrane policy (accept/quarantine/defer/discard).",
-	}), withToolObserver(m, "cog_ingest", m.toolIngest))
+	}, withToolObserver(m, "cog_ingest", m.toolIngest))
 
 	// Tool-call observability — reads the paired tool.call/tool.result events
 	// the wrapper above emits. Self-reflective: these two tools also go
 	// through withToolObserver and end up in their own query results.
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_read_tool_calls",
 		Description: "Query recent tool invocations and their outcomes. Returns call+result pairs from the ledger, filterable by tool_name, status (pending/success/error/rejected/timeout), source, ownership, call_id, or time window. Default limit 100, max 500. Arguments and output are opt-in via include_args/include_output. Fallback: grep '\"type\":\"tool\\.' .cog/ledger/<sid>/events.jsonl",
-	}), withToolObserver(m, "cog_read_tool_calls", m.toolReadToolCalls))
+	}, withToolObserver(m, "cog_read_tool_calls", m.toolReadToolCalls))
 
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_tail_tool_calls",
 		Description: "Tail tool-call events live. Replays recent tool.call / tool.result events (up to max_events, default 50), applying the same filters as cog_read_tool_calls. When Agent N's event bus lands, this will stream new events live; until then it returns a snapshot of the latest matching rows. Fallback: tail -f .cog/ledger/<sid>/events.jsonl | grep '\"type\":\"tool\\.'",
-	}), withToolObserver(m, "cog_tail_tool_calls", m.toolTailToolCalls))
+	}, withToolObserver(m, "cog_tail_tool_calls", m.toolTailToolCalls))
 
 	// Agent state / loop control — closes Agent F gap #8 per Agent T's design.
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_list_agents",
 		Description: "Enumerate active agent harness instances inside the kernel. Each entry summarises identity, state, and recent activity. Today returns one element (\"primary\") reflecting the ServeAgent singleton; forward-compatible for future multi-agent deployment. Fallback: kernel API endpoint /v1/agents (local port 6931)",
-	}), m.toolListAgents)
+	}, m.toolListAgents)
 
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_get_agent_state",
 		Description: "Full state snapshot of one agent instance — status summary, activity awareness, rolling cycle memory, pending proposals, inbox queue, and optionally the most recent cycle traces. Matches the shape of GET /v1/agents/{id}. Fallback: kernel API endpoint /v1/agents/primary (local port 6931)",
-	}), m.toolGetAgentState)
+	}, m.toolGetAgentState)
 
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_trigger_agent_loop",
 		Description: "Manually invoke one homeostatic cycle of the specified agent, outside the regular ticker. Equivalent to POST /v1/agents/{id}/tick. Returns immediately with a trigger receipt; cycle runs async unless wait=true. Refuses if a cycle is already in flight (overlap guard). Fallback: kernel API POST /v1/agents/primary/tick (local port 6931)",
-	}), m.toolTriggerAgentLoop)
+	}, m.toolTriggerAgentLoop)
 
-	mcp.AddTool(m.server, &mcp.Tool{
-		Name:        "cog_dispatch_to_harness",
-		Description: "Phase 2 transport: dispatch a task into the kernel-interior agent harness with structured return, optional concurrency (n=1..4), named tool scope, per-call tool narrowing, optional system-prompt override, and pluggable model routing (default: LM Studio via provider=\"lmstudio-darkstar\", resident gemma-4-26b at 127.0.0.1:1234). Synchronous: blocks until every slot completes, errors, or hits its per-slot timeout (default 30s, max 120s). Returns one DispatchResult per slot with content (the agent's final respond text), tool-call digests, duration, and turn count. Use this for the foveal->peripheral handoff — offload validation, rewriting, modality matching to the resident swarm instead of paying with Anthropic tokens. Named scopes (RFC-016): \"consolidation\" (default, 11 substrate tools: memory/field/coherence/identity; respond excluded from base), \"consolidation_with_respond\" (+ respond), \"consolidation_no_respond\" (no respond), \"audit\" (consolidation + cog_read_file + cog_grep_files), \"search\" (cog_resolve_uri/cog_search_memory/cog_query_field), \"observe\" (consolidation reads, no emit), \"emit\" (cog_emit_event only). Unknown scope names error immediately. Backward-compat note: cog_trigger_agent_loop still wakes the singleton with no payload; this tool is the new payload-bearing path.",
-	}, m.toolDispatchToHarness)
-
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_tail_kernel_log",
 		Description: "Read recent entries from the kernel's own diagnostic log (slog JSON at .cog/run/kernel.log.jsonl). Returns newest-first, optionally filtered by level, substring, and time range. This is the OPERATOR/DEBUG surface — for hash-chained event history use cog_read_ledger (when available); for client metabolites (turn metrics, attention, proprioceptive) use cog_search_traces. Fallback: tail -n 100 .cog/run/kernel.log.jsonl | jq -c .",
-	}), m.toolTailKernelLog)
+	}, m.toolTailKernelLog)
 
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name: "cog_read_conversation",
 		Description: "Read conversation turns (prompt + response pairs) from a session's chat history. " +
 			"Each turn is a complete user-to-assistant exchange; kernel tool calls are inlined when include_tools=true. " +
 			"Backed by the turn.completed ledger event + per-session sidecar (.cog/run/turns/<sid>.jsonl). " +
 			"Use after_turn / before_turn for pagination. Default: current process session, 20 turns, ascending. " +
 			"Fallback (kernel unavailable): jq -c . .cog/run/turns/<sid>.jsonl",
-	}), m.toolReadConversation)
+	}, m.toolReadConversation)
 
 	// Config mutation API (Agent O design — closes Agent F gaps #5 + #19).
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_read_config",
 		Description: "Read the kernel config (.cog/config/kernel.yaml). Returns the effective resolved config (defaults + file overrides). Optional include_raw_yaml returns the raw file bytes; include_defaults also returns the hardcoded defaults for diffing. kernel.yaml only — sibling configs (providers.yaml, secrets.yaml) are out of scope.",
-	}), m.toolReadConfig)
+	}, m.toolReadConfig)
 
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_write_config",
 		Description: "Merge a patch into the kernel config (.cog/config/kernel.yaml) using RFC 7396 JSON merge-patch semantics: fields omitted from the patch are left unchanged; explicit null removes a field and restores the default on next boot. Validated before persisting — returns violations without writing on failure. Atomic write + rotating .bak-<timestamp> backups (keeps 10). Takes effect on next daemon restart (requires_restart: true in response). Fallback: edit .cog/config/kernel.yaml and run `./scripts/cog restart`. No authentication — the kernel assumes a trusted local caller.",
-	}), m.toolWriteConfig)
+	}, m.toolWriteConfig)
 
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_rollback_config",
 		Description: "Restore kernel.yaml from a prior .bak-<timestamp> backup. Pass list_only=true to enumerate available backups without restoring. If backup is empty, the most recent backup is used. Atomic restore; response carries updated backup list.",
-	}), m.toolRollbackConfig)
+	}, m.toolRollbackConfig)
 
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_search_traces",
 		Description: "Search kernel trace JSONL streams in .cog/run/ (attention, proprioceptive, internal_requests). Filter by source, session_id, level, case-insensitive substring, and time range (since/until accept RFC3339 or duration like 5m/1h). Returns unified chronological results with per-source scan diagnostics. Fallback: ls .cog/run/*.jsonl && jq -c . .cog/run/<name>.jsonl | head",
-	}), m.toolSearchTraces)
+	}, m.toolSearchTraces)
 
 	// Memory section-index ops (RFC-017 Phase B). Port of the legacy
 	// `cog memory toc` / `cog memory index` verbs from the 2.5.0 monolith
@@ -400,38 +435,35 @@ func (m *MCPServer) registerTools() {
 	// path to generate or inspect the `sections:` frontmatter block.
 	// Without that block, every cog_read_cogdoc degrades to a full-doc
 	// read. See Phase 24 MCP API Coverage Audit for the gap analysis.
-	mcp.AddTool(m.server, &mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_memory_toc",
 		Description: "List a CogDoc's sections with line ranges and byte sizes. Default output is a pretty-printed text table showing total lines/bytes plus per-section nesting, line range, and size; pass as_yaml=true to get the `sections:` frontmatter YAML block that cog_memory_index injects. Useful for orienting to a long document before extracting a specific section via cog_read_cogdoc with #fragment. Fallback: ./scripts/cog memory toc <path> [--yaml]",
 	}, withToolObserver(m, "cog_memory_toc", m.toolMemoryTOC))
 
-	mcp.AddTool(m.server, &mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_memory_index",
 		Description: "Generate the `sections:` frontmatter block for a CogDoc and inject it into the file's frontmatter (replacing any prior sections field). Required for cheap section-addressed reads: without `sections:` every cog_read_cogdoc call with a section selector falls back to whole-document reads. Pass dry_run=true to preview the block without writing. Requires existing frontmatter; indexing a plain markdown file is a no-op by design (run cog_write_cogdoc first). Writes are atomic. Fallback: ./scripts/cog memory index <path> [--dry-run]",
 	}, withToolObserver(m, "cog_memory_index", m.toolMemoryIndex))
-
-	// Kernel-native session/handoff tools (mcp_sessions.go). The 8 tools
-	// complement the 8 cogos_* bridge tools living in cog-sandbox-mcp:
-	// both surfaces coexist by design — same kernel truth, two MCP
-	// doorways (amendment #5 of the Agent P hybrid plan).
-	m.registerSessionTools()
 
 	// Wave 3: mod3 proxy tools (mcp_modality_proxy.go). The kernel becomes
 	// the MCP front door for mod3 — HTTP-forwards synthesis/stop/voices/
 	// status and plays the returned audio/wav locally. Supersedes the
 	// installed binary's OpenClaw gateway which silently drops audio bytes.
+	// All mod3_* tools are plumbing (registerMod3Tools uses trackToolDeferred).
 	m.registerMod3Tools()
 
 	// Architecture skill plugin tools (mcp_architecture.go). 8 cog_architecture_*
 	// tools that subprocess-exec the Python implementations at
 	// {WorkspaceRoot}/.cog/skills/architecture/tools/architecture_*.py per the
-	// architecture-memory-canonical-form-and-projection ADR.
+	// architecture-memory-canonical-form-and-projection ADR. All plumbing
+	// (registerArchitectureTools uses trackToolDeferred).
 	m.registerArchitectureTools()
 
-	// Audit-scope read-only filesystem tools. Also registered as first-class
-	// MCP tools so they're callable directly from Claude Code sessions.
-	// In harness dispatches these are available only when scope="audit".
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	// Audit-scope read-only filesystem tools. Deferred/plumbing — reachable
+	// via cog_tool_search + cog_tool_invoke, or directly when a harness
+	// dispatch narrows scope="audit" (mcp_server.go's toolDispatchToHarness
+	// path resolves these by name, not via mcp.AddTool registration).
+	trackToolDeferred(m, &mcp.Tool{
 		Name: "cog_read_file",
 		Description: "Read an arbitrary file within the workspace root. " +
 			"res=abstract (default, ADR pointer-first): returns a pointer envelope — workspace-relative path, file size, " +
@@ -439,19 +471,19 @@ func (m *MCPServer) registerTools() {
 			"res=full: returns line-numbered content with optional offset/limit (default 500 lines). " +
 			"Rejects paths outside the workspace root. Use for source inspection and substrate-introspection tasks. " +
 			"Fallback: cat -n <path>",
-	}), withToolObserver(m, "cog_read_file", m.toolReadFile))
+	}, withToolObserver(m, "cog_read_file", m.toolReadFile))
 
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name: "cog_grep_files",
 		Description: "Regex search over files within the workspace root (uses ripgrep when available, falls back to pure-Go walk). " +
 			"res=abstract (default, ADR pointer-first): returns match count + unique matched file paths — no line text. " +
 			"res=full: returns per-match path/line/text entries. " +
 			"Rejects search paths outside the workspace root. Fallback: rg --no-heading -n <pattern> <path>",
-	}), withToolObserver(m, "cog_grep_files", m.toolGrepFiles))
+	}, withToolObserver(m, "cog_grep_files", m.toolGrepFiles))
 
 	// Phase 1B: peer-awareness packet (READ side of the 4E ambient-
 	// awareness loop; Phase 1A publishes channel.<sid>.activity).
-	mcp.AddTool(m.server, &mcp.Tool{
+	trackToolDeferred(m, &mcp.Tool{
 		Name: "cog_render_peer_awareness_packet",
 		Description: "Render a token-budgeted peer-awareness packet for a " +
 			"session. Combines the session's recent tailer activity, open " +
@@ -462,6 +494,11 @@ func (m *MCPServer) registerTools() {
 			"a UserPromptSubmit preamble. Fallback: kernel API endpoint " +
 			"/v1/peer-awareness?sid=<sid> (local port 6931)",
 	}, withToolObserver(m, "cog_render_peer_awareness_packet", m.toolRenderPeerAwarenessPacket))
+
+	// The porcelain/plumbing catalog itself: cog_tool_search (discover) and
+	// cog_tool_invoke (dispatch) are the two new eager tools that front the
+	// deferred plumbing set registered above.
+	m.registerToolCatalogTools()
 }
 
 // registerResources registers MCP Resources — read-only addressable data.

--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -260,7 +260,7 @@ func (m *MCPServer) Server() *mcp.Server {
 //
 // Porcelain/plumbing tool surface (workflow wkweyu50g, tier-then-trim
 // mechanism doc cog:mem/semantic/architecture/mcp-tool-surface-tier-then-trim
-// #Mechanism, RESOLVED): only the ~13-tool porcelain set below is registered
+// #Mechanism, RESOLVED): only the ~14-tool porcelain set below is registered
 // via mcp.AddTool (trackTool) — the set that appears in tools/list and is
 // eagerly visible to every harness. Everything else (the plumbing) routes
 // through trackToolDeferred into m.deferredHandlers instead, reachable only

--- a/internal/engine/mcp_sessions.go
+++ b/internal/engine/mcp_sessions.go
@@ -42,6 +42,13 @@ func (m *MCPServer) sessionsBackendReady() bool {
 // registerSessionTools installs the 8 cog_* session/handoff tools. Kept in
 // its own method so mcp_server.go stays tidy; the registration site in
 // registerTools calls this last.
+//
+// Porcelain/plumbing split (workflow wkweyu50g): register/list_sessions/
+// heartbeat/end_session/list_handoffs/claim_handoff are the six session tools
+// in the preload porcelain set — registered eagerly via mcp.AddTool.
+// offer_handoff, complete_handoff, and fork_session are less frequently
+// reached (offer/complete are the two ends of a lifecycle a session touches
+// at most once each; fork is a rare RFC-0005 primitive) and are deferred.
 func (m *MCPServer) registerSessionTools() {
 	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name: "cog_register_session",
@@ -79,15 +86,6 @@ func (m *MCPServer) registerSessionTools() {
 	}), withToolObserver(m, "cog_list_sessions", m.toolListSessions))
 
 	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
-		Name: "cog_offer_handoff",
-		Description: "Post a handoff.offer to bus_handoffs. Mints a new " +
-			"handoff_id (ho-<ms>-<hex>). task.title, task.goal, and a " +
-			"non-empty task.next_steps list are required. TTL defaults to " +
-			"3600s; expired offers are 409 on claim. Returns the full " +
-			"offer payload so the caller can inspect what was written.",
-	}), withToolObserver(m, "cog_offer_handoff", m.toolOfferHandoff))
-
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name: "cog_list_handoffs",
 		Description: "List tracked handoffs with optional filters: " +
 			"state (open|claimed|completed|expired) and for_session. The " +
@@ -104,12 +102,23 @@ func (m *MCPServer) registerSessionTools() {
 			"Returns the full offer payload on success.",
 	}), withToolObserver(m, "cog_claim_handoff", m.toolClaimHandoff))
 
-	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+	// ── Deferred (plumbing) ──────────────────────────────────────────────
+
+	trackToolDeferred(m, &mcp.Tool{
+		Name: "cog_offer_handoff",
+		Description: "Post a handoff.offer to bus_handoffs. Mints a new " +
+			"handoff_id (ho-<ms>-<hex>). task.title, task.goal, and a " +
+			"non-empty task.next_steps list are required. TTL defaults to " +
+			"3600s; expired offers are 409 on claim. Returns the full " +
+			"offer payload so the caller can inspect what was written.",
+	}, withToolObserver(m, "cog_offer_handoff", m.toolOfferHandoff))
+
+	trackToolDeferred(m, &mcp.Tool{
 		Name: "cog_complete_handoff",
 		Description: "Mark a claimed handoff as completed. Rejected with " +
 			"409 if the handoff has not been claimed yet or is already " +
 			"complete. Optional outcome, notes, and next_handoff_id.",
-	}), withToolObserver(m, "cog_complete_handoff", m.toolCompleteHandoff))
+	}, withToolObserver(m, "cog_complete_handoff", m.toolCompleteHandoff))
 
 	// RFC-0005: session forking primitive.
 	m.registerForkSessionTool()
@@ -133,7 +142,7 @@ type registerSessionInput struct {
 	// When Subject is non-empty and a harnessBackend is wired, a
 	// HarnessBindingCRD is created linking sessionID → Subject.
 	Subject     string `json:"subject,omitempty"`      // identity sub-slug (e.g. "chaz", "cog")
-	Iss         string `json:"iss,omitempty"`           // OIDC issuer hint (e.g. "anthropic.claude-code")
+	Iss         string `json:"iss,omitempty"`          // OIDC issuer hint (e.g. "anthropic.claude-code")
 	BindingType string `json:"binding_type,omitempty"` // "agent" (default) or "user"
 }
 

--- a/internal/engine/mcp_tool_catalog.go
+++ b/internal/engine/mcp_tool_catalog.go
@@ -177,8 +177,8 @@ func (m *MCPServer) toolToolSearch(ctx context.Context, req *mcp.CallToolRequest
 // ── cog_tool_invoke ───────────────────────────────────────────────────────
 
 type toolInvokeInput struct {
-	Name string          `json:"name" jsonschema:"The plumbing tool's name, as returned by cog_tool_search"`
-	Args json.RawMessage `json:"args,omitempty" jsonschema:"Arguments object for the underlying tool; omit or pass {} for tools with no required input"`
+	Name string         `json:"name" jsonschema:"The plumbing tool's name, as returned by cog_tool_search"`
+	Args map[string]any `json:"args,omitempty" jsonschema:"Arguments object for the underlying tool; omit or pass {} for tools with no required input"`
 }
 
 // toolToolInvoke implements cog_tool_invoke. See the file-level doc comment
@@ -222,7 +222,11 @@ func (m *MCPServer) toolToolInvoke(ctx context.Context, req *mcp.CallToolRequest
 		}
 	}
 
-	result, err := handler(ctx, req, input.Args)
+	argsJSON, err := json.Marshal(input.Args)
+	if err != nil {
+		return fallbackResult(fmt.Sprintf("cog_tool_invoke: marshal args for %s: %v", name, err), "")
+	}
+	result, err := handler(ctx, req, argsJSON)
 	if err != nil {
 		return fallbackResult(fmt.Sprintf("cog_tool_invoke: %s: %v", name, err), "")
 	}

--- a/internal/engine/mcp_tool_catalog.go
+++ b/internal/engine/mcp_tool_catalog.go
@@ -1,0 +1,230 @@
+// mcp_tool_catalog.go — cog_tool_search + cog_tool_invoke: the porcelain
+// front door onto the deferred plumbing catalog (workflow wkweyu50g,
+// tier-then-trim mechanism doc cog:mem/semantic/architecture/
+// mcp-tool-surface-tier-then-trim.cog.md #Mechanism, RESOLVED).
+//
+// Why these two tools exist: the kernel cannot ask an MCP client (Claude
+// Code or any other harness) to defer-load specific tools — defer_loading /
+// tool_search_tool_* are Anthropic-Messages-API client-side attributes with
+// no MCP wire equivalent. So instead of shrinking the *set* of tools the
+// kernel implements, the kernel shrinks the set it *advertises* via
+// mcp.AddTool (the porcelain, see registerTools) and moves everything else
+// (the plumbing, registered via trackToolDeferred into m.deferredHandlers)
+// behind these two tools:
+//
+//   - cog_tool_search(query, limit) — ranks the full catalog (both eager and
+//     deferred entries in m.toolMeta) by substring/token match and returns
+//     {name, description, input_schema, family} so a caller can discover a
+//     plumbing tool without it ever appearing in tools/list.
+//   - cog_tool_invoke(name, args) — looks up name in m.deferredHandlers and
+//     dispatches. Unknown names are rejected outright (no silent widening,
+//     mirroring KernelToolRegistry.Scoped in tool_loop.go).
+//
+// SECURITY-CRITICAL (ADR G2 PART C): cog_tool_invoke MUST NOT become a
+// confused-deputy bypass of per-tool capability gating. The normal
+// enforcement path (tool_observer.go's withToolObserver) keys off
+// req.Session.ID() — the REAL MCP transport session ID — resolved via
+// m.resolveTransportSession. If cog_tool_invoke simply called the deferred
+// handler in-process (or via a nested in-memory MCP transport a la
+// snapshotToolDefinitions/CallTool), the underlying handler's own
+// withToolObserver wrapping would see a *different* req (either the same
+// req.Session as the outer cog_tool_invoke call, which is fine, or — if
+// dispatched over a fresh in-memory transport pair — an empty/unrelated
+// session ID, which would silently skip enforcement entirely: the classic
+// confused-deputy shape).
+//
+// This file avoids that trap by checking capability BEFORE dispatch, using
+// the OUTER call's own req (the real transport session), against the name of
+// the UNDERLYING tool being invoked — then calling the deferred handler
+// in-process with that same req threaded through, so any capability check
+// inside the underlying handler (should one exist independently) still sees
+// the correct session. This is the same check withToolObserver performs,
+// applied one level up, for the tool that's actually about to run rather
+// than for "cog_tool_invoke" itself.
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// registerToolCatalogTools installs cog_tool_search and cog_tool_invoke —
+// the two porcelain tools that front the deferred plumbing catalog. Called
+// last from registerTools() so the full m.toolMeta / m.deferredHandlers
+// population (including these two tools' own entries) is available for
+// cog_tool_search to rank over.
+func (m *MCPServer) registerToolCatalogTools() {
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+		Name: "cog_tool_search",
+		Description: "Search the full CogOS MCP tool catalog — both the eager " +
+			"porcelain tools (already directly callable) and the deferred " +
+			"plumbing tools (invoke-only via cog_tool_invoke, not present in " +
+			"tools/list). Ranks by substring/token match over name, " +
+			"description, and family. Required: query. Optional: limit " +
+			"(default 10, max 50). Returns [{name, description, input_schema, " +
+			"family, eager}]. Use this to discover a plumbing tool's schema " +
+			"before calling cog_tool_invoke.",
+	}), withToolObserver(m, "cog_tool_search", m.toolToolSearch))
+
+	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
+		Name: "cog_tool_invoke",
+		Description: "Invoke a deferred (plumbing) MCP tool by name. Rejects " +
+			"unknown names — this is NOT a general-purpose dispatcher, only " +
+			"the closed set of tools registered as plumbing (see " +
+			"cog_tool_search). Required: name, args (object; pass {} for " +
+			"tools with no required input). Subject to the same per-tool " +
+			"capability-envelope gating (ADR G2 PART C) as calling the " +
+			"underlying tool directly — cog_tool_invoke is not a bypass. " +
+			"Returns the underlying tool's result verbatim.",
+	}), withToolObserver(m, "cog_tool_invoke", m.toolToolInvoke))
+}
+
+// ── cog_tool_search ──────────────────────────────────────────────────────
+
+type toolSearchInput struct {
+	Query string `json:"query" jsonschema:"Search query — matched as substring/token over tool name, description, and family"`
+	Limit int    `json:"limit,omitempty" jsonschema:"Maximum results (default 10, max 50)"`
+}
+
+type toolSearchResultEntry struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Family      string `json:"family"`
+	Eager       bool   `json:"eager"`
+	InputSchema any    `json:"input_schema,omitempty"`
+}
+
+// toolToolSearch implements cog_tool_search. In-memory ranking over
+// m.toolMeta is fine for the current catalog size (~57 rows); FTS5 over
+// constellation.db is the escalation path only if the catalog grows enough
+// to matter (see mcp-tool-surface-tier-then-trim.cog.md #Mechanism).
+func (m *MCPServer) toolToolSearch(ctx context.Context, req *mcp.CallToolRequest, input toolSearchInput) (*mcp.CallToolResult, any, error) {
+	query := strings.TrimSpace(input.Query)
+	if query == "" {
+		return fallbackResult("cog_tool_search: query is required", "")
+	}
+	limit := input.Limit
+	if limit <= 0 {
+		limit = 10
+	}
+	if limit > 50 {
+		limit = 50
+	}
+
+	terms := strings.Fields(strings.ToLower(query))
+
+	type scored struct {
+		entry mcpToolMeta
+		score int
+	}
+	var candidates []scored
+	for _, t := range m.toolMeta {
+		hay := strings.ToLower(t.Name + " " + t.Description + " " + t.Family)
+		score := 0
+		for _, term := range terms {
+			if term == "" {
+				continue
+			}
+			if strings.Contains(strings.ToLower(t.Name), term) {
+				score += 5
+			}
+			if strings.Contains(strings.ToLower(t.Family), term) {
+				score += 2
+			}
+			if strings.Contains(hay, term) {
+				score++
+			}
+		}
+		if score > 0 {
+			candidates = append(candidates, scored{entry: t, score: score})
+		}
+	}
+
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if candidates[i].score != candidates[j].score {
+			return candidates[i].score > candidates[j].score
+		}
+		return candidates[i].entry.Name < candidates[j].entry.Name
+	})
+
+	if len(candidates) > limit {
+		candidates = candidates[:limit]
+	}
+
+	results := make([]toolSearchResultEntry, 0, len(candidates))
+	for _, c := range candidates {
+		results = append(results, toolSearchResultEntry{
+			Name:        c.entry.Name,
+			Description: c.entry.Description,
+			Family:      c.entry.Family,
+			Eager:       c.entry.Eager,
+			InputSchema: c.entry.InputSchema,
+		})
+	}
+
+	return marshalResult(map[string]any{
+		"query":   query,
+		"count":   len(results),
+		"results": results,
+	})
+}
+
+// ── cog_tool_invoke ───────────────────────────────────────────────────────
+
+type toolInvokeInput struct {
+	Name string          `json:"name" jsonschema:"The plumbing tool's name, as returned by cog_tool_search"`
+	Args json.RawMessage `json:"args,omitempty" jsonschema:"Arguments object for the underlying tool; omit or pass {} for tools with no required input"`
+}
+
+// toolToolInvoke implements cog_tool_invoke. See the file-level doc comment
+// for the confused-deputy hazard this guards against and why the capability
+// check happens here, before dispatch, against req.Session.ID() (the real
+// transport session) rather than inside a nested/re-dispatched call.
+func (m *MCPServer) toolToolInvoke(ctx context.Context, req *mcp.CallToolRequest, input toolInvokeInput) (*mcp.CallToolResult, any, error) {
+	name := strings.TrimSpace(input.Name)
+	if name == "" {
+		return fallbackResult("cog_tool_invoke: name is required", "")
+	}
+
+	handler, ok := m.deferredHandlers[name]
+	if !ok {
+		// No silent widening: reject unknown names outright, mirroring
+		// KernelToolRegistry.Scoped (tool_loop.go) rather than falling
+		// through to some generic dispatch.
+		return fallbackResult(
+			fmt.Sprintf("cog_tool_invoke: unknown tool %q (not in the deferred plumbing catalog; use cog_tool_search to discover valid names)", name),
+			"",
+		)
+	}
+
+	// SECURITY-CRITICAL (ADR G2 PART C): gate the UNDERLYING tool (name),
+	// not "cog_tool_invoke" itself, using the OUTER call's real transport
+	// session — exactly the check withToolObserver performs for a direct
+	// call, applied here so a deferred tool gets the same enforcement it
+	// would have gotten had it been registered eagerly.
+	if m.cfg != nil && m.cfg.IdentityNakedDefault && m.capResolver != nil {
+		transportID := ""
+		if req != nil && req.Session != nil {
+			transportID = req.Session.ID()
+		}
+		if entry, ok := m.resolveTransportSession(transportID); ok && entry.Subject != "" {
+			if !m.capResolver.CanInvoke(entry.Subject, name) {
+				return fallbackResult(
+					"capability envelope denied: subject "+entry.Subject+" is not permitted to invoke "+name,
+					"",
+				)
+			}
+		}
+	}
+
+	result, err := handler(ctx, req, input.Args)
+	if err != nil {
+		return fallbackResult(fmt.Sprintf("cog_tool_invoke: %s: %v", name, err), "")
+	}
+	return result, nil, nil
+}

--- a/internal/engine/mcp_tool_catalog_test.go
+++ b/internal/engine/mcp_tool_catalog_test.go
@@ -1,0 +1,349 @@
+// mcp_tool_catalog_test.go — regression tests for the porcelain/plumbing
+// tool-surface split (workflow wkweyu50g): cog_tool_search, cog_tool_invoke,
+// and the eager/deferred partition itself.
+//
+// Test matrix:
+//  1. TestToolSearch_FindsKnownPlumbingTool — cog_tool_search returns
+//     cog_read_ledger with a non-empty input_schema.
+//  2. TestToolInvoke_ExecutesPlumbingToolEndToEnd — cog_tool_invoke runs
+//     cog_read_ledger and gets a real result back.
+//  3. TestToolInvoke_RejectsUnknownName — an unregistered/unknown name is
+//     refused, not silently dispatched.
+//  4. TestToolInvoke_EnforcesCapabilityGating — a capability-denied
+//     underlying tool is refused through cog_tool_invoke exactly as it
+//     would be refused via a direct call.
+//  5. TestPorcelainTool_DirectlyCallable — a porcelain tool (cog_get_state)
+//     is still directly registered/callable via CallTool.
+//  6. TestDeferredTool_NotInEagerToolsList — a deferred tool (cog_read_ledger)
+//     is NOT present in the live server's tools/list (ListTools), only in
+//     the toolMeta catalog cog_tool_search reads from.
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// newPlainMCPServer builds a minimal MCPServer with no gating/session
+// backend wiring — enough for the catalog tools, which don't require a
+// sessions backend.
+func newPlainMCPServer(t *testing.T) *MCPServer {
+	t.Helper()
+	root := t.TempDir()
+	cfg := &Config{WorkspaceRoot: root, CogDir: root + "/.cog"}
+	nucleus := &Nucleus{Name: "catalog-test"}
+	proc := NewProcess(cfg, nucleus)
+	return NewMCPServer(cfg, nucleus, proc)
+}
+
+// callToolJSON invokes name via MCPServer.CallTool (in-process transport)
+// and decodes the text result as JSON into a map.
+func callToolJSON(t *testing.T, m *MCPServer, name string, args map[string]any) (map[string]any, bool) {
+	t.Helper()
+	argsJSON, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+	text, isErr, callErr := m.CallTool(context.Background(), name, argsJSON)
+	if callErr != nil {
+		t.Fatalf("CallTool(%q) transport error: %v", name, callErr)
+	}
+	var result map[string]any
+	if len(text) > 0 {
+		if err := json.Unmarshal([]byte(text), &result); err != nil {
+			// Not every result is a JSON object (e.g. plain error text) —
+			// callers that need structured output should check isErr first.
+			return map[string]any{"_raw": text}, isErr
+		}
+	}
+	return result, isErr
+}
+
+// ─── 1. cog_tool_search finds a known plumbing tool ──────────────────────────
+
+func TestToolSearch_FindsKnownPlumbingTool(t *testing.T) {
+	t.Parallel()
+	m := newPlainMCPServer(t)
+
+	result, isErr := callToolJSON(t, m, "cog_tool_search", map[string]any{
+		"query": "cog_read_ledger",
+		"limit": 5,
+	})
+	if isErr {
+		t.Fatalf("cog_tool_search returned error result: %v", result)
+	}
+
+	results, ok := result["results"].([]any)
+	if !ok || len(results) == 0 {
+		t.Fatalf("expected non-empty results array; got %v", result)
+	}
+
+	var found map[string]any
+	for _, r := range results {
+		entry, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		if entry["name"] == "cog_read_ledger" {
+			found = entry
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("cog_read_ledger not found in search results: %v", results)
+	}
+	if eager, _ := found["eager"].(bool); eager {
+		t.Error("cog_read_ledger should be Eager=false (plumbing)")
+	}
+	schema, ok := found["input_schema"].(map[string]any)
+	if !ok || len(schema) == 0 {
+		t.Fatalf("cog_read_ledger input_schema missing or empty: %v", found["input_schema"])
+	}
+	if schema["type"] != "object" {
+		t.Errorf("input_schema[\"type\"] = %v; want \"object\"", schema["type"])
+	}
+}
+
+// ─── 2. cog_tool_invoke executes a plumbing tool end-to-end ──────────────────
+
+func TestToolInvoke_ExecutesPlumbingToolEndToEnd(t *testing.T) {
+	t.Parallel()
+	m := newPlainMCPServer(t)
+
+	result, isErr := callToolJSON(t, m, "cog_tool_invoke", map[string]any{
+		"name": "cog_read_ledger",
+		"args": map[string]any{},
+	})
+	if isErr {
+		t.Fatalf("cog_tool_invoke(cog_read_ledger) returned error result: %v", result)
+	}
+	// cappedMarshal(QueryLedger(...)) result shape — just confirm we got a
+	// real structured response back, not a fallback/error envelope.
+	if _, hasErrMsg := result["error"]; hasErrMsg {
+		t.Errorf("unexpected error field in successful invoke result: %v", result)
+	}
+}
+
+// ─── 3. cog_tool_invoke rejects an unknown name ───────────────────────────────
+
+func TestToolInvoke_RejectsUnknownName(t *testing.T) {
+	t.Parallel()
+	m := newPlainMCPServer(t)
+
+	text, isErr, callErr := m.CallTool(context.Background(), "cog_tool_invoke", []byte(`{"name":"cog_does_not_exist","args":{}}`))
+	if callErr != nil {
+		t.Fatalf("unexpected transport error: %v", callErr)
+	}
+	if !isErr {
+		t.Fatalf("expected IsError=true for unknown tool name; got text: %s", text)
+	}
+	if !g2ContainsAny(text, "unknown tool", "not in the deferred plumbing catalog") {
+		t.Errorf("expected an unknown-tool message; got: %s", text)
+	}
+
+	// Also verify the porcelain tools themselves are not reachable through
+	// cog_tool_invoke — they were never added to m.deferredHandlers, so this
+	// is really the same "unknown name" path, but worth pinning explicitly:
+	// invoke is not a second way to reach the eager set.
+	text2, isErr2, callErr2 := m.CallTool(context.Background(), "cog_tool_invoke", []byte(`{"name":"cog_get_state","args":{}}`))
+	if callErr2 != nil {
+		t.Fatalf("unexpected transport error: %v", callErr2)
+	}
+	if !isErr2 {
+		t.Errorf("expected cog_get_state (porcelain, not in deferredHandlers) to be rejected via invoke; got text: %s", text2)
+	}
+}
+
+// ─── 4. cog_tool_invoke enforces capResolver ──────────────────────────────────
+
+// TestToolInvoke_EnforcesCapabilityGating verifies that a capability-denied
+// underlying tool is refused through cog_tool_invoke exactly as it would be
+// refused via a direct call — the security-critical property from ADR G2
+// PART C. Uses the real Streamable HTTP transport so req.Session.ID() is
+// non-empty and resolves through the correlation store, same pattern as
+// TestG2_CapabilityGating_FlagOn_Denied in mcp_sessions_g2_test.go.
+//
+// Note: this test does NOT reuse callToolViaStreamableWithCorrelation from
+// mcp_sessions_g2_test.go — that helper mints a harness session_id of
+// "gating-pre-<subject>-<toolName>", and sessionIDPattern (sessions.go) only
+// allows [a-z0-9-]; "cog_tool_invoke" contains underscores and would fail
+// session_id validation, silently skipping the correlation record. A local
+// variant here mints an ASCII-lowercase-hyphen-only session_id instead.
+func TestToolInvoke_EnforcesCapabilityGating(t *testing.T) {
+	t.Parallel()
+	m, gater := newMCPServerWithGating(t, true /* flagOn */)
+
+	// Baseline: allowed subject can invoke the deferred tool through
+	// cog_tool_invoke.
+	okAllowed, textAllowed := invokeViaStreamableWithCorrelation(t, m, "galadriel",
+		"cog_read_ledger", map[string]any{})
+	if !okAllowed {
+		t.Fatalf("expected allowed subject to succeed via cog_tool_invoke; got: %s", textAllowed)
+	}
+
+	// Deny gimli from calling cog_read_ledger directly (the UNDERLYING tool
+	// name, not cog_tool_invoke).
+	gater.deny["gimli/cog_read_ledger"] = struct{}{}
+
+	okDenied, textDenied := invokeViaStreamableWithCorrelation(t, m, "gimli",
+		"cog_read_ledger", map[string]any{})
+	if okDenied {
+		t.Fatalf("expected capability-denied subject to be refused via cog_tool_invoke; got success: %s", textDenied)
+	}
+	if !g2ContainsAny(textDenied, "capability envelope denied", "not permitted") {
+		t.Errorf("expected denial message; got: %s", textDenied)
+	}
+
+	// Confirm cog_tool_invoke itself was NOT denied (only the underlying
+	// tool is gated) — i.e. the deny entry is keyed to cog_read_ledger, not
+	// cog_tool_invoke, proving the check targets the right name.
+	if _, stillDenied := gater.deny["gimli/cog_tool_invoke"]; stillDenied {
+		t.Fatal("test setup error: deny map should not contain cog_tool_invoke")
+	}
+}
+
+// invokeViaStreamableWithCorrelation is a cog_tool_invoke-specific variant of
+// callToolViaStreamableWithCorrelation (mcp_sessions_g2_test.go) that mints a
+// session_id compatible with sessionIDPattern (ASCII-lowercase, hyphens only
+// — no underscores), then calls cog_tool_invoke with the given underlying
+// tool name + args on that correlated transport session.
+func invokeViaStreamableWithCorrelation(
+	t *testing.T, m *MCPServer, subject, underlyingTool string, underlyingArgs map[string]any,
+) (bool, string) {
+	t.Helper()
+	handler := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
+		return m.server
+	}, nil)
+	httpSrv := httptest.NewServer(handler)
+	t.Cleanup(httpSrv.Close)
+
+	ctx := t.Context()
+	client := mcp.NewClient(&mcp.Implementation{Name: "invoke-gating-test", Version: "1"}, nil)
+	transport := &mcp.StreamableClientTransport{Endpoint: httpSrv.URL + "/"}
+	session, err := client.Connect(ctx, transport, nil)
+	if err != nil {
+		t.Fatalf("client.Connect: %v", err)
+	}
+	defer session.Close()
+
+	_, regErr := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "cog_register_session",
+		Arguments: map[string]any{
+			"session_id": "invoke-gate-" + subject,
+			"workspace":  "/tmp/ws",
+			"role":       "agent",
+			"subject":    subject,
+		},
+	})
+	if regErr != nil {
+		t.Fatalf("pre-register failed: %v", regErr)
+	}
+
+	result, callErr := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "cog_tool_invoke",
+		Arguments: map[string]any{
+			"name": underlyingTool,
+			"args": underlyingArgs,
+		},
+	})
+	if callErr != nil {
+		return false, callErr.Error()
+	}
+	if result == nil || len(result.Content) == 0 {
+		return true, ""
+	}
+	text := ""
+	for _, c := range result.Content {
+		if tc, ok := c.(*mcp.TextContent); ok {
+			text += tc.Text
+		}
+	}
+	return !result.IsError, text
+}
+
+// ─── 5. a porcelain tool is still directly registered/callable ───────────────
+
+func TestPorcelainTool_DirectlyCallable(t *testing.T) {
+	t.Parallel()
+	m := newPlainMCPServer(t)
+
+	result, isErr := callToolJSON(t, m, "cog_get_state", map[string]any{})
+	if isErr {
+		t.Fatalf("cog_get_state returned error result: %v", result)
+	}
+	if _, ok := result["state"]; !ok {
+		t.Errorf("expected \"state\" key in cog_get_state result; got %v", result)
+	}
+}
+
+// ─── 6. a deferred tool is NOT in the mcp.AddTool/tools-list set ─────────────
+
+func TestDeferredTool_NotInEagerToolsList(t *testing.T) {
+	t.Parallel()
+	m := newPlainMCPServer(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	serverSession, err := m.server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	defer serverSession.Close()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "catalog-test-client", Version: "1"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer clientSession.Close()
+
+	res, err := clientSession.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+
+	names := make(map[string]bool, len(res.Tools))
+	for _, tool := range res.Tools {
+		if tool != nil {
+			names[tool.Name] = true
+		}
+	}
+
+	if names["cog_read_ledger"] {
+		t.Error("cog_read_ledger (plumbing) should NOT appear in tools/list")
+	}
+	if names["mod3_speak"] {
+		t.Error("mod3_speak (plumbing) should NOT appear in tools/list")
+	}
+	if !names["cog_get_state"] {
+		t.Error("cog_get_state (porcelain) should appear in tools/list")
+	}
+	if !names["cog_tool_search"] {
+		t.Error("cog_tool_search (porcelain) should appear in tools/list")
+	}
+	if !names["cog_tool_invoke"] {
+		t.Error("cog_tool_invoke (porcelain) should appear in tools/list")
+	}
+
+	// Cross-check against toolMeta: cog_read_ledger IS present there
+	// (Eager=false), just not on the live server.
+	var deferredMetaFound bool
+	for _, tm := range m.toolMeta {
+		if tm.Name == "cog_read_ledger" {
+			deferredMetaFound = true
+			if tm.Eager {
+				t.Error("cog_read_ledger toolMeta entry should have Eager=false")
+			}
+		}
+	}
+	if !deferredMetaFound {
+		t.Error("cog_read_ledger should still be present in m.toolMeta (deferred catalog)")
+	}
+}

--- a/internal/engine/serve_manifest.go
+++ b/internal/engine/serve_manifest.go
@@ -23,12 +23,14 @@
 package engine
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -232,6 +234,68 @@ func (m *MCPServer) backfillEagerSchemas() {
 		if s, ok := schemaByName[m.toolMeta[i].Name]; ok {
 			m.toolMeta[i].InputSchema = s
 		}
+	}
+}
+
+// deferredToolHandler is the untyped dispatch shape stored in
+// m.deferredHandlers for plumbing tools (porcelain/plumbing tool surface,
+// workflow wkweyu50g). argsJSON is the raw JSON arguments object (possibly
+// nil/empty); the handler is responsible for unmarshaling into its own typed
+// input, mirroring what mcp.AddTool's generated glue does for eager tools.
+type deferredToolHandler func(ctx context.Context, req *mcp.CallToolRequest, argsJSON json.RawMessage) (*mcp.CallToolResult, error)
+
+// trackToolDeferred registers a plumbing tool WITHOUT calling mcp.AddTool —
+// it never reaches the server's live tool registry, so it never appears in
+// tools/list. This is the mechanism half of the porcelain/plumbing split:
+// only the ~13 porcelain tools go through mcp.AddTool (trackTool); everything
+// else routes through here into m.deferredHandlers, reachable at runtime only
+// via cog_tool_search (discover) and cog_tool_invoke (dispatch).
+//
+// Generic over In so the input JSON Schema can be inferred exactly the way
+// mcp.AddTool infers it for eager tools (same jsonschema-go package, same
+// struct-tag conventions) — cog_tool_search callers get a real, usable
+// schema instead of an empty object. h is the typed handler, identical in
+// shape to what a normal mcp.AddTool registration would take; this function
+// wraps it into the untyped deferredToolHandler stored in the map.
+//
+// Best-effort on schema inference: a failure (should not happen for the
+// existing well-formed input structs) leaves InputSchema nil rather than
+// panicking — plumbing tools degrade to an empty-object schema in that case,
+// same as AddTool's "any" special case.
+func trackToolDeferred[In any](m *MCPServer, t *mcp.Tool, h mcp.ToolHandlerFor[In, any]) {
+	schema, err := jsonschema.For[In](nil)
+	var inputSchema any
+	if err == nil && schema != nil {
+		// Round-trip through JSON to a map[string]interface{} so the shape
+		// matches what backfillEagerSchemas stores for eager tools (both feed
+		// the same cog_tool_search / manifest JSON output).
+		if b, mErr := json.Marshal(schema); mErr == nil {
+			var m2 map[string]interface{}
+			if uErr := json.Unmarshal(b, &m2); uErr == nil {
+				inputSchema = m2
+			}
+		}
+	}
+
+	m.toolMeta = append(m.toolMeta, mcpToolMeta{
+		Name:        t.Name,
+		Description: t.Description,
+		Family:      classifyMCPFamily(t.Name),
+		Eager:       false,
+		InputSchema: inputSchema,
+	})
+
+	m.deferredHandlers[t.Name] = func(ctx context.Context, req *mcp.CallToolRequest, argsJSON json.RawMessage) (*mcp.CallToolResult, error) {
+		var in In
+		if len(argsJSON) > 0 {
+			if err := json.Unmarshal(argsJSON, &in); err != nil {
+				var errRes mcp.CallToolResult
+				errRes.SetError(err)
+				return &errRes, nil
+			}
+		}
+		result, _, err := h(ctx, req, in)
+		return result, err
 	}
 }
 

--- a/internal/engine/serve_manifest.go
+++ b/internal/engine/serve_manifest.go
@@ -44,6 +44,18 @@ type mcpToolMeta struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
 	Family      string `json:"family"`
+	// Eager reports whether this tool was registered on the live mcp.AddTool
+	// path (porcelain — appears in tools/list) versus the deferred catalog
+	// reached via cog_tool_search/cog_tool_invoke (plumbing — invoke-only).
+	// See trackToolDeferred and the tier-then-trim mechanism doc.
+	Eager bool `json:"eager"`
+	// InputSchema is the tool's JSON Schema, captured off the *mcp.Tool
+	// pointer in trackTool/trackToolDeferred BEFORE the pointer is handed to
+	// mcp.AddTool (which internally copies via `tt := *t`, so reading the
+	// schema off the original after that point would still work for the
+	// pointer itself, but capturing here keeps deferred tools — which never
+	// reach mcp.AddTool at all — populated the same way as eager ones).
+	InputSchema any `json:"input_schema,omitempty"`
 }
 
 // route registers a handler on mux and records the (method, path) tuple onto
@@ -166,13 +178,61 @@ func classifyMCPFamily(name string) string {
 //
 // Returning the pointer means each existing registration changes by one
 // wrapping call — no separate metadata list, no risk of drift.
+//
+// InputSchema capture: t.InputSchema is read here, BEFORE the pointer is
+// handed to mcp.AddTool, per the design note in mcpToolMeta. In practice this
+// is almost always nil at this point — every call site in this codebase
+// relies on mcp.AddTool's automatic schema inference from the handler's `In`
+// type parameter (see AddTool's doc comment: "If the tool's input schema is
+// nil, it is set to the schema inferred from the In type parameter"), and
+// that inference writes the result onto an internal copy (`tt := *t`) the SDK
+// makes inside toolForErr — never back onto the original *t this function
+// holds. So for eager tools registered via mcp.AddTool with inference, the
+// InputSchema field captured here stays nil; it is backfilled after
+// registration completes by backfillEagerSchemas (constructor, after
+// registerTools/registerResources), which queries the live server the same
+// way snapshotToolDefinitions does. This function still captures whatever is
+// present on t at call time so explicitly-schema'd tools (t.InputSchema set
+// on the literal) are captured immediately and correctly.
 func (m *MCPServer) trackTool(t *mcp.Tool) *mcp.Tool {
 	m.toolMeta = append(m.toolMeta, mcpToolMeta{
 		Name:        t.Name,
 		Description: t.Description,
 		Family:      classifyMCPFamily(t.Name),
+		Eager:       true,
+		InputSchema: t.InputSchema,
 	})
 	return t
+}
+
+// backfillEagerSchemas fills in m.toolMeta[i].InputSchema for every eager
+// entry whose schema wasn't captured at registration time (the common case —
+// see trackTool's doc comment on why inferred schemas aren't visible on the
+// original *mcp.Tool pointer). It queries the now-fully-registered live
+// server via the same in-process ListTools mechanism snapshotToolDefinitions
+// uses, so this must run after registerTools()/registerResources() return.
+// Best-effort: a query failure leaves InputSchema nil on affected entries
+// rather than failing construction.
+func (m *MCPServer) backfillEagerSchemas() {
+	if m.server == nil {
+		return
+	}
+	defs := snapshotToolDefinitions(m.server)
+	if len(defs) == 0 {
+		return
+	}
+	schemaByName := make(map[string]map[string]interface{}, len(defs))
+	for _, d := range defs {
+		schemaByName[d.Name] = d.InputSchema
+	}
+	for i := range m.toolMeta {
+		if !m.toolMeta[i].Eager || m.toolMeta[i].InputSchema != nil {
+			continue
+		}
+		if s, ok := schemaByName[m.toolMeta[i].Name]; ok {
+			m.toolMeta[i].InputSchema = s
+		}
+	}
 }
 
 // TrackTool is the exported equivalent of trackTool for use by extension

--- a/internal/engine/serve_manifest_test.go
+++ b/internal/engine/serve_manifest_test.go
@@ -188,6 +188,51 @@ func TestClassifyMCPFamily(t *testing.T) {
 	}
 }
 
+// TestTrackTool_InputSchemaBackfilled verifies that after NewMCPServer
+// finishes construction, an eager tool's toolMeta entry carries a non-empty
+// InputSchema — proving backfillEagerSchemas actually populates the field
+// mcp.AddTool's inference never writes back onto the original *mcp.Tool
+// pointer captured by trackTool.
+func TestTrackTool_InputSchemaBackfilled(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	cfg := &Config{WorkspaceRoot: root, CogDir: root + "/.cog"}
+	nucleus := &Nucleus{Name: "schema-test"}
+	proc := NewProcess(cfg, nucleus)
+	m := NewMCPServer(cfg, nucleus, proc)
+
+	var found *mcpToolMeta
+	for i := range m.toolMeta {
+		if m.toolMeta[i].Name == "cog_search_memory" {
+			found = &m.toolMeta[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("cog_search_memory not present in toolMeta")
+	}
+	if !found.Eager {
+		t.Error("cog_search_memory should be Eager=true (porcelain)")
+	}
+	if found.InputSchema == nil {
+		t.Fatal("cog_search_memory InputSchema should be non-nil after backfillEagerSchemas")
+	}
+	schema, ok := found.InputSchema.(map[string]interface{})
+	if !ok {
+		t.Fatalf("InputSchema type = %T; want map[string]interface{}", found.InputSchema)
+	}
+	if schema["type"] != "object" {
+		t.Errorf("InputSchema[\"type\"] = %v; want \"object\"", schema["type"])
+	}
+	props, ok := schema["properties"].(map[string]interface{})
+	if !ok || len(props) == 0 {
+		t.Errorf("InputSchema properties missing or empty: %v", schema["properties"])
+	}
+	if _, ok := props["query"]; !ok {
+		t.Errorf("expected \"query\" property in cog_search_memory schema; got %v", props)
+	}
+}
+
 // keys is a local helper to extract map keys for test diagnostics.
 func keys(m map[string]bool) []string {
 	out := make([]string, 0, len(m))

--- a/internal/engine/serve_mcp.go
+++ b/internal/engine/serve_mcp.go
@@ -37,6 +37,13 @@ func (s *Server) registerMCPRoutes(mux *http.ServeMux) {
 	if RegisterMCPExtensions != nil {
 		RegisterMCPExtensions(mcpSrv)
 	}
+	// Extension hooks above may register additional EAGER tools via
+	// srv.TrackTool *after* the constructor's initial backfillEagerSchemas ran,
+	// leaving their inferred InputSchemas nil in toolMeta (e.g. conversations'
+	// cog_search_conversations / cog_get_conversation_turn). Re-run the
+	// idempotent backfill now that the live server holds every extension tool,
+	// so cog_tool_search returns real schemas for them too.
+	mcpSrv.backfillEagerSchemas()
 	s.mcpServer = mcpSrv
 	h := mcpSrv.Handler()
 	s.routeH(mux, "GET /mcp", mcpGetHandler(h))


### PR DESCRIPTION
## What & why

Gives the kernel's MCP surface a **porcelain/plumbing** shape via Anthropic's Tool Search Tool pattern (progressive disclosure). Grounded in the canonical `plumbing-vs-porcelain-interface` cogdoc + the 2025-11-07 code-execution-with-MCP breakthrough. Design: `cog:mem/semantic/architecture/mcp-tool-surface-tier-then-trim` (#Mechanism, RESOLVED via spike wkweyu50g).

**Mechanism (server-autonomous — works under any harness).** `defer_loading`/`tool_search_tool_*` are Anthropic-API attributes set *client-side*; an MCP server can't emit them and Claude Code exposes no per-tool eager knob. So instead of splitting the server: register only the **~14 porcelain** as real `mcp.AddTool` tools, and move the **~43 plumbing** OFF the `mcp.AddTool` path into a catalog reached via two new porcelain tools:

- **`cog_tool_search(query, limit)`** — ranked `{name, description, input_schema, family}` over the full catalog (eager + deferred).
- **`cog_tool_invoke(name, args)`** — generic dispatch into the deferred handler, in-process.

Advertised schema surface drops **57 → ~14** (better tool-selection accuracy, less token cost). No tool is dropped (14 eager + 43 deferred = 57).

## Security (the load-bearing piece)

`cog_tool_invoke` is a generic invoker, so it must not weaken authorization. It replicates `withToolObserver`'s gate **exactly** — `IdentityNakedDefault && capResolver != nil`, resolving the **outer real transport session** (`req.Session.ID()`) and calling `CanInvoke(subject, <underlying tool name>)` — so a capability that denies `cog_read_ledger` directly also denies it through invoke. It deliberately does **not** reuse the in-memory-transport `CallTool` pattern (that would spawn a nested session and lose the caller's identity — a confused-deputy hole). Unknown names are rejected (no silent widening). Proven end-to-end by `TestToolInvoke_EnforcesCapabilityGating` over a real Streamable HTTP transport.

## Verification

`go build -tags fts5 ./...` clean; `go test -tags 'fts5 sqlite_fts5' ./internal/engine/...` green. New tests: catalog search/invoke, unknown-name rejection, capability gating, porcelain-still-eager, deferred-absent-from-tools-list, InputSchema backfill. The extension-timing bug (extension eager tools kept nil schemas because `backfillEagerSchemas` ran before `RegisterMCPExtensions`) is fixed by re-running the idempotent backfill after the hook.

## Known consequences / follow-ups (non-blocking)

- **Plumbing is invoke-only** (by design) — reachable via `cog_tool_invoke`, not as direct MCP tools. The kernel-agent chat path still reaches plumbing because `cog_tool_search`/`cog_tool_invoke` are eager/auto-injected.
- **In-process `MCPServer.CallTool` + compat tool-ownership classification** now treat a directly-named plumbing tool as external (unadvertised); a future change should resolve deferred tools by name in that path. Latent edge (normal clients use invoke); flagged, not fixed here.
- **Deferred-arg validation**: `cog_tool_invoke` dispatches via `json.Unmarshal` rather than the SDK's schema `Validate`, so a deferred tool doesn't reject additional-properties the way an eager one does. Auth is enforced; strictness is a follow-up.
- Memory-tool rename (`cog_read_cogdoc → cog_memory_read`) intentionally NOT done here — separate migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)