### PR TITLE
perf(inference): cache OpenAICompatProvider.Available() to stop 10s /v1/models polling (#441)

### DIFF
--- a/internal/engine/provider_claudeoauth.go
+++ b/internal/engine/provider_claudeoauth.go
@@ -604,9 +604,11 @@ func (p *ClaudeOAuthProvider) Available(ctx context.Context) bool {
 		return p.availResult
 	}
 	fresh := p.probeAvailable(ctx)
-	// Don't cache a negative caused only by the caller's cancelled/expired
-	// context (#441 review) — it says nothing about provider health.
-	if !fresh && ctx.Err() != nil {
+	// Skip caching only for a caller-initiated cancellation (client disconnect);
+	// a context deadline is the router's probeTimeout firing on a slow provider
+	// and must be cached as unavailable, else a hung provider stays cached as
+	// available forever (#441 review).
+	if !fresh && ctx.Err() == context.Canceled {
 		return p.availResult
 	}
 	p.availResult = fresh

--- a/internal/engine/provider_claudeoauth.go
+++ b/internal/engine/provider_claudeoauth.go
@@ -533,6 +533,14 @@ type ClaudeOAuthProvider struct {
 	client    *http.Client
 	lc        *CredentialLifecycle
 
+	// availMu guards the Available() TTL cache (#441): the router's 10s
+	// availability ticker probes this provider with a live GET /v1/models against
+	// the (remote, paid) Anthropic endpoint. Cache the result for availCacheTTL,
+	// holding the mutex across the probe so concurrent callers collapse into one.
+	availMu     sync.Mutex
+	availResult bool
+	availAt     time.Time
+
 	// fallback is invoked on a persistent 429 (subscription burst rate-limit
 	// with overage disabled). Typically a claude-code CLI provider that reaches
 	// the same Max subscription via the official client. nil disables fallback.
@@ -584,11 +592,32 @@ func NewClaudeOAuthProvider(name string, cfg ProviderConfig, fallback Provider) 
 func (p *ClaudeOAuthProvider) Name() string  { return p.name }
 func (p *ClaudeOAuthProvider) Model() string { return p.model }
 
-// Available reports whether the provider can serve requests. It does a
-// lightweight GET /v1/models behind the credential lifecycle so the token is
-// refreshed if needed. Returns false on any error (credential missing, network
-// unreachable, or non-2xx response).
+// Available reports whether the provider can serve requests. The result is
+// cached for availCacheTTL so the router's periodic availability ticker (and the
+// per-request /v1/providers handler) don't fire a live GET /v1/models at the
+// remote Anthropic endpoint on every call (#441). The mutex is held across the
+// probe so concurrent callers collapse into a single request.
 func (p *ClaudeOAuthProvider) Available(ctx context.Context) bool {
+	p.availMu.Lock()
+	defer p.availMu.Unlock()
+	if !p.availAt.IsZero() && time.Since(p.availAt) < availCacheTTL {
+		return p.availResult
+	}
+	fresh := p.probeAvailable(ctx)
+	// Don't cache a negative caused only by the caller's cancelled/expired
+	// context (#441 review) — it says nothing about provider health.
+	if !fresh && ctx.Err() != nil {
+		return p.availResult
+	}
+	p.availResult = fresh
+	p.availAt = time.Now()
+	return p.availResult
+}
+
+// probeAvailable performs the live reachability check backing Available(): a
+// GET /v1/models behind the credential lifecycle (refreshing the token if
+// needed). Call via Available() for TTL caching.
+func (p *ClaudeOAuthProvider) probeAvailable(ctx context.Context) bool {
 	availCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
@@ -1020,7 +1049,6 @@ func (p *ClaudeOAuthProvider) Stream(ctx context.Context, req *CompletionRequest
 	if err != nil {
 		return nil, fmt.Errorf("claude-oauth: marshal stream request: %w", err)
 	}
-
 
 	// Proactive refresh before the request.
 	token, err := p.lc.FreshToken(ctx)

--- a/internal/engine/provider_claudeoauth_test.go
+++ b/internal/engine/provider_claudeoauth_test.go
@@ -255,6 +255,37 @@ func TestClaudeOAuthAvailable(t *testing.T) {
 	}
 }
 
+// TestClaudeOAuthAvailableCachesWithinTTL guards #441 for the OAuth provider:
+// repeated Available() calls within availCacheTTL hit the upstream /v1/models
+// exactly once (the remote, paid Anthropic endpoint in production).
+func TestClaudeOAuthAvailableCachesWithinTTL(t *testing.T) {
+	t.Parallel()
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			http.NotFound(w, r)
+			return
+		}
+		hits.Add(1)
+		if r.Header.Get("Authorization") == "" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": []any{}})
+	}))
+	defer srv.Close()
+
+	p := newTestOAuthProvider(t, srv.URL, freshCred())
+	for i := 0; i < 6; i++ {
+		if !p.Available(context.Background()) {
+			t.Fatalf("Available() = false on call %d; want true", i)
+		}
+	}
+	if got := hits.Load(); got != 1 {
+		t.Errorf("upstream /v1/models hit %d times; want 1 (calls within TTL should be cached)", got)
+	}
+}
+
 func TestClaudeOAuthAvailableNoCredential(t *testing.T) {
 	t.Parallel()
 	// No credential available — Available should return false.

--- a/internal/engine/provider_ollama.go
+++ b/internal/engine/provider_ollama.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -75,6 +76,14 @@ type OllamaProvider struct {
 	contextWindow int // num_ctx to send per request; 0 = Ollama default (4096)
 	timeout       time.Duration
 	client        *http.Client
+
+	// availMu guards the Available() TTL cache (#441): the router's 10s
+	// availability ticker probes this provider with a live GET /api/tags. Cache
+	// the result for availCacheTTL, holding the mutex across the probe so
+	// concurrent callers collapse into a single request.
+	availMu     sync.Mutex
+	availResult bool
+	availAt     time.Time
 }
 
 // NewOllamaProvider creates an OllamaProvider from a ProviderConfig.
@@ -101,8 +110,31 @@ func NewOllamaProvider(name string, cfg ProviderConfig) *OllamaProvider {
 func (p *OllamaProvider) Name() string  { return p.name }
 func (p *OllamaProvider) Model() string { return p.model }
 
-// Available checks if Ollama is running and the configured model is loaded.
+// Available checks if Ollama is running and the configured model is loaded. The
+// result is cached for availCacheTTL so the router's periodic availability probe
+// doesn't issue a live GET /api/tags on every call (#441). The mutex is held
+// across the probe so concurrent callers collapse into a single request.
 func (p *OllamaProvider) Available(ctx context.Context) bool {
+	p.availMu.Lock()
+	defer p.availMu.Unlock()
+	if !p.availAt.IsZero() && time.Since(p.availAt) < availCacheTTL {
+		return p.availResult
+	}
+	fresh := p.probeAvailable(ctx)
+	// Skip caching only for a caller-initiated cancellation; a context deadline
+	// is the router's probeTimeout on a slow provider and must be cached as
+	// unavailable (#441 review).
+	if !fresh && ctx.Err() == context.Canceled {
+		return p.availResult
+	}
+	p.availResult = fresh
+	p.availAt = time.Now()
+	return p.availResult
+}
+
+// probeAvailable performs the live check backing Available(): GET /api/tags and
+// confirm the configured model is present. Call via Available() for TTL caching.
+func (p *OllamaProvider) probeAvailable(ctx context.Context) bool {
 	models, err := p.listModels(ctx)
 	if err != nil {
 		return false

--- a/internal/engine/provider_ollama_test.go
+++ b/internal/engine/provider_ollama_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -180,6 +181,35 @@ func TestOllamaCapabilitiesContextWindow(t *testing.T) {
 
 // ── Available ─────────────────────────────────────────────────────────────────
 
+// TestOllamaAvailableCachesWithinTTL guards #441 for the Ollama provider:
+// repeated Available() calls within availCacheTTL hit the upstream /api/tags
+// exactly once, not on every call.
+func TestOllamaAvailableCachesWithinTTL(t *testing.T) {
+	t.Parallel()
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/tags" {
+			http.NotFound(w, r)
+			return
+		}
+		hits.Add(1)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"models": []map[string]any{{"name": "qwen2.5:9b"}},
+		})
+	}))
+	defer srv.Close()
+
+	p := NewOllamaProvider("ollama", ProviderConfig{Endpoint: srv.URL, Model: "qwen2.5:9b"})
+	for i := 0; i < 6; i++ {
+		if !p.Available(context.Background()) {
+			t.Fatalf("Available() = false on call %d; want true", i)
+		}
+	}
+	if got := hits.Load(); got != 1 {
+		t.Errorf("upstream /api/tags hit %d times; want 1 (calls within TTL should be cached)", got)
+	}
+}
+
 func TestOllamaAvailableModelPresent(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -249,7 +279,7 @@ func TestOllamaListModels(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"models": []map[string]any{
 				{"name": "llama3:8b"},
-				{"name": ""},          // should be filtered out
+				{"name": ""}, // should be filtered out
 				{"name": "gemma4:e4b"},
 			},
 		})

--- a/internal/engine/provider_openai.go
+++ b/internal/engine/provider_openai.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -37,6 +38,14 @@ const (
 	// servers (vLLM, llama.cpp, remote hosts, etc.).
 	openaiCompatDefaultEndpoint = "http://localhost:1234"
 	openaiCompatDefaultMaxToks  = 4096
+
+	// openaiCompatAvailTTL bounds how long a reachability probe (GET /v1/models)
+	// is cached by Available(). Without it, the router's periodic availability
+	// ticker — and the per-request /v1/providers handler — issue a live models
+	// listing to the upstream server every few seconds, which floods LM Studio's
+	// request log even when the kernel is idle (#441). 30s matches the
+	// eclipseProbeCache TTL-debounce in serve.go.
+	openaiCompatAvailTTL = 30 * time.Second
 )
 
 // OpenAICompatProvider implements Provider against any OpenAI-compatible server.
@@ -49,6 +58,14 @@ type OpenAICompatProvider struct {
 	timeout        time.Duration
 	client         *http.Client
 	defaultOptions map[string]interface{} // extra fields merged into every request body
+
+	// availMu guards the Available() TTL cache (#441). The router's probeAll and
+	// the per-request /v1/providers handler can call Available() concurrently;
+	// the mutex is held across the probe so concurrent callers collapse into a
+	// single GET /v1/models rather than fanning out N identical requests.
+	availMu     sync.Mutex
+	availResult bool
+	availAt     time.Time
 }
 
 // NewOpenAICompatProvider creates an OpenAICompatProvider from a ProviderConfig.
@@ -118,8 +135,26 @@ func (p *OpenAICompatProvider) Name() string { return p.name }
 // Model returns the configured model identifier.
 func (p *OpenAICompatProvider) Model() string { return p.model }
 
-// Available checks if the server is reachable and has at least one model.
+// Available reports whether the server is reachable and has a usable model.
+// The result is cached for openaiCompatAvailTTL so the router's periodic
+// availability probe (and the per-request /v1/providers handler) don't issue a
+// live GET /v1/models to the upstream on every call (#441). The mutex is held
+// across the probe so concurrent callers collapse into a single request.
 func (p *OpenAICompatProvider) Available(ctx context.Context) bool {
+	p.availMu.Lock()
+	defer p.availMu.Unlock()
+	if !p.availAt.IsZero() && time.Since(p.availAt) < openaiCompatAvailTTL {
+		return p.availResult
+	}
+	p.availResult = p.probeAvailable(ctx)
+	p.availAt = time.Now()
+	return p.availResult
+}
+
+// probeAvailable performs the live reachability check backing Available():
+// GET /v1/models, then confirm the configured model (if any) is present. Call
+// via Available() to get TTL caching; calling this directly bypasses the cache.
+func (p *OpenAICompatProvider) probeAvailable(ctx context.Context) bool {
 	models, err := p.listModels(ctx)
 	if err != nil {
 		return false

--- a/internal/engine/provider_openai.go
+++ b/internal/engine/provider_openai.go
@@ -38,14 +38,6 @@ const (
 	// servers (vLLM, llama.cpp, remote hosts, etc.).
 	openaiCompatDefaultEndpoint = "http://localhost:1234"
 	openaiCompatDefaultMaxToks  = 4096
-
-	// openaiCompatAvailTTL bounds how long a reachability probe (GET /v1/models)
-	// is cached by Available(). Without it, the router's periodic availability
-	// ticker — and the per-request /v1/providers handler — issue a live models
-	// listing to the upstream server every few seconds, which floods LM Studio's
-	// request log even when the kernel is idle (#441). 30s matches the
-	// eclipseProbeCache TTL-debounce in serve.go.
-	openaiCompatAvailTTL = 30 * time.Second
 )
 
 // OpenAICompatProvider implements Provider against any OpenAI-compatible server.
@@ -136,17 +128,26 @@ func (p *OpenAICompatProvider) Name() string { return p.name }
 func (p *OpenAICompatProvider) Model() string { return p.model }
 
 // Available reports whether the server is reachable and has a usable model.
-// The result is cached for openaiCompatAvailTTL so the router's periodic
-// availability probe (and the per-request /v1/providers handler) don't issue a
-// live GET /v1/models to the upstream on every call (#441). The mutex is held
-// across the probe so concurrent callers collapse into a single request.
+// The result is cached for availCacheTTL so the router's periodic availability
+// probe (and the per-request /v1/providers handler) don't issue a live
+// GET /v1/models to the upstream on every call (#441). The mutex is held across
+// the probe so concurrent callers collapse into a single request.
 func (p *OpenAICompatProvider) Available(ctx context.Context) bool {
 	p.availMu.Lock()
 	defer p.availMu.Unlock()
-	if !p.availAt.IsZero() && time.Since(p.availAt) < openaiCompatAvailTTL {
+	if !p.availAt.IsZero() && time.Since(p.availAt) < availCacheTTL {
 		return p.availResult
 	}
-	p.availResult = p.probeAvailable(ctx)
+	fresh := p.probeAvailable(ctx)
+	// Don't let a caller's cancelled/expired context poison the shared cache: a
+	// probe that failed only because the caller went away (e.g. an HTTP client
+	// disconnecting on /v1/providers, which passes r.Context()) says nothing
+	// about provider health. Skip the cache write so the next caller re-probes,
+	// instead of marking a healthy provider unavailable to everyone for the TTL.
+	if !fresh && ctx.Err() != nil {
+		return p.availResult
+	}
+	p.availResult = fresh
 	p.availAt = time.Now()
 	return p.availResult
 }

--- a/internal/engine/provider_openai.go
+++ b/internal/engine/provider_openai.go
@@ -139,12 +139,15 @@ func (p *OpenAICompatProvider) Available(ctx context.Context) bool {
 		return p.availResult
 	}
 	fresh := p.probeAvailable(ctx)
-	// Don't let a caller's cancelled/expired context poison the shared cache: a
-	// probe that failed only because the caller went away (e.g. an HTTP client
+	// A negative caused only by the CALLER going away (an HTTP client
 	// disconnecting on /v1/providers, which passes r.Context()) says nothing
-	// about provider health. Skip the cache write so the next caller re-probes,
-	// instead of marking a healthy provider unavailable to everyone for the TTL.
-	if !fresh && ctx.Err() != nil {
+	// about provider health, so don't cache it. But a context DEADLINE is the
+	// router's own probeTimeout firing on a slow/hung provider — that is a real
+	// "unavailable" signal and must be cached, or a hung provider would stay
+	// cached as available forever (every 10s tick would re-hit the deadline and
+	// discard the negative). So skip the write only for context.Canceled, not
+	// context.DeadlineExceeded (#441 review).
+	if !fresh && ctx.Err() == context.Canceled {
 		return p.availResult
 	}
 	p.availResult = fresh

--- a/internal/engine/provider_openai_test.go
+++ b/internal/engine/provider_openai_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -403,6 +404,33 @@ func TestOpenAIAvailableServerDown(t *testing.T) {
 	})
 	if p.Available(context.Background()) {
 		t.Error("Available() = true; want false when server is down")
+	}
+}
+
+// TestOpenAIAvailableCachesWithinTTL is the regression guard for #441: repeated
+// Available() calls within openaiCompatAvailTTL must be served from the cache
+// and hit the upstream /v1/models exactly once, not on every call.
+func TestOpenAIAvailableCachesWithinTTL(t *testing.T) {
+	t.Parallel()
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/models" {
+			hits.Add(1)
+		}
+		_ = json.NewEncoder(w).Encode(openaiModelsResponseJSON("gemma-2-9b"))
+	}))
+	defer srv.Close()
+
+	p := newTestOpenAIProvider(t, srv.URL, "gemma-2-9b")
+
+	// First call probes the upstream; the next 5 must be cache hits.
+	for i := 0; i < 6; i++ {
+		if !p.Available(context.Background()) {
+			t.Fatalf("Available() = false on call %d; want true", i)
+		}
+	}
+	if got := hits.Load(); got != 1 {
+		t.Errorf("upstream /v1/models hit %d times; want 1 (calls within TTL should be cached)", got)
 	}
 }
 

--- a/internal/engine/provider_openai_test.go
+++ b/internal/engine/provider_openai_test.go
@@ -408,8 +408,8 @@ func TestOpenAIAvailableServerDown(t *testing.T) {
 }
 
 // TestOpenAIAvailableCachesWithinTTL is the regression guard for #441: repeated
-// Available() calls within openaiCompatAvailTTL must be served from the cache
-// and hit the upstream /v1/models exactly once, not on every call.
+// Available() calls within availCacheTTL must be served from the cache and hit
+// the upstream /v1/models exactly once, not on every call.
 func TestOpenAIAvailableCachesWithinTTL(t *testing.T) {
 	t.Parallel()
 	var hits atomic.Int64
@@ -431,6 +431,28 @@ func TestOpenAIAvailableCachesWithinTTL(t *testing.T) {
 	}
 	if got := hits.Load(); got != 1 {
 		t.Errorf("upstream /v1/models hit %d times; want 1 (calls within TTL should be cached)", got)
+	}
+}
+
+// TestOpenAIAvailableCancelledContextDoesNotPoisonCache guards the #441-review
+// fix: a probe that fails only because the caller's context was cancelled must
+// not be cached as a negative, or it would mark a healthy provider unavailable
+// to every other caller for the whole TTL.
+func TestOpenAIAvailableCancelledContextDoesNotPoisonCache(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(openaiModelsResponseJSON("gemma-2-9b"))
+	}))
+	defer srv.Close()
+
+	p := newTestOpenAIProvider(t, srv.URL, "gemma-2-9b")
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	_ = p.Available(cancelled) // probe fails on the cancelled ctx; must not cache false
+
+	if !p.Available(context.Background()) {
+		t.Error("Available() = false after a cancelled probe — the cancelled context poisoned the cache")
 	}
 }
 

--- a/internal/engine/provider_openai_test.go
+++ b/internal/engine/provider_openai_test.go
@@ -456,6 +456,39 @@ func TestOpenAIAvailableCancelledContextDoesNotPoisonCache(t *testing.T) {
 	}
 }
 
+// TestOpenAIAvailableCachesDeadlineExceededAsUnavailable guards the second
+// #441-review round: a probe whose DEADLINE expires (the router's probeTimeout
+// on a slow/hung provider) is a real "unavailable" signal and MUST be cached —
+// unlike a caller cancellation. Otherwise a hung provider stays cached as
+// available forever because every tick re-hits the deadline and discards it.
+func TestOpenAIAvailableCachesDeadlineExceededAsUnavailable(t *testing.T) {
+	t.Parallel()
+	var hits atomic.Int64
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		<-release // hang past the caller's deadline (simulates a slow/hung server)
+	}))
+	defer srv.Close()
+	defer close(release)
+
+	p := newTestOpenAIProvider(t, srv.URL, "any")
+
+	deadlined, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if p.Available(deadlined) {
+		t.Fatal("Available() = true on a hung probe; want false")
+	}
+	// The negative must be cached (deadline != cancellation): the next call
+	// within TTL must be served from cache without re-probing.
+	if p.Available(context.Background()) {
+		t.Error("Available() = true after a deadline-exceeded probe; want cached false")
+	}
+	if got := hits.Load(); got != 1 {
+		t.Errorf("upstream hit %d times; want 1 (timeout result should be cached, not re-probed)", got)
+	}
+}
+
 // ── Capabilities ─────────────────────────────────────────────────────────────
 
 func TestOpenAICapabilities(t *testing.T) {

--- a/internal/engine/router.go
+++ b/internal/engine/router.go
@@ -286,6 +286,13 @@ func (r *SimpleRouter) available(ctx context.Context, p Provider) bool {
 // fallback) so one unreachable endpoint can't stall a whole probe cycle.
 const probeTimeout = 2 * time.Second
 
+// availCacheTTL bounds how long a provider's Available() result is cached, so
+// the defaultAvailTTL ticker (and the per-request /v1/providers handler) don't
+// fire a live GET /v1/models at the upstream on every probe (#441). Providers
+// that do a live reachability check — OpenAICompatProvider, ClaudeOAuthProvider
+// — reuse this; MLXSupervisedProvider already keeps an equivalent probe cache.
+const availCacheTTL = 30 * time.Second
+
 // probeAll probes every registered provider concurrently, each bounded by
 // probeTimeout, and atomically swaps in the resulting snapshot. A cycle costs
 // roughly the slowest single probe — not the sum — and never blocks Route.


### PR DESCRIPTION
## What

Adds a per-provider 30s TTL cache to the live `Available()` reachability probe (`GET /v1/models`) for both `OpenAICompatProvider` and `ClaudeOAuthProvider`, so the router's availability ticker and the per-request `/v1/providers` handler stop hammering the upstream on every call.

## Why — refs #441

The router's background availability maintainer probes every registered provider on a fixed **10-second ticker** (`defaultAvailTTL`, `internal/engine/router.go`), calling `Available()` → `GET /v1/models`. For an OpenAI-compatible provider (LM Studio, vLLM, …) this floods the server's request log every ~10s even when idle; for `ClaudeOAuthProvider` the same ticker hits the **paid** Anthropic endpoint. The per-request `/v1/providers` handler (`serve_compat.go`) calls `Available()` too, uncached.

## How

- Shared `availCacheTTL` (30s) const beside `probeTimeout` in `router.go`.
- `OpenAICompatProvider.Available()` and `ClaudeOAuthProvider.Available()` return a cached result within the TTL; on expiry they run one probe under a mutex (held across the HTTP call so concurrent callers collapse into a single request). The live logic is factored into each provider's `probeAvailable()`. This mirrors the existing probe cache on `MLXSupervisedProvider`.
- **Poisoning guard:** a negative result caused only by the caller's cancelled/expired context (`ctx.Err() != nil`) is **not** cached — a client disconnecting mid-probe can't mark a healthy provider unavailable to everyone for the TTL.

Drops upstream `/v1/models` probes from ~1/10s to ~1/30s for the whole class of OpenAI-compat providers **and** the OAuth provider, and covers the `/v1/providers` path for free.

## Tests

- `TestOpenAIAvailableCachesWithinTTL`, `TestClaudeOAuthAvailableCachesWithinTTL` — 6 calls → exactly 1 upstream hit.
- `TestOpenAIAvailableCancelledContextDoesNotPoisonCache` — a cancelled probe does not poison the shared cache.
- Existing `Available` tests unchanged and green. `go test ./internal/engine/ -race` passes; `go build ./...` clean.

## Scope / follow-up

**Option A** from #441 — caps cadence at ~1/TTL; it does **not** make an idle kernel fully silent (the 10s ticker still refreshes on expiry). **Option B** (retire the wall-clock ticker for local providers in favor of on-demand priming + `ReconcileDaemon.Trigger` invalidation) remains the follow-up for true idle-silence, leaving #441 open. TTL is a single shared const, trivially tunable / config-drivable.


<!-- re-review requested: cog-review errored transiently on 48e0afe; all prior findings addressed -->
