### PR TITLE
fix(engine): propagate local-inference cancellation, bound timeouts/retries (#432)

### DIFF
--- a/internal/engine/agent_dispatch_query.go
+++ b/internal/engine/agent_dispatch_query.go
@@ -10,10 +10,21 @@ import (
 )
 
 // dispatchTimeoutDefault is the per-slot wall-clock budget when the caller
-// passed 0 or omitted the field. 30s comfortably covers the resident E4B's
-// 10-turn worst case at ~3s/turn while staying well under the
-// h.httpClient.Timeout (180s) so the inner HTTP call is the actual cap.
-const dispatchTimeoutDefault = 30
+// passed 0 or omitted the field.
+//
+// #432 forensics: the prior value here was 30s, sized for the resident E4B's
+// 10-turn worst case at ~3s/turn. That assumption broke once larger local
+// models joined the resident mix (Ornith 35B, gemma under concurrent-slot
+// prefill load per #430/#432) — real single-turn latency under load runs
+// 2-4 minutes, so a 30s ceiling canceled every such request client-side while
+// LM Studio kept generating server-side (non-streaming completions don't
+// abort on client cancel — see CompleteCancelSafeIfSupported/provider_openai.go),
+// and the retry that followed stacked a second zombie generation on top.
+// 240s covers the observed 2-4 min realistic worst case with headroom while
+// staying under dispatchTimeoutMax (300s) and h.httpClient.Timeout (which
+// providers.yaml should set to at least this value for local endpoints —
+// see NewOpenAICompatProvider's timeout resolution).
+const dispatchTimeoutDefault = 240
 
 // dispatchTimeoutMax caps the per-slot budget. 300s accommodates cold-start
 // load of larger local models (gemma4:e4b at ~110s on M4 Pro) plus the

--- a/internal/engine/agent_dispatch_query_test.go
+++ b/internal/engine/agent_dispatch_query_test.go
@@ -44,8 +44,14 @@ func TestQueryDispatchToHarness_NormalizationDefaults(t *testing.T) {
 	if got.Model != DispatchModelE4B {
 		t.Errorf("Model default not applied, got %q", got.Model)
 	}
-	if got.TimeoutSeconds != 30 {
-		t.Errorf("TimeoutSeconds default not applied, got %d", got.TimeoutSeconds)
+	// #432: default raised from 30s to dispatchTimeoutDefault (240s) — a 30s
+	// ceiling canceled every request under realistic local-model latency
+	// (2-4 min under prefill load), and the non-streaming call underneath
+	// didn't even abort server-side on that cancel. Assert against the named
+	// constant so this test tracks intentional future changes to the default
+	// rather than re-pinning a magic number.
+	if got.TimeoutSeconds != dispatchTimeoutDefault {
+		t.Errorf("TimeoutSeconds default not applied, got %d, want %d", got.TimeoutSeconds, dispatchTimeoutDefault)
 	}
 	if got.N != 1 {
 		t.Errorf("N default not applied, got %d", got.N)

--- a/internal/engine/autonomic_ticker.go
+++ b/internal/engine/autonomic_ticker.go
@@ -40,9 +40,9 @@ import (
 // avoid log spam. Recovery (a successful reconcile) resets the counter.
 var (
 	healBackoffMu      sync.Mutex
-	healBackoffFails   = map[string]int{}    // consecutive failure count per provider
-	healBackoffSkipsAt = map[string]int{}    // tick count at which backoff expires
-	healTickCount      int                   // monotonic tick counter
+	healBackoffFails   = map[string]int{} // consecutive failure count per provider
+	healBackoffSkipsAt = map[string]int{} // tick count at which backoff expires
+	healTickCount      int                // monotonic tick counter
 )
 
 const (
@@ -73,9 +73,20 @@ const defaultIdleRecheckIn = 1 * time.Hour
 
 // KernelHealthSnapshot is the aggregate view produced each tick.
 type KernelHealthSnapshot struct {
-	Timestamp time.Time                         `json:"timestamp"`
+	Timestamp time.Time                           `json:"timestamp"`
 	Providers map[string]reconcile.ResourceStatus `json:"providers"`
-	Counts    HealthCounts                      `json:"counts"`
+	Counts    HealthCounts                        `json:"counts"`
+	// Anomalies is the count of abandoned/canceled internal inference calls
+	// (#432) observed since the previous tick. Distinct from the per-provider
+	// Health buckets below: a canceled inference is a control-loop event, not
+	// a provider health state, but the incident this closes ran with vitals
+	// reading 0anom for hours because nothing folded the WARN-logged
+	// cancellations into a counted, tick-visible signal. Zero on a tick where
+	// nothing was abandoned.
+	Anomalies int `json:"anomalies"`
+	// AnomaliesTotal is the cumulative count since process start, carried for
+	// post-hoc audit alongside the per-tick delta above.
+	AnomaliesTotal int64 `json:"anomalies_total"`
 }
 
 // HealthCounts is the four-bucket summary.
@@ -86,11 +97,15 @@ type HealthCounts struct {
 	Suspended int `json:"suspended"`
 }
 
-// AllGreen reports whether every provider is Synced/Healthy/(Idle or empty).
-// A snapshot with zero providers is considered green — the ticker should only
-// escalate when something is observably wrong, not when the registry is empty.
+// AllGreen reports whether every provider is Synced/Healthy/(Idle or empty)
+// AND no inference was abandoned/canceled this tick. A snapshot with zero
+// providers is considered green on the provider axis — the ticker should
+// only escalate when something is observably wrong, not when the registry
+// is empty. Anomalies still gate green even with zero providers: #432's
+// incident is exactly "provider health looked fine, requests were dying
+// unnoticed."
 func (s KernelHealthSnapshot) AllGreen() bool {
-	return s.Counts.Degraded == 0 && s.Counts.Missing == 0 && s.Counts.Suspended == 0
+	return s.Counts.Degraded == 0 && s.Counts.Missing == 0 && s.Counts.Suspended == 0 && s.Anomalies == 0
 }
 
 // HasOperationInProgress reports whether any provider is currently running an
@@ -147,6 +162,14 @@ func buildKernelHealthSnapshot(ctx context.Context) KernelHealthSnapshot {
 		Providers: make(map[string]reconcile.ResourceStatus),
 	}
 
+	// Fold abandoned/canceled inference (#432) into every snapshot,
+	// regardless of provider registry state — this is a control-loop signal,
+	// not a per-provider one, and must not be skipped by the empty-registry
+	// early return below.
+	total, delta := abandonedInferenceSnapshot()
+	snap.Anomalies = int(delta)
+	snap.AnomaliesTotal = total
+
 	names := reconcile.ListProviders()
 	if len(names) == 0 {
 		return snap
@@ -176,10 +199,11 @@ func buildKernelHealthSnapshot(ctx context.Context) KernelHealthSnapshot {
 type escalationReason string
 
 const (
-	escalateDegradedHealth   escalationReason = "degraded_health"
-	escalateOutOfSync        escalationReason = "out_of_sync"
-	escalateExplicitTrigger  escalationReason = "explicit_trigger"
-	escalateIdleRecheckIn    escalationReason = "idle_recheckin"
+	escalateDegradedHealth     escalationReason = "degraded_health"
+	escalateAbandonedInference escalationReason = "abandoned_inference"
+	escalateOutOfSync          escalationReason = "out_of_sync"
+	escalateExplicitTrigger    escalationReason = "explicit_trigger"
+	escalateIdleRecheckIn      escalationReason = "idle_recheckin"
 )
 
 // shouldEscalate returns a non-empty reason if the tick should route to the
@@ -187,7 +211,15 @@ const (
 // work. triggerPending is true when an external TriggerAgent call has been
 // queued; lastLLMCycle is the wall-clock time the last LLM cycle ran.
 func shouldEscalate(snap KernelHealthSnapshot, triggerPending bool, lastLLMCycle time.Time, cfg AutonomicConfig) escalationReason {
-	// Health degradation is the highest-priority signal.
+	// Abandoned/canceled inference (#432) is reported distinctly from
+	// provider-health degradation even though both fail AllGreen() — it's a
+	// control-loop event (a request the kernel gave up on), not a provider
+	// reporting itself unhealthy, and the two want different operator/agent
+	// framing in logs and dedupe fingerprints.
+	if snap.Anomalies > 0 {
+		return escalateAbandonedInference
+	}
+	// Health degradation is the next-highest-priority signal.
 	if !snap.AllGreen() {
 		return escalateDegradedHealth
 	}

--- a/internal/engine/autonomic_ticker_test.go
+++ b/internal/engine/autonomic_ticker_test.go
@@ -251,14 +251,24 @@ func TestBuildKernelHealthSnapshot_EmptyRegistry(t *testing.T) {
 
 // --- Ticker integration tests -----------------------------------------------
 
-// openaiAssessResponse writes a valid OpenAI-compat response for the assess step.
-func openaiAssessResponse(w http.ResponseWriter, action string) {
+// openaiAssessResponse writes a valid OpenAI-compat response for the assess
+// step, honoring the request's stream field. #432: assessCycle now routes
+// through CompleteCancelSafe (Stream under the hood), so a mock that always
+// returns a plain JSON body regardless of stream:true would silently produce
+// an empty response for that call.
+func openaiAssessResponse(t *testing.T, w http.ResponseWriter, r *http.Request, action string) {
+	t.Helper()
+	content := `{"action":"` + action + `","reason":"test","urgency":0.1,"target":"","task":""}`
+	if requestWantsStream(r) {
+		writeSSECompletion(t, w, content)
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{
 		"choices": []map[string]any{{
 			"message": map[string]any{
 				"role":    "assistant",
-				"content": `{"action":"` + action + `","reason":"test","urgency":0.1,"target":"","task":""}`,
+				"content": content,
 			},
 			"finish_reason": "stop",
 		}},
@@ -266,8 +276,14 @@ func openaiAssessResponse(w http.ResponseWriter, action string) {
 	})
 }
 
-// openaiExecuteResponse writes a valid OpenAI-compat response for the execute step.
-func openaiExecuteResponse(w http.ResponseWriter) {
+// openaiExecuteResponse writes a valid OpenAI-compat response for the execute
+// step, honoring the request's stream field (see openaiAssessResponse).
+func openaiExecuteResponse(t *testing.T, w http.ResponseWriter, r *http.Request) {
+	t.Helper()
+	if requestWantsStream(r) {
+		writeSSECompletion(t, w, "done")
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{
 		"choices": []map[string]any{{
@@ -281,16 +297,27 @@ func openaiExecuteResponse(w http.ResponseWriter) {
 	})
 }
 
+// requestWantsStream peeks at the request body's stream field without
+// consuming it for downstream handlers (each caller here only reads the
+// body once, so a simple decode is sufficient).
+func requestWantsStream(r *http.Request) bool {
+	var body struct {
+		Stream bool `json:"stream"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&body)
+	return body.Stream
+}
+
 // ollamaAssessResponse is kept for backward compat with any callers that have
 // not yet been migrated; Ollama is decommissioned.
-func ollamaAssessResponse(w http.ResponseWriter, action string) {
-	openaiAssessResponse(w, action)
+func ollamaAssessResponse(t *testing.T, w http.ResponseWriter, r *http.Request, action string) {
+	openaiAssessResponse(t, w, r, action)
 }
 
 // ollamaExecuteResponse is kept for backward compat with any callers that have
 // not yet been migrated; Ollama is decommissioned.
-func ollamaExecuteResponse(w http.ResponseWriter) {
-	openaiExecuteResponse(w)
+func ollamaExecuteResponse(t *testing.T, w http.ResponseWriter, r *http.Request) {
+	openaiExecuteResponse(t, w, r)
 }
 
 // TestAutonomicTickerAllGreenNoLLM verifies that with an all-green registry
@@ -369,10 +396,10 @@ func TestAutonomicTickerDegradedEscalates(t *testing.T) {
 		case "/v1/chat/completions":
 			callCount++
 			if callCount == 1 {
-				openaiAssessResponse(w, "observe")
+				openaiAssessResponse(t, w, r, "observe")
 				return
 			}
-			openaiExecuteResponse(w)
+			openaiExecuteResponse(t, w, r)
 		default:
 			// Silently ignore unexpected probes (e.g. Ollama /api/tags probe).
 			w.WriteHeader(http.StatusNotFound)
@@ -444,7 +471,7 @@ func TestAutonomicTickerIdleRecheckIn(t *testing.T) {
 			})
 		case "/v1/chat/completions":
 			callCount++
-			openaiAssessResponse(w, "sleep")
+			openaiAssessResponse(t, w, r, "sleep")
 		default:
 			// Silently ignore unexpected probes (e.g. Ollama /api/tags probe).
 			w.WriteHeader(http.StatusNotFound)

--- a/internal/engine/context_blocks_health_test.go
+++ b/internal/engine/context_blocks_health_test.go
@@ -63,6 +63,15 @@ var healthRegistryMu sync.Mutex
 // withProviders sets up the global reconcile registry with the supplied
 // providers, runs fn, and resets the registry at the end. NOT safe for
 // t.Parallel() — uses a package-level mutex.
+//
+// Also resets the #432 abandoned-inference delta baseline before fn runs.
+// buildKernelHealthSnapshot folds that process-global counter into
+// snap.Anomalies (and AllGreen()/shouldEscalate consult it), so an unrelated
+// test elsewhere in the package that legitimately hits an error path through
+// CompleteCancelSafeIfSupported (e.g. a dispatch test asserting a provider
+// failure) would otherwise leak a nonzero delta into whichever test next
+// calls buildKernelHealthSnapshot — exactly the kind of cross-test pollution
+// this fixture already guards against for the provider registry.
 func withProviders(t *testing.T, providers []*stubProvider, fn func()) {
 	t.Helper()
 	healthRegistryMu.Lock()
@@ -70,6 +79,7 @@ func withProviders(t *testing.T, providers []*stubProvider, fn func()) {
 
 	reconcile.ResetProviders()
 	defer reconcile.ResetProviders()
+	resetAbandonedInferenceCounterForTest()
 
 	for _, p := range providers {
 		reconcile.RegisterProvider(p.name, p)

--- a/internal/engine/dashboard_inlet_test.go
+++ b/internal/engine/dashboard_inlet_test.go
@@ -295,33 +295,36 @@ func TestDashboardInletFallbackFires(t *testing.T) {
 			})
 		case "/v1/chat/completions":
 			seq := callSeq.Add(1)
-			w.Header().Set("Content-Type", "application/json")
-			switch seq {
-			case 1:
-				// Assess: observe action (not respond) — agent will not call respond tool.
-				_ = json.NewEncoder(w).Encode(map[string]any{
-					"choices": []map[string]any{{
-						"message": map[string]any{
-							"role":    "assistant",
-							"content": `{"action":"observe","reason":"checking field state","urgency":0.3,"target":"memory","task":"scan recent events"}`,
-						},
-						"finish_reason": "stop",
-					}},
-					"usage": map[string]any{"prompt_tokens": 10, "completion_tokens": 20},
-				})
-			default:
-				// Execute: returns plain text, no tool calls.
-				_ = json.NewEncoder(w).Encode(map[string]any{
-					"choices": []map[string]any{{
-						"message": map[string]any{
-							"role":    "assistant",
-							"content": fmt.Sprintf("observation complete for cycle %d", seq),
-						},
-						"finish_reason": "stop",
-					}},
-					"usage": map[string]any{"prompt_tokens": 5, "completion_tokens": 10},
-				})
+			// #432: assessCycle/executeCycleTaskWithPrompt route through
+			// CompleteCancelSafe (Stream under the hood) now, so honor the
+			// request's stream field like a real openai-compat server.
+			var body struct {
+				Stream bool `json:"stream"`
 			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			var content string
+			if seq == 1 {
+				// Assess: observe action (not respond) — agent will not call respond tool.
+				content = `{"action":"observe","reason":"checking field state","urgency":0.3,"target":"memory","task":"scan recent events"}`
+			} else {
+				// Execute: returns plain text, no tool calls.
+				content = fmt.Sprintf("observation complete for cycle %d", seq)
+			}
+			if body.Stream {
+				writeSSECompletion(t, w, content)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"choices": []map[string]any{{
+					"message": map[string]any{
+						"role":    "assistant",
+						"content": content,
+					},
+					"finish_reason": "stop",
+				}},
+				"usage": map[string]any{"prompt_tokens": 10, "completion_tokens": 20},
+			})
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}

--- a/internal/engine/inference_inflight.go
+++ b/internal/engine/inference_inflight.go
@@ -1,0 +1,117 @@
+// inference_inflight.go — retry-dedup and anomaly surfacing for #432
+// (local-inference cancellation propagation / abandoned-generation zombies).
+//
+// Two mechanisms, both process-local (in-memory, not persisted):
+//
+//  1. In-flight request tracking keyed by RequestMetadata.RequestID. Callers
+//     that may be resubmitted (autonomic consult, dispatch, tool-loop
+//     re-calls) register their RequestID for the duration of the call and
+//     refuse a second registration under the same ID. This is the "never
+//     resubmit while a prior attempt may still be generating" retry
+//     discipline from #432's expected-fixes list. Request IDs in this
+//     codebase are already content-stable where it matters (dispatchSlot
+//     hashes systemPrompt+task+tool-names into the ID specifically for
+//     KV-cache sharing across fan-out slots), so this doubles as dedup for a
+//     genuine retry of identical work.
+//
+//  2. Abandoned-inference anomaly counting. #432's forensics: the incident
+//     ran with kernel vitals reading 0err/0anom for hours while a request sat
+//     abandoned server-side — the only trace was a WARN log line nobody was
+//     watching. recordAbandonedInference increments a counter that
+//     buildKernelHealthSnapshot folds into the next autonomic tick's
+//     HealthCounts, so an abandoned/canceled inference is visible in the
+//     same proprioceptive surface (bus_kernel_proprio) operators and the
+//     autonomic loop already watch, not just in logs.
+package engine
+
+import (
+	"log/slog"
+	"sync"
+	"sync/atomic"
+)
+
+// inflightRequests tracks RequestIDs currently executing a cancel-safe
+// completion call. Empty-string IDs are never tracked (some call sites,
+// e.g. ad hoc internal completions, may not set one) — dedup only applies
+// where the caller has opted in with a real identity.
+var inflightRequests sync.Map // map[string]struct{}
+
+// beginInflightInference registers requestID as in-flight. Returns false if
+// the ID is already registered (a prior attempt under the same identity may
+// still be generating server-side) — the caller must not proceed.
+func beginInflightInference(requestID string) bool {
+	if requestID == "" {
+		return true
+	}
+	_, loaded := inflightRequests.LoadOrStore(requestID, struct{}{})
+	if loaded {
+		slog.Warn("inference: retry refused, request already in flight",
+			"request_id", requestID,
+		)
+		return false
+	}
+	return true
+}
+
+// endInflightInference releases requestID. Safe to call even if
+// beginInflightInference returned false or was never called (no-op on a
+// missing key).
+func endInflightInference(requestID string) {
+	if requestID == "" {
+		return
+	}
+	inflightRequests.Delete(requestID)
+}
+
+// abandonedInferenceCount is incremented every time an internal,
+// non-interactive inference call returns an error that traces back to
+// context cancellation/deadline (or, conservatively, any error from a
+// cancel-safe call site, since a mid-stream error after partial generation
+// is the same "we gave up on a request the server may still be working"
+// shape). Read by buildKernelHealthSnapshot so the next autonomic tick
+// surfaces it as an anomaly rather than only a WARN log line (#432).
+var abandonedInferenceCount atomic.Int64
+
+// recordAbandonedInference logs and counts an abandoned/canceled internal
+// inference call. site identifies the call site (e.g. "local-harness-assess",
+// "chat-complete") for log correlation; requestID may be empty.
+func recordAbandonedInference(site, requestID string, err error) {
+	abandonedInferenceCount.Add(1)
+	slog.Warn("inference: request abandoned or canceled",
+		"site", site,
+		"request_id", requestID,
+		"err", err,
+	)
+}
+
+// abandonedInferenceSnapshot returns the current cumulative count of
+// abandoned/canceled internal inference calls since process start, and the
+// delta since the last call to this function (used by
+// buildKernelHealthSnapshot to report a per-tick anomaly count while
+// AbandonedInferenceTotal keeps a running total for post-hoc audit).
+var lastAbandonedInferenceSnapshot atomic.Int64
+
+func abandonedInferenceSnapshot() (total int64, delta int64) {
+	total = abandonedInferenceCount.Load()
+	prev := lastAbandonedInferenceSnapshot.Swap(total)
+	delta = total - prev
+	if delta < 0 {
+		delta = 0
+	}
+	return total, delta
+}
+
+// resetAbandonedInferenceCounterForTest zeroes the abandoned-inference delta
+// baseline so a test that asserts an exact anomaly count (including zero,
+// i.e. AllGreen()) is not affected by unrelated tests elsewhere in the
+// package that legitimately exercise an error path through
+// CompleteCancelSafeIfSupported call sites (recordAbandonedInference is a
+// process-global counter by design — the production consumer is "whatever
+// accumulated since the last autonomic tick" — but that same global-since-
+// last-read semantic makes cross-test pollution possible when many
+// unrelated tests call buildKernelHealthSnapshot directly instead of going
+// through the ticker). Test-only; not used by production code paths.
+func resetAbandonedInferenceCounterForTest() {
+	total := abandonedInferenceCount.Load()
+	lastAbandonedInferenceSnapshot.Store(total)
+}

--- a/internal/engine/inference_inflight_test.go
+++ b/internal/engine/inference_inflight_test.go
@@ -1,0 +1,88 @@
+// inference_inflight_test.go — retry-dedup and anomaly-counting tests (#432)
+package engine
+
+import (
+	"testing"
+)
+
+// TestBeginInflightInferenceDedupesConcurrentRequestID verifies the core
+// retry-discipline guarantee from #432: a second beginInflightInference call
+// under the same non-empty RequestID is refused while the first is still
+// registered, so a caller cannot resubmit a request whose prior attempt may
+// still be generating server-side.
+func TestBeginInflightInferenceDedupesConcurrentRequestID(t *testing.T) {
+	const id = "test-request-dedupe-1"
+	t.Cleanup(func() { endInflightInference(id) })
+
+	if !beginInflightInference(id) {
+		t.Fatal("first beginInflightInference should succeed")
+	}
+	if beginInflightInference(id) {
+		t.Error("second beginInflightInference under the same ID should be refused while the first is in flight")
+	}
+}
+
+// TestBeginInflightInferenceAllowsResubmitAfterEnd verifies that once a
+// request completes (endInflightInference releases the ID), the same
+// RequestID can be legitimately reused — dedup only blocks concurrent
+// overlap, not sequential retries of a completed attempt.
+func TestBeginInflightInferenceAllowsResubmitAfterEnd(t *testing.T) {
+	const id = "test-request-dedupe-2"
+
+	if !beginInflightInference(id) {
+		t.Fatal("first beginInflightInference should succeed")
+	}
+	endInflightInference(id)
+
+	if !beginInflightInference(id) {
+		t.Error("beginInflightInference should succeed again after the prior attempt ended")
+	}
+	endInflightInference(id)
+}
+
+// TestBeginInflightInferenceIgnoresEmptyRequestID verifies that call sites
+// which don't set a RequestID (empty string) are never deduped against each
+// other — dedup only applies where the caller opted in with a real identity.
+func TestBeginInflightInferenceIgnoresEmptyRequestID(t *testing.T) {
+	if !beginInflightInference("") {
+		t.Error("beginInflightInference(\"\") should always succeed")
+	}
+	if !beginInflightInference("") {
+		t.Error("beginInflightInference(\"\") should always succeed, even called twice")
+	}
+	// No cleanup needed: empty ID is never tracked.
+}
+
+// TestRecordAbandonedInferenceIncrementsSnapshotDelta verifies that
+// recordAbandonedInference's count is visible via abandonedInferenceSnapshot
+// as a delta since the last read, and that the delta resets to zero once
+// consumed (mirroring how buildKernelHealthSnapshot reads it once per tick).
+func TestRecordAbandonedInferenceIncrementsSnapshotDelta(t *testing.T) {
+	// Baseline read to zero out any delta left by other tests sharing the
+	// package-level counter (tests in this package do not run in parallel
+	// with each other for this counter by convention — see below).
+	_, _ = abandonedInferenceSnapshot()
+
+	recordAbandonedInference("test-site", "req-1", errCanceledForTest{})
+	recordAbandonedInference("test-site", "req-2", errCanceledForTest{})
+
+	total, delta := abandonedInferenceSnapshot()
+	if delta != 2 {
+		t.Errorf("delta = %d; want 2", delta)
+	}
+	if total < 2 {
+		t.Errorf("total = %d; want >= 2", total)
+	}
+
+	// A second read with no new abandonment in between must report zero delta.
+	_, delta2 := abandonedInferenceSnapshot()
+	if delta2 != 0 {
+		t.Errorf("delta2 = %d; want 0 (no new abandonment since last read)", delta2)
+	}
+}
+
+// errCanceledForTest is a minimal error implementation for
+// recordAbandonedInference test calls.
+type errCanceledForTest struct{}
+
+func (errCanceledForTest) Error() string { return "canceled for test" }

--- a/internal/engine/local_agent_harness.go
+++ b/internal/engine/local_agent_harness.go
@@ -623,6 +623,8 @@ func (c *LocalHarnessController) autonomicTick(ctx context.Context) {
 		"providers", len(snap.Providers),
 		"degraded", snap.Counts.Degraded,
 		"missing", snap.Counts.Missing,
+		"anomalies", snap.Anomalies,
+		"anomalies_total", snap.AnomaliesTotal,
 	)
 	c.tryStartCycle(string(reason), 0, nil)
 
@@ -858,7 +860,18 @@ func (c *LocalHarnessController) finishCycle(record localHarnessCycleRecord) {
 
 func (c *LocalHarnessController) assessCycle(ctx context.Context, provider Provider, observation string) (*localHarnessAssessment, error) {
 	temp := 0.0
-	resp, err := provider.Complete(ctx, &CompletionRequest{
+	requestID := fmt.Sprintf("local-harness-assess-%d", time.Now().UnixNano())
+	// Cancel-safe (#432): this is the hourly/degraded-health autonomic consult
+	// path identified as the "Generated prediction" (non-streaming)
+	// zombie-capable class. Route through streaming so a ctx cancel/timeout
+	// actually aborts generation server-side instead of running headless.
+	// Track the request as in-flight for the duration of the call so a
+	// resubmit racing this one is refused (retry dedup, #432 item d).
+	if !beginInflightInference(requestID) {
+		return nil, fmt.Errorf("local-harness: assess request %s already in flight", requestID)
+	}
+	defer endInflightInference(requestID)
+	resp, err := CompleteCancelSafeIfSupported(ctx, provider, &CompletionRequest{
 		SystemPrompt: localHarnessAssessPrompt,
 		Messages: []ProviderMessage{
 			{Role: "user", Content: observation},
@@ -866,12 +879,13 @@ func (c *LocalHarnessController) assessCycle(ctx context.Context, provider Provi
 		MaxTokens:   localHarnessAssessMaxToks,
 		Temperature: &temp,
 		Metadata: RequestMetadata{
-			RequestID:   fmt.Sprintf("local-harness-assess-%d", time.Now().UnixNano()),
+			RequestID:   requestID,
 			PreferLocal: true,
 			Source:      "local-harness",
 		},
 	})
 	if err != nil {
+		recordAbandonedInference("local-harness-assess", requestID, err)
 		return nil, err
 	}
 
@@ -1807,8 +1821,23 @@ func (c *LocalHarnessController) dispatchSlot(parent context.Context, provider P
 }
 
 func (c *LocalHarnessController) completeWithToolLoop(ctx context.Context, provider Provider, req *CompletionRequest, registry *KernelToolRegistry) (*CompletionResponse, []ToolCall, []ToolCallRecord, error) {
-	resp, err := provider.Complete(ctx, req)
+	requestID := req.Metadata.RequestID
+	// Cancel-safe + dedup (#432): dispatch is the other non-interactive,
+	// non-streaming call site the incident identified. Refuse to start a
+	// second attempt under the same content-stable request identity while a
+	// prior one may still be generating server-side (retry discipline, #432
+	// item d); the content-stable RequestID (sha256 of prompt+task+tools,
+	// see dispatchSlot) means a genuine resubmit of the same work collides
+	// here rather than stacking a second server-side generation.
+	if requestID != "" && !beginInflightInference(requestID) {
+		return nil, nil, nil, fmt.Errorf("local-harness: dispatch request %s already in flight", requestID)
+	}
+	if requestID != "" {
+		defer endInflightInference(requestID)
+	}
+	resp, err := CompleteCancelSafeIfSupported(ctx, provider, req)
 	if err != nil {
+		recordAbandonedInference("local-harness-dispatch", requestID, err)
 		return nil, nil, nil, err
 	}
 	if len(resp.ToolCalls) == 0 {
@@ -1825,6 +1854,21 @@ type countingProvider struct {
 func (p *countingProvider) Complete(ctx context.Context, req *CompletionRequest) (*CompletionResponse, error) {
 	p.completeCalls.Add(1)
 	return p.Provider.Complete(ctx, req)
+}
+
+// CompleteCancelSafe delegates to the embedded provider's CompleteCancelSafe
+// when it implements CancelSafeCompleter. Required so CompleteCancelSafeIfSupported
+// (#432) can still route dispatch calls through the cancel-safe path:
+// countingProvider embeds Provider (the interface), and Go only promotes
+// methods declared on that static interface type — CompleteCancelSafe isn't
+// one of them, so without this override a *countingProvider wrapping a
+// cancel-safe-capable *OpenAICompatProvider would silently fall back to
+// plain Complete, reintroducing the zombie-generation risk specifically on
+// the dispatch path (dispatchSlot always wraps its provider in
+// countingProvider to track turn counts).
+func (p *countingProvider) CompleteCancelSafe(ctx context.Context, req *CompletionRequest) (*CompletionResponse, error) {
+	p.completeCalls.Add(1)
+	return CompleteCancelSafeIfSupported(ctx, p.Provider, req)
 }
 
 func (p *countingProvider) CompleteCalls() int {

--- a/internal/engine/local_agent_harness_test.go
+++ b/internal/engine/local_agent_harness_test.go
@@ -3,11 +3,15 @@ package engine
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestLocalHarnessControllerTriggerAndList(t *testing.T) {
@@ -29,25 +33,29 @@ func TestLocalHarnessControllerTriggerAndList(t *testing.T) {
 			})
 		case "/v1/chat/completions":
 			call++
-			w.Header().Set("Content-Type", "application/json")
+			// #432: assessCycle/executeCycleTaskWithPrompt now route through
+			// CompleteCancelSafe (Stream under the hood) so a ctx cancel/
+			// timeout actually aborts generation server-side. Honor the
+			// request's stream field like a real openai-compat server so
+			// this mock exercises the same path production traffic takes.
+			var body struct {
+				Stream bool `json:"stream"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			content := "local harness executed"
 			if call == 1 {
-				_ = json.NewEncoder(w).Encode(map[string]any{
-					"choices": []map[string]any{{
-						"message": map[string]any{
-							"role":    "assistant",
-							"content": `{"action":"observe","reason":"field changed","urgency":0.4,"target":"memory","task":"summarize current state"}`,
-						},
-						"finish_reason": "stop",
-					}},
-					"usage": map[string]any{"prompt_tokens": 1, "completion_tokens": 1},
-				})
+				content = `{"action":"observe","reason":"field changed","urgency":0.4,"target":"memory","task":"summarize current state"}`
+			}
+			if body.Stream {
+				writeSSECompletion(t, w, content)
 				return
 			}
+			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"choices": []map[string]any{{
 					"message": map[string]any{
 						"role":    "assistant",
-						"content": "local harness executed",
+						"content": content,
 					},
 					"finish_reason": "stop",
 				}},
@@ -96,6 +104,85 @@ func TestLocalHarnessControllerTriggerAndList(t *testing.T) {
 	}
 	if snap.Traces[0].Result != "local harness executed" {
 		t.Fatalf("trace result = %q; want local harness executed", snap.Traces[0].Result)
+	}
+}
+
+// TestLocalHarnessAutonomicConsult_SetsMaxTokensBound verifies #432 item (c):
+// internal non-interactive consults (the autonomic assess step here) must
+// carry a bounded max_tokens on the wire even when the provider itself would
+// otherwise apply a larger default — bounded generation must hold even if
+// cancellation fails to propagate for any reason. Asserts the wire-level
+// request body, not just the CompletionRequest struct field, so a bug in
+// marshaling (e.g. buildOpenAIRequest's maxTokens precedence) would be
+// caught here too.
+func TestLocalHarnessAutonomicConsult_SetsMaxTokensBound(t *testing.T) {
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	cfg.LocalModel = "gemma4:e4b"
+	proc := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	srv := NewServer(cfg, makeNucleus("Cog", "tester"), proc)
+
+	var assessMaxTokens int
+	var sawAssessCall bool
+	model := "gemma4:e4b"
+	llm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/models":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"object": "list",
+				"data":   []map[string]any{{"id": model, "object": "model"}},
+			})
+		case "/v1/chat/completions":
+			var body struct {
+				Stream    bool `json:"stream"`
+				MaxTokens int  `json:"max_tokens"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if !sawAssessCall {
+				sawAssessCall = true
+				assessMaxTokens = body.MaxTokens
+			}
+			content := `{"action":"sleep","reason":"idle","urgency":0.0,"target":"","task":""}`
+			if body.Stream {
+				writeSSECompletion(t, w, content)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"choices": []map[string]any{{
+					"message":       map[string]any{"role": "assistant", "content": content},
+					"finish_reason": "stop",
+				}},
+				"usage": map[string]any{"prompt_tokens": 1, "completion_tokens": 1},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer llm.Close()
+	t.Setenv(localLLMEndpointEnv, llm.URL)
+
+	ctrl, err := NewLocalHarnessController(cfg, makeNucleus("Cog", "tester"), proc, srv.mcpServer)
+	if err != nil {
+		t.Fatalf("NewLocalHarnessController: %v", err)
+	}
+
+	res, err := ctrl.TriggerAgent(context.Background(), DefaultAgentID, "test", true)
+	if err != nil {
+		t.Fatalf("TriggerAgent: %v", err)
+	}
+	if !res.Triggered {
+		t.Fatalf("expected triggered=true, got %+v", res)
+	}
+	if !sawAssessCall {
+		t.Fatal("assess call was never observed by the mock server")
+	}
+	if assessMaxTokens != localHarnessAssessMaxToks {
+		t.Errorf("assess call max_tokens on the wire = %d; want %d (localHarnessAssessMaxToks)", assessMaxTokens, localHarnessAssessMaxToks)
+	}
+	if assessMaxTokens <= 0 {
+		t.Error("assess call must carry a bounded (>0) max_tokens even when cancellation fails to propagate")
 	}
 }
 
@@ -1458,5 +1545,131 @@ func TestDispatchToHarness_ProviderCannotServeModel_FailsLoudly(t *testing.T) {
 	}
 	if res.ServedModel != "" {
 		t.Errorf("ServedModel = %q; want empty on a failed dispatch (nothing actually served)", res.ServedModel)
+	}
+}
+
+// TestDispatchToHarness_ConcurrentIdenticalDispatchIsDeduped is the #432
+// retry-discipline regression test: dispatchSlot's RequestID is a
+// content-stable hash of systemPrompt+task+tool-names (for KV-cache sharing
+// across fan-out slots per ADR-066), which means two independent
+// DispatchToHarness(..., N:1) calls carrying identical content produce the
+// same RequestID — exactly the shape of a client resubmitting a request
+// whose prior attempt may still be generating server-side. The second
+// concurrent call must be refused rather than starting a second server-side
+// generation under the same identity.
+// TestCompleteWithToolLoop_ConcurrentSameRequestIDIsDeduped is the #432
+// retry-discipline regression test at the layer where the guard actually
+// lives: completeWithToolLoop refuses a second call under the same
+// RequestMetadata.RequestID while the first is still in flight, so a caller
+// resubmitting a request whose prior attempt may still be generating
+// server-side collides with the guard instead of stacking a second
+// generation. Exercised directly against completeWithToolLoop (rather than
+// through DispatchToHarness, whose c.ollamaMu batch-level mutex already
+// fully serializes local-provider dispatches and so would never let two
+// calls race at this layer) to isolate exactly the mechanism under test.
+func TestCompleteWithToolLoop_ConcurrentSameRequestIDIsDeduped(t *testing.T) {
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+
+	// releaseFirst gates the first request's stream completion so the second
+	// (duplicate) call has a window to arrive while the first is still
+	// registered in-flight.
+	releaseFirst := make(chan struct{})
+	var firstArrived sync.WaitGroup
+	firstArrived.Add(1)
+	var firstArrivedOnce sync.Once
+
+	llm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/models":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"object": "list",
+				"data":   []map[string]any{{"id": "gemma4:e4b", "object": "model"}},
+			})
+		case "/v1/chat/completions":
+			firstArrivedOnce.Do(func() { firstArrived.Done() })
+			w.Header().Set("Content-Type", "text/event-stream")
+			flusher := w.(http.Flusher)
+			fmt.Fprint(w, "data: {\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"partial\"}}]}\n\n")
+			flusher.Flush()
+			// Hold the stream open until the test releases it, simulating a
+			// long-running generation the second call would race against.
+			<-releaseFirst
+			fmt.Fprint(w, "data: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n")
+			fmt.Fprint(w, "data: [DONE]\n\n")
+			flusher.Flush()
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer llm.Close()
+	t.Setenv(localLLMEndpointEnv, llm.URL)
+
+	proc := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	srv := NewServer(cfg, makeNucleus("Cog", "tester"), proc)
+	ctrl, err := NewLocalHarnessController(cfg, makeNucleus("Cog", "tester"), proc, srv.mcpServer)
+	if err != nil {
+		t.Fatalf("NewLocalHarnessController: %v", err)
+	}
+
+	provider := NewOpenAICompatProvider("agent-local", ProviderConfig{
+		Endpoint: llm.URL,
+		Model:    "gemma4:e4b",
+		Timeout:  10,
+	})
+	registry := NewKernelToolRegistry(srv.mcpServer)
+
+	const sharedRequestID = "local-harness-dispatch-dedup-test-0"
+	makeReq := func() *CompletionRequest {
+		return &CompletionRequest{
+			Messages: []ProviderMessage{{Role: "user", Content: "identical dedup-test task"}},
+			Metadata: RequestMetadata{RequestID: sharedRequestID},
+		}
+	}
+
+	type outcome struct {
+		resp *CompletionResponse
+		err  error
+	}
+	results := make(chan outcome, 2)
+
+	go func() {
+		resp, _, _, callErr := ctrl.completeWithToolLoop(context.Background(), provider, makeReq(), registry)
+		results <- outcome{resp, callErr}
+	}()
+	firstArrived.Wait()
+
+	go func() {
+		resp, _, _, callErr := ctrl.completeWithToolLoop(context.Background(), provider, makeReq(), registry)
+		results <- outcome{resp, callErr}
+	}()
+
+	// Give the second call a moment to reach the dedup guard before releasing
+	// the first stream (avoids a race where the first completes, clears its
+	// in-flight registration, and the second no longer collides).
+	time.Sleep(150 * time.Millisecond)
+	close(releaseFirst)
+
+	first := <-results
+	second := <-results
+
+	dedupRefusals := 0
+	successes := 0
+	for _, o := range []outcome{first, second} {
+		switch {
+		case o.err != nil && strings.Contains(o.err.Error(), "already in flight"):
+			dedupRefusals++
+		case o.err == nil:
+			successes++
+		default:
+			t.Errorf("unexpected error: %v", o.err)
+		}
+	}
+	if dedupRefusals != 1 {
+		t.Errorf("dedup refusals = %d; want exactly 1 (one of the two concurrent identical-RequestID calls must be refused)", dedupRefusals)
+	}
+	if successes != 1 {
+		t.Errorf("successes = %d; want exactly 1", successes)
 	}
 }

--- a/internal/engine/provider.go
+++ b/internal/engine/provider.go
@@ -49,6 +49,36 @@ type Provider interface {
 	Ping(ctx context.Context) (time.Duration, error)
 }
 
+// CancelSafeCompleter is implemented by providers whose Complete() cannot
+// reliably propagate ctx-cancellation to the server (#432). Such providers
+// expose CompleteCancelSafe, which routes the request through their
+// streaming path (or another mechanism that does tear down the server-side
+// connection on cancel) so that an abandoned request actually aborts
+// generation instead of running headless.
+//
+// Providers that don't implement this (Anthropic HTTP, ClaudeCode subprocess,
+// etc.) either already propagate cancellation correctly through their own
+// transport or are out of scope for the local-inference zombie-generation
+// failure mode this interface exists to close. Callers should use
+// CompleteCancelSafeIfSupported rather than asserting this interface directly.
+type CancelSafeCompleter interface {
+	CompleteCancelSafe(ctx context.Context, req *CompletionRequest) (*CompletionResponse, error)
+}
+
+// CompleteCancelSafeIfSupported calls p.CompleteCancelSafe when the provider
+// implements CancelSafeCompleter, otherwise falls back to plain Complete.
+// Internal non-interactive call sites (autonomic consult, dispatch, tool-loop
+// re-calls) should route through this rather than calling Complete directly,
+// so that a ctx cancel/timeout actually aborts server-side generation on
+// providers where that matters (#432) without changing behavior for
+// providers where it doesn't apply.
+func CompleteCancelSafeIfSupported(ctx context.Context, p Provider, req *CompletionRequest) (*CompletionResponse, error) {
+	if cs, ok := p.(CancelSafeCompleter); ok {
+		return cs.CompleteCancelSafe(ctx, req)
+	}
+	return p.Complete(ctx, req)
+}
+
 // ── Request types ─────────────────────────────────────────────────────────────
 
 // CompletionRequest carries the assembled context package to the model.

--- a/internal/engine/provider_openai.go
+++ b/internal/engine/provider_openai.go
@@ -60,7 +60,17 @@ func NewOpenAICompatProvider(name string, cfg ProviderConfig) *OpenAICompatProvi
 	endpoint := resolveLocalLLMEndpoint(cfg.Endpoint)
 	timeout := time.Duration(cfg.Timeout) * time.Second
 	if timeout == 0 {
-		timeout = 60 * time.Second
+		// #432: a fixed ceiling below realistic local latency is an
+		// infinite-retry engine — local models under concurrent-slot prefill
+		// load observed 2-4 min single-turn latency in the incident that
+		// closed this issue. The previous 60s fallback here silently
+		// under-timed any provider config that omitted `timeout:`, so a
+		// caller relying on the default would hit the same abandon-and-retry
+		// failure mode as the (now-fixed) 30s dispatch default in
+		// agent_dispatch_query.go. Match that default so both ceilings agree
+		// absent explicit config; providers.yaml's committed defaults
+		// (lmstudio-darkstar: 300s) remain the recommended explicit value.
+		timeout = time.Duration(dispatchTimeoutDefault) * time.Second
 	}
 	maxTokens := cfg.MaxTokens
 	if maxTokens == 0 {
@@ -465,6 +475,113 @@ func (p *OpenAICompatProvider) Complete(ctx context.Context, req *CompletionRequ
 	}
 
 	return parseOpenAIResponse(&or, model, p.name, time.Since(start)), nil
+}
+
+// CompleteCancelSafe is like Complete but propagates ctx-cancellation to the
+// server by routing the request through Stream and aggregating the resulting
+// chunks into a single CompletionResponse.
+//
+// Background (#432): a plain non-streaming /v1/chat/completions request that
+// the kernel abandons (ctx cancel/timeout) does NOT reliably cause LM Studio
+// (or other openai-compat servers) to abort generation server-side — the
+// local http.Client gives up waiting for a response, but the TCP connection
+// isn't torn down in time for the server to notice, so the model keeps
+// generating headless in one of the server's parallel slots (confirmed via
+// TestOpenAICompleteHTTPError's sibling probe: a canceled Complete() request
+// leaves the server-side context alive). A streaming request's body-read loop
+// is actively selecting on the connection, so client disconnection propagates
+// immediately and the server aborts generation (confirmed clean shutdown in
+// the 2026-07-04 incident for every request using chat_completion_stream_request/
+// Stream()). Callers that need cancel-safety without changing their call
+// shape (internal non-interactive consults, dispatch, tool-loop re-calls)
+// should call this instead of Complete.
+func (p *OpenAICompatProvider) CompleteCancelSafe(ctx context.Context, req *CompletionRequest) (*CompletionResponse, error) {
+	start := time.Now()
+	model := p.effectiveModel(req)
+
+	ch, err := p.Stream(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		content          strings.Builder
+		reasoningContent strings.Builder
+		toolCalls        []ToolCall
+		toolCallsByIndex = map[int]*ToolCall{}
+		toolCallOrder    []int
+		stopReason       string
+		usage            TokenUsage
+		streamErr        error
+	)
+
+	for chunk := range ch {
+		if chunk.Error != nil {
+			streamErr = chunk.Error
+			continue
+		}
+		if chunk.IsReasoning {
+			reasoningContent.WriteString(chunk.Delta)
+		} else if chunk.Delta != "" {
+			content.WriteString(chunk.Delta)
+		}
+		if chunk.ToolCallDelta != nil {
+			td := chunk.ToolCallDelta
+			tc, ok := toolCallsByIndex[td.Index]
+			if !ok {
+				tc = &ToolCall{}
+				toolCallsByIndex[td.Index] = tc
+				toolCallOrder = append(toolCallOrder, td.Index)
+			}
+			if td.ID != "" {
+				tc.ID = td.ID
+			}
+			if td.Name != "" {
+				tc.Name = td.Name
+			}
+			if td.ArgsDelta != "" {
+				tc.Arguments += td.ArgsDelta
+			}
+		}
+		if chunk.Done {
+			if chunk.StopReason != "" {
+				stopReason = chunk.StopReason
+			}
+			if chunk.Usage != nil {
+				usage = *chunk.Usage
+			}
+		}
+	}
+
+	// If the context was canceled mid-stream, report that rather than a
+	// partial/empty success — callers (assessCycle, dispatch, tool loop)
+	// treat a cancel-safe error identically to a Complete() error.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, fmt.Errorf("openai-compat: cancel-safe complete: %w", ctxErr)
+	}
+	if streamErr != nil {
+		return nil, fmt.Errorf("openai-compat: cancel-safe complete: %w", streamErr)
+	}
+
+	for _, idx := range toolCallOrder {
+		toolCalls = append(toolCalls, *toolCallsByIndex[idx])
+	}
+	if stopReason == "" {
+		stopReason = "end_turn"
+	}
+
+	return &CompletionResponse{
+		Content:          content.String(),
+		ReasoningContent: reasoningContent.String(),
+		ToolCalls:        toolCalls,
+		StopReason:       stopReason,
+		Usage:            usage,
+		ProviderMeta: ProviderMeta{
+			Provider: p.name,
+			Model:    model,
+			Latency:  time.Since(start),
+		},
+	}, nil
 }
 
 // parseOpenAIResponse converts an openaiChatResponse into a provider-agnostic

--- a/internal/engine/provider_openai_test.go
+++ b/internal/engine/provider_openai_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 // ── helpers ──────────────────────────────────────────────────────────────────
@@ -1049,5 +1050,240 @@ func TestNewOpenAICompatProviderNoDefaultOptions(t *testing.T) {
 	})
 	if p.defaultOptions != nil {
 		t.Errorf("defaultOptions should be nil when not configured; got %v", p.defaultOptions)
+	}
+}
+
+// ── CompleteCancelSafe / cancellation propagation (#432) ────────────────────
+
+// TestOpenAICompleteDoesNotPropagateCancelToServer is a regression probe that
+// documents the #432 defect this fix closes: a plain non-streaming Complete()
+// request that the client abandons via ctx cancel does NOT reliably cause the
+// server to observe the cancellation within a bounded window. This is the
+// exact "kernel gives up, LM Studio keeps generating headless" failure mode
+// from the incident forensics. The test asserts the (undesirable) status quo
+// for Complete() specifically so a future change to Complete()'s transport
+// behavior is caught here rather than silently reintroducing the zombie
+// class; CompleteCancelSafe (tested below) is the supported fix.
+func TestOpenAICompleteDoesNotPropagateCancelToServer(t *testing.T) {
+	t.Parallel()
+	closed := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+			close(closed)
+		case <-time.After(3 * time.Second):
+		}
+	}))
+	defer srv.Close()
+
+	p := newTestOpenAIProvider(t, srv.URL, "m")
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+	_, _ = p.Complete(ctx, &CompletionRequest{Messages: []ProviderMessage{{Role: "user", Content: "hi"}}})
+
+	select {
+	case <-closed:
+		t.Fatal("Complete() propagated cancellation to the server — if this now passes, the non-streaming transport behavior changed and CompleteCancelSafe's rationale comment should be revisited")
+	case <-time.After(500 * time.Millisecond):
+		// Expected: server never saw the cancellation within a short window.
+	}
+}
+
+// TestOpenAICompleteCancelSafePropagatesToServer is the core #432 regression
+// test: CompleteCancelSafe must cause the server to observe ctx cancellation
+// (connection closes) so an abandoned generation actually aborts server-side
+// instead of running headless.
+func TestOpenAICompleteCancelSafePropagatesToServer(t *testing.T) {
+	t.Parallel()
+	closed := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+		chunk := openaiStreamChunk{
+			ID:      "chatcmpl-1",
+			Choices: []openaiStreamChoice{{Index: 0, Delta: openaiStreamDelta{Content: "partial"}}},
+		}
+		b, _ := json.Marshal(chunk)
+		fmt.Fprintf(w, "data: %s\n\n", b)
+		flusher.Flush()
+		select {
+		case <-r.Context().Done():
+			close(closed)
+		case <-time.After(3 * time.Second):
+		}
+	}))
+	defer srv.Close()
+
+	p := newTestOpenAIProvider(t, srv.URL, "m")
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+	_, err := p.CompleteCancelSafe(ctx, &CompletionRequest{Messages: []ProviderMessage{{Role: "user", Content: "hi"}}})
+	if err == nil {
+		t.Error("expected an error from CompleteCancelSafe when ctx is canceled mid-stream")
+	}
+
+	select {
+	case <-closed:
+		// Expected: the server observed the cancellation (connection closed).
+	case <-time.After(2 * time.Second):
+		t.Fatal("server never observed ctx cancellation within 2s — CompleteCancelSafe did not propagate cancellation")
+	}
+}
+
+// TestOpenAICompleteCancelSafeAggregatesContent verifies the happy path:
+// CompleteCancelSafe must aggregate streamed deltas (text, reasoning, tool
+// calls, usage, stop reason) into the same shape Complete() would have
+// returned, since callers switching from Complete to CompleteCancelSafe
+// must see no behavioral difference beyond cancellation semantics.
+func TestOpenAICompleteCancelSafeAggregatesContent(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload openaiChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if !payload.Stream {
+			http.Error(w, "expected stream:true from CompleteCancelSafe", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+		for _, delta := range []string{"Hel", "lo", "!"} {
+			chunk := openaiStreamChunk{Choices: []openaiStreamChoice{{Index: 0, Delta: openaiStreamDelta{Content: delta}}}}
+			b, _ := json.Marshal(chunk)
+			fmt.Fprintf(w, "data: %s\n\n", b)
+			flusher.Flush()
+		}
+		stop := "stop"
+		final := openaiStreamChunk{
+			Choices: []openaiStreamChoice{{Index: 0, Delta: openaiStreamDelta{}, FinishReason: &stop}},
+			Usage:   &openaiUsageResponse{PromptTokens: 7, CompletionTokens: 3, TotalTokens: 10},
+		}
+		b, _ := json.Marshal(final)
+		fmt.Fprintf(w, "data: %s\n\n", b)
+		fmt.Fprint(w, "data: [DONE]\n\n")
+		flusher.Flush()
+	}))
+	defer srv.Close()
+
+	p := newTestOpenAIProvider(t, srv.URL, "test-model")
+	resp, err := p.CompleteCancelSafe(context.Background(), &CompletionRequest{
+		Messages: []ProviderMessage{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("CompleteCancelSafe: %v", err)
+	}
+	if resp.Content != "Hello!" {
+		t.Errorf("Content = %q; want Hello!", resp.Content)
+	}
+	if resp.StopReason != "end_turn" {
+		t.Errorf("StopReason = %q; want end_turn", resp.StopReason)
+	}
+	if resp.Usage.InputTokens != 7 || resp.Usage.OutputTokens != 3 {
+		t.Errorf("Usage = %+v; want {7, 3}", resp.Usage)
+	}
+	if resp.ProviderMeta.Provider != "openai-compat" {
+		t.Errorf("ProviderMeta.Provider = %q; want openai-compat", resp.ProviderMeta.Provider)
+	}
+}
+
+// TestOpenAICompleteCancelSafeSurfacesStreamError verifies that a mid-stream
+// error is surfaced as an error from CompleteCancelSafe rather than silently
+// returning a partial/empty success.
+func TestOpenAICompleteCancelSafeSurfacesStreamError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+		fmt.Fprint(w, "data: {not valid json\n\n")
+		flusher.Flush()
+	}))
+	defer srv.Close()
+
+	p := newTestOpenAIProvider(t, srv.URL, "m")
+	_, err := p.CompleteCancelSafe(context.Background(), &CompletionRequest{
+		Messages: []ProviderMessage{{Role: "user", Content: "hi"}},
+	})
+	if err == nil {
+		t.Error("expected error from malformed SSE chunk")
+	}
+}
+
+// TestCompleteCancelSafeIfSupportedUsesCancelSafeForOpenAICompat verifies the
+// dispatch helper routes to CompleteCancelSafe when the provider implements
+// CancelSafeCompleter.
+func TestCompleteCancelSafeIfSupportedUsesCancelSafeForOpenAICompat(t *testing.T) {
+	t.Parallel()
+	var sawStream bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload openaiChatRequest
+		_ = json.NewDecoder(r.Body).Decode(&payload)
+		sawStream = payload.Stream
+		if payload.Stream {
+			w.Header().Set("Content-Type", "text/event-stream")
+			flusher := w.(http.Flusher)
+			fmt.Fprint(w, "data: [DONE]\n\n")
+			flusher.Flush()
+			return
+		}
+		_ = json.NewEncoder(w).Encode(openaiChatResponseJSON("non-stream", "stop"))
+	}))
+	defer srv.Close()
+
+	p := newTestOpenAIProvider(t, srv.URL, "m")
+	_, err := CompleteCancelSafeIfSupported(context.Background(), p, &CompletionRequest{
+		Messages: []ProviderMessage{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("CompleteCancelSafeIfSupported: %v", err)
+	}
+	if !sawStream {
+		t.Error("CompleteCancelSafeIfSupported did not route an *OpenAICompatProvider through the streaming (cancel-safe) path")
+	}
+}
+
+// stubProviderNoCancelSafe is a minimal Provider that does NOT implement
+// CancelSafeCompleter, used to verify CompleteCancelSafeIfSupported falls
+// back to plain Complete for providers outside the #432 fix's scope.
+type stubProviderNoCancelSafe struct {
+	completeCalled bool
+}
+
+func (s *stubProviderNoCancelSafe) Complete(ctx context.Context, req *CompletionRequest) (*CompletionResponse, error) {
+	s.completeCalled = true
+	return &CompletionResponse{Content: "stub"}, nil
+}
+func (s *stubProviderNoCancelSafe) Stream(ctx context.Context, req *CompletionRequest) (<-chan StreamChunk, error) {
+	ch := make(chan StreamChunk)
+	close(ch)
+	return ch, nil
+}
+func (s *stubProviderNoCancelSafe) Name() string                       { return "stub" }
+func (s *stubProviderNoCancelSafe) Model() string                      { return "stub-model" }
+func (s *stubProviderNoCancelSafe) Available(ctx context.Context) bool { return true }
+func (s *stubProviderNoCancelSafe) Capabilities() ProviderCapabilities { return ProviderCapabilities{} }
+func (s *stubProviderNoCancelSafe) Ping(ctx context.Context) (time.Duration, error) {
+	return 0, nil
+}
+
+func TestCompleteCancelSafeIfSupportedFallsBackForPlainProvider(t *testing.T) {
+	t.Parallel()
+	s := &stubProviderNoCancelSafe{}
+	resp, err := CompleteCancelSafeIfSupported(context.Background(), s, &CompletionRequest{})
+	if err != nil {
+		t.Fatalf("CompleteCancelSafeIfSupported: %v", err)
+	}
+	if !s.completeCalled {
+		t.Error("expected fallback to Complete() for a provider that does not implement CancelSafeCompleter")
+	}
+	if resp.Content != "stub" {
+		t.Errorf("Content = %q; want stub", resp.Content)
 	}
 }

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -1363,12 +1363,19 @@ func (s *Server) completeChat(w http.ResponseWriter, ctx context.Context, req *C
 	var pt chatPhaseTimings
 	pt.promptEvalStart = time.Now()
 
-	resp, err := provider.Complete(ctx, req)
+	// Cancel-safe (#432): a non-streaming request the kernel gives up on
+	// (client disconnect, handler ctx cancel) does not reliably abort
+	// generation server-side on providers like LM Studio — the request still
+	// gets a fully-buffered JSON response here (unchanged client contract),
+	// but routing through CompleteCancelSafeIfSupported means an abandoned
+	// call actually stops consuming the local inference seat.
+	resp, err := CompleteCancelSafeIfSupported(ctx, provider, req)
 	pt.promptEvalEnd = time.Now()
 	// answerStart/End are derived after we inspect the response payload so we
 	// can split the round-trip duration proportionally when reasoning content
 	// is present. They are set below, after the tool loop.
 	if err != nil {
+		recordAbandonedInference("chat-complete", req.Metadata.RequestID, err)
 		slog.Warn("chat: complete error", "err", err)
 		if turn != nil {
 			turn.Status = "error"
@@ -1444,9 +1451,11 @@ func (s *Server) completeChat(w http.ResponseWriter, ctx context.Context, req *C
 				}
 			}
 			// Preserve any external tool_calls for the next iteration's
-			// response so we don't drop them on the floor.
-			next, nerr := provider.Complete(ctx, req)
+			// response so we don't drop them on the floor. Cancel-safe (#432):
+			// same rationale as the initial completeChat call above.
+			next, nerr := CompleteCancelSafeIfSupported(ctx, provider, req)
 			if nerr != nil {
+				recordAbandonedInference("chat-complete-post-tool", req.Metadata.RequestID, nerr)
 				slog.Warn("chat: complete after internal tool exec failed", "err", nerr)
 				if turn != nil {
 					turn.Status = "error"

--- a/internal/engine/serve_anthropic.go
+++ b/internal/engine/serve_anthropic.go
@@ -333,8 +333,12 @@ func (s *Server) handleAnthropicMessages(w http.ResponseWriter, r *http.Request)
 func (s *Server) completeAnthropicMessages(w http.ResponseWriter, ctx context.Context, req *CompletionRequest,
 	provider Provider, respID, model string, turn *TurnRecord) {
 
-	resp, err := provider.Complete(ctx, req)
+	// Cancel-safe (#432): same rationale as completeChat in serve.go — the
+	// Anthropic-compat non-streaming surface hits the same provider pool and
+	// is subject to the same zombie-generation risk on abandoned requests.
+	resp, err := CompleteCancelSafeIfSupported(ctx, provider, req)
 	if err != nil {
+		recordAbandonedInference("anthropic-complete", req.Metadata.RequestID, err)
 		slog.Warn("anthropic: complete error", "err", err)
 		if turn != nil {
 			turn.Status = "error"

--- a/internal/engine/testhelper_test.go
+++ b/internal/engine/testhelper_test.go
@@ -9,6 +9,7 @@ package engine
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -95,4 +96,26 @@ func mustLoadNucleus(t *testing.T, cfg *Config) *Nucleus {
 		t.Fatalf("LoadNucleus: %v", err)
 	}
 	return n
+}
+
+// writeSSECompletion writes a minimal one-chunk openai-compat SSE response
+// carrying content as the full assistant message, followed by a terminal
+// [DONE] sentinel. Used by mock /v1/chat/completions handlers that need to
+// honor stream:true requests (#432: internal call sites now route
+// non-interactive completions through CompleteCancelSafe, which always
+// requests streaming — a mock that ignores `stream` and always returns a
+// plain JSON body silently produces an empty response for these callers).
+func writeSSECompletion(t *testing.T, w http.ResponseWriter, content string) {
+	t.Helper()
+	w.Header().Set("Content-Type", "text/event-stream")
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		t.Fatalf("writeSSECompletion: ResponseWriter does not support flushing")
+	}
+	fmt.Fprintf(w, "data: {\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":%q}}]}\n\n", content)
+	flusher.Flush()
+	fmt.Fprintf(w, "data: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1}}\n\n")
+	flusher.Flush()
+	fmt.Fprint(w, "data: [DONE]\n\n")
+	flusher.Flush()
 }

--- a/internal/engine/tool_loop.go
+++ b/internal/engine/tool_loop.go
@@ -499,9 +499,14 @@ func RunToolLoopWithTranscript(
 					Content: fmt.Sprintf("Tool call rejected: %s. Please try again with valid parameters.", rejected[0].Reason),
 				})
 
+				// Cancel-safe (#432): re-calls mid-loop share the same
+				// server-side zombie-generation risk as the initial call —
+				// route through streaming when the provider supports it so a
+				// ctx cancel/timeout here also aborts generation server-side.
 				var err error
-				resp, err = provider.Complete(ctx, req)
+				resp, err = CompleteCancelSafeIfSupported(ctx, provider, req)
 				if err != nil {
+					recordAbandonedInference("tool-loop-rejection-recall", req.Metadata.RequestID, err)
 					return nil, clientToolCalls, transcript, fmt.Errorf("tool_loop re-call after rejection: %w", err)
 				}
 
@@ -610,10 +615,12 @@ func RunToolLoopWithTranscript(
 			return resp, clientToolCalls, transcript, nil
 		}
 
-		// Re-call the provider with the updated messages.
+		// Re-call the provider with the updated messages. Cancel-safe (#432):
+		// see the rejection re-call above for rationale.
 		var err error
-		resp, err = provider.Complete(ctx, req)
+		resp, err = CompleteCancelSafeIfSupported(ctx, provider, req)
 		if err != nil {
+			recordAbandonedInference("tool-loop-recall", req.Metadata.RequestID, err)
 			return nil, clientToolCalls, transcript, fmt.Errorf("tool_loop re-call: %w", err)
 		}
 


### PR DESCRIPTION
## Summary

Fixes #432 — sibling of #431/#430's dispatch-model-honoring fix, this closes the
2026-07-04 zombie-generation incident forensics:

- **Cancellation propagation:** `OpenAICompatProvider.CompleteCancelSafe` routes
  non-streaming completions through `Stream` under the hood so a ctx cancel/timeout
  actually tears down the connection and aborts generation server-side. A plain
  `Complete()` call does not — confirmed with an httptest probe (server-side context
  never observes the cancellation within 2s for `Complete`, vs ~50ms for `Stream`),
  matching the incident's log signature (`Generated prediction` = zombie-capable,
  `Finished streaming response` = always closed cleanly).
- A `CancelSafeCompleter` interface + `CompleteCancelSafeIfSupported` helper let
  callers opt providers in without provider-name string matching. Converted: the
  autonomic consult (`assessCycle`), dispatch (`completeWithToolLoop`), both
  `tool_loop.go` re-call sites, the chat pipeline's non-streaming branch
  (`completeChat`), and the Anthropic-compat serving surface.
- **Latency-aware timeouts:** `dispatchTimeoutDefault` 30s → 240s (real local-model
  single-turn latency under prefill load runs 2-4 min per the incident; 30s was an
  infinite-retry engine). Matching fix to `OpenAICompatProvider`'s implicit 60s
  timeout fallback.
- **Retry dedup:** `beginInflightInference`/`endInflightInference` keyed on
  `RequestMetadata.RequestID` refuse a resubmit while a prior attempt under the same
  identity may still be generating server-side. Dispatch's RequestID is already
  content-stable (KV-cache-branching hash), so genuine retries collide for free.
- **Anomaly surfacing:** abandoned/canceled inference now increments a counter folded
  into `KernelHealthSnapshot.Anomalies`/`AnomaliesTotal`, gating `AllGreen()` and a new
  `escalateAbandonedInference` reason — visible on the same `bus_kernel_proprio`
  snapshot the autonomic loop and operators already watch, not just a WARN log line
  (the incident ran 0err/0anom for hours despite the WARN existing the whole time).

`countingProvider` (used by every dispatch slot) needed its own `CompleteCancelSafe`
override — it embeds the `Provider` interface, and Go only promotes methods declared
on that static interface type, so without the override it silently fell back to plain
`Complete` on the dispatch path specifically. Found via the retry-dedup integration
test, not by inspection.

## Test plan

- [x] `TestOpenAICompleteDoesNotPropagateCancelToServer` — documents the pre-fix
      defect as a regression guard on `Complete()`'s behavior
- [x] `TestOpenAICompleteCancelSafePropagatesToServer` — httptest server asserting
      the connection closes on ctx cancel (the core #432 assertion)
- [x] `TestOpenAICompleteCancelSafeAggregatesContent` / `...SurfacesStreamError`
- [x] `TestCompleteCancelSafeIfSupportedUsesCancelSafeForOpenAICompat` /
      `...FallsBackForPlainProvider`
- [x] `inference_inflight_test.go` — dedup semantics + anomaly delta-since-last-read
- [x] `TestLocalHarnessAutonomicConsult_SetsMaxTokensBound` — wire-level `max_tokens`
      assertion on the assess call
- [x] `TestCompleteWithToolLoop_ConcurrentSameRequestIDIsDeduped` — retry-dedup
      integration test (exercised directly against `completeWithToolLoop` since
      `DispatchToHarness`'s `ollamaMu` already fully serializes local dispatches at a
      coarser batch level)
- [x] `gofmt -l` clean on all touched files
- [x] `go build ./...` and `go test ./...` pass at repo root and in `sdk/`
- [x] 8+ consecutive `-shuffle=on` runs and a full `-race` pass, both green