### PR TITLE
fix(dispatch,mcp): LM Studio default endpoint + eager-tool error surface

### DIFF
--- a/internal/engine/local_llm_test.go
+++ b/internal/engine/local_llm_test.go
@@ -5,6 +5,28 @@ import (
 	"testing"
 )
 
+// ── resolveLocalLLMEndpoint ────────────────────────────────────────────────────
+
+// TestResolveLocalLLMEndpointDefaultsToLMStudioNotOllama pins the no-config,
+// no-env fallback to LM Studio's port (:1234), not Ollama's (:11434).
+// Regression for flight review 2026-07-03 §5.2: a no-provider
+// cog_dispatch_to_harness call resolves through resolveLocalLLMEndpoint ->
+// NewOpenAICompatProvider when no explicit provider/state-route/
+// harness_provider path fires (see local_agent_harness.go Path 3). Before
+// this fix, openaiCompatDefaultEndpoint had drifted back to Ollama's
+// decommissioned :11434 (tombstoned in PR #417), so this exact path
+// dead-ended connection-refused instead of reaching the resident LM Studio
+// backend. Uses t.Setenv rather than t.Parallel so COGOS_LLM_ENDPOINT is
+// deterministically unset for the duration of this test.
+func TestResolveLocalLLMEndpointDefaultsToLMStudioNotOllama(t *testing.T) {
+	t.Setenv(localLLMEndpointEnv, "")
+	got := resolveLocalLLMEndpoint("")
+	want := "http://localhost:1234"
+	if got != want {
+		t.Errorf("resolveLocalLLMEndpoint(\"\") = %q; want %q (LM Studio, not Ollama's decommissioned :11434)", got, want)
+	}
+}
+
 // ── normalizeModelNameForOllama ───────────────────────────────────────────────
 
 func TestNormalizeModelNameForOllama(t *testing.T) {

--- a/internal/engine/mcp_tool_catalog.go
+++ b/internal/engine/mcp_tool_catalog.go
@@ -196,10 +196,25 @@ func (m *MCPServer) toolToolInvoke(ctx context.Context, req *mcp.CallToolRequest
 		// No silent widening: reject unknown names outright, mirroring
 		// KernelToolRegistry.Scoped (tool_loop.go) rather than falling
 		// through to some generic dispatch.
-		return fallbackResult(
-			fmt.Sprintf("cog_tool_invoke: unknown tool %q (not in the deferred plumbing catalog; use cog_tool_search to discover valid names)", name),
-			"",
-		)
+		//
+		// Two distinct rejection reasons, per flight review 2026-07-03 §5.4:
+		// a genuinely unknown/misspelled name vs. a name that IS a real tool
+		// but is eager (already directly callable, never registered into
+		// m.deferredHandlers). The flight model (gemma-4-26b) hit the eager
+		// case twice in a row against the generic "not in the deferred
+		// plumbing catalog" message before self-correcting — naming the
+		// corrective action inline collapses that to one attempt.
+		if eagerToolExists(m.toolMeta, name) {
+			return fallbackResult(
+				fmt.Sprintf("cog_tool_invoke: tool %q is eager — call it directly, not via cog_tool_invoke", name),
+				"",
+			)
+		}
+		msg := fmt.Sprintf("cog_tool_invoke: unknown tool %q (not in the deferred plumbing catalog; use cog_tool_search to discover valid names)", name)
+		if suggestions := nearestToolNames(m.toolMeta, name, 3); len(suggestions) > 0 {
+			msg += fmt.Sprintf("; did you mean: %s?", strings.Join(suggestions, ", "))
+		}
+		return fallbackResult(msg, "")
 	}
 
 	// SECURITY-CRITICAL (ADR G2 PART C): gate the UNDERLYING tool (name),
@@ -248,4 +263,94 @@ func (m *MCPServer) toolToolInvoke(ctx context.Context, req *mcp.CallToolRequest
 		return fallbackResult(fmt.Sprintf("cog_tool_invoke: %s: %v", name, err), "")
 	}
 	return result, nil, nil
+}
+
+// eagerToolExists reports whether name matches a registered EAGER tool in
+// toolMeta (i.e. a porcelain tool, already directly callable via CallTool /
+// tools-list — never routed through m.deferredHandlers). Used to distinguish
+// "you called cog_tool_invoke on a tool that should be called directly"
+// from "this name doesn't exist in the catalog at all".
+func eagerToolExists(toolMeta []mcpToolMeta, name string) bool {
+	for _, t := range toolMeta {
+		if t.Eager && t.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// nearestToolNames returns up to limit tool names from the full catalog
+// (both eager and deferred) ranked by Levenshtein distance to name, for
+// typo-correction suggestions on an unknown-name rejection. Cheap win per
+// flight review 2026-07-03 §5.4: catalog size is ~57 entries, so a full
+// O(n) distance scan per rejection is negligible.
+func nearestToolNames(toolMeta []mcpToolMeta, name string, limit int) []string {
+	if name == "" || len(toolMeta) == 0 {
+		return nil
+	}
+	type scored struct {
+		name string
+		dist int
+	}
+	candidates := make([]scored, 0, len(toolMeta))
+	for _, t := range toolMeta {
+		if t.Name == "" {
+			continue
+		}
+		candidates = append(candidates, scored{name: t.Name, dist: levenshtein(name, t.Name)})
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if candidates[i].dist != candidates[j].dist {
+			return candidates[i].dist < candidates[j].dist
+		}
+		return candidates[i].name < candidates[j].name
+	})
+	if len(candidates) > limit {
+		candidates = candidates[:limit]
+	}
+	out := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		out = append(out, c.name)
+	}
+	return out
+}
+
+// levenshtein computes the classic edit-distance metric between two strings
+// (single-byte-rune ops: insert, delete, substitute), using an O(min(len))-
+// space rolling two-row implementation. Case-insensitive so a caller's
+// slightly-wrong-cased guess still ranks near its intended target.
+func levenshtein(a, b string) int {
+	a = strings.ToLower(a)
+	b = strings.ToLower(b)
+	ar, br := []rune(a), []rune(b)
+	if len(ar) < len(br) {
+		ar, br = br, ar
+	}
+	prev := make([]int, len(br)+1)
+	curr := make([]int, len(br)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(ar); i++ {
+		curr[0] = i
+		for j := 1; j <= len(br); j++ {
+			cost := 1
+			if ar[i-1] == br[j-1] {
+				cost = 0
+			}
+			del := prev[j] + 1
+			ins := curr[j-1] + 1
+			sub := prev[j-1] + cost
+			m := del
+			if ins < m {
+				m = ins
+			}
+			if sub < m {
+				m = sub
+			}
+			curr[j] = m
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(br)]
 }

--- a/internal/engine/mcp_tool_catalog_test.go
+++ b/internal/engine/mcp_tool_catalog_test.go
@@ -17,6 +17,12 @@
 //  6. TestDeferredTool_NotInEagerToolsList — a deferred tool (cog_read_ledger)
 //     is NOT present in the live server's tools/list (ListTools), only in
 //     the toolMeta catalog cog_tool_search reads from.
+//  7. TestToolInvoke_EagerToolNamesCorrectiveAction — cog_tool_invoke on an
+//     eager tool names the fix inline ("call it directly") instead of the
+//     generic unknown-name message (flight review 2026-07-03 §5.4).
+//  8. TestToolInvoke_UnknownNameSuggestsNearestMatches (+ the two focused
+//     unit tests below) — a genuinely unknown/misspelled name keeps the
+//     generic message but gains nearest-name-match suggestions.
 package engine
 
 import (
@@ -412,5 +418,101 @@ func TestDeferredTool_NotInEagerToolsList(t *testing.T) {
 	}
 	if !deferredMetaFound {
 		t.Error("cog_read_ledger should still be present in m.toolMeta (deferred catalog)")
+	}
+}
+
+// ─── 7. cog_tool_invoke on an EAGER tool names the corrective action ─────────
+
+// TestToolInvoke_EagerToolNamesCorrectiveAction is the regression for flight
+// review 2026-07-03 §5.4: cog_tool_invoke("cog_get_state", ...) — a porcelain
+// (eager) tool, never registered into m.deferredHandlers — previously
+// returned the same generic "not in the deferred plumbing catalog" message
+// as a genuinely unknown name. The flight model (gemma-4-26b) burned two
+// attempts on this before self-correcting. The eager case must instead name
+// the fix inline: call the tool directly.
+func TestToolInvoke_EagerToolNamesCorrectiveAction(t *testing.T) {
+	t.Parallel()
+	m := newPlainMCPServer(t)
+
+	text, isErr, callErr := m.CallTool(context.Background(), "cog_tool_invoke", []byte(`{"name":"cog_get_state","args":{}}`))
+	if callErr != nil {
+		t.Fatalf("unexpected transport error: %v", callErr)
+	}
+	if !isErr {
+		t.Fatalf("expected cog_get_state (eager, not in deferredHandlers) to be rejected via invoke; got text: %s", text)
+	}
+	if !g2ContainsAny(text, "is eager", "call it directly") {
+		t.Errorf("expected an eager-tool corrective message naming direct call; got: %s", text)
+	}
+	// Must NOT fall back to the generic unknown-name message — that's the
+	// whole point of the distinction.
+	if g2ContainsAny(text, "not in the deferred plumbing catalog") {
+		t.Errorf("eager-tool rejection should not reuse the generic unknown-name message; got: %s", text)
+	}
+}
+
+// ─── 8. cog_tool_invoke on an unknown/misspelled name suggests near matches ──
+
+// TestToolInvoke_UnknownNameSuggestsNearestMatches verifies the cheap-win
+// typo-correction addition: a name that is neither in m.deferredHandlers nor
+// a known eager tool keeps the original generic message, but gains up to 3
+// nearest-name suggestions from the full catalog so an operator/model with a
+// slightly-wrong name gets a corrective nudge instead of a dead end.
+func TestToolInvoke_UnknownNameSuggestsNearestMatches(t *testing.T) {
+	t.Parallel()
+	m := newPlainMCPServer(t)
+
+	// A near-miss on a real deferred tool name.
+	text, isErr, callErr := m.CallTool(context.Background(), "cog_tool_invoke", []byte(`{"name":"cog_read_ledgr","args":{}}`))
+	if callErr != nil {
+		t.Fatalf("unexpected transport error: %v", callErr)
+	}
+	if !isErr {
+		t.Fatalf("expected cog_read_ledgr (misspelled, unknown) to be rejected; got text: %s", text)
+	}
+	if !g2ContainsAny(text, "not in the deferred plumbing catalog") {
+		t.Errorf("expected the generic unknown-name message to still be present; got: %s", text)
+	}
+	if !g2ContainsAny(text, "did you mean", "cog_read_ledger") {
+		t.Errorf("expected a nearest-match suggestion including cog_read_ledger; got: %s", text)
+	}
+}
+
+// TestNearestToolNames_RanksClosestFirst is a focused unit test on the
+// suggestion-ranking helper itself, independent of the MCP transport.
+func TestNearestToolNames_RanksClosestFirst(t *testing.T) {
+	t.Parallel()
+	toolMeta := []mcpToolMeta{
+		{Name: "cog_read_ledger", Eager: false},
+		{Name: "cog_read_cogdoc", Eager: true},
+		{Name: "mod3_speak", Eager: false},
+	}
+
+	got := nearestToolNames(toolMeta, "cog_read_ledgr", 2)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 suggestions; got %v", got)
+	}
+	if got[0] != "cog_read_ledger" {
+		t.Errorf("closest match = %q; want cog_read_ledger", got[0])
+	}
+}
+
+// TestEagerToolExists_DistinguishesEagerFromDeferred pins the lookup helper
+// cog_tool_invoke's rejection path uses to decide which message to return.
+func TestEagerToolExists_DistinguishesEagerFromDeferred(t *testing.T) {
+	t.Parallel()
+	toolMeta := []mcpToolMeta{
+		{Name: "cog_get_state", Eager: true},
+		{Name: "cog_read_ledger", Eager: false},
+	}
+
+	if !eagerToolExists(toolMeta, "cog_get_state") {
+		t.Error("cog_get_state should be reported as an eager tool")
+	}
+	if eagerToolExists(toolMeta, "cog_read_ledger") {
+		t.Error("cog_read_ledger is deferred (Eager=false), should not be reported eager")
+	}
+	if eagerToolExists(toolMeta, "cog_does_not_exist") {
+		t.Error("a name absent from toolMeta entirely should not be reported eager")
 	}
 }

--- a/internal/engine/provider_openai.go
+++ b/internal/engine/provider_openai.go
@@ -25,9 +25,17 @@ import (
 const (
 	// openaiCompatDefaultEndpoint is the fallback endpoint when no Endpoint is
 	// configured and the COGOS_LLM_ENDPOINT environment variable is unset.
-	// Defaults to the Ollama loopback port; override via config or env for
-	// other servers (LM Studio on :1234, vLLM, llama.cpp, remote hosts, etc.).
-	openaiCompatDefaultEndpoint = "http://localhost:11434"
+	// Defaults to LM Studio's loopback port (the live local backend since
+	// PR #417 decommissioned Ollama's :11434 as the default — see
+	// provider_ollama.go's decommission header and router.go's
+	// probeLocalBackend/defaultProvidersConfig, both of which already probe
+	// LM Studio :1234 first). This constant had drifted back to Ollama's
+	// :11434 after that decommission, which meant a no-provider dispatch
+	// (resolveLocalLLMEndpoint -> NewOpenAICompatProvider) dead-ended
+	// connection-refused instead of reaching the resident LM Studio backend
+	// (flight review 2026-07-03 §5.2). Override via config or env for other
+	// servers (vLLM, llama.cpp, remote hosts, etc.).
+	openaiCompatDefaultEndpoint = "http://localhost:1234"
 	openaiCompatDefaultMaxToks  = 4096
 )
 
@@ -46,7 +54,7 @@ type OpenAICompatProvider struct {
 // NewOpenAICompatProvider creates an OpenAICompatProvider from a ProviderConfig.
 //
 // Endpoint resolution order: cfg.Endpoint > COGOS_LLM_ENDPOINT env >
-// openaiCompatDefaultEndpoint (localhost Ollama default). This lets users
+// openaiCompatDefaultEndpoint (localhost LM Studio default). This lets users
 // point at an arbitrary OpenAI-compatible server without editing config.
 func NewOpenAICompatProvider(name string, cfg ProviderConfig) *OpenAICompatProvider {
 	endpoint := resolveLocalLLMEndpoint(cfg.Endpoint)
@@ -258,8 +266,8 @@ type openaiToolCallDetail struct {
 
 // Non-streaming response.
 type openaiChatResponse struct {
-	ID      string              `json:"id"`
-	Choices []openaiChoice      `json:"choices"`
+	ID      string               `json:"id"`
+	Choices []openaiChoice       `json:"choices"`
 	Usage   *openaiUsageResponse `json:"usage,omitempty"`
 }
 
@@ -277,15 +285,15 @@ type openaiUsageResponse struct {
 
 // SSE streaming chunk.
 type openaiStreamChunk struct {
-	ID      string                   `json:"id"`
-	Choices []openaiStreamChoice     `json:"choices"`
-	Usage   *openaiUsageResponse     `json:"usage,omitempty"` // some servers send usage on final chunk
+	ID      string               `json:"id"`
+	Choices []openaiStreamChoice `json:"choices"`
+	Usage   *openaiUsageResponse `json:"usage,omitempty"` // some servers send usage on final chunk
 }
 
 type openaiStreamChoice struct {
-	Index        int                `json:"index"`
-	Delta        openaiStreamDelta  `json:"delta"`
-	FinishReason *string            `json:"finish_reason"` // pointer: null until final chunk
+	Index        int               `json:"index"`
+	Delta        openaiStreamDelta `json:"delta"`
+	FinishReason *string           `json:"finish_reason"` // pointer: null until final chunk
 }
 
 type openaiStreamDelta struct {


### PR DESCRIPTION
## Summary

Two small kernel DX fixes from the 2026-07-03 flight review (`flight-review.md` §5), ranked #2 and #4 in its fix list.

- **§5.2 — `cog_dispatch_to_harness` default endpoint.** `openaiCompatDefaultEndpoint` (`internal/engine/provider_openai.go`) had drifted back to Ollama's decommissioned `:11434` after PR #417 moved the default local backend to LM Studio (`lmstudio-darkstar`, `127.0.0.1:1234`). A no-provider dispatch that falls through to the legacy local-LLM probe (no explicit `provider`, no process-state route, no `harness_provider` config) resolved through this constant and dead-ended connection-refused against the tombstoned Ollama port. A solo offline model has no operator available to hand it a provider override, so this was a real dead end for unattended self-dispatch — reproduced live against the running kernel daemon before this fix (`last_reason: "local llm unavailable at http://localhost:11434 ... connection refused"`).

- **§5.4 — eager-vs-deferred at the `cog_tool_invoke` error surface.** Calling `cog_tool_invoke` on an EAGER tool (a porcelain tool never registered into `m.deferredHandlers`) returned the same generic "not in the deferred plumbing catalog" message as a genuinely unknown name. The flight model (gemma-4-26b) hit this twice in a row against `cog_get_state` before self-correcting. The eager case now names the fix inline; genuinely unknown names additionally get up to 3 nearest-name (Levenshtein) suggestions for typos.

Context: issues around #421 (adjacent flight-review follow-ups tracked separately).

## Verification

- Live-route check against a built binary on a scratch port + scratch workspace mirroring the real provider config (`~/workspaces/cog/.cog/config/providers*.yaml`): with process-state routing and `harness_provider` both absent (forcing the exact legacy-probe path the bug lived in), a no-provider dispatch now succeeds against LM Studio on `:1234` (`content: "pong"`, resolved model = the resident gemma-4-26b snapshot) instead of failing against `:11434`.
- The always-running kernel daemon on `:6931` was left untouched throughout (confirmed its stale in-memory cycle error still shows the pre-fix `:11434` failure, since it's running the old binary — expected, not restarted per instructions).

## Test plan

- [x] `gofmt -l` clean on all changed files
- [x] `go build ./...` (root module + `sdk/`)
- [x] `go test -tags fts5 ./...` (root module + `sdk/`) — all green
- [x] New regression test `TestResolveLocalLLMEndpointDefaultsToLMStudioNotOllama` pins the default to `:1234`
- [x] Extended `TestToolInvoke_*` family: `TestToolInvoke_EagerToolNamesCorrectiveAction`, `TestToolInvoke_UnknownNameSuggestsNearestMatches`, plus focused unit tests on the new `eagerToolExists`/`nearestToolNames` helpers
- [x] Live dispatch verification described above