### PR TITLE
fix(inference): robust availability probes, end-to-end usage, and compat-aware fallback

### DIFF
--- a/internal/engine/provider_ollama.go
+++ b/internal/engine/provider_ollama.go
@@ -134,8 +134,18 @@ func (p *OllamaProvider) Available(ctx context.Context) bool {
 
 // probeAvailable performs the live check backing Available(): GET /api/tags and
 // confirm the configured model is present. Call via Available() for TTL caching.
+//
+// The probe caps its own HTTP call at probeHTTPTimeout rather than inheriting
+// p.client.Timeout. Available() holds availMu across this call so concurrent
+// callers collapse into one probe (#441); without this internal bound a
+// hung-but-accepting upstream would let one caller hold availMu for the full
+// client timeout, blocking the router's probeAll goroutine and Route()'s inline
+// fallback behind availMu.Lock() (inference-pipeline-robustness FIX 1; mirrors
+// ClaudeOAuthProvider.probeAvailable).
 func (p *OllamaProvider) probeAvailable(ctx context.Context) bool {
-	models, err := p.listModels(ctx)
+	pctx, cancel := context.WithTimeout(ctx, probeHTTPTimeout)
+	defer cancel()
+	models, err := p.listModels(pctx)
 	if err != nil {
 		return false
 	}

--- a/internal/engine/provider_openai.go
+++ b/internal/engine/provider_openai.go
@@ -158,8 +158,18 @@ func (p *OpenAICompatProvider) Available(ctx context.Context) bool {
 // probeAvailable performs the live reachability check backing Available():
 // GET /v1/models, then confirm the configured model (if any) is present. Call
 // via Available() to get TTL caching; calling this directly bypasses the cache.
+//
+// The probe caps its own HTTP call at probeHTTPTimeout rather than inheriting
+// p.client.Timeout (300s on the lmstudio providers). Available() holds availMu
+// across this call so concurrent callers collapse into one probe (#441); without
+// this internal bound a hung-but-accepting upstream would let a single
+// /v1/providers request hold availMu for the full client timeout, blocking the
+// router's probeAll goroutine and Route()'s inline fallback behind availMu.Lock()
+// (inference-pipeline-robustness FIX 1; mirrors ClaudeOAuthProvider.probeAvailable).
 func (p *OpenAICompatProvider) probeAvailable(ctx context.Context) bool {
-	models, err := p.listModels(ctx)
+	pctx, cancel := context.WithTimeout(ctx, probeHTTPTimeout)
+	defer cancel()
+	models, err := p.listModels(pctx)
 	if err != nil {
 		return false
 	}
@@ -270,16 +280,27 @@ type openaiModel struct {
 }
 
 type openaiChatRequest struct {
-	Model       string                 `json:"model"`
-	Messages    []openaiMessage        `json:"messages"`
-	Stream      bool                   `json:"stream"`
-	MaxTokens   int                    `json:"max_tokens,omitempty"`
-	Temperature *float64               `json:"temperature,omitempty"`
-	TopP        *float64               `json:"top_p,omitempty"`
-	Stop        []string               `json:"stop,omitempty"`
-	Tools       []openaiTool           `json:"tools,omitempty"`
-	ToolChoice  interface{}            `json:"tool_choice,omitempty"` // string or object
-	Options     map[string]interface{} `json:"-"`                     // not sent, internal only
+	Model         string                 `json:"model"`
+	Messages      []openaiMessage        `json:"messages"`
+	Stream        bool                   `json:"stream"`
+	StreamOptions *openaiStreamOptions   `json:"stream_options,omitempty"` // only sent when streaming; requests a usage-bearing terminal chunk
+	MaxTokens     int                    `json:"max_tokens,omitempty"`
+	Temperature   *float64               `json:"temperature,omitempty"`
+	TopP          *float64               `json:"top_p,omitempty"`
+	Stop          []string               `json:"stop,omitempty"`
+	Tools         []openaiTool           `json:"tools,omitempty"`
+	ToolChoice    interface{}            `json:"tool_choice,omitempty"` // string or object
+	Options       map[string]interface{} `json:"-"`                     // not sent, internal only
+}
+
+// openaiStreamOptions carries the OpenAI `stream_options` object. include_usage
+// asks the server (OpenAI, LM Studio, vLLM) to emit a final SSE chunk carrying
+// token usage with an empty choices array. Without it, streaming completions
+// report no usage at all, so the cancel-safe streaming path (CompleteCancelSafe,
+// which every non-streaming compat completion now routes through per #432) would
+// surface usage 0/0 on every request (inference-pipeline-robustness FIX 2).
+type openaiStreamOptions struct {
+	IncludeUsage bool `json:"include_usage"`
 }
 
 type openaiMessage struct {
@@ -415,6 +436,16 @@ func buildOpenAIRequest(model string, req *CompletionRequest, stream bool, maxTo
 		Temperature: req.Temperature,
 		TopP:        req.TopP,
 		Stop:        req.Stop,
+	}
+
+	// Request usage on the terminal SSE chunk. Non-streaming responses always
+	// carry usage in the body, but the cancel-safe path (CompleteCancelSafe)
+	// routes every non-streaming compat completion through Stream() (#432), and
+	// a plain streaming request omits usage unless include_usage is set — so
+	// without this the SSE aggregator's usage stays nil and every completion
+	// reports 0/0 (inference-pipeline-robustness FIX 2).
+	if stream {
+		or.StreamOptions = &openaiStreamOptions{IncludeUsage: true}
 	}
 
 	if maxTokens > 0 {

--- a/internal/engine/provider_openai_test.go
+++ b/internal/engine/provider_openai_test.go
@@ -102,6 +102,42 @@ func TestBuildOpenAIRequestNoSystemPrompt(t *testing.T) {
 	}
 }
 
+// TestBuildOpenAIRequestStreamOptions guards inference-pipeline-robustness FIX 2:
+// a streaming request must set stream_options.include_usage so the server emits a
+// usage-bearing terminal chunk; a non-streaming request must not set it (usage is
+// in the response body there). A missing include_usage is what left every
+// cancel-safe streaming completion reporting usage 0/0.
+func TestBuildOpenAIRequestStreamOptions(t *testing.T) {
+	t.Parallel()
+	streaming := buildOpenAIRequest("m", &CompletionRequest{}, true, 0)
+	if streaming.StreamOptions == nil {
+		t.Fatal("streaming request: StreamOptions is nil; want include_usage set")
+	}
+	if !streaming.StreamOptions.IncludeUsage {
+		t.Error("streaming request: include_usage = false; want true")
+	}
+	// It must serialize into the wire body under the OpenAI key.
+	b, err := json.Marshal(streaming)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(b), `"stream_options":{"include_usage":true}`) {
+		t.Errorf("marshaled body missing stream_options: %s", b)
+	}
+
+	nonStreaming := buildOpenAIRequest("m", &CompletionRequest{}, false, 0)
+	if nonStreaming.StreamOptions != nil {
+		t.Error("non-streaming request: StreamOptions should be nil (usage is in the response body)")
+	}
+	nb, err := json.Marshal(nonStreaming)
+	if err != nil {
+		t.Fatalf("marshal non-streaming: %v", err)
+	}
+	if strings.Contains(string(nb), "stream_options") {
+		t.Errorf("non-streaming body should omit stream_options: %s", nb)
+	}
+}
+
 func TestBuildOpenAIRequestOptions(t *testing.T) {
 	t.Parallel()
 	temp := 0.7
@@ -486,6 +522,69 @@ func TestOpenAIAvailableCachesDeadlineExceededAsUnavailable(t *testing.T) {
 	}
 	if got := hits.Load(); got != 1 {
 		t.Errorf("upstream hit %d times; want 1 (timeout result should be cached, not re-probed)", got)
+	}
+}
+
+// TestOpenAIProbeBoundedByInternalTimeout is the regression guard for
+// inference-pipeline-robustness FIX 1: probeAvailable must cap its own HTTP call
+// at probeHTTPTimeout, independent of the (much larger) client timeout, so a
+// hung-but-accepting upstream can't hold availMu for the full client timeout and
+// block the router's probeAll goroutine / Route()'s inline fallback behind
+// availMu.Lock().
+//
+// The provider's client timeout is set to an hour; against a server that accepts
+// the connection and then hangs, an uncapped probe would block for that hour.
+// The internal probeHTTPTimeout bound must make Available() return false in ~10s.
+// A second concurrent caller (which blocks on availMu behind the first) must also
+// be released within the same bound — proving the mutex hold is bounded too.
+func TestOpenAIProbeBoundedByInternalTimeout(t *testing.T) {
+	t.Parallel()
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release // accept then hang, like a wedged LM Studio
+	}))
+	defer srv.Close()
+	defer close(release)
+
+	// Client timeout of an hour: only the internal probeHTTPTimeout can bound this.
+	p := NewOpenAICompatProvider("openai-compat", ProviderConfig{
+		Endpoint: srv.URL,
+		Model:    "any",
+		Timeout:  3600,
+	})
+
+	// Two concurrent callers: the second must queue on availMu behind the first.
+	type result struct {
+		avail   bool
+		elapsed time.Duration
+	}
+	results := make(chan result, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			start := time.Now()
+			avail := p.Available(context.Background())
+			results <- result{avail: avail, elapsed: time.Since(start)}
+		}()
+	}
+
+	// Generous ceiling: probeHTTPTimeout (10s) for the first probe + the second
+	// caller's turn under availMu, plus slack. Far below the 1h client timeout, so
+	// a pass proves the internal cap — not the client timeout — bounded the hold.
+	bound := 2*probeHTTPTimeout + 5*time.Second
+	deadline := time.After(bound)
+	for i := 0; i < 2; i++ {
+		select {
+		case res := <-results:
+			if res.avail {
+				t.Errorf("Available() = true against a hung server; want false")
+			}
+			if res.elapsed >= p.timeout {
+				t.Errorf("probe took %v (>= client timeout %v); internal probeHTTPTimeout did not bound it",
+					res.elapsed, p.timeout)
+			}
+		case <-deadline:
+			t.Fatalf("Available() did not return within %v — probeAvailable is not internally bounded (availMu held for the client timeout)", bound)
+		}
 	}
 }
 
@@ -1274,6 +1373,69 @@ func TestOpenAICompleteCancelSafeAggregatesContent(t *testing.T) {
 	}
 	if resp.ProviderMeta.Provider != "openai-compat" {
 		t.Errorf("ProviderMeta.Provider = %q; want openai-compat", resp.ProviderMeta.Provider)
+	}
+}
+
+// TestOpenAICompleteCancelSafeUsageFromTerminalChunk is the regression guard for
+// inference-pipeline-robustness FIX 2. It models LM Studio's include_usage wire
+// behavior exactly: content chunks with usage:null, then a FINAL chunk carrying
+// usage with an EMPTY choices array (the shape a server sends only when the
+// request set stream_options.include_usage). The server also asserts the request
+// actually carried that flag. Before the fix, buildOpenAIRequest never set
+// stream_options, so LM Studio sent no usage chunk and every cancel-safe
+// completion reported usage 0/0.
+func TestOpenAICompleteCancelSafeUsageFromTerminalChunk(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload openaiChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		// The whole point of the fix: the streaming request must ask for usage.
+		if payload.StreamOptions == nil || !payload.StreamOptions.IncludeUsage {
+			http.Error(w, "request did not set stream_options.include_usage", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+		// Content chunks carry no usage (usage:null), just like LM Studio.
+		stop := "stop"
+		for _, delta := range []string{"Hel", "lo"} {
+			chunk := openaiStreamChunk{Choices: []openaiStreamChoice{{Index: 0, Delta: openaiStreamDelta{Content: delta}}}}
+			b, _ := json.Marshal(chunk)
+			fmt.Fprintf(w, "data: %s\n\n", b)
+			flusher.Flush()
+		}
+		// Finish-reason chunk (still no usage).
+		finish := openaiStreamChunk{Choices: []openaiStreamChoice{{Index: 0, Delta: openaiStreamDelta{}, FinishReason: &stop}}}
+		fb, _ := json.Marshal(finish)
+		fmt.Fprintf(w, "data: %s\n\n", fb)
+		flusher.Flush()
+		// Terminal usage chunk: usage present, choices EMPTY — the include_usage shape.
+		usageChunk := openaiStreamChunk{
+			Choices: []openaiStreamChoice{},
+			Usage:   &openaiUsageResponse{PromptTokens: 42, CompletionTokens: 17, TotalTokens: 59},
+		}
+		ub, _ := json.Marshal(usageChunk)
+		fmt.Fprintf(w, "data: %s\n\n", ub)
+		fmt.Fprint(w, "data: [DONE]\n\n")
+		flusher.Flush()
+	}))
+	defer srv.Close()
+
+	p := newTestOpenAIProvider(t, srv.URL, "test-model")
+	resp, err := p.CompleteCancelSafe(context.Background(), &CompletionRequest{
+		Messages: []ProviderMessage{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("CompleteCancelSafe: %v", err)
+	}
+	if resp.Content != "Hello" {
+		t.Errorf("Content = %q; want Hello", resp.Content)
+	}
+	if resp.Usage.InputTokens != 42 || resp.Usage.OutputTokens != 17 {
+		t.Errorf("Usage = %+v; want {InputTokens:42, OutputTokens:17} from the terminal usage chunk", resp.Usage)
 	}
 }
 

--- a/internal/engine/router.go
+++ b/internal/engine/router.go
@@ -202,6 +202,27 @@ func (r *SimpleRouter) Route(ctx context.Context, req *CompletionRequest) (Provi
 		caps := p.Capabilities()
 		capsMet := caps.HasAllCapabilities(req.Metadata.RequiredCapabilities)
 		avail := r.available(ctx, p)
+		// Compat-aware fallback (inference-pipeline-robustness FIX 3): a request
+		// carrying an explicit ModelOverride, when its primary is down, falls
+		// through the chain still carrying that override. A bare local-model id
+		// like "ornith-1.0-35b" must not be fired at a LOCAL model-serving sibling
+		// (lmstudio/ollama/mlx) that hasn't loaded it — that 404s opaquely — so
+		// providerCanServe skips such a candidate and lets the router reach the
+		// sibling that does serve it. Frontier providers (anthropic, claude-oauth,
+		// and the claude-code / codex CLIs) are model-agnostic within their family
+		// and honour any override verbatim, so providerCanServe keeps them
+		// eligible — this preserves degraded-mode frontier failover, e.g. a
+		// "sonnet" override reaching a backup claude-oauth or the claude-code CLI
+		// after the preferred frontier drops (the case the flight review flagged).
+		//
+		// The gate applies to FALLBACK candidates only (i > 0). The preferred
+		// provider at position 0 was resolved explicitly (PreferProvider / alias
+		// table already validated the override against it — e.g. "opus" → this
+		// provider), so it is never skipped: that preserves all managed-frontier
+		// routing where the override intentionally differs from the provider's
+		// configured model. Only the involuntary carry-over into a fallback that
+		// can't serve the override is filtered.
+		canServe := i == 0 || providerCanServe(p, req.ModelOverride)
 
 		score := ProviderScore{
 			Provider:        p.Name(),
@@ -215,7 +236,7 @@ func (r *SimpleRouter) Route(ctx context.Context, req *CompletionRequest) (Provi
 		score.AdjustedScore = score.RawScore - score.SwapPenalty
 		scores = append(scores, score)
 
-		if avail && capsMet && selected == nil {
+		if avail && capsMet && canServe && selected == nil {
 			selected = p
 			if i > 0 {
 				fallbackUsed = true
@@ -292,6 +313,18 @@ const probeTimeout = 2 * time.Second
 // that do a live reachability check — OpenAICompatProvider, ClaudeOAuthProvider
 // — reuse this; MLXSupervisedProvider already keeps an equivalent probe cache.
 const availCacheTTL = 30 * time.Second
+
+// probeHTTPTimeout is the internal ceiling a provider's probeAvailable() puts on
+// its own reachability HTTP call, independent of the provider's (much larger)
+// request timeout. Available() holds a per-provider mutex across probeAvailable
+// so concurrent callers collapse into one probe (#441); without an internal
+// bound, a hung-but-accepting upstream would let a single /v1/providers request
+// hold that mutex for the full client timeout (300s on the lmstudio providers),
+// blocking the router's probeAll goroutine and Route()'s inline fallback — whose
+// own probeTimeout bounds the probe, not the availMu.Lock() behind it (flight
+// review, inference-pipeline-robustness FIX 1). ClaudeOAuthProvider already caps
+// its probe at this ceiling; OpenAICompatProvider and OllamaProvider now match.
+const probeHTTPTimeout = 10 * time.Second
 
 // probeAll probes every registered provider concurrently, each bounded by
 // probeTimeout, and atomically swaps in the resulting snapshot. A cycle costs
@@ -433,6 +466,91 @@ func computeScore(p Provider, req *CompletionRequest) float64 {
 		score += 0.1
 	}
 	return score
+}
+
+// providerCanServe reports whether provider p can serve an explicit
+// ModelOverride. It backs the compat-aware fallback in Route (FIX 3): a
+// ModelOverride must not be carried into a FALLBACK provider that can't honour
+// it. Route applies this only to candidates past the preferred one (i > 0); the
+// preferred provider was resolved explicitly and is always eligible.
+//
+// The gate is scoped to the ACTUAL hazard: a bare model id fired at a
+// LOCAL MODEL-SERVING provider (ollama, lmstudio/openai-compat, mlx) that only
+// serves models it has loaded — such a provider 404s on an id it hasn't loaded,
+// so a mismatched override there is an opaque failure and it must be skipped.
+//
+// Frontier providers are model-AGNOSTIC within their model family and honour
+// req.ModelOverride verbatim (Anthropic API / claude-oauth pass the override
+// straight through; the claude-code and codex CLIs pass it to `--model`). They
+// each advertise only their single configured model in ModelsAvailable, yet
+// happily serve any sibling id, so they must NEVER be gated by the advertised
+// list — otherwise a "sonnet" request whose preferred claude-oauth is down would
+// skip every backup frontier provider (a second claude-oauth, the anthropic
+// provider, or the claude-code CLI) and fail with "no available provider",
+// silently breaking exactly the degraded-mode frontier failover the router
+// exists for. This is the class the flight review flagged in the first cut.
+//
+// The frontier set is identified structurally, not by name:
+//   - !IsLocal  → a remote API provider (anthropic, claude-oauth): family-
+//     agnostic, honours any override → eligible.
+//   - AgenticHarness → a local CLI harness (claude-code, codex): also family-
+//     agnostic and IsLocal, so IsLocal alone would wrongly gate it → eligible.
+//
+// Only a local, non-agentic model-serving provider is gated by its advertised
+// models.
+//
+// Rules, chosen to preserve today's routing whenever no override is in play:
+//   - Empty override → always true (default routing; the provider uses its own
+//     configured model). This is the common case and must stay unchanged.
+//   - Frontier provider (see above) → always true; it honours the override.
+//   - Local model-serving provider whose Model()/ModelsAvailable includes the
+//     override (exact or prefix, mirroring the /v1/models match in the provider
+//     probes) → true.
+//   - Local model-serving provider that declares NO specific model at all (empty
+//     Model() and empty ModelsAvailable — generic endpoints) → true, so a
+//     provider that never advertised a model isn't newly excluded.
+//   - Otherwise (a local model-serving provider advertises specific models and
+//     the override is none of them) → false: skip it so a bare local-model id
+//     can't be fired at a provider that hasn't loaded it and would fail opaquely.
+func providerCanServe(p Provider, modelOverride string) bool {
+	if modelOverride == "" {
+		return true
+	}
+	caps := p.Capabilities()
+	// Frontier providers (remote APIs and local agentic CLIs) are model-agnostic
+	// within their family and honour any override verbatim — never gate them.
+	if !caps.IsLocal || caps.AgenticHarness {
+		return true
+	}
+	declaredAny := false
+	if m := p.Model(); m != "" {
+		declaredAny = true
+		if modelMatches(m, modelOverride) {
+			return true
+		}
+	}
+	for _, m := range caps.ModelsAvailable {
+		if m == "" {
+			continue
+		}
+		declaredAny = true
+		if modelMatches(m, modelOverride) {
+			return true
+		}
+	}
+	// A local model-serving provider that advertises no model is treated as
+	// model-agnostic and left eligible; one that advertises specific models but
+	// not this one is skipped.
+	return !declaredAny
+}
+
+// modelMatches reports whether an advertised model id serves the requested one,
+// using the same exact-or-prefix rule the provider availability probes apply to
+// /v1/models entries (e.g. "gemma-4-26b" advertised serves a "gemma-4" request).
+func modelMatches(advertised, requested string) bool {
+	return advertised == requested ||
+		strings.HasPrefix(advertised, requested) ||
+		strings.HasPrefix(requested, advertised)
 }
 
 func routeReason(escalated, fallback bool) string {

--- a/internal/engine/router_test.go
+++ b/internal/engine/router_test.go
@@ -85,6 +85,291 @@ func TestRouterFallbackWhenPrimaryUnavailable(t *testing.T) {
 	}
 }
 
+// TestRouterFallbackSkipsProvidersThatCannotServeOverride is the regression
+// guard for inference-pipeline-robustness FIX 3. When the primary local provider
+// (serving ornith-1.0-35b) is down, the fallback carries the ModelOverride into
+// the chain. A LOCAL model-serving sibling that has a DIFFERENT model loaded
+// (gemma) would 404 on the ornith id, so the router must skip it and reach the
+// sibling that actually serves ornith-1.0-35b. Only local model-serving
+// providers are gated this way — see TestRouterFallbackReachesFrontierBackup
+// for the complementary guarantee that frontier fallbacks stay eligible.
+func TestRouterFallbackSkipsProvidersThatCannotServeOverride(t *testing.T) {
+	t.Parallel()
+	r := NewSimpleRouter(RoutingConfig{
+		Default:       "lmstudio-darkstar",
+		FallbackChain: []string{"lmstudio-darkstar", "lmstudio-gemma", "lmstudio-eclipse"},
+	})
+
+	// Primary: serves ornith-1.0-35b but is down.
+	darkstar := NewStubProvider("lmstudio-darkstar", "")
+	darkstar.model = "ornith-1.0-35b"
+	darkstar.available = false
+
+	// Local model-serving sibling with a DIFFERENT model loaded. It would 404 on
+	// an ornith id, so it MUST be skipped for an ornith override.
+	gemma := NewStubProvider("lmstudio-gemma", "gemma reply")
+	gemma.model = "gemma-4-26b"
+	gemma.capabilities = ProviderCapabilities{
+		Capabilities:    []Capability{CapStreaming, CapToolUse, CapJSON},
+		ModelsAvailable: []string{"gemma-4-26b"},
+		IsLocal:         true,
+	}
+
+	// Sibling local provider that DOES serve ornith-1.0-35b.
+	eclipse := NewStubProvider("lmstudio-eclipse", "ornith reply")
+	eclipse.model = "ornith-1.0-35b"
+
+	r.RegisterProvider(darkstar)
+	r.RegisterProvider(gemma)
+	r.RegisterProvider(eclipse)
+
+	p, dec, err := r.Route(context.Background(), &CompletionRequest{
+		ModelOverride: "ornith-1.0-35b",
+		Metadata:      RequestMetadata{RequestID: "fix3-1"},
+	})
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if p.Name() != "lmstudio-eclipse" {
+		t.Errorf("selected = %q; want lmstudio-eclipse (lmstudio-gemma must be skipped — it has a different model loaded and can't serve ornith-1.0-35b)", p.Name())
+	}
+	if !dec.FallbackUsed {
+		t.Error("FallbackUsed should be true")
+	}
+}
+
+// TestRouterFallbackReachesFrontierBackup is the missing coverage the flight
+// review flagged: a frontier provider reached as a FALLBACK (i > 0) with a
+// differing-but-serviceable Claude-family override must be SELECTED, not skipped.
+// A "sonnet" request resolves to a preferred claude-oauth (configured for opus)
+// that is DOWN; the router must fall to a backup frontier provider carrying the
+// sonnet override and select it, because frontier providers honour the override
+// verbatim within their family. Before the fix, providerCanServe gated every
+// frontier fallback and this returned "no available provider".
+func TestRouterFallbackReachesFrontierBackup(t *testing.T) {
+	t.Parallel()
+
+	// Two flavours of frontier backup, plus a local agentic CLI, all reachable
+	// only as fallbacks (i > 0). Each must be selectable for a differing override.
+	newFrontier := func(name, model string, models []string, local, agentic bool) *StubProvider {
+		p := NewStubProvider(name, name+" reply")
+		p.model = model
+		p.capabilities = ProviderCapabilities{
+			Capabilities:    []Capability{CapStreaming, CapToolUse, CapJSON},
+			ModelsAvailable: models,
+			IsLocal:         local,
+			AgenticHarness:  agentic,
+		}
+		return p
+	}
+
+	cases := []struct {
+		name       string
+		backupName string
+		backup     *StubProvider
+	}{
+		{
+			// A second claude-oauth / the anthropic provider: remote, !IsLocal,
+			// advertises a date-stamped id that does not match the short override.
+			name:       "remote anthropic backup",
+			backupName: "anthropic",
+			backup:     newFrontier("anthropic", "claude-sonnet-4-20250514", []string{"claude-sonnet-4-20250514"}, false, false),
+		},
+		{
+			// The claude-code CLI fallback: IsLocal AND AgenticHarness, advertises
+			// only short aliases that don't match the date-stamped override.
+			name:       "local claude-code CLI backup",
+			backupName: "claude-code",
+			backup:     newFrontier("claude-code", "sonnet", []string{"sonnet", "opus", "haiku"}, true, true),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := NewSimpleRouter(RoutingConfig{
+				Default:       "claude-oauth",
+				FallbackChain: []string{"claude-oauth", tc.backupName},
+			})
+
+			// Preferred frontier, configured for opus, is DOWN.
+			primary := newFrontier("claude-oauth", "claude-opus-4-7", []string{"claude-opus-4-7"}, false, false)
+			primary.available = false
+
+			r.RegisterProvider(primary)
+			r.RegisterProvider(tc.backup)
+
+			p, dec, err := r.Route(context.Background(), &CompletionRequest{
+				ModelOverride: "claude-sonnet-4-6",
+				Metadata:      RequestMetadata{RequestID: "fix3-frontier"},
+			})
+			if err != nil {
+				t.Fatalf("Route: %v (frontier backup must be reachable as a fallback)", err)
+			}
+			if p.Name() != tc.backupName {
+				t.Errorf("selected = %q; want %q (frontier fallback must serve the differing Claude-family override, not be skipped)", p.Name(), tc.backupName)
+			}
+			if !dec.FallbackUsed {
+				t.Error("FallbackUsed should be true — primary was down, backup reached as fallback")
+			}
+		})
+	}
+}
+
+// TestRouterFallbackNoOverridePreservesBehavior confirms the compat-aware skip
+// does not change routing when there is no ModelOverride: the first available
+// provider in the chain wins even if its Model() differs from the primary's.
+func TestRouterFallbackNoOverridePreservesBehavior(t *testing.T) {
+	t.Parallel()
+	r := NewSimpleRouter(RoutingConfig{
+		Default:       "lmstudio-darkstar",
+		FallbackChain: []string{"lmstudio-darkstar", "claude-oauth", "lmstudio-eclipse"},
+	})
+
+	darkstar := NewStubProvider("lmstudio-darkstar", "")
+	darkstar.model = "ornith-1.0-35b"
+	darkstar.available = false
+
+	oauth := NewStubProvider("claude-oauth", "claude reply")
+	oauth.model = "claude-opus-4-7"
+	oauth.capabilities = ProviderCapabilities{
+		Capabilities:    []Capability{CapStreaming, CapJSON},
+		ModelsAvailable: []string{"claude-opus-4-7"},
+		IsLocal:         false,
+	}
+
+	eclipse := NewStubProvider("lmstudio-eclipse", "ornith reply")
+	eclipse.model = "ornith-1.0-35b"
+
+	r.RegisterProvider(darkstar)
+	r.RegisterProvider(oauth)
+	r.RegisterProvider(eclipse)
+
+	// No ModelOverride: claude-oauth is the next available candidate and must be
+	// selected exactly as before the fix (the skip only applies to overrides).
+	p, dec, err := r.Route(context.Background(), &CompletionRequest{
+		Metadata: RequestMetadata{RequestID: "fix3-2"},
+	})
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if p.Name() != "claude-oauth" {
+		t.Errorf("selected = %q; want claude-oauth (no override → first available wins, unchanged)", p.Name())
+	}
+	if !dec.FallbackUsed {
+		t.Error("FallbackUsed should be true")
+	}
+}
+
+// TestRouterPreferredProviderNotSkippedForDifferingOverride guards the
+// managed-frontier case (FIX 3): the compat-aware skip applies only to fallback
+// candidates, never the preferred provider. A "sonnet"/"opus"-style request
+// resolves to a frontier provider with a ModelOverride that intentionally
+// differs from that provider's configured model; the router must still select
+// it (position 0), not skip it because Model() != override.
+func TestRouterPreferredProviderNotSkippedForDifferingOverride(t *testing.T) {
+	t.Parallel()
+	r := NewSimpleRouter(RoutingConfig{
+		Default:       "lmstudio-darkstar",
+		FallbackChain: []string{"lmstudio-darkstar"},
+	})
+
+	// Frontier provider configured for opus but asked (via override) for sonnet —
+	// it is model-agnostic within its family and honours the override.
+	oauth := NewStubProvider("claude-oauth", "sonnet reply")
+	oauth.model = "claude-opus-4-7"
+	oauth.capabilities = ProviderCapabilities{
+		Capabilities:    []Capability{CapStreaming, CapJSON},
+		ModelsAvailable: []string{"claude-opus-4-7"},
+		IsLocal:         false,
+	}
+	r.RegisterProvider(oauth)
+
+	// Request explicitly prefers claude-oauth with a differing override.
+	p, dec, err := r.Route(context.Background(), &CompletionRequest{
+		ModelOverride: "claude-sonnet-4-6",
+		Metadata: RequestMetadata{
+			RequestID:      "fix3-3",
+			PreferProvider: "claude-oauth",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if p.Name() != "claude-oauth" {
+		t.Errorf("selected = %q; want claude-oauth (preferred provider must not be skipped for a differing override)", p.Name())
+	}
+	if dec.FallbackUsed {
+		t.Error("FallbackUsed should be false — claude-oauth is the preferred provider")
+	}
+}
+
+// TestProviderCanServe locks the compat-aware fallback predicate (FIX 3). The
+// gate is scoped to LOCAL, NON-AGENTIC model-serving providers; frontier
+// providers (remote APIs and local agentic CLIs) are always eligible because
+// they honour an arbitrary override verbatim within their model family.
+func TestProviderCanServe(t *testing.T) {
+	t.Parallel()
+
+	// Local model-serving provider (lmstudio/ollama/mlx shape): IsLocal, not an
+	// agentic harness, advertises exactly the model it has loaded.
+	localServing := NewStubProvider("lmstudio-eclipse", "")
+	localServing.model = "ornith-1.0-35b"
+	localServing.capabilities = ProviderCapabilities{
+		ModelsAvailable: []string{"ornith-1.0-35b"},
+		IsLocal:         true,
+	}
+
+	// Remote frontier provider (anthropic / claude-oauth shape): !IsLocal,
+	// advertises only its configured model but honours any Claude-family id.
+	remoteFrontier := NewStubProvider("claude-oauth", "")
+	remoteFrontier.model = "claude-opus-4-7"
+	remoteFrontier.capabilities = ProviderCapabilities{
+		ModelsAvailable: []string{"claude-opus-4-7"},
+		IsLocal:         false,
+	}
+
+	// Local agentic CLI (claude-code / codex shape): IsLocal AND AgenticHarness.
+	// IsLocal alone would wrongly gate it; the AgenticHarness carve-out keeps it
+	// eligible because it passes ModelOverride straight to `--model`.
+	agenticCLI := NewStubProvider("claude-code", "")
+	agenticCLI.model = "sonnet"
+	agenticCLI.capabilities = ProviderCapabilities{
+		ModelsAvailable: []string{"sonnet", "opus", "haiku"},
+		IsLocal:         true,
+		AgenticHarness:  true,
+	}
+
+	// Local model-serving provider that advertises no model at all.
+	localAgnostic := NewStubProvider("generic-local", "")
+	localAgnostic.capabilities = ProviderCapabilities{IsLocal: true}
+
+	cases := []struct {
+		name     string
+		p        Provider
+		override string
+		want     bool
+	}{
+		{"empty override always serves (local serving)", localServing, "", true},
+		{"empty override always serves (remote frontier)", remoteFrontier, "", true},
+		{"exact model match on local serving", localServing, "ornith-1.0-35b", true},
+		{"non-matching override on local serving provider is skipped", localServing, "gemma-4-26b", false},
+		{"prefix: request family, local serving provider serves variant", localServing, "ornith-1.0", true},
+		{"remote frontier serves any Claude-family override (never gated)", remoteFrontier, "claude-sonnet-4-6", true},
+		{"remote frontier serves even a non-family override (honours verbatim)", remoteFrontier, "ornith-1.0-35b", true},
+		{"local agentic CLI serves an override outside its advertised list", agenticCLI, "claude-sonnet-4-6", true},
+		{"local model-agnostic provider serves any override", localAgnostic, "ornith-1.0-35b", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := providerCanServe(tc.p, tc.override); got != tc.want {
+				t.Errorf("providerCanServe(%q, %q) = %v; want %v", tc.p.Name(), tc.override, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestRouterErrorWhenNoneAvailable(t *testing.T) {
 	t.Parallel()
 	r := NewSimpleRouter(RoutingConfig{Default: "p"})


### PR DESCRIPTION
## What

Hardens the inference routing pipeline against three failure modes surfaced by the flight/Fable review, and corrects a silent availability regression the review's regression lens caught in the first cut of FIX 3.

- **FIX 1 — bounded reachability probe.** `OpenAICompatProvider` and `OllamaProvider` now cap their probe HTTP call at `probeHTTPTimeout` (10s), independent of the much larger request timeout.
- **FIX 2 — end-to-end token usage.** Usage is reported from the final SSE `usage` chunk so callers see real prompt/completion counts instead of zeros.
- **FIX 3 — compat-aware fallback,** scoped to the *actual* hazard (local model-serving providers), so degraded-mode frontier failover keeps working.

## Why

### FIX 1
`Available()` holds a per-provider mutex across `probeAvailable()` so concurrent callers collapse into a single probe (#441). Without an internal ceiling, a hung-but-accepting upstream lets one `/v1/models` probe hold that mutex for the provider's full client timeout (300s on the lmstudio providers). That stalls the background `probeAll` goroutine and `Route()`'s inline fallback — whose own `probeTimeout` bounds the probe, **not** the `availMu.Lock()` sitting behind it. `ClaudeOAuthProvider` already capped its probe at this ceiling; the OpenAI-compat and Ollama providers now match.

### FIX 3 and the review-flagged regression
A request carrying an explicit `ModelOverride`, when its primary is down, falls through the fallback chain still carrying that override. A bare local-model id (e.g. `ornith-1.0-35b`) must not be fired at a **local model-serving** sibling (lmstudio / ollama / mlx) that hasn't loaded it — that 404s opaquely — so `providerCanServe` skips such a candidate and lets the router reach the sibling that does serve it.

The **first cut of FIX 3** gated *every* fallback provider whose advertised models did not include the override. That silently broke the degraded-mode frontier failover the router exists for:

- A `sonnet` request resolves to `{PreferProvider: claude-oauth, ModelOverride: "claude-sonnet-4-6"}`.
- The preferred `claude-oauth` (configured `claude-opus-4-7`) is **down** (expired OAuth / 429 / deregistered) and drops at position 0.
- The router falls to a backup frontier provider — a second `claude-oauth`, the `anthropic` provider (`claude-sonnet-4-20250514`), or the `claude-code` CLI (advertising `[sonnet, opus, haiku]`).
- Under the first cut, `providerCanServe` returned **false** for all of them (none of those advertised ids exact/prefix-match `claude-sonnet-4-6`), so `Route` returned `no available provider`.

Frontier providers are model-**agnostic** within their family and honour `ModelOverride` verbatim (`provider_anthropic.go`, `provider_claudeoauth.go` pass it straight to the API; `provider_claudecode.go`, `provider_codex.go` pass it to `--model`). The gate must never apply to them.

## How

`providerCanServe` now scopes the gate to the actual hazard — a **local, non-agentic model-serving provider** — identified structurally rather than by name:

- `!IsLocal` → remote API provider (`anthropic`, `claude-oauth`): family-agnostic, honours any override → **eligible**.
- `AgenticHarness` → local CLI harness (`claude-code`, `codex`): also family-agnostic and runs locally, so `IsLocal` alone would wrongly gate it → **eligible**.
- Only a local, non-agentic provider is gated by its advertised `Model()` / `ModelsAvailable` (exact-or-prefix, mirroring the `/v1/models` match the availability probes use).

The `i == 0` preferred-provider carve-out in `Route` is unchanged: the preferred provider was resolved explicitly and is never skipped. The gate applies only to involuntary carry-over into a fallback (`i > 0`).

Note: the reviewer's suggested `!IsLocal` predicate is directionally correct but would have missed `claude-code` / `codex`, which are `IsLocal: true` frontier CLIs. The `AgenticHarness` carve-out covers them.

## Tests

`go build ./...`, `go vet ./internal/engine/`, and `go test ./internal/engine/ -race -count=1` all pass.

- **`TestRouterFallbackReachesFrontierBackup`** (new) — the missing coverage the review flagged. A frontier provider reached as a **fallback** (`i > 0`) with a differing-but-serviceable Claude-family override is **selected** with `FallbackUsed=true`, for both a remote `anthropic` backup (`claude-sonnet-4-20250514`) and the local `claude-code` CLI backup (`[sonnet, opus, haiku]`). Verified to fail against the first-cut predicate and pass against the fix.
- **`TestRouterFallbackSkipsProvidersThatCannotServeOverride`** — retargeted to the real hazard: a local sibling with a *different* model loaded (`gemma-4-26b`) is skipped so the router reaches the local sibling serving `ornith-1.0-35b`.
- **`TestProviderCanServe`** — rewritten to assert the structural gate: local model-serving providers are gated by advertised models; remote and agentic-CLI frontier providers are always eligible (including for a non-family override, which they honour verbatim).
- Existing `TestRouterFallbackNoOverridePreservesBehavior` and `TestRouterPreferredProviderNotSkippedForDifferingOverride` unchanged and still green.

## Review provenance

Addresses the flight/Fable review findings for the `inference-pipeline-robustness` track. The FIX 1 (races/deadlock) and FIX 2 (end-to-end usage) lenses were verified clean; this PR additionally resolves the regression-lens **blocker** on the FIX 3 frontier-fallback path.
