### PR TITLE
fix(self-update): harden write-ahead kernel.toml maintainer (Fable review)

### DIFF
--- a/internal/engine/cli_selfupdate_kerneltoml.go
+++ b/internal/engine/cli_selfupdate_kerneltoml.go
@@ -1,0 +1,382 @@
+// cli_selfupdate_kerneltoml.go — write-ahead maintenance of .cog/conf/kernel.toml.
+//
+// kernel.toml is intended as the single source of truth for the pinned kernel
+// binary version + per-platform sha256 checksums: an installer seeds it once and
+// the daemon self-update path is expected to keep it reconciled with the running
+// binary so the recorded version never drifts ahead of what is actually running
+// (issue #442). This file provides the daemon side of that contract.
+//
+// DORMANT-BY-DESIGN until the SOT lands. As of this change the repo does NOT yet
+// carry a .cog/conf/kernel.toml, an installer that writes one, or any reader of
+// [kernel.checksums]; those arrive in a separate change (and, for an external
+// installer, may live outside this repo). writeAheadKernelTOML therefore treats
+// an ABSENT kernel.toml as a silent no-op: on every current workspace the swap
+// sequence is byte-for-byte unchanged and there is no maintenance to perform.
+// The maintainer only becomes active once a kernel.toml is present to reconcile.
+//
+// When a kernel.toml IS present, this file gives the darwin updater a
+// write-ahead (ledger-first) maintainer: BEFORE downloading the new binary, the
+// updater records the new [kernel].version + the current platform's sha256 into
+// kernel.toml (the ledger entry the swap then reconciles toward). If any later
+// step fails — checksum mismatch, smoke-test, swap, restart, or health
+// verification — the prior kernel.toml bytes (and file mode) are restored so the
+// recorded version never claims a binary that is not actually running.
+//
+// The edit is deliberately surgical (line-based) rather than a full TOML
+// round-trip: the repo carries no TOML library, and a byte-preserving edit is
+// the only way to keep comments, the release/checksums URL templates, and every
+// OTHER platform's checksum entry intact (issue #442 migration note: "never
+// blank non-current platforms"). Semantics mirror the YAML node-patch approach
+// in config_write.go — touch only the keys we own, leave the rest verbatim.
+// Layouts a line-based edit cannot make valid (see patchKernelTOML) return an
+// error so the caller aborts the write-ahead rather than emit invalid TOML.
+package engine
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// kernelTOMLRel is the workspace-relative path to the pinned-version SOT.
+// NOTE: this lives under .cog/conf/ (distinct from the writable kernel.yaml
+// under .cog/config/); the two are different files with different owners.
+const kernelTOMLRel = ".cog/conf/kernel.toml"
+
+// kernelTOMLSnapshot captures enough state to restore kernel.toml write-ahead
+// maintenance if a later apply step fails. Existed==false means there was no
+// kernel.toml to maintain (a workspace that never opted into the pinned-version
+// SOT); in that case the maintainer is a no-op and rollback is a no-op too.
+type kernelTOMLSnapshot struct {
+	path      string // absolute path, "" when no workspace root was known
+	existed   bool   // whether a kernel.toml was present before the write-ahead
+	prior     []byte // verbatim prior bytes (only meaningful when existed)
+	priorPerm os.FileMode
+}
+
+// kernelTOMLPlatformKey returns the [kernel.checksums] key for assetName. The
+// section is keyed by "<goos>-<goarch>" (e.g. "darwin-arm64"), which is the
+// release asset name with the leading "cogos-" prefix and any ".exe" suffix
+// stripped. Returns ("", false) when assetName is not in the expected shape.
+func kernelTOMLPlatformKey(assetName string) (string, bool) {
+	key := strings.TrimSuffix(assetName, ".exe")
+	key, ok := strings.CutPrefix(key, "cogos-")
+	if !ok || key == "" {
+		return "", false
+	}
+	return key, true
+}
+
+// writeAheadKernelTOML records version + the current platform's sha256 into
+// kernel.toml BEFORE the binary is downloaded, returning a snapshot the caller
+// uses to roll the entry back on a later failure.
+//
+// Contract:
+//   - root=="" (no known workspace) → no-op snapshot (existed=false).
+//   - kernel.toml absent            → no-op snapshot (existed=false). We do NOT
+//     synthesize a fresh file: a partial kernel.toml (current platform only, no
+//     URL templates) would break the shell install path that reads it. A
+//     workspace that never had kernel.toml stays without one.
+//   - kernel.toml present           → surgically set [kernel].version and the
+//     current platform's [kernel.checksums.<key>], preserving comments, URL
+//     templates, and every other platform's entry; snapshot holds the prior
+//     bytes for rollback.
+func writeAheadKernelTOML(root, version, assetName, sum string) (kernelTOMLSnapshot, error) {
+	if root == "" {
+		return kernelTOMLSnapshot{}, nil
+	}
+	path := filepath.Join(root, kernelTOMLRel)
+	snap := kernelTOMLSnapshot{path: path, priorPerm: 0o644}
+
+	prior, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Not maintained here — leave the workspace as-is.
+			return snap, nil
+		}
+		return snap, fmt.Errorf("read %s: %w", path, err)
+	}
+	if info, serr := os.Stat(path); serr == nil {
+		snap.priorPerm = info.Mode().Perm()
+	}
+	snap.existed = true
+	snap.prior = prior
+
+	key, ok := kernelTOMLPlatformKey(assetName)
+	if !ok {
+		return snap, fmt.Errorf("cannot derive kernel.toml platform key from asset %q", assetName)
+	}
+
+	updated, err := patchKernelTOML(prior, version, key, sum)
+	if err != nil {
+		return snap, fmt.Errorf("patch %s: %w", path, err)
+	}
+	if err := atomicWriteConfigFile(path, updated); err != nil {
+		return snap, fmt.Errorf("write %s: %w", path, err)
+	}
+	// atomicWriteConfigFile writes via os.CreateTemp (0o600) + rename, so restore
+	// the file's prior mode — a config SOT silently narrowing from 0o644 to 0o600
+	// can surprise a non-root reader (e.g. the shell install path).
+	if err := os.Chmod(path, snap.priorPerm); err != nil {
+		return snap, fmt.Errorf("restore mode on %s: %w", path, err)
+	}
+	return snap, nil
+}
+
+// rollbackKernelTOML restores the pre-write-ahead kernel.toml bytes. It is a
+// no-op when the maintainer was a no-op (no root / no prior file). Returns any
+// restore error so the caller can log it loudly — a failed kernel.toml rollback
+// leaves the recorded version ahead of the running binary, the exact drift #442
+// is closing.
+func rollbackKernelTOML(snap kernelTOMLSnapshot) error {
+	if !snap.existed || snap.path == "" {
+		return nil
+	}
+	if err := atomicWriteConfigFile(snap.path, snap.prior); err != nil {
+		return fmt.Errorf("restore %s: %w", snap.path, err)
+	}
+	// Restore the original mode too (atomicWriteConfigFile lands 0o600); rollback
+	// must return the file to its exact pre-write-ahead state, mode included.
+	if err := os.Chmod(snap.path, snap.priorPerm); err != nil {
+		return fmt.Errorf("restore mode on %s: %w", snap.path, err)
+	}
+	return nil
+}
+
+// patchKernelTOML returns src with [kernel].version set to version and the
+// [kernel.checksums] entry for platformKey set to sum, preserving everything
+// else byte-for-byte where possible. The edit is line-based and TOML-aware only
+// to the depth this file needs:
+//
+//   - The top-level `version = "..."` under [kernel] is replaced in place.
+//   - Within [kernel.checksums], an existing `<platformKey> = "..."` line is
+//     replaced in place; if absent, a new line is appended to that section.
+//   - A [kernel.checksums.<platformKey>] subtable form is also recognised and
+//     updated in place, so both the inline-key and subtable layouts round-trip.
+//
+// A missing [kernel].version or a missing [kernel.checksums] section is created
+// conservatively so the write-ahead record is never silently dropped. Two
+// non-canonical layouts, however, cannot be patched into valid TOML by a
+// line-based edit and so return an error rather than emitting a file a strict
+// parser would reject (the caller then aborts the write-ahead, leaving the
+// running binary untouched):
+//
+//   - a bare top-level `version = "..."` defined before any [kernel] header
+//     (inserting a fresh [kernel].version would duplicate the key and strand the
+//     stale value), and
+//   - checksums present only as [kernel.checksums.<other>] subtables with no
+//     inline [kernel.checksums] header, when the current platform is absent
+//     (appending an inline [kernel.checksums] table after its child subtable is
+//     a parent-redefined-after-child error).
+func patchKernelTOML(src []byte, version, platformKey, sum string) ([]byte, error) {
+	if platformKey == "" {
+		return nil, fmt.Errorf("empty platform key")
+	}
+	// Normalise line endings we emit to "\n"; detect a trailing newline so we
+	// can preserve "no trailing newline" files faithfully.
+	text := string(src)
+	hadTrailingNL := strings.HasSuffix(text, "\n")
+	lines := strings.Split(text, "\n")
+	// strings.Split on a trailing-NL string yields a final empty element; drop
+	// it so appends land before, then re-add the newline at the end.
+	if hadTrailingNL && len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+
+	// Track the active TOML table header as we scan.
+	currentTable := ""
+	versionSet := false
+	checksumSet := false
+	checksumsSectionLine := -1       // index of the [kernel.checksums] header, if seen
+	bareVersionBeforeKernel := false // top-level `version` seen before any [kernel] header
+	sawChecksumsSubtable := false    // any [kernel.checksums.<x>] subtable header seen
+
+	quoted := func(s string) string { return "\"" + s + "\"" }
+
+	for i, raw := range lines {
+		trimmed := strings.TrimSpace(raw)
+		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+			currentTable = strings.TrimSpace(trimmed[1 : len(trimmed)-1])
+			if currentTable == "kernel.checksums" {
+				checksumsSectionLine = i
+			}
+			if strings.HasPrefix(currentTable, "kernel.checksums.") {
+				sawChecksumsSubtable = true
+			}
+			continue
+		}
+		// Skip comments / blanks for key matching.
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		key, ok := tomlLineKey(trimmed)
+		if !ok {
+			continue
+		}
+
+		switch {
+		case currentTable == "" && key == "version":
+			// A bare `version` at the document root (before any table header).
+			// We cannot safely add a [kernel].version without duplicating the
+			// key, so flag it and error out below rather than corrupt the file.
+			bareVersionBeforeKernel = true
+		case currentTable == "kernel" && key == "version" && !versionSet:
+			lines[i] = replaceTOMLValue(raw, "version", quoted(version))
+			versionSet = true
+		case currentTable == "kernel.checksums" && key == platformKey && !checksumSet:
+			lines[i] = replaceTOMLValue(raw, platformKey, quoted(sum))
+			checksumSet = true
+		case currentTable == "kernel.checksums."+platformKey && key == "sha256" && !checksumSet:
+			// Subtable layout: [kernel.checksums.<key>] / sha256 = "..."
+			lines[i] = replaceTOMLValue(raw, "sha256", quoted(sum))
+			checksumSet = true
+		}
+	}
+
+	// Refuse to patch layouts a line-based edit cannot make valid. Erroring here
+	// aborts the write-ahead in the caller, leaving the running binary untouched,
+	// which is strictly safer than emitting TOML a strict parser would reject.
+	if !versionSet && bareVersionBeforeKernel {
+		return nil, fmt.Errorf("kernel.toml has a top-level `version` before any [kernel] header; refusing to patch (would duplicate the version key)")
+	}
+	if !checksumSet && checksumsSectionLine < 0 && sawChecksumsSubtable {
+		return nil, fmt.Errorf("kernel.toml defines checksums only as [kernel.checksums.<platform>] subtables and the current platform %q is absent; refusing to patch (appending an inline [kernel.checksums] table after its subtable is invalid TOML)", platformKey)
+	}
+
+	// If [kernel].version was never present, insert it. Create a [kernel]
+	// header at the top when there isn't one.
+	if !versionSet {
+		lines = ensureKernelVersion(lines, version)
+	}
+
+	// If the current platform's checksum line was never present, append it to
+	// the [kernel.checksums] section (creating the section when absent).
+	if !checksumSet {
+		lines = ensureChecksumEntry(lines, checksumsSectionLine, platformKey, quoted(sum))
+	}
+
+	out := strings.Join(lines, "\n")
+	if hadTrailingNL {
+		out += "\n"
+	}
+	return []byte(out), nil
+}
+
+// tomlLineKey returns the bare key of a `key = value` line, normalising a
+// quoted key to its unquoted form so it compares equal to the platform key we
+// match against. TOML permits quoted bare keys — `"darwin-arm64" = "..."` is a
+// valid and common spelling for a hyphenated key — so a naive verbatim compare
+// would miss the current-platform line and (wrongly) append a duplicate entry.
+// Returns ok=false for non-assignment lines.
+func tomlLineKey(trimmed string) (string, bool) {
+	eq := strings.IndexByte(trimmed, '=')
+	if eq <= 0 {
+		return "", false
+	}
+	key := strings.TrimSpace(trimmed[:eq])
+	if key == "" {
+		return "", false
+	}
+	key = unquoteTOMLKey(key)
+	if key == "" {
+		return "", false
+	}
+	// Reject inline-table / array bracket noise that isn't a plain key.
+	if strings.ContainsAny(key, "[]{}") {
+		return "", false
+	}
+	return key, true
+}
+
+// unquoteTOMLKey strips a single matched pair of surrounding double or single
+// quotes from a TOML key so `"darwin-arm64"` and `'darwin-arm64'` both normalise
+// to `darwin-arm64`. A key without surrounding quotes is returned unchanged.
+func unquoteTOMLKey(key string) string {
+	if len(key) >= 2 {
+		if (key[0] == '"' && key[len(key)-1] == '"') ||
+			(key[0] == '\'' && key[len(key)-1] == '\'') {
+			return key[1 : len(key)-1]
+		}
+	}
+	return key
+}
+
+// replaceTOMLValue rewrites the value of a `<key> = <old>` line in place,
+// preserving the key exactly as it was written (including any surrounding
+// quotes), the leading indentation, and any trailing inline comment. The passed
+// key argument is used only as a fallback; the on-line key text is authoritative
+// so a quoted key round-trips as-quoted rather than being rewritten bare (which
+// would leave the original quoted line behind and duplicate the entry).
+func replaceTOMLValue(raw, key, newValue string) string {
+	indent := raw[:len(raw)-len(strings.TrimLeft(raw, " \t"))]
+	// Preserve the key text as it appears on the line (up to the '='), so a
+	// quoted key stays quoted. Fall back to the bare key argument if the line
+	// somehow has no '=' (it always does here, but be defensive).
+	keyText := key
+	if eq := strings.IndexByte(raw, '='); eq >= 0 {
+		keyText = strings.TrimSpace(raw[len(indent):eq])
+	}
+	// Preserve a trailing inline comment (best-effort: split on the first " #").
+	comment := ""
+	if idx := strings.Index(raw, " #"); idx >= 0 {
+		// Only treat as a comment if it appears after the '=' assignment.
+		if eq := strings.IndexByte(raw, '='); eq >= 0 && idx > eq {
+			comment = raw[idx:]
+		}
+	}
+	return fmt.Sprintf("%s%s = %s%s", indent, keyText, newValue, comment)
+}
+
+// ensureKernelVersion inserts `version = "<v>"` under a [kernel] table. If a
+// [kernel] header exists, the line is inserted directly after it; otherwise a
+// fresh [kernel] table is prepended.
+func ensureKernelVersion(lines []string, version string) []string {
+	value := "version = \"" + version + "\""
+	for i, raw := range lines {
+		if strings.TrimSpace(raw) == "[kernel]" {
+			out := make([]string, 0, len(lines)+1)
+			out = append(out, lines[:i+1]...)
+			out = append(out, value)
+			out = append(out, lines[i+1:]...)
+			return out
+		}
+	}
+	// No [kernel] header: prepend a fresh table.
+	prefix := []string{"[kernel]", value, ""}
+	return append(prefix, lines...)
+}
+
+// ensureChecksumEntry appends `<key> = <quotedSum>` to the [kernel.checksums]
+// section. sectionLine is the index of the section header if it was seen, else
+// -1 (in which case a fresh section is appended to the end of the file).
+func ensureChecksumEntry(lines []string, sectionLine int, platformKey, quotedSum string) []string {
+	entry := platformKey + " = " + quotedSum
+	if sectionLine < 0 {
+		// Append a fresh section at end of file.
+		tail := []string{"", "[kernel.checksums]", entry}
+		return append(lines, tail...)
+	}
+	// Insert the entry at the end of the existing [kernel.checksums] block:
+	// scan forward to the next table header (or EOF) and insert before it,
+	// after the last non-blank line so we sit tight against the section body.
+	insertAt := len(lines)
+	for i := sectionLine + 1; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+			insertAt = i
+			break
+		}
+	}
+	// Back up over trailing blank lines within the section so the new entry
+	// sits directly under the existing keys.
+	for insertAt > sectionLine+1 && strings.TrimSpace(lines[insertAt-1]) == "" {
+		insertAt--
+	}
+	out := make([]string, 0, len(lines)+1)
+	out = append(out, lines[:insertAt]...)
+	out = append(out, entry)
+	out = append(out, lines[insertAt:]...)
+	return out
+}

--- a/internal/engine/cli_selfupdate_kerneltoml.go
+++ b/internal/engine/cli_selfupdate_kerneltoml.go
@@ -117,10 +117,16 @@ func writeAheadKernelTOML(root, version, assetName, sum string) (kernelTOMLSnaps
 	}
 	// atomicWriteConfigFile writes via os.CreateTemp (0o600) + rename, so restore
 	// the file's prior mode — a config SOT silently narrowing from 0o644 to 0o600
-	// can surprise a non-root reader (e.g. the shell install path).
-	if err := os.Chmod(path, snap.priorPerm); err != nil {
-		return snap, fmt.Errorf("restore mode on %s: %w", path, err)
-	}
+	// can surprise a non-root reader (e.g. the shell install path). Best-effort:
+	// the atomic write above has already committed the new content (rename is
+	// all-or-nothing), so a failed mode restore must NOT be returned as an error.
+	// If it were, the caller would treat write-ahead as "nothing written" and
+	// abort WITHOUT rollback, leaving kernel.toml recording a version that was
+	// never installed — the exact #442 drift. Consequence of best-effort: this
+	// function now returns a non-nil error only from paths that ran BEFORE the
+	// atomic commit (patch failure, write failure), so an error always means
+	// kernel.toml is unchanged and the caller's abort-without-rollback is safe.
+	_ = os.Chmod(path, snap.priorPerm)
 	return snap, nil
 }
 
@@ -136,11 +142,11 @@ func rollbackKernelTOML(snap kernelTOMLSnapshot) error {
 	if err := atomicWriteConfigFile(snap.path, snap.prior); err != nil {
 		return fmt.Errorf("restore %s: %w", snap.path, err)
 	}
-	// Restore the original mode too (atomicWriteConfigFile lands 0o600); rollback
-	// must return the file to its exact pre-write-ahead state, mode included.
-	if err := os.Chmod(snap.path, snap.priorPerm); err != nil {
-		return fmt.Errorf("restore mode on %s: %w", snap.path, err)
-	}
+	// Restore the original mode too (atomicWriteConfigFile lands 0o600). Best-effort
+	// for the same reason as the write-ahead path: the content restore above is what
+	// undoes the drift; a failed mode restore must not report the rollback (which
+	// already returned the file to its prior bytes) as failed.
+	_ = os.Chmod(snap.path, snap.priorPerm)
 	return nil
 }
 

--- a/internal/engine/cli_selfupdate_kerneltoml_test.go
+++ b/internal/engine/cli_selfupdate_kerneltoml_test.go
@@ -1,0 +1,302 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// sampleKernelTOML mirrors the shipped .cog/conf/kernel.toml layout: header
+// comments, a [kernel] table with a version + URL templates, and a
+// [kernel.checksums] table with the current platform plus a comment.
+const sampleKernelTOML = `# Single source of truth for the cogos kernel binary version + checksums.
+# Set at initial install; the goal is for the self-update provider to keep this
+# reconciled with the running daemon.
+
+[kernel]
+version = "v0.16.15"
+release_url_template = "https://github.com/myrgic/cogos/releases/download/{version}/cogos-{os}-{arch}"
+checksums_url_template = "https://github.com/myrgic/cogos/releases/download/{version}/checksums.txt"
+
+[kernel.checksums]
+darwin-arm64 = "32a4f1608d402ff316bfa8584a42fe1ca6e98a7c00ac87112c29ea9f6a9659b3"
+linux-amd64 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+# Other platforms can be added by reading the full checksums.txt from the release.
+`
+
+func TestKernelTOMLPlatformKey(t *testing.T) {
+	cases := []struct {
+		asset  string
+		want   string
+		wantOK bool
+	}{
+		{"cogos-darwin-arm64", "darwin-arm64", true},
+		{"cogos-linux-amd64", "linux-amd64", true},
+		{"cogos-windows-amd64.exe", "windows-amd64", true},
+		{"cogos-", "", false},
+		{"notcogos-darwin-arm64", "", false},
+		{"", "", false},
+	}
+	for _, c := range cases {
+		got, ok := kernelTOMLPlatformKey(c.asset)
+		if got != c.want || ok != c.wantOK {
+			t.Errorf("kernelTOMLPlatformKey(%q) = (%q,%v); want (%q,%v)", c.asset, got, ok, c.want, c.wantOK)
+		}
+	}
+}
+
+func TestPatchKernelTOML_UpdatesVersionAndCurrentPlatform(t *testing.T) {
+	out, err := patchKernelTOML([]byte(sampleKernelTOML), "v0.16.16", "darwin-arm64", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	if err != nil {
+		t.Fatalf("patchKernelTOML: %v", err)
+	}
+	s := string(out)
+
+	if !strings.Contains(s, `version = "v0.16.16"`) {
+		t.Errorf("version not updated:\n%s", s)
+	}
+	if strings.Contains(s, `version = "v0.16.15"`) {
+		t.Errorf("stale version still present:\n%s", s)
+	}
+	if !strings.Contains(s, `darwin-arm64 = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"`) {
+		t.Errorf("current-platform checksum not updated:\n%s", s)
+	}
+	// Other platform preserved verbatim (issue #442: never blank non-current).
+	if !strings.Contains(s, `linux-amd64 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"`) {
+		t.Errorf("other-platform checksum must be preserved:\n%s", s)
+	}
+	// URL templates and comments preserved.
+	if !strings.Contains(s, "release_url_template = ") {
+		t.Errorf("release_url_template must be preserved:\n%s", s)
+	}
+	if !strings.Contains(s, "# Single source of truth") {
+		t.Errorf("header comment must be preserved:\n%s", s)
+	}
+	if !strings.Contains(s, "# Other platforms can be added") {
+		t.Errorf("checksums-section comment must be preserved:\n%s", s)
+	}
+	// Trailing newline preserved.
+	if !strings.HasSuffix(s, "\n") {
+		t.Errorf("trailing newline must be preserved")
+	}
+}
+
+func TestPatchKernelTOML_AppendsMissingPlatform(t *testing.T) {
+	// windows-amd64 is not present in the sample; a write-ahead for it must add
+	// the entry to [kernel.checksums] without touching the existing platforms.
+	out, err := patchKernelTOML([]byte(sampleKernelTOML), "v0.16.16", "windows-amd64", "cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe")
+	if err != nil {
+		t.Fatalf("patchKernelTOML: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, `windows-amd64 = "cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe"`) {
+		t.Errorf("new platform entry not appended:\n%s", s)
+	}
+	if !strings.Contains(s, `darwin-arm64 = "32a4f1`) {
+		t.Errorf("existing darwin entry must survive:\n%s", s)
+	}
+	if !strings.Contains(s, `linux-amd64 = "aaaa`) {
+		t.Errorf("existing linux entry must survive:\n%s", s)
+	}
+	// The new entry must land inside the [kernel.checksums] section, i.e. before
+	// no later table header (there is none here) and after the header.
+	secIdx := strings.Index(s, "[kernel.checksums]")
+	winIdx := strings.Index(s, "windows-amd64 =")
+	if secIdx < 0 || winIdx < secIdx {
+		t.Errorf("windows entry must appear after the [kernel.checksums] header:\n%s", s)
+	}
+}
+
+func TestPatchKernelTOML_CreatesMissingChecksumsSection(t *testing.T) {
+	src := "[kernel]\nversion = \"v0.16.15\"\n"
+	out, err := patchKernelTOML([]byte(src), "v0.16.16", "darwin-arm64", "beefbeef")
+	if err != nil {
+		t.Fatalf("patchKernelTOML: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, "[kernel.checksums]") {
+		t.Errorf("missing [kernel.checksums] section must be created:\n%s", s)
+	}
+	if !strings.Contains(s, `darwin-arm64 = "beefbeef"`) {
+		t.Errorf("checksum entry must be created:\n%s", s)
+	}
+	if !strings.Contains(s, `version = "v0.16.16"`) {
+		t.Errorf("version must be updated:\n%s", s)
+	}
+}
+
+func TestPatchKernelTOML_CreatesMissingVersion(t *testing.T) {
+	src := "[kernel]\nrelease_url_template = \"x\"\n\n[kernel.checksums]\ndarwin-arm64 = \"old\"\n"
+	out, err := patchKernelTOML([]byte(src), "v0.16.16", "darwin-arm64", "new")
+	if err != nil {
+		t.Fatalf("patchKernelTOML: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, `version = "v0.16.16"`) {
+		t.Errorf("version must be inserted under [kernel]:\n%s", s)
+	}
+	if !strings.Contains(s, `darwin-arm64 = "new"`) {
+		t.Errorf("checksum must be updated:\n%s", s)
+	}
+	// Version must appear before the checksums section (i.e. inside [kernel]).
+	if strings.Index(s, `version = "v0.16.16"`) > strings.Index(s, "[kernel.checksums]") {
+		t.Errorf("inserted version must live under [kernel], not after checksums:\n%s", s)
+	}
+}
+
+func TestPatchKernelTOML_SubtableLayout(t *testing.T) {
+	src := "[kernel]\nversion = \"v0.16.15\"\n\n[kernel.checksums.darwin-arm64]\nsha256 = \"old\"\n"
+	out, err := patchKernelTOML([]byte(src), "v0.16.16", "darwin-arm64", "newsum")
+	if err != nil {
+		t.Fatalf("patchKernelTOML: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, `sha256 = "newsum"`) {
+		t.Errorf("subtable sha256 must be updated:\n%s", s)
+	}
+	if strings.Contains(s, `sha256 = "old"`) {
+		t.Errorf("stale subtable sha256 must be gone:\n%s", s)
+	}
+}
+
+// TestPatchKernelTOML_QuotedKeyReplacedInPlace guards the review finding that a
+// quoted checksum key (valid TOML for a hyphenated key) was not matched against
+// the bare platform key, so the current-platform entry was replaced in place by
+// a SECOND appended `darwin-arm64 = ...` line — duplicate-key TOML that strict
+// parsers reject. Exactly one entry must survive, updated in place, quoted form
+// preserved.
+func TestPatchKernelTOML_QuotedKeyReplacedInPlace(t *testing.T) {
+	src := "[kernel]\nversion = \"v0.16.15\"\n\n[kernel.checksums]\n\"darwin-arm64\" = \"OLD\"\n"
+	out, err := patchKernelTOML([]byte(src), "v0.16.16", "darwin-arm64", "NEWSUM")
+	if err != nil {
+		t.Fatalf("patchKernelTOML: %v", err)
+	}
+	s := string(out)
+	if n := strings.Count(s, "darwin-arm64"); n != 1 {
+		t.Errorf("expected exactly one darwin-arm64 entry, got %d:\n%s", n, s)
+	}
+	if strings.Contains(s, "OLD") {
+		t.Errorf("stale checksum must be replaced, not left behind:\n%s", s)
+	}
+	if !strings.Contains(s, `"darwin-arm64" = "NEWSUM"`) {
+		t.Errorf("quoted key must be updated in place, quoting preserved:\n%s", s)
+	}
+}
+
+// Single-quoted keys ('darwin-arm64') are also valid TOML and must match.
+func TestPatchKernelTOML_SingleQuotedKeyReplacedInPlace(t *testing.T) {
+	src := "[kernel]\nversion = \"v0.16.15\"\n\n[kernel.checksums]\n'darwin-arm64' = \"OLD\"\n"
+	out, err := patchKernelTOML([]byte(src), "v0.16.16", "darwin-arm64", "NEWSUM")
+	if err != nil {
+		t.Fatalf("patchKernelTOML: %v", err)
+	}
+	s := string(out)
+	if n := strings.Count(s, "darwin-arm64"); n != 1 {
+		t.Errorf("expected exactly one darwin-arm64 entry, got %d:\n%s", n, s)
+	}
+	if !strings.Contains(s, `'darwin-arm64' = "NEWSUM"`) {
+		t.Errorf("single-quoted key must be updated in place:\n%s", s)
+	}
+}
+
+// TestPatchKernelTOML_BareVersionBeforeKernelErrors guards the finding that a
+// top-level bare `version` before any [kernel] header caused a fresh
+// [kernel].version to be prepended — duplicating the version key and stranding
+// the stale value. The safe behaviour is to refuse (caller aborts write-ahead,
+// running binary untouched) rather than emit invalid/misleading TOML.
+func TestPatchKernelTOML_BareVersionBeforeKernelErrors(t *testing.T) {
+	src := "version = \"v0.16.15\"\n\n[kernel]\nrelease_url_template = \"x\"\n\n[kernel.checksums]\ndarwin-arm64 = \"old\"\n"
+	if _, err := patchKernelTOML([]byte(src), "v0.16.16", "darwin-arm64", "new"); err == nil {
+		t.Error("expected an error for a top-level version before [kernel], got nil")
+	}
+}
+
+// TestPatchKernelTOML_SubtableOnlyMissingCurrentErrors guards the finding that,
+// when checksums are defined ONLY via [kernel.checksums.<other>] subtables and
+// the current platform is absent, appending an inline [kernel.checksums] table
+// after its child subtable is invalid TOML (parent redefined after child). The
+// safe behaviour is to refuse rather than emit that layout.
+func TestPatchKernelTOML_SubtableOnlyMissingCurrentErrors(t *testing.T) {
+	src := "[kernel]\nversion = \"v0.16.15\"\n\n[kernel.checksums.linux-amd64]\nsha256 = \"old\"\n"
+	if _, err := patchKernelTOML([]byte(src), "v0.16.16", "darwin-arm64", "new"); err == nil {
+		t.Error("expected an error for subtable-only checksums missing the current platform, got nil")
+	}
+}
+
+func TestWriteAheadKernelTOML_NoRootIsNoOp(t *testing.T) {
+	snap, err := writeAheadKernelTOML("", "v0.16.16", "cogos-darwin-arm64", "abc")
+	if err != nil {
+		t.Fatalf("writeAheadKernelTOML: %v", err)
+	}
+	if snap.existed {
+		t.Error("no-root write-ahead must be a no-op snapshot")
+	}
+	if err := rollbackKernelTOML(snap); err != nil {
+		t.Errorf("rollback of a no-op snapshot must succeed: %v", err)
+	}
+}
+
+func TestWriteAheadKernelTOML_AbsentFileIsNoOp(t *testing.T) {
+	root := t.TempDir() // no .cog/conf/kernel.toml
+	snap, err := writeAheadKernelTOML(root, "v0.16.16", "cogos-darwin-arm64", "abc")
+	if err != nil {
+		t.Fatalf("writeAheadKernelTOML: %v", err)
+	}
+	if snap.existed {
+		t.Error("absent-file write-ahead must not synthesize a kernel.toml")
+	}
+	if _, statErr := os.Stat(filepath.Join(root, kernelTOMLRel)); !os.IsNotExist(statErr) {
+		t.Error("write-ahead must NOT create kernel.toml when it was absent")
+	}
+}
+
+func TestWriteAheadKernelTOML_WritesThenRollsBack(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, kernelTOMLRel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(sampleKernelTOML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	snap, err := writeAheadKernelTOML(root, "v0.16.16", "cogos-darwin-arm64", "feedface")
+	if err != nil {
+		t.Fatalf("writeAheadKernelTOML: %v", err)
+	}
+	if !snap.existed {
+		t.Fatal("snapshot must record that a kernel.toml existed")
+	}
+
+	// After write-ahead: version + darwin checksum updated on disk.
+	afterWrite, _ := os.ReadFile(path)
+	if !strings.Contains(string(afterWrite), `version = "v0.16.16"`) {
+		t.Errorf("on-disk kernel.toml must show the new version after write-ahead:\n%s", afterWrite)
+	}
+	if !strings.Contains(string(afterWrite), `darwin-arm64 = "feedface"`) {
+		t.Errorf("on-disk kernel.toml must show the new checksum after write-ahead:\n%s", afterWrite)
+	}
+	// File mode must be preserved across the write-ahead (atomicWriteConfigFile
+	// otherwise narrows it to 0o600 via os.CreateTemp).
+	if fi, serr := os.Stat(path); serr != nil {
+		t.Fatalf("stat after write-ahead: %v", serr)
+	} else if fi.Mode().Perm() != 0o644 {
+		t.Errorf("write-ahead must preserve mode 0o644, got %o", fi.Mode().Perm())
+	}
+
+	// Rollback restores the exact prior bytes.
+	if err := rollbackKernelTOML(snap); err != nil {
+		t.Fatalf("rollbackKernelTOML: %v", err)
+	}
+	restored, _ := os.ReadFile(path)
+	if string(restored) != sampleKernelTOML {
+		t.Errorf("rollback must restore the exact prior bytes.\n got:\n%s\nwant:\n%s", restored, sampleKernelTOML)
+	}
+	// Rollback must restore the original mode too.
+	if fi, serr := os.Stat(path); serr != nil {
+		t.Fatalf("stat after rollback: %v", serr)
+	} else if fi.Mode().Perm() != 0o644 {
+		t.Errorf("rollback must restore mode 0o644, got %o", fi.Mode().Perm())
+	}
+}

--- a/internal/engine/cli_selfupdate_test.go
+++ b/internal/engine/cli_selfupdate_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -249,6 +250,144 @@ func TestRunApplyRenameFailRestoresFromBak(t *testing.T) {
 	got, _ := os.ReadFile(filepath.Join(binDir, "cogos"))
 	if string(got) != string(origContent) {
 		t.Errorf("rename-fail path must restore original from .bak; got %q", got)
+	}
+}
+
+// ─── #442: write-ahead kernel.toml maintenance ───────────────────────────────
+
+// seedKernelTOML writes a kernel.toml under u.root/.cog/conf and returns its
+// path. The seeded darwin checksum is intentionally wrong so a successful
+// write-ahead is observable as the CORRECTED value on disk.
+func seedKernelTOML(t *testing.T, u *selfUpdater) string {
+	t.Helper()
+	path := filepath.Join(u.root, kernelTOMLRel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// The checksums section is keyed by the platform key (asset name minus the
+	// "cogos-" prefix / ".exe" suffix), matching the shipped kernel.toml layout.
+	platKey, ok := kernelTOMLPlatformKey(assetName())
+	if !ok {
+		t.Fatalf("cannot derive platform key from %q", assetName())
+	}
+	body := "[kernel]\nversion = \"v0.16.4\"\n\n[kernel.checksums]\n" +
+		platKey + " = \"STALE\"\nlinux-amd64 = \"keepme\"\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestRunApplyWriteAheadRecordsKernelTOMLOnSuccess asserts the ledger-first
+// contract: on a successful update, kernel.toml carries the new version + the
+// current platform's real checksum, with other platforms preserved.
+func TestRunApplyWriteAheadRecordsKernelTOMLOnSuccess(t *testing.T) {
+	u, _ := newTestUpdater(t, "v0.16.5")
+	ktPath := seedKernelTOML(t, u)
+	payload, sum := newPayload(t, "v0.16.5")
+
+	u.download = func(ctx context.Context, url, dst string) error {
+		return os.WriteFile(dst, payload, 0o644)
+	}
+	u.fetchText = func(ctx context.Context, url string) (string, error) {
+		return fmt.Sprintf("%s  %s\n%s  linux-amd64\n", sum, assetName(), suHashBytes([]byte("x"))), nil
+	}
+	if err := runApplyWithStubResolve(u); err != nil {
+		t.Fatalf("runApply: %v", err)
+	}
+
+	got, _ := os.ReadFile(ktPath)
+	s := string(got)
+	platKey, _ := kernelTOMLPlatformKey(assetName())
+	if !strings.Contains(s, `version = "v0.16.5"`) {
+		t.Errorf("kernel.toml version must be updated write-ahead:\n%s", s)
+	}
+	if !strings.Contains(s, platKey+` = "`+sum+`"`) {
+		t.Errorf("kernel.toml current-platform checksum must be the real sum:\n%s", s)
+	}
+	if strings.Contains(s, `STALE`) {
+		t.Errorf("stale checksum must be gone:\n%s", s)
+	}
+	if !strings.Contains(s, `linux-amd64 = "keepme"`) {
+		t.Errorf("other-platform checksum must be preserved:\n%s", s)
+	}
+}
+
+// TestRunApplyWriteAheadRollsBackKernelTOMLOnHealthFail asserts that when the
+// health poll fails after the swap, kernel.toml is restored to its pre-update
+// bytes (recorded version never claims the failed target).
+func TestRunApplyWriteAheadRollsBackKernelTOMLOnHealthFail(t *testing.T) {
+	u, _ := newTestUpdater(t, "v0.16.5")
+	ktPath := seedKernelTOML(t, u)
+	before, _ := os.ReadFile(ktPath)
+	payload, sum := newPayload(t, "v0.16.5")
+
+	u.download = func(ctx context.Context, url, dst string) error {
+		return os.WriteFile(dst, payload, 0o644)
+	}
+	u.fetchText = func(ctx context.Context, url string) (string, error) {
+		return fmt.Sprintf("%s  %s\n", sum, assetName()), nil
+	}
+	u.healthPoll = func(time.Duration) error { return fmt.Errorf("never healthy") }
+	u.rollbackPoll = func(time.Duration, string) error { return nil }
+
+	if err := runApplyWithStubResolve(u); err == nil {
+		t.Fatal("expected health-fail to surface as error (rolled back)")
+	}
+
+	after, _ := os.ReadFile(ktPath)
+	if string(after) != string(before) {
+		t.Errorf("kernel.toml must be rolled back to pre-update bytes on health failure.\n got:\n%s\nwant:\n%s", after, before)
+	}
+}
+
+// TestRunApplyWriteAheadRollsBackKernelTOMLOnChecksumFail asserts the ledger is
+// restored when the downloaded binary fails checksum verification (the record
+// was written before the download, so it must be un-written).
+func TestRunApplyWriteAheadRollsBackKernelTOMLOnChecksumFail(t *testing.T) {
+	u, _ := newTestUpdater(t, "v0.16.5")
+	ktPath := seedKernelTOML(t, u)
+	before, _ := os.ReadFile(ktPath)
+	payload, _ := newPayload(t, "v0.16.5")
+
+	u.download = func(ctx context.Context, url, dst string) error {
+		return os.WriteFile(dst, payload, 0o644)
+	}
+	// checksums.txt advertises a sum that does not match the downloaded payload.
+	u.fetchText = func(ctx context.Context, url string) (string, error) {
+		return fmt.Sprintf("%s  %s\n", suHashBytes([]byte("mismatch")), assetName()), nil
+	}
+	if err := runApplyWithStubResolve(u); err == nil {
+		t.Fatal("expected checksum-fail error")
+	}
+	after, _ := os.ReadFile(ktPath)
+	if string(after) != string(before) {
+		t.Errorf("kernel.toml must be rolled back on checksum failure.\n got:\n%s\nwant:\n%s", after, before)
+	}
+}
+
+// TestRunApplyAbortsWhenChecksumEntryMissing asserts the write-ahead refuses to
+// proceed (and touches nothing) when the release checksums.txt lacks an entry
+// for the current platform — there is no sha to record.
+func TestRunApplyAbortsWhenChecksumEntryMissing(t *testing.T) {
+	u, _ := newTestUpdater(t, "v0.16.5")
+	ktPath := seedKernelTOML(t, u)
+	before, _ := os.ReadFile(ktPath)
+	payload, _ := newPayload(t, "v0.16.5")
+
+	u.download = func(ctx context.Context, url, dst string) error {
+		return os.WriteFile(dst, payload, 0o644)
+	}
+	// checksums.txt has only some OTHER platform, not the current one.
+	u.fetchText = func(ctx context.Context, url string) (string, error) {
+		return "deadbeef  cogos-some-otherplatform\n", nil
+	}
+	if err := runApplyWithStubResolve(u); err == nil {
+		t.Fatal("expected abort when no checksum entry exists for the current platform")
+	}
+	after, _ := os.ReadFile(ktPath)
+	if string(after) != string(before) {
+		t.Errorf("kernel.toml must be untouched when the write-ahead cannot resolve a checksum.\n got:\n%s\nwant:\n%s", after, before)
 	}
 }
 

--- a/internal/engine/cli_selfupdate_unix.go
+++ b/internal/engine/cli_selfupdate_unix.go
@@ -139,7 +139,10 @@ func (u *selfUpdater) run() error {
 	return u.runApply(ctx)
 }
 
-// runApply performs the download→verify→swap→restart→health→rollback core.
+// runApply performs the write-ahead→download→verify→swap→restart→health→rollback
+// core. kernel.toml is the ledger: its version + current-platform checksum are
+// recorded BEFORE the binary is downloaded, and rolled back together with the
+// binary if any later step fails (issue #442).
 func (u *selfUpdater) runApply(ctx context.Context) error {
 	binPath := filepath.Join(u.binDir, "cogos")
 	bakPath := binPath + ".bak"
@@ -151,8 +154,40 @@ func (u *selfUpdater) runApply(ctx context.Context) error {
 		return fmt.Errorf("resolve %s: %w", u.toTag, err)
 	}
 
+	// WRITE-AHEAD (ledger-first) — fetch checksums.txt and record the target
+	// version + current-platform sha256 into kernel.toml BEFORE downloading the
+	// binary. The checksum we verify against below is the one we just wrote, so
+	// kernel.toml is the authority the swap reconciles toward, not a copy
+	// patched afterward. Fetching checksums up front (previously fetched after
+	// the download) is the only reordering the write-ahead requires.
+	sums, err := u.fetchText(ctx, target.ChecksumURL)
+	if err != nil {
+		return fmt.Errorf("download checksums: %w", err)
+	}
+	wantSum, ok := checksumFor(target.AssetName, sums)
+	if !ok {
+		return fmt.Errorf("no checksum entry for %s in release checksums.txt", target.AssetName)
+	}
+	ktSnap, err := writeAheadKernelTOML(u.root, u.toTag, target.AssetName, wantSum)
+	if err != nil {
+		// The ledger write itself failed: nothing downloaded, running binary
+		// untouched. Surface the error; the reconcile loop retries next tick.
+		return fmt.Errorf("write-ahead kernel.toml: %w (running binary untouched)", err)
+	}
+	if ktSnap.existed {
+		u.logf("write-ahead: recorded %s + %s checksum in %s", u.toTag, target.AssetName, ktSnap.path)
+	}
+	// rollbackLedger restores kernel.toml to its pre-write-ahead bytes and logs
+	// loudly on failure (a stuck-ahead kernel.toml is the exact drift #442 fixes).
+	rollbackLedger := func() {
+		if rerr := rollbackKernelTOML(ktSnap); rerr != nil {
+			u.logf("FATAL: kernel.toml rollback failed: %v; recorded version may be ahead of the running binary at %s", rerr, ktSnap.path)
+		}
+	}
+
 	// Pre-flight disk check: require ≥ 2× the running binary size free.
 	if err := u.preflightDisk(binPath); err != nil {
+		rollbackLedger()
 		return err
 	}
 
@@ -160,25 +195,25 @@ func (u *selfUpdater) runApply(ctx context.Context) error {
 	u.logf("downloading %s", target.AssetURL)
 	if err := u.download(ctx, target.AssetURL, newPath); err != nil {
 		_ = os.Remove(newPath)
+		rollbackLedger()
 		return fmt.Errorf("download binary: %w", err)
 	}
-	// From here on, always clean up newPath on any abort before the swap.
+	// From here on, always clean up newPath (and roll back the ledger) on any
+	// abort before the swap.
 	cleanupNew := func() { _ = os.Remove(newPath) }
 
-	// GATE L — checksum verify against checksums.txt.
-	sums, err := u.fetchText(ctx, target.ChecksumURL)
-	if err != nil {
+	// GATE L — checksum verify against the sha256 recorded write-ahead in
+	// kernel.toml (== the current platform's entry in the release checksums.txt).
+	if err := verifyChecksumAgainst(newPath, wantSum); err != nil {
 		cleanupNew()
-		return fmt.Errorf("download checksums: %w", err)
-	}
-	if err := verifyChecksum(newPath, target.AssetName, sums); err != nil {
-		cleanupNew()
+		rollbackLedger()
 		return fmt.Errorf("checksum verify: %w (running binary untouched)", err)
 	}
 
 	// Step 10 — make the new binary executable.
 	if err := os.Chmod(newPath, 0o755); err != nil {
 		cleanupNew()
+		rollbackLedger()
 		return fmt.Errorf("chmod new binary: %w", err)
 	}
 
@@ -186,16 +221,19 @@ func (u *selfUpdater) runApply(ctx context.Context) error {
 	got, err := u.smokeTest(newPath)
 	if err != nil {
 		cleanupNew()
+		rollbackLedger()
 		return fmt.Errorf("smoke-test new binary: %w (running binary untouched)", err)
 	}
 	if !versionFieldEqual(got, u.toTag) {
 		cleanupNew()
+		rollbackLedger()
 		return fmt.Errorf("downloaded binary reports %q, expected %s (running binary untouched)", got, u.toTag)
 	}
 
 	// Step 12 — backup the current binary by COPY (old binary stays in place).
 	if err := copyFileMode(binPath, bakPath, 0o755); err != nil {
 		cleanupNew()
+		rollbackLedger()
 		return fmt.Errorf("backup current binary: %w (running binary untouched)", err)
 	}
 
@@ -205,9 +243,11 @@ func (u *selfUpdater) runApply(ctx context.Context) error {
 		// Swap failed; restore from .bak to be safe (binPath may be intact, but
 		// restore is idempotent and known-good).
 		if rerr := os.Rename(bakPath, binPath); rerr != nil {
+			rollbackLedger()
 			u.logf("FATAL: swap failed (%v) AND restore failed (%v); manually run: cp %s %s", err, rerr, bakPath, binPath)
 			return fmt.Errorf("swap failed and restore failed: %w", err)
 		}
+		rollbackLedger()
 		return fmt.Errorf("atomic swap failed, restored from backup: %w", err)
 	}
 	u.logf("swapped binary to %s (backup at %s)", u.toTag, bakPath)
@@ -215,16 +255,17 @@ func (u *selfUpdater) runApply(ctx context.Context) error {
 	// Step 14 — restart the kernel.
 	if err := u.kickstart(); err != nil {
 		u.logf("kickstart failed after swap: %v; rolling back", err)
-		return u.rollback(binPath, bakPath, fmt.Errorf("kickstart: %w", err))
+		return u.rollback(binPath, bakPath, ktSnap, fmt.Errorf("kickstart: %w", err))
 	}
 
 	// GATE O — health poll: require status ok AND version == target within 30s.
 	if err := u.healthPoll(healthDeadline); err != nil {
 		u.logf("health did not converge to %s within %s: %v; rolling back", u.toTag, healthDeadline, err)
-		return u.rollback(binPath, bakPath, err)
+		return u.rollback(binPath, bakPath, ktSnap, err)
 	}
 
-	// Success — remove the backup, release lock (deferred), exit 0.
+	// Success — remove the backup, release lock (deferred), exit 0. kernel.toml
+	// already records the now-running version (written write-ahead).
 	if err := os.Remove(bakPath); err != nil && !os.IsNotExist(err) {
 		u.logf("warning: could not remove backup %s: %v", bakPath, err)
 	}
@@ -232,8 +273,18 @@ func (u *selfUpdater) runApply(ctx context.Context) error {
 	return nil
 }
 
-// rollback restores the backup binary and re-validates health. GATE P.
-func (u *selfUpdater) rollback(binPath, bakPath string, cause error) error {
+// rollback restores the backup binary AND the write-ahead kernel.toml entry,
+// then re-validates health. GATE P. kernel.toml is rolled back first so the
+// recorded version never claims the failed target once the old binary is back.
+func (u *selfUpdater) rollback(binPath, bakPath string, ktSnap kernelTOMLSnapshot, cause error) error {
+	// Roll the ledger back first: if this fails we still restore the binary, but
+	// we log loudly because a stuck-ahead kernel.toml is the drift #442 fixes.
+	if kerr := rollbackKernelTOML(ktSnap); kerr != nil {
+		u.logf("FATAL: kernel.toml rollback failed during binary rollback: %v; recorded version may be ahead of the restored binary at %s", kerr, ktSnap.path)
+	} else if ktSnap.existed {
+		u.logf("rolled back kernel.toml to the pre-update version at %s", ktSnap.path)
+	}
+
 	if err := os.Rename(bakPath, binPath); err != nil {
 		u.logf("FATAL: rollback restore failed: %v; the operator must manually run: cp %s %s", err, bakPath, binPath)
 		return fmt.Errorf("rollback restore failed (original cause: %v): %w", cause, err)
@@ -495,6 +546,24 @@ func verifyChecksum(path, assetName, checksums string) error {
 	}
 	if !strings.EqualFold(got, want) {
 		return fmt.Errorf("sha256 mismatch for %s: got %s, want %s", assetName, got, want)
+	}
+	return nil
+}
+
+// verifyChecksumAgainst computes sha256(path) and matches it against a single
+// expected hex digest (the one recorded write-ahead in kernel.toml). Used by the
+// #442 write-ahead path, which has already extracted the current-platform digest
+// via checksumFor and does not need to re-parse the full checksums.txt.
+func verifyChecksumAgainst(path, want string) error {
+	if want == "" {
+		return fmt.Errorf("empty expected checksum")
+	}
+	got, err := sha256File(path)
+	if err != nil {
+		return err
+	}
+	if !strings.EqualFold(got, want) {
+		return fmt.Errorf("sha256 mismatch: got %s, want %s", got, want)
 	}
 	return nil
 }


### PR DESCRIPTION
## What

Introduces the daemon-side write-ahead maintainer for `.cog/conf/kernel.toml`
(the pinned kernel version + per-platform sha256 checksums SOT, issue #442) and
hardens it against the correctness and premise findings from a rigorous Fable
review. Every issue below was reproduced by direct probe before fixing.

New file `internal/engine/cli_selfupdate_kerneltoml.go` records, BEFORE the
binary is downloaded, the target `[kernel].version` + the current platform's
sha256 into `kernel.toml` (the ledger entry the swap reconciles toward), and
restores the prior bytes on any later failure so the recorded version never
claims a binary that is not actually running.

## Why

The self-update apply path previously routed around `kernel.toml`, so any file
that pins the version/checksums would drift stale after every auto-update. The
write-ahead maintainer closes that drift. The review surfaced four ways the
first cut of this file could either corrupt the SOT it is meant to keep correct
or misrepresent its own state; this PR fixes all four.

## How

**Correctness — `patchKernelTOML`**

- **Quoted checksum keys are now matched.** A quoted `"darwin-arm64" = "..."`
  (valid TOML, common for hyphenated keys) did not compare equal to the bare
  platform key, so the current-platform line was not replaced in place and a
  **second** `darwin-arm64 = "..."` line was appended — duplicate-key TOML that
  strict parsers reject, defeating #442 on exactly the file it maintains.
  `tomlLineKey` now normalises a quoted key (double- or single-quoted) to its
  bare form for matching, and `replaceTOMLValue` preserves the on-line key text
  so the entry is rewritten in place with its quoting intact. One entry, updated.
- **Two non-canonical layouts now fail loudly** instead of emitting invalid
  TOML: (a) a bare top-level `version` before any `[kernel]` header (a prepended
  fresh `[kernel].version` would duplicate the key and strand the stale value);
  (b) checksums present only as `[kernel.checksums.<other>]` subtables with the
  current platform absent (appending an inline `[kernel.checksums]` after its
  child subtable is a parent-redefined-after-child error). Erroring aborts the
  write-ahead in the caller with the running binary untouched — strictly safer
  than corrupting the SOT.

**Permission preservation — write-ahead + rollback**

- `atomicWriteConfigFile` writes via `os.CreateTemp` (0o600) + rename and never
  applied the captured `priorPerm`, so a 0o644 `kernel.toml` silently narrowed
  to 0o600 and stayed there even after rollback. `writeAheadKernelTOML` and
  `rollbackKernelTOML` now `os.Chmod` back to the snapshot's `priorPerm`, so the
  file keeps its original mode across both write-ahead and rollback.

**Premise / documentation**

- The original file header asserted a broken-then-fixed state that cannot be
  reproduced against this tree: there is **no** `.cog/conf/kernel.toml`, **no**
  installer that seeds it, and **no** reader of `[kernel.checksums]` anywhere in
  the repo. The header is corrected to state the maintainer is
  **dormant-by-design** — an absent `kernel.toml` is a silent no-op, so the
  binary swap/restart/rollback sequence is byte-for-byte unchanged on every
  current workspace (hence no regression risk to the running daemon) — and only
  becomes active once a separate change lands the SOT file plus the installer
  (which, for an external installer, may live outside this repo).

## Tests

- Quoted- and single-quoted-key in-place replacement: exactly one entry, stale
  value gone, quoting preserved.
- Both malformed layouts assert `patchKernelTOML` returns an error.
- `TestWriteAheadKernelTOML_WritesThenRollsBack` now asserts file mode `0o644`
  is preserved across write-ahead and restored on rollback.
- Existing write-ahead integration tests (`TestRunApplyWriteAhead*`, seeded with
  the canonical inline layout) continue to pass — the new error paths only fire
  on the non-canonical hand-edited layouts.
- `go build ./...`, `go vet ./internal/engine/`, and
  `go test ./internal/engine/ -race -count=1` all pass (go1.25.5).

## Review provenance

Addresses the findings of a Fable review across two lenses (correctness of the
write-ahead ledger; no-regression + conventions for the apply/restart/rollback
path). The two `major`, two `minor` findings are all resolved here.
