### PR TITLE
fix(sessions): forked sessions and lineage survive kernel restart

### DIFF
--- a/internal/engine/cli_mcp.go
+++ b/internal/engine/cli_mcp.go
@@ -129,12 +129,24 @@ func runMCPServeEngine(args []string, defaultWorkspace string, stderr io.Writer)
 	// Wire session-management backends so cog_register_session /
 	// cog_list_sessions / cog_offer_handoff / cog_list_handoffs / etc. work
 	// over stdio (same registries the HTTP path uses, just no live Server).
+	//
+	// forkRegistry mirrors serve.go's wiring (SetForkRegistry) so
+	// cog_fork_session over stdio also gets a live lineage index — without
+	// this, the stdio MCP path silently skipped fork-registry updates
+	// entirely (m.forkRegistry stayed nil; see the nil-safe check in
+	// mcp_fork_session.go). ReplaySessionRegistry's session.fork case and
+	// ReplayForkRegistry both read the durable session.fork bus events so a
+	// restart of this process reconstructs prior forks instead of starting
+	// blank.
 	busSessions := NewBusSessionManager(cfg.WorkspaceRoot)
 	sessionRegistry := NewSessionRegistry()
 	handoffRegistry := NewHandoffRegistry()
+	forkRegistry := NewForkRegistry()
 	_ = ReplaySessionRegistry(busSessions, sessionRegistry)
 	_ = ReplayHandoffRegistry(busSessions, handoffRegistry)
+	_ = ReplayForkRegistry(busSessions, forkRegistry)
 	server.SetSessionsBackend(busSessions, sessionRegistry, handoffRegistry)
+	server.SetForkRegistry(forkRegistry)
 
 	// Wire a signal-aware context so shells (or hosts like Claude Desktop)
 	// that send SIGINT/SIGTERM on shutdown get a clean exit.

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -252,8 +252,17 @@ func NewServer(cfg *Config, nucleus *Nucleus, process *Process) *Server {
 	// Replay bus_sessions + bus_handoffs into the in-memory registries so
 	// the kernel starts with an accurate derived view. Bus is authoritative
 	// either way; this just warms the read path.
+	//
+	// ReplaySessionRegistry's session.fork case reconstructs fork-child rows
+	// (cog_fork_session / POST /v1/sessions/{id}/fork register the child with
+	// appendFn=nil — the fork bus event is the child's only durable record).
+	// ReplayForkRegistry separately rebuilds the parent→children lineage
+	// index consumed by ForkChildren/ForkAncestors, which was otherwise
+	// reinitialized empty on every restart (s.forkRegistry = NewForkRegistry()
+	// above) with no path back from the bus.
 	_ = ReplaySessionRegistry(s.busSessions, s.sessionRegistry)
 	_ = ReplayHandoffRegistry(s.busSessions, s.handoffRegistry)
+	_ = ReplayForkRegistry(s.busSessions, s.forkRegistry)
 
 	// Resolve the bind address. Default stays 127.0.0.1 (loopback-only);
 	// callers may override via Config.BindAddr to listen on all interfaces

--- a/internal/engine/session_fork.go
+++ b/internal/engine/session_fork.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"sort"
 	"sync"
 	"time"
 )
@@ -108,6 +109,53 @@ func NewForkRegistry() *ForkRegistry {
 		children: make(map[string][]forkEntry),
 		byChild:  make(map[string]forkEntry),
 	}
+}
+
+// ReplayForkRegistry reads bus_sessions events through the given manager and
+// reconstructs the in-memory fork lineage (parent→children map, byChild
+// ancestor index). session.fork events live on BusSessions alongside
+// session.register/heartbeat/end — the fork body's lineage fields
+// (ParentSessionID, ChildSessionID, ForkPoint, PinnedUntil) are the only
+// durable record of a fork relationship; before this function existed,
+// ForkRegistry was reinitialized empty at every startup (serve.go), so all
+// lineage was lost across a restart even though the bus event itself
+// persisted.
+//
+// Mirrors ReplaySessionRegistry: sorted ascending by Seq for deterministic
+// replay order, and safe to call with a nil manager or registry (no-op).
+// Uses the event's own timestamp as forkTime so PinnedUntil / default
+// 7-day-from-fork-point expiry match what was computed at fork time,
+// not wall-clock-at-restart.
+func ReplayForkRegistry(mgr *BusSessionManager, fr *ForkRegistry) error {
+	if mgr == nil || fr == nil {
+		return nil
+	}
+	events, err := mgr.ReadEvents(BusSessions)
+	if err != nil {
+		slog.Warn("session.fork: replay read failed", "bus", BusSessions, "err", err)
+		return err
+	}
+	sort.SliceStable(events, func(i, j int) bool {
+		return events[i].Seq < events[j].Seq
+	})
+	replayed := 0
+	for _, evt := range events {
+		if evt.Type != string(KindSessionFork) {
+			continue
+		}
+		body := parseSessionForkPayload(evt.Payload)
+		if body == nil {
+			continue
+		}
+		forkTime, err := parseBusTS(evt.Ts)
+		if err != nil {
+			forkTime = time.Now().UTC()
+		}
+		fr.Record(*body, forkTime)
+		replayed++
+	}
+	slog.Info("session.fork: replay complete", "forks", replayed, "events", len(events))
+	return nil
 }
 
 // Record adds a fork relationship to the registry.

--- a/internal/engine/session_fork_test.go
+++ b/internal/engine/session_fork_test.go
@@ -631,3 +631,169 @@ func TestMCP_ForkSession_RoundTrip(t *testing.T) {
 		t.Errorf("child %q not in forkRegistry after MCP fork; got %v", forkOut.ChildSessionID, children)
 	}
 }
+
+// ─── Cold-restart durability tests ───────────────────────────────────────────
+//
+// Regression coverage for the durability gap: cog_fork_session /
+// POST /v1/sessions/{id}/fork register the child session with
+// appendFn=nil (ApplyRegister never appends its own bus event — the
+// session.fork event written just before IS the child's only durable
+// record). Before this fix:
+//   - ReplaySessionRegistry's switch had no case for "session.fork", so the
+//     child row existed only in the live in-memory registry and vanished on
+//     restart even though the bus event persisted.
+//   - ForkRegistry had no replay path at all and was unconditionally
+//     reinitialized empty (NewForkRegistry()) at every startup, so lineage
+//     (ForkChildren / ForkAncestors) never survived a restart.
+//
+// These tests boot a fresh *Server rooted at the same workspace (mirrors
+// TestReplayOnStartup's pattern), which is exactly how the kernel
+// reconstructs its warm caches from the bus on a real process restart.
+
+func TestReplayOnStartup_ForkSurvivesRestart(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	cfg := &Config{WorkspaceRoot: root, CogDir: root + "/.cog", Port: 0}
+	nucleus := &Nucleus{Name: "test"}
+	proc := NewProcess(cfg, nucleus)
+	srv1 := NewServer(cfg, nucleus, proc)
+	ts1 := httptest.NewServer(srv1.Handler())
+	t.Cleanup(func() { ts1.Close() })
+
+	registerParent(t, ts1, "restart-parent-a")
+
+	resp := postJSON(t, ts1.URL+"/v1/sessions/restart-parent-a/fork", map[string]any{
+		"overlay": map[string]any{
+			"role": map[string]any{"role": "btw-aside"},
+		},
+	})
+	if resp.StatusCode != http.StatusCreated {
+		resp.Body.Close()
+		t.Fatalf("fork status = %d, want 201", resp.StatusCode)
+	}
+	var out forkSessionHTTPResponse
+	decodeJSON(t, resp, &out)
+	if out.ChildSessionID == "" {
+		t.Fatal("child_session_id is empty")
+	}
+
+	// Sanity: pre-restart, both registries reflect the fork.
+	if _, ok := srv1.sessionRegistry.Get(out.ChildSessionID); !ok {
+		t.Fatalf("precondition failed: child %q not in live registry before restart", out.ChildSessionID)
+	}
+	preChildren := srv1.forkRegistry.ForkChildren("restart-parent-a", time.Now().UTC())
+	if len(preChildren) == 0 {
+		t.Fatal("precondition failed: forkRegistry empty before restart")
+	}
+
+	ts1.Close()
+
+	// Boot a fresh Server rooted at the same workspace — this is the
+	// process-restart path: NewServer constructs brand-new, empty
+	// sessionRegistry / forkRegistry instances and replays them from the
+	// bus (ReplaySessionRegistry, ReplayForkRegistry) before serving.
+	srv2 := NewServer(cfg, nucleus, proc)
+
+	// 1. Parent row reconstructs from its session.register event.
+	parentRow, ok := srv2.sessionRegistry.Get("restart-parent-a")
+	if !ok || parentRow == nil {
+		t.Fatal("parent session not replayed after restart")
+	}
+	if parentRow.Ended {
+		t.Error("parent session should not be marked ended after replay")
+	}
+
+	// 2. Child row reconstructs from the session.fork event alone (it was
+	// never registered via a session.register event — ApplyRegister was
+	// called with appendFn=nil at fork time).
+	childRow, ok := srv2.sessionRegistry.Get(out.ChildSessionID)
+	if !ok || childRow == nil {
+		t.Fatalf("child session %q not replayed after restart (durability bug: fork event dropped)", out.ChildSessionID)
+	}
+	if childRow.Role != "btw-aside" {
+		t.Errorf("child.Role after replay = %q, want btw-aside (overlay should be honored)", childRow.Role)
+	}
+	if childRow.Workspace != parentRow.Workspace {
+		t.Errorf("child.Workspace after replay = %q, want inherited %q", childRow.Workspace, parentRow.Workspace)
+	}
+
+	// 3. Fork lineage (ForkRegistry) reconstructs from the same event.
+	childrenAfter := srv2.forkRegistry.ForkChildren("restart-parent-a", time.Now().UTC())
+	found := false
+	for _, c := range childrenAfter {
+		if c == out.ChildSessionID {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("forkRegistry.ForkChildren(parent) after restart = %v, want to include %q", childrenAfter, out.ChildSessionID)
+	}
+
+	ancestors := srv2.forkRegistry.ForkAncestors(out.ChildSessionID)
+	if len(ancestors) == 0 {
+		t.Error("forkRegistry.ForkAncestors(child) after restart is empty, want at least the parent")
+	} else if ancestors[0].SessionID != "restart-parent-a" {
+		t.Errorf("ancestors[0].SessionID after restart = %q, want restart-parent-a", ancestors[0].SessionID)
+	}
+}
+
+// TestReplayOnStartup_ForkPinnedUntilSurvivesRestart covers the
+// pin_duration / PinnedUntil field specifically: it must be replayed
+// verbatim so GC expiry semantics (RFC-0005 §Garbage collection) match what
+// was computed at fork time, not a default recomputed at restart.
+func TestReplayOnStartup_ForkPinnedUntilSurvivesRestart(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	cfg := &Config{WorkspaceRoot: root, CogDir: root + "/.cog", Port: 0}
+	nucleus := &Nucleus{Name: "test"}
+	proc := NewProcess(cfg, nucleus)
+	srv1 := NewServer(cfg, nucleus, proc)
+	ts1 := httptest.NewServer(srv1.Handler())
+	t.Cleanup(func() { ts1.Close() })
+
+	registerParent(t, ts1, "restart-parent-pin")
+
+	resp := postJSON(t, ts1.URL+"/v1/sessions/restart-parent-pin/fork", map[string]any{
+		"pin_duration": "P30D",
+	})
+	if resp.StatusCode != http.StatusCreated {
+		resp.Body.Close()
+		t.Fatalf("fork status = %d, want 201", resp.StatusCode)
+	}
+	var out forkSessionHTTPResponse
+	decodeJSON(t, resp, &out)
+	if out.PinnedUntil == "" {
+		t.Fatal("precondition failed: pinned_until not set pre-restart")
+	}
+	wantPinnedUntil, err := time.Parse(time.RFC3339, out.PinnedUntil)
+	if err != nil {
+		t.Fatalf("parse pinned_until: %v", err)
+	}
+
+	ts1.Close()
+	srv2 := NewServer(cfg, nucleus, proc)
+
+	// A reference time far short of the 7-day default retention but still
+	// before the 30-day pin: if PinnedUntil didn't survive replay, the
+	// entry would already look expired at the default retention window and
+	// ForkChildren would incorrectly exclude it long before 30 days are up.
+	// Use "just before the 30-day pin" as the check, and "just after the
+	// unpinned 7-day default" to prove the pin (not the default) is in effect.
+	checkAt := time.Now().UTC().Add(10 * 24 * time.Hour) // > default 7d, < pinned 30d
+	if checkAt.After(wantPinnedUntil) {
+		t.Fatalf("test setup invariant broken: checkAt %v is after pinnedUntil %v", checkAt, wantPinnedUntil)
+	}
+
+	children := srv2.forkRegistry.ForkChildren("restart-parent-pin", checkAt)
+	found := false
+	for _, c := range children {
+		if c == out.ChildSessionID {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("forkRegistry.ForkChildren(parent, +10d) after restart = %v, want to include %q "+
+			"(PinnedUntil=P30D should have survived replay, not fallen back to the 7-day default)",
+			children, out.ChildSessionID)
+	}
+}

--- a/internal/engine/sessions.go
+++ b/internal/engine/sessions.go
@@ -28,6 +28,7 @@
 package engine
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -659,6 +660,45 @@ func ReplaySessionRegistry(mgr *BusSessionManager, reg *SessionRegistry) error {
 			}
 			reg.mu.Unlock()
 
+		case string(KindSessionFork):
+			// RFC-0005 fork event. The child session is never separately
+			// registered via EvtSessionRegister — cog_fork_session and the
+			// HTTP fork handler both call SessionRegistry.ApplyRegister with
+			// appendFn=nil (the fork bus event IS the durable record of the
+			// child's existence). Without this case, the child row is
+			// present only in the in-memory registry and is silently
+			// dropped on cold restart. Reconstruct the child row here from
+			// the fork body, mirroring deriveChildState's derivation logic
+			// (mcp_fork_session.go) so replay and live-path produce the same
+			// shape.
+			body := parseSessionForkPayload(evt.Payload)
+			if body == nil || body.ChildSessionID == "" {
+				continue
+			}
+			regAt := evt.Ts
+			registeredAt, _ := parseBusTS(regAt)
+			child := SessionState{
+				SessionID:    body.ChildSessionID,
+				Role:         "fork-child",
+				RegisteredAt: registeredAt,
+				LastSeen:     registeredAt,
+			}
+			reg.mu.Lock()
+			if parent, ok := reg.rows[body.ParentSessionID]; ok {
+				child.Workspace = parent.Workspace
+				child.Role = parent.Role
+				child.Model = parent.Model
+				child.Hostname = parent.Hostname
+			}
+			reg.mu.Unlock()
+			if body.Overlay.Role != nil && body.Overlay.Role.Role != "" {
+				child.Role = body.Overlay.Role.Role
+			}
+			reg.mu.Lock()
+			row := child
+			reg.rows[body.ChildSessionID] = &row
+			reg.mu.Unlock()
+
 		case EvtSessionEnd:
 			payload := evt.Payload
 			if payload == nil {
@@ -820,6 +860,31 @@ func parseSessionPayload(fromField string, p map[string]interface{}) *SessionSta
 		state.Extras[k] = v
 	}
 	return state
+}
+
+// parseSessionForkPayload reconstructs a SessionForkBody from a session.fork
+// bus event's payload map. The payload is written by both fork call sites
+// (mcp_fork_session.go, serve_fork_session.go) via json.Marshal(body) then
+// json.Unmarshal into map[string]interface{} — so a JSON round-trip back
+// into the struct is exact and tolerates the nested Overlay/PinnedUntil
+// shapes without hand-picking each field (unlike parseSessionPayload, which
+// deals with a looser bridge-authored shape).
+func parseSessionForkPayload(p map[string]interface{}) *SessionForkBody {
+	if p == nil {
+		return nil
+	}
+	raw, err := json.Marshal(p)
+	if err != nil {
+		return nil
+	}
+	var body SessionForkBody
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return nil
+	}
+	if body.ChildSessionID == "" {
+		return nil
+	}
+	return &body
 }
 
 // parseHandoffOffer reconstructs a HandoffState from a bus.offer payload.


### PR DESCRIPTION
## Summary

Forked sessions (RFC-0005 `cog_fork_session` / `POST /v1/sessions/{id}/fork`) did not survive a kernel restart:

- Both fork call sites register the child session via `SessionRegistry.ApplyRegister` with `appendFn=nil`, relying on the `session.fork` bus event written just before as the child's only durable record.
- `ReplaySessionRegistry`'s event-type switch had no case for `"session.fork"`, so the child row existed only in the live in-memory registry and was silently dropped on cold restart.
- `ForkRegistry` (the parent→child lineage index backing `ForkChildren`/`ForkAncestors`) had no replay path at all and was unconditionally reinitialized empty at startup.
- The stdio MCP path (`cli_mcp.go`) additionally never wired a `ForkRegistry` at all, so `cog_fork_session` over stdio silently skipped lineage tracking even at runtime (nil-safe no-op), independent of the restart bug.

The fork event's content-derivation (`ParentSessionHash`/`ForkPoint` via `LatestEventHash`, KV block hash overlay) was already correct and identical across both transports — this PR only closes the durability gap.

## Fix

- `ReplaySessionRegistry` (`internal/engine/sessions.go`) gains a `session.fork` case that reconstructs the child `SessionState`, mirroring `deriveChildState`'s derivation (inherit workspace/role/model/hostname from the parent row already replayed earlier in the seq-ordered pass, then apply the overlay's role layer).
- New `ReplayForkRegistry` (`internal/engine/session_fork.go`) replays `session.fork` events into `ForkRegistry.Record`, using each event's own bus timestamp as `forkTime` so `PinnedUntil` / the default 7-day-from-fork-point retention match what was computed at fork time, not wall-clock-at-restart.
- New `parseSessionForkPayload` helper does a JSON round-trip from the bus payload map back into `SessionForkBody` — safe because both fork call sites write via `json.Marshal(body)` into the map, so this recovers the nested `Overlay`/`PinnedUntil` fields exactly.
- Wired into both startup paths for transport parity: `serve.go` (HTTP) and `cli_mcp.go` (stdio MCP, which now also constructs and wires a `ForkRegistry` for the first time).

## Test plan

- [x] `TestReplayOnStartup_ForkSurvivesRestart` — forks a session over HTTP, boots a second `Server` against the same workspace (the existing `TestReplayOnStartup` pattern), asserts the parent row, the child row (role/workspace inherited, overlay honored), `ForkChildren`, and `ForkAncestors` all reconstruct from bus replay alone.
- [x] `TestReplayOnStartup_ForkPinnedUntilSurvivesRestart` — same restart pattern with `pin_duration=P30D`, asserts the child is still present in `ForkChildren` at +10 days (past the unpinned 7-day default, before the 30-day pin), proving `PinnedUntil` itself survives replay rather than falling back to default retention.
- [x] Verified both new tests fail against the pre-fix code (reverted the fix, kept the tests) with the exact expected failure messages, confirming they catch the regression rather than passing vacuously.
- [x] `go build ./...` clean, `go vet ./...` clean.
- [x] `go test ./internal/engine/...` — all pass (27s).
- [x] `go test ./...` — all pass except pre-existing `internal/acp` `TestSpike_*` failures, confirmed identical on unmodified `origin/main` (local-auth-session precondition, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)