### PR TITLE
fix(ci): gate must fail closed — neutral passes a required check on GitHub

### DIFF
--- a/.github/pr-review-rubric.md
+++ b/.github/pr-review-rubric.md
@@ -92,11 +92,21 @@ Two channels carry every verdict. The GitHub review is the authority surface:
 on a solo-maintainer repo this is the only way to require approvals at all,
 since authors cannot approve their own PRs), `request_changes` → a
 REQUEST_CHANGES review, `comment` → a COMMENT review; infra errors post no
-review, because an error must never spend approval. The check-run `cog-review`
-maps approve → success, request_changes → failure, anything else → neutral;
-branch protection treats only success as passing, so silence and errors fail
-closed. Consumers of the verdict must trust only reviews authored by
-`github-actions[bot]` whose `commit_id` equals the head they care about — that
-pair cannot be forged by comment text. The merge action itself always belongs
-to a person or their delegated operator workflow — the gate can approve and
-block, it cannot act.
+review, because an error must never spend approval.
+
+The check-run `cog-review` is where fail-closed actually lives, and it is
+sharper than it looks: **GitHub treats a `neutral` required check as PASSING,
+not blocking.** So the mapping is `approve` → success and **everything else
+(`request_changes`, `comment`, reviewer error, sandbox-canary failure,
+unconfigured token) → `failure`** — a blocking conclusion. Merge requires an
+explicit clean approve; a soft, absent, or errored verdict blocks. (An earlier
+version mapped the soft/error cases to `neutral` and documented them as "fail
+closed" — they were fail *open*; corrected once the check became required.)
+The reviewer call retries a few times so a transient blip doesn't wedge a PR
+under this stricter mapping. Consumers of the verdict must trust only reviews
+authored by `github-actions[bot]` whose `commit_id` equals the head they care
+about — that pair cannot be forged by comment text. The merge action itself
+always belongs to a person or their delegated operator workflow — the gate can
+approve and block, it cannot act. `enforce_admins: false` on the protected
+branch is the deliberate release valve: an admin can override a blocked gate
+(e.g. a persistent reviewer outage), and GitHub records the override visibly.

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -118,9 +118,12 @@ jobs:
         run: |
           if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
+            # failure, NOT neutral: GitHub treats a neutral required check as
+            # PASSING, so neutral here would let PRs merge with no reviewer
+            # configured — fail OPEN. Only an explicit approve may pass.
             gh api "repos/$REPO_FULL/check-runs" \
               -f name='cog-review' -f head_sha="$HEAD_SHA" \
-              -f status='completed' -f conclusion='neutral' \
+              -f status='completed' -f conclusion='failure' \
               -f 'output[title]=Reviewer not configured' \
               -f 'output[summary]=CLAUDE_CODE_OAUTH_TOKEN secret is not set. Mint one with `claude setup-token` and add it as a repo/org secret to enable the AI review gate.'
           else
@@ -238,9 +241,11 @@ jobs:
           else
             echo "sandbox=fail" >> "$GITHUB_OUTPUT"
             echo "::error::Sandbox canary failed: expected both tools (Read, Grep) DENIED, got denied=$DENIED_N allowed=$ALLOWED_N. Skipping review (fail closed)."
+            # failure, NOT neutral (neutral passes a required check) — an
+            # unproven sandbox must block the merge, not wave it through.
             gh api "repos/$REPO_FULL/check-runs" \
               -f name='cog-review' -f head_sha="$HEAD_SHA" \
-              -f status='completed' -f conclusion='neutral' \
+              -f status='completed' -f conclusion='failure' \
               -f 'output[title]=Reviewer sandbox verification failed' \
               -f 'output[summary]=The deny-list canary could not prove Read and Grep denial is in effect on /proc/version. Review skipped; no verdict issued. Fail closed.'
           fi
@@ -276,14 +281,30 @@ jobs:
           # Glob is excluded because it ignores --settings path denies
           # (round-6 finding). Any tool added here must also be added to
           # REVIEW_TOOLS so the deny-gen + canary cover it.
-          claude -p "$(cat /tmp/cog-review/prompt.md)" \
-            --output-format json \
-            --max-turns 40 \
-            --allowedTools "Read" "Grep" \
-            --settings "$DENY" \
-            --model "$COG_REVIEW_MODEL" \
-            > /tmp/cog-review/raw.json 2> /tmp/cog-review/stderr.log
-          CLAUDE_RC=$?
+          #
+          # Bounded retry: the reviewer occasionally returns a non-zero exit or
+          # unparseable output (observed transient Sonnet blips). Now that
+          # non-approve fails CLOSED (blocks the merge), a single transient
+          # flake would wedge a PR until re-run — so retry up to 3 attempts,
+          # accepting the first output that parses to a .verdict. This does not
+          # weaken fail-closed: a genuine request_changes parses on attempt 1
+          # and is kept; only unparseable/empty/error output is retried.
+          CLAUDE_RC=1
+          for attempt in 1 2 3; do
+            claude -p "$(cat /tmp/cog-review/prompt.md)" \
+              --output-format json \
+              --max-turns 40 \
+              --allowedTools "Read" "Grep" \
+              --settings "$DENY" \
+              --model "$COG_REVIEW_MODEL" \
+              > /tmp/cog-review/raw.json 2> /tmp/cog-review/stderr.log
+            CLAUDE_RC=$?
+            if [ "$CLAUDE_RC" = "0" ] && jq -e '.result' /tmp/cog-review/raw.json >/dev/null 2>&1; then
+              break
+            fi
+            echo "::warning::cog-review reviewer attempt $attempt failed (rc=$CLAUDE_RC or unparseable); retrying" >&2
+            sleep $((attempt * 5))
+          done
           set -e
           echo "CLAUDE_EXIT=$CLAUDE_RC" >> "$GITHUB_ENV"
           # Redact the literal token from anything downstream may read/post.
@@ -295,7 +316,7 @@ jobs:
 
       - name: Publish verdict (review + check run)
         # always() so a timed-out or crashed reviewer still posts an explicit
-        # error->neutral verdict instead of vanishing (fail closed WITH a
+        # error->failure verdict instead of vanishing (fail closed WITH a
         # signal). Skipped when the gate is unconfigured (no token) or the
         # canary already posted its own fail-closed check.
         if: always() && steps.cred.outputs.skip != 'true' && steps.canary.outputs.sandbox != 'fail'
@@ -343,14 +364,19 @@ jobs:
           SUMMARY=$(printf '%s' "$REVIEW" | jq -r '.summary')
 
           # Verdict maps to BOTH channels: a GitHub-native review (the
-          # authority: satisfies/blocks required-approvals) and a check-run
-          # (the fail-closed machine signal + marker carrier). error posts no
-          # review at all — an infra hiccup must never spend approval.
+          # authority: satisfies/blocks required-approvals) and a check-run.
+          # ONLY approve -> success; EVERYTHING else -> failure. GitHub treats
+          # a `neutral` required check as PASSING, so the old neutral mappings
+          # (comment, error) were fail-OPEN — a soft/absent verdict let the PR
+          # merge. Fail closed: merge requires an explicit clean approve. A
+          # `comment` still posts a COMMENT review (its notes are visible) but
+          # its check blocks. error posts no review — an infra hiccup must
+          # never spend approval — and its check blocks.
           case "$VERDICT" in
             approve)          CONCLUSION="success"; EVENT="APPROVE" ;;
             request_changes)  CONCLUSION="failure"; EVENT="REQUEST_CHANGES" ;;
-            comment)          CONCLUSION="neutral"; EVENT="COMMENT" ;;
-            *)                CONCLUSION="neutral"; VERDICT="error"; EVENT="" ;;
+            comment)          CONCLUSION="failure"; EVENT="COMMENT" ;;
+            *)                CONCLUSION="failure"; VERDICT="error"; EVENT="" ;;
           esac
 
           # Per-assignment fallbacks: normalization above should make these

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -17,10 +17,11 @@ name: PR Review Gate
 # pull_request_target no-checkout hardening, which is deliberately out of
 # scope for this pilot (see .github/pr-review-rubric.md).
 #
-# Fail-closed contract: the cog-review check-run reaches `success` only on an
-# explicit `approve` verdict. request_changes → failure; anything else —
-# parse errors, missing credentials, reviewer silence — lands `neutral`,
-# which does NOT satisfy a required status check. Silence is not approval.
+# Fail-closed contract: the cog-review check-run reaches `success` ONLY on an
+# explicit `approve` verdict. Everything else — request_changes, comment,
+# parse errors, missing credentials, sandbox-canary failure — lands `failure`,
+# a BLOCKING conclusion. (GitHub treats a `neutral` required check as PASSING,
+# so neutral would be fail-OPEN — never use it here.) Silence is not approval.
 
 on:
   pull_request:
@@ -107,9 +108,10 @@ jobs:
           fetch-depth: 0
 
       # Secrets are invisible to `if:` expressions, so credential gating is a
-      # step. Missing token → neutral check-run explaining setup, job ends
-      # green (the gate is "not configured", which fail-closed blocks merge if
-      # the check is required — but does not paint CI red on every PR).
+      # step. Missing token → failure check-run explaining setup (neutral would
+      # pass a required check — fail open — so an unconfigured reviewer must
+      # block, not wave PRs through). The job itself still ends green; the
+      # blocking signal is the check-run conclusion, not the job status.
       - name: Gate on reviewer credentials
         id: cred
         env:
@@ -174,8 +176,9 @@ jobs:
       # is never trusted statically: this step proves it live by asking the
       # sandboxed agent to read /proc/version (always present on the runner).
       # Only an explicit DENIED refusal passes; file content coming back, an
-      # empty reply, or a crashed canary all fail closed — review skipped,
-      # neutral check posted, no approval spent.
+      # empty reply, or a crashed canary all fail closed — review skipped, a
+      # `failure` check posted (neutral would pass a required check), no
+      # approval spent.
       - name: Verify reviewer sandbox (deny-list canary)
         id: canary
         if: steps.cred.outputs.skip != 'true'
@@ -299,10 +302,18 @@ jobs:
               --model "$COG_REVIEW_MODEL" \
               > /tmp/cog-review/raw.json 2> /tmp/cog-review/stderr.log
             CLAUDE_RC=$?
-            if [ "$CLAUDE_RC" = "0" ] && jq -e '.result' /tmp/cog-review/raw.json >/dev/null 2>&1; then
-              break
+            # Accept only when the envelope's .result actually parses to a
+            # .verdict — the SAME extraction the publish step uses. Checking
+            # merely that .result exists would break early on a prose/malformed
+            # .result (rc=0 but no verdict), i.e. exactly the "unparseable
+            # output" case this retry is meant to cover.
+            if [ "$CLAUDE_RC" = "0" ]; then
+              RES=$(jq -r '.result // empty' /tmp/cog-review/raw.json 2>/dev/null | sed -e 's/^```json//' -e 's/^```//' -e 's/```$//')
+              if printf '%s' "$RES" | jq -e '.verdict' >/dev/null 2>&1; then
+                break
+              fi
             fi
-            echo "::warning::cog-review reviewer attempt $attempt failed (rc=$CLAUDE_RC or unparseable); retrying" >&2
+            echo "::warning::cog-review reviewer attempt $attempt failed (rc=$CLAUDE_RC or output has no parseable .verdict); retrying" >&2
             sleep $((attempt * 5))
           done
           set -e

--- a/scripts/pr-await-review.sh
+++ b/scripts/pr-await-review.sh
@@ -87,6 +87,16 @@ done
 APPROVED_REVIEW=$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate \
   --jq "[.[] | select(.user.login == \"$BOT_LOGIN\" and .state == \"APPROVED\" and .commit_id == \"$HEAD_SHA\")] | last // empty")
 
+# --- Changes-requested check (server-set): a bot CHANGES_REQUESTED review at
+# head. The gate maps request_changes AND comment/error/canary-fail/no-token
+# ALL to check-run conclusion=failure (fail closed), so `failure` alone can no
+# longer distinguish "real findings to fix" (reconcile) from "no actionable
+# verdict" (escalate). The review STATE — also server-set and unforgeable —
+# does: CHANGES_REQUESTED means genuine findings; a COMMENTED review or NO
+# review (errors post none) means escalate to a human. ---
+CHANGES_REQUESTED_REVIEW=$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate \
+  --jq "[.[] | select(.user.login == \"$BOT_LOGIN\" and .state == \"CHANGES_REQUESTED\" and .commit_id == \"$HEAD_SHA\")] | last // empty")
+
 # --- Marker extraction is DISPLAY-ONLY (untrusted). The real marker is the
 # LAST line of the gate's body/summary (the workflow appends it after all
 # model-authored text), so take the last match, not the first — an injected
@@ -140,7 +150,16 @@ case "$CONCLUSION" in
     emit "$CONCLUSION" "$VERDICT" "escalate" 4 "$VERDICT_JSON"
     ;;
   failure)
-    emit "$CONCLUSION" "$VERDICT" "reconcile" 2 "$VERDICT_JSON"
+    # Only a genuine CHANGES_REQUESTED review means "findings to fix".
+    # comment / error / canary-fail / no-token also land here (fail closed)
+    # but carry no actionable findings — escalate to a human instead of
+    # telling the caller to push phantom fixes.
+    if [ -n "$CHANGES_REQUESTED_REVIEW" ]; then
+      echo "cog-review: request_changes (bot CHANGES_REQUESTED @ ${HEAD_SHA:0:7})" >&2
+      emit "$CONCLUSION" "$VERDICT" "reconcile" 2 "$VERDICT_JSON"
+    fi
+    echo "cog-review: blocking failure with NO changes-requested review (comment/error/canary/no-token) @ ${HEAD_SHA:0:7}; escalating" >&2
+    emit "$CONCLUSION" "$VERDICT" "escalate" 4 "$VERDICT_JSON"
     ;;
   *)
     emit "$CONCLUSION" "$VERDICT" "escalate" 4 "$VERDICT_JSON"


### PR DESCRIPTION
## What and why

The `cog-review` gate is now a required status check on `main`. That surfaced a correctness bug in its own design: **GitHub treats a `neutral` required check-run as PASSING, not blocking.** The gate mapped its fail-safe cases — reviewer error, sandbox-canary failure, unconfigured token — and the soft `comment` verdict all to `neutral`, and the rubric called that "fail closed." It was fail **open**: a broken, sandbox-unproven, or unconfigured reviewer would let a PR merge. PR #437 was the live proof — its `cog-review` errored to neutral and the PR read `CLEAN / MERGEABLE`.

## How

- **Only `approve` → `success`; everything else → `failure`** (a blocking conclusion): `request_changes`, `comment`, reviewer error, canary-fail, and unconfigured-token all now block. Merge requires an explicit clean approve. The unconfigured-token and canary-fail check posts change neutral→failure too.
- **Bounded 3-attempt retry** on the reviewer CLI call, accepting the first output that parses to a `.verdict`. Fail-closed amplifies the transient Sonnet blips we've seen (a flake would now wedge a PR), so this restores resilience without weakening the gate — a genuine `request_changes` parses on attempt 1 and is kept; only unparseable/empty/error output retries.
- **Rubric corrected** to describe the real GitHub semantics and name `enforce_admins: false` as the deliberate override valve for a persistent reviewer outage.

## Acceptance

- [x] No `conclusion='neutral'` remains in the workflow; comment/error/request_changes all map to failure
- [x] Reviewer call retries up to 3× on non-zero exit / unparseable output
- [x] Workflow YAML + all run-blocks pass `bash -n`

## Test evidence

Static: `bash -n` on every run block, YAML parse, and an assertion that no neutral conclusion survives. Live: this PR is itself reviewed by the (still-fail-open on `main`) gate; once merged, the corrected gate governs subsequent PRs including #437.