### PR TITLE
fix: FTS write-path hardening, drift-repair correctness, decommission leftovers

### DIFF
--- a/internal/engine/drift_repair_test.go
+++ b/internal/engine/drift_repair_test.go
@@ -1,0 +1,259 @@
+// drift_repair_test.go — first-ever coverage for searchMemoryFTSDriftRepair,
+// the lazy FTS drift-repair path in mcp_stubs.go. Exercises:
+//   - scope: only rows under .cog/mem/ are sampled (symmetric with mem_watcher);
+//     a drifted row outside the corpus is NOT repaired.
+//   - mtime drift: a row whose on-disk mtime differs from the stored mtime is
+//     repaired (IndexFile called).
+//   - equal-second content-hash tiebreak: a row whose mtime string matches but
+//     whose content changed within the same wall-clock second is repaired.
+//   - equal-second, unchanged content: no repair (no false positive).
+//   - widespread drift (> threshold): logs and skips inline repair.
+//   - no indexer wired: silent no-op.
+package engine
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// recordingIndexer implements ConstellationIndexer and records the paths passed
+// to IndexFile so tests can assert exactly which rows were repaired.
+type recordingIndexer struct {
+	mu    sync.Mutex
+	calls []string
+}
+
+func (r *recordingIndexer) IndexFile(path string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, path)
+	return nil
+}
+
+func (r *recordingIndexer) got() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.calls))
+	copy(out, r.calls)
+	return out
+}
+
+// withRepairIndexer swaps the package-level pkgFTSRepairIndexer for the duration
+// of a test and restores it afterward. Tests using this must NOT run in parallel
+// (the var is package-global).
+func withRepairIndexer(t *testing.T, idx ConstellationIndexer) {
+	t.Helper()
+	prev := pkgFTSRepairIndexer
+	pkgFTSRepairIndexer = idx
+	t.Cleanup(func() { pkgFTSRepairIndexer = prev })
+}
+
+// driftFixture builds a workspace with a real constellation.db at the daemon's
+// expected path and returns the workspace root. Documents are seeded via the
+// provided callback so each test controls its own rows.
+func driftFixture(t *testing.T, seed func(db *sql.DB, root string)) string {
+	t.Helper()
+	root := t.TempDir()
+	stateDir := filepath.Join(root, ".cog", ".state")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state: %v", err)
+	}
+	dbPath := filepath.Join(stateDir, "constellation.db")
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	schema := `
+CREATE TABLE documents (
+    id TEXT PRIMARY KEY,
+    path TEXT NOT NULL UNIQUE,
+    type TEXT NOT NULL,
+    title TEXT NOT NULL,
+    created TEXT NOT NULL,
+    updated TEXT,
+    sector TEXT,
+    status TEXT,
+    content TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    word_count INTEGER,
+    line_count INTEGER,
+    indexed_at TEXT NOT NULL,
+    file_mtime TEXT NOT NULL
+);`
+	if _, err := db.Exec(schema); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	seed(db, root)
+	return root
+}
+
+// writeMemCogdoc writes a cogdoc under root/.cog/mem/<rel> with the given body
+// and returns the absolute path. Frontmatter is minimal but real so the
+// content-hash tiebreak (which strips frontmatter) computes correctly.
+func writeMemCogdoc(t *testing.T, root, rel, body string) string {
+	t.Helper()
+	abs := filepath.Join(root, ".cog", "mem", rel)
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	content := "---\nid: x\ntype: note\ntitle: X\ncreated: 2026-01-01\n---\n\n" + body
+	if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return abs
+}
+
+// bodyHash mirrors the indexer's content-hash rule for a raw file's body.
+func bodyHash(body string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(body)))
+	return fmt.Sprintf("%x", sum)
+}
+
+func insertDoc(t *testing.T, db *sql.DB, id, path, contentHash, fileMtime string) {
+	t.Helper()
+	_, err := db.Exec(
+		`INSERT INTO documents (id, path, type, title, created, content, content_hash, indexed_at, file_mtime)
+		 VALUES (?, ?, 'note', 'X', '2026-01-01', 'x', ?, '2026-01-01T00:00:00Z', ?)`,
+		id, path, contentHash, fileMtime,
+	)
+	if err != nil {
+		t.Fatalf("insert doc %s: %v", id, err)
+	}
+}
+
+// TestDriftRepair_MtimeDrift: a mem cogdoc whose on-disk mtime differs from the
+// stored mtime is repaired.
+func TestDriftRepair_MtimeDrift(t *testing.T) {
+	var absPath string
+	root := driftFixture(t, func(db *sql.DB, root string) {
+		absPath = writeMemCogdoc(t, root, "semantic/drifted.cog.md", "body content")
+		// Stored mtime deliberately in the past → differs from the fresh file.
+		insertDoc(t, db, "drifted", absPath, bodyHash("body content"), "2020-01-01T00:00:00Z")
+	})
+
+	idx := &recordingIndexer{}
+	withRepairIndexer(t, idx)
+
+	searchMemoryFTSDriftRepair(root)
+
+	calls := idx.got()
+	if len(calls) != 1 || calls[0] != absPath {
+		t.Fatalf("expected exactly one repair of %s, got %v", absPath, calls)
+	}
+}
+
+// TestDriftRepair_ScopedToMemCorpus: a drifted row OUTSIDE .cog/mem/ must NOT be
+// sampled or repaired (symmetric with the mem_watcher scope).
+func TestDriftRepair_ScopedToMemCorpus(t *testing.T) {
+	root := driftFixture(t, func(db *sql.DB, root string) {
+		// A real file outside the mem corpus, with a stale stored mtime.
+		outsideDir := filepath.Join(root, ".cog", "sessions")
+		if err := os.MkdirAll(outsideDir, 0o755); err != nil {
+			t.Fatalf("mkdir sessions: %v", err)
+		}
+		outside := filepath.Join(outsideDir, "conv.cog.md")
+		if err := os.WriteFile(outside, []byte("session body"), 0o644); err != nil {
+			t.Fatalf("write outside: %v", err)
+		}
+		insertDoc(t, db, "conv", outside, "hash", "2020-01-01T00:00:00Z")
+	})
+
+	idx := &recordingIndexer{}
+	withRepairIndexer(t, idx)
+
+	searchMemoryFTSDriftRepair(root)
+
+	if calls := idx.got(); len(calls) != 0 {
+		t.Fatalf("expected no repair for out-of-corpus row, got %v", calls)
+	}
+}
+
+// TestDriftRepair_EqualSecondContentChanged: mtime string matches (same second)
+// but content changed → content-hash tiebreak must detect drift and repair.
+func TestDriftRepair_EqualSecondContentChanged(t *testing.T) {
+	var absPath string
+	root := driftFixture(t, func(db *sql.DB, root string) {
+		absPath = writeMemCogdoc(t, root, "semantic/samesecond.cog.md", "NEW content now")
+		info, err := os.Stat(absPath)
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		// Store the file's actual current mtime (so mtime strings match), but an
+		// OLD content hash (content changed within the same second).
+		storedMtime := info.ModTime().Format(time.RFC3339)
+		insertDoc(t, db, "samesecond", absPath, bodyHash("OLD content before"), storedMtime)
+	})
+
+	idx := &recordingIndexer{}
+	withRepairIndexer(t, idx)
+
+	searchMemoryFTSDriftRepair(root)
+
+	calls := idx.got()
+	if len(calls) != 1 || calls[0] != absPath {
+		t.Fatalf("expected content-hash tiebreak to repair %s, got %v", absPath, calls)
+	}
+}
+
+// TestDriftRepair_EqualSecondContentUnchanged: mtime string matches AND content
+// hash matches → no repair (no false positive from the tiebreak).
+func TestDriftRepair_EqualSecondContentUnchanged(t *testing.T) {
+	root := driftFixture(t, func(db *sql.DB, root string) {
+		abs := writeMemCogdoc(t, root, "semantic/clean.cog.md", "stable body")
+		info, err := os.Stat(abs)
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		storedMtime := info.ModTime().Format(time.RFC3339)
+		insertDoc(t, db, "clean", abs, bodyHash("stable body"), storedMtime)
+	})
+
+	idx := &recordingIndexer{}
+	withRepairIndexer(t, idx)
+
+	searchMemoryFTSDriftRepair(root)
+
+	if calls := idx.got(); len(calls) != 0 {
+		t.Fatalf("expected no repair for unchanged doc, got %v", calls)
+	}
+}
+
+// TestDriftRepair_WidespreadSkipsInline: more than the wide threshold of drifted
+// rows → the function logs and returns without repairing the bulk.
+func TestDriftRepair_WidespreadSkipsInline(t *testing.T) {
+	root := driftFixture(t, func(db *sql.DB, root string) {
+		for i := 0; i < 15; i++ { // > wideThresh (10)
+			rel := fmt.Sprintf("semantic/wide-%02d.cog.md", i)
+			abs := writeMemCogdoc(t, root, rel, fmt.Sprintf("body %d", i))
+			insertDoc(t, db, fmt.Sprintf("wide-%02d", i), abs, bodyHash("stale"), "2020-01-01T00:00:00Z")
+		}
+	})
+
+	idx := &recordingIndexer{}
+	withRepairIndexer(t, idx)
+
+	searchMemoryFTSDriftRepair(root)
+
+	if calls := idx.got(); len(calls) != 0 {
+		t.Fatalf("expected no inline repair when drift is widespread, got %d calls", len(calls))
+	}
+}
+
+// TestDriftRepair_NoIndexerIsNoOp: with no wired indexer the function returns
+// silently and does not panic even when the DB is absent.
+func TestDriftRepair_NoIndexerIsNoOp(t *testing.T) {
+	withRepairIndexer(t, nil)
+	// A workspace with no DB at all.
+	searchMemoryFTSDriftRepair(t.TempDir())
+}

--- a/internal/engine/mcp_stubs.go
+++ b/internal/engine/mcp_stubs.go
@@ -6,6 +6,7 @@
 package engine
 
 import (
+	"crypto/sha256"
 	"database/sql"
 	"fmt"
 	"log/slog"
@@ -70,6 +71,13 @@ func searchMemoryFTSDriftRepair(workspaceRoot string) {
 		wideThresh  = 10 // more than this many drifted rows → skip inline repair
 	)
 
+	// Budget bounds the whole repair pass. It is checked upfront and again
+	// between IndexFile calls (the only points at which we can cheaply yield —
+	// a single IndexFile is not internally time-sliceable). Establishing the
+	// deadline before any I/O means a hot search path that is already over
+	// budget from prior work does no scanning at all.
+	deadline := time.Now().Add(budgetMs * time.Millisecond)
+
 	dbPath := filepath.Join(workspaceRoot, ".cog", ".state", "constellation.db")
 	db, err := sql.Open("sqlite3", dbPath+"?mode=ro&_journal_mode=WAL&_busy_timeout=3000")
 	if err != nil {
@@ -77,10 +85,15 @@ func searchMemoryFTSDriftRepair(workspaceRoot string) {
 	}
 	defer db.Close()
 
-	// Sample recent documents, fetching path + stored mtime.
+	// Sample recent documents, fetching path + stored mtime + stored content
+	// hash. Scope the sample to the managed memory corpus ('%/.cog/mem/%') so
+	// it is symmetric with the mem_watcher (which only watches .cog/mem/) — a
+	// row indexed from outside the corpus is not something this lazy path can
+	// or should repair. content_hash is fetched for the equal-second tiebreak
+	// below.
 	rows, err := db.Query(
-		`SELECT path, file_mtime FROM documents
-		 WHERE path NOT LIKE '%.state/%'
+		`SELECT path, file_mtime, content_hash FROM documents
+		 WHERE path LIKE '%/.cog/mem/%'
 		 ORDER BY indexed_at DESC LIMIT ?`, sampleLimit,
 	)
 	if err != nil {
@@ -94,16 +107,27 @@ func searchMemoryFTSDriftRepair(workspaceRoot string) {
 	}
 	var drifted []entry
 	for rows.Next() {
-		var path, storedMtime string
-		if err := rows.Scan(&path, &storedMtime); err != nil {
+		var path, storedMtime, storedHash string
+		if err := rows.Scan(&path, &storedMtime, &storedHash); err != nil {
 			continue
 		}
 		info, statErr := os.Stat(path)
 		if statErr != nil {
-			continue // file removed — not a drift case for FTS
+			continue // file removed — not a drift case for FTS (prune handles it)
 		}
 		diskMtime := info.ModTime().Format(time.RFC3339)
 		if diskMtime != storedMtime {
+			drifted = append(drifted, entry{path: path, mtime: diskMtime})
+			continue
+		}
+		// Equal RFC3339 second: file_mtime is second-granular, so a file
+		// rewritten within the same wall-clock second as the last index reads
+		// as "unchanged" here — a false negative. Break the tie with a content
+		// hash: read the raw file, extract the cogdoc body the same way the
+		// indexer does, and compare its SHA-256 to the stored content_hash.
+		// Only runs on the (rare) equal-second case, so the extra read is not
+		// on the common path.
+		if h, ok := cogdocBodyHash(path); ok && h != storedHash {
 			drifted = append(drifted, entry{path: path, mtime: diskMtime})
 		}
 	}
@@ -120,7 +144,6 @@ func searchMemoryFTSDriftRepair(workspaceRoot string) {
 
 	// Repair drifted entries via the wired indexer handle.
 	// Budget: ~200ms total across all repairs; abort remaining on timeout.
-	deadline := time.Now().Add(budgetMs * time.Millisecond)
 	for _, e := range drifted {
 		if time.Now().After(deadline) {
 			break
@@ -129,6 +152,28 @@ func searchMemoryFTSDriftRepair(workspaceRoot string) {
 			slog.Warn("constellation: drift repair failed", "path", e.path, "err", err)
 		}
 	}
+}
+
+// cogdocBodyHash reads the cogdoc at path and returns the SHA-256 hex of its
+// body content, computed identically to the constellation indexer
+// (content = TrimSpace of everything after the second "---" delimiter, hashed
+// as sha256(content)). Returns ("", false) if the file cannot be read or does
+// not have the expected frontmatter delimiters. It is used only for the
+// equal-second mtime tiebreak in drift repair, so it deliberately mirrors the
+// indexer's parse-content rule without importing sdk/constellation
+// (package-boundary guard).
+func cogdocBodyHash(path string) (string, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+	parts := strings.SplitN(string(data), "---", 3)
+	if len(parts) < 3 {
+		return "", false
+	}
+	content := strings.TrimSpace(parts[2])
+	sum := sha256.Sum256([]byte(content))
+	return fmt.Sprintf("%x", sum), true
 }
 
 // searchMemoryFTS queries the constellation SQLite FTS5 index for matching documents.

--- a/internal/engine/mcp_tool_catalog.go
+++ b/internal/engine/mcp_tool_catalog.go
@@ -207,18 +207,35 @@ func (m *MCPServer) toolToolInvoke(ctx context.Context, req *mcp.CallToolRequest
 	// session — exactly the check withToolObserver performs for a direct
 	// call, applied here so a deferred tool gets the same enforcement it
 	// would have gotten had it been registered eagerly.
+	//
+	// FAIL CLOSED: cog_tool_invoke is the porcelain gateway to the entire
+	// deferred-plumbing catalog. When gating is enabled (IdentityNakedDefault
+	// AND a capResolver is wired) but the transport session cannot be resolved
+	// to a bound subject, we cannot evaluate the capability envelope for the
+	// underlying tool — so we DENY rather than dispatch. Permitting an
+	// unattributable caller to reach arbitrary plumbing tools would make
+	// cog_tool_invoke a confused-deputy bypass of per-tool gating, which is
+	// exactly the hazard this file exists to prevent. This is the stricter
+	// posture the gateway warrants: identity-less transport must not invoke
+	// plumbing when gating is on.
 	if m.cfg != nil && m.cfg.IdentityNakedDefault && m.capResolver != nil {
 		transportID := ""
 		if req != nil && req.Session != nil {
 			transportID = req.Session.ID()
 		}
-		if entry, ok := m.resolveTransportSession(transportID); ok && entry.Subject != "" {
-			if !m.capResolver.CanInvoke(entry.Subject, name) {
-				return fallbackResult(
-					"capability envelope denied: subject "+entry.Subject+" is not permitted to invoke "+name,
-					"",
-				)
-			}
+		entry, ok := m.resolveTransportSession(transportID)
+		if !ok || entry == nil || entry.Subject == "" {
+			return fallbackResult(
+				"capability envelope: cog_tool_invoke requires a resolved session identity when identity-naked gating is enabled; "+
+					"register the transport session (cog_register_session with a subject) before invoking plumbing tool "+name,
+				"",
+			)
+		}
+		if !m.capResolver.CanInvoke(entry.Subject, name) {
+			return fallbackResult(
+				"capability envelope denied: subject "+entry.Subject+" is not permitted to invoke "+name,
+				"",
+			)
 		}
 	}
 

--- a/internal/engine/mcp_tool_catalog_test.go
+++ b/internal/engine/mcp_tool_catalog_test.go
@@ -207,6 +207,73 @@ func TestToolInvoke_EnforcesCapabilityGating(t *testing.T) {
 	}
 }
 
+// TestToolInvoke_FailsClosedOnUnresolvedSession verifies the fail-closed nit:
+// when IdentityNakedDefault gating is enabled and a capResolver is wired, but
+// the transport session cannot be resolved to a bound subject (no
+// cog_register_session with a subject was performed), cog_tool_invoke must DENY
+// rather than dispatch. cog_tool_invoke is the porcelain gateway to the entire
+// deferred-plumbing catalog; permitting an unattributable caller to reach
+// arbitrary plumbing tools would make it a confused-deputy bypass of per-tool
+// capability gating.
+func TestToolInvoke_FailsClosedOnUnresolvedSession(t *testing.T) {
+	t.Parallel()
+	m, _ := newMCPServerWithGating(t, true /* flagOn */)
+
+	// Invoke WITHOUT registering a session first → correlation unresolved.
+	ok, text := invokeViaStreamableNoCorrelation(t, m, "cog_read_ledger", map[string]any{})
+	if ok {
+		t.Fatalf("expected fail-closed denial for unresolved session with gating on; got success: %s", text)
+	}
+	if !g2ContainsAny(text, "requires a resolved session identity", "capability envelope") {
+		t.Errorf("expected an unresolved-identity denial message; got: %s", text)
+	}
+}
+
+// invokeViaStreamableNoCorrelation calls cog_tool_invoke over the real
+// Streamable HTTP transport WITHOUT first calling cog_register_session, so the
+// transport session ID does not resolve to any subject in the correlation
+// store. Returns (!IsError, text).
+func invokeViaStreamableNoCorrelation(
+	t *testing.T, m *MCPServer, underlyingTool string, underlyingArgs map[string]any,
+) (bool, string) {
+	t.Helper()
+	handler := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
+		return m.server
+	}, nil)
+	httpSrv := httptest.NewServer(handler)
+	t.Cleanup(httpSrv.Close)
+
+	ctx := t.Context()
+	client := mcp.NewClient(&mcp.Implementation{Name: "invoke-nocorr-test", Version: "1"}, nil)
+	transport := &mcp.StreamableClientTransport{Endpoint: httpSrv.URL + "/"}
+	session, err := client.Connect(ctx, transport, nil)
+	if err != nil {
+		t.Fatalf("client.Connect: %v", err)
+	}
+	defer session.Close()
+
+	result, callErr := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "cog_tool_invoke",
+		Arguments: map[string]any{
+			"name": underlyingTool,
+			"args": underlyingArgs,
+		},
+	})
+	if callErr != nil {
+		return false, callErr.Error()
+	}
+	if result == nil || len(result.Content) == 0 {
+		return true, ""
+	}
+	text := ""
+	for _, c := range result.Content {
+		if tc, ok := c.(*mcp.TextContent); ok {
+			text += tc.Text
+		}
+	}
+	return !result.IsError, text
+}
+
 // invokeViaStreamableWithCorrelation is a cog_tool_invoke-specific variant of
 // callToolViaStreamableWithCorrelation (mcp_sessions_g2_test.go) that mints a
 // session_id compatible with sessionIDPattern (ASCII-lowercase, hyphens only

--- a/internal/engine/provider_pi.go
+++ b/internal/engine/provider_pi.go
@@ -1,15 +1,17 @@
 // provider_pi.go — PiProvider
 //
 // Implements Provider by spawning `pi -p` subprocesses for local agentic
-// inference. Pi handles the tool loop (read, bash, edit, write) against
-// local models via Ollama, while the kernel handles context assembly.
+// inference. Pi handles the tool loop (read, bash, edit, write) against local
+// models, while the kernel handles context assembly.
 //
 // This is the local counterpart to ClaudeCodeProvider:
 //   - ClaudeCodeProvider: cloud agentic inference (Claude Max via OAuth)
-//   - PiProvider: local agentic inference (Ollama via Pi)
+//   - PiProvider: local agentic inference via Pi
 //
 // The kernel assembles foveated context and injects it via --system-prompt.
-// Pi runs the agent loop. Ollama runs the model.
+// Pi runs the agent loop; the local backend runs the model. The default local
+// backend is LM Studio (lmstudio-darkstar, resident gemma-4-26b at
+// 127.0.0.1:1234) — see PR #417, which decommissioned Ollama as the default.
 //
 // Output: parsed from `--mode json` which emits NDJSON AgentSessionEvents.
 package engine
@@ -25,23 +27,34 @@ import (
 	"time"
 )
 
+// defaultLocalPiProvider is the pi `--provider` value used when a PiProvider
+// config does not specify one. Repointed from "ollama" to "lmstudio" to match
+// the engine's live local backend after PR #417 (Ollama decommissioned).
+const defaultLocalPiProvider = "lmstudio"
+
+// defaultLocalModel is the model used when a PiProvider config does not specify
+// one. The resident local model is google/gemma-4-26b-a4b via LM Studio
+// (lmstudio-darkstar), consistent with defaults/providers.yaml. Repointed from
+// defaultOllamaModel per PR #417.
+const defaultLocalModel = "google/gemma-4-26b-a4b"
+
 // PiProvider implements Provider by spawning pi CLI processes.
 type PiProvider struct {
-	name      string
-	provider  string // ollama, openrouter, etc.
-	model     string // gemma4:e4b, gemma4:e2b, etc.
-	thinking  string // off, minimal, low, medium, high, xhigh
-	timeout   time.Duration
-	piBinary  string // path to pi binary (default: "pi")
-	tools     string // comma-separated tools (default: "read,bash,edit,write")
-	procMgr   *ProcessManager
+	name     string
+	provider string // lmstudio, openrouter, etc.
+	model    string // e.g. google/gemma-4-26b-a4b
+	thinking string // off, minimal, low, medium, high, xhigh
+	timeout  time.Duration
+	piBinary string // path to pi binary (default: "pi")
+	tools    string // comma-separated tools (default: "read,bash,edit,write")
+	procMgr  *ProcessManager
 }
 
 // NewPiProvider creates a PiProvider from a ProviderConfig.
 func NewPiProvider(name string, cfg ProviderConfig, procMgr *ProcessManager) *PiProvider {
 	model := cfg.Model
 	if model == "" {
-		model = defaultOllamaModel
+		model = defaultLocalModel
 	}
 	timeout := time.Duration(cfg.Timeout) * time.Second
 	if timeout == 0 {
@@ -52,7 +65,7 @@ func NewPiProvider(name string, cfg ProviderConfig, procMgr *ProcessManager) *Pi
 		binary = cfg.Endpoint
 	}
 
-	provider := "ollama"
+	provider := defaultLocalPiProvider
 	thinking := "off"
 	tools := "read,bash,edit,write"
 

--- a/internal/engine/resolve.go
+++ b/internal/engine/resolve.go
@@ -64,8 +64,15 @@ var intentAliases = map[string]ModelResolution{
 	// Other provider aliases.
 	"codex": {PreferProvider: "codex"},
 	// Local/kernel aliases — injectKernelTools tells the gateway to wire tools.
-	"ollama":       {PreferProvider: "ollama", InjectKernelTools: true},
-	"kernel-agent": {PreferProvider: "ollama", InjectKernelTools: true},
+	// Repointed from the decommissioned "ollama" provider to "lmstudio-darkstar"
+	// (the live local backend, per PR #417). On a stock install no "ollama"
+	// provider is registered, so the old value resolved to nothing; the "ollama"
+	// alias key is kept as a convenience spelling that now routes to the live
+	// local provider. Installs that still declare an "ollama" provider in
+	// providers.yaml are unaffected — they select it by its provider name, not
+	// via this alias default.
+	"ollama":       {PreferProvider: "lmstudio-darkstar", InjectKernelTools: true},
+	"kernel-agent": {PreferProvider: "lmstudio-darkstar", InjectKernelTools: true},
 }
 
 // ResolveModelRequest maps a model string to a ModelResolution using the
@@ -80,11 +87,11 @@ var intentAliases = map[string]ModelResolution{
 // above); all other strings are unchanged:
 //
 //	""            → {} (empty, default routing)
-//	"local"       → resolved via router.FirstLocalProvider / ProviderForName("ollama")
+//	"local"       → resolved via router.FirstLocalProvider / ProviderForName("lmstudio-darkstar")
 //	"claude"      → {claude-oauth, ""}
 //	"codex"       → {codex, ""}
-//	"ollama"      → {ollama, "", injectKernelTools}
-//	"kernel-agent"→ {ollama, "", injectKernelTools}
+//	"ollama"      → {lmstudio-darkstar, "", injectKernelTools}
+//	"kernel-agent"→ {lmstudio-darkstar, "", injectKernelTools}
 //	named provider→ {name, ""} (ProviderForName)
 //	model id      → {provider, model} (ProviderForModel + ModelOverride)
 func ResolveModelRequest(router Router, model string, requestID string) ModelResolution {
@@ -96,6 +103,12 @@ func ResolveModelRequest(router Router, model string, requestID string) ModelRes
 	if model == "local" {
 		if router == nil {
 			return ModelResolution{}
+		}
+		// Prefer the live local backend (lmstudio-darkstar, per PR #417); fall
+		// back to a still-declared "ollama" provider for installs that kept it,
+		// then to any registered local provider.
+		if name, ok := router.ProviderForName("lmstudio-darkstar"); ok {
+			return ModelResolution{PreferProvider: name}
 		}
 		if name, ok := router.ProviderForName("ollama"); ok {
 			return ModelResolution{PreferProvider: name}

--- a/internal/engine/resolve_test.go
+++ b/internal/engine/resolve_test.go
@@ -119,9 +119,11 @@ func TestResolveModelRequest_Codex(t *testing.T) {
 
 func TestResolveModelRequest_OllamaInjectTools(t *testing.T) {
 	t.Parallel()
+	// The "ollama" alias is a convenience spelling that now routes to the live
+	// local backend (lmstudio-darkstar) after PR #417 decommissioned Ollama.
 	res := ResolveModelRequest(nil, "ollama", "req-3")
-	if res.PreferProvider != "ollama" {
-		t.Errorf("ollama: PreferProvider = %q; want ollama", res.PreferProvider)
+	if res.PreferProvider != "lmstudio-darkstar" {
+		t.Errorf("ollama: PreferProvider = %q; want lmstudio-darkstar", res.PreferProvider)
 	}
 	if !res.InjectKernelTools {
 		t.Error("ollama: InjectKernelTools should be true")
@@ -131,16 +133,31 @@ func TestResolveModelRequest_OllamaInjectTools(t *testing.T) {
 func TestResolveModelRequest_KernelAgentInjectTools(t *testing.T) {
 	t.Parallel()
 	res := ResolveModelRequest(nil, "kernel-agent", "req-4")
-	if res.PreferProvider != "ollama" {
-		t.Errorf("kernel-agent: PreferProvider = %q; want ollama", res.PreferProvider)
+	if res.PreferProvider != "lmstudio-darkstar" {
+		t.Errorf("kernel-agent: PreferProvider = %q; want lmstudio-darkstar", res.PreferProvider)
 	}
 	if !res.InjectKernelTools {
 		t.Error("kernel-agent: InjectKernelTools should be true")
 	}
 }
 
+func TestResolveModelRequest_Local_PrefersLMStudioDarkstar(t *testing.T) {
+	t.Parallel()
+	// When both the live default (lmstudio-darkstar) and a legacy "ollama"
+	// provider are registered, "local" must prefer lmstudio-darkstar.
+	r := newStubRouter().
+		addProvider("lmstudio-darkstar", "", true).
+		addProvider("ollama", "", true)
+	res := ResolveModelRequest(r, "local", "req-5b")
+	if res.PreferProvider != "lmstudio-darkstar" {
+		t.Errorf("local: PreferProvider = %q; want lmstudio-darkstar", res.PreferProvider)
+	}
+}
+
 func TestResolveModelRequest_Local_WithOllama(t *testing.T) {
 	t.Parallel()
+	// An install that still declares an "ollama" provider (no lmstudio-darkstar)
+	// keeps its behavior: "local" falls back to it.
 	r := newStubRouter().addProvider("ollama", "", true)
 	res := ResolveModelRequest(r, "local", "req-5")
 	if res.PreferProvider != "ollama" {

--- a/internal/engine/serve_anthropic.go
+++ b/internal/engine/serve_anthropic.go
@@ -181,7 +181,12 @@ func (s *Server) handleAnthropicMessages(w http.ResponseWriter, r *http.Request)
 	case "codex":
 		creq.Metadata.PreferProvider = "codex"
 	case "ollama":
-		creq.Metadata.PreferProvider = "ollama"
+		// "ollama" is kept as a convenience spelling that routes to the live
+		// local backend (lmstudio-darkstar) after PR #417 decommissioned the
+		// Ollama provider. On a stock install no "ollama" provider exists, so
+		// the old value routed to nothing; installs that still declare an
+		// "ollama" provider select it by its provider name via the default arm.
+		creq.Metadata.PreferProvider = "lmstudio-darkstar"
 	default:
 		creq.ModelOverride = oaiReq.Model
 	}

--- a/sdk/constellation/indexer.go
+++ b/sdk/constellation/indexer.go
@@ -20,6 +20,23 @@ import (
 // rebuild.
 var ftsMu sync.Mutex
 
+// indexMu serialises whole indexing operations (IndexFile / IndexWorkspace).
+//
+// The connection pool is MaxOpenConns(1), so at most one *statement* runs at a
+// time — but a single indexing operation is a MULTI-statement unit: db.Begin()
+// opens a transaction, indexCogdoc runs several Exec/Query calls, tx.Commit()
+// closes it, and then upsertFTSRow issues its own SAVEPOINT/DELETE/INSERT/RELEASE
+// sequence as autocommit statements. If two IndexFile calls interleave on the
+// single connection, one goroutine's SAVEPOINT (a transaction-control statement)
+// can be issued while another goroutine holds an open db.Begin() transaction on
+// the same connection, producing "cannot start a transaction within a
+// transaction" — a failure that was previously swallowed by a slog.Warn, silently
+// dropping the index update. Holding indexMu for the whole operation makes
+// concurrent IndexFile calls safe and lossless (they serialise instead of
+// racing). ftsMu still guards upsertFTSRow vs. rebuildFTS for callers that hold
+// neither (none today, but the invariant is preserved).
+var indexMu sync.Mutex
+
 // Cogdoc represents a parsed cogdoc with frontmatter and content.
 type Cogdoc struct {
 	ID               string
@@ -47,6 +64,13 @@ type Reference struct {
 
 // IndexWorkspace scans the workspace and indexes all cogdocs.
 func (c *Constellation) IndexWorkspace() error {
+	// Serialise against concurrent IndexFile calls: both open a db.Begin()
+	// transaction on the single-writer connection, and interleaving them
+	// corrupts transaction state (see indexMu). A full rebuild must own the
+	// connection for the duration of its transaction + FTS rebuild.
+	indexMu.Lock()
+	defer indexMu.Unlock()
+
 	tx, err := c.db.Begin()
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
@@ -100,6 +124,19 @@ func (c *Constellation) IndexWorkspace() error {
 		return fmt.Errorf("failed to walk workspace: %w", err)
 	}
 
+	// Prune ghost rows: cogdoc rows under .cog/mem/ whose backing file no longer
+	// exists on disk. Re-indexing is additive (INSERT OR REPLACE) and never
+	// removes rows for deleted files, so without this sweep a deleted cogdoc's
+	// row (and its FTS entry, tags, refs) persist forever. Scope the sweep to
+	// managed cogdoc paths ('%/.cog/mem/%.cog.md') so non-cogdoc rows indexed
+	// from outside the memory corpus (e.g. conversation/session documents) are
+	// never touched. tags / doc_references / backlinks cascade on delete;
+	// documents_fts is rebuilt from documents below.
+	pruned, err := c.pruneGhostCogdocs(tx)
+	if err != nil {
+		return fmt.Errorf("failed to prune ghost cogdocs: %w", err)
+	}
+
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
@@ -128,6 +165,9 @@ func (c *Constellation) IndexWorkspace() error {
 	} else {
 		fmt.Printf("Indexed %d cogdocs\n", indexed)
 	}
+	if pruned > 0 {
+		fmt.Printf("Pruned %d ghost cogdoc rows (files removed from disk)\n", pruned)
+	}
 
 	// Async: trigger embedding backfill if embed client is configured
 	if c.embedClient != nil {
@@ -150,16 +190,80 @@ func (c *Constellation) IndexWorkspace() error {
 	return nil
 }
 
+// pruneGhostCogdocs removes documents rows for managed cogdocs whose backing
+// file no longer exists on disk. It is the stat-based orphan sweep referenced in
+// IndexWorkspace's design note: re-indexing is additive and never deletes rows,
+// so deleted cogdocs would otherwise leave permanent ghost rows in the index.
+//
+// Scope is intentionally narrow: only rows whose path matches
+// '%/.cog/mem/%.cog.md' are candidates, so rows indexed from outside the memory
+// corpus are never removed. Deletes cascade to tags / doc_references / backlinks
+// (schema FKs, ON DELETE CASCADE); the caller rebuilds documents_fts from
+// documents afterward, so no explicit FTS delete is needed here. Returns the
+// number of rows pruned.
+func (c *Constellation) pruneGhostCogdocs(tx *sql.Tx) (int, error) {
+	rows, err := tx.Query(
+		`SELECT id, path FROM documents WHERE path LIKE '%/.cog/mem/%.cog.md'`,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("select cogdoc rows: %w", err)
+	}
+
+	type ghost struct {
+		id   string
+		path string
+	}
+	var ghosts []ghost
+	for rows.Next() {
+		var id, path string
+		if err := rows.Scan(&id, &path); err != nil {
+			rows.Close()
+			return 0, fmt.Errorf("scan cogdoc row: %w", err)
+		}
+		if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
+			ghosts = append(ghosts, ghost{id: id, path: path})
+		}
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return 0, fmt.Errorf("iterate cogdoc rows: %w", err)
+	}
+	// Close before issuing DELETEs: the single-writer connection cannot run a
+	// mutation while this cursor is still open.
+	rows.Close()
+
+	pruned := 0
+	for _, g := range ghosts {
+		if _, err := tx.Exec("DELETE FROM documents WHERE id = ?", g.id); err != nil {
+			return pruned, fmt.Errorf("delete ghost %s (%s): %w", g.id, g.path, err)
+		}
+		pruned++
+	}
+	return pruned, nil
+}
+
 // IndexFile indexes a single cogdoc file into the constellation.
 // This is the public entry point for incremental indexing (e.g., after
 // a decomposition stores a new CogDoc). It handles its own transaction,
 // FTS rebuild for the affected document, and optional async embedding.
 func (c *Constellation) IndexFile(path string) error {
+	// Serialise the whole operation (tx + commit + FTS upsert) against other
+	// IndexFile / IndexWorkspace callers. On the MaxOpenConns(1) pool an
+	// interleaved SAVEPOINT (from upsertFTSRow) and an open db.Begin() tx on the
+	// same connection otherwise trigger "cannot start a transaction within a
+	// transaction", which was silently swallowed and dropped the index update.
+	indexMu.Lock()
+	defer indexMu.Unlock()
+
 	tx, err := c.db.Begin()
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}
+	committed := false
 	defer func() {
+		if committed {
+			return
+		}
 		if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
 			fmt.Fprintf(os.Stderr, "Warning: IndexFile rollback: %v\n", err)
 		}
@@ -177,10 +281,12 @@ func (c *Constellation) IndexFile(path string) error {
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit tx: %w", err)
 	}
+	committed = true
 
 	if idErr != nil {
-		// Row absent means indexCogdoc skipped (unchanged hash). FTS already
-		// up-to-date for this document; nothing to do.
+		// Row absent should not happen: indexCogdoc always upserts a row for the
+		// path (even on unchanged-hash it now refreshes file_mtime in place).
+		// Treat as "nothing more to do" rather than an error.
 		return nil
 	}
 
@@ -230,7 +336,18 @@ func (c *Constellation) indexCogdoc(tx *sql.Tx, path string) error {
 	var existingHash string
 	err = tx.QueryRow("SELECT content_hash FROM documents WHERE path = ?", path).Scan(&existingHash)
 	if err == nil && existingHash == contentHash {
-		// Already indexed, no change
+		// Content unchanged, but the file may have been touched (mtime bumped
+		// with identical bytes — e.g. an editor rewrite or `touch`). The stored
+		// file_mtime is the ONLY signal the engine's lazy drift-repair uses to
+		// decide a row is stale; if we return here without refreshing it, the
+		// drift check flags this document as drifted on every search, forever,
+		// and re-indexes it needlessly. Cheaply update the stored mtime so a
+		// touched-but-unchanged file reports no drift on the next pass.
+		if _, uerr := tx.Exec(
+			"UPDATE documents SET file_mtime = ? WHERE path = ?", mtime, path,
+		); uerr != nil {
+			return fmt.Errorf("failed to refresh file_mtime on unchanged doc: %w", uerr)
+		}
 		return nil
 	}
 

--- a/sdk/constellation/indexer_hardening_test.go
+++ b/sdk/constellation/indexer_hardening_test.go
@@ -1,0 +1,286 @@
+package constellation
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestIndexFileConcurrentNoLoss is the regression test for the BLOCKER:
+// concurrent IndexFile calls previously raced on the single-writer connection
+// (one goroutine's SAVEPOINT in upsertFTSRow issued while another held an open
+// db.Begin() transaction) and produced "cannot start a transaction within a
+// transaction", a failure that was swallowed by a slog.Warn — silently dropping
+// index updates. With indexMu serialising the whole operation, 20 goroutines
+// hammering IndexFile must produce zero errors and full row coverage.
+func TestIndexFileConcurrentNoLoss(t *testing.T) {
+	c, cleanup := openTestDB(t)
+	defer cleanup()
+
+	const n = 20
+
+	// Pre-create N distinct cogdocs so every goroutine indexes a real file.
+	paths := make([]string, n)
+	for i := 0; i < n; i++ {
+		rel := fmt.Sprintf("semantic/hammer-%02d.cog.md", i)
+		paths[i] = writeCogdocInWorkspace(t, c,
+			rel,
+			fmt.Sprintf("id: hammer-%02d\ntype: note\ntitle: Hammer %02d\ncreated: 2026-01-01", i, i),
+			fmt.Sprintf("Concurrent index body number %02d with token hammertoken%02d.", i, i),
+		)
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, n)
+	start := make(chan struct{})
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(p string) {
+			defer wg.Done()
+			<-start // maximise contention: release all goroutines at once
+			if err := c.IndexFile(p); err != nil {
+				errCh <- fmt.Errorf("IndexFile(%s): %w", p, err)
+			}
+		}(paths[i])
+	}
+
+	close(start)
+	wg.Wait()
+	close(errCh)
+
+	var errs []error
+	for err := range errCh {
+		errs = append(errs, err)
+	}
+	if len(errs) != 0 {
+		t.Fatalf("expected zero IndexFile errors from %d concurrent goroutines, got %d: %v", n, len(errs), errs)
+	}
+
+	// Full row coverage: every document row present, and every FTS row present.
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("hammer-%02d", i)
+		var docCount, ftsCount int
+		if err := c.DB().QueryRow(`SELECT COUNT(*) FROM documents WHERE id = ?`, id).Scan(&docCount); err != nil {
+			t.Fatalf("documents count for %s: %v", id, err)
+		}
+		if docCount != 1 {
+			t.Errorf("expected exactly 1 documents row for %s, got %d", id, docCount)
+		}
+		if err := c.DB().QueryRow(`SELECT COUNT(*) FROM documents_fts WHERE id = ?`, id).Scan(&ftsCount); err != nil {
+			t.Fatalf("fts count for %s: %v", id, err)
+		}
+		if ftsCount != 1 {
+			t.Errorf("expected exactly 1 documents_fts row for %s, got %d (index update dropped)", id, ftsCount)
+		}
+	}
+
+	// And each unique token must be searchable — the FTS row content is correct.
+	for i := 0; i < n; i++ {
+		token := fmt.Sprintf("hammertoken%02d", i)
+		var found int
+		if err := c.DB().QueryRow(
+			`SELECT COUNT(*) FROM documents_fts WHERE documents_fts MATCH ?`, token,
+		).Scan(&found); err != nil {
+			t.Fatalf("FTS search for %s: %v", token, err)
+		}
+		if found != 1 {
+			t.Errorf("expected token %s searchable in exactly 1 doc, got %d", token, found)
+		}
+	}
+}
+
+// TestIndexFileConcurrentSamePath hammers IndexFile on a SINGLE shared path from
+// many goroutines. This is the tightest form of the transaction-state race
+// (every goroutine contends for the same row + FTS entry). It must produce zero
+// errors and leave exactly one document row and one FTS row.
+func TestIndexFileConcurrentSamePath(t *testing.T) {
+	c, cleanup := openTestDB(t)
+	defer cleanup()
+
+	path := writeCogdocInWorkspace(t, c,
+		"semantic/shared.cog.md",
+		"id: shared-doc\ntype: note\ntitle: Shared\ncreated: 2026-01-01",
+		"Shared body content with token sharedtoken.",
+	)
+
+	const n = 20
+	var wg sync.WaitGroup
+	errCh := make(chan error, n)
+	start := make(chan struct{})
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if err := c.IndexFile(path); err != nil {
+				errCh <- err
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		t.Errorf("IndexFile error on shared path: %v", err)
+	}
+
+	var docCount, ftsCount int
+	if err := c.DB().QueryRow(`SELECT COUNT(*) FROM documents WHERE id = 'shared-doc'`).Scan(&docCount); err != nil {
+		t.Fatalf("documents count: %v", err)
+	}
+	if docCount != 1 {
+		t.Errorf("expected 1 documents row for shared-doc, got %d", docCount)
+	}
+	if err := c.DB().QueryRow(`SELECT COUNT(*) FROM documents_fts WHERE id = 'shared-doc'`).Scan(&ftsCount); err != nil {
+		t.Fatalf("fts count: %v", err)
+	}
+	if ftsCount != 1 {
+		t.Errorf("expected 1 documents_fts row for shared-doc, got %d", ftsCount)
+	}
+}
+
+// TestIndexCogdocHashSkipRefreshesMtime is the regression test for the MAJOR
+// hash-skip bug: indexCogdoc's early return on a content-hash match previously
+// preceded the only file_mtime write, so a touched-but-unchanged file kept a
+// stale stored mtime and was flagged as drifted by the engine's drift repair on
+// every search, forever. After the fix, a hash-match path must still refresh the
+// stored file_mtime in place.
+func TestIndexCogdocHashSkipRefreshesMtime(t *testing.T) {
+	c, cleanup := openTestDB(t)
+	defer cleanup()
+
+	path := writeCogdocInWorkspace(t, c,
+		"semantic/touchme.cog.md",
+		"id: touch-doc\ntype: note\ntitle: Touch Me\ncreated: 2026-01-01",
+		"Unchanging body content.",
+	)
+
+	if err := c.IndexFile(path); err != nil {
+		t.Fatalf("initial IndexFile: %v", err)
+	}
+
+	var mtime1 string
+	if err := c.DB().QueryRow(`SELECT file_mtime FROM documents WHERE id = 'touch-doc'`).Scan(&mtime1); err != nil {
+		t.Fatalf("read mtime1: %v", err)
+	}
+
+	// Touch the file: bump mtime forward by 5 minutes without changing content.
+	future := time.Now().Add(5 * time.Minute)
+	if err := os.Chtimes(path, future, future); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	// Re-index. Content hash matches, so indexCogdoc takes the early-return
+	// branch — but it must now refresh file_mtime.
+	if err := c.IndexFile(path); err != nil {
+		t.Fatalf("re-IndexFile after touch: %v", err)
+	}
+
+	var mtime2 string
+	if err := c.DB().QueryRow(`SELECT file_mtime FROM documents WHERE id = 'touch-doc'`).Scan(&mtime2); err != nil {
+		t.Fatalf("read mtime2: %v", err)
+	}
+	if mtime2 == mtime1 {
+		t.Fatalf("stored file_mtime not refreshed on touched-but-unchanged file: still %q", mtime2)
+	}
+
+	// The refreshed stored mtime must equal the on-disk mtime (no residual
+	// drift): a second-pass drift check would report clean.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	wantMtime := info.ModTime().Format(time.RFC3339)
+	if mtime2 != wantMtime {
+		t.Errorf("refreshed stored mtime %q != on-disk mtime %q (drift would persist)", mtime2, wantMtime)
+	}
+}
+
+// TestIndexWorkspacePrunesGhostCogdocs is the regression test for the additive-
+// only reindex path leaving permanent ghost rows: a cogdoc whose file is deleted
+// from disk previously kept its documents/FTS/tags/refs rows forever. After the
+// fix, IndexWorkspace (the reindex path) prunes rows for managed cogdocs
+// (path LIKE '%/.cog/mem/%.cog.md') whose files are gone, while leaving rows for
+// still-present files untouched.
+func TestIndexWorkspacePrunesGhostCogdocs(t *testing.T) {
+	c, cleanup := openTestDB(t)
+	defer cleanup()
+
+	keepPath := writeCogdocInWorkspace(t, c,
+		"semantic/keep.cog.md",
+		"id: keep-doc\ntype: note\ntitle: Keep\ncreated: 2026-01-01\ntags:\n  - keeptag",
+		"Body that stays. Token keepstoken.",
+	)
+	_ = keepPath
+	ghostPath := writeCogdocInWorkspace(t, c,
+		"semantic/ghost.cog.md",
+		"id: ghost-doc\ntype: note\ntitle: Ghost\ncreated: 2026-01-01\ntags:\n  - ghosttag",
+		"Body that will vanish. Token ghoststoken.",
+	)
+
+	// First index: both docs present.
+	if err := c.IndexWorkspace(); err != nil {
+		t.Fatalf("first IndexWorkspace: %v", err)
+	}
+	for _, id := range []string{"keep-doc", "ghost-doc"} {
+		var n int
+		if err := c.DB().QueryRow(`SELECT COUNT(*) FROM documents WHERE id = ?`, id).Scan(&n); err != nil {
+			t.Fatalf("count %s: %v", id, err)
+		}
+		if n != 1 {
+			t.Fatalf("expected %s indexed after first pass, got %d", id, n)
+		}
+	}
+
+	// Delete the ghost file on disk.
+	if err := os.Remove(ghostPath); err != nil {
+		t.Fatalf("remove ghost file: %v", err)
+	}
+
+	// Re-index: ghost row (and its cascaded tags) must be pruned; keep row stays.
+	if err := c.IndexWorkspace(); err != nil {
+		t.Fatalf("second IndexWorkspace: %v", err)
+	}
+
+	var ghostDocs, ghostFTS, ghostTags int
+	if err := c.DB().QueryRow(`SELECT COUNT(*) FROM documents WHERE id = 'ghost-doc'`).Scan(&ghostDocs); err != nil {
+		t.Fatalf("ghost doc count: %v", err)
+	}
+	if ghostDocs != 0 {
+		t.Errorf("expected ghost-doc pruned from documents, got %d rows", ghostDocs)
+	}
+	if err := c.DB().QueryRow(`SELECT COUNT(*) FROM documents_fts WHERE id = 'ghost-doc'`).Scan(&ghostFTS); err != nil {
+		t.Fatalf("ghost fts count: %v", err)
+	}
+	if ghostFTS != 0 {
+		t.Errorf("expected ghost-doc pruned from documents_fts, got %d rows", ghostFTS)
+	}
+	if err := c.DB().QueryRow(`SELECT COUNT(*) FROM tags WHERE document_id = 'ghost-doc'`).Scan(&ghostTags); err != nil {
+		t.Fatalf("ghost tags count: %v", err)
+	}
+	if ghostTags != 0 {
+		t.Errorf("expected ghost-doc tags cascade-deleted, got %d rows", ghostTags)
+	}
+
+	// The surviving doc must be untouched and still searchable.
+	var keepDocs int
+	if err := c.DB().QueryRow(`SELECT COUNT(*) FROM documents WHERE id = 'keep-doc'`).Scan(&keepDocs); err != nil {
+		t.Fatalf("keep doc count: %v", err)
+	}
+	if keepDocs != 1 {
+		t.Errorf("expected keep-doc to survive prune, got %d rows", keepDocs)
+	}
+	var keepFound int
+	if err := c.DB().QueryRow(
+		`SELECT COUNT(*) FROM documents_fts WHERE documents_fts MATCH 'keepstoken'`,
+	).Scan(&keepFound); err != nil {
+		t.Fatalf("keep search: %v", err)
+	}
+	if keepFound != 1 {
+		t.Errorf("expected keep-doc still searchable after prune, got %d", keepFound)
+	}
+}


### PR DESCRIPTION
## What changed

Implements six adversarially-reviewed findings against the FTS write path, the lazy drift-repair path, and leftovers from the Ollama decommission (PR #417). Each finding was verified on `origin/main` @ e38ae77 before fixing (item 3 re-verified after earlier verifiers read a stale tree — all three sub-findings were confirmed real and live).

### 1. BLOCKER — concurrent `IndexFile` corrupts transaction state
- **Finding:** `upsertFTSRow` (sdk/constellation/indexer.go) issued `SAVEPOINT`/`RELEASE` as raw autocommit statements on the `MaxOpenConns(1)` pool while concurrent `IndexFile` calls held open `db.Begin()` transactions on the same connection → "cannot start a transaction within a transaction", swallowed by a warning — index updates silently dropped.
- **Fix:** new package-level `indexMu` serializes the whole indexing operation (`IndexFile` and `IndexWorkspace`): begin → index → commit → FTS upsert as one unit. Smallest lossless design; `ftsMu` invariant retained.
- **Test:** `TestIndexFileConcurrentNoLoss` (20 goroutines, distinct paths — zero errors, full document + FTS row coverage, every token searchable) and `TestIndexFileConcurrentSamePath` (20 goroutines, one shared path). Both race-detector clean.

### 2. MAJOR — hash-skip never refreshes `file_mtime`
- **Finding:** `indexCogdoc`'s early return on a content-hash match preceded the only `file_mtime` write, so any touched-but-unchanged file was re-flagged as drifted by the engine's drift repair on every search, forever.
- **Fix:** the hash-match branch now issues `UPDATE documents SET file_mtime = ? WHERE path = ?` before returning (mtime is the only stale field; no separate on-disk size column is stored).
- **Test:** `TestIndexCogdocHashSkipRefreshesMtime` — index, `os.Chtimes` +5min with identical content, re-index; asserts the stored mtime updates and equals the on-disk RFC3339 mtime (a second drift pass reports clean).

### 3. Drift repair (`searchMemoryFTSDriftRepair`, internal/engine/mcp_stubs.go) — re-verified, all three real
- **(a) Equal-second false negative:** second-granularity RFC3339 comparison only; no content fallback. **Fix:** equal-mtime rows get a content-hash tiebreak — `cogdocBodyHash` mirrors the indexer's content rule (TrimSpace after the second `---`, sha256) without importing `sdk/constellation`, preserving the package-boundary guard.
- **(b) Budget:** the ~200ms deadline was computed after sampling and only checked between iterations. **Fix:** deadline established upfront, before any I/O; still checked between `IndexFile` calls (a single `IndexFile` is not internally time-sliceable — documented).
- **(c) Sample scope:** query excluded only `%.state/%`, asymmetric with the mem watcher (which watches only `.cog/mem/`). **Fix:** sample scoped to `path LIKE '%/.cog/mem/%'`.
- **Test:** first-ever coverage for this function (`drift_repair_test.go`, 6 tests): mtime-drift repair, out-of-corpus row not repaired, equal-second changed content repaired, equal-second unchanged content not repaired, widespread drift (>10) skips inline repair, nil indexer no-op.

### 4. Reindex prune — ghost rows for deleted files
- **Finding:** the reindex path is additive/upsert-only; rows whose files no longer exist persist forever (12 live ghosts at review time).
- **Fix:** `pruneGhostCogdocs` runs inside `IndexWorkspace`'s transaction — stat-based sweep of rows matching `path LIKE '%/.cog/mem/%.cog.md'`, deleting rows whose file is gone. Tags/refs/backlinks cascade via schema FKs; `documents_fts` is rebuilt immediately after. This is the "dedicated stat-based sweep" the in-code design note called for.
- **Test:** `TestIndexWorkspacePrunesGhostCogdocs` — deleted-file fixture; ghost purged from `documents`/`documents_fts`/`tags`, survivor intact and searchable.

### 5. Decommission leftovers (follow-up to #417)
- **(a)** `provider_pi.go`: `NewPiProvider` defaulted model to `defaultOllamaModel` and provider to `"ollama"`. Repointed via new `defaultLocalPiProvider` (`"lmstudio"`) and `defaultLocalModel` (`"google/gemma-4-26b-a4b"`, matching `defaults/providers.yaml`).
- **(b)** `resolve.go` intent aliases `"ollama"`/`"kernel-agent"` and the `serve_anthropic.go` `case "ollama"` hardcoded `PreferProvider: "ollama"` — dead on a stock install (no such provider registered post-#417). Repointed to `"lmstudio-darkstar"`. The dynamic `"local"` alias now probes `lmstudio-darkstar` → `ollama` → first local, so configured installs that kept an `ollama` provider are behavior-identical.
- **Test:** alias tests updated to the intentionally-changed values; new `TestResolveModelRequest_Local_PrefersLMStudioDarkstar`; the ollama-fallback test unchanged (pins preserved behavior).

### 6. Fail-closed: `cog_tool_invoke` with unresolved session identity
- **Finding:** with `IdentityNakedDefault` gating enabled and a capResolver wired, an unresolved transport-session correlation skipped enforcement entirely — an unattributable caller could dispatch any deferred plumbing tool (confused-deputy bypass of per-tool gating).
- **Fix:** that case now DENIES with a clear error directing the caller to `cog_register_session` with a subject first. Flag-off and resolved-subject paths unchanged.
- **Test:** `TestToolInvoke_FailsClosedOnUnresolvedSession` (real Streamable HTTP transport, no prior registration → denied); existing `TestToolInvoke_EnforcesCapabilityGating` still green.

## Gates

- `gofmt -l` clean on all touched files (`provider_pi.go` picked up a pre-existing struct misalignment fix)
- `go build ./...` — root + sdk modules, plus `GOOS=windows GOARCH=amd64 go build ./...`
- `go vet ./...` — root + sdk
- `go test -tags fts5 ./...` — full suite, root + sdk modules, all green; new concurrency tests additionally verified with `-race`
- golangci-lint v2.11.4 — 0 issues in touched packages (2 pre-existing staticcheck findings in `sdk/constellation/query.go`, untouched here)

## Out of scope

Session-registry TTL reaper (separate PR), legacy root-package `*.go`, mod3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
