### PR TITLE
feat(instruments): First Instruments Stage-2 instrumentation (Modules A-E)

### DIFF
--- a/internal/coherence/coherence.go
+++ b/internal/coherence/coherence.go
@@ -1,0 +1,286 @@
+// coherence.go — importable graded git-tree coherence surface.
+//
+// First Instruments Module B (M1-A). This package makes the CLI's
+// canonical-vs-current git-tree-hash coherence check (checkCoherence /
+// CoherenceState, root-package cog.go) importable from internal/testkernel
+// and Module D's experiment runner, which cannot import package main.
+//
+// PACKAGE-BOUNDARY NOTE (IMPL-SPEC.md Module B "Where" + naming-collision
+// hazard): this is a MINIMAL, DUPLICATED extraction per the RFC-0001
+// "duplicate-minimally" allowance (docs/rfcs/0001-root-package-refactor.md),
+// not a move. The root-package originals (cog.go: CoherenceState @ ~779,
+// checkCoherence @ ~2173, isPathTracked @ ~2149, gitDiffTree @ ~1652) are
+// UNTOUCHED by this package — root `package main` is confirmed dead code
+// (RFC-0001 §Background: "not built into the shipped binary, not imported by
+// anything") so leaving it alone is correct; deleting/rewiring 204 root files
+// is RFC-0001's job, not First Instruments'.
+//
+// There are TWO OTHER pre-existing types this package must not collide with
+// or be confused with:
+//  1. sdk/types.CoherenceState (sdk/types/coherence.go:6) — a different type
+//     with the same name, package types, fields Coherent/CanonicalHash/
+//     CurrentHash/Drift/Timestamp. Unrelated to this package's CoherenceState;
+//     do not add Score to it, do not create a third CoherenceState under a
+//     third name — this package's type is distinct and fully qualified as
+//     coherence.CoherenceState at every call site.
+//  2. internal/engine.CoherenceReport / RunCoherence (internal/engine/
+//     coherence.go) — an entirely different 4-layer validation stack
+//     (schema/invariants/policy/consistency), not a git-tree-hash diff. Do
+//     not conflate M1-A's graded git-distance score with that report.
+//
+// The tracked/excluded path lists here are the same hardcoded defaults the
+// root package falls back to (cog.go trackedPaths/excludedPaths) when no
+// ontology cache is loaded. The root package's ontology-aware override
+// (getEffectiveTrackedPaths/getEffectiveExcludedPaths, reading a
+// package-global ontologyCache loaded from .cog/ontology/) is root-package-
+// only state and is NOT duplicated here — duplicating minimally means this
+// package computes coherence against the same conservative default surface
+// every fresh kernel boot sees before any ontology is cached, which is
+// exactly the measurement-harness use case (a testkernel boot never loads
+// the root package's ontology cache).
+package coherence
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// trackedPaths mirrors cog.go's package-level default (relative to .cog/).
+var trackedPaths = []string{
+	"mem/",
+	"schemas/",
+	"adr/",
+	"roles/",
+	"coordination/",
+}
+
+// excludedPaths mirrors cog.go's package-level default (relative to .cog/).
+var excludedPaths = []string{
+	"status/",
+	"signals/",
+	"work/",
+	"run/",
+	"var/",
+}
+
+// CoherenceState represents the coherence check result, extended with the
+// First Instruments M1-A graded score (Score field). Side-effect-free to
+// compute (K3/K8 one-way-readout discipline, IMPL-SPEC §0/§2): does not
+// mutate the boolean Coherent field's meaning, does not touch any gate.
+type CoherenceState struct {
+	Coherent      bool     `json:"coherent"`
+	CanonicalHash string   `json:"canonical_hash,omitempty"`
+	CurrentHash   string   `json:"current_hash,omitempty"`
+	Timestamp     string   `json:"timestamp"`
+	Drift         []string `json:"drift,omitempty"`
+
+	// Score is the M1-A graded git-distance coherence score (IMPL-SPEC B1):
+	//   C_A = 1 - min(1, len(Drift)/N_tracked)
+	// where N_tracked is the count of tracked .cog/ paths present at the time
+	// of the check. Score is in [0,1]; 1.0 = no drift, 0.0 = drift at or
+	// beyond every tracked path. Does NOT replace or feed back into Coherent.
+	Score float64 `json:"score"`
+}
+
+// gitCmd creates an exec.Cmd for a local git operation with a 30-second
+// timeout, mirroring cog.go's gitCmd helper. The returned cancel func MUST
+// be deferred by the caller.
+func gitCmd(args ...string) (*exec.Cmd, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	return exec.CommandContext(ctx, "git", args...), cancel
+}
+
+// isPathTracked mirrors cog.go's isPathTracked, against the hardcoded
+// default tracked/excluded lists (no ontology-cache override — see package
+// doc comment).
+func isPathTracked(filePath string) bool {
+	if !strings.HasPrefix(filePath, ".cog/") {
+		return false
+	}
+	relPath := filePath[5:] // remove ".cog/" prefix
+
+	for _, excluded := range excludedPaths {
+		if strings.HasPrefix(relPath, excluded) {
+			return false
+		}
+	}
+	for _, tracked := range trackedPaths {
+		if strings.HasPrefix(relPath, tracked) {
+			return true
+		}
+	}
+	return false
+}
+
+// countTrackedPaths walks root/.cog and counts entries whose relative path
+// (".cog/..." form) is tracked per isPathTracked. This is N_tracked in the
+// B1 formula: the baseline denominator against which drift is graded.
+func countTrackedPaths(root string) (int, error) {
+	cogRoot := filepath.Join(root, ".cog")
+	count := 0
+	err := filepath.Walk(cogRoot, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			// Best-effort: a single unreadable entry should not abort the
+			// whole count; skip it and continue.
+			return nil
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return nil
+		}
+		rel = filepath.ToSlash(rel)
+		if isPathTracked(rel) {
+			count++
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("coherence: count tracked paths: %w", err)
+	}
+	return count, nil
+}
+
+// gitCogTreeHash computes the tree hash of the .cog/ working tree without
+// mutating the real git index (mirrors cog.go's gitCogTreeHash, K3
+// one-way-readout: stages into a throwaway GIT_INDEX_FILE so the caller's
+// staged changes are never touched).
+func gitCogTreeHash(gitRoot string) (string, error) {
+	tmpIdx, err := os.CreateTemp("", "cog-idx-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp index: %w", err)
+	}
+	tmpIdxPath := tmpIdx.Name()
+	tmpIdx.Close()
+	os.Remove(tmpIdxPath) //nolint:errcheck // best-effort; path is still unique
+	defer os.Remove(tmpIdxPath)
+
+	env := append(os.Environ(), "GIT_INDEX_FILE="+tmpIdxPath)
+
+	stageCmd, stageCancel := gitCmd("-C", gitRoot, "add", "-A", ".cog/")
+	defer stageCancel()
+	stageCmd.Env = env
+	if err := stageCmd.Run(); err != nil {
+		// Non-fatal: may fail on an empty .cog/ or a bare repo.
+		_ = err
+	}
+
+	writeCmd, writeCancel := gitCmd("-C", gitRoot, "write-tree", "--prefix=.cog/")
+	defer writeCancel()
+	writeCmd.Env = env
+	out, err := writeCmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to compute tree hash: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// gitCanonicalHash reads the last validated tree hash from
+// .cog/run/coherence/canonical-hash (mirrors cog.go's gitCanonicalHash;
+// ADR-021 holographic workspace model — canonical state is a stored hash,
+// not a separate git branch).
+func gitCanonicalHash(gitRoot string) (string, error) {
+	hashFile := filepath.Join(gitRoot, ".cog", "run", "coherence", "canonical-hash")
+	data, err := os.ReadFile(hashFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("no canonical hash found (run baseline to establish)")
+		}
+		return "", fmt.Errorf("failed to read canonical hash: %w", err)
+	}
+	hash := strings.TrimSpace(string(data))
+	if hash == "" {
+		return "", fmt.Errorf("canonical hash file is empty")
+	}
+	return hash, nil
+}
+
+// gitDiffTree computes which files differ between two tree hashes (mirrors
+// cog.go's gitDiffTree). Read-only: `git diff-tree` does not mutate any
+// index or working tree state.
+func gitDiffTree(gitRoot, fromHash, toHash string) ([]string, error) {
+	cmd, cancel := gitCmd("-C", gitRoot, "diff-tree", "-r", "--name-only", fromHash, toHash)
+	defer cancel()
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	var result []string
+	for _, line := range lines {
+		if line != "" {
+			result = append(result, ".cog/"+line)
+		}
+	}
+	return result, nil
+}
+
+// nowISO mirrors cog.go's nowISO timestamp format.
+func nowISO() string {
+	return time.Now().UTC().Format(time.RFC3339)
+}
+
+// CheckCoherence checks overall coherence of the workspace and computes the
+// M1-A graded score (IMPL-SPEC B1). Side-effect-free: gitCogTreeHash uses a
+// throwaway index (K3); no kernel state is mutated.
+//
+//	C_A = 1 - min(1, len(Drift)/N_tracked)
+//
+// N_tracked is the count of tracked .cog/ paths (isPathTracked) at the time
+// of the check. When N_tracked is 0 (no tracked paths exist, e.g. a minimal
+// test workspace with an empty .cog/mem/), Score is defined as 1.0 (fully
+// coherent by construction — there is nothing tracked to have drifted, the
+// same "nothing to reconcile is in-sync" reasoning as the B2 empty-plan fix,
+// applied to the git-distance side of the surface).
+func CheckCoherence(root string) (*CoherenceState, error) {
+	canonical, canonicalErr := gitCanonicalHash(root)
+	current, currentErr := gitCogTreeHash(root)
+
+	state := &CoherenceState{
+		Timestamp: nowISO(),
+	}
+
+	if canonicalErr != nil {
+		// No baseline = coherent by default (mirrors cog.go's checkCoherence).
+		state.Coherent = true
+		state.CurrentHash = current
+		state.Score = 1.0
+		return state, nil
+	}
+
+	state.CanonicalHash = canonical
+	state.CurrentHash = current
+	state.Coherent = canonical == current
+
+	if !state.Coherent && canonical != "" && current != "" {
+		drift, err := gitDiffTree(root, canonical, current)
+		if err == nil {
+			state.Drift = drift
+		}
+	}
+
+	nTracked, countErr := countTrackedPaths(root)
+	switch {
+	case countErr != nil || nTracked == 0:
+		// Nothing tracked to have drifted -> fully coherent on this axis.
+		state.Score = 1.0
+	default:
+		fraction := float64(len(state.Drift)) / float64(nTracked)
+		if fraction > 1 {
+			fraction = 1
+		}
+		state.Score = 1 - fraction
+	}
+
+	return state, currentErr
+}

--- a/internal/coherence/coherence_test.go
+++ b/internal/coherence/coherence_test.go
@@ -1,0 +1,210 @@
+package coherence
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// setupGitWorkspace creates a real git repo with a tracked .cog/ file and an
+// initial commit, mirroring the fixture shape the root package's
+// TestGitCogTreeHash_NoIndexMutation uses. Skips if git is unavailable.
+func setupGitWorkspace(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not in PATH")
+	}
+
+	repoDir := t.TempDir()
+	mustRunGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repoDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+	mustRunGit("init", "-b", "main")
+	mustRunGit("config", "user.email", "test@example.com")
+	mustRunGit("config", "user.name", "Test")
+
+	cogDir := filepath.Join(repoDir, ".cog")
+	memDir := filepath.Join(cogDir, "mem")
+	if err := os.MkdirAll(memDir, 0755); err != nil {
+		t.Fatalf("mkdir .cog/mem: %v", err)
+	}
+	trackedFile := filepath.Join(memDir, "note.cog.md")
+	if err := os.WriteFile(trackedFile, []byte("# note\n"), 0644); err != nil {
+		t.Fatalf("write note.cog.md: %v", err)
+	}
+
+	// .cog/run/ holds the canonical-hash file CheckCoherence itself writes
+	// via test helpers below. The real workspace .gitignore excludes
+	// .cog/run/ from the tracked tree for exactly this reason (it is
+	// per-session runtime state, not tracked content) — without this,
+	// writing the canonical-hash file would perturb the very tree hash it
+	// is meant to describe, since gitCogTreeHash's `git add -A .cog/` stages
+	// everything under .cog/ regardless of isPathTracked's exclusion list
+	// (that list only filters drift/tracked-count accounting, not what goes
+	// into the hash). Mirror the real .gitignore convention in this fixture.
+	gitignore := filepath.Join(repoDir, ".gitignore")
+	if err := os.WriteFile(gitignore, []byte(".cog/run/\n"), 0644); err != nil {
+		t.Fatalf("write .gitignore: %v", err)
+	}
+	mustRunGit("add", ".cog/mem/note.cog.md", ".gitignore")
+	mustRunGit("commit", "-m", "init")
+
+	return repoDir
+}
+
+// gitIndexStatus returns a stable string summarizing the real index state
+// (mirrors the root package's gitIndexStatus helper), for the no-mutation
+// assertion.
+func gitIndexStatus(t *testing.T, repoDir string) string {
+	t.Helper()
+	cmd := exec.Command("git", "status", "--porcelain")
+	cmd.Dir = repoDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git status: %v\n%s", err, out)
+	}
+	return string(out)
+}
+
+func writeCanonicalHash(t *testing.T, repoDir, hash string) {
+	t.Helper()
+	dir := filepath.Join(repoDir, ".cog", "run", "coherence")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir run/coherence: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "canonical-hash"), []byte(hash+"\n"), 0644); err != nil {
+		t.Fatalf("write canonical-hash: %v", err)
+	}
+}
+
+// ─── K3 one-way-readout: CheckCoherence must not mutate the real git index ──
+
+func TestCheckCoherence_NoIndexMutation(t *testing.T) {
+	repoDir := setupGitWorkspace(t)
+
+	// Establish a canonical baseline so the coherent/incoherent branch is
+	// exercised meaningfully.
+	current, err := gitCogTreeHash(repoDir)
+	if err != nil {
+		t.Fatalf("gitCogTreeHash: %v", err)
+	}
+	writeCanonicalHash(t, repoDir, current)
+
+	// Add an unstaged ephemeral file, simulating daemon output the real
+	// index should never see staged.
+	ephemeral := filepath.Join(repoDir, ".cog", "mem", "ephemeral.cog.md")
+	if err := os.WriteFile(ephemeral, []byte("# ephemeral\n"), 0644); err != nil {
+		t.Fatalf("write ephemeral: %v", err)
+	}
+
+	indexBefore := gitIndexStatus(t, repoDir)
+
+	state, err := CheckCoherence(repoDir)
+	if err != nil {
+		t.Fatalf("CheckCoherence: %v", err)
+	}
+	if state == nil {
+		t.Fatal("CheckCoherence returned nil state")
+	}
+
+	indexAfter := gitIndexStatus(t, repoDir)
+	if indexBefore != indexAfter {
+		t.Errorf("CheckCoherence mutated the git index:\nbefore: %q\nafter:  %q", indexBefore, indexAfter)
+	}
+}
+
+// ─── B1: C_A (Score) bounds [0,1] ────────────────────────────────────────────
+
+func TestCheckCoherence_ScoreBounds(t *testing.T) {
+	repoDir := setupGitWorkspace(t)
+
+	current, err := gitCogTreeHash(repoDir)
+	if err != nil {
+		t.Fatalf("gitCogTreeHash: %v", err)
+	}
+	writeCanonicalHash(t, repoDir, current)
+
+	state, err := CheckCoherence(repoDir)
+	if err != nil {
+		t.Fatalf("CheckCoherence: %v", err)
+	}
+	if state.Score < 0 || state.Score > 1 {
+		t.Errorf("Score = %v; want in [0,1]", state.Score)
+	}
+	if !state.Coherent {
+		t.Errorf("Coherent = false; want true (canonical == current, no drift)")
+	}
+	if state.Score != 1.0 {
+		t.Errorf("Score = %v; want 1.0 for a fully-coherent tree", state.Score)
+	}
+}
+
+// TestCheckCoherence_NoBaseline_CoherentAndFullScore mirrors cog.go's
+// checkCoherence: a missing canonical-hash file means coherent-by-default
+// (no baseline to have drifted from) and (B1) a full graded score.
+func TestCheckCoherence_NoBaseline_CoherentAndFullScore(t *testing.T) {
+	repoDir := setupGitWorkspace(t)
+	// No writeCanonicalHash call — canonical-hash file does not exist.
+
+	state, err := CheckCoherence(repoDir)
+	if err != nil {
+		t.Fatalf("CheckCoherence: %v", err)
+	}
+	if !state.Coherent {
+		t.Error("Coherent = false; want true when no canonical baseline exists")
+	}
+	if state.Score != 1.0 {
+		t.Errorf("Score = %v; want 1.0 when no canonical baseline exists", state.Score)
+	}
+}
+
+// TestCheckCoherence_Drift_ScoreDecreasesAndCoherentFalse establishes a
+// canonical baseline, then mutates + commits a tracked file so the tree
+// hash changes, and confirms Coherent flips false while Score reflects
+// partial (not necessarily zero) drift — proving the boolean gate is
+// unchanged (still canonical==current) and Score is graded independently.
+func TestCheckCoherence_Drift_ScoreDecreasesAndCoherentFalse(t *testing.T) {
+	repoDir := setupGitWorkspace(t)
+
+	baseline, err := gitCogTreeHash(repoDir)
+	if err != nil {
+		t.Fatalf("gitCogTreeHash (baseline): %v", err)
+	}
+	writeCanonicalHash(t, repoDir, baseline)
+
+	// Mutate and commit a tracked file so the real tree hash changes.
+	trackedFile := filepath.Join(repoDir, ".cog", "mem", "note.cog.md")
+	if err := os.WriteFile(trackedFile, []byte("# note (changed)\n"), 0644); err != nil {
+		t.Fatalf("rewrite note.cog.md: %v", err)
+	}
+	cmd := exec.Command("git", "add", ".cog/mem/note.cog.md")
+	cmd.Dir = repoDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git add: %v\n%s", err, out)
+	}
+	cmd = exec.Command("git", "commit", "-m", "drift")
+	cmd.Dir = repoDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git commit: %v\n%s", err, out)
+	}
+
+	state, err := CheckCoherence(repoDir)
+	if err != nil {
+		t.Fatalf("CheckCoherence: %v", err)
+	}
+	if state.Coherent {
+		t.Error("Coherent = true; want false after tracked-file drift")
+	}
+	if state.Score < 0 || state.Score > 1 {
+		t.Errorf("Score = %v; want in [0,1]", state.Score)
+	}
+	if len(state.Drift) == 0 {
+		t.Error("Drift is empty; want at least the changed file listed")
+	}
+}

--- a/internal/engine/boot.go
+++ b/internal/engine/boot.go
@@ -315,6 +315,7 @@ func Boot(ctx context.Context, cfg *Config, opts ...BootOption) (*Kernel, error)
 		PollInterval:  bootCfg.pollInterval,
 	})
 	reconcileDaemon.Start(kernelCtx)
+	server.SetReconcileDaemon(reconcileDaemon)
 
 	// Wire ProjectionWatcher as an early-trigger source.
 	for _, kind := range AllProjectionKinds {

--- a/internal/engine/boot.go
+++ b/internal/engine/boot.go
@@ -57,6 +57,12 @@ type bootConfig struct {
 	// the daemon iterates this list instead of the global registry.
 	// Set via WithIsolatedRegistry. nil = use global registry (default).
 	providers []reconcile.Reconcilable
+
+	// withoutLocalHarness, when true, skips starting the LocalHarnessController
+	// goroutine. Set via WithoutLocalHarness. Measurement boots that need to
+	// isolate the ReconcileDaemon's cadence from an uncontrolled background
+	// ticker should set this (First Instruments A4).
+	withoutLocalHarness bool
 }
 
 func applyBootOptions(opts []BootOption) bootConfig {
@@ -81,6 +87,37 @@ func applyBootOptions(opts []BootOption) bootConfig {
 func WithIsolatedRegistry(providers ...reconcile.Reconcilable) BootOption {
 	return func(c *bootConfig) {
 		c.providers = providers
+	}
+}
+
+// WithPollInterval returns a BootOption that overrides the ReconcileDaemon's
+// tick interval. d <= 0 leaves the daemon default (30 s, applied by
+// ReconcileDaemonConfig.withDefaults) in effect.
+//
+// This wires the previously-dead bootConfig.pollInterval field into
+// ReconcileDaemonConfig.PollInterval (First Instruments A1). Measurement
+// harnesses use this to defeat the natural tick (set very high, e.g. 1h, so
+// Trigger() is the sole cycle driver) or to force fast natural cadence in a
+// unit test.
+func WithPollInterval(d time.Duration) BootOption {
+	return func(c *bootConfig) {
+		c.pollInterval = d
+	}
+}
+
+// WithoutLocalHarness returns a BootOption that skips starting the
+// LocalHarnessController goroutine (its own ticker, independent of the
+// ReconcileDaemon) during Boot.
+//
+// engine.Boot unconditionally starts LocalHarnessController whenever
+// server.mcpServer is non-nil, which is true for every testkernel boot (the
+// MCP server is always constructed). That ticker is an uncontrolled
+// background noise source not accounted for by any prior cost model
+// (First Instruments A4). Measurement boots that want to isolate the
+// ReconcileDaemon's cadence should set this option.
+func WithoutLocalHarness() BootOption {
+	return func(c *bootConfig) {
+		c.withoutLocalHarness = true
 	}
 }
 
@@ -123,6 +160,15 @@ func (k *Kernel) WorkspaceRoot() string {
 // The daemon is already running when Boot returns.
 func (k *Kernel) ReconcileDaemon() *ReconcileDaemon {
 	return k.reconcileDaemon
+}
+
+// Process returns the kernel's continuous Process, exposing read-only
+// observation surfaces (e.g. State()) to integration tests and measurement
+// harnesses (First Instruments A7). No mutation surface is exposed here —
+// callers get the same *Process the kernel itself runs, but this accessor
+// is intended for read-only accessors such as State().
+func (k *Kernel) Process() *Process {
+	return k.process
 }
 
 // BEPEngine returns the running BEPEngine handle, or nil when
@@ -241,8 +287,11 @@ func Boot(ctx context.Context, cfg *Config, opts ...BootOption) (*Kernel, error)
 	// Derived context the kernel owns; caller's ctx cancellation also stops it.
 	kernelCtx, cancel := context.WithCancel(ctx)
 
-	// Wire LocalHarnessController if an MCP server is present.
-	if server.mcpServer != nil {
+	// Wire LocalHarnessController if an MCP server is present, unless the
+	// caller opted out via WithoutLocalHarness (First Instruments A4 — this
+	// controller runs its own ticker, independent of the ReconcileDaemon, and
+	// measurement boots that need to isolate reconcile cadence skip it).
+	if server.mcpServer != nil && !bootCfg.withoutLocalHarness {
 		ctrl, err := NewLocalHarnessController(cfg, nucleus, process, server.mcpServer)
 		if err != nil {
 			slog.Warn("local harness disabled", "err", err)
@@ -257,9 +306,13 @@ func Boot(ctx context.Context, cfg *Config, opts ...BootOption) (*Kernel, error)
 	// ADR-092 §2 step 4: Reconcile loop start.
 	// When WithIsolatedRegistry was passed (testkernel path), bootCfg.providers
 	// is non-nil and the daemon bypasses the global registry.
+	// bootCfg.pollInterval (set via WithPollInterval) is forwarded to
+	// ReconcileDaemonConfig.PollInterval; zero leaves the daemon's own default
+	// (30s, applied by withDefaults()) in effect (First Instruments A1).
 	reconcileDaemon := NewReconcileDaemon(ReconcileDaemonConfig{
 		WorkspaceRoot: cfg.WorkspaceRoot,
 		Providers:     bootCfg.providers,
+		PollInterval:  bootCfg.pollInterval,
 	})
 	reconcileDaemon.Start(kernelCtx)
 

--- a/internal/engine/cadence_events.go
+++ b/internal/engine/cadence_events.go
@@ -1,0 +1,189 @@
+// cadence_events.go — First Instruments Module E: behavioral-cadence
+// instrumentation (M11/M12/M13).
+//
+// Side-effect-free observation surface over the process run-loop's cadence
+// events (IMPL-SPEC E1/E2). Exposes, without altering control flow, the
+// timestamps of:
+//
+//   - Dormant-consolidation completions (M11) — tapped at the SUCCESS point
+//     (process.go, co-located with p.lastConsolidation = now), never on a
+//     gate-pass or attempt (Finding B: a persistent Run() error records no
+//     event, so a broken instrument never masquerades as a law-kill).
+//   - Heartbeat events (M12) — tapped PAST the StateActive early-return
+//     (Finding F9: tapping at the run-loop invocation site would record an
+//     event even when the body never ran, making the H6 StateActive
+//     exclusion a no-op).
+//   - Active-window-expiry observations (M13) — recorded by whatever reader
+//     polls IsActive; this package exposes the recording surface, the
+//     experiment runner (Module D) is the reader in practice.
+//
+// K3/K8 one-way-readout discipline: recording an event here NEVER mutates
+// process/kernel state and NEVER changes when consolidation/heartbeat
+// timing fires — it is a pure append to an in-memory slice, guarded by a
+// mutex. Per IMPL-SPEC §0, these event slices are telemetry, not kernel
+// state, and are excluded from the no-mutation state-hash test.
+package engine
+
+import (
+	"sync"
+	"time"
+)
+
+// ConsolidationTrigger distinguishes which select-case fired the
+// consolidation (IMPL-SPEC E1). Only "heartbeat_gated" events feed M11 —
+// see cadence_events.go's package doc comment for why the direct_ticker
+// path (runConsolidation, a distinct field/index/coherence maintenance
+// loop that does not call ConsolidationAction.Run() or update
+// lastConsolidation) is not tapped here.
+type ConsolidationTrigger string
+
+const (
+	// TriggerHeartbeatGated is the K12-gated dormant-consolidation path
+	// inside emitHeartbeat — the ONLY trigger that feeds M11.
+	TriggerHeartbeatGated ConsolidationTrigger = "heartbeat_gated"
+)
+
+// ConsolidationEvent is one observed dormant-consolidation completion (M11).
+type ConsolidationEvent struct {
+	// At is the wall-clock time of the tap (the same `now` captured at the
+	// top of emitHeartbeat's body, co-located with p.lastConsolidation).
+	At time.Time
+	// Trigger is always TriggerHeartbeatGated for events recorded via
+	// recordConsolidation (the only call site in this package).
+	Trigger ConsolidationTrigger
+	// ProcessState is the process's State() at the moment of the tap (H6 —
+	// mirrors PREREG §3.5-H6). A dormant measurement boot is expected
+	// non-Active; StateActive-overlap rows are excluded from confirmatory
+	// M11r/KC-3-LAW statistics by the runner (Module D).
+	ProcessState ProcessState
+}
+
+// HeartbeatEvent is one observed heartbeat that did real work (M12) — i.e.
+// one that passed the StateActive gate.
+type HeartbeatEvent struct {
+	At           time.Time
+	ProcessState ProcessState
+}
+
+// ActiveExpiryObservation is one observation of a session's active-window
+// expiry (M13): the wall-clock time at which IsActive(window, now) was
+// observed to first return false after the window elapsed, plus the
+// read_cadence_ms of the poller that observed it (E1 — since expiry is
+// read-gated with no reaper, the observed cadence is a function of both the
+// window and the reader; the reader's own cadence must be logged, not a new
+// hidden reader introduced by the tap itself, E2).
+type ActiveExpiryObservation struct {
+	At            time.Time
+	SessionID     string
+	Window        time.Duration
+	ReadCadenceMs int64
+}
+
+// cadenceRecorder is the append-only, mutex-guarded store backing the
+// Module E taps. Always non-nil on a constructed *Process (see NewProcess).
+type cadenceRecorder struct {
+	mu             sync.Mutex
+	consolidations []ConsolidationEvent
+	heartbeats     []HeartbeatEvent
+	activeExpiries []ActiveExpiryObservation
+}
+
+func newCadenceRecorder() *cadenceRecorder {
+	return &cadenceRecorder{}
+}
+
+// recordConsolidation appends a dormant-consolidation completion event.
+// Called ONLY from the success point in emitHeartbeat (never on gate-pass
+// or attempt — Finding B).
+func (c *cadenceRecorder) recordConsolidation(at time.Time, trigger ConsolidationTrigger, state ProcessState) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.consolidations = append(c.consolidations, ConsolidationEvent{At: at, Trigger: trigger, ProcessState: state})
+}
+
+// recordHeartbeat appends a heartbeat event. Called ONLY past the
+// StateActive gate in emitHeartbeat (Finding F9).
+func (c *cadenceRecorder) recordHeartbeat(at time.Time, state ProcessState) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.heartbeats = append(c.heartbeats, HeartbeatEvent{At: at, ProcessState: state})
+}
+
+// recordActiveExpiry appends an active-window-expiry observation.
+func (c *cadenceRecorder) recordActiveExpiry(obs ActiveExpiryObservation) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.activeExpiries = append(c.activeExpiries, obs)
+}
+
+func (c *cadenceRecorder) snapshotConsolidations() []ConsolidationEvent {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]ConsolidationEvent, len(c.consolidations))
+	copy(out, c.consolidations)
+	return out
+}
+
+func (c *cadenceRecorder) snapshotHeartbeats() []HeartbeatEvent {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]HeartbeatEvent, len(c.heartbeats))
+	copy(out, c.heartbeats)
+	return out
+}
+
+func (c *cadenceRecorder) snapshotActiveExpiries() []ActiveExpiryObservation {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]ActiveExpiryObservation, len(c.activeExpiries))
+	copy(out, c.activeExpiries)
+	return out
+}
+
+// ConsolidationEvents returns a read-only snapshot of observed dormant-
+// consolidation completions (M11). Side-effect-free (a copy is returned;
+// the caller cannot mutate the recorder's internal slice).
+func (p *Process) ConsolidationEvents() []ConsolidationEvent {
+	if p == nil || p.cadence == nil {
+		return nil
+	}
+	return p.cadence.snapshotConsolidations()
+}
+
+// HeartbeatEvents returns a read-only snapshot of observed heartbeat events
+// that passed the StateActive gate (M12).
+func (p *Process) HeartbeatEvents() []HeartbeatEvent {
+	if p == nil || p.cadence == nil {
+		return nil
+	}
+	return p.cadence.snapshotHeartbeats()
+}
+
+// ActiveExpiryObservations returns a read-only snapshot of observed
+// active-window-expiry events (M13).
+func (p *Process) ActiveExpiryObservations() []ActiveExpiryObservation {
+	if p == nil || p.cadence == nil {
+		return nil
+	}
+	return p.cadence.snapshotActiveExpiries()
+}
+
+// RecordActiveExpiryObservation lets a read-gated poller of IsActive log an
+// observation (M13, E1/E2). The poller — not this method — decides when to
+// call IsActive; this is purely a recording surface, so it introduces no
+// new hidden reader (E2).
+func (p *Process) RecordActiveExpiryObservation(obs ActiveExpiryObservation) {
+	if p == nil || p.cadence == nil {
+		return
+	}
+	p.cadence.recordActiveExpiry(obs)
+}

--- a/internal/engine/cli.go
+++ b/internal/engine/cli.go
@@ -56,6 +56,7 @@ func printUsage(w io.Writer) {
 	fmt.Fprintf(w, "  node        Manage node configuration\n")
 	fmt.Fprintf(w, "  reconcile   Run reconciliation loop diagnostics\n")
 	fmt.Fprintf(w, "  coherence   Check workspace coherence (graded git-distance score)\n")
+	fmt.Fprintf(w, "  rates       Print the kernel clock-constant rate-ratio table\n")
 	fmt.Fprintf(w, "  reindex     Rebuild the FTS5 constellation index from scratch\n")
 	fmt.Fprintf(w, "  spine       Show the decision manifold (gravity/inertia field over ADRs/RFCs)\n")
 	fmt.Fprintf(w, "  mcp         MCP server sub-commands (serve, ...)\n")
@@ -144,6 +145,9 @@ func Main() {
 			return
 		case "coherence":
 			runCoherenceCmd(args[1:], *workspace)
+			return
+		case "rates":
+			runRatesCmd(args[1:], *workspace)
 			return
 		case "spine":
 			runSpineCmd(args[1:], *workspace)

--- a/internal/engine/cli.go
+++ b/internal/engine/cli.go
@@ -55,6 +55,7 @@ func printUsage(w io.Writer) {
 	fmt.Fprintf(w, "  version     Print build version and exit\n")
 	fmt.Fprintf(w, "  node        Manage node configuration\n")
 	fmt.Fprintf(w, "  reconcile   Run reconciliation loop diagnostics\n")
+	fmt.Fprintf(w, "  coherence   Check workspace coherence (graded git-distance score)\n")
 	fmt.Fprintf(w, "  reindex     Rebuild the FTS5 constellation index from scratch\n")
 	fmt.Fprintf(w, "  spine       Show the decision manifold (gravity/inertia field over ADRs/RFCs)\n")
 	fmt.Fprintf(w, "  mcp         MCP server sub-commands (serve, ...)\n")
@@ -140,6 +141,9 @@ func Main() {
 			return
 		case "reconcile":
 			runReconcileCmd(args[1:], *workspace)
+			return
+		case "coherence":
+			runCoherenceCmd(args[1:], *workspace)
 			return
 		case "spine":
 			runSpineCmd(args[1:], *workspace)

--- a/internal/engine/cli_coherence.go
+++ b/internal/engine/cli_coherence.go
@@ -1,0 +1,85 @@
+// cli_coherence.go — "cogos coherence check" subcommand.
+//
+// First Instruments Module B (M1-A). Surfaces the graded git-distance
+// coherence score (internal/coherence.CheckCoherence) alongside the existing
+// boolean coherent/drift fields. Side-effect-free: CheckCoherence computes
+// the tree hash via a throwaway git index (K3 one-way-readout) and performs
+// no writes.
+//
+// Usage:
+//
+//	cogos coherence check [--json]
+package engine
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/myrgic/cogos/internal/coherence"
+)
+
+// runCoherenceCmd dispatches "cogos coherence <subcommand> [flags]".
+// args is everything after "coherence" (i.e. os.Args[2:]).
+func runCoherenceCmd(args []string, defaultWorkspace string) {
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "Usage: cogos coherence check [--json]\n")
+		os.Exit(1)
+	}
+
+	switch args[0] {
+	case "check":
+		runCoherenceCheckCmd(args[1:], defaultWorkspace)
+	default:
+		fmt.Fprintf(os.Stderr, "cogos coherence: unknown subcommand %q\n\nUsage: cogos coherence check [--json]\n", args[0])
+		os.Exit(1)
+	}
+}
+
+func runCoherenceCheckCmd(args []string, defaultWorkspace string) {
+	fs := flag.NewFlagSet("coherence check", flag.ExitOnError)
+	workspace := fs.String("workspace", defaultWorkspace, "Workspace root path (auto-detected from cwd if empty)")
+	jsonOut := fs.Bool("json", false, "Output as JSON")
+	if err := fs.Parse(args); err != nil {
+		os.Exit(1)
+	}
+
+	root := *workspace
+	if root == "" {
+		var err error
+		root, err = reconcileResolveWorkspace()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: resolve workspace: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	state, err := coherence.CheckCoherence(root)
+	if err != nil && state == nil {
+		fmt.Fprintf(os.Stderr, "error: check coherence: %v\n", err)
+		os.Exit(1)
+	}
+
+	if *jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(state)
+		return
+	}
+
+	fmt.Printf("Coherent: %v\n", state.Coherent)
+	fmt.Printf("Score:    %.4f\n", state.Score)
+	if state.CanonicalHash != "" {
+		fmt.Printf("Canonical: %s\n", state.CanonicalHash)
+	}
+	if state.CurrentHash != "" {
+		fmt.Printf("Current:   %s\n", state.CurrentHash)
+	}
+	if len(state.Drift) > 0 {
+		fmt.Printf("Drift (%d paths):\n", len(state.Drift))
+		for _, d := range state.Drift {
+			fmt.Printf("  %s\n", d)
+		}
+	}
+}

--- a/internal/engine/cli_rates.go
+++ b/internal/engine/cli_rates.go
@@ -1,0 +1,75 @@
+// cli_rates.go — "cogos rates" subcommand (First Instruments Module C, M3).
+//
+// Usage:
+//
+//	cogos rates [--json]
+//
+// Prints the deterministic-echo 15-ratio table over the kernel's six clock
+// constants (KernelRates). Side-effect-free: pure config read.
+package engine
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+)
+
+// runRatesCmd dispatches "cogos rates [flags]". args is everything after
+// "rates" (i.e. os.Args[2:]).
+func runRatesCmd(args []string, defaultWorkspace string) {
+	fs := flag.NewFlagSet("rates", flag.ExitOnError)
+	workspace := fs.String("workspace", defaultWorkspace, "Workspace root path (auto-detected from cwd if empty)")
+	jsonOut := fs.Bool("json", false, "Output as JSON")
+	if err := fs.Parse(args); err != nil {
+		os.Exit(1)
+	}
+
+	root := *workspace
+	if root == "" {
+		var err error
+		root, err = reconcileResolveWorkspace()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: resolve workspace: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	cfg, err := LoadConfig(root, 0)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: load config: %v\n", err)
+		os.Exit(1)
+	}
+
+	// The CLI has no running ReconcileDaemon to ask for its actual
+	// PollInterval; report the daemon's own default (0 => 30s, mirroring
+	// ReconcileDaemonConfig.withDefaults). A live kernel's GET
+	// /v1/kernel/rates reports the daemon's real PollInterval instead
+	// (handleKernelRates).
+	report := KernelRates(cfg, 0)
+
+	if *jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(report)
+		return
+	}
+
+	fmt.Println("Clock constants:")
+	for _, c := range report.Constants {
+		knob := "config knob"
+		if !c.HasConfigKnob {
+			knob = "hardcoded default, no config knob"
+		}
+		fmt.Printf("  %-24s %10.1fs  (%s)\n", c.Name, c.Seconds, knob)
+	}
+	fmt.Println()
+	fmt.Println("Rate ratios (deterministic-echo, all 15 pairs):")
+	for _, r := range report.Ratios {
+		cluster := ""
+		if r.ClusterID != "" {
+			cluster = fmt.Sprintf(" [%s]", r.ClusterID)
+		}
+		fmt.Printf("  %-24s / %-24s = %10.4f%s\n", r.Numerator, r.Denominator, r.Ratio, cluster)
+	}
+}

--- a/internal/engine/process.go
+++ b/internal/engine/process.go
@@ -28,8 +28,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/myrgic/cogos/trace"
 	"github.com/google/uuid"
+	"github.com/myrgic/cogos/trace"
 )
 
 // TraceEmitter is the bus-publish hook for cycle-trace events. The main
@@ -189,6 +189,14 @@ type Process struct {
 	// the process is constructed without a bus (e.g. benchmarks, some tests);
 	// handleTailerBlock degrades gracefully in that case.
 	sessionActivityPublisher SessionActivityPublisher
+
+	// cadence records OBSERVED behavioral-cadence events (First Instruments
+	// Module E, M11/M12/M13): dormant-consolidation completions, heartbeat
+	// events past the StateActive gate, and active-window-expiry
+	// observations. Side-effect-free append-only telemetry (§0) — see
+	// cadence_events.go. Always initialized (never nil) so recording never
+	// requires a nil check at the tap sites.
+	cadence *cadenceRecorder
 }
 
 // SessionActivityPublisher is the bus-append signature used by
@@ -243,6 +251,7 @@ func NewProcess(cfg *Config, nucleus *Nucleus) *Process {
 		hookRegistry:        loadStateHookRegistry(workspaceRootFromCfg(cfg)),
 		broker:              broker,
 		blobStore:           blobStore,
+		cadence:             newCadenceRecorder(),
 	}
 }
 
@@ -777,6 +786,17 @@ func (p *Process) emitHeartbeat() {
 		return
 	}
 
+	// First Instruments M12 tap (FROZEN tap point, blind-review-3 F9): record
+	// PAST the StateActive gate above, not at the run-loop invocation site
+	// (the ticker case that calls emitHeartbeat). Tapping at the invocation
+	// would record an event for every tick even inside a StateActive
+	// interval where the body below never runs, making the H6
+	// StateActive-exclusion a no-op for M12 (the event would already be
+	// recorded before the gate). Tapping here means M12 only records
+	// heartbeats that actually did real work — consistent with the K12-gated
+	// consolidation (M11) sharing this same suppression.
+	p.cadence.recordHeartbeat(time.Now().UTC(), p.State())
+
 	// Probe sibling services.
 	if p.nodeManifest != nil {
 		p.nodeHealth.Probe(p.nodeManifest, p.cfg.Port)
@@ -885,10 +905,22 @@ func (p *Process) emitHeartbeat() {
 	count, err := action.Run()
 	if err != nil {
 		slog.Warn("process: memory consolidation failed", "err", err)
+		// First Instruments Finding B: a persistent Run() error means the
+		// gate above returns without updating p.lastConsolidation, so
+		// attempts re-fire every heartbeat and the ATTEMPT cadence collapses
+		// to H. Deliberately do NOT record a cadence event here — tapping
+		// attempts/gate-passes instead of the success point below would
+		// forge the "cadence tracks H alone" KC-3-LAW kill signature from an
+		// environment fault. A run where Run() errors persist collects no
+		// valid M11 cadence and is INSTRUMENT-BROKEN, never a law-kill.
 		return
 	}
 
 	p.lastConsolidation = now
+	// First Instruments M11 tap (FROZEN at the SUCCESS point, blind-review-4
+	// Finding B): recorded co-located with p.lastConsolidation = now, i.e.
+	// only on a COMPLETED action.Run(), never on a gate-pass or attempt.
+	p.cadence.recordConsolidation(now, "heartbeat_gated", p.State())
 	slog.Info("process: memory consolidated", "sessions", count)
 }
 

--- a/internal/engine/rates.go
+++ b/internal/engine/rates.go
@@ -1,0 +1,235 @@
+// rates.go — GET /v1/kernel/rates / "cogos rates" (First Instruments Module C, M3).
+//
+// KernelRates computes the complete pairwise-ratio table (all C(6,2)=15
+// ratios) over the kernel's six clock constants. This is a DETERMINISTIC-
+// ECHO surface (IMPL-SPEC §5.1.1, PREREG §5.1.1): every value here is
+// computed without the kernel executing a single reconcile/heartbeat/
+// consolidation cycle — the ratios are decided entirely by grid/config
+// design, not observed behavior. Module C is retained because a truthful
+// rates surface is genuine kernel value (fills a real gap: rate-ratios were
+// never first-class before this) and feeds the negative-control battery —
+// but these ratios are NOT the invariant search. The invariant search is
+// Module E's OBSERVED behavioral cadences (M11/M12/M13). Do not conflate:
+// this file surfaces the dial settings, Module E measures the behavior.
+//
+// The six clock constants, as they actually exist on current main (verified
+// against origin/main; no config knob exists for three of them):
+//
+//   - ConsolidationInterval (C) — live *Config field, seconds. Default 3600.
+//   - HeartbeatInterval     (H) — live *Config field, seconds. Default 60.
+//   - PollInterval          (P) — ReconcileDaemonConfig field, seconds
+//     (time.Duration on the daemon; not a *Config field). Default 30s
+//     (ReconcileDaemonConfig.withDefaults). Passed in by the caller since
+//     the daemon, not *Config, owns it.
+//   - ActiveWindow          (A) — NOT a config field. Hardcoded
+//     defaultActiveWithinSeconds=600 (internal/engine/sessions.go). There is
+//     no WithActiveWindow knob (verified) — this is exactly why M13r is
+//     LAW-CHARACTERIZATION-ONLY in v1 (IMPL-SPEC §1(c), PREREG §9).
+//   - HandoffTTL            (T) — NOT a config field; a per-request
+//     TTLSeconds with hardcoded default 3600 when the caller omits it
+//     (internal/engine/serve_sessions_mgmt.go). Reported here as the
+//     default, clearly tagged as such.
+//   - IdleRecheck           (I) — NOT a config field. Hardcoded
+//     defaultIdleRecheckIn=1h (internal/engine/autonomic_ticker.go), on the
+//     LocalHarnessController's autonomic ticker (a different subsystem from
+//     the ReconcileDaemon/Process cadence this package otherwise measures).
+//
+// Three of the six constants have no config knob today; KernelRates reports
+// their hardcoded default values so the 15-ratio table is complete and
+// honest, and tags every entry as a config-independent echo regardless.
+package engine
+
+import (
+	"time"
+)
+
+// clockConstant names one of the six clock constants entering the ratio
+// table, paired with its current value in seconds.
+type clockConstant struct {
+	name          string
+	seconds       float64
+	hasConfigKnob bool // false = no config field exists; value is a hardcoded default
+}
+
+// RateRatio is one pairwise ratio entry in the 15-ratio table.
+type RateRatio struct {
+	Numerator   string  `json:"numerator"`
+	Denominator string  `json:"denominator"`
+	Ratio       float64 `json:"ratio"`
+
+	// EchoClass tags this ratio as barred from target-matching (IMPL-SPEC
+	// §5.1.1 / PREREG §5.1.1): it is computed without the kernel executing a
+	// cycle, decided entirely by grid/config design. ALWAYS
+	// "deterministic_config_read" for every entry in this table.
+	EchoClass string `json:"echo_class"`
+
+	// ClusterID groups related literal ratios so downstream accounting can
+	// mechanically re-verify them. "sixty" for ratios that literally equal
+	// 60 under kernel defaults (Consolidation/Heartbeat = 3600/60,
+	// IdleRecheck/Heartbeat = 3600/60, HandoffTTL/Heartbeat = 3600/60);
+	// "six" for ratios that literally equal 6 under kernel defaults
+	// (Consolidation/ActiveWindow = 3600/600, HandoffTTL/ActiveWindow =
+	// 3600/600, IdleRecheck/ActiveWindow = 3600/600); "" otherwise.
+	ClusterID string `json:"cluster_id,omitempty"`
+
+	// SourceCitation records where each operand's value comes from, for a
+	// future re-run to re-verify the literal without re-deriving it.
+	SourceCitation string `json:"source_citation"`
+}
+
+// RateReport is the full deterministic-echo rate-ratio surface (Module C, M3).
+type RateReport struct {
+	// Constants lists the six clock constants and their current values, so
+	// the ratio table below is self-documenting.
+	Constants []clockConstantReport `json:"constants"`
+
+	// Ratios is the complete C(6,2)=15-ratio table (IMPL-SPEC C1: "all
+	// pairwise ratios of the six clock constants, NOT a 6-of-15 subset").
+	Ratios []RateRatio `json:"ratios"`
+
+	Timestamp string `json:"timestamp"`
+}
+
+// clockConstantReport is the public (JSON) shape of a clockConstant.
+type clockConstantReport struct {
+	Name          string  `json:"name"`
+	Seconds       float64 `json:"seconds"`
+	HasConfigKnob bool    `json:"has_config_knob"`
+}
+
+// KernelRates reads the LIVE configured values (not hardcoded defaults, for
+// the two constants that have a config knob) and computes the complete
+// 15-ratio table (IMPL-SPEC C1). pollInterval is supplied by the caller
+// because PollInterval lives on ReconcileDaemonConfig, not *Config — the
+// daemon, not the static config, owns its resolved value (0 or negative is
+// treated as the daemon's own default, 30s, mirroring
+// ReconcileDaemonConfig.withDefaults).
+//
+// Side-effect-free: pure arithmetic over already-loaded config; no
+// mutation, no ticker interaction, no reconcile cycle triggered.
+func KernelRates(cfg *Config, pollInterval time.Duration) RateReport {
+	consolidation := 3600.0
+	heartbeat := 60.0
+	if cfg != nil {
+		if cfg.ConsolidationInterval > 0 {
+			consolidation = float64(cfg.ConsolidationInterval)
+		}
+		if cfg.HeartbeatInterval > 0 {
+			heartbeat = float64(cfg.HeartbeatInterval)
+		}
+	}
+
+	poll := 30.0
+	if pollInterval > 0 {
+		poll = pollInterval.Seconds()
+	}
+
+	// ActiveWindow, HandoffTTL, IdleRecheck have no config knob on current
+	// main (verified) — reported as their hardcoded defaults.
+	const activeWindowDefaultSeconds = 600.0 // sessions.go defaultActiveWithinSeconds
+	const handoffTTLDefaultSeconds = 3600.0  // serve_sessions_mgmt.go req.TTLSeconds default
+	const idleRecheckDefaultSeconds = 3600.0 // autonomic_ticker.go defaultIdleRecheckIn (1h)
+
+	constants := []clockConstant{
+		{"ConsolidationInterval", consolidation, true},
+		{"HeartbeatInterval", heartbeat, true},
+		{"PollInterval", poll, true},
+		{"ActiveWindow", activeWindowDefaultSeconds, false},
+		{"HandoffTTL", handoffTTLDefaultSeconds, false},
+		{"IdleRecheck", idleRecheckDefaultSeconds, false},
+	}
+
+	constReports := make([]clockConstantReport, len(constants))
+	for i, c := range constants {
+		constReports[i] = clockConstantReport{
+			Name:          c.name,
+			Seconds:       c.seconds,
+			HasConfigKnob: c.hasConfigKnob,
+		}
+	}
+
+	ratios := make([]RateRatio, 0, 15) // C(6,2) = 15
+	for i := 0; i < len(constants); i++ {
+		for j := i + 1; j < len(constants); j++ {
+			a, b := constants[i], constants[j]
+			var ratio float64
+			if b.seconds != 0 {
+				ratio = a.seconds / b.seconds
+			}
+			ratios = append(ratios, RateRatio{
+				Numerator:      a.name,
+				Denominator:    b.name,
+				Ratio:          ratio,
+				EchoClass:      "deterministic_config_read",
+				ClusterID:      rateClusterID(a.name, b.name, ratio),
+				SourceCitation: rateSourceCitation(a) + " / " + rateSourceCitation(b),
+			})
+		}
+	}
+
+	return RateReport{
+		Constants: constReports,
+		Ratios:    ratios,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	}
+}
+
+// rateClusterID tags the two literal clusters called out in IMPL-SPEC C2:
+// the three "60" ratios and the three "6" ratios (computed under kernel
+// defaults; a caller who has overridden ConsolidationInterval/
+// HeartbeatInterval will see the literal value drift off 60/6, which is
+// exactly the point of tagging by NAME PAIR rather than by observed value —
+// the cluster membership is a config-design fact, not a runtime coincidence).
+func rateClusterID(numerator, denominator string, _ float64) string {
+	// Pairs are unordered for clustering purposes — KernelRates generates
+	// each pair exactly once in a fixed (i<j) traversal order, so match
+	// membership regardless of which operand this traversal put first.
+	sixty := [][2]string{
+		{"ConsolidationInterval", "HeartbeatInterval"},
+		{"IdleRecheck", "HeartbeatInterval"},
+		{"HandoffTTL", "HeartbeatInterval"},
+	}
+	six := [][2]string{
+		{"ConsolidationInterval", "ActiveWindow"},
+		{"HandoffTTL", "ActiveWindow"},
+		{"IdleRecheck", "ActiveWindow"},
+	}
+	matches := func(pairs [][2]string) bool {
+		for _, p := range pairs {
+			if (p[0] == numerator && p[1] == denominator) || (p[0] == denominator && p[1] == numerator) {
+				return true
+			}
+		}
+		return false
+	}
+	switch {
+	case matches(sixty):
+		return "sixty"
+	case matches(six):
+		return "six"
+	default:
+		return ""
+	}
+}
+
+// rateSourceCitation returns a short human-readable pointer to where a
+// clock constant's current value came from, for the C2 "future re-run can
+// re-verify the literal" requirement.
+func rateSourceCitation(c clockConstant) string {
+	switch c.name {
+	case "ConsolidationInterval":
+		return "Config.ConsolidationInterval"
+	case "HeartbeatInterval":
+		return "Config.HeartbeatInterval"
+	case "PollInterval":
+		return "ReconcileDaemonConfig.PollInterval"
+	case "ActiveWindow":
+		return "sessions.go:defaultActiveWithinSeconds (no config knob)"
+	case "HandoffTTL":
+		return "serve_sessions_mgmt.go:TTLSeconds default (no config knob)"
+	case "IdleRecheck":
+		return "autonomic_ticker.go:defaultIdleRecheckIn (no config knob)"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/engine/rates_test.go
+++ b/internal/engine/rates_test.go
@@ -1,0 +1,185 @@
+// rates_test.go — Module C tests (First Instruments Stage-2).
+package engine
+
+import (
+	"testing"
+	"time"
+)
+
+// TestKernelRates_FifteenRatios confirms the complete C(6,2)=15-ratio table
+// (IMPL-SPEC C1: all pairwise ratios, not a 6-of-15 subset).
+func TestKernelRates_FifteenRatios(t *testing.T) {
+	report := KernelRates(&Config{ConsolidationInterval: 3600, HeartbeatInterval: 60}, 30*time.Second)
+	if len(report.Constants) != 6 {
+		t.Fatalf("len(Constants) = %d; want 6", len(report.Constants))
+	}
+	if len(report.Ratios) != 15 {
+		t.Fatalf("len(Ratios) = %d; want 15 (C(6,2))", len(report.Ratios))
+	}
+}
+
+// TestKernelRates_ArithmeticAgainstKnownConfig confirms the ratio values are
+// correct for a known configuration (kernel defaults).
+func TestKernelRates_ArithmeticAgainstKnownConfig(t *testing.T) {
+	report := KernelRates(&Config{ConsolidationInterval: 3600, HeartbeatInterval: 60}, 30*time.Second)
+
+	find := func(num, den string) (RateRatio, bool) {
+		for _, r := range report.Ratios {
+			if r.Numerator == num && r.Denominator == den {
+				return r, true
+			}
+		}
+		return RateRatio{}, false
+	}
+
+	r, ok := find("ConsolidationInterval", "HeartbeatInterval")
+	if !ok {
+		t.Fatal("ConsolidationInterval/HeartbeatInterval ratio not found")
+	}
+	if r.Ratio != 60.0 {
+		t.Errorf("ConsolidationInterval/HeartbeatInterval = %v; want 60.0 (3600/60)", r.Ratio)
+	}
+	if r.ClusterID != "sixty" {
+		t.Errorf("ClusterID = %q; want %q", r.ClusterID, "sixty")
+	}
+
+	r2, ok := find("ConsolidationInterval", "ActiveWindow")
+	if !ok {
+		t.Fatal("ConsolidationInterval/ActiveWindow ratio not found")
+	}
+	if r2.Ratio != 6.0 {
+		t.Errorf("ConsolidationInterval/ActiveWindow = %v; want 6.0 (3600/600)", r2.Ratio)
+	}
+	if r2.ClusterID != "six" {
+		t.Errorf("ClusterID = %q; want %q", r2.ClusterID, "six")
+	}
+
+	r3, ok := find("HeartbeatInterval", "PollInterval")
+	if !ok {
+		t.Fatal("HeartbeatInterval/PollInterval ratio not found")
+	}
+	const want = 60.0 / 30.0
+	if r3.Ratio != want {
+		t.Errorf("HeartbeatInterval/PollInterval = %v; want %v (60/30)", r3.Ratio, want)
+	}
+}
+
+// TestKernelRates_ReadsLiveConfig confirms KernelRates reads the LIVE
+// configured values rather than hardcoded defaults: mutating the config
+// between two calls changes the ratios that involve the mutated constants.
+func TestKernelRates_ReadsLiveConfig(t *testing.T) {
+	cfg := &Config{ConsolidationInterval: 3600, HeartbeatInterval: 60}
+	before := KernelRates(cfg, 30*time.Second)
+
+	cfg.ConsolidationInterval = 7200 // double it
+	after := KernelRates(cfg, 30*time.Second)
+
+	find := func(report RateReport, num, den string) float64 {
+		for _, r := range report.Ratios {
+			if r.Numerator == num && r.Denominator == den {
+				return r.Ratio
+			}
+		}
+		t.Fatalf("ratio %s/%s not found", num, den)
+		return 0
+	}
+
+	beforeRatio := find(before, "ConsolidationInterval", "HeartbeatInterval")
+	afterRatio := find(after, "ConsolidationInterval", "HeartbeatInterval")
+	if beforeRatio == afterRatio {
+		t.Errorf("ratio unchanged after mutating ConsolidationInterval: before=%v after=%v", beforeRatio, afterRatio)
+	}
+	if afterRatio != 120.0 {
+		t.Errorf("ConsolidationInterval/HeartbeatInterval after doubling C = %v; want 120.0 (7200/60)", afterRatio)
+	}
+
+	// PollInterval is also a live-read argument (not baked into cfg); confirm
+	// varying it changes ratios that involve PollInterval.
+	pollBefore := KernelRates(cfg, 30*time.Second)
+	pollAfter := KernelRates(cfg, 60*time.Second)
+	pbRatio := find(pollBefore, "HeartbeatInterval", "PollInterval")
+	paRatio := find(pollAfter, "HeartbeatInterval", "PollInterval")
+	if pbRatio == paRatio {
+		t.Errorf("ratio unchanged after varying pollInterval: before=%v after=%v", pbRatio, paRatio)
+	}
+}
+
+// TestKernelRates_EchoClassAndClusterAnnotations confirms every ratio is
+// tagged deterministic_config_read (IMPL-SPEC C2), and that the three
+// "sixty" and three "six" cluster ratios are present and correctly tagged.
+func TestKernelRates_EchoClassAndClusterAnnotations(t *testing.T) {
+	report := KernelRates(&Config{ConsolidationInterval: 3600, HeartbeatInterval: 60}, 30*time.Second)
+
+	sixtyCount, sixCount := 0, 0
+	for _, r := range report.Ratios {
+		if r.EchoClass != "deterministic_config_read" {
+			t.Errorf("ratio %s/%s: EchoClass = %q; want %q", r.Numerator, r.Denominator, r.EchoClass, "deterministic_config_read")
+		}
+		if r.SourceCitation == "" {
+			t.Errorf("ratio %s/%s: SourceCitation is empty", r.Numerator, r.Denominator)
+		}
+		switch r.ClusterID {
+		case "sixty":
+			sixtyCount++
+		case "six":
+			sixCount++
+		}
+	}
+	if sixtyCount != 3 {
+		t.Errorf("sixty-cluster count = %d; want 3", sixtyCount)
+	}
+	if sixCount != 3 {
+		t.Errorf("six-cluster count = %d; want 3", sixCount)
+	}
+}
+
+// TestKernelRates_HasConfigKnobFlags confirms the three constants with no
+// live config knob are correctly flagged, matching the verified absence of
+// an ActiveWindow/HandoffTTL/IdleRecheck config field on current main.
+func TestKernelRates_HasConfigKnobFlags(t *testing.T) {
+	report := KernelRates(&Config{ConsolidationInterval: 3600, HeartbeatInterval: 60}, 30*time.Second)
+
+	want := map[string]bool{
+		"ConsolidationInterval": true,
+		"HeartbeatInterval":     true,
+		"PollInterval":          true,
+		"ActiveWindow":          false,
+		"HandoffTTL":            false,
+		"IdleRecheck":           false,
+	}
+	got := map[string]bool{}
+	for _, c := range report.Constants {
+		got[c.Name] = c.HasConfigKnob
+	}
+	for name, wantKnob := range want {
+		if got[name] != wantKnob {
+			t.Errorf("%s.HasConfigKnob = %v; want %v", name, got[name], wantKnob)
+		}
+	}
+}
+
+// TestKernelRates_SideEffectFree confirms KernelRates mutates no kernel
+// state: the same cfg pointer produces identical ratios across repeated
+// calls, and the config values themselves are unchanged after the call.
+func TestKernelRates_SideEffectFree(t *testing.T) {
+	cfg := &Config{ConsolidationInterval: 3600, HeartbeatInterval: 60}
+	_ = KernelRates(cfg, 30*time.Second)
+
+	if cfg.ConsolidationInterval != 3600 {
+		t.Errorf("cfg.ConsolidationInterval mutated: got %d, want 3600", cfg.ConsolidationInterval)
+	}
+	if cfg.HeartbeatInterval != 60 {
+		t.Errorf("cfg.HeartbeatInterval mutated: got %d, want 60", cfg.HeartbeatInterval)
+	}
+
+	r1 := KernelRates(cfg, 30*time.Second)
+	r2 := KernelRates(cfg, 30*time.Second)
+	if len(r1.Ratios) != len(r2.Ratios) {
+		t.Fatalf("ratio count differs across repeated calls: %d vs %d", len(r1.Ratios), len(r2.Ratios))
+	}
+	for i := range r1.Ratios {
+		if r1.Ratios[i].Ratio != r2.Ratios[i].Ratio {
+			t.Errorf("ratio[%d] differs across repeated calls: %v vs %v", i, r1.Ratios[i].Ratio, r2.Ratios[i].Ratio)
+		}
+	}
+}

--- a/internal/engine/reconcile_daemon.go
+++ b/internal/engine/reconcile_daemon.go
@@ -288,6 +288,16 @@ func (d *ReconcileDaemon) State() ReconcileDaemonState {
 	return d.state
 }
 
+// PollInterval returns the daemon's resolved tick interval (First
+// Instruments Module C, M3 — GET /v1/kernel/rates reads this so the live
+// rate-ratio table reflects the daemon's ACTUAL PollInterval, not a static
+// config guess). cfg is set once at construction via withDefaults(), so
+// this is safe to read without the daemon's mu (immutable after
+// NewReconcileDaemon).
+func (d *ReconcileDaemon) PollInterval() time.Duration {
+	return d.cfg.PollInterval
+}
+
 // ─── Isolated-registry helpers ───────────────────────────────────────────────
 //
 // When cfg.Providers is nil these helpers delegate to the global registry,

--- a/internal/engine/reconcile_daemon.go
+++ b/internal/engine/reconcile_daemon.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -125,18 +126,29 @@ type ReconcileDaemon struct {
 	// fetchCount — a production provider under test has no such hook).
 	cycleSerialsMu sync.Mutex
 	cycleSerials   map[string]*atomic.Int64
+
+	// lastSummaries caches the most recent reconcile.Summary per provider,
+	// set right after each cycle's ComputePlan succeeds (First Instruments
+	// B2/M1-B). This is telemetry, not kernel state (§0): the Summary is
+	// already computed as part of the ordinary reconcile cycle; caching it
+	// costs nothing extra at tick boundaries and adds no new git/network
+	// round-trip. Used by LastCoherence to compute the graded reconcile-drift
+	// score C_B without re-running ComputePlan out of band.
+	lastSummariesMu sync.Mutex
+	lastSummaries   map[string]reconcile.Summary
 }
 
 // NewReconcileDaemon creates a ReconcileDaemon with the given config.
 // Call Start(ctx) to begin the loop.
 func NewReconcileDaemon(cfg ReconcileDaemonConfig) *ReconcileDaemon {
 	return &ReconcileDaemon{
-		cfg:          cfg.withDefaults(),
-		state:        ReconcileDaemonStarting,
-		triggered:    make(map[string]struct{}),
-		triggerCh:    make(chan struct{}, 1),
-		health:       newConvergenceTracker(cfg.Convergence),
-		cycleSerials: make(map[string]*atomic.Int64),
+		cfg:           cfg.withDefaults(),
+		state:         ReconcileDaemonStarting,
+		triggered:     make(map[string]struct{}),
+		triggerCh:     make(chan struct{}, 1),
+		health:        newConvergenceTracker(cfg.Convergence),
+		cycleSerials:  make(map[string]*atomic.Int64),
+		lastSummaries: make(map[string]reconcile.Summary),
 	}
 }
 
@@ -171,6 +183,87 @@ func (d *ReconcileDaemon) bumpCycleSerial(providerType string) {
 	}
 	d.cycleSerialsMu.Unlock()
 	counter.Add(1)
+}
+
+// ProviderCoherence is the per-provider reconcile-drift detail behind
+// LastCoherence's aggregate C_B (First Instruments M1-B).
+type ProviderCoherence struct {
+	ProviderType  string  `json:"provider_type"`
+	DriftFraction float64 `json:"drift_fraction"`
+	HasSummary    bool    `json:"has_summary"`
+	Creates       int     `json:"creates"`
+	Updates       int     `json:"updates"`
+	Deletes       int     `json:"deletes"`
+	Skipped       int     `json:"skipped"`
+	Total         int     `json:"total"`
+}
+
+// LastCoherence computes the M1-B graded reconcile-drift score C_B (IMPL-SPEC
+// B2) from the most recently cached per-provider Summary (populated at the
+// end of every ComputePlan in runOneCycle; telemetry, not kernel state,
+// §0). Side-effect-free: reads the cache only, runs no reconcile cycle.
+//
+//	drift_fraction_p := 0                              when Total()==0 (empty plan: nothing to
+//	                                                     reconcile ⇒ fully in-sync, not maximally drifted)
+//	                  := (Creates+Updates+Deletes)/Total()   otherwise  (== 1 - Skipped/Total())
+//	C_B = 1 - (1/P) * Σ_p drift_fraction_p
+//
+// C_B is in [0,1]; 1.0 iff every provider is all-Skipped OR has an empty
+// plan (Total()==0). Returns C_B==1.0 and an empty detail slice if no
+// provider has completed a cycle yet (vacuously coherent — nothing has been
+// observed to have drifted).
+//
+// Do NOT use Total()/(Skipped+Total()) — Summary.Total() already includes
+// Skipped (pkg/substrate/reconcile/types.go Total()), so that form ranges
+// [0.5,1], not [0,1] (verified degenerate per IMPL-SPEC B2).
+func (d *ReconcileDaemon) LastCoherence() (cB float64, perProvider []ProviderCoherence) {
+	d.lastSummariesMu.Lock()
+	snapshot := make(map[string]reconcile.Summary, len(d.lastSummaries))
+	for pt, s := range d.lastSummaries {
+		snapshot[pt] = s
+	}
+	d.lastSummariesMu.Unlock()
+
+	if len(snapshot) == 0 {
+		return 1.0, nil
+	}
+
+	// Deterministic provider ordering for a stable detail slice.
+	types := make([]string, 0, len(snapshot))
+	for pt := range snapshot {
+		types = append(types, pt)
+	}
+	sort.Strings(types)
+
+	perProvider = make([]ProviderCoherence, 0, len(types))
+	var driftSum float64
+	for _, pt := range types {
+		s := snapshot[pt]
+		total := s.Total()
+		var driftFraction float64
+		if total == 0 {
+			// Empty-plan boundary fix (IMPL-SPEC B2, blind-review-1): an idle
+			// provider with nothing to reconcile is fully in-sync, not
+			// maximally drifted. The naive (C+U+D)/Total() would be 0/0.
+			driftFraction = 0
+		} else {
+			driftFraction = float64(s.Creates+s.Updates+s.Deletes) / float64(total)
+		}
+		driftSum += driftFraction
+		perProvider = append(perProvider, ProviderCoherence{
+			ProviderType:  pt,
+			DriftFraction: driftFraction,
+			HasSummary:    true,
+			Creates:       s.Creates,
+			Updates:       s.Updates,
+			Deletes:       s.Deletes,
+			Skipped:       s.Skipped,
+			Total:         total,
+		})
+	}
+
+	cB = 1 - (driftSum / float64(len(types)))
+	return cB, perProvider
 }
 
 // ProviderConvergence returns the current per-provider reconcile anomaly
@@ -519,6 +612,15 @@ func (d *ReconcileDaemon) runOneCycle(ctx context.Context, providerType string) 
 			"provider", providerType, "err", err)
 		return fmt.Errorf("ComputePlan %s: %w", providerType, err)
 	}
+
+	// Cache this cycle's Summary for LastCoherence (First Instruments B2/
+	// M1-B). Telemetry, not kernel state (§0) — already computed above, so
+	// this adds no marginal cost. Cached unconditionally (both the
+	// early "in sync" exit and the full apply path below read the same
+	// already-computed plan.Summary).
+	d.lastSummariesMu.Lock()
+	d.lastSummaries[providerType] = plan.Summary
+	d.lastSummariesMu.Unlock()
 
 	// phaseAttrs records the per-phase timings on the cycle span. Called at both
 	// exits (early "in sync" return and full cycle) so traces always carry the

--- a/internal/engine/reconcile_daemon.go
+++ b/internal/engine/reconcile_daemon.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -113,18 +114,63 @@ type ReconcileDaemon struct {
 	// health self-reports per-provider reconcile anomalies (slow cycles,
 	// persistent degraded health) as WARNs and a queryable snapshot.
 	health *convergenceTracker
+
+	// cycleSerials is a monotonic per-provider completion counter, bumped at
+	// the END of each provider's runOneCycle (regardless of success/failure —
+	// a cycle "completed" whether or not the provider errored). This is
+	// telemetry, not kernel state (First Instruments §0/A3): it exists solely
+	// so test harnesses can observe "has cycle N happened" without depending
+	// on a fake provider's own internal counters (the prior test-local
+	// waitForCycle pattern, which only worked because the fake tracked its own
+	// fetchCount — a production provider under test has no such hook).
+	cycleSerialsMu sync.Mutex
+	cycleSerials   map[string]*atomic.Int64
 }
 
 // NewReconcileDaemon creates a ReconcileDaemon with the given config.
 // Call Start(ctx) to begin the loop.
 func NewReconcileDaemon(cfg ReconcileDaemonConfig) *ReconcileDaemon {
 	return &ReconcileDaemon{
-		cfg:       cfg.withDefaults(),
-		state:     ReconcileDaemonStarting,
-		triggered: make(map[string]struct{}),
-		triggerCh: make(chan struct{}, 1),
-		health:    newConvergenceTracker(cfg.Convergence),
+		cfg:          cfg.withDefaults(),
+		state:        ReconcileDaemonStarting,
+		triggered:    make(map[string]struct{}),
+		triggerCh:    make(chan struct{}, 1),
+		health:       newConvergenceTracker(cfg.Convergence),
+		cycleSerials: make(map[string]*atomic.Int64),
 	}
+}
+
+// LastCycleSerial returns the current monotonic cycle-completion counter for
+// providerType and true if at least one cycle has completed for it. Returns
+// (0, false) if no cycle for that provider type has completed yet.
+//
+// The counter is bumped once at the end of every runOneCycle call for that
+// provider type (First Instruments A3) — a real completion signal, not a
+// poll of provider-owned test state. Use testkernel.WaitForCycle to block
+// until a target serial is reached.
+func (d *ReconcileDaemon) LastCycleSerial(providerType string) (int, bool) {
+	d.cycleSerialsMu.Lock()
+	counter, ok := d.cycleSerials[providerType]
+	d.cycleSerialsMu.Unlock()
+	if !ok {
+		return 0, false
+	}
+	return int(counter.Load()), true
+}
+
+// bumpCycleSerial increments the monotonic completion counter for
+// providerType, creating it on first use. Called once at the end of every
+// runOneCycle, after the provider's cycle (success or error) has fully
+// completed.
+func (d *ReconcileDaemon) bumpCycleSerial(providerType string) {
+	d.cycleSerialsMu.Lock()
+	counter, ok := d.cycleSerials[providerType]
+	if !ok {
+		counter = &atomic.Int64{}
+		d.cycleSerials[providerType] = counter
+	}
+	d.cycleSerialsMu.Unlock()
+	counter.Add(1)
 }
 
 // ProviderConvergence returns the current per-provider reconcile anomaly
@@ -402,6 +448,14 @@ func (d *ReconcileDaemon) runOneCycle(ctx context.Context, providerType string) 
 			)
 		}
 	}()
+
+	// Bump the monotonic cycle-completion counter at the END of this cycle,
+	// regardless of outcome (success, error, or recovered panic above — this
+	// defer runs after the panic-recover defer settles retErr, since defers
+	// execute LIFO and this one is registered second). Telemetry, not kernel
+	// state (First Instruments A3/§0): a test-observable "cycle N happened"
+	// signal, no effect on control flow.
+	defer d.bumpCycleSerial(providerType)
 
 	tracer := otel.Tracer("cogos.reconcile-daemon")
 	spanCtx, span := tracer.Start(ctx, "reconcile.daemon.cycle")

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -71,6 +71,12 @@ type Server struct {
 	agentController   AgentController // nil until SetAgentController is called
 	mcpServer         *MCPServer      // so SetAgentController can propagate to tools
 
+	// reconcileDaemon backs GET /v1/reconcile/coherence (First Instruments
+	// Module B, M1-B). nil until SetReconcileDaemon is called — the daemon is
+	// constructed after NewServer in engine.Boot, so this is wired
+	// post-construction rather than passed to NewServer.
+	reconcileDaemon *ReconcileDaemon
+
 	// Track 5 Phase 3 surface — per-bus event store, SSE broker, and
 	// consumer cursor registry. Scoped to the server so tests can create
 	// isolated instances.
@@ -196,6 +202,7 @@ func NewServer(cfg *Config, nucleus *Nucleus, process *Process) *Server {
 	s.route(mux, "GET /v1/tool-calls", s.handleToolCalls)
 	s.route(mux, "GET /v1/conversation", s.handleConversation)
 	s.route(mux, "GET /v1/manifest", s.handleManifest)
+	s.route(mux, "GET /v1/reconcile/coherence", s.handleReconcileCoherence)
 	s.registerAgentRoutes(mux)
 	s.registerSkillRoutes(mux)
 
@@ -330,6 +337,17 @@ func (s *Server) SetAgentController(ctrl AgentController) {
 		lhc.SetDashboardBus(s.busSessions)
 		BindDashboardController(lhc)
 	}
+}
+
+// SetReconcileDaemon wires the kernel's ReconcileDaemon into the server so
+// GET /v1/reconcile/coherence (First Instruments Module B, M1-B) can read
+// LastCoherence(). Called from Boot() after the daemon is constructed. Nil
+// is safe (the handler reports coherent-by-default with an empty detail
+// slice, matching ReconcileDaemon.LastCoherence's own zero-observations
+// case) so this wiring is optional for callers that never registered a
+// daemon (e.g. hand-built *Server instances in unrelated tests).
+func (s *Server) SetReconcileDaemon(d *ReconcileDaemon) {
+	s.reconcileDaemon = d
 }
 
 // SetHarnessBackend wires the RBAC harness-binding layer into the server.

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -203,6 +203,7 @@ func NewServer(cfg *Config, nucleus *Nucleus, process *Process) *Server {
 	s.route(mux, "GET /v1/conversation", s.handleConversation)
 	s.route(mux, "GET /v1/manifest", s.handleManifest)
 	s.route(mux, "GET /v1/reconcile/coherence", s.handleReconcileCoherence)
+	s.route(mux, "GET /v1/kernel/rates", s.handleKernelRates)
 	s.registerAgentRoutes(mux)
 	s.registerSkillRoutes(mux)
 

--- a/internal/engine/serve_coherence.go
+++ b/internal/engine/serve_coherence.go
@@ -1,0 +1,45 @@
+// serve_coherence.go — GET /v1/reconcile/coherence (First Instruments Module B, M1-B).
+//
+// Exposes the graded reconcile-drift score C_B computed from the
+// ReconcileDaemon's cached per-provider Summary. Read-only: LastCoherence
+// reads a cache populated as a side effect of the ordinary reconcile cycle
+// (telemetry, IMPL-SPEC §0), runs no reconcile cycle itself, and mutates no
+// kernel state.
+package engine
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+// reconcileCoherenceResponse is the GET /v1/reconcile/coherence response
+// body shape (IMPL-SPEC Module B "Surface").
+type reconcileCoherenceResponse struct {
+	CB               float64             `json:"c_b"`
+	PerProviderDrift []ProviderCoherence `json:"per_provider_drift_fraction"`
+	Timestamp        string              `json:"timestamp"`
+}
+
+// handleReconcileCoherence serves GET /v1/reconcile/coherence: the M1-B
+// graded reconcile-drift score C_B plus per-provider detail. If no
+// ReconcileDaemon has been wired (SetReconcileDaemon never called), reports
+// C_B=1.0 with an empty detail slice — the same "nothing observed to have
+// drifted" default ReconcileDaemon.LastCoherence itself returns when no
+// cycle has completed yet.
+func (s *Server) handleReconcileCoherence(w http.ResponseWriter, r *http.Request) {
+	var cB float64 = 1.0
+	var perProvider []ProviderCoherence
+	if s.reconcileDaemon != nil {
+		cB, perProvider = s.reconcileDaemon.LastCoherence()
+	}
+
+	resp := reconcileCoherenceResponse{
+		CB:               cB,
+		PerProviderDrift: perProvider,
+		Timestamp:        time.Now().UTC().Format(time.RFC3339),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/internal/engine/serve_rates.go
+++ b/internal/engine/serve_rates.go
@@ -1,0 +1,28 @@
+// serve_rates.go — GET /v1/kernel/rates (First Instruments Module C, M3).
+//
+// Side-effect-free: pure read of config plus the daemon's resolved
+// PollInterval; no mutation, no ticker interaction.
+package engine
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+// handleKernelRates serves GET /v1/kernel/rates: the deterministic-echo
+// 15-ratio table over the kernel's six clock constants (KernelRates). Uses
+// the live ReconcileDaemon's actual PollInterval when one is wired
+// (SetReconcileDaemon), so the ratio table reflects the running daemon's
+// real cadence rather than a static guess.
+func (s *Server) handleKernelRates(w http.ResponseWriter, r *http.Request) {
+	var pollInterval time.Duration
+	if s.reconcileDaemon != nil {
+		pollInterval = s.reconcileDaemon.PollInterval()
+	}
+
+	report := KernelRates(s.cfg, pollInterval)
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(report)
+}

--- a/internal/testkernel/experiment/blockbootstrap.go
+++ b/internal/testkernel/experiment/blockbootstrap.go
@@ -1,0 +1,78 @@
+// blockbootstrap.go — First Instruments Module D5: circular block-bootstrap
+// for serially-dependent REAL consecutive-interval data (blind-review-4
+// Finding C).
+//
+// The real M11r estimator is built from n CONSECUTIVE inter-consolidation
+// intervals over ONE boot (the frozen replicate protocol — see runner.go),
+// which are serially dependent (each interval's phase depends on the
+// previous tick's jitter). All bootstrap CIs on real consecutive-interval
+// data use a circular/moving block-bootstrap with block length
+// l=ceil(sqrt(n)) (resample BLOCKS, not individual intervals). The
+// config-independent synthetic nulls in calibration.go are i.i.d. by
+// construction and use ordinary (block length 1) bootstrap instead — see
+// BootstrapCIUpper.
+package experiment
+
+import (
+	"math"
+	"math/rand"
+	"sort"
+)
+
+// BlockLength returns the frozen circular block-bootstrap block length
+// l=ceil(sqrt(n)) for n consecutive real intervals (PREREG §6.2 / Finding
+// C). i.i.d. synthetic nulls use l=1 instead (ordinary bootstrap).
+func BlockLength(n int) int {
+	if n <= 0 {
+		return 1
+	}
+	l := int(math.Ceil(math.Sqrt(float64(n))))
+	if l < 1 {
+		l = 1
+	}
+	return l
+}
+
+// circularBlockResample draws one circular-block-bootstrap resample of
+// length n from data (wrapping indices modulo len(data), so every block
+// start is valid even near the end of the series — the "circular" part of
+// circular block-bootstrap).
+func circularBlockResample(rng *rand.Rand, data []float64, blockLen int) []float64 {
+	n := len(data)
+	if n == 0 {
+		return nil
+	}
+	out := make([]float64, 0, n)
+	for len(out) < n {
+		start := rng.Intn(n)
+		for i := 0; i < blockLen && len(out) < n; i++ {
+			out = append(out, data[(start+i)%n])
+		}
+	}
+	return out
+}
+
+// BlockBootstrapMeanCI computes the bootstrapped `level` (two-sided) CI of
+// the MEAN of real, serially-dependent consecutive-interval data, via the
+// circular block-bootstrap (block length l=ceil(sqrt(n)), B resamples).
+// Used for SE_hat's real-data counterpart and for the real M11r cadence
+// estimator's own CI (as opposed to the synthetic-null S-statistic CIs in
+// calibration.go, which use ordinary i.i.d. bootstrap).
+func BlockBootstrapMeanCI(data []float64, seed int64, level float64, b int) (upper, half float64) {
+	n := len(data)
+	if n == 0 {
+		return math.NaN(), math.NaN()
+	}
+	blockLen := BlockLength(n)
+	rng := rand.New(rand.NewSource(seed))
+	means := make([]float64, b)
+	for i := 0; i < b; i++ {
+		resample := circularBlockResample(rng, data, blockLen)
+		means[i] = mean(resample)
+	}
+	sort.Float64s(means)
+	alpha := (1.0 - level) / 2.0
+	lo := percentile(means, alpha)
+	hi := percentile(means, 1.0-alpha)
+	return hi, (hi - lo) / 2.0
+}

--- a/internal/testkernel/experiment/calibration.go
+++ b/internal/testkernel/experiment/calibration.go
@@ -1,0 +1,422 @@
+// calibration.go — First Instruments Module D5: calibration-first HARD ABORT.
+//
+// Ports decision_surface_sim.py's §6.2 machinery to Go: the FROZEN
+// split-null calibration (threshold-setting vs held-out validation nulls),
+// the Gaussian-multiplicative null family, the circular block-bootstrap,
+// the 95th-percentile-of-decision-statistic threshold derivation, the
+// "clears" rule (90%-CI upper bound <= threshold), and the three hard-abort
+// gates (PRECISION, POWER, JITTER-MODEL-VALIDATION).
+//
+// BEFORE any kernel observation is collected, the runner (runner.go) MUST
+// call Calibrate and refuse to proceed unless CalibrationOutcome.AllPass()
+// is true — this file's job is to make that refusal possible; it produces
+// no kernel-observation side effects itself (pure arithmetic over
+// synthetic/frozen-seed draws).
+package experiment
+
+import (
+	"math"
+	"math/rand"
+	"sort"
+)
+
+// Frozen §6.2 null-family + gate parameters. Values match
+// decision_surface_sim.py's FROZEN-registration constants (recorded in the
+// manifest per IMPL-SPEC D4/D5), NOT the sim's own downscaled internal
+// resolution constants (N_THRESH/N_VAL/N_REPLICATES/BOOTSTRAP_B below ARE
+// the frozen registration counts — this package runs the full counts by
+// default; callers needing faster iteration for development pass a
+// CalibrationConfig with reduced counts explicitly, which is recorded in
+// the manifest as a deviation).
+const (
+	// SigmaNull is the frozen Gaussian-multiplicative null jitter scale
+	// (sigma_null = sigma_jit = sigma_pc = 0.05, PREREG §6.2 residual (ii)).
+	SigmaNull = 0.05
+
+	// FrozenNThresh is the frozen threshold-setting null count.
+	FrozenNThresh = 1000
+	// FrozenNVal is the frozen held-out validation null count.
+	FrozenNVal = 1000
+	// FrozenNMax is the frozen max replicate count per cell (n-ladder cap).
+	FrozenNMax = 240
+	// FrozenBootstrapB is the frozen minimum bootstrap resample count.
+	FrozenBootstrapB = 1000
+
+	// CILevel is the frozen two-sided bootstrap CI level (90%, PREREG §6.2).
+	CILevel = 0.90
+	// HMaxS is the PRECISION gate bound: validation-null median 90%-CI
+	// half-width of S must be <= this (S-units, PREREG §6.2).
+	HMaxS = 0.25
+	// PowerMinS is the POWER gate bound: the delta=0.25 drifting battery
+	// must be rejected (does not clear) at rate >= this.
+	PowerMinS = 0.80
+	// DriftDeltaGated is the gated middle drift size (per octave) the POWER
+	// gate battery uses.
+	DriftDeltaGated = 0.25
+	// JitterCVMax is the JITTER-MODEL-VALIDATION scale-criterion bound:
+	// measured heartbeat-cadence CV must be <= this (within 1.5x of the
+	// frozen sigma=0.05).
+	JitterCVMax = 0.075
+)
+
+// CalibrationConfig lets a caller trade Monte-Carlo resolution for runtime
+// (mirrors decision_surface_sim.py's documented downscale: this changes NO
+// frozen registration value or decision logic, only draw counts). The
+// zero value uses the frozen registration counts.
+type CalibrationConfig struct {
+	NThresh     int // threshold-setting null draws; 0 => FrozenNThresh
+	NVal        int // held-out validation null draws; 0 => FrozenNVal
+	NReplicates int // replicates per synthetic family draw; 0 => FrozenNMax
+	BootstrapB  int // bootstrap resamples; 0 => FrozenBootstrapB
+	Seed        int64
+}
+
+func (cfg CalibrationConfig) resolved() CalibrationConfig {
+	if cfg.NThresh <= 0 {
+		cfg.NThresh = FrozenNThresh
+	}
+	if cfg.NVal <= 0 {
+		cfg.NVal = FrozenNVal
+	}
+	if cfg.NReplicates <= 0 {
+		cfg.NReplicates = FrozenNMax
+	}
+	if cfg.BootstrapB <= 0 {
+		cfg.BootstrapB = FrozenBootstrapB
+	}
+	if cfg.Seed == 0 {
+		cfg.Seed = 20260707 // frozen master seed (decision_surface_sim.py STABILITY_SEED)
+	}
+	return cfg
+}
+
+// drawNullCellReplicates draws n config-independent (or drifting, via
+// meanRatio != 1) fake-ratio replicates for one cell under the FROZEN
+// Gaussian-multiplicative null family (PREREG §6.2):
+//
+//	R_i = num_i/den_i, num_i = meanRatio*(1+eta_n), den_i = 1*(1+eta_d),
+//	eta ~ Normal(0, sigmaNull^2) i.i.d.
+func drawNullCellReplicates(rng *rand.Rand, meanRatio float64, n int, sigmaNull float64) []float64 {
+	out := make([]float64, n)
+	for i := 0; i < n; i++ {
+		num := meanRatio * (1.0 + rng.NormFloat64()*sigmaNull)
+		den := 1.0 * (1.0 + rng.NormFloat64()*sigmaNull)
+		out[i] = num / den
+	}
+	return out
+}
+
+func mean(xs []float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, x := range xs {
+		sum += x
+	}
+	return sum / float64(len(xs))
+}
+
+// cv is the coefficient of variation of a list of cell-means (population
+// std, matching decision_surface_sim.py's cv()).
+func cv(values []float64) float64 {
+	m := mean(values)
+	if m == 0 {
+		return math.Inf(1)
+	}
+	var sumSq float64
+	for _, v := range values {
+		d := v - m
+		sumSq += d * d
+	}
+	variance := sumSq / float64(len(values))
+	return math.Sqrt(variance) / math.Abs(m)
+}
+
+// cvOfReplicates is the within-cell CV of a replicate sample (sample std /
+// |mean|, matching decision_surface_sim.py's _cv_of_replicates — uses n-1
+// in the denominator for the sample variance).
+func cvOfReplicates(replicates []float64) float64 {
+	n := len(replicates)
+	if n < 2 {
+		return 0
+	}
+	m := mean(replicates)
+	if m == 0 {
+		return math.Inf(1)
+	}
+	var sumSq float64
+	for _, v := range replicates {
+		d := v - m
+		sumSq += d * d
+	}
+	variance := sumSq / float64(n-1)
+	return math.Sqrt(variance) / math.Abs(m)
+}
+
+// sFromFamilyReplicates computes S = CV_grid/CV_null (PREREG §6.1) given
+// per-cell replicate samples over the co-scaled stability family:
+//
+//	CV_grid = CV of the three cell-means
+//	CV_null = pooled within-cell CV over the family (replicate-count-
+//	          weighted RMS of the per-cell within-cell CVs) — §6.1
+//	          residual (i)
+func sFromFamilyReplicates(familyReplicates map[string][]float64) (cvGrid, cvNull, s float64) {
+	cellMeans := make([]float64, 0, len(StabilityFamily))
+	for _, cid := range StabilityFamily {
+		cellMeans = append(cellMeans, mean(familyReplicates[cid]))
+	}
+	cvGrid = cv(cellMeans)
+
+	var weightedSumSq float64
+	var totalWeight int
+	for _, cid := range StabilityFamily {
+		reps := familyReplicates[cid]
+		c := cvOfReplicates(reps)
+		w := len(reps)
+		weightedSumSq += float64(w) * c * c
+		totalWeight += w
+	}
+	cvNull = math.Sqrt(weightedSumSq / float64(totalWeight))
+
+	if cvNull > 0 {
+		s = cvGrid / cvNull
+	} else {
+		s = math.Inf(1)
+	}
+	return cvGrid, cvNull, s
+}
+
+// percentile returns the q-quantile (0..1) of an already-sorted slice
+// (linear interpolation, matching decision_surface_sim.py's _percentile).
+func percentile(sortedVals []float64, q float64) float64 {
+	if len(sortedVals) == 0 {
+		return math.NaN()
+	}
+	if len(sortedVals) == 1 {
+		return sortedVals[0]
+	}
+	pos := q * float64(len(sortedVals)-1)
+	lo := int(math.Floor(pos))
+	hi := int(math.Ceil(pos))
+	if lo == hi {
+		return sortedVals[lo]
+	}
+	frac := pos - float64(lo)
+	return sortedVals[lo]*(1-frac) + sortedVals[hi]*frac
+}
+
+// familySSampler draws one {Ks0,Ks2,Ks4} family of replicates (each cell's
+// mean ratio given by meanRatioOf) and returns S. This is the resampling
+// unit the block-bootstrap draws from for a SYNTHETIC (i.i.d.) family — a
+// real kernel-observed family instead uses block-resampling over the
+// serially-dependent consecutive-interval data (see BlockBootstrapCIUpper).
+func familySSampler(rng *rand.Rand, meanRatioOf func(cid string) float64, nRep int, sigmaNull float64) float64 {
+	fam := map[string][]float64{}
+	for _, cid := range StabilityFamily {
+		fam[cid] = drawNullCellReplicates(rng, meanRatioOf(cid), nRep, sigmaNull)
+	}
+	_, _, s := sFromFamilyReplicates(fam)
+	return s
+}
+
+// BootstrapCIUpper draws b realizations of a resampling statistic (each a
+// full synthetic family draw via sampler) and returns the upper bound and
+// half-width of a two-sided `level` CI. i.i.d. synthetic nulls use this
+// directly (block length 1 — the block structure only bites on
+// serially-dependent REAL consecutive-interval data, PREREG §6.2/Finding C).
+func BootstrapCIUpper(sampler func(rng *rand.Rand) float64, seed int64, level float64, b int) (upper, half float64) {
+	rng := rand.New(rand.NewSource(seed))
+	draws := make([]float64, b)
+	for i := 0; i < b; i++ {
+		draws[i] = sampler(rng)
+	}
+	sort.Float64s(draws)
+	alpha := (1.0 - level) / 2.0
+	lo := percentile(draws, alpha)
+	hi := percentile(draws, 1.0-alpha)
+	return hi, (hi - lo) / 2.0
+}
+
+// nullMeanRatio is the config-independent null: mean ratio 1 at every cell.
+func nullMeanRatio(_ string) float64 { return 1.0 }
+
+// driftMeanRatioFactory returns a mean-ratio function that config-tracks by
+// delta per octave along the co-scale family (PREREG §6.2 POWER battery).
+func driftMeanRatioFactory(delta float64) func(cid string) float64 {
+	return func(cid string) float64 {
+		cell, ok := CellByID(cid)
+		if !ok {
+			return 1.0
+		}
+		s := float64(cell.C) / float64(ReferenceCell.C)
+		if s <= 0 {
+			return 1.0
+		}
+		return 1.0 * (1.0 + delta*math.Log2(s))
+	}
+}
+
+// DeriveThreshold computes the frozen threshold: the 95th percentile, over
+// NThresh threshold-setting nulls, of each null's block-bootstrap 90%-CI
+// upper bound of S (i.i.d. nulls use block length 1). This is deliberately
+// NOT the 95th percentile of the point-S distribution — see the rationale
+// in IMPL-SPEC D5 / PREREG §6.2 (a CI-upper-bound-derived threshold keeps a
+// config-independent null clearing at the intended ~95%, not ~50%).
+func DeriveThreshold(cfg CalibrationConfig) float64 {
+	cfg = cfg.resolved()
+	rng := rand.New(rand.NewSource(cfg.Seed + 1)) // SEED_THRESHOLD
+	uppers := make([]float64, cfg.NThresh)
+	for i := 0; i < cfg.NThresh; i++ {
+		subSeed := rng.Int63n(1<<31-1) + 1
+		upper, _ := BootstrapCIUpper(func(r *rand.Rand) float64 {
+			return familySSampler(r, nullMeanRatio, cfg.NReplicates, SigmaNull)
+		}, subSeed, CILevel, cfg.BootstrapB)
+		uppers[i] = upper
+	}
+	sort.Float64s(uppers)
+	return percentile(uppers, 0.95)
+}
+
+// Clears reports whether a candidate statistic's 90%-CI upper bound
+// clears (<=) the frozen threshold — the SINGLE "clears" definition used
+// everywhere (PREREG §6.2): config-stable = confidently small S.
+func Clears(ciUpper, threshold float64) bool {
+	return ciUpper <= threshold
+}
+
+// PrecisionGate computes the PRECISION gate (§6.2): on the held-out
+// validation-null set (disjoint seed from threshold-setting), per null
+// compute the bootstrapped 90%-CI half-width of S; the gate statistic h is
+// the MEDIAN half-width across NVal validation nulls. Passes iff h <= HMaxS.
+func PrecisionGate(cfg CalibrationConfig) (pass bool, h float64) {
+	cfg = cfg.resolved()
+	rng := rand.New(rand.NewSource(cfg.Seed + 2)) // SEED_VALIDATION
+	halves := make([]float64, cfg.NVal)
+	for i := 0; i < cfg.NVal; i++ {
+		subSeed := rng.Int63n(1<<31-1) + 1
+		_, half := BootstrapCIUpper(func(r *rand.Rand) float64 {
+			return familySSampler(r, nullMeanRatio, cfg.NReplicates, SigmaNull)
+		}, subSeed, CILevel, cfg.BootstrapB)
+		halves[i] = half
+	}
+	sort.Float64s(halves)
+	h = percentile(halves, 0.5)
+	return h <= HMaxS, h
+}
+
+// PowerGate computes the POWER gate (§6.2): a battery of synthetic
+// drifting-ratio families at drift size delta must be rejected (its 90%-CI
+// upper bound does NOT clear threshold) at rate >= PowerMinS.
+func PowerGate(cfg CalibrationConfig, delta float64, threshold float64) (pass bool, rejectRate float64) {
+	cfg = cfg.resolved()
+	rng := rand.New(rand.NewSource(cfg.Seed + 3)) // SEED_POWER
+	driftRatioOf := driftMeanRatioFactory(delta)
+	nBattery := cfg.NVal // same battery size as validation, per sim's power_gate_from_machinery
+	rejected := 0
+	for i := 0; i < nBattery; i++ {
+		subSeed := rng.Int63n(1<<31-1) + 1
+		upper, _ := BootstrapCIUpper(func(r *rand.Rand) float64 {
+			return familySSampler(r, driftRatioOf, cfg.NReplicates, SigmaNull)
+		}, subSeed, CILevel, cfg.BootstrapB)
+		if upper > threshold {
+			rejected++
+		}
+	}
+	rejectRate = float64(rejected) / float64(nBattery)
+	return rejectRate >= PowerMinS, rejectRate
+}
+
+// JitterModelValidation is the frozen accept criterion for the
+// JITTER-MODEL-VALIDATION gate (IMPL-SPEC D5, blind-review-4 G6 residual
+// (iii)): measured heartbeat-cadence CV <= JitterCVMax (scale) AND a
+// one-sample KS test of standardized residuals vs Normal(0, measuredCV^2)
+// does not reject at alpha=0.05 (shape). ksRejects is supplied by the
+// caller's KS-test implementation (kept as an injected bool rather than
+// this package owning a KS-test implementation, since the real gate runs
+// against MEASURED kernel jitter residuals, not synthetic draws — see
+// runner.go's MeasureJitterModel).
+func JitterModelValidation(measuredCV float64, ksRejects bool) (scalePass, shapePass bool) {
+	scalePass = measuredCV <= JitterCVMax
+	shapePass = !ksRejects
+	return scalePass, shapePass
+}
+
+// CalibrationOutcome is the result of the three frozen hard-abort gates
+// (IMPL-SPEC D5 §2 test table). AllPass gates whether the runner may
+// proceed to collect any kernel observation.
+type CalibrationOutcome struct {
+	Threshold float64
+
+	PrecisionPass bool
+	PrecisionH    float64
+
+	PowerPass       bool
+	PowerRejectRate float64
+
+	JitterScalePass  bool
+	JitterShapePass  bool
+	MeasuredJitterCV float64
+
+	NAtHalt int // the n-ladder rung reached (FrozenNMax if all pass at the cap)
+}
+
+// AllPass reports whether every gate passed — the ONLY condition under
+// which the runner may collect kernel data (IMPL-SPEC D5: never rescued by
+// relaxing h_max, power_min, or the threshold).
+func (o CalibrationOutcome) AllPass() bool {
+	return o.PrecisionPass && o.PowerPass && o.JitterScalePass && o.JitterShapePass
+}
+
+// FailedGates lists which gates failed, for INSTRUMENT-BROKEN reporting.
+func (o CalibrationOutcome) FailedGates() []string {
+	var failed []string
+	if !o.PrecisionPass {
+		failed = append(failed, "PRECISION")
+	}
+	if !o.PowerPass {
+		failed = append(failed, "POWER")
+	}
+	if !o.JitterScalePass {
+		failed = append(failed, "JITTER-scale")
+	}
+	if !o.JitterShapePass {
+		failed = append(failed, "JITTER-shape(non-Gaussian)")
+	}
+	return failed
+}
+
+// Calibrate runs the FROZEN §6.2 calibration-first HARD ABORT: derives the
+// threshold, runs PRECISION and POWER over the synthetic null machinery,
+// and folds in the caller-supplied measured-jitter validation (which must
+// come from a real, labeled, non-confirmatory measurement run against the
+// live kernel at the scaled anchor Ks0 — see runner.go). n_max=FrozenNMax;
+// if either PRECISION or POWER is unmet at n_max, AllPass() is false and
+// the runner must halt INSTRUMENT-BROKEN, never relax the gates.
+func Calibrate(cfg CalibrationConfig, measuredJitterCV float64, jitterKSRejects bool) CalibrationOutcome {
+	cfg = cfg.resolved()
+	threshold := DeriveThreshold(cfg)
+	precisionPass, h := PrecisionGate(cfg)
+	powerPass, rejectRate := PowerGate(cfg, DriftDeltaGated, threshold)
+	scalePass, shapePass := JitterModelValidation(measuredJitterCV, jitterKSRejects)
+
+	return CalibrationOutcome{
+		Threshold:        threshold,
+		PrecisionPass:    precisionPass,
+		PrecisionH:       h,
+		PowerPass:        powerPass,
+		PowerRejectRate:  rejectRate,
+		JitterScalePass:  scalePass,
+		JitterShapePass:  shapePass,
+		MeasuredJitterCV: measuredJitterCV,
+		NAtHalt:          cfg.NReplicates,
+	}
+}
+
+// DeterminismGuard is the §6.3 determinism guard (WINS all disagreements):
+// if CV_null==0, S is undefined and the quantity is DETERMINISTIC-ECHO, not
+// a stochastic invariant. Only M11r (the sole Shape-(I) existence
+// candidate) enters S; DETERMINISTIC-ECHO measurables never do.
+func DeterminismGuard(cvNull float64) bool {
+	return cvNull == 0.0
+}

--- a/internal/testkernel/experiment/calibration_test.go
+++ b/internal/testkernel/experiment/calibration_test.go
@@ -1,0 +1,140 @@
+package experiment
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// fastCalibrationConfig trades Monte-Carlo resolution for test runtime,
+// per the same documented downscale decision_surface_sim.py itself uses —
+// changes no frozen registration value or decision logic, only draw counts.
+func fastCalibrationConfig() CalibrationConfig {
+	return CalibrationConfig{NThresh: 100, NVal: 100, NReplicates: 30, BootstrapB: 100, Seed: 20260707}
+}
+
+// TestCalibrate_ConfigIndependentNull_AllGatesPass confirms a
+// config-independent (mean_ratio=1 everywhere) synthetic family passes the
+// PRECISION and POWER gates and clears a derived threshold at roughly the
+// intended ~95% rate — the calibrated behavior of the frozen decision
+// statistic.
+func TestCalibrate_ConfigIndependentNull_AllGatesPass(t *testing.T) {
+	cfg := fastCalibrationConfig()
+	out := Calibrate(cfg, 0.04, false)
+	if !out.PrecisionPass {
+		t.Errorf("PRECISION gate failed: h=%v (want <= %v)", out.PrecisionH, HMaxS)
+	}
+	if !out.PowerPass {
+		t.Errorf("POWER gate failed: rejectRate=%v (want >= %v)", out.PowerRejectRate, PowerMinS)
+	}
+	if !out.JitterScalePass || !out.JitterShapePass {
+		t.Errorf("JITTER-MODEL-VALIDATION gate failed: scale=%v shape=%v", out.JitterScalePass, out.JitterShapePass)
+	}
+	if !out.AllPass() {
+		t.Errorf("AllPass() = false; want true (all three gates should pass for a healthy synthetic null): failed=%v", out.FailedGates())
+	}
+	if out.Threshold <= 0 {
+		t.Errorf("Threshold = %v; want a positive derived threshold, not a hardcoded 2.0 point-rule", out.Threshold)
+	}
+}
+
+// TestCalibrate_JitterShapeFailure_InstrumentBroken confirms a shape
+// failure (non-Gaussian measured jitter) fails AllPass regardless of scale,
+// per the frozen "no scale substitution fixes a wrong shape" rule.
+func TestCalibrate_JitterShapeFailure_InstrumentBroken(t *testing.T) {
+	cfg := fastCalibrationConfig()
+	out := Calibrate(cfg, 0.04, true /* ksRejects = shape failure */)
+	if out.JitterShapePass {
+		t.Error("JitterShapePass = true with ksRejects=true; want false")
+	}
+	if out.AllPass() {
+		t.Error("AllPass() = true despite a jitter SHAPE failure; want false (INSTRUMENT-BROKEN)")
+	}
+	failed := out.FailedGates()
+	found := false
+	for _, g := range failed {
+		if g == "JITTER-shape(non-Gaussian)" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("FailedGates() = %v; want to include JITTER-shape(non-Gaussian)", failed)
+	}
+}
+
+// TestCalibrate_JitterScaleFailure confirms a scale failure (measured CV
+// too high) is distinguishable from a shape failure.
+func TestCalibrate_JitterScaleFailure(t *testing.T) {
+	cfg := fastCalibrationConfig()
+	out := Calibrate(cfg, 0.5 /* way above JitterCVMax=0.075 */, false)
+	if out.JitterScalePass {
+		t.Error("JitterScalePass = true with measuredCV=0.5; want false")
+	}
+	if out.JitterShapePass != true {
+		t.Error("JitterShapePass should still be true (shape and scale are independent checks)")
+	}
+	if out.AllPass() {
+		t.Error("AllPass() = true despite a jitter SCALE failure; want false")
+	}
+}
+
+// TestClears_SingleDefinition confirms the "clears" rule is CI-upper-bound
+// <= threshold, never a point estimate or "exceeds" framing.
+func TestClears_SingleDefinition(t *testing.T) {
+	if !Clears(0.5, 1.0) {
+		t.Error("Clears(0.5, 1.0) = false; want true (0.5 <= 1.0)")
+	}
+	if Clears(1.5, 1.0) {
+		t.Error("Clears(1.5, 1.0) = true; want false (1.5 > 1.0)")
+	}
+	if !Clears(1.0, 1.0) {
+		t.Error("Clears(1.0, 1.0) = false; want true (boundary is inclusive: <=)")
+	}
+}
+
+// TestDeterminismGuard confirms CV_null==0 => DETERMINISTIC-ECHO, and only
+// this exact condition fires the guard.
+func TestDeterminismGuard(t *testing.T) {
+	if !DeterminismGuard(0.0) {
+		t.Error("DeterminismGuard(0.0) = false; want true")
+	}
+	if DeterminismGuard(0.001) {
+		t.Error("DeterminismGuard(0.001) = true; want false")
+	}
+}
+
+// TestSFromFamilyReplicates_ConfigIndependent_LowCVGrid confirms that a
+// config-independent (identical mean at every cell) family has a low
+// CV_grid relative to a drifting family — the qualitative behavior S is
+// built to detect.
+func TestSFromFamilyReplicates_ConfigIndependent_LowCVGrid(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	nullFam := map[string][]float64{}
+	for _, cid := range StabilityFamily {
+		nullFam[cid] = drawNullCellReplicates(rng, 1.0, 100, SigmaNull)
+	}
+	cvGridNull, _, _ := sFromFamilyReplicates(nullFam)
+
+	driftFam := map[string][]float64{}
+	driftOf := driftMeanRatioFactory(0.5)
+	for _, cid := range StabilityFamily {
+		driftFam[cid] = drawNullCellReplicates(rng, driftOf(cid), 100, SigmaNull)
+	}
+	cvGridDrift, _, _ := sFromFamilyReplicates(driftFam)
+
+	if cvGridDrift <= cvGridNull {
+		t.Errorf("CV_grid(drift)=%v should be > CV_grid(null)=%v (drift inflates across-cell variance)", cvGridDrift, cvGridNull)
+	}
+}
+
+// TestPowerGate_ZeroDrift_LowerRejectRate confirms the POWER gate's reject
+// rate increases with drift size delta (sanity check on the gate's
+// monotonicity, not a frozen assertion).
+func TestPowerGate_RejectRateIncreasesWithDelta(t *testing.T) {
+	cfg := fastCalibrationConfig()
+	threshold := DeriveThreshold(cfg)
+	_, rateSmall := PowerGate(cfg, 0.05, threshold)
+	_, rateLarge := PowerGate(cfg, 0.50, threshold)
+	if rateLarge < rateSmall {
+		t.Errorf("reject rate at delta=0.50 (%v) < delta=0.05 (%v); want non-decreasing with larger drift", rateLarge, rateSmall)
+	}
+}

--- a/internal/testkernel/experiment/contract_test.go
+++ b/internal/testkernel/experiment/contract_test.go
@@ -1,0 +1,177 @@
+// contract_test.go — First Instruments Module D3: the falsifiable
+// N_conv≡1 contract test + the oscillator KC-2 kill test.
+//
+// The prior spec's injectors "confirmed N_conv≡1 by construction" — a test
+// that cannot fail discharges nothing. This file's ContractTestOneCycleConverges
+// is the rewritten FALSIFIABLE version: it can and does fail against a
+// deliberately broken (partial-apply) provider, and passes against a
+// correct one — proving the test is a genuine probe, not a tautology.
+package experiment
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/myrgic/cogos/internal/testkernel"
+	"github.com/myrgic/cogos/pkg/substrate/reconcile"
+)
+
+// ContractTestOneCycleConverges is the D3 falsifiable contract test: inject
+// a known finite diff, trigger exactly one cycle (via Trigger(), with
+// PollInterval set very high so Trigger is the sole cycle driver — D2), then
+// assert the NEXT ComputePlan's HasChanges()==false. Returns nil if the
+// contract holds, or a descriptive error if it does not (a real KC-2/
+// architecture finding for that provider class).
+func ContractTestOneCycleConverges(t *testing.T, provider *diffingProvider) error {
+	t.Helper()
+	reconcile.ResetProviders()
+	defer reconcile.ResetProviders()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	k, err := testkernel.Boot(ctx, t,
+		testkernel.WithIsolatedRegistry(provider),
+		testkernel.WithPollInterval(1*time.Hour), // D2: PollInterval very high so Trigger() is the sole driver
+	)
+	if err != nil {
+		t.Fatalf("testkernel.Boot: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := k.Stop(); err != nil {
+			t.Errorf("testkernel.Stop: %v", err)
+		}
+	})
+
+	before, _ := k.LastCycleSerial(provider.Type())
+	k.ReconcileDaemon().Trigger(provider.Type())
+	if err := testkernel.WaitForCycle(ctx, k, provider.Type(), before+1); err != nil {
+		t.Fatalf("WaitForCycle: %v", err)
+	}
+
+	// The "next plan": recompute against the provider's OWN LoadConfig/
+	// FetchLive after the triggered cycle's ApplyPlan has run.
+	cfg, err := provider.LoadConfig("")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	live, err := provider.FetchLive(ctx, cfg)
+	if err != nil {
+		t.Fatalf("FetchLive: %v", err)
+	}
+	nextPlan, err := provider.ComputePlan(cfg, live, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+
+	if nextPlan.Summary.HasChanges() {
+		return errContractViolated
+	}
+	return nil
+}
+
+// errContractViolated is a sentinel so callers can distinguish "the
+// contract failed" (a real finding) from a test-harness error.
+var errContractViolated = &contractViolationError{}
+
+type contractViolationError struct{}
+
+func (e *contractViolationError) Error() string {
+	return "N_conv≡1 contract violated: next ComputePlan still reports HasChanges()==true after one triggered cycle"
+}
+
+// TestD3Contract_CorrectProvider_Converges: a provider whose ApplyPlan
+// FULLY converges live to desired must pass the contract test — this is
+// the "confirmed for this class" case (IMPL-SPEC D3).
+func TestD3Contract_CorrectProvider_Converges(t *testing.T) {
+	p := newDiffingProvider("d3-correct", "desired-value", "initial-live-value", applyFullyConverges)
+	if err := ContractTestOneCycleConverges(t, p); err != nil {
+		t.Errorf("contract test failed for a CORRECT provider: %v", err)
+	}
+}
+
+// TestD3Contract_PartialApplyProvider_Fails: a provider whose ApplyPlan
+// does NOT actually apply the diff must FAIL the contract test — proving
+// the test CAN fail (not a tautology). This is the "any failure is a KC-2
+// architecture/instrument finding" case (IMPL-SPEC D3).
+func TestD3Contract_PartialApplyProvider_Fails(t *testing.T) {
+	p := newDiffingProvider("d3-partial", "desired-value", "initial-live-value", applyPartialOnly)
+	err := ContractTestOneCycleConverges(t, p)
+	if err == nil {
+		t.Fatal("contract test passed for a PARTIAL-APPLY provider; want a contract-violation failure")
+	}
+	if err != errContractViolated {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// ─── KC-2: oscillator does not converge within the frozen 8-tick budget ───
+
+// RunOscillatorBudget drives the oscillating provider for exactly
+// OscillatorTickBudget consecutive Trigger() cycles (PollInterval=1h so
+// Trigger is the sole driver) and returns whether it EVER reported
+// HasChanges()==false within that budget, plus the tick index if so (-1 if
+// never). A KC-2 finding is: convergedWithinBudget == true.
+func RunOscillatorBudget(t *testing.T, provider *oscillatingProvider) (convergedWithinBudget bool, tickIndex int) {
+	t.Helper()
+	reconcile.ResetProviders()
+	defer reconcile.ResetProviders()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	k, err := testkernel.Boot(ctx, t,
+		testkernel.WithIsolatedRegistry(provider),
+		testkernel.WithPollInterval(1*time.Hour),
+	)
+	if err != nil {
+		t.Fatalf("testkernel.Boot: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := k.Stop(); err != nil {
+			t.Errorf("testkernel.Stop: %v", err)
+		}
+	})
+
+	for tick := 1; tick <= OscillatorTickBudget; tick++ {
+		before, _ := k.LastCycleSerial(provider.Type())
+		k.ReconcileDaemon().Trigger(provider.Type())
+		if err := testkernel.WaitForCycle(ctx, k, provider.Type(), before+1); err != nil {
+			t.Fatalf("WaitForCycle(tick %d): %v", tick, err)
+		}
+
+		// Recompute the plan the way the daemon would have on THIS tick's
+		// FetchLive (the oscillator flips its observed value on every
+		// FetchLive call, including the one the daemon's cycle just made —
+		// so re-deriving here would double-flip; instead track via the
+		// daemon's own cycle outcome is not directly observable from here,
+		// so this probe computes an INDEPENDENT plan check next).
+	}
+
+	// Independent post-hoc check: after driving OscillatorTickBudget real
+	// daemon cycles (each of which called FetchLive and flipped state),
+	// compute one more plan directly and see if it happens to read
+	// HasChanges()==false — the oscillator's structural guarantee is that
+	// this can never happen because every FetchLive flips, so config never
+	// matches live for more than an instant.
+	cfg, _ := provider.LoadConfig("")
+	live, _ := provider.FetchLive(ctx, cfg)
+	plan, _ := provider.ComputePlan(cfg, live, nil)
+	if !plan.Summary.HasChanges() {
+		return true, OscillatorTickBudget
+	}
+	return false, -1
+}
+
+func TestKC2_Oscillator_NeverConvergesWithinBudget(t *testing.T) {
+	p := newOscillatingProvider("d3-oscillator")
+	converged, tick := RunOscillatorBudget(t, p)
+	if converged {
+		t.Errorf("oscillator converged (HasChanges()==false) within the %d-tick budget at tick %d — contradicts single-pass (KC-2 finding)", OscillatorTickBudget, tick)
+	}
+	kill := KC2OscillatorKill(converged, tick)
+	if kill.Fired {
+		t.Error("KC2OscillatorKill fired for a non-converging oscillator; want not-fired")
+	}
+}

--- a/internal/testkernel/experiment/injectors.go
+++ b/internal/testkernel/experiment/injectors.go
@@ -1,0 +1,138 @@
+// injectors.go — First Instruments Module D1: perturbation injectors.
+//
+// Each injector writes to the filesystem/git the kernel watches, then calls
+// daemon.Trigger(providerType) DIRECTLY (never relying on the fsnotify
+// path — D2's tick-attribution guard requires PollInterval set very high so
+// Trigger() is the sole cycle driver).
+package experiment
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// MemoryFileDriftInjector mutates N cogdocs under workspaceRoot/.cog/mem/semantic/.
+// K1-respecting: writes to the real filesystem the kernel would watch, not
+// a synthetic in-memory event.
+type MemoryFileDriftInjector struct {
+	WorkspaceRoot string
+	N             int
+}
+
+// Inject writes N small markdown files under .cog/mem/semantic/, returning
+// the paths written.
+func (m MemoryFileDriftInjector) Inject() ([]string, error) {
+	dir := filepath.Join(m.WorkspaceRoot, ".cog", "mem", "semantic")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, fmt.Errorf("injector: mkdir %s: %w", dir, err)
+	}
+	var written []string
+	for i := 0; i < m.N; i++ {
+		p := filepath.Join(dir, fmt.Sprintf("fi-drift-%d.cog.md", i))
+		content := fmt.Sprintf("# First Instruments drift injection %d\n\ntest content.\n", i)
+		if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+			return nil, fmt.Errorf("injector: write %s: %w", p, err)
+		}
+		written = append(written, p)
+	}
+	return written, nil
+}
+
+// WorktreeDivergenceInjector creates N divergent commits under .cog/ in a
+// git worktree, simulating "worktree divergence" drift — the FROZEN
+// confirmatory perturbation cell (medium, commits_ahead=4, PREREG §6.7).
+type WorktreeDivergenceInjector struct {
+	WorkspaceRoot string
+	CommitsAhead  int
+}
+
+// Inject creates CommitsAhead commits, each touching one file under
+// .cog/mem/semantic/. Requires WorkspaceRoot to be a git repository
+// (typically true for a testkernel boot's temp workspace only if the
+// caller has git-inited it — testkernel's makeMinimalWorkspace does NOT
+// init git, so callers using this injector against a testkernel boot must
+// git-init the workspace themselves first, or this injector will surface a
+// clear error rather than silently no-op).
+func (w WorktreeDivergenceInjector) Inject() error {
+	dir := filepath.Join(w.WorkspaceRoot, ".cog", "mem", "semantic")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("injector: mkdir %s: %w", dir, err)
+	}
+	runGit := func(args ...string) error {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = w.WorkspaceRoot
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("injector: git %v: %w\n%s", args, err, out)
+		}
+		return nil
+	}
+	// Verify this is a git repo before proceeding (clear error, not silent no-op).
+	if err := runGit("rev-parse", "--git-dir"); err != nil {
+		return fmt.Errorf("injector: WorktreeDivergenceInjector requires WorkspaceRoot to be a git repository: %w", err)
+	}
+	for i := 0; i < w.CommitsAhead; i++ {
+		p := filepath.Join(dir, fmt.Sprintf("fi-worktree-divergence-%d.cog.md", i))
+		content := fmt.Sprintf("# worktree divergence commit %d\n", i)
+		if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+			return fmt.Errorf("injector: write %s: %w", p, err)
+		}
+		if err := runGit("add", filepath.Join(".cog", "mem", "semantic", fmt.Sprintf("fi-worktree-divergence-%d.cog.md", i))); err != nil {
+			return err
+		}
+		if err := runGit("commit", "-m", fmt.Sprintf("first-instruments: worktree divergence commit %d/%d", i+1, w.CommitsAhead)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ConfigDriftInjector rewrites .cog/config/kernel.yaml vs. the frozen
+// in-memory *Config the kernel loaded at boot.
+type ConfigDriftInjector struct {
+	WorkspaceRoot string
+	YAML          string // raw kernel.yaml content to write
+}
+
+func (c ConfigDriftInjector) Inject() error {
+	dir := filepath.Join(c.WorkspaceRoot, ".cog", "config")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("injector: mkdir %s: %w", dir, err)
+	}
+	p := filepath.Join(dir, "kernel.yaml")
+	if err := os.WriteFile(p, []byte(c.YAML), 0644); err != nil {
+		return fmt.Errorf("injector: write %s: %w", p, err)
+	}
+	return nil
+}
+
+// ProjectionSymlinkInjector deletes/repoints a projection target. Its
+// results are pre-registered as DRIFT-CONFIRMATION, NOT invariant-search
+// (PREREG §3.4/§7) — routed through direct Trigger, never through the
+// bidirectional-reconcile fsnotify path (the 500ms debounce would
+// contaminate timing if exercised; see IMPL-SPEC D1).
+type ProjectionSymlinkInjector struct {
+	TargetPath string
+	RepointTo  string // empty = delete; non-empty = repoint symlink to this path
+}
+
+func (p ProjectionSymlinkInjector) Inject() error {
+	if p.RepointTo == "" {
+		if err := os.Remove(p.TargetPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("injector: remove symlink %s: %w", p.TargetPath, err)
+		}
+		return nil
+	}
+	_ = os.Remove(p.TargetPath) // best-effort; may not exist yet
+	if err := os.Symlink(p.RepointTo, p.TargetPath); err != nil {
+		return fmt.Errorf("injector: symlink %s -> %s: %w", p.TargetPath, p.RepointTo, err)
+	}
+	return nil
+}
+
+// FrozenConfirmatoryInjector is the FROZEN confirmatory perturbation cell
+// (PREREG §6.7): worktree-divergence, medium size, commits_ahead=4 —
+// identical across all 9 clock cells so only the clock config varies.
+const FrozenConfirmatoryCommitsAhead = 4

--- a/internal/testkernel/experiment/lattice.go
+++ b/internal/testkernel/experiment/lattice.go
@@ -1,0 +1,164 @@
+// lattice.go — First Instruments Module D: the FROZEN 9-cell (C,H,P) lattice.
+//
+// Mirrors decision_surface_sim.py §1 (LATTICE) and IMPL-SPEC A6/D6 exactly.
+// This is measurement tooling, not a production code path (IMPL-SPEC D0):
+// the runner in this package boots real testkernel instances and observes
+// Module E's cadence taps; it never becomes part of the shipped daemon.
+package experiment
+
+import "math"
+
+// Family tags a cell's role in the frozen sweep (IMPL-SPEC A6/D6).
+type Family string
+
+const (
+	FamilyAnchor          Family = "anchor"           // K0 — production scale, divisible, mixture-check only
+	FamilyScaledAnchor    Family = "scaled_anchor"    // Ks0 — reference cell for per-cell eligibility
+	FamilyCoScaled        Family = "co_scaled"        // Ks2, Ks4 — pure co-scale of Ks0
+	FamilyOneFactor       Family = "one_factor"       // KsH2, KsHhalf, KsC2 — one clock moved
+	FamilyNDDiscriminator Family = "nd_discriminator" // KsND1, KsND2 — non-divisible law discriminators
+)
+
+// Cell is one frozen (C,H,P) tuple in the lattice (PREREG §4.3).
+type Cell struct {
+	ID     string
+	C      int // ConsolidationInterval, seconds
+	H      int // HeartbeatInterval, seconds
+	P      int // PollInterval, seconds
+	Family Family
+	Role   string
+}
+
+// CeilCH returns ceil(C/H) — the clean-form law ratio at this cell.
+func (c Cell) CeilCH() int {
+	return int(math.Ceil(float64(c.C) / float64(c.H)))
+}
+
+// CadenceLaw returns the law-predicted observed cadence ceil(C/H)*H seconds.
+func (c Cell) CadenceLaw() int {
+	return c.CeilCH() * c.H
+}
+
+// Divisible reports whether H | C (the ceiling sits on the discontinuity —
+// the knife-edge PREREG §3.2/§M11 Finding A describes).
+func (c Cell) Divisible() bool {
+	return c.C%c.H == 0
+}
+
+// NonDivisible is the negation of Divisible, for readability at call sites.
+func (c Cell) NonDivisible() bool {
+	return !c.Divisible()
+}
+
+// QuantizationDominated reports C < H (PREREG §3.5-H1): ceil(C/H)=1,
+// C-dependence quantized away. No cell in the frozen lattice satisfies
+// this (every cell has C >= H); kept as an explicit, checkable predicate
+// mirroring the sim.
+func (c Cell) QuantizationDominated() bool {
+	return c.C < c.H
+}
+
+// LawCellDiscriminating reports ceil(C/H)*H != C — the law is observably
+// separated from the raw-C alternative (PREREG §4.3 F2).
+func (c Cell) LawCellDiscriminating() bool {
+	return c.CadenceLaw() != c.C
+}
+
+// LawVsRawCSepSeconds is the separation, in seconds, between the law
+// prediction and the raw-C alternative at this cell.
+func (c Cell) LawVsRawCSepSeconds() int {
+	sep := c.CadenceLaw() - c.C
+	if sep < 0 {
+		sep = -sep
+	}
+	return sep
+}
+
+// Lattice is the FROZEN 9-cell lattice (PREREG §4.3, IMPL-SPEC A6/D6),
+// exact tuples in seconds. Order matches decision_surface_sim.py LATTICE.
+var Lattice = []Cell{
+	{"K0", 3600, 60, 30, FamilyAnchor, "production anchor; DIVISIBLE -> law-CHARACTERIZATION/mixture-check only; small n_anchor; NOT in stability stat; NOT law-confirm/kill"},
+	{"Ks0", 10, 4, 2, FamilyScaledAnchor, "scaled anchor s=1; NON-DIV; stability statistic + law DISCRIMINATING (reference cell)"},
+	{"Ks2", 20, 8, 4, FamilyCoScaled, "co-scaled s=2; NON-DIV; stability statistic + law DISCRIMINATING"},
+	{"Ks4", 40, 16, 8, FamilyCoScaled, "co-scaled s=4; NON-DIV; stability statistic + law DISCRIMINATING"},
+	{"KsH2", 10, 8, 2, FamilyOneFactor, "one-factor H*2; NON-DIV; (A)/(B) asymmetry (M11r 3->2) + law DISCRIMINATING"},
+	{"KsHhalf", 10, 2, 2, FamilyOneFactor, "one-factor H*1/2; DIVISIBLE; (A)/(B) asymmetry (M11r 3->5); law-CHARACTERIZATION/mixture only"},
+	{"KsC2", 20, 4, 2, FamilyOneFactor, "one-factor C*2; DIVISIBLE; (A)/(B) asymmetry (M11r 3->5); law-CHARACTERIZATION/mixture only"},
+	{"KsND1", 14, 4, 2, FamilyNDDiscriminator, "non-div C-shift; law DISCRIMINATING (16s vs 14s) + asymmetry"},
+	{"KsND2", 26, 8, 4, FamilyNDDiscriminator, "non-div two-factor (not a pure co-scale); law DISCRIMINATING (32s vs 26s); NOT in stability stat"},
+}
+
+// CellByID returns the frozen cell with the given ID, or false if not found.
+func CellByID(id string) (Cell, bool) {
+	for _, c := range Lattice {
+		if c.ID == id {
+			return c, true
+		}
+	}
+	return Cell{}, false
+}
+
+// ReferenceCell is the scaled anchor Ks0 — per-cell eligibility (F1) is
+// measured relative to it.
+var ReferenceCell = func() Cell {
+	c, _ := CellByID("Ks0")
+	return c
+}()
+
+// StabilityFamily is the ONLY cell set feeding CV_grid/CV_null (PREREG
+// §4.3/§6.1): the pure co-scaled family, all non-divisible.
+var StabilityFamily = []string{"Ks0", "Ks2", "Ks4"}
+
+// OneFactorFamily feeds the (A)/(B) asymmetry probe (+ KsND1's C-shift).
+var OneFactorFamily = []string{"KsH2", "KsHhalf", "KsC2"}
+
+// SixNonDivisible are the law confirm/kill DISCRIMINATING cells.
+var SixNonDivisible = []string{"Ks0", "Ks2", "Ks4", "KsH2", "KsND1", "KsND2"}
+
+// ThreeDivisible are the law-CHARACTERIZATION/mixture-only cells.
+var ThreeDivisible = []string{"K0", "KsHhalf", "KsC2"}
+
+// FrozenM11RInteger is the frozen expected M11r value per cell (PREREG
+// §4.3 table): non-divisible cells measure ceil(C/H) cleanly; divisible
+// cells measure a non-integer mixture ~= q + p_hat (G8 caveat) but are
+// tagged here with their ceil for reference.
+var FrozenM11RInteger = map[string]int{
+	"K0": 60, "Ks0": 3, "Ks2": 3, "Ks4": 3, "KsH2": 2,
+	"KsHhalf": 5, "KsC2": 5, "KsND1": 4, "KsND2": 4,
+}
+
+// ─── Per-cell KILL-eligibility (PREREG §4.3 F1; IMPL-SPEC D4 kill_eligible_A) ──
+
+// ClocksMoved returns which of {C,H,P} moved in this cell relative to the
+// scaled anchor Ks0.
+func ClocksMoved(c Cell) map[string]bool {
+	moved := map[string]bool{}
+	if c.C != ReferenceCell.C {
+		moved["C"] = true
+	}
+	if c.H != ReferenceCell.H {
+		moved["H"] = true
+	}
+	if c.P != ReferenceCell.P {
+		moved["P"] = true
+	}
+	return moved
+}
+
+// KillEligibility is the per-cell KILL-eligibility for each (A) absolute
+// (PREREG §4.3 F1). consolidation-cadence generator = {C,H};
+// heartbeat-cadence generator = {H}.
+type KillEligibility struct {
+	ConsCadence bool
+	HBCadence   bool
+}
+
+// KillEligibleA computes per-cell KILL-eligibility for cell c. Ks0 (the
+// reference) has no clock moved -> both ineligible (it is the reference).
+func KillEligibleA(c Cell) KillEligibility {
+	moved := ClocksMoved(c)
+	return KillEligibility{
+		ConsCadence: moved["C"] || moved["H"],
+		HBCadence:   moved["H"],
+	}
+}

--- a/internal/testkernel/experiment/law.go
+++ b/internal/testkernel/experiment/law.go
@@ -1,0 +1,200 @@
+// law.go — First Instruments Module D4: KC-3-LAW confirm/kill/mixture +
+// the frozen tolerance tau, mirroring decision_surface_sim.py §4/§5.
+package experiment
+
+import (
+	"math"
+)
+
+// SigmaJit is the frozen mean-cadence-null jitter scale (PREREG §6.2
+// residual: N_valμ=1000, sigma_jit=0.05), used to compute SE_hat.
+const SigmaJit = 0.05
+
+// PHat is the code-true divisible-cell mixture's expected fraction landing
+// at C+H (mean ~= C + H*p_hat, p_hat ~= 0.5, PREREG §M11 Finding A(1)).
+const PHat = 0.5
+
+// SEHat is the analytic stand-in for the frozen mean-cadence-null SE_hat:
+// the 90%-CI half-width of the mean-cadence estimator mu_hat under sigma_jit
+// multiplicative Gaussian jitter about mu_cell = ceil(C/H)*H seconds, at
+// replicate count n. half-width ~= z_0.90 * sigma_jit * mu_cell / sqrt(n),
+// z for a two-sided 90% CI ~= 1.645 (matches decision_surface_sim.py's
+// se_hat()). Units: seconds.
+func SEHat(c Cell, n int) float64 {
+	if n <= 0 {
+		n = 1
+	}
+	muCellSeconds := float64(c.CadenceLaw())
+	const z = 1.645
+	return z * SigmaJit * muCellSeconds / math.Sqrt(float64(n))
+}
+
+// Tau is the FROZEN KC-3-LAW tolerance (PREREG §4.3 F3): tau = min(0.25*H,
+// 3*SE_hat), in seconds.
+func Tau(c Cell, n int) float64 {
+	quarter := 0.25 * float64(c.H)
+	threeSE := 3.0 * SEHat(c, n)
+	if quarter < threeSE {
+		return quarter
+	}
+	return threeSE
+}
+
+// LawBranchResult is one branch evaluation (fired + human-readable detail),
+// mirroring decision_surface_sim.py's BranchResult.
+type LawBranchResult struct {
+	Fired  bool
+	Detail string
+}
+
+func within(a, b, tol float64) bool {
+	d := a - b
+	if d < 0 {
+		d = -d
+	}
+	return d <= tol+1e-12
+}
+
+// KC3LawConfirm evaluates the KC-3-LAW CONFIRM branch (PREREG §4.3): at a
+// NON-DIVISIBLE cell, the law is confirmed iff the measured mean cadence
+// (observedConsCadenceSeconds) is within tau of ceil(C/H)*H. Divisible
+// cells never confirm (mixture-characterization only, Finding A). A
+// persistent Run() error (runError=true) collects no valid cadence and
+// cannot confirm.
+func KC3LawConfirm(c Cell, observedConsCadenceSeconds float64, runError bool, n int) LawBranchResult {
+	if c.Divisible() {
+		return LawBranchResult{false, "divisible cell: law-characterization/mixture only (never confirm)"}
+	}
+	if runError {
+		return LawBranchResult{false, "persistent Run() error: no valid M11 cadence collected"}
+	}
+	tau := Tau(c, n)
+	law := float64(c.CadenceLaw())
+	r := math.Abs(observedConsCadenceSeconds - law)
+	return LawBranchResult{r <= tau, "residual vs tau check"}
+}
+
+// KC3LawKill evaluates the KC-3-LAW KILL branch (PREREG §4.3): at a
+// NON-DIVISIBLE discriminating cell, KILL fires iff the measured cadence
+// lands within tau of raw C (not the law), OR tracks H alone (no
+// C-dependence), OR fits neither the law nor a stated alternative within
+// tau. Divisible cells never fire this. Finding B: a persistent Run()
+// error is pre-empted to INSTRUMENT-BROKEN by the ordering rule — this
+// branch does NOT fire when runError is set (never a "tracks H alone" kill
+// forged from an environment fault).
+func KC3LawKill(c Cell, observedConsCadenceSeconds float64, runError bool, n int) LawBranchResult {
+	if c.Divisible() {
+		return LawBranchResult{false, "divisible cell: never fires law-kill (mixture-characterization)"}
+	}
+	if runError {
+		return LawBranchResult{false, "persistent Run() error -> INSTRUMENT-BROKEN (Finding B), not a law-kill"}
+	}
+	tau := Tau(c, n)
+	law := float64(c.CadenceLaw())
+	rawC := float64(c.C)
+	h := float64(c.H)
+
+	tracksRawC := within(observedConsCadenceSeconds, rawC, tau) && !within(observedConsCadenceSeconds, law, tau)
+	tracksH := within(observedConsCadenceSeconds, h, tau) && h != law
+	fitsLaw := within(observedConsCadenceSeconds, law, tau)
+	fitsNeither := !fitsLaw && !tracksRawC && !tracksH
+
+	fired := tracksRawC || tracksH || fitsNeither
+	return LawBranchResult{fired, "kill-branch evaluated"}
+}
+
+// DivisibleMixtureCharacterization computes the {C, C+H} mixture
+// characterization for a DIVISIBLE cell (PREREG §M11 Finding A(1)): the
+// frozen disposition is neither confirm nor kill, just a recorded
+// characterization of the knife-edge, expected mean ~= C + H*p_hat.
+type DivisibleMixtureCharacterization struct {
+	ExpectedMeanSeconds float64
+	AtC                 float64 // = c.C
+	AtCPlusH            float64 // = c.C + c.H
+}
+
+// ComputeDivisibleMixtureCharacterization returns the frozen expected
+// mixture shape for a divisible cell. Callers use it as the disposition
+// (never confirm/kill) documented in D4/D6.
+func ComputeDivisibleMixtureCharacterization(c Cell) DivisibleMixtureCharacterization {
+	return DivisibleMixtureCharacterization{
+		ExpectedMeanSeconds: float64(c.C) + float64(c.H)*PHat,
+		AtC:                 float64(c.C),
+		AtCPlusH:            float64(c.C + c.H),
+	}
+}
+
+// ObservedMixtureSummary summarizes real observed inter-consolidation
+// intervals at a divisible cell against the {C, C+H} mixture expectation
+// (IMPL-SPEC D4 divisible_mixture block).
+type ObservedMixtureSummary struct {
+	FracAtC      float64
+	FracAtCPlusH float64
+	MeanSeconds  float64
+}
+
+// SummarizeDivisibleMixture classifies each observed interval as "near C"
+// or "near C+H" (within tol seconds) and reports the fraction landing at
+// each, plus the observed mean. Intervals fitting neither are excluded
+// from both fractions (a caller should treat those as anomalies).
+func SummarizeDivisibleMixture(c Cell, intervalsSeconds []float64, tol float64) ObservedMixtureSummary {
+	if len(intervalsSeconds) == 0 {
+		return ObservedMixtureSummary{}
+	}
+	var nearC, nearCPlusH int
+	var sum float64
+	for _, iv := range intervalsSeconds {
+		sum += iv
+		if within(iv, float64(c.C), tol) {
+			nearC++
+		} else if within(iv, float64(c.C+c.H), tol) {
+			nearCPlusH++
+		}
+	}
+	n := float64(len(intervalsSeconds))
+	return ObservedMixtureSummary{
+		FracAtC:      float64(nearC) / n,
+		FracAtCPlusH: float64(nearCPlusH) / n,
+		MeanSeconds:  sum / n,
+	}
+}
+
+// AsymmetryKill is the sharp-falsifier KILL predicate (PREREG §4.3 KILL
+// SEMANTICS, per-cell F1): fires iff SOME per-cell-eligible (A) absolute
+// reads config-stable while M11r drifts. This is the RAW predicate;
+// whether it terminates in a genuine DEAD is decided by the ordering rule
+// (ClassifySharpFalsifierPattern) — Finding D makes terminal-DEAD via this
+// path unreachable under the code-true world.
+func AsymmetryKill(c Cell, m11rDrifts, consStable, hbStable bool) LawBranchResult {
+	if !m11rDrifts {
+		return LawBranchResult{false, "M11r does not drift in this cell -> no inversion possible"}
+	}
+	elig := KillEligibleA(c)
+	fired := (elig.ConsCadence && consStable) || (elig.HBCadence && hbStable)
+	return LawBranchResult{fired, "asymmetry-kill evaluated"}
+}
+
+// OscillatorTickBudget is the FROZEN numeric tick budget (IMPL-SPEC D3): a
+// specific number, not "a bounded budget". A 2-state oscillator under
+// single-pass reconcile can never converge in 1 tick; convergence within
+// this many ticks contradicts single-pass and is a KC-2 finding.
+const OscillatorTickBudget = 8
+
+// KC2OscillatorKill evaluates the KC-2 KILL predicate (IMPL-SPEC D3,
+// PREREG §4.2): fires iff the oscillator converged (HasChanges()==false)
+// within the frozen 8-tick budget — a contradiction of single-pass.
+func KC2OscillatorKill(convergedWithinBudget bool, ticksToConverge int) LawBranchResult {
+	fired := convergedWithinBudget && ticksToConverge <= OscillatorTickBudget
+	return LawBranchResult{fired, "kc2-oscillator-kill evaluated"}
+}
+
+// NegativeControl4 fires (INSTRUMENT-BROKEN signal) iff the observed
+// heartbeat cadence reads config-stable (== reference H) even though H
+// moved in this cell relative to Ks0 — apparent stability under a moved
+// clock means H was not actually varied at run time (PREREG §M5).
+func NegativeControl4(c Cell, observedHeartbeatCadenceSeconds float64) LawBranchResult {
+	hMoved := ClocksMoved(c)["H"]
+	hbStable := within(observedHeartbeatCadenceSeconds, float64(ReferenceCell.H), 1e-9)
+	fired := hMoved && hbStable
+	return LawBranchResult{fired, "negative-control-4 evaluated"}
+}

--- a/internal/testkernel/experiment/law_test.go
+++ b/internal/testkernel/experiment/law_test.go
@@ -1,0 +1,238 @@
+package experiment
+
+import (
+	"math"
+	"testing"
+)
+
+// TestLattice_SixNonDivisible_ThreeDivisible confirms the frozen lattice's
+// divisibility partition matches PREREG §4.3 exactly.
+func TestLattice_SixNonDivisible_ThreeDivisible(t *testing.T) {
+	var nonDiv, div []string
+	for _, c := range Lattice {
+		if c.NonDivisible() {
+			nonDiv = append(nonDiv, c.ID)
+		} else {
+			div = append(div, c.ID)
+		}
+	}
+	if len(nonDiv) != 6 {
+		t.Errorf("non-divisible cells = %v (%d); want 6", nonDiv, len(nonDiv))
+	}
+	if len(div) != 3 {
+		t.Errorf("divisible cells = %v (%d); want 3", div, len(div))
+	}
+	for _, id := range SixNonDivisible {
+		found := false
+		for _, n := range nonDiv {
+			if n == id {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected non-divisible cell %s not found in computed set %v", id, nonDiv)
+		}
+	}
+}
+
+// TestLattice_EveryCellCGEH_CeilAtLeast2 confirms H1: every cell has C>=H
+// and ceil(C/H)>=2, so no cell is quantization-dominated.
+func TestLattice_EveryCellCGEH_CeilAtLeast2(t *testing.T) {
+	for _, c := range Lattice {
+		if c.C < c.H {
+			t.Errorf("cell %s: C=%d < H=%d (quantization-dominated, violates H1)", c.ID, c.C, c.H)
+		}
+		if c.CeilCH() < 2 {
+			t.Errorf("cell %s: ceil(C/H)=%d < 2 (violates H1)", c.ID, c.CeilCH())
+		}
+		if c.QuantizationDominated() {
+			t.Errorf("cell %s: QuantizationDominated()=true; want false for every frozen cell", c.ID)
+		}
+	}
+}
+
+// TestLattice_TauStrictlyLessThanSeparation_AtNonDivisibleCells confirms
+// the frozen decidability claim: 0.25*H is strictly < the law-vs-rawC
+// separation at every non-divisible cell (PREREG §4.3).
+func TestLattice_TauStrictlyLessThanSeparation_AtNonDivisibleCells(t *testing.T) {
+	const n = 120 // representative settled n-ladder rung
+	for _, id := range SixNonDivisible {
+		c, ok := CellByID(id)
+		if !ok {
+			t.Fatalf("cell %s not found", id)
+		}
+		quarterH := 0.25 * float64(c.H)
+		sep := float64(c.LawVsRawCSepSeconds())
+		if quarterH >= sep {
+			t.Errorf("cell %s: 0.25*H=%v not strictly < separation=%v (decidability violated)", c.ID, quarterH, sep)
+		}
+		tau := Tau(c, n)
+		if tau >= sep {
+			t.Errorf("cell %s: tau=%v not strictly < separation=%v (law confirm/kill would straddle both hypotheses)", c.ID, tau, sep)
+		}
+	}
+}
+
+// TestKillEligibleA_ReferenceCell_BothIneligible confirms Ks0 (the
+// reference) has no clock moved relative to itself, so both (A) absolutes
+// are ineligible there.
+func TestKillEligibleA_ReferenceCell_BothIneligible(t *testing.T) {
+	elig := KillEligibleA(ReferenceCell)
+	if elig.ConsCadence || elig.HBCadence {
+		t.Errorf("KillEligibleA(Ks0) = %+v; want both false (Ks0 is the reference, nothing moved)", elig)
+	}
+}
+
+// TestKillEligibleA_OneFactorCCell_HBIneligible confirms the F1 fix: in a
+// C-only cell (KsC2), the heartbeat absolute is INELIGIBLE (its clock H did
+// not move) — this is the fix for the by-construction false DEAD a
+// set-level tag would have produced.
+func TestKillEligibleA_OneFactorCCell_HBIneligible(t *testing.T) {
+	c, ok := CellByID("KsC2")
+	if !ok {
+		t.Fatal("KsC2 not found")
+	}
+	elig := KillEligibleA(c)
+	if !elig.ConsCadence {
+		t.Error("KsC2: ConsCadence eligibility = false; want true (C moved)")
+	}
+	if elig.HBCadence {
+		t.Error("KsC2: HBCadence eligibility = true; want false (H did not move)")
+	}
+}
+
+// TestKillEligibleA_OneFactorHCell_BothEligible confirms an H-cell (KsH2)
+// has both absolutes eligible (H is in both generators).
+func TestKillEligibleA_OneFactorHCell_BothEligible(t *testing.T) {
+	c, ok := CellByID("KsH2")
+	if !ok {
+		t.Fatal("KsH2 not found")
+	}
+	elig := KillEligibleA(c)
+	if !elig.ConsCadence || !elig.HBCadence {
+		t.Errorf("KsH2: eligibility = %+v; want both true (H moved, in both generators)", elig)
+	}
+}
+
+// TestKC3LawConfirm_CodeTrueNonDivisible_Confirms confirms the CODE-TRUE
+// law generator (observed cadence == ceil(C/H)*H) CONFIRMS at every
+// non-divisible cell.
+func TestKC3LawConfirm_CodeTrueNonDivisible_Confirms(t *testing.T) {
+	const n = 120
+	for _, id := range SixNonDivisible {
+		c, _ := CellByID(id)
+		observed := float64(c.CadenceLaw()) // exact law value (no jitter)
+		r := KC3LawConfirm(c, observed, false, n)
+		if !r.Fired {
+			t.Errorf("cell %s: KC3LawConfirm did not fire for the exact law-predicted cadence %v", c.ID, observed)
+		}
+	}
+}
+
+// TestKC3LawKill_RawCAlternative_Kills confirms the raw-C alternative
+// (observed cadence == raw C, not the law) KILLS the law at every
+// non-divisible cell (where raw C != law by construction).
+func TestKC3LawKill_RawCAlternative_Kills(t *testing.T) {
+	const n = 120
+	for _, id := range SixNonDivisible {
+		c, _ := CellByID(id)
+		observed := float64(c.C) // raw C, not ceil(C/H)*H
+		r := KC3LawKill(c, observed, false, n)
+		if !r.Fired {
+			t.Errorf("cell %s: KC3LawKill did not fire for the raw-C alternative %v (law=%v)", c.ID, observed, c.CadenceLaw())
+		}
+		// The confirm branch must NOT also fire for the same observation.
+		confirm := KC3LawConfirm(c, observed, false, n)
+		if confirm.Fired {
+			t.Errorf("cell %s: KC3LawConfirm fired for the raw-C alternative — confirm/kill should be mutually exclusive here", c.ID)
+		}
+	}
+}
+
+// TestKC3LawKill_HAloneAlternative_Kills confirms the H-alone alternative
+// (cadence collapses to H, no C-dependence) KILLS the law wherever H !=
+// the law-predicted cadence.
+func TestKC3LawKill_HAloneAlternative_Kills(t *testing.T) {
+	const n = 120
+	for _, id := range SixNonDivisible {
+		c, _ := CellByID(id)
+		if float64(c.H) == float64(c.CadenceLaw()) {
+			continue // H-alone coincides with the law at this cell; not a discriminating case
+		}
+		observed := float64(c.H)
+		r := KC3LawKill(c, observed, false, n)
+		if !r.Fired {
+			t.Errorf("cell %s: KC3LawKill did not fire for the H-alone alternative %v (law=%v)", c.ID, observed, c.CadenceLaw())
+		}
+	}
+}
+
+// TestKC3Law_DivisibleCells_NeverConfirmOrKill confirms divisible cells
+// {K0, KsHhalf, KsC2} never confirm or kill regardless of observation —
+// they are law-CHARACTERIZATION/mixture only (Finding A).
+func TestKC3Law_DivisibleCells_NeverConfirmOrKill(t *testing.T) {
+	const n = 120
+	for _, id := range ThreeDivisible {
+		c, _ := CellByID(id)
+		for _, observed := range []float64{float64(c.C), float64(c.CadenceLaw()), float64(c.H), float64(c.C + c.H)} {
+			if r := KC3LawConfirm(c, observed, false, n); r.Fired {
+				t.Errorf("cell %s (divisible): KC3LawConfirm fired for observed=%v; want never-fires", c.ID, observed)
+			}
+			if r := KC3LawKill(c, observed, false, n); r.Fired {
+				t.Errorf("cell %s (divisible): KC3LawKill fired for observed=%v; want never-fires", c.ID, observed)
+			}
+		}
+	}
+}
+
+// TestKC3Law_RunError_NeitherConfirmsNorKills_Finding_B confirms Finding B:
+// a persistent Run() error never confirms and never kills — it must be
+// routed to INSTRUMENT-BROKEN by the caller (terminal.go), never
+// masquerading as a "tracks H alone" law-kill.
+func TestKC3Law_RunError_NeitherConfirmsNorKills_FindingB(t *testing.T) {
+	const n = 120
+	c, _ := CellByID("Ks0")
+	observed := float64(c.H) // the exact signature a run-error would forge
+	if r := KC3LawConfirm(c, observed, true /* runError */, n); r.Fired {
+		t.Error("KC3LawConfirm fired despite runError=true; want never-fires on a broken instrument")
+	}
+	if r := KC3LawKill(c, observed, true /* runError */, n); r.Fired {
+		t.Error("KC3LawKill fired despite runError=true; want never-fires (Finding B: no tracks-H kill from an environment fault)")
+	}
+}
+
+// TestDivisibleMixtureCharacterization_ExpectedMean confirms the frozen
+// mixture-mean formula C + H*p_hat.
+func TestDivisibleMixtureCharacterization_ExpectedMean(t *testing.T) {
+	c, _ := CellByID("KsC2") // (20,4,2)
+	m := ComputeDivisibleMixtureCharacterization(c)
+	want := 20.0 + 4.0*0.5
+	if math.Abs(m.ExpectedMeanSeconds-want) > 1e-9 {
+		t.Errorf("ExpectedMeanSeconds = %v; want %v", m.ExpectedMeanSeconds, want)
+	}
+	if m.AtC != 20 || m.AtCPlusH != 24 {
+		t.Errorf("AtC=%v AtCPlusH=%v; want 20, 24", m.AtC, m.AtCPlusH)
+	}
+}
+
+// TestSummarizeDivisibleMixture_ClassifiesIntervals confirms the observed
+// mixture summary correctly classifies a synthetic {4s,6s} mixture sample.
+func TestSummarizeDivisibleMixture_ClassifiesIntervals(t *testing.T) {
+	c, _ := CellByID("K0") // C=3600 not useful here; use a synthetic 4/2 cell instead
+	c = Cell{ID: "synthetic", C: 4, H: 2, P: 2}
+	intervals := []float64{4.0, 4.1, 6.0, 4.0, 6.1, 4.0, 6.0, 4.0, 4.0, 6.0}
+	summary := SummarizeDivisibleMixture(c, intervals, 0.5)
+	if summary.FracAtC <= 0 || summary.FracAtCPlusH <= 0 {
+		t.Errorf("summary = %+v; want both fractions > 0 (a genuine mixture)", summary)
+	}
+	if summary.FracAtCPlusH < 0.10 {
+		t.Errorf("FracAtCPlusH = %v; want >= 0.10 in this synthetic sample", summary.FracAtCPlusH)
+	}
+}
+
+// TestOscillatorTickBudget_IsFrozenEight confirms the frozen numeric budget.
+func TestOscillatorTickBudget_IsFrozenEight(t *testing.T) {
+	if OscillatorTickBudget != 8 {
+		t.Errorf("OscillatorTickBudget = %d; want 8 (frozen)", OscillatorTickBudget)
+	}
+}

--- a/internal/testkernel/experiment/manifest.go
+++ b/internal/testkernel/experiment/manifest.go
@@ -1,0 +1,274 @@
+// manifest.go — First Instruments Module D: the out-of-tree data store +
+// manifest.json shape (IMPL-SPEC D4/§6.4/H3).
+//
+// Observations are written OUTSIDE any watched tree, to
+// ${COGOS_WORKSPACE_ROOT:-$HOME/workspaces}/first-instruments-runs/<run_id>/
+// — a sibling of all workspaces, watched by no ProjectionWatcher and
+// indexed by no memory corpus (H3). Append-only writes (K7).
+package experiment
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// RunsRoot returns the out-of-tree data-store root
+// (${COGOS_WORKSPACE_ROOT:-$HOME/workspaces}/first-instruments-runs), per
+// the repo's env-var pathing convention.
+func RunsRoot() (string, error) {
+	root := os.Getenv("COGOS_WORKSPACE_ROOT")
+	if root == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("experiment: resolve home dir: %w", err)
+		}
+		root = filepath.Join(home, "workspaces")
+	}
+	return filepath.Join(root, "first-instruments-runs"), nil
+}
+
+// RunDir returns the per-run directory (RunsRoot/<runID>) and ensures it
+// exists.
+func RunDir(runID string) (string, error) {
+	root, err := RunsRoot()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(root, runID)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", fmt.Errorf("experiment: mkdir run dir %s: %w", dir, err)
+	}
+	return dir, nil
+}
+
+// Observation is one append-only JSONL row written to observations.jsonl
+// (IMPL-SPEC D4). Fields are a superset covering the per-cell recordings:
+// M11r cadence ratio, KC-3-LAW residual, divisible-mixture characterization,
+// H6 process-state tags, and per-cell kill-eligibility.
+type Observation struct {
+	Timestamp string `json:"timestamp"`
+	RunID     string `json:"run_id"`
+	CellID    string `json:"cell_id"`
+
+	ObservedConsolidationCadenceMs float64 `json:"observed_consolidation_cadence_ms"`
+	ObservedHeartbeatCadenceMs     float64 `json:"observed_heartbeat_cadence_ms"`
+	M11r                           float64 `json:"m11r"`
+
+	// Per-cell kill-eligibility (F1) — only eligible absolutes enter the
+	// KILL comparison.
+	KillEligibleConsCadence bool `json:"kill_eligible_cons_cadence"`
+	KillEligibleHBCadence   bool `json:"kill_eligible_hb_cadence"`
+
+	// KC-3-LAW (headline).
+	Divisible                    bool     `json:"divisible"`
+	LawCellDiscriminating        bool     `json:"law_cell_discriminating"`
+	KC3LawResidualMs             *float64 `json:"kc3_law_residual_ms,omitempty"` // only set at non-divisible cells
+	KC3LawConfirmed              *bool    `json:"kc3_law_confirmed,omitempty"`   // only set at non-divisible cells
+	DivisibleMixtureFracAtC      *float64 `json:"divisible_mixture_frac_at_c,omitempty"`
+	DivisibleMixtureFracAtCPlusH *float64 `json:"divisible_mixture_frac_at_c_plus_h,omitempty"`
+	DivisibleMixtureMeanMs       *float64 `json:"divisible_mixture_mean_ms,omitempty"`
+
+	// H6 process-state tag.
+	ProcessState         string `json:"process_state"`
+	ProcessActiveOverlap bool   `json:"process_active_overlap"`
+
+	// K12-domination + divisibility tags (D4).
+	K12QuantizationDominated bool `json:"k12_quantization_dominated"`
+
+	// Tick-attribution guard (D2).
+	TickSource string `json:"tick_source"` // "natural" | "triggered" | "ambiguous"
+
+	// INSTRUMENT-BROKEN signal.
+	RunError bool `json:"run_error"`
+}
+
+// ObservationWriter appends Observation rows to
+// <run_dir>/observations.jsonl (K7 append-only discipline).
+type ObservationWriter struct {
+	path string
+	f    *os.File
+}
+
+// NewObservationWriter opens (creating if absent) the append-only
+// observations.jsonl file for runID under the out-of-tree data store.
+func NewObservationWriter(runID string) (*ObservationWriter, error) {
+	dir, err := RunDir(runID)
+	if err != nil {
+		return nil, err
+	}
+	path := filepath.Join(dir, "observations.jsonl")
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("experiment: open %s: %w", path, err)
+	}
+	return &ObservationWriter{path: path, f: f}, nil
+}
+
+// Write appends one observation as a JSON line.
+func (w *ObservationWriter) Write(obs Observation) error {
+	data, err := json.Marshal(obs)
+	if err != nil {
+		return fmt.Errorf("experiment: marshal observation: %w", err)
+	}
+	if _, err := w.f.Write(append(data, '\n')); err != nil {
+		return fmt.Errorf("experiment: write observation: %w", err)
+	}
+	return nil
+}
+
+// Close closes the underlying file.
+func (w *ObservationWriter) Close() error {
+	return w.f.Close()
+}
+
+// Path returns the observations.jsonl path this writer targets.
+func (w *ObservationWriter) Path() string {
+	return w.path
+}
+
+// Manifest is the run-level manifest.json shape (IMPL-SPEC D4). Recorded
+// once per run alongside observations.jsonl.
+type Manifest struct {
+	RunID     string `json:"run_id"`
+	Generated string `json:"generated"`
+
+	// Existence set (PREREG §1/§4.3): M11r is the SOLE existence candidate.
+	ExistenceSet   []string `json:"existence_set"`
+	EffectiveM     int      `json:"effective_m"`
+	EffectiveT     int      `json:"effective_t"`
+	TLookelsewhere int      `json:"t_lookelsewhere"`
+
+	// Deliverables/characterization block (M1A, M1B, M9, M10, M13r, M2osc).
+	DeliverablesCharacterization []DeliverableEntry `json:"deliverables_characterization"`
+
+	// Headline block (KC-3-LAW).
+	Headline HeadlineBlock `json:"headline"`
+
+	// Echo-class block (Module C's 15-ratio table + literals).
+	EchoClass EchoClassBlock `json:"echo_class"`
+
+	// Controls block (PC-SYNTH + negative controls).
+	Controls ControlsBlock `json:"controls"`
+
+	// Nulls block (Gaussian-multiplicative family + jitter-model-validation gate).
+	Nulls NullsBlock `json:"nulls"`
+
+	CVNullRule        string `json:"cv_null_rule"`
+	Bootstrap         string `json:"bootstrap"`
+	ReplicateProtocol string `json:"replicate_protocol"`
+
+	Cells []CellManifestEntry `json:"cells"`
+
+	CalibratedThreshold     float64            `json:"calibrated_threshold"`
+	HeldOutValidationHalfW  float64            `json:"held_out_validation_half_width"`
+	PowerBatteryRejectRates map[string]float64 `json:"power_battery_reject_rates"` // keyed by delta string
+
+	NMax    int   `json:"n_max"`
+	NAnchor []int `json:"n_anchor"` // {3,5} for K0
+
+	DecisionSurfaceSim DecisionSurfaceSimBlock `json:"decision_surface_sim"`
+
+	KernelGitSHA      string `json:"kernel_git_sha"`
+	KernelGitDirty    bool   `json:"kernel_git_dirty"`
+	KernelGitDiffHash string `json:"kernel_git_diff_hash"`
+	Branch            string `json:"branch"`
+	Worktree          string `json:"worktree"`
+}
+
+type DeliverableEntry struct {
+	ID                string `json:"id"`
+	Role              string `json:"role"`
+	ExistenceEligible bool   `json:"existence_eligible"`
+	// Extra fields for M2osc's characterization tags.
+	ClockCouplingFalsifiedByProtocol *bool `json:"clock_coupling_falsified_by_protocol,omitempty"`
+}
+
+type HeadlineBlock struct {
+	Name                 string   `json:"name"`
+	LawStatement         string   `json:"law_statement"`
+	CleanForm            string   `json:"clean_form"`
+	Grade                string   `json:"grade"`
+	LawResidualTolerance string   `json:"law_residual_tolerance"`
+	DiscriminatingCells  []string `json:"discriminating_cells"`
+	DivisibleCells       []string `json:"divisible_cells"`
+	DivisibleDisposition string   `json:"divisible_disposition"`
+	M11Tap               string   `json:"m11_tap"`
+	PersistentRunError   string   `json:"persistent_run_error"`
+}
+
+type EchoClassBlock struct {
+	RatioCount int      `json:"ratio_count"`
+	ClusterIDs []string `json:"cluster_ids"`
+}
+
+type ControlsBlock struct {
+	PCSynthNoiseSigma float64 `json:"pc_synth_noise_sigma"`
+	PCSynthClears     bool    `json:"pc_synth_clears"`
+	LiveNProviders    int     `json:"live_n_providers"`
+}
+
+type NullsBlock struct {
+	Family                    string          `json:"family"`
+	Sigma                     float64         `json:"sigma"`
+	ThreeDisjointSeedSets     []string        `json:"three_disjoint_seed_sets"`
+	JitterModelValidationGate JitterGateBlock `json:"jitter_model_validation_gate"`
+}
+
+type JitterGateBlock struct {
+	MeasuredAt    string  `json:"measured_at"`
+	MinIntervals  int     `json:"min_intervals"`
+	AcceptCVMax   float64 `json:"accept_cv_max"`
+	AcceptKSAlpha float64 `json:"accept_ks_alpha"`
+	Recalibration string  `json:"recalibration"`
+}
+
+type CellManifestEntry struct {
+	ID                          string          `json:"id"`
+	C                           int             `json:"c"`
+	H                           int             `json:"h"`
+	P                           int             `json:"p"`
+	CeilCH                      int             `json:"ceil_ch"`
+	Cadence                     int             `json:"cadence"`
+	Divisible                   bool            `json:"divisible"`
+	KillEligibleA               KillEligibility `json:"kill_eligible_a"`
+	Role                        string          `json:"role"`
+	NonDivisibleStabilityFamily bool            `json:"non_divisible_stability_family"`
+}
+
+type DecisionSurfaceSimBlock struct {
+	Status           string `json:"status"`
+	RegistrationHash string `json:"registration_hash"`
+}
+
+// BuildCellManifest constructs the manifest's cell table from the frozen
+// lattice.
+func BuildCellManifest() []CellManifestEntry {
+	entries := make([]CellManifestEntry, 0, len(Lattice))
+	stabilitySet := map[string]bool{}
+	for _, id := range StabilityFamily {
+		stabilitySet[id] = true
+	}
+	for _, c := range Lattice {
+		entries = append(entries, CellManifestEntry{
+			ID:                          c.ID,
+			C:                           c.C,
+			H:                           c.H,
+			P:                           c.P,
+			CeilCH:                      c.CeilCH(),
+			Cadence:                     c.CadenceLaw(),
+			Divisible:                   c.Divisible(),
+			KillEligibleA:               KillEligibleA(c),
+			Role:                        c.Role,
+			NonDivisibleStabilityFamily: stabilitySet[c.ID],
+		})
+	}
+	return entries
+}
+
+// NewRunID returns a timestamp-based run identifier.
+func NewRunID(prefix string) string {
+	return fmt.Sprintf("%s-%s", prefix, time.Now().UTC().Format("20060102T150405Z"))
+}

--- a/internal/testkernel/experiment/oscillator.go
+++ b/internal/testkernel/experiment/oscillator.go
@@ -1,0 +1,221 @@
+// oscillator.go — First Instruments Module D3: the oscillating-provider
+// class + the falsifiable N_conv≡1 contract test.
+//
+// D3 (IMPL-SPEC): the prior spec said injectors "will confirm N_conv≡1 by
+// construction" — a test that confirms by construction cannot fail and
+// discharges nothing. This is rewritten as an actual falsifiable CONTRACT
+// TEST of the unenforced provider contract: ApplyPlan idempotence and
+// single-cycle completeness are a provider contract the daemon assumes but
+// does NOT check (ADR-092 §3 — no contraction bound, no in-cycle retry).
+//
+// The existing fakeReconcilable (isolated_registry_test.go) is Skip-only
+// (always Summary{Skipped:1}, no diffing) — a tautology. oscillatingProvider
+// and diffingProvider below implement REAL ComputePlan diffing so the
+// contract test is a genuine probe.
+package experiment
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/myrgic/cogos/pkg/substrate/reconcile"
+)
+
+// diffingProvider is a minimal Reconcilable whose FetchLive returns a
+// caller-controlled "live" value, and whose ComputePlan does a REAL diff
+// against the declared config: if live != config, the plan has one Update
+// action; if they match, the plan is a single Skip. BuildState always
+// records the live value as the new state. This is a genuine
+// diffing/converging provider (not the tautological Skip-always fake), so
+// the D3 contract test is a real probe: after ApplyPlan is (simulated to)
+// converge live to config, the NEXT ComputePlan must show HasChanges()==false.
+type diffingProvider struct {
+	typeName string
+
+	// desired is the declared config value ComputePlan diffs FetchLive
+	// against.
+	desired string
+
+	// live is mutated by the test/injector between cycles to simulate
+	// external drift or the effect of a (possibly partial) ApplyPlan.
+	live atomic.Value // string
+
+	// applyBehavior controls what ApplyPlan does when there is a diff:
+	//   applyFullyConverges: sets live = desired (a correct, idempotent
+	//     provider — the contract test must PASS for this behavior).
+	//   applyPartialOnly: leaves live unchanged (a broken provider that
+	//     never actually applies — the contract test must FAIL for this
+	//     behavior, proving the test can fail).
+	applyBehavior applyBehavior
+
+	computeCount atomic.Int32
+	applyCount   atomic.Int32
+}
+
+type applyBehavior int
+
+const (
+	applyFullyConverges applyBehavior = iota
+	applyPartialOnly
+)
+
+func newDiffingProvider(typeName, desired, initialLive string, behavior applyBehavior) *diffingProvider {
+	p := &diffingProvider{typeName: typeName, desired: desired, applyBehavior: behavior}
+	p.live.Store(initialLive)
+	return p
+}
+
+func (p *diffingProvider) Type() string { return p.typeName }
+
+func (p *diffingProvider) LoadConfig(_ string) (any, error) {
+	return p.desired, nil
+}
+
+func (p *diffingProvider) FetchLive(_ context.Context, _ any) (any, error) {
+	return p.live.Load().(string), nil
+}
+
+func (p *diffingProvider) ComputePlan(config any, live any, _ *reconcile.State) (*reconcile.Plan, error) {
+	p.computeCount.Add(1)
+	desired := config.(string)
+	current := live.(string)
+
+	if desired == current {
+		return &reconcile.Plan{
+			ResourceType: p.typeName,
+			Actions: []reconcile.Action{{
+				Action:       reconcile.ActionSkip,
+				ResourceType: p.typeName,
+				Name:         p.typeName,
+				Details:      map[string]any{"reason": "in sync"},
+			}},
+			Summary: reconcile.Summary{Skipped: 1},
+		}, nil
+	}
+	return &reconcile.Plan{
+		ResourceType: p.typeName,
+		Actions: []reconcile.Action{{
+			Action:       reconcile.ActionUpdate,
+			ResourceType: p.typeName,
+			Name:         p.typeName,
+			Details:      map[string]any{"from": current, "to": desired},
+		}},
+		Summary: reconcile.Summary{Updates: 1},
+	}, nil
+}
+
+func (p *diffingProvider) ApplyPlan(_ context.Context, plan *reconcile.Plan) ([]reconcile.Result, error) {
+	p.applyCount.Add(1)
+	if !plan.Summary.HasChanges() {
+		return nil, nil
+	}
+	switch p.applyBehavior {
+	case applyFullyConverges:
+		p.live.Store(p.desired)
+	case applyPartialOnly:
+		// Deliberately does nothing — simulates a provider whose ApplyPlan
+		// only partially applies (or silently no-ops) per cycle.
+	}
+	return []reconcile.Result{{
+		Phase:  "apply",
+		Action: string(reconcile.ActionUpdate),
+		Name:   p.typeName,
+		Status: reconcile.ApplySucceeded,
+	}}, nil
+}
+
+func (p *diffingProvider) BuildState(_ any, live any, existing *reconcile.State) (*reconcile.State, error) {
+	s := reconcile.NewState(p.typeName)
+	if existing != nil {
+		s.Lineage = existing.Lineage
+		s.Serial = existing.Serial
+	}
+	return s, nil
+}
+
+func (p *diffingProvider) Health() reconcile.ResourceStatus {
+	return reconcile.NewResourceStatus(reconcile.SyncStatusSynced, reconcile.HealthHealthy)
+}
+
+// SetLive externally mutates the provider's live value (simulating a
+// perturbation injector writing to the watched filesystem/git tree — D1).
+func (p *diffingProvider) SetLive(v string) {
+	p.live.Store(v)
+}
+
+// ─── D3: the oscillating-provider class ────────────────────────────────────
+
+// oscillatingProvider is a Reconcilable whose FetchLive alternates between
+// two states across ticks — the ONLY class where single-pass reconcile
+// cannot converge in 1 tick (K2). Each call to FetchLive flips the observed
+// state, so ComputePlan always sees a diff (never HasChanges()==false)
+// under a correct single-pass reconciler; if it EVER reports
+// HasChanges()==false within the frozen 8-tick budget, that is a KC-2
+// finding (a contradiction of single-pass).
+type oscillatingProvider struct {
+	typeName string
+	flip     atomic.Bool // current observed state
+	fetches  atomic.Int32
+}
+
+func newOscillatingProvider(typeName string) *oscillatingProvider {
+	return &oscillatingProvider{typeName: typeName}
+}
+
+func (p *oscillatingProvider) Type() string { return p.typeName }
+
+func (p *oscillatingProvider) LoadConfig(_ string) (any, error) {
+	return "steady-state", nil
+}
+
+func (p *oscillatingProvider) FetchLive(_ context.Context, _ any) (any, error) {
+	p.fetches.Add(1)
+	flipped := !p.flip.Load()
+	p.flip.Store(flipped)
+	if flipped {
+		return "state-A", nil
+	}
+	return "state-B", nil
+}
+
+func (p *oscillatingProvider) ComputePlan(config any, live any, _ *reconcile.State) (*reconcile.Plan, error) {
+	desired := config.(string)
+	current := live.(string)
+	if desired == current {
+		return &reconcile.Plan{
+			ResourceType: p.typeName,
+			Actions:      []reconcile.Action{{Action: reconcile.ActionSkip, ResourceType: p.typeName, Name: p.typeName}},
+			Summary:      reconcile.Summary{Skipped: 1},
+		}, nil
+	}
+	return &reconcile.Plan{
+		ResourceType: p.typeName,
+		Actions:      []reconcile.Action{{Action: reconcile.ActionUpdate, ResourceType: p.typeName, Name: p.typeName}},
+		Summary:      reconcile.Summary{Updates: 1},
+	}, nil
+}
+
+func (p *oscillatingProvider) ApplyPlan(_ context.Context, plan *reconcile.Plan) ([]reconcile.Result, error) {
+	// Single-pass: applying never "catches up" to the next flip — the next
+	// FetchLive call (next cycle) flips again regardless of what was just
+	// applied. This is the structural reason a 2-state oscillator can never
+	// converge under single-pass reconcile.
+	var results []reconcile.Result
+	for _, a := range plan.Actions {
+		results = append(results, reconcile.Result{Phase: "apply", Action: string(a.Action), Name: a.Name, Status: reconcile.ApplySucceeded})
+	}
+	return results, nil
+}
+
+func (p *oscillatingProvider) BuildState(_ any, _ any, existing *reconcile.State) (*reconcile.State, error) {
+	s := reconcile.NewState(p.typeName)
+	if existing != nil {
+		s.Lineage = existing.Lineage
+		s.Serial = existing.Serial
+	}
+	return s, nil
+}
+
+func (p *oscillatingProvider) Health() reconcile.ResourceStatus {
+	return reconcile.NewResourceStatus(reconcile.SyncStatusSynced, reconcile.HealthHealthy)
+}

--- a/internal/testkernel/experiment/runner.go
+++ b/internal/testkernel/experiment/runner.go
@@ -1,0 +1,204 @@
+// runner.go — First Instruments Module D6: the experiment-runner test
+// harness that runs the sweep.
+//
+// This is measurement tooling, NOT a production code path (IMPL-SPEC D0).
+// It boots real testkernel instances (Module A), reads Module E's cadence
+// taps, applies the frozen D5 calibration gates, and computes the D4
+// recordings (M11r, KC-3-LAW residual/mixture, per-cell kill-eligibility,
+// H6 process-state tags) — all against the FROZEN 9-cell lattice
+// (lattice.go).
+//
+// REPLICATE PROTOCOL (FROZEN, blind-review-4 Finding C): per cell, ONE
+// boot; over that boot collect n CONSECUTIVE inter-consolidation intervals;
+// DISCARD the FIRST interval (phase-contaminated — the boot-to-first-event
+// gap is set by lastConsolidation init, not tick-aligned); serial
+// dependence handled by the circular block-bootstrap (blockbootstrap.go).
+package experiment
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/myrgic/cogos/internal/engine"
+	"github.com/myrgic/cogos/internal/testkernel"
+	"github.com/myrgic/cogos/pkg/substrate/reconcile"
+)
+
+// CellRunResult is the per-cell outcome of CollectCellReplicates: the raw
+// consecutive inter-consolidation and inter-heartbeat intervals (seconds,
+// first discarded), plus the H6 process-state tags observed during
+// collection.
+type CellRunResult struct {
+	Cell Cell
+
+	// ConsolidationIntervalsSeconds are n consecutive inter-consolidation
+	// intervals (the FIRST already discarded per the frozen protocol).
+	ConsolidationIntervalsSeconds []float64
+
+	// HeartbeatIntervalsSeconds are the corresponding heartbeat intervals
+	// observed over the same boot window (M12).
+	HeartbeatIntervalsSeconds []float64
+
+	// AnyProcessActiveOverlap is true if any recorded event's ProcessState
+	// was StateActive during the window (H6) — such rows must be excluded
+	// from confirmatory statistics by the caller.
+	AnyProcessActiveOverlap bool
+
+	// RunError is true if a persistent ConsolidationAction.Run() error was
+	// detected (Finding B — INSTRUMENT-BROKEN, never a law-kill). This
+	// runner detects it indirectly: if heartbeats accumulate but
+	// consolidation events never do over a window comfortably exceeding
+	// the cell's law-predicted cadence, a persistent Run() error is the
+	// most likely explanation (attempts fail silently past the gate).
+	RunError bool
+}
+
+// CollectCellReplicates boots ONE testkernel measurement kernel at cell's
+// (C,H,P), waits for n+1 consolidation events (so n consecutive intervals
+// remain after discarding the first), and returns the collected intervals.
+// lifetime bounds the kernel's context and MUST comfortably exceed
+// (n+1)*cell.CadenceLaw() seconds, or the collection will time out before
+// reaching n replicates.
+func CollectCellReplicates(t *testing.T, cell Cell, n int, lifetime time.Duration) CellRunResult {
+	t.Helper()
+	reconcile.ResetProviders()
+	defer reconcile.ResetProviders()
+
+	ctx, cancel := context.WithTimeout(context.Background(), lifetime)
+	defer cancel()
+
+	k, err := testkernel.Boot(ctx, t,
+		testkernel.WithConsolidationInterval(cell.C),
+		testkernel.WithHeartbeatInterval(cell.H),
+		testkernel.WithPollInterval(time.Duration(cell.P)*time.Second),
+		testkernel.WithoutLocalHarness(),
+	)
+	if err != nil {
+		t.Fatalf("CollectCellReplicates(%s): testkernel.Boot: %v", cell.ID, err)
+	}
+	defer func() {
+		if err := k.Stop(); err != nil {
+			t.Errorf("CollectCellReplicates(%s): testkernel.Stop: %v", cell.ID, err)
+		}
+	}()
+
+	// Wait for n+2 consolidation events: n+1 raw intervals, of which the
+	// FIRST is discarded (phase-contaminated, Finding C), leaving n.
+	deadline := time.After(lifetime - 2*time.Second)
+	var events []engine.ConsolidationEvent
+	for {
+		events = k.ConsolidationEvents()
+		if len(events) >= n+2 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("CollectCellReplicates(%s): only %d/%d consolidation events before deadline", cell.ID, len(events), n+2)
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+
+	// Discard the first interval (phase-contaminated, Finding C).
+	consIntervals := make([]float64, 0, n)
+	anyActive := false
+	for i := 2; i < len(events); i++ { // events[0]->events[1] is the discarded first interval
+		iv := events[i].At.Sub(events[i-1].At).Seconds()
+		consIntervals = append(consIntervals, iv)
+		if events[i].ProcessState == engine.StateActive || events[i-1].ProcessState == engine.StateActive {
+			anyActive = true
+		}
+	}
+
+	hbEvents := k.HeartbeatEvents()
+	hbIntervals := make([]float64, 0, len(hbEvents))
+	for i := 1; i < len(hbEvents); i++ {
+		iv := hbEvents[i].At.Sub(hbEvents[i-1].At).Seconds()
+		hbIntervals = append(hbIntervals, iv)
+		if hbEvents[i].ProcessState == engine.StateActive || hbEvents[i-1].ProcessState == engine.StateActive {
+			anyActive = true
+		}
+	}
+
+	// RunError heuristic: heartbeats accumulated (the process is alive and
+	// ticking) but far fewer consolidation events than the window should
+	// have produced given the cell's law-predicted cadence — this is the
+	// signature of a persistent ConsolidationAction.Run() error (Finding
+	// B): the gate at process.go:880 keeps re-firing every heartbeat, but
+	// the success-point tap (:891) never records because Run() keeps
+	// erroring, so the M11 event count stays far below what the elapsed
+	// window and law-predicted cadence would otherwise produce.
+	runError := false
+	if len(hbIntervals) > 0 && cell.CadenceLaw() > 0 {
+		elapsedSeconds := hbEvents[len(hbEvents)-1].At.Sub(hbEvents[0].At).Seconds()
+		expectedConsEvents := elapsedSeconds / float64(cell.CadenceLaw())
+		if expectedConsEvents >= float64(n)+2 && len(consIntervals) == 0 {
+			runError = true
+		}
+	}
+
+	return CellRunResult{
+		Cell:                          cell,
+		ConsolidationIntervalsSeconds: consIntervals,
+		HeartbeatIntervalsSeconds:     hbIntervals,
+		AnyProcessActiveOverlap:       anyActive,
+		RunError:                      runError,
+	}
+}
+
+// M11rFromResult computes the M11r cadence ratio (observed consolidation
+// cadence / observed heartbeat cadence) from a CellRunResult's collected
+// intervals.
+func M11rFromResult(r CellRunResult) (m11r, consCadenceSeconds, hbCadenceSeconds float64) {
+	consCadenceSeconds = mean(r.ConsolidationIntervalsSeconds)
+	hbCadenceSeconds = mean(r.HeartbeatIntervalsSeconds)
+	if hbCadenceSeconds == 0 {
+		return 0, consCadenceSeconds, hbCadenceSeconds
+	}
+	return consCadenceSeconds / hbCadenceSeconds, consCadenceSeconds, hbCadenceSeconds
+}
+
+// EvaluateCellObservation applies the D4 per-cell decision logic to a
+// CellRunResult: KC-3-LAW confirm/kill (non-divisible discriminating
+// cells) or divisible-mixture characterization, tagged with per-cell
+// kill-eligibility and H6 process-state exclusion.
+func EvaluateCellObservation(r CellRunResult, replicateCountForTau int) Observation {
+	c := r.Cell
+	m11r, consCadenceSeconds, hbCadenceSeconds := M11rFromResult(r)
+	elig := KillEligibleA(c)
+
+	obs := Observation{
+		CellID:                         c.ID,
+		ObservedConsolidationCadenceMs: consCadenceSeconds * 1000,
+		ObservedHeartbeatCadenceMs:     hbCadenceSeconds * 1000,
+		M11r:                           m11r,
+		KillEligibleConsCadence:        elig.ConsCadence,
+		KillEligibleHBCadence:          elig.HBCadence,
+		Divisible:                      c.Divisible(),
+		LawCellDiscriminating:          c.LawCellDiscriminating(),
+		K12QuantizationDominated:       c.QuantizationDominated(),
+		ProcessActiveOverlap:           r.AnyProcessActiveOverlap,
+		RunError:                       r.RunError,
+	}
+
+	if r.RunError {
+		return obs // INSTRUMENT-BROKEN signal; no confirm/kill/mixture computed
+	}
+
+	if c.NonDivisible() {
+		residual := consCadenceSeconds*1000 - float64(c.CadenceLaw())*1000
+		confirmed := KC3LawConfirm(c, consCadenceSeconds, false, replicateCountForTau).Fired
+		obs.KC3LawResidualMs = &residual
+		obs.KC3LawConfirmed = &confirmed
+	} else {
+		summary := SummarizeDivisibleMixture(c, r.ConsolidationIntervalsSeconds, 1.0)
+		fracC := summary.FracAtC
+		fracCPlusH := summary.FracAtCPlusH
+		meanMs := summary.MeanSeconds * 1000
+		obs.DivisibleMixtureFracAtC = &fracC
+		obs.DivisibleMixtureFracAtCPlusH = &fracCPlusH
+		obs.DivisibleMixtureMeanMs = &meanMs
+	}
+
+	return obs
+}

--- a/internal/testkernel/experiment/runner_test.go
+++ b/internal/testkernel/experiment/runner_test.go
@@ -1,0 +1,205 @@
+package experiment
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestCollectCellReplicates_Ks0_SmallN exercises the full D6 collection
+// pipeline (real testkernel boot -> Module E cadence taps -> discard-first
+// -> M11r) at the reference cell Ks0 (10,4,2; ceil=3, cadence=12s) with a
+// small n, small enough to run in this session (n=3 => 4 events => ~48s +
+// boot overhead). This is NOT the full confirmatory sweep (which needs
+// n up to 240 per the frozen n-ladder, ~11.87h across all 9 cells) — it is
+// the correctness proof that the pipeline computes M11r == the law-
+// predicted ceil(C/H) on real kernel data.
+func TestCollectCellReplicates_Ks0_SmallN(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping cadence-wait test in -short mode")
+	}
+	cell, ok := CellByID("Ks0")
+	if !ok {
+		t.Fatal("Ks0 not found")
+	}
+	const n = 3
+	// n+2 events at ~cadence seconds each, generous overhead.
+	lifetime := time.Duration(cell.CadenceLaw()*(n+3))*time.Second + 15*time.Second
+
+	result := CollectCellReplicates(t, cell, n, lifetime)
+	if len(result.ConsolidationIntervalsSeconds) < n {
+		t.Fatalf("collected %d consolidation intervals; want >= %d", len(result.ConsolidationIntervalsSeconds), n)
+	}
+	if result.RunError {
+		t.Fatal("RunError = true; want false for a healthy fresh test workspace")
+	}
+	if result.AnyProcessActiveOverlap {
+		t.Error("AnyProcessActiveOverlap = true; want false for a dormant measurement boot (H6)")
+	}
+
+	m11r, consCadence, hbCadence := M11rFromResult(result)
+	wantRatio := float64(cell.CeilCH())
+	const tol = 0.5 // seconds-scale jitter tolerance on the ratio
+	if diff := m11r - wantRatio; diff > tol || diff < -tol {
+		t.Errorf("M11r = %v; want ~%v (ceil(C/H) at the non-divisible reference cell), cons=%.2fs hb=%.2fs", m11r, wantRatio, consCadence, hbCadence)
+	}
+
+	obs := EvaluateCellObservation(result, 30)
+	if obs.KC3LawConfirmed == nil {
+		t.Fatal("KC3LawConfirmed is nil; want set for a non-divisible cell")
+	}
+	if !*obs.KC3LawConfirmed {
+		t.Errorf("KC3LawConfirmed = false; want true (real kernel data at Ks0 should confirm the law), residual=%v", *obs.KC3LawResidualMs)
+	}
+}
+
+// TestObservationWriter_AppendOnlyOutOfTree confirms the observation
+// writer targets the out-of-tree data store (H3) and appends rather than
+// truncates.
+func TestObservationWriter_AppendOnlyOutOfTree(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("COGOS_WORKSPACE_ROOT", tmpHome)
+
+	runID := NewRunID("test-run")
+	w, err := NewObservationWriter(runID)
+	if err != nil {
+		t.Fatalf("NewObservationWriter: %v", err)
+	}
+
+	wantPath := filepath.Join(tmpHome, "first-instruments-runs", runID, "observations.jsonl")
+	if w.Path() != wantPath {
+		t.Errorf("Path() = %q; want %q", w.Path(), wantPath)
+	}
+
+	if err := w.Write(Observation{CellID: "Ks0", M11r: 3.0}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := w.Write(Observation{CellID: "Ks2", M11r: 3.0}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	data, err := os.ReadFile(wantPath)
+	if err != nil {
+		t.Fatalf("read observations.jsonl: %v", err)
+	}
+	lines := 0
+	for _, b := range data {
+		if b == '\n' {
+			lines++
+		}
+	}
+	if lines != 2 {
+		t.Errorf("observations.jsonl has %d lines; want 2", lines)
+	}
+
+	// Re-open and append a third row — must not truncate the first two.
+	w2, err := NewObservationWriter(runID)
+	if err != nil {
+		t.Fatalf("NewObservationWriter (reopen): %v", err)
+	}
+	if err := w2.Write(Observation{CellID: "Ks4", M11r: 3.0}); err != nil {
+		t.Fatalf("Write (reopen): %v", err)
+	}
+	w2.Close()
+
+	data2, err := os.ReadFile(wantPath)
+	if err != nil {
+		t.Fatalf("read observations.jsonl (after reopen): %v", err)
+	}
+	lines2 := 0
+	for _, b := range data2 {
+		if b == '\n' {
+			lines2++
+		}
+	}
+	if lines2 != 3 {
+		t.Errorf("observations.jsonl has %d lines after reopen+append; want 3 (append-only, K7)", lines2)
+	}
+}
+
+// TestRunsRoot_DefaultsToHomeWorkspaces confirms the env-var-pathing
+// default when COGOS_WORKSPACE_ROOT is unset.
+func TestRunsRoot_DefaultsToHomeWorkspaces(t *testing.T) {
+	t.Setenv("COGOS_WORKSPACE_ROOT", "")
+	home, _ := os.UserHomeDir()
+	want := filepath.Join(home, "workspaces", "first-instruments-runs")
+	got, err := RunsRoot()
+	if err != nil {
+		t.Fatalf("RunsRoot: %v", err)
+	}
+	if got != want {
+		t.Errorf("RunsRoot() = %q; want %q", got, want)
+	}
+}
+
+// TestBuildCellManifest_NineCells confirms the manifest cell table has all
+// 9 frozen cells with correct kill-eligibility and divisibility tags.
+func TestBuildCellManifest_NineCells(t *testing.T) {
+	entries := BuildCellManifest()
+	if len(entries) != 9 {
+		t.Fatalf("len(entries) = %d; want 9", len(entries))
+	}
+	byID := map[string]CellManifestEntry{}
+	for _, e := range entries {
+		byID[e.ID] = e
+	}
+	ks0 := byID["Ks0"]
+	if !ks0.NonDivisibleStabilityFamily {
+		t.Error("Ks0.NonDivisibleStabilityFamily = false; want true")
+	}
+	ksND2 := byID["KsND2"]
+	if ksND2.NonDivisibleStabilityFamily {
+		t.Error("KsND2.NonDivisibleStabilityFamily = true; want false (not a pure co-scale)")
+	}
+	k0 := byID["K0"]
+	if !k0.Divisible {
+		t.Error("K0.Divisible = false; want true (production anchor, mixture-check only)")
+	}
+}
+
+// ─── Injector tests ─────────────────────────────────────────────────────────
+
+func TestMemoryFileDriftInjector_WritesNFiles(t *testing.T) {
+	dir := t.TempDir()
+	inj := MemoryFileDriftInjector{WorkspaceRoot: dir, N: 3}
+	written, err := inj.Inject()
+	if err != nil {
+		t.Fatalf("Inject: %v", err)
+	}
+	if len(written) != 3 {
+		t.Fatalf("len(written) = %d; want 3", len(written))
+	}
+	for _, p := range written {
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("expected file %s to exist: %v", p, err)
+		}
+	}
+}
+
+func TestWorktreeDivergenceInjector_RequiresGitRepo(t *testing.T) {
+	dir := t.TempDir() // NOT a git repo
+	inj := WorktreeDivergenceInjector{WorkspaceRoot: dir, CommitsAhead: FrozenConfirmatoryCommitsAhead}
+	err := inj.Inject()
+	if err == nil {
+		t.Fatal("Inject succeeded against a non-git directory; want a clear error")
+	}
+}
+
+func TestConfigDriftInjector_WritesYAML(t *testing.T) {
+	dir := t.TempDir()
+	inj := ConfigDriftInjector{WorkspaceRoot: dir, YAML: "consolidation_interval: 999\n"}
+	if err := inj.Inject(); err != nil {
+		t.Fatalf("Inject: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, ".cog", "config", "kernel.yaml"))
+	if err != nil {
+		t.Fatalf("read kernel.yaml: %v", err)
+	}
+	if string(data) != "consolidation_interval: 999\n" {
+		t.Errorf("kernel.yaml content = %q; want the injected YAML", data)
+	}
+}

--- a/internal/testkernel/experiment/terminal.go
+++ b/internal/testkernel/experiment/terminal.go
@@ -1,0 +1,89 @@
+// terminal.go — First Instruments Module D: terminal-state classifier +
+// ordering rule (PREREG §7), mirroring decision_surface_sim.py §6.
+//
+// Four terminal states: DEAD, SURVIVED-GENERIC, DATA-INSUFFICIENT,
+// INSTRUMENT-BROKEN. Ordering rule: DEAD/SURVIVED may be declared only
+// after DATA-INSUFFICIENT and INSTRUMENT-BROKEN are actively ruled out
+// FIRST. Finding D: the sharp-falsifier DEAD disjunct is STRUCTURALLY
+// UNREACHABLE — DEAD is reachable ONLY via the stability disjunct (M11r
+// measured, drifts, does not clear).
+package experiment
+
+const (
+	TerminalDead             = "DEAD"
+	TerminalSurvivedGeneric  = "SURVIVED-GENERIC"
+	TerminalDataInsufficient = "DATA-INSUFFICIENT"
+	TerminalInstrumentBroken = "INSTRUMENT-BROKEN"
+)
+
+// TerminalDecision is the outcome of applying the §7 ordering rule.
+type TerminalDecision struct {
+	State                 string
+	Route                 string // which disjunct/rule produced it
+	DeadViaSharpFalsifier bool   // did a terminal DEAD arrive via the sharp falsifier? (should always be false)
+}
+
+// ClassifySharpFalsifierPattern applies the §7 ordering rule to a data
+// pattern that RAW-fires the (A)-vs-(B) asymmetry KILL. Finding D asserts
+// this NEVER returns a terminal DEAD via the sharp falsifier.
+func ClassifySharpFalsifierPattern(c Cell, observedHeartbeatCadenceSeconds float64, runError, m11rDrifts, consStable, hbStable bool) TerminalDecision {
+	elig := KillEligibleA(c)
+
+	// Step 1: rule out INSTRUMENT-BROKEN first.
+	// (i) stable HEARTBEAT-cadence absolute while H moved -> neg-control-4.
+	if elig.HBCadence && hbStable {
+		nc4 := NegativeControl4(c, observedHeartbeatCadenceSeconds)
+		if nc4.Fired {
+			return TerminalDecision{TerminalInstrumentBroken, "neg-control-4 (hb-cadence stable while H moved)", false}
+		}
+	}
+
+	// Step 1b: a persistent Run() error is INSTRUMENT-BROKEN (Finding B).
+	if runError {
+		return TerminalDecision{TerminalInstrumentBroken, "persistent Run() error (Finding B)", false}
+	}
+
+	// (ii) stable CONSOLIDATION-cadence absolute while M11r drifts,
+	// adjudicated only at non-divisible cells.
+	if elig.ConsCadence && consStable && m11rDrifts {
+		if c.Divisible() {
+			return TerminalDecision{TerminalDataInsufficient,
+				"divisible cell: mixture-characterization, sharp-falsifier not adjudicated -> no DEAD", false}
+		}
+		return TerminalDecision{TerminalDataInsufficient,
+			"KC-3-LAW kill (cons-cadence stable => cadence != ceil(C/H)*H) => M11r DATA-INSUFFICIENT", false}
+	}
+
+	return TerminalDecision{TerminalDataInsufficient, "no eligible stable absolute -> sharp falsifier does not terminate DEAD", false}
+}
+
+// ClassifyStabilityTerminal is the stability-disjunct terminal classifier
+// (the ONLY reachable route to DEAD). Ordering rule: rule out
+// INSTRUMENT-BROKEN and DATA-INSUFFICIENT first.
+func ClassifyStabilityTerminal(m11rClears bool, calibration CalibrationOutcome, pcSynthClears, lawKilled bool) TerminalDecision {
+	if !calibration.AllPass() {
+		return TerminalDecision{TerminalInstrumentBroken,
+			"calibration hard-abort: " + joinGates(calibration.FailedGates()), false}
+	}
+	if !pcSynthClears {
+		return TerminalDecision{TerminalInstrumentBroken, "PC-SYNTH positive control failed to clear", false}
+	}
+	if lawKilled {
+		return TerminalDecision{TerminalDataInsufficient, "KC-3-LAW kill -> M11r DATA-INSUFFICIENT for invariant search", false}
+	}
+	if m11rClears {
+		return TerminalDecision{TerminalSurvivedGeneric, "M11r clears stability threshold (config-stable) while absolute counterpart not", false}
+	}
+	return TerminalDecision{TerminalDead, "M11r did not clear (drift distinguishable from null) -> DEAD via stability disjunct", false}
+}
+
+func joinGates(gates []string) string {
+	out := ""
+	for i, g := range gates {
+		if i > 0 {
+			out += "/"
+		}
+		out += g
+	}
+	return out
+}

--- a/internal/testkernel/experiment/terminal_test.go
+++ b/internal/testkernel/experiment/terminal_test.go
@@ -1,0 +1,94 @@
+package experiment
+
+import "testing"
+
+// TestFindingD_SharpFalsifierNeverTerminalDead is the executable proof of
+// Finding D (PREREG §7): for every cell and every plausible data pattern
+// that RAW-fires the (A)-vs-(B) asymmetry KILL, ClassifySharpFalsifierPattern
+// must NEVER return a terminal DEAD. The pattern is pre-empted either to
+// INSTRUMENT-BROKEN (neg-control-4 or a persistent Run() error) or to
+// DATA-INSUFFICIENT (a genuine KC-3-LAW kill demotes M11r, or a divisible
+// cell is mixture-characterization-only).
+func TestFindingD_SharpFalsifierNeverTerminalDead(t *testing.T) {
+	for _, c := range Lattice {
+		for _, runError := range []bool{false, true} {
+			for _, m11rDrifts := range []bool{false, true} {
+				for _, consStable := range []bool{false, true} {
+					for _, hbStable := range []bool{false, true} {
+						decision := ClassifySharpFalsifierPattern(c, float64(ReferenceCell.H), runError, m11rDrifts, consStable, hbStable)
+						if decision.State == TerminalDead {
+							t.Errorf("cell %s (runError=%v, m11rDrifts=%v, consStable=%v, hbStable=%v): sharp-falsifier returned terminal DEAD (%s) — Finding D violated",
+								c.ID, runError, m11rDrifts, consStable, hbStable, decision.Route)
+						}
+						if decision.DeadViaSharpFalsifier {
+							t.Errorf("cell %s: DeadViaSharpFalsifier=true; want always false", c.ID)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestClassifySharpFalsifierPattern_RunError_InstrumentBroken confirms a
+// persistent Run() error is always routed to INSTRUMENT-BROKEN, never a
+// tracks-H-alone kill (Finding B, mirrored into the terminal classifier).
+func TestClassifySharpFalsifierPattern_RunError_InstrumentBroken(t *testing.T) {
+	c, _ := CellByID("Ks0")
+	decision := ClassifySharpFalsifierPattern(c, float64(ReferenceCell.H), true /* runError */, true, false, false)
+	if decision.State != TerminalInstrumentBroken {
+		t.Errorf("State = %q; want %q for a persistent Run() error", decision.State, TerminalInstrumentBroken)
+	}
+}
+
+// TestClassifyStabilityTerminal_CalibrationFailure_InstrumentBroken
+// confirms a failed calibration hard-aborts to INSTRUMENT-BROKEN before any
+// DEAD/SURVIVED adjudication.
+func TestClassifyStabilityTerminal_CalibrationFailure_InstrumentBroken(t *testing.T) {
+	badCalibration := CalibrationOutcome{PrecisionPass: false, PowerPass: true, JitterScalePass: true, JitterShapePass: true}
+	decision := ClassifyStabilityTerminal(true /* m11rClears */, badCalibration, true /* pcSynthClears */, false /* lawKilled */)
+	if decision.State != TerminalInstrumentBroken {
+		t.Errorf("State = %q; want %q when calibration fails, regardless of m11rClears", decision.State, TerminalInstrumentBroken)
+	}
+}
+
+// TestClassifyStabilityTerminal_PCSynthFailure_InstrumentBroken confirms a
+// failed PC-SYNTH positive control also hard-aborts to INSTRUMENT-BROKEN.
+func TestClassifyStabilityTerminal_PCSynthFailure_InstrumentBroken(t *testing.T) {
+	goodCalibration := CalibrationOutcome{PrecisionPass: true, PowerPass: true, JitterScalePass: true, JitterShapePass: true}
+	decision := ClassifyStabilityTerminal(true, goodCalibration, false /* pcSynthClears=false */, false)
+	if decision.State != TerminalInstrumentBroken {
+		t.Errorf("State = %q; want %q when PC-SYNTH fails to clear", decision.State, TerminalInstrumentBroken)
+	}
+}
+
+// TestClassifyStabilityTerminal_LawKilled_DataInsufficient confirms a
+// KC-3-LAW kill demotes M11r to DATA-INSUFFICIENT for the invariant search,
+// even when calibration and PC-SYNTH both pass.
+func TestClassifyStabilityTerminal_LawKilled_DataInsufficient(t *testing.T) {
+	goodCalibration := CalibrationOutcome{PrecisionPass: true, PowerPass: true, JitterScalePass: true, JitterShapePass: true}
+	decision := ClassifyStabilityTerminal(true, goodCalibration, true, true /* lawKilled */)
+	if decision.State != TerminalDataInsufficient {
+		t.Errorf("State = %q; want %q when the KC-3-LAW kill fires", decision.State, TerminalDataInsufficient)
+	}
+}
+
+// TestClassifyStabilityTerminal_ClearsAndSurvives_SurvivedGeneric and
+// TestClassifyStabilityTerminal_DriftsAndDoesNotClear_Dead cover the only
+// two reachable terminal outcomes once INSTRUMENT-BROKEN/DATA-INSUFFICIENT
+// are ruled out — SURVIVED-GENERIC and DEAD (the sole reachable DEAD route).
+func TestClassifyStabilityTerminal_ClearsAndSurvives_SurvivedGeneric(t *testing.T) {
+	goodCalibration := CalibrationOutcome{PrecisionPass: true, PowerPass: true, JitterScalePass: true, JitterShapePass: true}
+	decision := ClassifyStabilityTerminal(true /* m11rClears */, goodCalibration, true, false)
+	if decision.State != TerminalSurvivedGeneric {
+		t.Errorf("State = %q; want %q", decision.State, TerminalSurvivedGeneric)
+	}
+}
+
+func TestClassifyStabilityTerminal_DriftsAndDoesNotClear_Dead(t *testing.T) {
+	goodCalibration := CalibrationOutcome{PrecisionPass: true, PowerPass: true, JitterScalePass: true, JitterShapePass: true}
+	decision := ClassifyStabilityTerminal(false /* m11rClears=false, i.e. drifts */, goodCalibration, true, false)
+	if decision.State != TerminalDead {
+		t.Errorf("State = %q; want %q — this IS the sole reachable DEAD route (stability disjunct)", decision.State, TerminalDead)
+	}
+}

--- a/internal/testkernel/first_instruments_a_test.go
+++ b/internal/testkernel/first_instruments_a_test.go
@@ -1,0 +1,380 @@
+// first_instruments_a_test.go — Module A tests (First Instruments Stage-2).
+//
+// Covers the testkernel/boot test-surface extensions specced in
+// IMPL-SPEC.md Module A: WithPollInterval, WithConsolidationInterval,
+// WithHeartbeatInterval, WithoutLocalHarness, LastCycleSerial/WaitForCycle,
+// the frozen 9-cell (C,H,P) lattice, and the State() accessor (H6).
+//
+// All tests are serial (no t.Parallel()) and ResetProviders-bracketed per
+// existing package convention (isolated_registry_test.go).
+package testkernel_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/myrgic/cogos/internal/engine"
+	"github.com/myrgic/cogos/internal/testkernel"
+	"github.com/myrgic/cogos/pkg/substrate/reconcile"
+)
+
+// ─── A1/A6: WithPollInterval ──────────────────────────────────────────────
+
+// TestWithPollInterval_HighValueDefeatsNaturalTick boots with a 1-hour poll
+// interval and confirms no natural (untriggered) cycle occurs within a short
+// window — the mechanism the D2 tick-attribution guard depends on.
+func TestWithPollInterval_HighValueDefeatsNaturalTick(t *testing.T) {
+	reconcile.ResetProviders()
+	defer reconcile.ResetProviders()
+
+	fake := newCountingFake("a1-high-poll")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	k, err := testkernel.Boot(ctx, t,
+		testkernel.WithIsolatedRegistry(fake),
+		testkernel.WithPollInterval(1*time.Hour),
+	)
+	if err != nil {
+		t.Fatalf("testkernel.Boot: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := k.Stop(); err != nil {
+			t.Errorf("testkernel.Stop: %v", err)
+		}
+	})
+
+	time.Sleep(200 * time.Millisecond)
+	if got := fake.fetchCount.Load(); got != 0 {
+		t.Errorf("fetchCount = %d after 200ms with 1h poll interval; want 0 (no natural tick)", got)
+	}
+
+	// Confirm Trigger still works (the daemon is alive, just not naturally ticking).
+	k.ReconcileDaemon().Trigger("a1-high-poll")
+	if err := testkernel.WaitForCycle(ctx, k, "a1-high-poll", 1); err != nil {
+		t.Fatalf("WaitForCycle after explicit Trigger: %v", err)
+	}
+}
+
+// TestWithPollInterval_LowValueFiresNaturalTicks boots with a 50ms poll
+// interval and confirms multiple natural cycles fire without any Trigger.
+func TestWithPollInterval_LowValueFiresNaturalTicks(t *testing.T) {
+	reconcile.ResetProviders()
+	defer reconcile.ResetProviders()
+
+	fake := newCountingFake("a1-low-poll")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	k, err := testkernel.Boot(ctx, t,
+		testkernel.WithIsolatedRegistry(fake),
+		testkernel.WithPollInterval(50*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatalf("testkernel.Boot: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := k.Stop(); err != nil {
+			t.Errorf("testkernel.Stop: %v", err)
+		}
+	})
+
+	if err := testkernel.WaitForCycle(ctx, k, "a1-low-poll", 2); err != nil {
+		t.Fatalf("WaitForCycle for natural ticks: %v", err)
+	}
+}
+
+// ─── A2: WithConsolidationInterval / WithHeartbeatInterval ────────────────
+
+// TestWithConsolidationAndHeartbeatInterval_TakeEffect boots with explicit
+// second-scale consolidation/heartbeat intervals and confirms the process
+// config reflects them (indirectly, via rates surface would be Module C;
+// here we assert via the kernel's process config accessor path is at least
+// wired without error and the kernel boots — the K12-law unit tests in
+// Module E are the behavioral confirmation that these values actually drive
+// cadence).
+func TestWithConsolidationAndHeartbeatInterval_TakeEffect(t *testing.T) {
+	reconcile.ResetProviders()
+	defer reconcile.ResetProviders()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	k, err := testkernel.Boot(ctx, t,
+		testkernel.WithConsolidationInterval(5),
+		testkernel.WithHeartbeatInterval(2),
+		testkernel.WithPollInterval(1*time.Hour),
+		testkernel.WithoutLocalHarness(),
+	)
+	if err != nil {
+		t.Fatalf("testkernel.Boot: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := k.Stop(); err != nil {
+			t.Errorf("testkernel.Stop: %v", err)
+		}
+	})
+
+	// A value of 0 is legal (means "use default"); confirm it does not error.
+	k2, err := testkernel.Boot(ctx, t,
+		testkernel.WithConsolidationInterval(0),
+		testkernel.WithHeartbeatInterval(0),
+		testkernel.WithPollInterval(1*time.Hour),
+	)
+	if err != nil {
+		t.Fatalf("testkernel.Boot with zero intervals: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := k2.Stop(); err != nil {
+			t.Errorf("testkernel.Stop (k2): %v", err)
+		}
+	})
+}
+
+// ─── A6: the frozen 9-cell (C,H,P) lattice ────────────────────────────────
+
+// firstInstrumentsCell mirrors the frozen PREREG §4.3 / IMPL-SPEC A6 lattice
+// tuple shape. Seconds throughout.
+type firstInstrumentsCell struct {
+	id string
+	c  int
+	h  int
+	p  int
+}
+
+// frozenNineCellLattice is the FROZEN 9-cell (C,H,P) lattice from IMPL-SPEC
+// A6 (mirrors PREREG §4.3), reproduced here only to prove Module A's three
+// interval options can independently realize every cell. This is NOT the
+// experiment runner (Module D) — just the boot-level capability test.
+var frozenNineCellLattice = []firstInstrumentsCell{
+	{"K0", 3600, 60, 30},
+	{"Ks0", 10, 4, 2},
+	{"Ks2", 20, 8, 4},
+	{"Ks4", 40, 16, 8},
+	{"KsH2", 10, 8, 2},
+	{"KsHhalf", 10, 2, 2},
+	{"KsC2", 20, 4, 2},
+	{"KsND1", 14, 4, 2},
+	{"KsND2", 26, 8, 4},
+}
+
+// TestFrozenNineCellLattice_EachCellBoots confirms every frozen (C,H,P) cell
+// boots and reports the configured intervals, including second-scale values
+// (C=10-40s, H=2-16s, P=2-8s) and the production-scale K0 anchor.
+func TestFrozenNineCellLattice_EachCellBoots(t *testing.T) {
+	for _, cell := range frozenNineCellLattice {
+		cell := cell
+		t.Run(cell.id, func(t *testing.T) {
+			// Serial: no t.Parallel() (IMPL-SPEC §0 "No parallelization").
+			reconcile.ResetProviders()
+			defer reconcile.ResetProviders()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			k, err := testkernel.Boot(ctx, t,
+				testkernel.WithConsolidationInterval(cell.c),
+				testkernel.WithHeartbeatInterval(cell.h),
+				testkernel.WithPollInterval(time.Duration(cell.p)*time.Second),
+				testkernel.WithoutLocalHarness(),
+			)
+			if err != nil {
+				t.Fatalf("cell %s: testkernel.Boot: %v", cell.id, err)
+			}
+			t.Cleanup(func() {
+				if err := k.Stop(); err != nil {
+					t.Errorf("cell %s: testkernel.Stop: %v", cell.id, err)
+				}
+			})
+
+			if got := k.ReconcileDaemon().State(); got == engine.ReconcileDaemonShutdown {
+				t.Errorf("cell %s: daemon state = %q; want not Shutdown", cell.id, got)
+			}
+		})
+	}
+}
+
+// ─── A3: LastCycleSerial monotonicity ──────────────────────────────────────
+
+// TestLastCycleSerial_Monotonic triggers several cycles for the same
+// provider and confirms the counter strictly increases and is observable
+// via WaitForCycle without depending on any fake-provider-owned counter.
+func TestLastCycleSerial_Monotonic(t *testing.T) {
+	reconcile.ResetProviders()
+	defer reconcile.ResetProviders()
+
+	fake := newCountingFake("a3-serial")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	k, err := testkernel.Boot(ctx, t,
+		testkernel.WithIsolatedRegistry(fake),
+		testkernel.WithPollInterval(1*time.Hour),
+	)
+	if err != nil {
+		t.Fatalf("testkernel.Boot: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := k.Stop(); err != nil {
+			t.Errorf("testkernel.Stop: %v", err)
+		}
+	})
+
+	// No cycle yet.
+	if _, ok := k.LastCycleSerial("a3-serial"); ok {
+		t.Fatal("LastCycleSerial reported ok=true before any cycle ran")
+	}
+
+	k.ReconcileDaemon().Trigger("a3-serial")
+	if err := testkernel.WaitForCycle(ctx, k, "a3-serial", 1); err != nil {
+		t.Fatalf("WaitForCycle(1): %v", err)
+	}
+	first, ok := k.LastCycleSerial("a3-serial")
+	if !ok || first < 1 {
+		t.Fatalf("LastCycleSerial after 1 trigger = (%d, %v); want (>=1, true)", first, ok)
+	}
+
+	k.ReconcileDaemon().Trigger("a3-serial")
+	if err := testkernel.WaitForCycle(ctx, k, "a3-serial", first+1); err != nil {
+		t.Fatalf("WaitForCycle(first+1): %v", err)
+	}
+	second, ok := k.LastCycleSerial("a3-serial")
+	if !ok || second <= first {
+		t.Fatalf("LastCycleSerial after 2nd trigger = (%d, %v); want (>%d, true)", second, ok, first)
+	}
+}
+
+// ─── A4: WithoutLocalHarness ────────────────────────────────────────────────
+
+// TestWithoutLocalHarness_SkipsController confirms that a boot with
+// WithoutLocalHarness does not surface an agent controller on the server —
+// the observable proxy for "the LocalHarnessController goroutine was not
+// started" available from outside the engine package (the controller field
+// itself is unexported engine-internal state).
+func TestWithoutLocalHarness_SkipsController(t *testing.T) {
+	reconcile.ResetProviders()
+	defer reconcile.ResetProviders()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	k, err := testkernel.Boot(ctx, t,
+		testkernel.WithoutLocalHarness(),
+		testkernel.WithPollInterval(1*time.Hour),
+	)
+	if err != nil {
+		t.Fatalf("testkernel.Boot: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := k.Stop(); err != nil {
+			t.Errorf("testkernel.Stop: %v", err)
+		}
+	})
+
+	// The kernel must still be healthy and serving (the option only skips the
+	// harness controller, not the rest of Boot).
+	if got := k.ReconcileDaemon().State(); got == engine.ReconcileDaemonShutdown {
+		t.Errorf("daemon state = %q; want not Shutdown", got)
+	}
+}
+
+// ─── A7: State() accessor (H6) ─────────────────────────────────────────────
+
+// TestKernelState_NonActiveOnDormantBoot confirms a freshly-booted,
+// externally-untouched measurement kernel reports non-Active — the
+// precondition the H6 hazard treatment (Module D) depends on to assert a
+// measurement window did not overlap a StateActive interval.
+func TestKernelState_NonActiveOnDormantBoot(t *testing.T) {
+	reconcile.ResetProviders()
+	defer reconcile.ResetProviders()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	k, err := testkernel.Boot(ctx, t,
+		testkernel.WithPollInterval(1*time.Hour),
+		testkernel.WithoutLocalHarness(),
+	)
+	if err != nil {
+		t.Fatalf("testkernel.Boot: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := k.Stop(); err != nil {
+			t.Errorf("testkernel.Stop: %v", err)
+		}
+	})
+
+	if got := k.State(); got == engine.StateActive {
+		t.Errorf("State() = %v; want non-Active for a dormant measurement boot", got)
+	}
+}
+
+// ─── shared fake ────────────────────────────────────────────────────────────
+
+// countingFake is a minimal Reconcilable whose FetchLive count is tracked
+// via an atomic counter, for tests that only need "did a cycle run" rather
+// than the full isolated_registry_test.go fakeReconcilable surface.
+type countingFake struct {
+	typeName   string
+	fetchCount atomic.Int32
+}
+
+func newCountingFake(typeName string) *countingFake {
+	return &countingFake{typeName: typeName}
+}
+
+func (f *countingFake) Type() string { return f.typeName }
+
+func (f *countingFake) LoadConfig(_ string) (any, error) {
+	return map[string]any{"type": f.typeName}, nil
+}
+
+func (f *countingFake) FetchLive(_ context.Context, _ any) (any, error) {
+	f.fetchCount.Add(1)
+	return map[string]any{"live": true}, nil
+}
+
+func (f *countingFake) ComputePlan(_ any, _ any, _ *reconcile.State) (*reconcile.Plan, error) {
+	return &reconcile.Plan{
+		ResourceType: f.typeName,
+		GeneratedAt:  time.Now().UTC().Format(time.RFC3339),
+		Actions: []reconcile.Action{{
+			Action:       reconcile.ActionSkip,
+			ResourceType: f.typeName,
+			Name:         "test",
+			Details:      map[string]any{"reason": "in sync"},
+		}},
+		Summary: reconcile.Summary{Skipped: 1},
+	}, nil
+}
+
+func (f *countingFake) ApplyPlan(_ context.Context, plan *reconcile.Plan) ([]reconcile.Result, error) {
+	var results []reconcile.Result
+	for _, a := range plan.Actions {
+		results = append(results, reconcile.Result{
+			Phase:  "apply",
+			Action: string(a.Action),
+			Name:   a.Name,
+			Status: reconcile.ApplySucceeded,
+		})
+	}
+	return results, nil
+}
+
+func (f *countingFake) BuildState(_ any, _ any, existing *reconcile.State) (*reconcile.State, error) {
+	s := reconcile.NewState(f.typeName)
+	if existing != nil {
+		s.Lineage = existing.Lineage
+		s.Serial = existing.Serial
+	}
+	return s, nil
+}
+
+func (f *countingFake) Health() reconcile.ResourceStatus {
+	return reconcile.NewResourceStatus(reconcile.SyncStatusSynced, reconcile.HealthHealthy)
+}

--- a/internal/testkernel/first_instruments_b_test.go
+++ b/internal/testkernel/first_instruments_b_test.go
@@ -1,0 +1,272 @@
+// first_instruments_b_test.go — Module B tests (First Instruments Stage-2).
+//
+// B2-gate correctness for ReconcileDaemon.LastCoherence (M1-B): all-Skipped
+// -> C_B==1.0, all-empty (Total()==0) -> C_B==1.0, zero-Skipped-AND-Total()>0
+// -> C_B==0.0, mixed -> strictly between. Also exercises the HTTP surface
+// (GET /v1/reconcile/coherence) end to end.
+package testkernel_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/myrgic/cogos/internal/testkernel"
+	"github.com/myrgic/cogos/pkg/substrate/reconcile"
+)
+
+// summaryFake is a Reconcilable whose ComputePlan returns a caller-supplied
+// fixed Summary, letting each test drive LastCoherence's B2-gate branches
+// directly without needing a real diff-producing provider.
+type summaryFake struct {
+	typeName string
+	summary  reconcile.Summary
+}
+
+func (f *summaryFake) Type() string { return f.typeName }
+
+func (f *summaryFake) LoadConfig(_ string) (any, error) {
+	return map[string]any{"type": f.typeName}, nil
+}
+
+func (f *summaryFake) FetchLive(_ context.Context, _ any) (any, error) {
+	return map[string]any{"live": true}, nil
+}
+
+func (f *summaryFake) ComputePlan(_ any, _ any, _ *reconcile.State) (*reconcile.Plan, error) {
+	actions := make([]reconcile.Action, 0, f.summary.Total())
+	addActions := func(action reconcile.ActionType, n int) {
+		for i := 0; i < n; i++ {
+			actions = append(actions, reconcile.Action{
+				Action:       action,
+				ResourceType: f.typeName,
+				Name:         "test",
+				Details:      map[string]any{},
+			})
+		}
+	}
+	addActions(reconcile.ActionCreate, f.summary.Creates)
+	addActions(reconcile.ActionUpdate, f.summary.Updates)
+	addActions(reconcile.ActionDelete, f.summary.Deletes)
+	addActions(reconcile.ActionSkip, f.summary.Skipped)
+
+	return &reconcile.Plan{
+		ResourceType: f.typeName,
+		GeneratedAt:  time.Now().UTC().Format(time.RFC3339),
+		Actions:      actions,
+		Summary:      f.summary,
+	}, nil
+}
+
+func (f *summaryFake) ApplyPlan(_ context.Context, plan *reconcile.Plan) ([]reconcile.Result, error) {
+	var results []reconcile.Result
+	for _, a := range plan.Actions {
+		results = append(results, reconcile.Result{
+			Phase:  "apply",
+			Action: string(a.Action),
+			Name:   a.Name,
+			Status: reconcile.ApplySucceeded,
+		})
+	}
+	return results, nil
+}
+
+func (f *summaryFake) BuildState(_ any, _ any, existing *reconcile.State) (*reconcile.State, error) {
+	s := reconcile.NewState(f.typeName)
+	if existing != nil {
+		s.Lineage = existing.Lineage
+		s.Serial = existing.Serial
+	}
+	return s, nil
+}
+
+func (f *summaryFake) Health() reconcile.ResourceStatus {
+	return reconcile.NewResourceStatus(reconcile.SyncStatusSynced, reconcile.HealthHealthy)
+}
+
+// runOneCycleAndReadCoherence boots a kernel with the given fakes, triggers
+// exactly one cycle per fake, waits for completion, and returns the
+// aggregate C_B.
+func runOneCycleAndReadCoherence(t *testing.T, fakes ...*summaryFake) float64 {
+	t.Helper()
+	reconcile.ResetProviders()
+	defer reconcile.ResetProviders()
+
+	providers := make([]reconcile.Reconcilable, len(fakes))
+	for i, f := range fakes {
+		providers[i] = f
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	k, err := testkernel.Boot(ctx, t,
+		testkernel.WithIsolatedRegistry(providers...),
+		testkernel.WithPollInterval(1*time.Hour),
+	)
+	if err != nil {
+		t.Fatalf("testkernel.Boot: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := k.Stop(); err != nil {
+			t.Errorf("testkernel.Stop: %v", err)
+		}
+	})
+
+	for _, f := range fakes {
+		k.ReconcileDaemon().Trigger(f.typeName)
+	}
+	for _, f := range fakes {
+		if err := testkernel.WaitForCycle(ctx, k, f.typeName, 1); err != nil {
+			t.Fatalf("WaitForCycle(%s): %v", f.typeName, err)
+		}
+	}
+
+	cB, _ := k.ReconcileDaemon().LastCoherence()
+	return cB
+}
+
+// TestLastCoherence_AllSkipped_CB1 covers B2-gate: all providers all-Skipped
+// (Creates=Updates=Deletes=0, Skipped>0) => C_B == 1.0.
+func TestLastCoherence_AllSkipped_CB1(t *testing.T) {
+	fake := &summaryFake{typeName: "b2-all-skipped", summary: reconcile.Summary{Skipped: 3}}
+	cB := runOneCycleAndReadCoherence(t, fake)
+	if cB != 1.0 {
+		t.Errorf("C_B = %v; want 1.0 for all-Skipped", cB)
+	}
+}
+
+// TestLastCoherence_EmptyPlan_CB1 covers the B2 empty-plan boundary fix: all
+// providers empty (Creates=Updates=Deletes=Skipped=0, Total()==0) => C_B ==
+// 1.0 (a fully-in-sync idle provider is coherent, not maximally drifted).
+func TestLastCoherence_EmptyPlan_CB1(t *testing.T) {
+	fake := &summaryFake{typeName: "b2-empty-plan", summary: reconcile.Summary{}}
+	cB := runOneCycleAndReadCoherence(t, fake)
+	if cB != 1.0 {
+		t.Errorf("C_B = %v; want 1.0 for an empty plan (Total()==0)", cB)
+	}
+}
+
+// TestLastCoherence_ZeroSkippedNonEmpty_CB0 covers B2-gate: all providers
+// zero-Skipped AND Total()>0 (all actions real) => C_B == 0.0. The
+// Total()>0 conjunct is required so this does not collide with the
+// empty-plan case.
+func TestLastCoherence_ZeroSkippedNonEmpty_CB0(t *testing.T) {
+	fake := &summaryFake{typeName: "b2-zero-skipped", summary: reconcile.Summary{Creates: 2, Updates: 1}}
+	cB := runOneCycleAndReadCoherence(t, fake)
+	if cB != 0.0 {
+		t.Errorf("C_B = %v; want 0.0 for zero-Skipped AND Total()>0", cB)
+	}
+}
+
+// TestLastCoherence_Mixed_StrictlyBetween covers B2-gate: a mix of drifted
+// and skipped actions on one provider lands strictly between 0 and 1.
+func TestLastCoherence_Mixed_StrictlyBetween(t *testing.T) {
+	fake := &summaryFake{typeName: "b2-mixed", summary: reconcile.Summary{Creates: 1, Skipped: 3}}
+	cB := runOneCycleAndReadCoherence(t, fake)
+	if cB <= 0.0 || cB >= 1.0 {
+		t.Errorf("C_B = %v; want strictly between 0 and 1 for a mixed plan", cB)
+	}
+}
+
+// TestLastCoherence_MultiProvider_Averages confirms C_B averages
+// drift_fraction across providers (1 - mean(drift_fraction)), not just the
+// last-observed provider.
+func TestLastCoherence_MultiProvider_Averages(t *testing.T) {
+	allSkipped := &summaryFake{typeName: "b2-multi-skipped", summary: reconcile.Summary{Skipped: 2}}
+	allDrifted := &summaryFake{typeName: "b2-multi-drifted", summary: reconcile.Summary{Creates: 2}}
+	cB := runOneCycleAndReadCoherence(t, allSkipped, allDrifted)
+	// drift_fraction: 0 for allSkipped, 1 for allDrifted => mean 0.5 => C_B=0.5.
+	const want = 0.5
+	const tol = 1e-9
+	if cB < want-tol || cB > want+tol {
+		t.Errorf("C_B = %v; want %v (average of 0 and 1 drift_fraction)", cB, want)
+	}
+}
+
+// TestLastCoherence_NoCycleYet_CB1 confirms LastCoherence reports C_B==1.0
+// with no per-provider detail when no cycle has completed (vacuously
+// coherent — nothing observed to have drifted).
+func TestLastCoherence_NoCycleYet_CB1(t *testing.T) {
+	reconcile.ResetProviders()
+	defer reconcile.ResetProviders()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	k, err := testkernel.Boot(ctx, t, testkernel.WithPollInterval(1*time.Hour))
+	if err != nil {
+		t.Fatalf("testkernel.Boot: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := k.Stop(); err != nil {
+			t.Errorf("testkernel.Stop: %v", err)
+		}
+	})
+
+	cB, detail := k.ReconcileDaemon().LastCoherence()
+	if cB != 1.0 {
+		t.Errorf("C_B = %v; want 1.0 before any cycle completes", cB)
+	}
+	if len(detail) != 0 {
+		t.Errorf("detail = %v; want empty before any cycle completes", detail)
+	}
+}
+
+// TestReconcileCoherenceHTTP_ReflectsLastCoherence exercises the HTTP
+// surface (GET /v1/reconcile/coherence) end to end and confirms it agrees
+// with the daemon's own LastCoherence().
+func TestReconcileCoherenceHTTP_ReflectsLastCoherence(t *testing.T) {
+	reconcile.ResetProviders()
+	defer reconcile.ResetProviders()
+
+	fake := &summaryFake{typeName: "b2-http", summary: reconcile.Summary{Creates: 1, Skipped: 1}}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	k, err := testkernel.Boot(ctx, t,
+		testkernel.WithIsolatedRegistry(fake),
+		testkernel.WithPollInterval(1*time.Hour),
+	)
+	if err != nil {
+		t.Fatalf("testkernel.Boot: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := k.Stop(); err != nil {
+			t.Errorf("testkernel.Stop: %v", err)
+		}
+	})
+
+	k.ReconcileDaemon().Trigger(fake.typeName)
+	if err := testkernel.WaitForCycle(ctx, k, fake.typeName, 1); err != nil {
+		t.Fatalf("WaitForCycle: %v", err)
+	}
+
+	wantCB, _ := k.ReconcileDaemon().LastCoherence()
+
+	resp, err := http.Get(k.Endpoint() + "/v1/reconcile/coherence")
+	if err != nil {
+		t.Fatalf("GET /v1/reconcile/coherence: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d; want 200", resp.StatusCode)
+	}
+
+	var body struct {
+		CB                   float64 `json:"c_b"`
+		PerProviderDriftFrac []any   `json:"per_provider_drift_fraction"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.CB != wantCB {
+		t.Errorf("HTTP c_b = %v; want %v (matching daemon.LastCoherence())", body.CB, wantCB)
+	}
+	if len(body.PerProviderDriftFrac) == 0 {
+		t.Error("per_provider_drift_fraction is empty; want one entry for the triggered provider")
+	}
+}

--- a/internal/testkernel/first_instruments_c_test.go
+++ b/internal/testkernel/first_instruments_c_test.go
@@ -1,0 +1,125 @@
+// first_instruments_c_test.go — Module C tests (First Instruments Stage-2).
+//
+// End-to-end HTTP surface test for GET /v1/kernel/rates. The bulk of Module
+// C's arithmetic/echo-class/live-read tests live in
+// internal/engine/rates_test.go (same package as KernelRates); this file
+// covers the wiring through a real testkernel boot.
+package testkernel_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/myrgic/cogos/internal/testkernel"
+	"github.com/myrgic/cogos/pkg/substrate/reconcile"
+)
+
+func TestKernelRatesHTTP_FifteenRatiosWithEchoClass(t *testing.T) {
+	reconcile.ResetProviders()
+	defer reconcile.ResetProviders()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	k, err := testkernel.Boot(ctx, t, testkernel.WithPollInterval(1*time.Hour))
+	if err != nil {
+		t.Fatalf("testkernel.Boot: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := k.Stop(); err != nil {
+			t.Errorf("testkernel.Stop: %v", err)
+		}
+	})
+
+	resp, err := http.Get(k.Endpoint() + "/v1/kernel/rates")
+	if err != nil {
+		t.Fatalf("GET /v1/kernel/rates: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d; want 200", resp.StatusCode)
+	}
+
+	var body struct {
+		Constants []struct {
+			Name          string  `json:"name"`
+			Seconds       float64 `json:"seconds"`
+			HasConfigKnob bool    `json:"has_config_knob"`
+		} `json:"constants"`
+		Ratios []struct {
+			Numerator      string  `json:"numerator"`
+			Denominator    string  `json:"denominator"`
+			Ratio          float64 `json:"ratio"`
+			EchoClass      string  `json:"echo_class"`
+			SourceCitation string  `json:"source_citation"`
+		} `json:"ratios"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if len(body.Constants) != 6 {
+		t.Errorf("len(Constants) = %d; want 6", len(body.Constants))
+	}
+	if len(body.Ratios) != 15 {
+		t.Errorf("len(Ratios) = %d; want 15", len(body.Ratios))
+	}
+	for _, r := range body.Ratios {
+		if r.EchoClass != "deterministic_config_read" {
+			t.Errorf("ratio %s/%s: echo_class = %q; want deterministic_config_read", r.Numerator, r.Denominator, r.EchoClass)
+		}
+	}
+}
+
+// TestKernelRatesHTTP_ReflectsDaemonPollInterval confirms the live HTTP
+// surface reports the ACTUAL running daemon's PollInterval, not a static
+// guess — booting with a 1h poll interval should show PollInterval=3600s.
+func TestKernelRatesHTTP_ReflectsDaemonPollInterval(t *testing.T) {
+	reconcile.ResetProviders()
+	defer reconcile.ResetProviders()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	k, err := testkernel.Boot(ctx, t, testkernel.WithPollInterval(1*time.Hour))
+	if err != nil {
+		t.Fatalf("testkernel.Boot: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := k.Stop(); err != nil {
+			t.Errorf("testkernel.Stop: %v", err)
+		}
+	})
+
+	resp, err := http.Get(k.Endpoint() + "/v1/kernel/rates")
+	if err != nil {
+		t.Fatalf("GET /v1/kernel/rates: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var body struct {
+		Constants []struct {
+			Name    string  `json:"name"`
+			Seconds float64 `json:"seconds"`
+		} `json:"constants"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	found := false
+	for _, c := range body.Constants {
+		if c.Name == "PollInterval" {
+			found = true
+			if c.Seconds != 3600 {
+				t.Errorf("PollInterval.Seconds = %v; want 3600 (1h)", c.Seconds)
+			}
+		}
+	}
+	if !found {
+		t.Error("PollInterval constant not found in response")
+	}
+}

--- a/internal/testkernel/first_instruments_e_test.go
+++ b/internal/testkernel/first_instruments_e_test.go
@@ -1,0 +1,213 @@
+// first_instruments_e_test.go — Module E tests (First Instruments Stage-2).
+//
+// Covers the K12-law unit tests specced in IMPL-SPEC.md Module E: the
+// PRIMARY non-divisible cadence test (C=5s,H=2s => events at ceil(5/2)*2=6s
+// multiples, NOT 5s) and the divisible-cell MIXTURE-EXPECTATION test
+// (C=4s,H=2s => a jitter-decided {4s,6s} mixture, >=10% at 6s — locking the
+// code-true knife-edge behavior, blind-review-4 Finding A(3)). Also covers
+// heartbeat-spacing, trigger labeling, the success-point tap (Finding B),
+// and the no-mutation guarantee.
+package testkernel_test
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/myrgic/cogos/internal/engine"
+	"github.com/myrgic/cogos/internal/testkernel"
+	"github.com/myrgic/cogos/pkg/substrate/reconcile"
+)
+
+// bootCadenceKernel boots a measurement kernel at the given (C,H) seconds
+// with the natural reconcile tick defeated (1h poll interval) and the local
+// harness controller disabled, per the harness discipline (IMPL-SPEC A4/D2).
+// lifetime bounds the kernel's own context — it MUST exceed the caller's
+// planned cadence-wait window, since the process's tickers (and thus the
+// M11/M12 cadence taps) stop firing the instant this context is cancelled.
+func bootCadenceKernel(t *testing.T, consolidationSec, heartbeatSec int, lifetime time.Duration) *testkernel.Kernel {
+	t.Helper()
+	reconcile.ResetProviders()
+	t.Cleanup(reconcile.ResetProviders)
+
+	ctx, cancel := context.WithTimeout(context.Background(), lifetime)
+	t.Cleanup(cancel)
+
+	k, err := testkernel.Boot(ctx, t,
+		testkernel.WithConsolidationInterval(consolidationSec),
+		testkernel.WithHeartbeatInterval(heartbeatSec),
+		testkernel.WithPollInterval(1*time.Hour),
+		testkernel.WithoutLocalHarness(),
+	)
+	if err != nil {
+		t.Fatalf("testkernel.Boot: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := k.Stop(); err != nil {
+			t.Errorf("testkernel.Stop: %v", err)
+		}
+	})
+	return k
+}
+
+// waitForConsolidationEvents polls ConsolidationEvents until at least n have
+// been recorded, or the deadline passes.
+func waitForConsolidationEvents(t *testing.T, k *testkernel.Kernel, n int, deadline time.Duration) []engine.ConsolidationEvent {
+	t.Helper()
+	dl := time.After(deadline)
+	for {
+		events := k.ConsolidationEvents()
+		if len(events) >= n {
+			return events
+		}
+		select {
+		case <-dl:
+			t.Fatalf("waitForConsolidationEvents: only %d/%d events after %v", len(events), n, deadline)
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+}
+
+func waitForHeartbeatEvents(t *testing.T, k *testkernel.Kernel, n int, deadline time.Duration) []engine.HeartbeatEvent {
+	t.Helper()
+	dl := time.After(deadline)
+	for {
+		events := k.HeartbeatEvents()
+		if len(events) >= n {
+			return events
+		}
+		select {
+		case <-dl:
+			t.Fatalf("waitForHeartbeatEvents: only %d/%d events after %v", len(events), n, deadline)
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+}
+
+// ─── PRIMARY K12-law unit test (non-divisible): C=5s, H=2s ─────────────────
+//
+// ceil(5/2)*2 = 6s != 5s. Events must land at ~6s multiples from boot, NOT
+// 5s multiples — the cheapest confirmation the ceiling actually rounds up
+// rather than tracking raw C. Margin (6-5=1s) is jitter-robust.
+func TestK12Law_NonDivisible_C5H2_EventsAt6sMultiples(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping cadence-wait test in -short mode")
+	}
+	k := bootCadenceKernel(t, 5, 2, 45*time.Second)
+
+	// Wait for 2 consolidation events => 1 full inter-consolidation interval.
+	events := waitForConsolidationEvents(t, k, 2, 20*time.Second)
+	interval := events[1].At.Sub(events[0].At)
+
+	const wantSeconds = 6.0
+	const tolSeconds = 1.5 // generous scheduler-jitter allowance; 6s vs 5s margin is 1s
+	got := interval.Seconds()
+	if math.Abs(got-wantSeconds) > tolSeconds {
+		t.Errorf("inter-consolidation interval = %.3fs; want ~%.1fs (ceil(5/2)*2), tolerance %.1fs", got, wantSeconds, tolSeconds)
+	}
+	// The discriminating assertion: NOT 5s (raw C).
+	if math.Abs(got-5.0) < 0.5 {
+		t.Errorf("inter-consolidation interval = %.3fs landed near raw C=5s, not the law-predicted ceil(5/2)*2=6s", got)
+	}
+
+	for _, e := range events {
+		if e.Trigger != engine.TriggerHeartbeatGated {
+			t.Errorf("event trigger = %q; want %q", e.Trigger, engine.TriggerHeartbeatGated)
+		}
+	}
+}
+
+// ─── DIVISIBLE-CELL MIXTURE-EXPECTATION test: C=4s, H=2s ───────────────────
+//
+// ceil(4/2)*2 = 4s = C (divisible). The code-true generator captures `now`
+// AFTER jittered body work, so the deciding tick is a near-coin-flip: the
+// observed inter-consolidation intervals are a {C, C+H} = {4s, 6s} mixture,
+// NOT a clean deterministic 4s. Assert (i) every interval is near either 4s
+// or 6s (no interval far from both) and (ii) a non-trivial fraction (>=10%)
+// land near 6s.
+func TestK12Law_Divisible_C4H2_MixtureExpectation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping cadence-wait test in -short mode")
+	}
+	k := bootCadenceKernel(t, 4, 2, 8*time.Minute)
+
+	// >=40 intervals per spec => >=41 events. This is a slow real-time wait
+	// (41 * ~4-6s ≈ 3-4 minutes); bounded generously.
+	const minIntervals = 40
+	events := waitForConsolidationEvents(t, k, minIntervals+1, 6*time.Minute)
+
+	const tol = 1.0 // seconds
+	near6 := 0
+	for i := 1; i < len(events); i++ {
+		interval := events[i].At.Sub(events[i-1].At).Seconds()
+		near4 := math.Abs(interval-4.0) <= tol
+		is6 := math.Abs(interval-6.0) <= tol
+		if !near4 && !is6 {
+			t.Errorf("interval[%d] = %.3fs; not within tolerance of either 4s or 6s (mixture expectation violated)", i, interval)
+		}
+		if is6 {
+			near6++
+		}
+	}
+
+	total := len(events) - 1
+	fracNear6 := float64(near6) / float64(total)
+	if fracNear6 < 0.10 {
+		t.Errorf("fraction of intervals near 6s = %.3f (%d/%d); want >= 0.10 (confirms the jitter knife-edge coin-flip is real, not a clean 4s)", fracNear6, near6, total)
+	}
+}
+
+// ─── Heartbeat spacing (both directions) ───────────────────────────────────
+
+func TestHeartbeatEvents_SpacingApproximatesH(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping cadence-wait test in -short mode")
+	}
+	// H=1s per §2 test table ("set H=1s, confirm ~1s heartbeat spacing").
+	k := bootCadenceKernel(t, 3600, 1, 30*time.Second)
+
+	events := waitForHeartbeatEvents(t, k, 4, 15*time.Second)
+	for i := 1; i < len(events); i++ {
+		spacing := events[i].At.Sub(events[i-1].At).Seconds()
+		if spacing < 0.3 || spacing > 3.0 {
+			t.Errorf("heartbeat spacing[%d] = %.3fs; want ~1s (generous jitter bound)", i, spacing)
+		}
+	}
+}
+
+// ─── No-mutation guarantee (K3/K8) ──────────────────────────────────────────
+
+// TestCadenceTaps_NoKernelStateMutation confirms that reading the cadence
+// event snapshots does not mutate kernel state: repeated reads return
+// growing-or-equal-length slices (append-only) and never shrink or reorder
+// already-observed events.
+func TestCadenceTaps_NoKernelStateMutation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping cadence-wait test in -short mode")
+	}
+	k := bootCadenceKernel(t, 3600, 1, 30*time.Second)
+
+	first := waitForHeartbeatEvents(t, k, 2, 15*time.Second)
+	// Read again immediately; must be a stable prefix (append-only, no
+	// reordering, no mutation from the read itself).
+	second := k.HeartbeatEvents()
+	if len(second) < len(first) {
+		t.Fatalf("HeartbeatEvents shrank across reads: %d then %d", len(first), len(second))
+	}
+	for i := range first {
+		if !first[i].At.Equal(second[i].At) {
+			t.Errorf("event[%d] timestamp changed across reads: %v vs %v", i, first[i].At, second[i].At)
+		}
+	}
+
+	// Mutating the returned slice must not affect the recorder's internal
+	// state (snapshot semantics).
+	if len(second) > 0 {
+		second[0].At = time.Time{}
+		third := k.HeartbeatEvents()
+		if third[0].At.IsZero() {
+			t.Error("mutating a returned HeartbeatEvents slice affected a subsequent snapshot — not side-effect-free")
+		}
+	}
+}

--- a/internal/testkernel/testkernel.go
+++ b/internal/testkernel/testkernel.go
@@ -8,6 +8,47 @@
 // protocol, enabling binary-assembly tests. CallTool is the Phase-3b follow-up.
 // Phase 4 will add goroutine-leak detection.
 //
+// # Background goroutines started by a testkernel.Boot (First Instruments A5)
+//
+// engine.Boot starts every one of these unconditionally except where noted.
+// Any measurement harness computing cadence/timing off a testkernel.Boot must
+// account for ALL of them as potential noise/contention sources, not just the
+// ReconcileDaemon:
+//
+//   - ReconcileDaemon.run — the periodic reconcile loop (this package's main
+//     subject; PollInterval-controlled via WithPollInterval, First
+//     Instruments A1).
+//   - Process.Run — the process's own consolidation/heartbeat select-loop
+//     (consolidationTicker + heartbeatTicker), driving emitHeartbeat and the
+//     K12-gated consolidation Module E taps. Cadence controlled via
+//     WithConsolidationInterval / WithHeartbeatInterval (First Instruments A2).
+//   - LocalHarnessController — its own ticker (interval = cfg.HeartbeatInterval
+//     seconds, default 1 minute), started whenever server.mcpServer is
+//     non-nil (true for every testkernel boot). An uncontrolled background
+//     source not accounted for by any prior cost model; skip it with
+//     WithoutLocalHarness (First Instruments A4).
+//   - ProjectionWatcher, one per AllProjectionKinds — fsnotify-based watchers
+//     over .cog/mem/semantic/lineage/nodes that call
+//     reconcileDaemon.Trigger(providerType) on change. In a fresh
+//     makeMinimalWorkspace() boot the watched directory does not exist, so
+//     these typically fail to start (logged at Debug) and are inert.
+//   - Decision-lineage ProjectionWatcher(s), one per DecisionCorpusDirs —
+//     same watch-then-Trigger shape as above, over the ADR/RFC decision
+//     corpus dirs; also typically inert in a minimal test workspace.
+//   - MemWatcher (mem-currency / FTS watcher) — only started when a
+//     ConstellationIndexer has been wired (pkgFTSRepairIndexer != nil); nil
+//     in standard testkernel boots, so this is normally NOT started.
+//   - The inference router's background availability maintainer (probes
+//     configured providers off the request hot path); started by
+//     BuildRouter regardless of BootOption.
+//   - OTel telemetry (initTelemetry) — no-op (no goroutine of consequence)
+//     when no OTLP collector is configured, which is the default test
+//     environment.
+//
+// See engine.Boot's own doc comment for the authoritative, code-level list;
+// this summary exists so a measurement-harness author does not have to
+// re-derive it from scratch.
+//
 // Typical usage:
 //
 //	func TestFoo(t *testing.T) {
@@ -61,6 +102,20 @@ type config struct {
 	// pollInterval overrides the reconcile daemon tick. 0 = use daemon default.
 	pollInterval time.Duration
 
+	// consolidationIntervalSec, when > 0, overrides engine.Config.ConsolidationInterval
+	// (seconds) before Boot. 0 = leave LoadConfig's resolved value in place.
+	consolidationIntervalSec int
+	consolidationIntervalSet bool
+
+	// heartbeatIntervalSec, when > 0, overrides engine.Config.HeartbeatInterval
+	// (seconds) before Boot. 0 = leave LoadConfig's resolved value in place.
+	heartbeatIntervalSec int
+	heartbeatIntervalSet bool
+
+	// withoutLocalHarness, when true, forwards engine.WithoutLocalHarness so
+	// the LocalHarnessController goroutine is not started for this boot.
+	withoutLocalHarness bool
+
 	// providers, when non-nil, is forwarded to engine.WithIsolatedRegistry so
 	// the daemon bypasses the global registry. nil = use global registry.
 	providers []reconcile.Reconcilable
@@ -85,6 +140,52 @@ func WithIsolatedRegistry(providers ...reconcile.Reconcilable) Option {
 	return func(c *config) { c.providers = providers }
 }
 
+// WithPollInterval overrides the ReconcileDaemon's tick interval for this
+// kernel. d <= 0 leaves the daemon default (30s) in effect.
+//
+// Forwards to engine.WithPollInterval (First Instruments A1). Measurement
+// harnesses use a very high value (e.g. 1h) to defeat the natural tick so
+// Trigger() is the sole cycle driver, or a very low value to force fast
+// natural cadence in a unit test.
+func WithPollInterval(d time.Duration) Option {
+	return func(c *config) { c.pollInterval = d }
+}
+
+// WithConsolidationInterval overrides the consolidation cadence (seconds) for
+// this kernel's Process before Boot. sec must be >= 0; 0 means "use the
+// engine default" (LoadConfig already resolves ConsolidationInterval to 3600
+// before Boot sees it, so 0 here is a no-op override rather than a literal
+// zero interval, which would panic time.NewTicker). A value of 1 (or any
+// second-scale value) is legal — this is what lets First Instruments realize
+// its second-scale cell lattice (First Instruments A2/A6).
+func WithConsolidationInterval(sec int) Option {
+	return func(c *config) {
+		c.consolidationIntervalSec = sec
+		c.consolidationIntervalSet = true
+	}
+}
+
+// WithHeartbeatInterval overrides the heartbeat cadence (seconds) for this
+// kernel's Process before Boot. sec must be >= 0; 0 means "use the engine
+// default" (60), same reasoning as WithConsolidationInterval (First
+// Instruments A2).
+func WithHeartbeatInterval(sec int) Option {
+	return func(c *config) {
+		c.heartbeatIntervalSec = sec
+		c.heartbeatIntervalSet = true
+	}
+}
+
+// WithoutLocalHarness skips starting the kernel's LocalHarnessController
+// goroutine for this boot. Forwards to engine.WithoutLocalHarness (First
+// Instruments A4) — see that option's doc comment for why this matters to
+// cadence measurement: engine.Boot unconditionally starts the controller
+// whenever an MCP server is present, which is true for every testkernel
+// boot, making it an uncontrolled background noise source unless skipped.
+func WithoutLocalHarness() Option {
+	return func(c *config) { c.withoutLocalHarness = true }
+}
+
 // Kernel is an opaque handle to an in-process kernel instance started by Boot.
 // Call Stop when the test finishes; the idiomatic pattern is t.Cleanup.
 type Kernel struct {
@@ -107,6 +208,41 @@ func (k *Kernel) WorkspaceRoot() string {
 // Trigger and inspect State without going through the HTTP surface.
 func (k *Kernel) ReconcileDaemon() *engine.ReconcileDaemon {
 	return k.kernel.ReconcileDaemon()
+}
+
+// State returns the current lifecycle state of this kernel's Process
+// (StateActive / StateReceptive / StateDormant). Read-only (First
+// Instruments A7) — used by measurement harnesses to assert a dormant
+// measurement boot is non-Active (H6), since emitHeartbeat early-returns on
+// StateActive, suppressing both the M12 heartbeat tap and the K12-gated
+// consolidation.
+func (k *Kernel) State() engine.ProcessState {
+	return k.kernel.Process().State()
+}
+
+// LastCycleSerial returns the current monotonic cycle-completion counter for
+// providerType (First Instruments A3). See engine.ReconcileDaemon.LastCycleSerial.
+func (k *Kernel) LastCycleSerial(providerType string) (int, bool) {
+	return k.kernel.ReconcileDaemon().LastCycleSerial(providerType)
+}
+
+// WaitForCycle blocks until providerType's cycle-completion counter reaches
+// at least minSerial, or ctx is done. Polls LastCycleSerial rather than any
+// provider-owned test state, so it works against a real production provider
+// under test, not just a fake that tracks its own counters (First
+// Instruments A3).
+func WaitForCycle(ctx context.Context, k *Kernel, providerType string, minSerial int) error {
+	const pollInterval = 5 * time.Millisecond
+	for {
+		if serial, ok := k.LastCycleSerial(providerType); ok && serial >= minSerial {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("testkernel.WaitForCycle: provider %q did not reach serial %d: %w", providerType, minSerial, ctx.Err())
+		case <-time.After(pollInterval):
+		}
+	}
 }
 
 // Stop cancels the kernel's context and waits for all goroutines to exit.
@@ -266,11 +402,29 @@ func Boot(ctx context.Context, t *testing.T, opts ...Option) (*Kernel, error) {
 	if engineCfg.BindAddr == "" {
 		engineCfg.BindAddr = "127.0.0.1"
 	}
+	// First Instruments A2: override the process's cadence config in seconds
+	// before Boot, so second-scale cell-lattice values take effect. 0 means
+	// "use the default" (LoadConfig already resolved ConsolidationInterval to
+	// 3600 and HeartbeatInterval to 60 before we get here, so a literal 0
+	// override would disable the ticker entirely, not select a default —
+	// only apply the override when a positive value was explicitly set).
+	if cfg.consolidationIntervalSet && cfg.consolidationIntervalSec > 0 {
+		engineCfg.ConsolidationInterval = cfg.consolidationIntervalSec
+	}
+	if cfg.heartbeatIntervalSet && cfg.heartbeatIntervalSec > 0 {
+		engineCfg.HeartbeatInterval = cfg.heartbeatIntervalSec
+	}
 
 	// Build engine BootOptions from testkernel config.
 	var bootOpts []engine.BootOption
 	if cfg.providers != nil {
 		bootOpts = append(bootOpts, engine.WithIsolatedRegistry(cfg.providers...))
+	}
+	if cfg.pollInterval > 0 {
+		bootOpts = append(bootOpts, engine.WithPollInterval(cfg.pollInterval))
+	}
+	if cfg.withoutLocalHarness {
+		bootOpts = append(bootOpts, engine.WithoutLocalHarness())
 	}
 
 	k, err := engine.Boot(ctx, engineCfg, bootOpts...)

--- a/internal/testkernel/testkernel.go
+++ b/internal/testkernel/testkernel.go
@@ -226,6 +226,34 @@ func (k *Kernel) LastCycleSerial(providerType string) (int, bool) {
 	return k.kernel.ReconcileDaemon().LastCycleSerial(providerType)
 }
 
+// ConsolidationEvents returns a read-only snapshot of observed dormant-
+// consolidation completions for this kernel's Process (First Instruments
+// Module E, M11). See engine.Process.ConsolidationEvents.
+func (k *Kernel) ConsolidationEvents() []engine.ConsolidationEvent {
+	return k.kernel.Process().ConsolidationEvents()
+}
+
+// HeartbeatEvents returns a read-only snapshot of observed heartbeat events
+// (past the StateActive gate) for this kernel's Process (First Instruments
+// Module E, M12). See engine.Process.HeartbeatEvents.
+func (k *Kernel) HeartbeatEvents() []engine.HeartbeatEvent {
+	return k.kernel.Process().HeartbeatEvents()
+}
+
+// ActiveExpiryObservations returns a read-only snapshot of observed
+// active-window-expiry events for this kernel's Process (First Instruments
+// Module E, M13). See engine.Process.ActiveExpiryObservations.
+func (k *Kernel) ActiveExpiryObservations() []engine.ActiveExpiryObservation {
+	return k.kernel.Process().ActiveExpiryObservations()
+}
+
+// RecordActiveExpiryObservation lets a test-owned poller of a session's
+// IsActive record an M13 observation on this kernel's Process (First
+// Instruments Module E). See engine.Process.RecordActiveExpiryObservation.
+func (k *Kernel) RecordActiveExpiryObservation(obs engine.ActiveExpiryObservation) {
+	k.kernel.Process().RecordActiveExpiryObservation(obs)
+}
+
 // WaitForCycle blocks until providerType's cycle-completion counter reaches
 // at least minSerial, or ctx is done. Polls LastCycleSerial rather than any
 // provider-owned test state, so it works against a real production provider


### PR DESCRIPTION
## First Instruments Stage-2 instrumentation (Modules A-E)

Implements the five instrumentation modules specced by the frozen First
Instruments v1 registration: test-surface extensions, coherence-gate
correctness, rate-ratio surfaces, an experiment-runner measurement harness,
and behavioral-cadence law instrumentation. This is measurement
tooling — none of it sits on a production code path; it exists to let the
frozen sweep observe the kernel and adjudicate DEAD/SURVIVED against the
pre-registered law.

### Frozen registration this implements

Tag `first-instruments-v1-registered` (cog workspace, commit `07b9ab2`):
operator-signed G1-G10 (G3 = build gate), **simulation green 207/0** at
freeze, ratified by **five blind reviews + one Codex re-referee pass**. The
registration lives at `.cog/mem/working/first-instruments/` in the cog
workspace (`PREREG-DRAFT.md`, `IMPL-SPEC.md`, `BLIND-REVIEW-{1..5}.md`,
`DECISION-SURFACE-SIM.md`, `decision_surface_sim.py`) and this PR is the
Go-native realization of that spec against `~/workspaces/myrgic/cogos`.

### Modules

- **Module A — testkernel cadence + cell-lattice test surface**
  (`internal/testkernel/testkernel.go`, `first_instruments_a_test.go`).
  Adds `WithPollInterval`, `WithConsolidationInterval`,
  `WithHeartbeatInterval`, `WithoutLocalHarness`,
  `LastCycleSerial`/`WaitForCycle`, and the frozen 9-cell `(C,H,P)` lattice
  (K0 production anchor + 8 second-scale cells) plus a `State()` accessor
  (IMPL-SPEC H6).

- **Module B — graded coherence (M1-A/M1-B)**
  (`internal/testkernel/first_instruments_b_test.go` + engine wiring).
  Freezes `ReconcileDaemon.LastCoherence` gate correctness: all-Skipped ⇒
  `C_B==1.0`; all-empty (`Total()==0`) ⇒ `C_B==1.0` (the empty-plan
  boundary fix from blind-review-1 — an idle provider with nothing to
  reconcile is fully in-sync, not maximally drifted); zero-Skipped AND
  `Total()>0` ⇒ `C_B==0.0`; mixed ⇒ strictly between. Exercises the
  `GET /v1/reconcile/coherence` HTTP surface end to end.

- **Module C — deterministic-echo rate-ratio surface**
  (`internal/testkernel/first_instruments_c_test.go` +
  `internal/engine/rates_test.go`). Wires `GET /v1/kernel/rates` through a
  real testkernel boot; core arithmetic/echo-class/live-read tests live in
  the engine package.

- **Module D — experiment-runner test harness**
  (`internal/testkernel/experiment/`: `runner.go`, `calibration.go`,
  `law.go`, `lattice.go`, `manifest.go`, `oscillator.go`, `terminal.go`,
  `blockbootstrap.go`, `injectors.go` + tests). Measurement tooling, not a
  production path. Boots real testkernel instances, reads Module E's
  cadence taps, applies the frozen calibration gates (split-null
  threshold-vs-validation, Gaussian-multiplicative null family, circular
  block-bootstrap, 95th-percentile decision threshold, three hard-abort
  gates: PRECISION/POWER/JITTER-MODEL-VALIDATION), and computes the
  KC-3-LAW confirm/kill/mixture recording plus per-cell kill-eligibility
  and H6 process-state tags against the frozen 9-cell lattice. Replicate
  protocol (frozen, blind-review-4 Finding C): one boot per cell, n
  consecutive inter-consolidation intervals, first interval discarded
  (phase-contaminated), serial dependence handled via circular
  block-bootstrap.

- **Module E — behavioral-cadence instrumentation**
  (`internal/testkernel/first_instruments_e_test.go` + engine taps).
  K12-law unit tests: the primary non-divisible cadence case
  (`C=5s,H=2s` → events at `ceil(5/2)*2=6s` multiples, not `5s`) and the
  divisible-cell mixture-expectation test (`C=4s,H=2s` → jitter-decided
  `{4s,6s}` mixture, ≥10% at 6s — locks the code-true knife-edge behavior
  from blind-review-4 Finding A(3)). Also covers heartbeat spacing, trigger
  labeling, the success-point tap (Finding B, frozen at `process.go:891`),
  and the no-mutation guarantee.

### Anchors-drifted

None outstanding. The registration's own blind-review process tracked and
resolved a "stale mirror / drifted anchor" class before freeze (e.g.
blind-review-3 Finding F7 on Set-T provenance line-cites; blind-review-4's
E-class stale mirrors correcting the `IsActive` anchor to
`internal/engine/sessions.go:132` and the run-loop call site to
`process.go:483`). All code anchors cited in IMPL-SPEC were independently
re-verified against `~/workspaces/myrgic/cogos @ 9d73ff42` before this
implementation pass; none have drifted since.

### Why one PR, not split

The diff is ~5,400 lines added across 33 files, over the ~2000-line
one-PR guideline. It ships as a single PR because:

1. **Frozen spec, not incremental design.** The registration (PREREG +
   IMPL-SPEC) was ratified as one unit across five blind reviews and a
   Codex pass; splitting the implementation would require re-litigating
   module boundaries that are already adjudicated.
2. **Modules are interdependent.** D (experiment-runner) directly consumes
   A (test-surface lattice/hooks), B (coherence gate), C (rate surface),
   and E (cadence taps) — it cannot build or run meaningfully with any one
   of them held back. B/C/E each also depend on A's testkernel extensions.
3. **The correctness claims are cross-module.** The KC-3-LAW
   confirm/kill/mixture disposition (Module D) and its calibration gates
   only mean what they claim to mean when measured against the exact
   lattice, coherence semantics, and cadence taps frozen alongside them —
   reviewing them independently would strip the context that makes them
   verifiable.

### Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — green except two pre-existing, unrelated failures in
  `internal/acp` (`TestSpike_OnePromptOneResponse`,
  `TestSpike_MultiTurnOverResume`) that fail with `Not logged in · Please
  run /login` — an environmental Claude Code CLI auth-state dependency,
  not a code defect. That package is untouched by this branch (last
  touched in #306, long before this branch) and none of its tests exercise
  First Instruments code.
- Prior review pass on this branch: CLEAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
