### PR TITLE
feat(dispatch): async job handle + harness capability gating

### DIFF
--- a/internal/engine/dispatch_capability_gating_test.go
+++ b/internal/engine/dispatch_capability_gating_test.go
@@ -1,0 +1,314 @@
+// dispatch_capability_gating_test.go — coverage for the harness-loop
+// capability gating added to dispatchSlot (local_agent_harness.go). The
+// sketch's original "thread identity through the harness" deliverable was
+// already ~60% shipped (attribution: DispatchIdentity, subject resolution,
+// ledger attribution, per-tool-call trace attribution); the genuine gap
+// closed here is honoring the wired capabilityGater when
+// IdentityNakedDefault is true — the file's own prior comment named this
+// exact gap ("No capability gating here; this is observability metadata
+// only").
+//
+// Test matrix:
+//  1. flag on + gater present + bound subject + gater denies a tool
+//     -> the denied tool is absent from the tools list sent to the provider.
+//  2. flag off (default) -> tools list unchanged regardless of gater/subject
+//     (byte-for-byte parity with pre-change behavior, mirroring the chat
+//     path's own stated contract).
+//  3. flag on + no gater wired (capResolver nil, the honest default — see
+//     mcp_sessions_identity.go: SetCapabilityResolver has zero production
+//     callers) -> permit-by-default, tools list unchanged.
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// This file reuses the fakeCapabilityGater / newFakeCapabilityGater test
+// double already defined in mcp_sessions_g2_test.go (same package, PART C
+// capability gating tests) rather than redeclaring an equivalent fake.
+
+// toolsFromChatCompletionRequest decodes the "tools" field of an OpenAI-
+// compat /v1/chat/completions request body and returns the function names,
+// in the order the provider sent them.
+func toolsFromChatCompletionRequest(t *testing.T, body []byte) []string {
+	t.Helper()
+	var payload struct {
+		Tools []struct {
+			Function struct {
+				Name string `json:"name"`
+			} `json:"function"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("decode chat completion request: %v (body=%s)", err, body)
+	}
+	names := make([]string, len(payload.Tools))
+	for i, tl := range payload.Tools {
+		names[i] = tl.Function.Name
+	}
+	return names
+}
+
+// toolCapture is a mutex-guarded recorder for the tools array seen on each
+// /v1/chat/completions request, safe for the httptest handler goroutine to
+// write to and the test goroutine to read from.
+type toolCapture struct {
+	mu    sync.Mutex
+	calls [][]string
+}
+
+func (c *toolCapture) add(names []string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls = append(c.calls, names)
+}
+
+func (c *toolCapture) snapshot() [][]string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([][]string, len(c.calls))
+	copy(out, c.calls)
+	return out
+}
+
+// newRecordingLLMServer returns an httptest server that behaves like a
+// minimal OpenAI-compat endpoint (models + chat/completions; honors the
+// request's stream field like a real server, per the #432-era harness test
+// convention in local_agent_harness_test.go), always responding with plain
+// text content (no tool_calls) so the tool loop terminates after one turn.
+// Records the tools array from every /v1/chat/completions request into cap.
+func newRecordingLLMServer(t *testing.T, model string, cap *toolCapture) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/models":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"object": "list",
+				"data":   []map[string]any{{"id": model, "object": "model"}},
+			})
+		case "/v1/chat/completions":
+			bodyBytes, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read chat completion request body: %v", err)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			cap.add(toolsFromChatCompletionRequest(t, bodyBytes))
+
+			var body struct {
+				Stream bool `json:"stream"`
+			}
+			_ = json.Unmarshal(bodyBytes, &body)
+
+			content := "done"
+			if body.Stream {
+				writeSSECompletion(t, w, content)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":     "chatcmpl-gate-test",
+				"object": "chat.completion",
+				"model":  model,
+				"choices": []map[string]any{{
+					"index":         0,
+					"message":       map[string]any{"role": "assistant", "content": content},
+					"finish_reason": "stop",
+				}},
+				"usage": map[string]any{"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+// dispatchGatingHarness builds a LocalHarnessController wired to a recording
+// fake LLM server, with providers.yaml pointing dispatch at it directly (so
+// no state-routing ambiguity). Returns the controller and the tool capture.
+func dispatchGatingHarness(t *testing.T) (*LocalHarnessController, *toolCapture, *httptest.Server) {
+	t.Helper()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+
+	model := "gemma-4-e4b"
+	captured := &toolCapture{}
+	llm := newRecordingLLMServer(t, model, captured)
+	t.Cleanup(llm.Close)
+
+	writeTestFile(t, filepath.Join(root, ".cog", "config", "providers.yaml"), `providers:
+  test-harness:
+    type: openai
+    endpoint: `+llm.URL+`
+    model: `+model+`
+`)
+
+	proc := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	srv := NewServer(cfg, makeNucleus("Cog", "tester"), proc)
+	ctrl, err := NewLocalHarnessController(cfg, makeNucleus("Cog", "tester"), proc, srv.mcpServer)
+	if err != nil {
+		t.Fatalf("NewLocalHarnessController: %v", err)
+	}
+	return ctrl, captured, llm
+}
+
+// TestDispatchSlot_CapabilityGating_FlagOn_DeniedToolFiltered is the test
+// that fails without the change: before capabilityGater() / the gating
+// block in dispatchSlot existed, a denied tool would still appear in the
+// tools list sent to the provider even with IdentityNakedDefault=true and a
+// gater wired, because the identity fields were observability-only.
+func TestDispatchSlot_CapabilityGating_FlagOn_DeniedToolFiltered(t *testing.T) {
+	ctrl, captured, _ := dispatchGatingHarness(t)
+	ctrl.cfg.IdentityNakedDefault = true
+	gater := newFakeCapabilityGater()
+	gater.deny["bound-user/cog_emit_event"] = struct{}{}
+	ctrl.mcpSrv.SetCapabilityResolver(gater)
+
+	batch, err := ctrl.DispatchToHarness(context.Background(), DispatchRequest{
+		Task:           "do a thing",
+		Provider:       "test-harness",
+		N:              1,
+		TimeoutSeconds: 10,
+		Identity:       DispatchIdentity{Sub: "bound-user"},
+	})
+	if err != nil {
+		t.Fatalf("DispatchToHarness: %v", err)
+	}
+	if len(batch.Results) != 1 || !batch.Results[0].Success {
+		t.Fatalf("dispatch did not succeed: %+v", batch.Results)
+	}
+	calls := captured.snapshot()
+	if len(calls) == 0 {
+		t.Fatal("provider was never called; nothing captured")
+	}
+	tools := calls[0]
+	for _, name := range tools {
+		if name == "cog_emit_event" {
+			t.Fatalf("denied tool cog_emit_event present in tools sent to provider: %v", tools)
+		}
+	}
+	if len(tools) == 0 {
+		t.Fatal("expected some tools to remain after filtering (only one of eleven was denied)")
+	}
+}
+
+// TestDispatchSlot_CapabilityGating_FlagOff_Unchanged mirrors the chat
+// path's own stated contract: IdentityNakedDefault=false (the default) must
+// leave tool injection byte-for-byte unchanged, even with a gater wired that
+// would otherwise deny a tool and a bound subject present.
+func TestDispatchSlot_CapabilityGating_FlagOff_Unchanged(t *testing.T) {
+	ctrl, captured, _ := dispatchGatingHarness(t)
+	// IdentityNakedDefault left at its zero value (false).
+	gater := newFakeCapabilityGater()
+	gater.deny["bound-user/cog_emit_event"] = struct{}{}
+	ctrl.mcpSrv.SetCapabilityResolver(gater)
+
+	batch, err := ctrl.DispatchToHarness(context.Background(), DispatchRequest{
+		Task:           "do a thing",
+		Provider:       "test-harness",
+		N:              1,
+		TimeoutSeconds: 10,
+		Identity:       DispatchIdentity{Sub: "bound-user"},
+	})
+	if err != nil {
+		t.Fatalf("DispatchToHarness: %v", err)
+	}
+	calls := captured.snapshot()
+	if len(calls) == 0 {
+		t.Fatal("provider was never called")
+	}
+	tools := calls[0]
+	found := false
+	for _, name := range tools {
+		if name == "cog_emit_event" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected cog_emit_event to remain present with the dark flag off, got %v", tools)
+	}
+	_ = batch
+}
+
+// TestDispatchSlot_CapabilityGating_NoGaterWired_PermitByDefault covers the
+// honest-default case the plan calls out: SetCapabilityResolver has zero
+// production callers today, so capResolver is nil at runtime everywhere.
+// Flag on + nil gater must permit everything (same as flag off).
+func TestDispatchSlot_CapabilityGating_NoGaterWired_PermitByDefault(t *testing.T) {
+	ctrl, captured, _ := dispatchGatingHarness(t)
+	ctrl.cfg.IdentityNakedDefault = true
+	// No SetCapabilityResolver call — capResolver stays nil.
+
+	_, err := ctrl.DispatchToHarness(context.Background(), DispatchRequest{
+		Task:           "do a thing",
+		Provider:       "test-harness",
+		N:              1,
+		TimeoutSeconds: 10,
+		Identity:       DispatchIdentity{Sub: "bound-user"},
+	})
+	if err != nil {
+		t.Fatalf("DispatchToHarness: %v", err)
+	}
+	calls := captured.snapshot()
+	if len(calls) == 0 {
+		t.Fatal("provider was never called")
+	}
+	tools := calls[0]
+	found := false
+	for _, name := range tools {
+		if name == "cog_emit_event" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected permit-by-default (no gater wired) to leave cog_emit_event present, got %v", tools)
+	}
+}
+
+// TestDispatchSlot_CapabilityGating_AnonymousSubjectNotGated covers the
+// third gate condition: an anonymous dispatch (no Identity.Sub) has no
+// envelope to check and must not be gated even with the flag on and a
+// gater wired, mirroring the chat path's bound.Bound check.
+func TestDispatchSlot_CapabilityGating_AnonymousSubjectNotGated(t *testing.T) {
+	ctrl, captured, _ := dispatchGatingHarness(t)
+	ctrl.cfg.IdentityNakedDefault = true
+	gater := newFakeCapabilityGater()
+	gater.deny["anonymous/cog_emit_event"] = struct{}{}
+	ctrl.mcpSrv.SetCapabilityResolver(gater)
+
+	// No Identity.Sub supplied -> subject resolves to "anonymous" inside
+	// DispatchToHarness (local_agent_harness.go). Even though the fake gater
+	// would deny cog_emit_event for "anonymous", the gating block's own
+	// subject != "anonymous" condition must skip filtering entirely.
+	_, err := ctrl.DispatchToHarness(context.Background(), DispatchRequest{
+		Task:           "do a thing",
+		Provider:       "test-harness",
+		N:              1,
+		TimeoutSeconds: 10,
+	})
+	if err != nil {
+		t.Fatalf("DispatchToHarness: %v", err)
+	}
+	calls := captured.snapshot()
+	if len(calls) == 0 {
+		t.Fatal("provider was never called")
+	}
+	tools := calls[0]
+	found := false
+	for _, name := range tools {
+		if name == "cog_emit_event" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected anonymous subject to bypass gating, got %v", tools)
+	}
+}

--- a/internal/engine/dispatch_capability_gating_test.go
+++ b/internal/engine/dispatch_capability_gating_test.go
@@ -200,6 +200,146 @@ func TestDispatchSlot_CapabilityGating_FlagOn_DeniedToolFiltered(t *testing.T) {
 	}
 }
 
+// TestDispatchSlot_CapabilityGating_DoesNotCorruptSharedRegistry is the
+// regression test for the FINDING 1+2 blocker: registry.Definitions()
+// (tool_loop.go) returns c.dispatchTools' own backing slice by reference,
+// and filterToolsByCapability (serve_kernel_agent_tools.go) compacts
+// creq.Tools IN PLACE (`out := creq.Tools[:0]`). Without copying the
+// definitions slice before handing it to CompletionRequest.Tools, a single
+// gated dispatch permanently truncates the shared c.dispatchTools registry —
+// every dispatch afterward, gated or not, sees the same missing tool.
+//
+// Denies the FIRST tool in the default "consolidation" scope order
+// (cog_resolve_uri, index 0) rather than the last, because a fix that only
+// happens to work when the compaction removes the tail element (no shift
+// needed) would still corrupt the shared slice for any other position.
+func TestDispatchSlot_CapabilityGating_DoesNotCorruptSharedRegistry(t *testing.T) {
+	ctrl, captured, _ := dispatchGatingHarness(t)
+
+	firstToolName := harnessToolScopes[defaultHarnessScopeName][0]
+	if firstToolName != "cog_resolve_uri" {
+		t.Fatalf("test assumes cog_resolve_uri is index 0 of %q scope, got %q — update the test", defaultHarnessScopeName, firstToolName)
+	}
+	fullToolCount := len(harnessToolScopes[defaultHarnessScopeName])
+
+	// Dispatch 1: gating flag ON, gater denies the first tool for this subject.
+	ctrl.cfg.IdentityNakedDefault = true
+	gater := newFakeCapabilityGater()
+	gater.deny["bound-user/"+firstToolName] = struct{}{}
+	ctrl.mcpSrv.SetCapabilityResolver(gater)
+
+	if _, err := ctrl.DispatchToHarness(context.Background(), DispatchRequest{
+		Task:           "gated dispatch",
+		Provider:       "test-harness",
+		N:              1,
+		TimeoutSeconds: 10,
+		Identity:       DispatchIdentity{Sub: "bound-user"},
+	}); err != nil {
+		t.Fatalf("gated DispatchToHarness: %v", err)
+	}
+
+	calls := captured.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 provider call after gated dispatch, got %d", len(calls))
+	}
+	gatedTools := calls[0]
+	if len(gatedTools) != fullToolCount-1 {
+		t.Fatalf("gated dispatch: expected %d tools (one denied), got %d: %v", fullToolCount-1, len(gatedTools), gatedTools)
+	}
+	for _, name := range gatedTools {
+		if name == firstToolName {
+			t.Fatalf("gated dispatch: denied tool %q still present: %v", firstToolName, gatedTools)
+		}
+	}
+
+	// Dispatch 2: gating flag OFF (default) — must see the FULL, unmodified
+	// tool list. If dispatchSlot handed filterToolsByCapability the shared
+	// registry slice by reference, dispatch 1's in-place compaction already
+	// dropped firstToolName from c.dispatchTools permanently, and this
+	// second — ungated — dispatch would incorrectly come up one tool short.
+	ctrl.cfg.IdentityNakedDefault = false
+
+	if _, err := ctrl.DispatchToHarness(context.Background(), DispatchRequest{
+		Task:           "ungated dispatch",
+		Provider:       "test-harness",
+		N:              1,
+		TimeoutSeconds: 10,
+		Identity:       DispatchIdentity{Sub: "bound-user"},
+	}); err != nil {
+		t.Fatalf("ungated DispatchToHarness: %v", err)
+	}
+
+	calls = captured.snapshot()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 provider calls total, got %d", len(calls))
+	}
+	ungatedTools := calls[1]
+	if len(ungatedTools) != fullToolCount {
+		t.Fatalf("shared registry corrupted by prior gated dispatch: expected %d tools, got %d: %v", fullToolCount, len(ungatedTools), ungatedTools)
+	}
+	found := false
+	for _, name := range ungatedTools {
+		if name == firstToolName {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("shared registry corrupted: %q missing from ungated dispatch's tool list: %v", firstToolName, ungatedTools)
+	}
+}
+
+// TestDispatchSlot_CapabilityGating_ConcurrentFanOutRaceClean is the -race
+// guard for FINDING 2: N>1 fan-out slots run in parallel goroutines
+// (local_agent_harness.go DispatchToHarness's `for i := 0; i < req.N; i++ {
+// go func...}`), each calling dispatchSlot -> registry.Definitions() against
+// the SAME shared c.dispatchTools. Before the copy-before-filter fix, a gated
+// slot's in-place compaction of creq.Tools raced against every other
+// concurrently-running slot reading/writing that identical backing array —
+// a data race `go test -race` catches directly, independent of the
+// single-goroutine ordering bug the other regression test exercises.
+func TestDispatchSlot_CapabilityGating_ConcurrentFanOutRaceClean(t *testing.T) {
+	ctrl, captured, _ := dispatchGatingHarness(t)
+	ctrl.cfg.IdentityNakedDefault = true
+	gater := newFakeCapabilityGater()
+	gater.deny["bound-user/cog_resolve_uri"] = struct{}{}
+	ctrl.mcpSrv.SetCapabilityResolver(gater)
+
+	batch, err := ctrl.DispatchToHarness(context.Background(), DispatchRequest{
+		Task:           "fan out",
+		Provider:       "test-harness",
+		N:              4,
+		TimeoutSeconds: 10,
+		Identity:       DispatchIdentity{Sub: "bound-user"},
+	})
+	if err != nil {
+		t.Fatalf("DispatchToHarness: %v", err)
+	}
+	if len(batch.Results) != 4 {
+		t.Fatalf("expected 4 results, got %d", len(batch.Results))
+	}
+	for i, res := range batch.Results {
+		if !res.Success {
+			t.Errorf("slot %d did not succeed: %+v", i, res)
+		}
+	}
+
+	calls := captured.snapshot()
+	if len(calls) != 4 {
+		t.Fatalf("expected 4 provider calls, got %d", len(calls))
+	}
+	fullToolCount := len(harnessToolScopes[defaultHarnessScopeName])
+	for i, tools := range calls {
+		if len(tools) != fullToolCount-1 {
+			t.Errorf("slot %d: expected %d tools (one denied), got %d: %v", i, fullToolCount-1, len(tools), tools)
+		}
+		for _, name := range tools {
+			if name == "cog_resolve_uri" {
+				t.Errorf("slot %d: denied tool cog_resolve_uri present: %v", i, tools)
+			}
+		}
+	}
+}
+
 // TestDispatchSlot_CapabilityGating_FlagOff_Unchanged mirrors the chat
 // path's own stated contract: IdentityNakedDefault=false (the default) must
 // leave tool injection byte-for-byte unchanged, even with a gater wired that

--- a/internal/engine/dispatch_jobs.go
+++ b/internal/engine/dispatch_jobs.go
@@ -1,0 +1,207 @@
+// dispatch_jobs.go — async job handle registry for cog_dispatch_to_harness.
+//
+// Problem: cog_dispatch_to_harness is fully synchronous — the MCP request
+// blocks until every fan-out slot completes, errors, or times out (up to
+// dispatch_timeout_cap_seconds, default 600s). Some MCP clients (notably the
+// window an interactive Claude Code turn gets before the harness gives up
+// and the request context is torn down) close well before that. The caller
+// never sees the result even though the dispatch completed successfully.
+//
+// This file adds an optional async path: when the caller sets Async=true on
+// the dispatchToHarnessInput, toolDispatchToHarness registers a job, spawns
+// the real dispatch in a goroutine running under a DETACHED context (see
+// dispatch_jobs.go's use of context.WithoutCancel in mcp_server.go), and
+// returns a job handle immediately. The caller polls the job by id — via the
+// HTTP surface (GET /v1/dispatch-jobs/{id}, the primary poll surface per the
+// design) or the cog_poll_dispatch MCP convenience tool — until it reaches a
+// terminal state (done/failed).
+//
+// Detach-from-request-context rationale (#432, e4e6aca): the MCP request's
+// context is canceled the instant toolDispatchToHarness returns the receipt.
+// If the spawned goroutine inherited that context unmodified, the dispatch
+// would be canceled out from under itself the moment the receipt was
+// returned — reintroducing exactly the zombie-generation / cancel-races-
+// ahead-of-server-completion failure mode #432 fixed for the synchronous
+// path. context.WithoutCancel severs that link; a fresh WithTimeout derived
+// from the request's TimeoutSeconds (falling back to the dispatch default)
+// bounds the goroutine's lifetime independently.
+package engine
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// DispatchJobState is the lifecycle state of one async dispatch job.
+type DispatchJobState string
+
+const (
+	DispatchJobPending DispatchJobState = "pending"
+	DispatchJobRunning DispatchJobState = "running"
+	DispatchJobDone    DispatchJobState = "done"
+	DispatchJobFailed  DispatchJobState = "failed"
+)
+
+// dispatchJobTTL is how long a terminal (done/failed) job record is kept
+// before lazy GC reclaims it. 30 minutes gives a caller ample time to poll
+// after the dispatch finishes without the registry growing unbounded across
+// a long-running kernel process. Not caller-configurable today — this is
+// kernel-internal bookkeeping, not a dispatch parameter.
+const dispatchJobTTL = 30 * time.Minute
+
+// DispatchJobRecord is one entry in the DispatchJobRegistry. Result and Err
+// are populated only once State reaches a terminal value (done/failed).
+type DispatchJobRecord struct {
+	JobID     string
+	CycleID   string // correlates to the harness.dispatch.* ledger events (local_agent_harness.go)
+	State     DispatchJobState
+	Result    *DispatchBatchResult
+	Err       string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// snapshot returns a defensive copy safe to hand to a caller outside the
+// registry's lock.
+func (r *DispatchJobRecord) snapshot() *DispatchJobRecord {
+	if r == nil {
+		return nil
+	}
+	cp := *r
+	return &cp
+}
+
+// DispatchJobRegistry is an in-memory, mutex-guarded store of async dispatch
+// jobs keyed by a freshly-minted UUID (NOT the per-slot content-keyed
+// RequestID computed inside dispatchSlot — that key collides on identical
+// dispatch content by design, which makes it unfit as a job-registry primary
+// key; see local_agent_harness.go's dispatchSlot contentKey and the KV-cache-
+// branching rationale documented there).
+//
+// Lazy GC: expired terminal records are swept opportunistically on every
+// Create call rather than on a background ticker — this keeps the registry
+// dependency-free (no goroutine to start/stop) at the cost of only reclaiming
+// memory when new jobs are created. Acceptable for the expected usage shape
+// (jobs created steadily during normal operation); a kernel that dispatches
+// once and never again also never accumulates more than one stale record.
+type DispatchJobRegistry struct {
+	mu   sync.Mutex
+	jobs map[string]*DispatchJobRecord
+	ttl  time.Duration
+	now  func() time.Time // overridable for tests
+}
+
+// NewDispatchJobRegistry constructs an empty registry with the default TTL.
+func NewDispatchJobRegistry() *DispatchJobRegistry {
+	return &DispatchJobRegistry{
+		jobs: make(map[string]*DispatchJobRecord),
+		ttl:  dispatchJobTTL,
+		now:  time.Now,
+	}
+}
+
+// Create allocates a new job in the pending state and returns its id. Sweeps
+// expired terminal records first (lazy GC).
+func (reg *DispatchJobRegistry) Create(cycleID string) string {
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+	reg.gcLocked()
+
+	jobID := uuid.NewString()
+	now := reg.now()
+	reg.jobs[jobID] = &DispatchJobRecord{
+		JobID:     jobID,
+		CycleID:   cycleID,
+		State:     DispatchJobPending,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	return jobID
+}
+
+// MarkRunning transitions a job to running. No-op if the job is unknown or
+// already terminal (defensive — should not happen in normal operation since
+// exactly one goroutine owns each job's transitions).
+func (reg *DispatchJobRegistry) MarkRunning(jobID string) {
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+	rec, ok := reg.jobs[jobID]
+	if !ok || isTerminal(rec.State) {
+		return
+	}
+	rec.State = DispatchJobRunning
+	rec.UpdatedAt = reg.now()
+}
+
+// Complete transitions a job to done with the given result.
+func (reg *DispatchJobRegistry) Complete(jobID string, result *DispatchBatchResult) {
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+	rec, ok := reg.jobs[jobID]
+	if !ok {
+		return
+	}
+	rec.State = DispatchJobDone
+	rec.Result = result
+	rec.UpdatedAt = reg.now()
+}
+
+// Fail transitions a job to failed with the given error message.
+func (reg *DispatchJobRegistry) Fail(jobID string, errMsg string) {
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+	rec, ok := reg.jobs[jobID]
+	if !ok {
+		return
+	}
+	rec.State = DispatchJobFailed
+	rec.Err = errMsg
+	rec.UpdatedAt = reg.now()
+}
+
+// Get returns a defensive copy of the job record, or (nil, false) when the
+// id is unknown (never registered, or already GC'd past its TTL).
+func (reg *DispatchJobRegistry) Get(jobID string) (*DispatchJobRecord, bool) {
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+	rec, ok := reg.jobs[jobID]
+	if !ok {
+		return nil, false
+	}
+	return rec.snapshot(), true
+}
+
+// gcLocked removes terminal records older than ttl. Caller must hold reg.mu.
+func (reg *DispatchJobRegistry) gcLocked() {
+	cutoff := reg.now().Add(-reg.ttl)
+	for id, rec := range reg.jobs {
+		if isTerminal(rec.State) && rec.UpdatedAt.Before(cutoff) {
+			delete(reg.jobs, id)
+		}
+	}
+}
+
+func isTerminal(s DispatchJobState) bool {
+	return s == DispatchJobDone || s == DispatchJobFailed
+}
+
+// dispatchAsyncDefaultTimeoutSeconds bounds the detached goroutine's context
+// when the request carried no explicit TimeoutSeconds. Mirrors
+// dispatchTimeoutDefault (agent_dispatch_query.go) so the async path's
+// no-timeout-specified behavior matches the synchronous path's.
+const dispatchAsyncDefaultTimeoutSeconds = dispatchTimeoutDefault
+
+// detachedDispatchContext returns a context that has severed cancellation
+// from parent (see package doc above / #432 e4e6aca) but still carries a
+// bounded deadline of its own. seconds<=0 falls back to
+// dispatchAsyncDefaultTimeoutSeconds.
+func detachedDispatchContext(parent context.Context, seconds int) (context.Context, context.CancelFunc) {
+	if seconds <= 0 {
+		seconds = dispatchAsyncDefaultTimeoutSeconds
+	}
+	detached := context.WithoutCancel(parent)
+	return context.WithTimeout(detached, time.Duration(seconds)*time.Second)
+}

--- a/internal/engine/dispatch_jobs.go
+++ b/internal/engine/dispatch_jobs.go
@@ -65,12 +65,44 @@ type DispatchJobRecord struct {
 }
 
 // snapshot returns a defensive copy safe to hand to a caller outside the
-// registry's lock.
+// registry's lock. `cp := *r` alone only copies the struct's own fields —
+// Result is a *DispatchBatchResult, so a shallow copy would still share the
+// pointee with whatever Complete() stored in the registry. A caller mutating
+// rec.Result.Results[i] (or appending to rec.Result.Notes) would silently
+// corrupt the registry's copy for every other Get() — exactly the aliasing
+// bug TestDispatchJobRegistry_GetReturnsDefensiveCopy is meant to guard
+// against, just one level deeper than that test currently reaches. Deep-copy
+// Result (and its nested Results/ToolCalls/Notes slices, all value-typed
+// leaves) so the returned record is safe to mutate freely.
 func (r *DispatchJobRecord) snapshot() *DispatchJobRecord {
 	if r == nil {
 		return nil
 	}
 	cp := *r
+	cp.Result = cp.Result.deepCopy()
+	return &cp
+}
+
+// deepCopy returns a copy of b with its own backing arrays for Results (and
+// each result's ToolCalls) and Notes, so mutating the copy can never be
+// observed by a concurrent reader holding the original. nil-receiver-safe.
+func (b *DispatchBatchResult) deepCopy() *DispatchBatchResult {
+	if b == nil {
+		return nil
+	}
+	cp := *b
+	if b.Results != nil {
+		cp.Results = make([]DispatchResult, len(b.Results))
+		for i, res := range b.Results {
+			if res.ToolCalls != nil {
+				res.ToolCalls = append([]DispatchToolCallSummary(nil), res.ToolCalls...)
+			}
+			cp.Results[i] = res
+		}
+	}
+	if b.Notes != nil {
+		cp.Notes = append([]string(nil), b.Notes...)
+	}
 	return &cp
 }
 
@@ -194,14 +226,43 @@ func isTerminal(s DispatchJobState) bool {
 // no-timeout-specified behavior matches the synchronous path's.
 const dispatchAsyncDefaultTimeoutSeconds = dispatchTimeoutDefault
 
+// dispatchAsyncQueueHeadroomSeconds covers the time an async dispatch may
+// spend BLOCKED ON ollamaMu (local_agent_harness.go) before its per-slot
+// budget even starts ticking.
+//
+// QueryDispatchToHarnessRouted -> DispatchToHarness acquires ollamaMu before
+// any per-slot context is created (dispatchSlot's own context.WithTimeout is
+// derived from this same outer ctx, further downstream). If the outer
+// deadline set here also has to cover that queueing wait, a kernel that's
+// mid-metabolic-cycle (documented worst case ~2-4 minutes under load per
+// dispatchTimeoutDefault's #432 forensics) can burn the caller's entire
+// requested budget just waiting for the lock — so the async dispatch fails
+// with deadline-exceeded in precisely the busy-kernel case async dispatch
+// exists to survive, while the equivalent synchronous call (whose caller
+// controls its own wait) succeeds once the lock frees up.
+//
+// Fix: give the detached context's own deadline headroom above the caller's
+// requested per-slot budget, sized to the same worst-case queueing window
+// already documented for the mutex. This keeps DispatchToHarness's locking
+// untouched (no restructuring to "start the per-slot clock after Lock()",
+// which would require plumbing a second context boundary through every
+// provider-resolution branch above the lock) while ensuring the per-slot
+// budget the caller asked for is actually available once the slot starts
+// running, not eaten by time spent waiting in line for a busy accelerator.
+const dispatchAsyncQueueHeadroomSeconds = 240
+
 // detachedDispatchContext returns a context that has severed cancellation
 // from parent (see package doc above / #432 e4e6aca) but still carries a
 // bounded deadline of its own. seconds<=0 falls back to
-// dispatchAsyncDefaultTimeoutSeconds.
+// dispatchAsyncDefaultTimeoutSeconds. The deadline is stamped at
+// seconds+dispatchAsyncQueueHeadroomSeconds so a busy-kernel wait on
+// ollamaMu doesn't cannibalize the per-slot budget the caller requested
+// (see dispatchAsyncQueueHeadroomSeconds doc).
 func detachedDispatchContext(parent context.Context, seconds int) (context.Context, context.CancelFunc) {
 	if seconds <= 0 {
 		seconds = dispatchAsyncDefaultTimeoutSeconds
 	}
 	detached := context.WithoutCancel(parent)
-	return context.WithTimeout(detached, time.Duration(seconds)*time.Second)
+	budget := time.Duration(seconds+dispatchAsyncQueueHeadroomSeconds) * time.Second
+	return context.WithTimeout(detached, budget)
 }

--- a/internal/engine/dispatch_jobs_test.go
+++ b/internal/engine/dispatch_jobs_test.go
@@ -88,6 +88,87 @@ func TestDispatchJobRegistry_GetReturnsDefensiveCopy(t *testing.T) {
 	}
 }
 
+// TestDispatchJobRegistry_GetResultIsDeepCopy is the regression test for
+// FINDING 4: TestDispatchJobRegistry_GetReturnsDefensiveCopy above only
+// mutates the top-level State field of the returned record, which is a
+// value type on DispatchJobRecord and was always safe (cp := *r copies it).
+// It never exercised Result, a *DispatchBatchResult pointer — a plain
+// `cp := *r` shallow copy leaves cp.Result pointing at the SAME
+// DispatchBatchResult (and the same nested Results/ToolCalls/Notes slices)
+// still stored in the registry, so the "defensive copy" claim the test name
+// makes was never actually verified for the field most likely to be mutated
+// by a real caller (e.g. a poll handler appending to Results or Notes).
+//
+// This test mutates the batch result returned by Get and confirms a second
+// Get is unaffected, at every level: the Result pointer itself, the Results
+// slice, an individual DispatchResult's ToolCalls slice, and the Notes
+// slice.
+func TestDispatchJobRegistry_GetResultIsDeepCopy(t *testing.T) {
+	t.Parallel()
+	reg := NewDispatchJobRegistry()
+	jobID := reg.Create("")
+
+	original := &DispatchBatchResult{
+		Results: []DispatchResult{
+			{
+				Index:   0,
+				Success: true,
+				Content: "original content",
+				ToolCalls: []DispatchToolCallSummary{
+					{Name: "cog_resolve_uri", ArgsDigest: "orig-args"},
+				},
+			},
+		},
+		TotalDurationSec: 1.5,
+		Notes:            []string{"original note"},
+	}
+	reg.Complete(jobID, original)
+
+	rec, ok := reg.Get(jobID)
+	if !ok {
+		t.Fatal("job not found after Complete")
+	}
+
+	// Mutate every level of the returned copy.
+	if rec.Result == original {
+		t.Fatal("Get returned the same *DispatchBatchResult pointer stored via Complete; not a defensive copy")
+	}
+	rec.Result.TotalDurationSec = 99
+	rec.Result.Results[0].Content = "mutated content"
+	rec.Result.Results[0].ToolCalls[0].ArgsDigest = "mutated-args"
+	rec.Result.Notes[0] = "mutated note"
+	rec.Result.Notes = append(rec.Result.Notes, "appended note")
+	rec.Result.Results = append(rec.Result.Results, DispatchResult{Index: 1})
+
+	rec2, ok := reg.Get(jobID)
+	if !ok {
+		t.Fatal("job not found on second Get")
+	}
+	if rec2.Result.TotalDurationSec != 1.5 {
+		t.Errorf("TotalDurationSec leaked mutation: got %v, want 1.5", rec2.Result.TotalDurationSec)
+	}
+	if len(rec2.Result.Results) != 1 {
+		t.Fatalf("Results length leaked mutation: got %d, want 1", len(rec2.Result.Results))
+	}
+	if rec2.Result.Results[0].Content != "original content" {
+		t.Errorf("Results[0].Content leaked mutation: got %q, want %q", rec2.Result.Results[0].Content, "original content")
+	}
+	if rec2.Result.Results[0].ToolCalls[0].ArgsDigest != "orig-args" {
+		t.Errorf("Results[0].ToolCalls[0].ArgsDigest leaked mutation: got %q, want %q", rec2.Result.Results[0].ToolCalls[0].ArgsDigest, "orig-args")
+	}
+	if len(rec2.Result.Notes) != 1 || rec2.Result.Notes[0] != "original note" {
+		t.Errorf("Notes leaked mutation: got %v, want [%q]", rec2.Result.Notes, "original note")
+	}
+
+	// Also confirm the ORIGINAL passed into Complete was never touched —
+	// guards against a future refactor that copies on write into the
+	// registry instead of on read out of it (equally valid, but must
+	// actually happen somewhere).
+	if original.TotalDurationSec != 1.5 || original.Results[0].Content != "original content" {
+		t.Error("the original DispatchBatchResult passed to Complete was mutated by a Get-side copy; snapshot must not alias it")
+	}
+}
+
 // TestDispatchJobRegistry_LazyGCReclaimsExpiredTerminalJobs verifies the TTL
 // sweep: a terminal job older than the TTL is removed on the next Create
 // call (lazy GC, no background ticker).
@@ -130,6 +211,95 @@ func TestDispatchJobRegistry_LazyGCDoesNotReclaimPending(t *testing.T) {
 
 	if _, ok := reg.Get(pendingJob); !ok {
 		t.Fatal("pending job was reclaimed by GC; only terminal jobs should be TTL-eligible")
+	}
+}
+
+// --- detachedDispatchContext deadline sizing (FINDING 3) --------------------
+
+// TestDetachedDispatchContext_DeadlineHasQueueHeadroom is the regression test
+// for FINDING 3: detachedDispatchContext previously stamped the async
+// goroutine's deadline as exactly req.TimeoutSeconds from "now" — the same
+// instant startAsyncDispatch fires, BEFORE the dispatch has even reached
+// DispatchToHarness's ollamaMu.Lock() (local_agent_harness.go), let alone
+// acquired it. QueryDispatchToHarnessRouted -> DispatchToHarness -> the
+// per-slot context.WithTimeout in dispatchSlot are all derived from this one
+// outer deadline, so a busy kernel (metabolic cycle mid-run, holding
+// ollamaMu for the documented 2-4 minute worst case — see
+// dispatchTimeoutDefault's #432 forensics) burns the caller's entire
+// requested budget just queueing for the lock. The per-slot work then starts
+// with little-to-no time left and fails deadline-exceeded — precisely the
+// busy-kernel case async dispatch exists to survive, while the equivalent
+// synchronous call (whose caller supplies its own patience) succeeds once
+// the lock frees up.
+//
+// This test only exercises the deadline arithmetic in isolation (no real
+// ollamaMu contention — that needs a live LocalHarnessController and a
+// concurrent metabolic cycle, out of scope for a fast unit test) but it
+// directly catches a regression to the pre-fix "deadline == now +
+// TimeoutSeconds" shape, which is the root cause the finding identifies.
+func TestDetachedDispatchContext_DeadlineHasQueueHeadroom(t *testing.T) {
+	t.Parallel()
+
+	requestedSeconds := 30
+	ctx, cancel := detachedDispatchContext(context.Background(), requestedSeconds)
+	defer cancel()
+	after := time.Now()
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("detachedDispatchContext returned a context with no deadline")
+	}
+
+	// A plain context.WithTimeout(parent, requestedSeconds) deadline lands at
+	// before/after + requestedSeconds give or take nanoseconds of scheduling
+	// jitter — nowhere near a full minute of slack. Requiring at least 60s of
+	// headroom (well under dispatchAsyncQueueHeadroomSeconds=240) is a bright
+	// line that only a real headroom-add can cross, so this fails cleanly
+	// against the pre-fix "no headroom at all" shape instead of passing on
+	// jitter alone.
+	const minHeadroomForTest = 60 * time.Second
+	noHeadroomDeadline := after.Add(time.Duration(requestedSeconds) * time.Second)
+	if !deadline.After(noHeadroomDeadline.Add(minHeadroomForTest)) {
+		t.Fatalf(
+			"deadline has no meaningful queueing headroom above the requested %ds budget: "+
+				"deadline=%s, no-headroom deadline would be ~%s (delta=%s, want >= %s) — "+
+				"a busy-kernel ollamaMu wait can now consume the entire per-slot "+
+				"budget before any dispatch work starts",
+			requestedSeconds, deadline, noHeadroomDeadline, deadline.Sub(noHeadroomDeadline), minHeadroomForTest)
+	}
+
+	// Sanity bound: the headroom shouldn't be unbounded either — confirm the
+	// deadline still lands within [before, after] + requested + headroom, so
+	// a future change can't silently balloon this into an effectively-infinite
+	// timeout.
+	maxExpected := after.Add(time.Duration(requestedSeconds+dispatchAsyncQueueHeadroomSeconds) * time.Second)
+	if deadline.After(maxExpected) {
+		t.Fatalf("deadline %s exceeds requested+headroom bound %s", deadline, maxExpected)
+	}
+}
+
+// TestDetachedDispatchContext_DefaultTimeoutAlsoGetsHeadroom confirms the
+// headroom applies on the no-explicit-timeout fallback path too (seconds<=0
+// -> dispatchAsyncDefaultTimeoutSeconds), not just the caller-specified case.
+func TestDetachedDispatchContext_DefaultTimeoutAlsoGetsHeadroom(t *testing.T) {
+	t.Parallel()
+
+	after := time.Now()
+	ctx, cancel := detachedDispatchContext(context.Background(), 0)
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("detachedDispatchContext returned a context with no deadline")
+	}
+
+	const minHeadroomForTest = 60 * time.Second
+	noHeadroomDeadline := after.Add(time.Duration(dispatchAsyncDefaultTimeoutSeconds) * time.Second)
+	if !deadline.After(noHeadroomDeadline.Add(minHeadroomForTest)) {
+		t.Fatalf(
+			"default-timeout deadline has no meaningful queueing headroom: deadline=%s, "+
+				"no-headroom deadline would be ~%s (delta=%s, want >= %s)",
+			deadline, noHeadroomDeadline, deadline.Sub(noHeadroomDeadline), minHeadroomForTest)
 	}
 }
 

--- a/internal/engine/dispatch_jobs_test.go
+++ b/internal/engine/dispatch_jobs_test.go
@@ -506,10 +506,42 @@ func TestStartAsyncDispatch_ReceiptAndLedgerCarryNonEmptyCycleID(t *testing.T) {
 		t.Fatalf("no harness.dispatch.job.issued ledger event found for job %q", receipt.JobID)
 	}
 
-	// Unblock the fake dispatcher and wait out the goroutine (see
-	// waitForTerminalJob's comment on why this matters for t.TempDir cleanup).
+	// Unblock the fake dispatcher and wait out the goroutine. waitForTerminalJob
+	// only guarantees the REGISTRY has reached a terminal state
+	// (registry.Complete/Fail) — startAsyncDispatch's goroutine emits the
+	// harness.dispatch.job.completed ledger event (a second AppendEvent call
+	// into this same t.TempDir() workspace) AFTER that, so a bare
+	// waitForTerminalJob can still race t.TempDir()'s RemoveAll cleanup against
+	// that trailing ledger write. Also wait for the completed ledger event
+	// (root, not the registry) so this test doesn't reintroduce that flake.
 	close(block)
 	waitForTerminalJob(t, server, receipt.JobID)
+	waitForLedgerEvent(t, root, "harness.dispatch.job.completed", receipt.JobID)
+}
+
+// waitForLedgerEvent polls the ledger at workspaceRoot until an event of the
+// given type carrying data.payload.job_id == jobID appears, or a 5s deadline
+// elapses (test failure on timeout). Use this after waitForTerminalJob when a
+// test also needs to observe (or simply outlive) a ledger write that a
+// background goroutine performs strictly after the registry reaches a
+// terminal state — see startAsyncDispatch's Complete/Fail-then-EmitLedgerEvent
+// ordering.
+func waitForLedgerEvent(t *testing.T, workspaceRoot, eventType, jobID string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		res, err := QueryLedger(workspaceRoot, LedgerQuery{EventType: eventType, Limit: 20})
+		if err == nil {
+			for _, ev := range res.Events {
+				payload, _ := ev.Data["payload"].(map[string]any)
+				if id, _ := payload["job_id"].(string); id == jobID {
+					return
+				}
+			}
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("no %q ledger event observed for job %q within 5s", eventType, jobID)
 }
 
 // TestQueryDispatchToHarness_SyncPathUnaffectedByAsyncField is the flag-off

--- a/internal/engine/dispatch_jobs_test.go
+++ b/internal/engine/dispatch_jobs_test.go
@@ -1,0 +1,328 @@
+// dispatch_jobs_test.go — coverage for the async job-handle registry
+// (dispatch_jobs.go) and the async path through toolDispatchToHarness /
+// toolPollDispatch.
+package engine
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// --- DispatchJobRegistry unit tests -----------------------------------------
+
+func TestDispatchJobRegistry_LifecyclePendingToDone(t *testing.T) {
+	t.Parallel()
+	reg := NewDispatchJobRegistry()
+	jobID := reg.Create("cycle-1")
+
+	rec, ok := reg.Get(jobID)
+	if !ok {
+		t.Fatalf("Get(%q): not found immediately after Create", jobID)
+	}
+	if rec.State != DispatchJobPending {
+		t.Errorf("initial state = %q, want %q", rec.State, DispatchJobPending)
+	}
+	if rec.CycleID != "cycle-1" {
+		t.Errorf("CycleID = %q, want %q", rec.CycleID, "cycle-1")
+	}
+
+	reg.MarkRunning(jobID)
+	rec, _ = reg.Get(jobID)
+	if rec.State != DispatchJobRunning {
+		t.Errorf("state after MarkRunning = %q, want %q", rec.State, DispatchJobRunning)
+	}
+
+	result := &DispatchBatchResult{Results: []DispatchResult{{Index: 0, Success: true, Content: "ok"}}}
+	reg.Complete(jobID, result)
+	rec, _ = reg.Get(jobID)
+	if rec.State != DispatchJobDone {
+		t.Errorf("state after Complete = %q, want %q", rec.State, DispatchJobDone)
+	}
+	if rec.Result == nil || len(rec.Result.Results) != 1 || rec.Result.Results[0].Content != "ok" {
+		t.Errorf("Result not stored correctly: %+v", rec.Result)
+	}
+}
+
+func TestDispatchJobRegistry_Fail(t *testing.T) {
+	t.Parallel()
+	reg := NewDispatchJobRegistry()
+	jobID := reg.Create("")
+	reg.MarkRunning(jobID)
+	reg.Fail(jobID, "boom")
+
+	rec, ok := reg.Get(jobID)
+	if !ok {
+		t.Fatal("job not found after Fail")
+	}
+	if rec.State != DispatchJobFailed {
+		t.Errorf("state = %q, want %q", rec.State, DispatchJobFailed)
+	}
+	if rec.Err != "boom" {
+		t.Errorf("Err = %q, want %q", rec.Err, "boom")
+	}
+}
+
+func TestDispatchJobRegistry_UnknownJobNotFound(t *testing.T) {
+	t.Parallel()
+	reg := NewDispatchJobRegistry()
+	if _, ok := reg.Get("does-not-exist"); ok {
+		t.Fatal("expected unknown job id to be not-found")
+	}
+}
+
+// TestDispatchJobRegistry_GetReturnsDefensiveCopy guards against a caller
+// mutating the record it got back and corrupting the registry's internal
+// state for other readers.
+func TestDispatchJobRegistry_GetReturnsDefensiveCopy(t *testing.T) {
+	t.Parallel()
+	reg := NewDispatchJobRegistry()
+	jobID := reg.Create("")
+
+	rec, _ := reg.Get(jobID)
+	rec.State = DispatchJobFailed // mutate the caller's copy
+
+	rec2, _ := reg.Get(jobID)
+	if rec2.State != DispatchJobPending {
+		t.Fatalf("registry state leaked caller mutation: got %q, want %q", rec2.State, DispatchJobPending)
+	}
+}
+
+// TestDispatchJobRegistry_LazyGCReclaimsExpiredTerminalJobs verifies the TTL
+// sweep: a terminal job older than the TTL is removed on the next Create
+// call (lazy GC, no background ticker).
+func TestDispatchJobRegistry_LazyGCReclaimsExpiredTerminalJobs(t *testing.T) {
+	t.Parallel()
+	reg := NewDispatchJobRegistry()
+	reg.ttl = 10 * time.Millisecond
+
+	fakeNow := time.Now()
+	reg.now = func() time.Time { return fakeNow }
+
+	oldJob := reg.Create("")
+	reg.Complete(oldJob, &DispatchBatchResult{})
+
+	// Advance fake time past the TTL, then create a new job — this should
+	// trigger gcLocked and evict oldJob.
+	fakeNow = fakeNow.Add(1 * time.Second)
+	_ = reg.Create("")
+
+	if _, ok := reg.Get(oldJob); ok {
+		t.Fatal("expected expired terminal job to be GC'd, but it is still present")
+	}
+}
+
+// TestDispatchJobRegistry_LazyGCDoesNotReclaimPending guards against GC
+// evicting an in-flight (non-terminal) job just because it's old — only
+// terminal (done/failed) records are TTL-eligible.
+func TestDispatchJobRegistry_LazyGCDoesNotReclaimPending(t *testing.T) {
+	t.Parallel()
+	reg := NewDispatchJobRegistry()
+	reg.ttl = 10 * time.Millisecond
+
+	fakeNow := time.Now()
+	reg.now = func() time.Time { return fakeNow }
+
+	pendingJob := reg.Create("")
+
+	fakeNow = fakeNow.Add(1 * time.Second)
+	_ = reg.Create("")
+
+	if _, ok := reg.Get(pendingJob); !ok {
+		t.Fatal("pending job was reclaimed by GC; only terminal jobs should be TTL-eligible")
+	}
+}
+
+// --- toolDispatchToHarness async path / toolPollDispatch --------------------
+
+// TestToolDispatchToHarness_AsyncReturnsImmediateJobHandle is the test that
+// fails without the change: without Async support, dispatching with
+// Async=true would either be ignored (falling through to the synchronous
+// path and blocking until fakeAgentDispatcher's canned result is available
+// — which for a fast fake wouldn't distinguish the paths) or the field
+// wouldn't exist at all. The meaningful assertion is that the response is a
+// job handle shape ({job_id, status:"pending"}), not a DispatchBatchResult.
+func TestToolDispatchToHarness_AsyncReturnsImmediateJobHandle(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	process := NewProcess(cfg, makeNucleus("Cog", "tester"))
+
+	block := make(chan struct{})
+	disp := &blockingDispatcher{
+		release: block,
+		canned:  &DispatchBatchResult{Results: []DispatchResult{{Index: 0, Success: true, Content: "done"}}},
+	}
+	server := NewMCPServerWithAgentController(cfg, makeNucleus("Cog", "tester"), process, disp)
+
+	result, _, err := server.toolDispatchToHarness(context.Background(), nil, dispatchToHarnessInput{
+		Task:  "do the thing",
+		Async: true,
+	})
+	if err != nil {
+		t.Fatalf("toolDispatchToHarness (async): %v", err)
+	}
+
+	var receipt dispatchJobReceipt
+	decodeMCPJSONForAgentTests(t, result, &receipt)
+	if receipt.JobID == "" {
+		t.Fatal("expected non-empty job_id in async receipt")
+	}
+	if receipt.Status != string(DispatchJobPending) {
+		t.Errorf("initial status = %q, want %q", receipt.Status, DispatchJobPending)
+	}
+
+	// Release the blocked dispatcher, then wait for the background goroutine
+	// to actually reach a terminal state before the test returns — otherwise
+	// t.TempDir()'s cleanup can race the goroutine's ledger write to
+	// .cog/ledger/ under the workspace root (the goroutine outlives the
+	// synchronous part of the test by design; this is the async path's whole
+	// point, so the test must wait it out rather than fire-and-forget).
+	close(block)
+	waitForTerminalJob(t, server, receipt.JobID)
+}
+
+// TestToolDispatchToHarness_AsyncPollTransitionsToDone exercises the full
+// async lifecycle: dispatch async, observe pending, unblock the fake
+// dispatcher, poll until done, and confirm the polled result matches what a
+// synchronous call would have returned for the same input.
+func TestToolDispatchToHarness_AsyncPollTransitionsToDone(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	process := NewProcess(cfg, makeNucleus("Cog", "tester"))
+
+	release := make(chan struct{})
+	canned := &DispatchBatchResult{Results: []DispatchResult{{Index: 0, Success: true, Content: "the answer"}}}
+	disp := &blockingDispatcher{release: release, canned: canned}
+	server := NewMCPServerWithAgentController(cfg, makeNucleus("Cog", "tester"), process, disp)
+
+	result, _, err := server.toolDispatchToHarness(context.Background(), nil, dispatchToHarnessInput{
+		Task:  "do the thing",
+		Async: true,
+	})
+	if err != nil {
+		t.Fatalf("toolDispatchToHarness (async): %v", err)
+	}
+	var receipt dispatchJobReceipt
+	decodeMCPJSONForAgentTests(t, result, &receipt)
+
+	// Poll immediately: still pending/running since the fake dispatcher is
+	// blocked on `release`.
+	pollResult, _, err := server.toolPollDispatch(context.Background(), nil, pollDispatchInput{JobID: receipt.JobID})
+	if err != nil {
+		t.Fatalf("toolPollDispatch (pre-release): %v", err)
+	}
+	var status dispatchJobStatusResponse
+	decodeMCPJSONForAgentTests(t, pollResult, &status)
+	if status.Status != string(DispatchJobPending) && status.Status != string(DispatchJobRunning) {
+		t.Fatalf("status before release = %q, want pending or running", status.Status)
+	}
+
+	close(release)
+
+	final := waitForTerminalJob(t, server, receipt.JobID)
+	if final.Status != string(DispatchJobDone) {
+		t.Fatalf("final status = %q, want %q (error=%q)", final.Status, DispatchJobDone, final.Error)
+	}
+	if final.Result == nil || len(final.Result.Results) != 1 || final.Result.Results[0].Content != "the answer" {
+		t.Fatalf("polled result does not match the synchronous canned result: %+v", final.Result)
+	}
+}
+
+// TestToolPollDispatch_UnknownJobIDReturnsClearError guards the not-found
+// path — an unknown or expired job_id must not panic or return an empty
+// success response.
+func TestToolPollDispatch_UnknownJobIDReturnsClearError(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	process := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	server := NewMCPServer(cfg, makeNucleus("Cog", "tester"), process)
+
+	result, _, err := server.toolPollDispatch(context.Background(), nil, pollDispatchInput{JobID: "no-such-job"})
+	if err != nil {
+		t.Fatalf("toolPollDispatch: %v", err)
+	}
+	if result == nil || len(result.Content) == 0 {
+		t.Fatal("expected a fallback error result for unknown job id")
+	}
+}
+
+// TestQueryDispatchToHarness_SyncPathUnaffectedByAsyncField is the flag-off
+// mirror: Async=false (the zero value / default) must behave byte-for-byte
+// like before this change — synchronous, returning a DispatchBatchResult
+// directly rather than a job receipt.
+func TestQueryDispatchToHarness_SyncPathUnaffectedByAsyncField(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	process := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	disp := &fakeAgentDispatcher{canned: &DispatchBatchResult{
+		Results: []DispatchResult{{Index: 0, Success: true, Content: "sync-result"}},
+	}}
+	server := NewMCPServerWithAgentController(cfg, makeNucleus("Cog", "tester"), process, disp)
+
+	result, _, err := server.toolDispatchToHarness(context.Background(), nil, dispatchToHarnessInput{
+		Task: "do the thing",
+		// Async omitted -> false.
+	})
+	if err != nil {
+		t.Fatalf("toolDispatchToHarness (sync): %v", err)
+	}
+	var batch DispatchBatchResult
+	decodeMCPJSONForAgentTests(t, result, &batch)
+	if len(batch.Results) != 1 || batch.Results[0].Content != "sync-result" {
+		t.Fatalf("sync path result mismatch: %+v", batch)
+	}
+}
+
+// waitForTerminalJob polls jobID via toolPollDispatch until it reaches a
+// terminal state (done/failed) or a 5s deadline elapses (test failure on
+// timeout). Callers that spawn a background dispatch goroutine (Async=true)
+// MUST wait it out this way before returning — t.TempDir()'s cleanup runs as
+// soon as the test function returns, and a still-running goroutine writing
+// to the workspace's .cog/ledger/ races that cleanup (see the comment in
+// TestToolDispatchToHarness_AsyncReturnsImmediateJobHandle).
+func waitForTerminalJob(t *testing.T, server *MCPServer, jobID string) dispatchJobStatusResponse {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var status dispatchJobStatusResponse
+	for time.Now().Before(deadline) {
+		pollResult, _, err := server.toolPollDispatch(context.Background(), nil, pollDispatchInput{JobID: jobID})
+		if err != nil {
+			t.Fatalf("toolPollDispatch: %v", err)
+		}
+		decodeMCPJSONForAgentTests(t, pollResult, &status)
+		if status.Status == string(DispatchJobDone) || status.Status == string(DispatchJobFailed) {
+			return status
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("job %q did not reach a terminal state within 5s (last status=%q)", jobID, status.Status)
+	return status
+}
+
+// --- test doubles ------------------------------------------------------------
+
+// blockingDispatcher is an AgentController+AgentDispatcher fake whose
+// DispatchToHarness call blocks on release before returning canned. Used to
+// deterministically observe the "pending" window of an async dispatch
+// before letting the underlying call complete.
+type blockingDispatcher struct {
+	fakeAgentController
+	release chan struct{}
+	canned  *DispatchBatchResult
+}
+
+func (b *blockingDispatcher) DispatchToHarness(ctx context.Context, req DispatchRequest) (*DispatchBatchResult, error) {
+	select {
+	case <-b.release:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	return b.canned, nil
+}
+
+// decodeMCPJSONForAgentTests is defined in agent_state_query_test.go (same
+// package) and reused here rather than duplicated.

--- a/internal/engine/dispatch_jobs_test.go
+++ b/internal/engine/dispatch_jobs_test.go
@@ -419,6 +419,99 @@ func TestToolPollDispatch_UnknownJobIDReturnsClearError(t *testing.T) {
 	}
 }
 
+// TestStartAsyncDispatch_ReceiptAndLedgerCarryNonEmptyCycleID is the
+// regression test for the confirmed cog-review finding on startAsyncDispatch
+// (mcp_server.go): it used to call m.dispatchJobs.Create("") unconditionally,
+// so the CycleID this PR's own docs describe (surfaced in the receipt +
+// correlatable against harness.dispatch.start/end via the
+// harness.dispatch.job.issued ledger event) was ALWAYS empty and never
+// surfaced anywhere.
+//
+// This exercises the REAL call site — toolDispatchToHarness's async branch,
+// which is what dispatchToHarnessAsync/startAsyncDispatch actually run
+// behind — rather than calling reg.Create("cycle-1") directly (that unit
+// test already exists in TestDispatchJobRegistry_LifecyclePendingToDone and
+// would keep passing even with the mint-a-real-id fix reverted, since it
+// never touches startAsyncDispatch).
+func TestStartAsyncDispatch_ReceiptAndLedgerCarryNonEmptyCycleID(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	process := NewProcess(cfg, makeNucleus("Cog", "tester"))
+
+	block := make(chan struct{})
+	disp := &blockingDispatcher{
+		release: block,
+		canned:  &DispatchBatchResult{Results: []DispatchResult{{Index: 0, Success: true, Content: "done"}}},
+	}
+	server := NewMCPServerWithAgentController(cfg, makeNucleus("Cog", "tester"), process, disp)
+
+	result, _, err := server.toolDispatchToHarness(context.Background(), nil, dispatchToHarnessInput{
+		Task:  "do the thing",
+		Async: true,
+	})
+	if err != nil {
+		t.Fatalf("toolDispatchToHarness (async): %v", err)
+	}
+
+	var receipt dispatchJobReceipt
+	decodeMCPJSONForAgentTests(t, result, &receipt)
+	if receipt.JobID == "" {
+		t.Fatal("expected non-empty job_id in async receipt")
+	}
+	if receipt.CycleID == "" {
+		t.Fatal("receipt.CycleID is empty — startAsyncDispatch minted no correlation id (Create(\"\") regression)")
+	}
+
+	// The registry record itself must carry the same id (not just the
+	// receipt) — this is what a poller sees via GET /v1/dispatch-jobs/{id}
+	// or cog_poll_dispatch.
+	rec, ok := server.dispatchJobs.Get(receipt.JobID)
+	if !ok {
+		t.Fatalf("job %q not found in registry immediately after creation", receipt.JobID)
+	}
+	if rec.CycleID != receipt.CycleID {
+		t.Fatalf("registry CycleID %q does not match receipt CycleID %q", rec.CycleID, receipt.CycleID)
+	}
+
+	// The harness.dispatch.job.issued ledger event must carry the same
+	// cycle_id — this is the correlation surface the PR's docs promise
+	// (correlatable against harness.dispatch.start/end emitted later by
+	// LocalHarnessController.DispatchToHarness for this same dispatch).
+	ledgerResult, err := QueryLedger(root, LedgerQuery{EventType: "harness.dispatch.job.issued", Limit: 10})
+	if err != nil {
+		t.Fatalf("QueryLedger: %v", err)
+	}
+	found := false
+	for _, ev := range ledgerResult.Events {
+		// EmitLedgerEvent files everything under event["payload"] verbatim
+		// (it only special-cases type/source/timestamp), so the fields set
+		// on startAsyncDispatch's "payload" map land at ev.Data["payload"],
+		// not ev.Data directly.
+		payload, _ := ev.Data["payload"].(map[string]any)
+		jobID, _ := payload["job_id"].(string)
+		if jobID != receipt.JobID {
+			continue
+		}
+		found = true
+		cycleID, _ := payload["cycle_id"].(string)
+		if cycleID == "" {
+			t.Fatalf("harness.dispatch.job.issued event for job %q has empty cycle_id", jobID)
+		}
+		if cycleID != receipt.CycleID {
+			t.Fatalf("ledger cycle_id %q does not match receipt CycleID %q", cycleID, receipt.CycleID)
+		}
+	}
+	if !found {
+		t.Fatalf("no harness.dispatch.job.issued ledger event found for job %q", receipt.JobID)
+	}
+
+	// Unblock the fake dispatcher and wait out the goroutine (see
+	// waitForTerminalJob's comment on why this matters for t.TempDir cleanup).
+	close(block)
+	waitForTerminalJob(t, server, receipt.JobID)
+}
+
 // TestQueryDispatchToHarness_SyncPathUnaffectedByAsyncField is the flag-off
 // mirror: Async=false (the zero value / default) must behave byte-for-byte
 // like before this change — synchronous, returning a DispatchBatchResult

--- a/internal/engine/local_agent_harness.go
+++ b/internal/engine/local_agent_harness.go
@@ -1689,7 +1689,20 @@ func (c *LocalHarnessController) dispatchSlot(parent context.Context, provider P
 	// identical fan-out slots share a KV-cache prefix. Hash (systemPrompt +
 	// task + sorted tool names); append idx only for per-slot log uniqueness —
 	// the prefix up to the dash is cache-relevant and identical across slots.
-	tools := registry.Definitions()
+	//
+	// registry.Definitions() returns the registry's own backing slice by
+	// reference (tool_loop.go KernelToolRegistry.Definitions), and registry
+	// here is c.dispatchTools — constructed once at controller-construction
+	// time and shared across every fan-out slot and every subsequent
+	// dispatch. filterToolsByCapability below compacts creq.Tools IN PLACE
+	// (serve_kernel_agent_tools.go: `out := creq.Tools[:0]`); handing it the
+	// live registry slice would let one gated dispatch permanently truncate
+	// the shared registry for every later dispatch, gated or not, and races
+	// under concurrent fan-out (N>1). Copy into a fresh slice first — the
+	// same "allocate fresh slices so we don't accidentally alias" discipline
+	// injectKernelAgentTools already applies to the chat path.
+	tools := make([]ToolDefinition, len(registry.Definitions()))
+	copy(tools, registry.Definitions())
 	toolNames := make([]string, len(tools))
 	for i, t := range tools {
 		toolNames[i] = t.Name

--- a/internal/engine/local_agent_harness.go
+++ b/internal/engine/local_agent_harness.go
@@ -384,6 +384,29 @@ type LocalHarnessController struct {
 	// KV-cache sharing. Content: identity (name + role inline, NOT the full Card),
 	// directive framing, scope sentinel, and workspace pointer (cog:// URI).
 	harnessOrientationBlock string
+
+	// mcpSrv is retained (previously the constructor accepted it only to
+	// build the tool registry, then dropped it) so dispatchSlot can reach a
+	// capability gater wired onto the MCP server *after* this controller was
+	// constructed (MCPServer.SetCapabilityResolver runs post-construction —
+	// see mcp_sessions_identity.go). Read lazily via capabilityGater() on
+	// every dispatch rather than snapshotted once, since the resolver can be
+	// wired (or, in tests, swapped) at any point in the process lifetime.
+	// Nil-safe: a nil mcpSrv (should not happen — NewLocalHarnessControllerWithScope
+	// already requires a non-nil mcpSrv) degrades capabilityGater() to nil,
+	// which is permit-by-default same as an unwired resolver.
+	mcpSrv *MCPServer
+}
+
+// capabilityGater returns the capability gater currently wired onto this
+// controller's MCP server, or nil when none is wired (permit-by-default).
+// See the mcpSrv field doc for why this is a lazy read rather than a
+// construction-time snapshot.
+func (c *LocalHarnessController) capabilityGater() capabilityGater {
+	if c == nil || c.mcpSrv == nil {
+		return nil
+	}
+	return c.mcpSrv.capResolver
 }
 
 func NewLocalHarnessController(cfg *Config, nucleus *Nucleus, process *Process, mcpSrv *MCPServer) (*LocalHarnessController, error) {
@@ -477,6 +500,7 @@ func NewLocalHarnessControllerWithScope(cfg *Config, nucleus *Nucleus, process *
 		interval:                 interval,
 		localProviderTimeout:     resolveLocalProviderTimeout(cfg),
 		harnessOrientationBlock:  orientationBlock,
+		mcpSrv:                   mcpSrv,
 	}, nil
 }
 
@@ -1698,6 +1722,31 @@ func (c *LocalHarnessController) dispatchSlot(parent context.Context, provider P
 			// provider adapters so the ledger InferenceEvent can record it.
 			Attribution: subject,
 		},
+	}
+
+	// Capability gating (RFC-identity-embedding, the gap the file previously
+	// called out explicitly at this spot: "No capability gating here; this
+	// is observability metadata only"). Reuses filterToolsByCapability
+	// (serve_kernel_agent_tools.go) — the same permit-by-default filter the
+	// chat path applies — rather than duplicating its logic here.
+	//
+	// Three-part gate, matching the chat path's own contract
+	// (serve.go: `cfg.IdentityNakedDefault && bound.Bound && capResolver != nil`):
+	//   - IdentityNakedDefault: the dark flag: false today by default
+	//     (config.go), so this is a no-op until an operator opts in.
+	//   - gater != nil: SetCapabilityResolver has zero production callers as
+	//     of this change (capResolver is nil at runtime everywhere) — so
+	//     even with the flag on, gating stays dark until separate boot
+	//     wiring constructs a CapabilityCache+CapabilityResolver. Acceptable:
+	//     same dark-flag posture as the chat path's existing (also-dark)
+	//     gates (tool_observer.go, mcp_tool_catalog.go, serve.go).
+	//   - subject != "anonymous": an unbound/unauthenticated dispatch has no
+	//     envelope to check against; mirrors the chat path's `bound.Bound`
+	//     check (bound.Subject would be irrelevant when not bound).
+	if c.cfg != nil && c.cfg.IdentityNakedDefault && subject != "" && subject != "anonymous" {
+		if gater := c.capabilityGater(); gater != nil {
+			filterToolsByCapability(compReq, subject, gater)
+		}
 	}
 
 	start := time.Now()

--- a/internal/engine/local_agent_harness.go
+++ b/internal/engine/local_agent_harness.go
@@ -1605,8 +1605,10 @@ func (c *LocalHarnessController) DispatchToHarness(ctx context.Context, req Disp
 	ctx = withDispatchCycleID(ctx, cycleID)
 
 	// RFC-identity-embedding I1/I2: resolve the caller subject for honest
-	// attribution in both bound and anonymous states. No capability gating here;
-	// this is observability metadata only (Wave-6b adds CRD validation).
+	// attribution in both bound and anonymous states. Capability gating on
+	// this subject happens later, in dispatchSlot, behind
+	// cfg.IdentityNakedDefault (see dispatchSlot's own comment for the
+	// three-part gate) — subject resolution here is just attribution.
 	subject := req.Identity.Sub
 	if subject == "" {
 		subject = "anonymous"

--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -136,6 +136,13 @@ type MCPServer struct {
 	// directly (package-boundary guard).  When non-nil, also stored in
 	// pkgFTSRepairIndexer so the free-function lazy-repair path can reach it.
 	constellationIndexer ConstellationIndexer
+
+	// dispatchJobs backs the async cog_dispatch_to_harness path (Async=true
+	// on dispatchToHarnessInput) and GET /v1/dispatch-jobs/{id}. Constructed
+	// unconditionally in NewMCPServerWithAgentController — never nil — so
+	// toolDispatchToHarness and the HTTP poll handler don't need a nil check
+	// before every use. See dispatch_jobs.go.
+	dispatchJobs *DispatchJobRegistry
 }
 
 // channelSessionBackend is the narrow surface the mod3 session-family MCP
@@ -173,6 +180,7 @@ func NewMCPServerWithAgentController(cfg *Config, nucleus *Nucleus, process *Pro
 		cogdocSvc:        NewCogDocService(cfg, process),
 		agentController:  ctrl,
 		deferredHandlers: make(map[string]deferredToolHandler),
+		dispatchJobs:     NewDispatchJobRegistry(),
 	}
 
 	m.registerTools()
@@ -307,7 +315,7 @@ func (m *MCPServer) registerTools() {
 
 	mcp.AddTool(m.server, m.trackTool(&mcp.Tool{
 		Name:        "cog_dispatch_to_harness",
-		Description: "Phase 2 transport: dispatch a task into the kernel-interior agent harness with structured return, optional concurrency (n=1..4), named tool scope, per-call tool narrowing, optional system-prompt override, and pluggable model routing (default: the resolved provider's configured default model — provider resolution follows harness_provider config and process-state routing; explicit provider/model params override). Synchronous: blocks until every slot completes, errors, or hits its per-slot timeout (default 240s; max = the kernel's dispatch timeout cap, dispatch_timeout_cap_seconds in kernel.yaml, default 600s — over-cap requests are rejected before any slot runs). Returns one DispatchResult per slot with content (the agent's final respond text), tool-call digests, duration, and turn count. Use this for the foveal->peripheral handoff — offload validation, rewriting, modality matching to the resident swarm instead of paying with Anthropic tokens. Named scopes (RFC-016): \"consolidation\" (default, 11 substrate tools: memory/field/coherence/identity; respond excluded from base), \"consolidation_with_respond\" (+ respond), \"consolidation_no_respond\" (no respond), \"audit\" (consolidation + cog_read_file + cog_grep_files), \"search\" (cog_resolve_uri/cog_search_memory/cog_query_field), \"observe\" (consolidation reads, no emit), \"emit\" (cog_emit_event only). Unknown scope names error immediately. Backward-compat note: cog_trigger_agent_loop still wakes the singleton with no payload; this tool is the new payload-bearing path.",
+		Description: "Phase 2 transport: dispatch a task into the kernel-interior agent harness with structured return, optional concurrency (n=1..4), named tool scope, per-call tool narrowing, optional system-prompt override, and pluggable model routing (default: the resolved provider's configured default model — provider resolution follows harness_provider config and process-state routing; explicit provider/model params override). Synchronous by default: blocks until every slot completes, errors, or hits its per-slot timeout (default 240s; max = the kernel's dispatch timeout cap, dispatch_timeout_cap_seconds in kernel.yaml, default 600s — over-cap requests are rejected before any slot runs). Returns one DispatchResult per slot with content (the agent's final respond text), tool-call digests, duration, and turn count. Set async=true to instead get an immediate {job_id, status:\"pending\"} receipt and poll via cog_poll_dispatch or GET /v1/dispatch-jobs/{id} — use this when the dispatch may outlive the caller's own request window. Use this for the foveal->peripheral handoff — offload validation, rewriting, modality matching to the resident swarm instead of paying with Anthropic tokens. Named scopes (RFC-016): \"consolidation\" (default, 11 substrate tools: memory/field/coherence/identity; respond excluded from base), \"consolidation_with_respond\" (+ respond), \"consolidation_no_respond\" (no respond), \"audit\" (consolidation + cog_read_file + cog_grep_files), \"search\" (cog_resolve_uri/cog_search_memory/cog_query_field), \"observe\" (consolidation reads, no emit), \"emit\" (cog_emit_event only). Unknown scope names error immediately. Backward-compat note: cog_trigger_agent_loop still wakes the singleton with no payload; this tool is the new payload-bearing path.",
 	}), m.toolDispatchToHarness)
 
 	// Kernel-native session/handoff tools (mcp_sessions.go). The porcelain
@@ -391,6 +399,11 @@ func (m *MCPServer) registerTools() {
 		Name:        "cog_trigger_agent_loop",
 		Description: "Manually invoke one homeostatic cycle of the specified agent, outside the regular ticker. Equivalent to POST /v1/agents/{id}/tick. Returns immediately with a trigger receipt; cycle runs async unless wait=true. Refuses if a cycle is already in flight (overlap guard). Fallback: kernel API POST /v1/agents/primary/tick (local port 6931)",
 	}, m.toolTriggerAgentLoop)
+
+	trackToolDeferred(m, &mcp.Tool{
+		Name:        "cog_poll_dispatch",
+		Description: "Poll the status of an async cog_dispatch_to_harness job (one issued with async=true). Returns {job_id, status: pending|running|done|failed, cycle_id, result, error, created_at, updated_at}. result/error populate only once status is terminal (done/failed). Jobs are retained for a bounded window after completion (~30m) then lazily reclaimed — an unknown job_id after that window returns a clear not-found error. Convenience wrapper; the primary poll surface is GET /v1/dispatch-jobs/{id} (local port 6931).",
+	}, m.toolPollDispatch)
 
 	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_tail_kernel_log",
@@ -882,6 +895,33 @@ type dispatchToHarnessInput struct {
 	Aud          string                 `json:"aud,omitempty" jsonschema:"OIDC-shaped identity claim: audience (e.g. \"cogos.kernel\")."`
 	Claims       map[string]interface{} `json:"claims,omitempty" jsonschema:"Free-form OIDC claim bag forwarded to the dispatch's trace metadata."`
 	TargetNode   string                 `json:"target_node,omitempty" jsonschema:"Phase 2 S4: when set, forward this dispatch to the named peer node over the authenticated BEP cluster channel. Requires cluster.enabled=true and the peer to be connected. Empty (default) runs on the local harness."`
+	Async        bool                   `json:"async,omitempty" jsonschema:"When true, return a job handle immediately ({job_id, status:\"pending\"}) instead of blocking until the dispatch completes. Poll the job via GET /v1/dispatch-jobs/{id} or the cog_poll_dispatch tool. Default false (synchronous, unchanged behavior)."`
+}
+
+// dispatchJobReceipt is the immediate response for an async dispatch — the
+// job handle a caller polls until it reaches a terminal state.
+type dispatchJobReceipt struct {
+	JobID   string `json:"job_id"`
+	Status  string `json:"status"`
+	CycleID string `json:"cycle_id,omitempty"`
+}
+
+// dispatchJobStatusResponse is the poll response shape for both the MCP
+// cog_poll_dispatch tool and GET /v1/dispatch-jobs/{id}. Result/Error are
+// populated only once Status is terminal (done/failed).
+type dispatchJobStatusResponse struct {
+	JobID     string               `json:"job_id"`
+	Status    string               `json:"status"`
+	CycleID   string               `json:"cycle_id,omitempty"`
+	Result    *DispatchBatchResult `json:"result,omitempty"`
+	Error     string               `json:"error,omitempty"`
+	CreatedAt string               `json:"created_at,omitempty"`
+	UpdatedAt string               `json:"updated_at,omitempty"`
+}
+
+// pollDispatchInput is the wire shape for cog_poll_dispatch.
+type pollDispatchInput struct {
+	JobID string `json:"job_id" jsonschema:"Required. The job_id returned by an async (Async=true) cog_dispatch_to_harness call."`
 }
 
 // readToolCallsInput mirrors ToolCallQuery for the MCP surface. Time bounds
@@ -2027,6 +2067,9 @@ func (m *MCPServer) toolTriggerAgentLoop(ctx context.Context, req *mcp.CallToolR
 // task-parameterized transport. See engine/agent_dispatch.go for the
 // underlying contract and the project_cogos_foveal_and_peripheral.md memory
 // note for the architectural framing.
+//
+// Async=true (dispatchToHarnessInput.Async) switches this from a blocking
+// call to a job-handle receipt: see dispatch_jobs.go and toolPollDispatch.
 func (m *MCPServer) toolDispatchToHarness(ctx context.Context, req *mcp.CallToolRequest, input dispatchToHarnessInput) (*mcp.CallToolResult, any, error) {
 	dr := DispatchRequest{
 		AgentID:        input.AgentID,
@@ -2050,11 +2093,123 @@ func (m *MCPServer) toolDispatchToHarness(ctx context.Context, req *mcp.CallTool
 		},
 		TargetNode: input.TargetNode,
 	}
+
+	if input.Async {
+		return m.dispatchToHarnessAsync(ctx, dr)
+	}
+
 	result, err := QueryDispatchToHarnessRouted(ctx, m.agentController, m.clusterRouter, dr)
 	if err != nil {
 		return agentErrorResult(err, "curl -X POST http://localhost:6931/v1/agents/primary/dispatch -d @body.json")
 	}
 	return m.cappedMarshal(result)
+}
+
+// dispatchToHarnessAsync is the MCP-tool-facing wrapper around
+// startAsyncDispatch — see that function for the mechanism.
+func (m *MCPServer) dispatchToHarnessAsync(ctx context.Context, dr DispatchRequest) (*mcp.CallToolResult, any, error) {
+	receipt := m.startAsyncDispatch(ctx, dr)
+	return marshalResult(receipt)
+}
+
+// startAsyncDispatch registers a job, spawns the real dispatch under a
+// context detached from the caller's request (see dispatch_jobs.go doc
+// comment — #432/e4e6aca: the request context dies the instant the calling
+// handler returns, and the goroutine must not inherit that cancellation),
+// and returns the job handle immediately. Shared by both transports that
+// accept async=true: the MCP tool (dispatchToHarnessAsync) and the HTTP
+// handler (Server.handleAgentDispatch, serve_agents.go).
+//
+// The job's CycleID is a registry-minted correlation id, not the harness-
+// internal cycle id LocalHarnessController.DispatchToHarness mints for its
+// own ledger events (local_agent_harness.go:1580) — that id is generated
+// inside the dispatcher and isn't visible at this layer before the call
+// starts. Both ids end up in the ledger (harness.dispatch.job.issued carries
+// this job's CycleID; harness.dispatch.start/end carry the dispatcher's) so
+// either can be used to locate the other via time-window correlation.
+func (m *MCPServer) startAsyncDispatch(ctx context.Context, dr DispatchRequest) dispatchJobReceipt {
+	jobID := m.dispatchJobs.Create("")
+	rec, _ := m.dispatchJobs.Get(jobID)
+
+	_ = EmitLedgerEvent(m.cfg, map[string]any{
+		"type":   "harness.dispatch.job.issued",
+		"source": "mcp-dispatch-async",
+		"payload": map[string]any{
+			"job_id": jobID,
+			"task":   truncateDigest(dr.Task),
+		},
+	})
+
+	detached, cancel := detachedDispatchContext(ctx, dr.TimeoutSeconds)
+	agentController := m.agentController
+	clusterRouter := m.clusterRouter
+	registry := m.dispatchJobs
+	cfg := m.cfg
+
+	go func() {
+		defer cancel()
+		registry.MarkRunning(jobID)
+		result, err := QueryDispatchToHarnessRouted(detached, agentController, clusterRouter, dr)
+		if err != nil {
+			registry.Fail(jobID, err.Error())
+			_ = EmitLedgerEvent(cfg, map[string]any{
+				"type":   "harness.dispatch.job.completed",
+				"source": "mcp-dispatch-async",
+				"payload": map[string]any{
+					"job_id": jobID,
+					"status": "failed",
+					"error":  err.Error(),
+				},
+			})
+			return
+		}
+		registry.Complete(jobID, result)
+		_ = EmitLedgerEvent(cfg, map[string]any{
+			"type":   "harness.dispatch.job.completed",
+			"source": "mcp-dispatch-async",
+			"payload": map[string]any{
+				"job_id": jobID,
+				"status": "done",
+			},
+		})
+	}()
+
+	receipt := dispatchJobReceipt{JobID: jobID, Status: string(DispatchJobPending)}
+	if rec != nil {
+		receipt.CycleID = rec.CycleID
+	}
+	return receipt
+}
+
+// toolPollDispatch implements cog_poll_dispatch — the MCP convenience poll
+// surface for an async cog_dispatch_to_harness job. The primary poll surface
+// is GET /v1/dispatch-jobs/{id} (serve_agents.go); this tool exists so a
+// caller that only has MCP available doesn't need the HTTP port.
+func (m *MCPServer) toolPollDispatch(ctx context.Context, req *mcp.CallToolRequest, input pollDispatchInput) (*mcp.CallToolResult, any, error) {
+	jobID := strings.TrimSpace(input.JobID)
+	if jobID == "" {
+		return fallbackResult("job_id is required", "curl http://localhost:6931/v1/dispatch-jobs/<job_id>")
+	}
+	rec, ok := m.dispatchJobs.Get(jobID)
+	if !ok {
+		return fallbackResult(fmt.Sprintf("no such dispatch job %q (unknown, or expired past the %s retention window)", jobID, dispatchJobTTL),
+			"curl http://localhost:6931/v1/dispatch-jobs/"+jobID)
+	}
+	return m.cappedMarshal(dispatchJobStatusFromRecord(rec))
+}
+
+// dispatchJobStatusFromRecord converts a DispatchJobRecord into the wire
+// response shape shared by the MCP poll tool and the HTTP poll route.
+func dispatchJobStatusFromRecord(rec *DispatchJobRecord) dispatchJobStatusResponse {
+	return dispatchJobStatusResponse{
+		JobID:     rec.JobID,
+		Status:    string(rec.State),
+		CycleID:   rec.CycleID,
+		Result:    rec.Result,
+		Error:     rec.Err,
+		CreatedAt: rec.CreatedAt.Format(time.RFC3339),
+		UpdatedAt: rec.UpdatedAt.Format(time.RFC3339),
+	}
 }
 
 // agentErrorResult translates AgentControllerError into the MCP fallback

--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -32,6 +32,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"gopkg.in/yaml.v3"
 )
@@ -2128,15 +2129,25 @@ func (m *MCPServer) dispatchToHarnessAsync(ctx context.Context, dr DispatchReque
 // this job's CycleID; harness.dispatch.start/end carry the dispatcher's) so
 // either can be used to locate the other via time-window correlation.
 func (m *MCPServer) startAsyncDispatch(ctx context.Context, dr DispatchRequest) dispatchJobReceipt {
-	jobID := m.dispatchJobs.Create("")
+	// Mint the registry's own correlation id up front. This is NOT the same
+	// id as the harness-internal cycleID DispatchToHarness mints later
+	// (local_agent_harness.go:1604) — that one doesn't exist yet at this
+	// layer, before the dispatch has even started. This id just needs to be
+	// non-empty and stable across the receipt + the job.issued ledger event
+	// so a caller (or a bus consumer correlating harness.dispatch.job.issued
+	// against harness.dispatch.start/end) has something to key on; see the
+	// package doc above this function for how the two ids relate.
+	cycleID := uuid.NewString()
+	jobID := m.dispatchJobs.Create(cycleID)
 	rec, _ := m.dispatchJobs.Get(jobID)
 
 	_ = EmitLedgerEvent(m.cfg, map[string]any{
 		"type":   "harness.dispatch.job.issued",
 		"source": "mcp-dispatch-async",
 		"payload": map[string]any{
-			"job_id": jobID,
-			"task":   truncateDigest(dr.Task),
+			"job_id":   jobID,
+			"cycle_id": cycleID,
+			"task":     truncateDigest(dr.Task),
 		},
 	})
 

--- a/internal/engine/serve_agents.go
+++ b/internal/engine/serve_agents.go
@@ -13,6 +13,15 @@ type triggerAgentHTTPInput struct {
 	Wait   bool   `json:"wait"`
 }
 
+// agentDispatchHTTPInput mirrors dispatchToHarnessInput's async field onto
+// the HTTP surface (POST /v1/agents/{id}/dispatch) — sibling-path discipline
+// with the MCP tool's Async parameter. Embeds DispatchRequest so all other
+// fields decode exactly as before; Async is the only addition.
+type agentDispatchHTTPInput struct {
+	DispatchRequest
+	Async bool `json:"async,omitempty"`
+}
+
 type agentStatusCompat struct {
 	AgentSummary
 	Uptime          string                `json:"uptime,omitempty"`
@@ -29,6 +38,7 @@ func (s *Server) registerAgentRoutes(mux *http.ServeMux) {
 	s.route(mux, "GET /v1/agents/{id}", s.handleAgentGet)
 	s.route(mux, "POST /v1/agents/{id}/tick", s.handleAgentTick)
 	s.route(mux, "POST /v1/agents/{id}/dispatch", s.handleAgentDispatch)
+	s.route(mux, "GET /v1/dispatch-jobs/{id}", s.handleDispatchJobGet)
 
 	// Legacy dashboard routes.
 	s.route(mux, "GET /v1/agent/status", s.handleAgentStatusCompat)
@@ -74,13 +84,14 @@ func (s *Server) handleAgentTick(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleAgentDispatch(w http.ResponseWriter, r *http.Request) {
-	var input DispatchRequest
-	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+	var wrapped agentDispatchHTTPInput
+	if err := json.NewDecoder(r.Body).Decode(&wrapped); err != nil {
 		writeAgentJSON(w, http.StatusBadRequest, map[string]any{
 			"error": "invalid_json",
 		})
 		return
 	}
+	input := wrapped.DispatchRequest
 	if input.AgentID == "" {
 		input.AgentID = r.PathValue("id")
 	}
@@ -88,12 +99,49 @@ func (s *Server) handleAgentDispatch(w http.ResponseWriter, r *http.Request) {
 	// cap with this node's configured dispatch_timeout_cap_seconds
 	// (default 600). Nil-receiver-safe.
 	input.TimeoutCapSeconds = s.cfg.DispatchTimeoutCap()
+
+	if wrapped.Async {
+		if s.mcpServer == nil {
+			writeAgentJSON(w, http.StatusServiceUnavailable, map[string]any{
+				"error": "async dispatch requires the MCP server (job registry) to be wired",
+				"code":  "unavailable",
+			})
+			return
+		}
+		receipt := s.mcpServer.startAsyncDispatch(r.Context(), input)
+		writeAgentJSON(w, http.StatusAccepted, receipt)
+		return
+	}
+
 	resp, err := QueryDispatchToHarness(r.Context(), s.agentController, input)
 	if err != nil {
 		writeAgentHTTPError(w, err)
 		return
 	}
 	writeAgentJSON(w, http.StatusOK, resp)
+}
+
+// handleDispatchJobGet implements GET /v1/dispatch-jobs/{id} — the primary
+// poll surface for an async cog_dispatch_to_harness job (mirrored by the
+// cog_poll_dispatch MCP tool for callers without HTTP access).
+func (s *Server) handleDispatchJobGet(w http.ResponseWriter, r *http.Request) {
+	if s.mcpServer == nil {
+		writeAgentJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"error": "dispatch job registry is not wired (MCP server not configured)",
+			"code":  "unavailable",
+		})
+		return
+	}
+	jobID := r.PathValue("id")
+	rec, ok := s.mcpServer.dispatchJobs.Get(jobID)
+	if !ok {
+		writeAgentJSON(w, http.StatusNotFound, map[string]any{
+			"error": fmt.Sprintf("no such dispatch job %q", jobID),
+			"code":  "not_found",
+		})
+		return
+	}
+	writeAgentJSON(w, http.StatusOK, dispatchJobStatusFromRecord(rec))
 }
 
 func (s *Server) handleAgentStatusCompat(w http.ResponseWriter, r *http.Request) {

--- a/internal/engine/serve_agents_test.go
+++ b/internal/engine/serve_agents_test.go
@@ -1,0 +1,273 @@
+// serve_agents_test.go — coverage for the HTTP dispatch-job surface added
+// alongside the async job-handle registry (dispatch_jobs.go): GET
+// /v1/dispatch-jobs/{id} (handleDispatchJobGet) and the async=true branch of
+// POST /v1/agents/{id}/dispatch (handleAgentDispatch). Both were previously
+// untested despite being called out in the PR description as the "primary"
+// poll surface (HTTP callers without MCP access use this; cog_poll_dispatch
+// is the MCP-side mirror already covered by dispatch_jobs_test.go).
+//
+// Tests route through srv.Handler() (the real corsMiddleware(mux) stack) so
+// path values ({id}) are resolved exactly as they are in production, rather
+// than calling the handler methods directly and faking r.PathValue.
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// --- GET /v1/dispatch-jobs/{id} ---------------------------------------------
+
+// TestHandleDispatchJobGet_HappyPathReturnsJobState drives a real async
+// dispatch through the MCP tool (so a genuine job lands in the registry) and
+// then polls it via the HTTP surface, confirming the shape matches the
+// MCP-side poll response (dispatchJobStatusResponse — same struct, same
+// json tags) and eventually reflects the terminal result.
+func TestHandleDispatchJobGet_HappyPathReturnsJobState(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+
+	block := make(chan struct{})
+	disp := &blockingDispatcher{
+		release: block,
+		canned:  &DispatchBatchResult{Results: []DispatchResult{{Index: 0, Success: true, Content: "the answer"}}},
+	}
+	srv.SetAgentController(disp)
+	if srv.mcpServer == nil {
+		t.Fatal("test server has no mcpServer wired; dispatch job registry cannot be reached")
+	}
+
+	receipt := srv.mcpServer.startAsyncDispatch(context.Background(), DispatchRequest{Task: "do the thing"})
+	if receipt.JobID == "" {
+		t.Fatal("startAsyncDispatch returned an empty job id")
+	}
+
+	// Poll while still in flight (fake dispatcher blocked on `release`).
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/dispatch-jobs/"+receipt.JobID, nil)
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("in-flight poll status = %d; want 200; body=%s", w.Code, w.Body.String())
+	}
+	var inFlight dispatchJobStatusResponse
+	if err := json.NewDecoder(w.Body).Decode(&inFlight); err != nil {
+		t.Fatalf("decode in-flight body: %v", err)
+	}
+	if inFlight.JobID != receipt.JobID {
+		t.Errorf("in-flight JobID = %q, want %q", inFlight.JobID, receipt.JobID)
+	}
+	if inFlight.Status != string(DispatchJobPending) && inFlight.Status != string(DispatchJobRunning) {
+		t.Errorf("in-flight Status = %q, want pending or running", inFlight.Status)
+	}
+
+	// Release the fake dispatcher and poll again until terminal.
+	close(block)
+	final := pollHTTPUntilTerminal(t, srv, receipt.JobID)
+	if final.Status != string(DispatchJobDone) {
+		t.Fatalf("final Status = %q, want %q (error=%q)", final.Status, DispatchJobDone, final.Error)
+	}
+	if final.Result == nil || len(final.Result.Results) != 1 || final.Result.Results[0].Content != "the answer" {
+		t.Fatalf("final Result mismatch: %+v", final.Result)
+	}
+	if final.CreatedAt == "" || final.UpdatedAt == "" {
+		t.Errorf("expected non-empty CreatedAt/UpdatedAt timestamps, got %+v", final)
+	}
+}
+
+// TestHandleDispatchJobGet_UnknownIDReturns404 guards the not-found path:
+// an id that was never registered (or has been GC'd past its TTL) must come
+// back as 404 with a JSON error body carrying code="not_found", matching
+// writeAgentHTTPError's AgentControllerError{Code:"not_found"} contract used
+// elsewhere on this surface (e.g. handleAgentGet).
+func TestHandleDispatchJobGet_UnknownIDReturns404(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/dispatch-jobs/no-such-job", nil)
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d; want 404; body=%s", w.Code, w.Body.String())
+	}
+	var body map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body["code"] != "not_found" {
+		t.Errorf(`body["code"] = %v, want "not_found"`, body["code"])
+	}
+	if body["error"] == nil || body["error"] == "" {
+		t.Error("expected a non-empty error message")
+	}
+}
+
+// TestHandleDispatchJobGet_MCPServerNilReturns503 covers the defensive guard
+// for a Server built without registerMCPRoutes ever wiring s.mcpServer
+// (mirrors handleAgentDispatch's identical guard a few lines above it in
+// serve_agents.go).
+func TestHandleDispatchJobGet_MCPServerNilReturns503(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	process := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	srv := &Server{cfg: cfg, nucleus: makeNucleus("Cog", "tester"), process: process}
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/dispatch-jobs/anything", nil)
+	req.SetPathValue("id", "anything")
+	srv.handleDispatchJobGet(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d; want 503; body=%s", w.Code, w.Body.String())
+	}
+}
+
+// --- POST /v1/agents/{id}/dispatch (async=true branch) ----------------------
+
+// TestHandleAgentDispatch_AsyncReturnsImmediateReceipt is the primary
+// regression test for the untested HTTP async dispatch branch: posting with
+// "async":true must return 202 Accepted with a job receipt immediately —
+// not block until the (slow/blocked) dispatcher finishes — and the job must
+// be pollable via GET /v1/dispatch-jobs/{id} afterwards.
+func TestHandleAgentDispatch_AsyncReturnsImmediateReceipt(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+
+	block := make(chan struct{})
+	disp := &blockingDispatcher{
+		release: block,
+		canned:  &DispatchBatchResult{Results: []DispatchResult{{Index: 0, Success: true, Content: "done"}}},
+	}
+	srv.SetAgentController(disp)
+
+	body := `{"task":"do the thing","async":true}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/agents/"+DefaultAgentID+"/dispatch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	// This call must return promptly even though the fake dispatcher is
+	// blocked on `release` — if the async branch didn't fire (e.g. the
+	// async field were ignored and fell through to the synchronous
+	// QueryDispatchToHarness call), this ServeHTTP call would hang until the
+	// test's own deadline, which is exactly the regression this test would
+	// catch.
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d; want 202 Accepted; body=%s", w.Code, w.Body.String())
+	}
+	var receipt dispatchJobReceipt
+	if err := json.NewDecoder(w.Body).Decode(&receipt); err != nil {
+		t.Fatalf("decode receipt: %v", err)
+	}
+	if receipt.JobID == "" {
+		t.Fatal("expected non-empty job_id in async receipt")
+	}
+	if receipt.Status != string(DispatchJobPending) {
+		t.Errorf("receipt.Status = %q, want %q", receipt.Status, DispatchJobPending)
+	}
+
+	// Confirm it is reachable via the poll surface, then let it finish so
+	// the goroutine doesn't race t.TempDir() cleanup.
+	pollW := httptest.NewRecorder()
+	pollReq := httptest.NewRequest(http.MethodGet, "/v1/dispatch-jobs/"+receipt.JobID, nil)
+	srv.Handler().ServeHTTP(pollW, pollReq)
+	if pollW.Code != http.StatusOK {
+		t.Fatalf("poll status = %d; want 200; body=%s", pollW.Code, pollW.Body.String())
+	}
+
+	close(block)
+	final := pollHTTPUntilTerminal(t, srv, receipt.JobID)
+	if final.Status != string(DispatchJobDone) {
+		t.Fatalf("final Status = %q, want %q (error=%q)", final.Status, DispatchJobDone, final.Error)
+	}
+}
+
+// TestHandleAgentDispatch_AsyncWithoutMCPServerReturns503 covers
+// handleAgentDispatch's guard: async=true with no MCP server wired (job
+// registry unreachable) must fail loudly with 503, not silently fall through
+// to a synchronous dispatch or panic on a nil s.mcpServer dereference.
+func TestHandleAgentDispatch_AsyncWithoutMCPServerReturns503(t *testing.T) {
+	t.Parallel()
+	root := makeWorkspace(t)
+	cfg := makeConfig(t, root)
+	process := NewProcess(cfg, makeNucleus("Cog", "tester"))
+	srv := &Server{cfg: cfg, nucleus: makeNucleus("Cog", "tester"), process: process}
+	srv.agentController = &fakeAgentDispatcher{cannedOk: true}
+
+	body := `{"task":"do the thing","async":true}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/agents/"+DefaultAgentID+"/dispatch", strings.NewReader(body))
+	req.SetPathValue("id", DefaultAgentID)
+	req.Header.Set("Content-Type", "application/json")
+	srv.handleAgentDispatch(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d; want 503; body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleAgentDispatch_SyncPathUnaffected is the flag-off sibling: async
+// omitted (defaults false) must behave as a normal synchronous dispatch,
+// returning 200 with a DispatchBatchResult body — confirming the new async
+// branch is additive and doesn't disturb the existing behavior this route
+// already had.
+func TestHandleAgentDispatch_SyncPathUnaffected(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t)
+	disp := &fakeAgentDispatcher{canned: &DispatchBatchResult{
+		Results: []DispatchResult{{Index: 0, Success: true, Content: "sync-result"}},
+	}}
+	srv.SetAgentController(disp)
+
+	body := `{"task":"do the thing"}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/agents/"+DefaultAgentID+"/dispatch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200; body=%s", w.Code, w.Body.String())
+	}
+	var batch DispatchBatchResult
+	if err := json.NewDecoder(w.Body).Decode(&batch); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if len(batch.Results) != 1 || batch.Results[0].Content != "sync-result" {
+		t.Fatalf("sync result mismatch: %+v", batch)
+	}
+}
+
+// pollHTTPUntilTerminal polls GET /v1/dispatch-jobs/{id} through srv.Handler()
+// until the job reaches a terminal state (done/failed) or a 5s deadline
+// elapses. Mirrors dispatch_jobs_test.go's waitForTerminalJob (MCP side) —
+// duplicated rather than shared because it drives a different transport
+// (real HTTP handler vs. direct tool-method call).
+func pollHTTPUntilTerminal(t *testing.T, srv *Server, jobID string) dispatchJobStatusResponse {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var status dispatchJobStatusResponse
+	for time.Now().Before(deadline) {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/v1/dispatch-jobs/"+jobID, nil)
+		srv.Handler().ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("poll status = %d; want 200; body=%s", w.Code, w.Body.String())
+		}
+		if err := json.NewDecoder(w.Body).Decode(&status); err != nil {
+			t.Fatalf("decode poll body: %v", err)
+		}
+		if status.Status == string(DispatchJobDone) || status.Status == string(DispatchJobFailed) {
+			return status
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("job %q did not reach a terminal state within 5s (last status=%q)", jobID, status.Status)
+	return status
+}


### PR DESCRIPTION
## Summary

Two independent, planner-cleared spec-gaps, built in the same worktree/branch per the plan (no hard ordering; near-zero file overlap):

- **S2 — async job handle for `cog_dispatch_to_harness`** (the `-32001` killer: interactive MCP request windows close before a synchronous dispatch — up to the 600s cap — completes, and the caller loses the result even though the dispatch itself succeeded).
- **S3 — harness-loop capability gating** behind the existing `IdentityNakedDefault` dark flag (re-scoped from the original sketch, which turned out to be ~60% already shipped — see below).

Do not merge; opened for review per the driving instructions.

---

## S2 — Async dispatch job handle

**What / Why:** `cog_dispatch_to_harness` blocks until every fan-out slot completes, errors, or times out. This adds an opt-in `async=true` path: an immediate `{job_id, status:"pending"}` receipt, then poll `cog_poll_dispatch` (MCP) or `GET /v1/dispatch-jobs/{id}` (HTTP, the primary poll surface — the MCP request window is the root cause this closes) until the job reaches `done`/`failed`.

**How:**
- `internal/engine/dispatch_jobs.go` (new) — `DispatchJobRegistry`: mutex-guarded map keyed by a **fresh UUID**, not the per-slot content-keyed `RequestID` computed in `dispatchSlot` (`local_agent_harness.go:1674-1693`), which collides by design on identical dispatch content and is unfit as a job-registry key. States `pending → running → done|failed`; lazy TTL GC (~30m) sweeps terminal records on `Create` rather than a background ticker.
- `internal/engine/mcp_server.go:869` area — `Async bool` added to `dispatchToHarnessInput`. `toolDispatchToHarness` branches to `startAsyncDispatch`, which registers the job and spawns the real dispatch under a context **detached** from the request (`context.WithoutCancel` + a fresh `WithTimeout` from `TimeoutSeconds`) — the MCP-request-context teardown that follows the immediate receipt return must not cancel the in-flight dispatch. See `#432`/`e4e6aca` on this exact cancellation-propagation hazard. `cog_poll_dispatch` registered as a deferred (plumbing) tool via `trackToolDeferred`. `MCPServer` gains a `dispatchJobs` registry field, constructed unconditionally in `NewMCPServerWithAgentController`.
- `internal/engine/serve_agents.go` — `GET /v1/dispatch-jobs/{id}` added to the route table (`s.route` pattern, `:31` area). `POST /v1/agents/{id}/dispatch` mirrors `async=true` via a wrapper input type embedding `DispatchRequest` (sibling-path discipline).
- Ledger: `harness.dispatch.job.issued` / `.completed` events correlate the job lifecycle. The job's own `CycleID` is a registry-minted id, honestly distinct from (but time-correlatable with) the harness-internal cycle id `LocalHarnessController.DispatchToHarness` mints for its own `harness.dispatch.start/end` events (`local_agent_harness.go:1580`) — the two aren't the same id because the harness-internal one doesn't exist yet when the async job is created.

**Test evidence** (`internal/engine/dispatch_jobs_test.go`): registry lifecycle (pending→running→done/failed, defensive-copy `Get`, TTL GC reclaiming only terminal jobs); async tool call returns an immediate job handle while the underlying dispatcher is blocked; poll transitions pending→done with a result matching what the synchronous path would return for the same input; unknown-job-id error handling; default (`async=false`) path unchanged. All green under `-race`.

---

## S3 — Harness-loop capability gating

**Re-scope note:** the original sketch's deliverable ("thread identity through the harness") is **already ~60% shipped**. `toolDispatchToHarness` already carries `Iss/Sub/Aud/Claims` into `DispatchIdentity` (`mcp_server.go:2045-2050`); `DispatchToHarness` already resolves `subject := req.Identity.Sub` with an `"anonymous"` fallback (`local_agent_harness.go:1586`), emits it on `harness.dispatch.start/end` ledger events, stamps `Metadata.Attribution` on every `CompletionRequest`, and emits per-tool-call traces with attribution. A PR built straight off the sketch would have been a no-op. The genuine gap is what the file's own comment names explicitly at that spot: *"No capability gating here; this is observability metadata only (Wave-6b adds CRD validation)."*

**What / Why:** close that one real gap — honor a wired `capabilityGater` inside the harness tool loop when `IdentityNakedDefault` is true, reusing the existing permit-by-default filter rather than duplicating its logic.

**How:**
- `internal/engine/local_agent_harness.go` — `LocalHarnessController` retains `mcpSrv` (previously accepted by `NewLocalHarnessControllerWithScope` only to build `NewKernelToolRegistry(mcpSrv)`, then dropped — confirmed `KernelToolRegistry` copies `cfg` only, no `MCPServer` retention, so the harness genuinely could not reach `capResolver` before this change). New `capabilityGater()` accessor reads `c.mcpSrv.capResolver` **lazily** (not snapshotted at construction) since `SetCapabilityResolver` runs post-construction. In `dispatchSlot`, when `cfg.IdentityNakedDefault && gater != nil && subject != "anonymous"`, calls `filterToolsByCapability` (`serve_kernel_agent_tools.go:91`, unmodified — reused as-is) to prune `compReq.Tools` before the completion request is sent. Mirrors the chat path's own three-part gate condition (`serve.go:994`).
- No `mcp_server.go` change needed for S3 (identity fields already wired).

**Honesty finding, carried forward per plan:** `SetCapabilityResolver` (`mcp_sessions_identity.go:65`) has **zero production callers** as of this change — `capResolver` is `nil` at runtime everywhere, so this gate is dark today, same posture as the chat path's own already-dark gates (`tool_observer.go:503`, `mcp_tool_catalog.go:236`, `serve.go:994`). It stays dark until separate boot wiring constructs a `CapabilityCache` + `CapabilityResolver`. Acceptable under the established `IdentityNakedDefault` dark-flag pattern (`config.go:182-189`); not a blocker for this PR, but flagging it explicitly rather than letting it pass silently.

**Test evidence** (`internal/engine/dispatch_capability_gating_test.go`): an httptest OpenAI-compat fake captures the `tools` array on every `/v1/chat/completions` request. Flag on + gater denies `cog_emit_event` + bound subject → tool absent from what the provider receives. Flag off (default) → unchanged. Flag on + no gater wired → permit-by-default, unchanged. Flag on + gater wired + anonymous subject (no `Identity.Sub`) → unchanged (no envelope to check, mirrors the chat path's `bound.Bound` condition). Confirmed the primary test **fails without the `dispatchSlot` change** (temporarily disabled the gate, watched it fail, restored it, watched it pass) before committing.

---

## Gates (both items)

- `gofmt -l` on all touched/new files: clean (repo baseline has ~55 pre-existing gofmt-nonconformant files unrelated to this work, confirmed via `git stash` diff — not introduced here).
- `go build ./...`: clean.
- `go vet ./...`: clean.
- `go test ./internal/engine/...`: full package green, including under `-race` for all new tests.
- Baseline: branch `feat/async-dispatch-job-handle` @ `ed0714a` built clean before any change (`go build ./internal/engine ./internal/identity`).

## Not done / deferred

- No `Subject()` dedup helper (plan called it optional) — there is currently exactly one call site for the anonymous-fallback (`local_agent_harness.go:1586`), so a helper would have no second caller to deduplicate against; adding one now would be speculative.
- Execution-time (post-hoc) tool-call rejection as defense-in-depth alongside the pre-filter — plan marked this optional; pre-filtering the tool definitions handed to the model is the primary, required mechanism and is what's implemented. Execution-time enforcement would touch the shared `tool_loop.go` path used well beyond the harness and was judged out of scope for this PR's blast radius.
