### PR TITLE
feat(observatory): LM Studio conversation ingest observer

### DIFF
--- a/cmd/lmstudio-observer/main.go
+++ b/cmd/lmstudio-observer/main.go
@@ -1,0 +1,90 @@
+// Command lmstudio-observer projects LM Studio local-model conversation
+// history into the CogOS Conversations Observatory's normalized ingest
+// surface, so LM Studio sessions become searchable via
+// cog_search_conversations / cog_list_conversations.
+//
+// It is a standalone, additive producer: it does not link against or modify
+// internal/engine or internal/conversations. It only writes normalized JSONL
+// files under <workspace>/.cog/observatory/ingest/lm-studio/, which the
+// existing (unmodified) conversations Reconcilable already knows how to
+// consume via its ingest_dirs configuration.
+//
+// Usage:
+//
+//	lmstudio-observer [--workspace PATH] [--lmstudio-dir PATH] [--force]
+//
+// --workspace defaults to $COGOS_WORKSPACE, then $HOME/workspaces/cog.
+// --lmstudio-dir defaults to $LMSTUDIO_CONVERSATIONS_DIR, then
+// $HOME/.lmstudio/conversations.
+//
+// Intended to run periodically (cron/launchd) or on demand; each run is
+// incremental — only conversation files that are new or changed since the
+// last run are re-parsed and re-emitted.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/myrgic/cogos/internal/lmstudio"
+)
+
+func main() {
+	os.Exit(run(os.Args[1:]))
+}
+
+func run(args []string) int {
+	fs := flag.NewFlagSet("lmstudio-observer", flag.ContinueOnError)
+	workspace := fs.String("workspace", "", "CogOS workspace root (default: $COGOS_WORKSPACE or $HOME/workspaces/cog)")
+	lmstudioDir := fs.String("lmstudio-dir", "", "LM Studio conversations dir (default: $LMSTUDIO_CONVERSATIONS_DIR or $HOME/.lmstudio/conversations)")
+	force := fs.Bool("force", false, "re-parse and re-emit every discovered conversation file, ignoring tracked state")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	root, err := resolveWorkspace(*workspace)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "lmstudio-observer:", err)
+		return 1
+	}
+
+	res, err := lmstudio.Run(lmstudio.RunOptions{
+		LMStudioDir:   *lmstudioDir,
+		WorkspaceRoot: root,
+		Force:         *force,
+	})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "lmstudio-observer:", err)
+		return 1
+	}
+
+	fmt.Printf("lmstudio-observer: scanned=%d emitted=%d skipped=%d turns=%d errors=%d\n",
+		res.Scanned, res.Emitted, res.Skipped, res.TotalTurns, len(res.Errors))
+	for _, e := range res.Errors {
+		fmt.Fprintln(os.Stderr, "  error:", e)
+	}
+	if len(res.Errors) > 0 {
+		return 1
+	}
+	return 0
+}
+
+// resolveWorkspace applies the same fallback convention documented in the
+// project's path-convention guidance: an explicit flag wins, then
+// $COGOS_WORKSPACE, then $HOME/workspaces/cog. Never hardcodes a specific
+// user's absolute path.
+func resolveWorkspace(explicit string) (string, error) {
+	if explicit != "" {
+		return explicit, nil
+	}
+	if env := os.Getenv("COGOS_WORKSPACE"); env != "" {
+		return env, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	return filepath.Join(home, "workspaces", "cog"), nil
+}

--- a/internal/lmstudio/emit.go
+++ b/internal/lmstudio/emit.go
@@ -1,0 +1,152 @@
+// emit.go — writes IngestRecords as JSONL into the observatory's normalized
+// ingest surface, and orchestrates a full discover -> parse -> emit pass.
+//
+// Layout produced: <workspace>/.cog/observatory/ingest/lm-studio/<session>.jsonl
+// One file per LM Studio conversation file, named after its derived session
+// id so re-emission overwrites the same file in place (the ingest consumer
+// re-parses a source's files wholesale on drift, so overwrite-in-place is the
+// correct semantics — matches how an incremental observer run is expected to
+// behave per internal/conversations/ingest_parser.go's file-provenance model).
+package lmstudio
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// IngestDir returns the ingest directory for this source under the given
+// workspace root: <root>/.cog/observatory/ingest/lm-studio.
+func IngestDir(workspaceRoot string) string {
+	return filepath.Join(workspaceRoot, ".cog", "observatory", "ingest", Source)
+}
+
+// StateFilePath returns the path of this observer's own emitted-state
+// tracking file. Kept separate from the ingest directory (which is consumed
+// by the kernel) and namespaced under the observer's own state, mirroring
+// how other long-running local tools keep run-state outside data
+// directories they don't own.
+func StateFilePath(workspaceRoot string) string {
+	return filepath.Join(workspaceRoot, ".cog", "state", "lmstudio-observer", "emitted.json")
+}
+
+// WriteJSONL serializes records as newline-delimited JSON and writes them to
+// path, atomically (temp file + rename). An empty records slice still writes
+// an empty file — this lets a conversation that lost all its content (e.g.
+// all turns were pure tool calls) clear a stale JSONL from a prior run.
+func WriteJSONL(path string, records []IngestRecord) error {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	for _, rec := range records {
+		if err := enc.Encode(rec); err != nil {
+			return fmt.Errorf("lmstudio: encode record for %s: %w", path, err)
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("lmstudio: mkdir %s: %w", filepath.Dir(path), err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, buf.Bytes(), 0o644); err != nil {
+		return fmt.Errorf("lmstudio: write temp %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("lmstudio: rename into place %s: %w", path, err)
+	}
+	return nil
+}
+
+// RunResult summarizes one orchestrated observer pass.
+type RunResult struct {
+	Scanned    int      // total conversation files discovered
+	Emitted    int      // files that were (re-)parsed and written
+	Skipped    int      // files unchanged since last run
+	TotalTurns int      // sum of ingest records written across emitted files
+	Errors     []string // per-file errors (non-fatal; the pass continues)
+}
+
+// RunOptions configures one observer pass.
+type RunOptions struct {
+	// LMStudioDir is the root to scan for *.conversation.json files.
+	// Defaults to DefaultLMStudioDir() when empty.
+	LMStudioDir string
+
+	// WorkspaceRoot is the CogOS workspace whose .cog/observatory/ingest/
+	// directory receives the emitted JSONL. Required.
+	WorkspaceRoot string
+
+	// MaxTurnLen caps emitted turn text length. Defaults to
+	// defaultMaxTurnLen (8192) when <= 0.
+	MaxTurnLen int
+
+	// Force re-emits every discovered file regardless of tracked state.
+	Force bool
+}
+
+// Run performs one discover -> parse -> emit pass: it scans opts.LMStudioDir
+// for conversation files, skips ones unchanged since the last recorded run
+// (per the state file under opts.WorkspaceRoot), parses and emits the rest as
+// normalized ingest JSONL, and persists updated state. Individual per-file
+// parse/write failures are recorded in RunResult.Errors and do not abort the
+// pass — one malformed conversation file must not block ingestion of the
+// rest of the corpus.
+func Run(opts RunOptions) (RunResult, error) {
+	var res RunResult
+
+	lmDir := opts.LMStudioDir
+	if lmDir == "" {
+		d, err := DefaultLMStudioDir()
+		if err != nil {
+			return res, err
+		}
+		lmDir = d
+	}
+	if opts.WorkspaceRoot == "" {
+		return res, fmt.Errorf("lmstudio: WorkspaceRoot is required")
+	}
+
+	files, err := DiscoverConversationFiles(lmDir)
+	if err != nil {
+		return res, err
+	}
+	res.Scanned = len(files)
+
+	statePath := StateFilePath(opts.WorkspaceRoot)
+	state, err := LoadEmittedState(statePath)
+	if err != nil {
+		return res, err
+	}
+
+	ingestDir := IngestDir(opts.WorkspaceRoot)
+
+	for _, f := range files {
+		if !opts.Force && !state.NeedsEmit(f) {
+			res.Skipped++
+			continue
+		}
+
+		sessionID, records, parseErr := ParseFile(f.Path, opts.MaxTurnLen)
+		if parseErr != nil {
+			res.Errors = append(res.Errors, parseErr.Error())
+			continue
+		}
+
+		outPath := filepath.Join(ingestDir, sessionID+".jsonl")
+		if writeErr := WriteJSONL(outPath, records); writeErr != nil {
+			res.Errors = append(res.Errors, writeErr.Error())
+			continue
+		}
+
+		state.Record(f)
+		res.Emitted++
+		res.TotalTurns += len(records)
+	}
+
+	if err := state.Save(statePath); err != nil {
+		return res, err
+	}
+
+	return res, nil
+}

--- a/internal/lmstudio/emit_test.go
+++ b/internal/lmstudio/emit_test.go
@@ -1,0 +1,126 @@
+// emit_test.go — end-to-end test of the discover -> parse -> emit pass
+// (Run), verifying: correct ingest directory layout, incremental skip
+// behavior on a second unchanged run, and re-emission after a file changes.
+package lmstudio
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRun_EmitsIngestJSONLIntoWorkspace(t *testing.T) {
+	lmDir := t.TempDir()
+	workspace := t.TempDir()
+	writeFixture(t, lmDir, "Cog.", "1700000000000.conversation.json")
+
+	res, err := Run(RunOptions{LMStudioDir: lmDir, WorkspaceRoot: workspace})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Scanned != 1 || res.Emitted != 1 || res.Skipped != 0 {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	if len(res.Errors) != 0 {
+		t.Fatalf("unexpected errors: %v", res.Errors)
+	}
+
+	wantPath := filepath.Join(IngestDir(workspace), "Cog.-1700000000000.jsonl")
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Fatalf("expected ingest file at %s: %v", wantPath, err)
+	}
+
+	// Second run over the same unchanged file must skip, not re-emit.
+	res2, err := Run(RunOptions{LMStudioDir: lmDir, WorkspaceRoot: workspace})
+	if err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	if res2.Emitted != 0 || res2.Skipped != 1 {
+		t.Fatalf("second run should skip unchanged file: %+v", res2)
+	}
+}
+
+func TestRun_ForceReemitsUnchangedFiles(t *testing.T) {
+	lmDir := t.TempDir()
+	workspace := t.TempDir()
+	writeFixture(t, lmDir, "Cog.", "1700000000000.conversation.json")
+
+	if _, err := Run(RunOptions{LMStudioDir: lmDir, WorkspaceRoot: workspace}); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	res, err := Run(RunOptions{LMStudioDir: lmDir, WorkspaceRoot: workspace, Force: true})
+	if err != nil {
+		t.Fatalf("forced Run: %v", err)
+	}
+	if res.Emitted != 1 || res.Skipped != 0 {
+		t.Fatalf("forced run should re-emit: %+v", res)
+	}
+}
+
+func TestRun_MissingWorkspaceRootErrors(t *testing.T) {
+	if _, err := Run(RunOptions{LMStudioDir: t.TempDir()}); err == nil {
+		t.Error("expected error for missing WorkspaceRoot")
+	}
+}
+
+func TestRun_MissingLMStudioDirIsNotFatal(t *testing.T) {
+	workspace := t.TempDir()
+	res, err := Run(RunOptions{
+		LMStudioDir:   filepath.Join(t.TempDir(), "no-such-dir"),
+		WorkspaceRoot: workspace,
+	})
+	if err != nil {
+		t.Fatalf("Run with missing lmstudio dir: %v", err)
+	}
+	if res.Scanned != 0 {
+		t.Errorf("Scanned = %d, want 0", res.Scanned)
+	}
+}
+
+func TestRun_OneMalformedFileDoesNotBlockOthers(t *testing.T) {
+	lmDir := t.TempDir()
+	workspace := t.TempDir()
+	writeFixture(t, lmDir, "Good", "111.conversation.json")
+
+	badDir := filepath.Join(lmDir, "Bad")
+	if err := os.MkdirAll(badDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(badDir, "222.conversation.json"), []byte("{not valid json"), 0o644); err != nil {
+		t.Fatalf("write malformed fixture: %v", err)
+	}
+
+	res, err := Run(RunOptions{LMStudioDir: lmDir, WorkspaceRoot: workspace})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Scanned != 2 {
+		t.Fatalf("Scanned = %d, want 2", res.Scanned)
+	}
+	if res.Emitted != 1 {
+		t.Fatalf("Emitted = %d, want 1 (the good file)", res.Emitted)
+	}
+	if len(res.Errors) != 1 {
+		t.Fatalf("Errors = %v, want exactly 1", res.Errors)
+	}
+
+	goodOut := filepath.Join(IngestDir(workspace), "Good-111.jsonl")
+	if _, err := os.Stat(goodOut); err != nil {
+		t.Errorf("expected good file emitted despite sibling error: %v", err)
+	}
+}
+
+func TestWriteJSONL_EmptyRecordsWritesEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.jsonl")
+	if err := WriteJSONL(path, nil); err != nil {
+		t.Fatalf("WriteJSONL(nil): %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(data) != 0 {
+		t.Errorf("expected empty file, got %d bytes", len(data))
+	}
+}

--- a/internal/lmstudio/parser.go
+++ b/internal/lmstudio/parser.go
@@ -1,0 +1,211 @@
+// parser.go — decodes one LM Studio *.conversation.json file into a
+// SessionID plus an ordered slice of IngestRecord.
+//
+// Extraction rules (mirroring internal/conversations/parser.go's approach
+// for Claude Code, adapted to LM Studio's shape):
+//   - Each LSMessage's *selected* version only is read (CurrentlySelected).
+//   - type "singleStep": role + concatenated text content blocks.
+//   - type "multiStep": walk Steps in order; "contentBlock" steps contribute
+//     text blocks (toolCallRequest/toolCallResult are skipped — tool
+//     input/output is not operator utterance, matching the CC parser's
+//     handling of tool_use/tool_result); "status", "debugInfoBlock", and
+//     "toolStatus" steps are skipped entirely.
+//   - Messages with no extracted text (e.g. a multiStep turn that is only
+//     tool calls with no prose) are dropped — never emitted as empty turns.
+//   - Text longer than maxTurnLen is truncated with " [truncated]" (the
+//     ingest consumer truncates again at its own limit, but truncating here
+//     keeps emitted JSONL lines bounded).
+package lmstudio
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// defaultMaxTurnLen mirrors internal/conversations.defaultMaxTurnLen. Kept as
+// an independent constant since this package must not import
+// internal/conversations (producer/consumer are decoupled by the ingest
+// surface, not by a Go dependency).
+const defaultMaxTurnLen = 8192
+
+// ParseFile reads and decodes one LM Studio conversation.json file at path,
+// returning the derived session id and the ordered ingest records for its
+// messages. Returns an error only for I/O or top-level JSON decode failure;
+// individual malformed/empty messages are skipped rather than erroring the
+// whole file.
+func ParseFile(path string, maxTurnLen int) (sessionID string, records []IngestRecord, err error) {
+	if maxTurnLen <= 0 {
+		maxTurnLen = defaultMaxTurnLen
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", nil, fmt.Errorf("lmstudio: read %s: %w", path, err)
+	}
+
+	var conv Conversation
+	if jsonErr := json.Unmarshal(data, &conv); jsonErr != nil {
+		return "", nil, fmt.Errorf("lmstudio: parse %s: %w", path, jsonErr)
+	}
+
+	sessionID = SessionIDFromPath(path)
+	model := ""
+	if conv.LastUsedModel != nil {
+		model = conv.LastUsedModel.Identifier
+	}
+
+	records = ExtractRecords(conv, sessionID, model, maxTurnLen)
+	return sessionID, records, nil
+}
+
+// SessionIDFromPath derives a stable session id from the conversation file
+// path: "<parent-folder>/<epoch-ms>" (the epoch-ms filename stem is unique
+// per LM Studio conversation; the parent folder name is included so two
+// folders sharing a stray epoch collision — not expected in practice — still
+// resolve to distinct ids).
+func SessionIDFromPath(path string) string {
+	base := strings.TrimSuffix(filepath.Base(path), ".conversation.json")
+	folder := filepath.Base(filepath.Dir(path))
+	return folder + "-" + base
+}
+
+// ExtractRecords walks conv.Messages in order and returns one IngestRecord
+// per message that has extractable text. turn_index is assigned
+// monotonically over the *emitted* records (skipped/empty messages do not
+// consume an index), matching the ingest consumer's own "assign monotonic
+// turn_index when absent" behavior — we assign explicitly here so re-emission
+// is deterministic regardless of consumer defaults.
+func ExtractRecords(conv Conversation, sessionID, modelIdentifier string, maxTurnLen int) []IngestRecord {
+	if maxTurnLen <= 0 {
+		maxTurnLen = defaultMaxTurnLen
+	}
+	ts := epochMsToRFC3339(conv.CreatedAt)
+
+	var out []IngestRecord
+	turnIdx := 0
+	for msgIdx, msg := range conv.Messages {
+		v := msg.Selected()
+		if v == nil {
+			continue
+		}
+
+		role := normalizeRole(v.Role)
+		if role == "" {
+			continue
+		}
+
+		var text string
+		switch v.Type {
+		case "singleStep":
+			text = joinTextBlocks(v.Content)
+		case "multiStep":
+			text = joinMultiStepText(v.Steps)
+		default:
+			// Unknown version type — skip rather than guess.
+			continue
+		}
+
+		text = strings.TrimSpace(text)
+		if text == "" {
+			continue
+		}
+		if len(text) > maxTurnLen {
+			text = text[:maxTurnLen] + " [truncated]"
+		}
+
+		rec := IngestRecord{
+			Schema:    IngestSchema,
+			Source:    Source,
+			SessionID: sessionID,
+			Role:      role,
+			Timestamp: ts,
+			Text:      text,
+			TurnIndex: turnIdx,
+			Refs: &IngestRefs{
+				StableID: stableID(sessionID, msgIdx),
+			},
+		}
+		if conv.Name != "" {
+			rec.SessionTitle = conv.Name
+		}
+		// LM Studio doesn't carry a per-message model id; attach the
+		// session-level lastUsedModel to assistant turns as free-text
+		// context by folding it into Identity is a poor fit (Identity means
+		// operator identity elsewhere in the observatory), so we leave it
+		// out of the v0.1 record. Model provenance is instead available via
+		// the session_title tie-back for now; a v0.2 mapping could add a
+		// dedicated field.
+		_ = modelIdentifier
+
+		out = append(out, rec)
+		turnIdx++
+	}
+	return out
+}
+
+// joinTextBlocks concatenates all "text" content blocks, skipping
+// tool-call/tool-result blocks (mirrors CC parser's tool_result/tool_use skip).
+func joinTextBlocks(blocks []LSContentBlock) string {
+	var parts []string
+	for _, b := range blocks {
+		if b.Type == "text" {
+			if t := strings.TrimSpace(b.Text); t != "" {
+				parts = append(parts, t)
+			}
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+// joinMultiStepText walks steps in order, extracting text from "contentBlock"
+// steps only. "status", "debugInfoBlock", and "toolStatus" steps carry no
+// operator-visible prose and are skipped.
+func joinMultiStepText(steps []LSStep) string {
+	var parts []string
+	for _, s := range steps {
+		if s.Type != "contentBlock" {
+			continue
+		}
+		if t := joinTextBlocks(s.Content); t != "" {
+			parts = append(parts, t)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+// normalizeRole maps LM Studio's role strings to the ingest schema's role
+// vocabulary (user/assistant/tool/system). Unrecognized roles return "" so
+// the caller skips the message rather than guessing.
+func normalizeRole(role string) string {
+	switch role {
+	case "user", "assistant", "tool", "system":
+		return role
+	default:
+		return ""
+	}
+}
+
+// stableID builds a per-message dedup key: "<source>:<session_id>:<msgIdx>".
+// Re-parsing the same file always yields the same stable_id for the same
+// message position, so re-emission is idempotent from the consumer's
+// perspective (ingestAccumulator dedups by refs.stable_id verbatim).
+func stableID(sessionID string, msgIdx int) string {
+	return fmt.Sprintf("%s:%s:%d", Source, sessionID, msgIdx)
+}
+
+// epochMsToRFC3339 converts an epoch-milliseconds timestamp to RFC3339. A
+// zero or negative input returns the Unix epoch in RFC3339 form rather than
+// an empty string, since the ingest consumer rejects records with an empty
+// timestamp field.
+func epochMsToRFC3339(epochMs int64) string {
+	if epochMs <= 0 {
+		return time.Unix(0, 0).UTC().Format(time.RFC3339)
+	}
+	sec := epochMs / 1000
+	nsec := (epochMs % 1000) * int64(time.Millisecond)
+	return time.Unix(sec, nsec).UTC().Format(time.RFC3339)
+}

--- a/internal/lmstudio/parser_test.go
+++ b/internal/lmstudio/parser_test.go
@@ -1,0 +1,370 @@
+// parser_test.go — unit tests for the LM Studio conversation.json parser.
+//
+// The fixture JSON below is synthesized to exercise the real shapes observed
+// in LM Studio's on-disk format (singleStep, multiStep with interleaved
+// text/toolCallRequest/toolCallResult content, skip-worthy toolStatus and
+// debugInfoBlock steps, and multi-version messages with a non-zero
+// currentlySelected index) using only generic placeholder text — it is not
+// derived from any real conversation content.
+package lmstudio
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fixtureConversationJSON is a small synthetic LM Studio conversation with
+// generic placeholder text only.
+const fixtureConversationJSON = `{
+  "name": "Test conversation title",
+  "createdAt": 1700000000000,
+  "systemPrompt": "",
+  "lastUsedModel": {
+    "identifier": "test-model-7b",
+    "indexedModelIdentifier": "test-org/test-model-7b-GGUF/test-model-7b-Q4.gguf"
+  },
+  "messages": [
+    {
+      "versions": [
+        {
+          "type": "singleStep",
+          "role": "user",
+          "content": [
+            { "type": "text", "text": "Hello, this is a test question." }
+          ]
+        }
+      ],
+      "currentlySelected": 0
+    },
+    {
+      "versions": [
+        {
+          "type": "multiStep",
+          "role": "assistant",
+          "senderInfo": { "senderName": "test-model-7b" },
+          "steps": [
+            {
+              "type": "contentBlock",
+              "content": [
+                { "type": "text", "text": "Let me look that up." },
+                { "type": "toolCallRequest", "name": "example_tool", "parameters": {"query": "placeholder"} }
+              ]
+            },
+            {
+              "type": "toolStatus"
+            },
+            {
+              "type": "contentBlock",
+              "content": [
+                { "type": "toolCallResult" }
+              ]
+            },
+            {
+              "type": "contentBlock",
+              "content": [
+                { "type": "text", "text": "Here is the answer based on the tool result." }
+              ]
+            },
+            {
+              "type": "debugInfoBlock"
+            }
+          ]
+        }
+      ],
+      "currentlySelected": 0
+    },
+    {
+      "versions": [
+        {
+          "type": "singleStep",
+          "role": "user",
+          "content": [
+            { "type": "text", "text": "First draft of a follow-up question." }
+          ]
+        },
+        {
+          "type": "singleStep",
+          "role": "user",
+          "content": [
+            { "type": "text", "text": "Edited follow-up question (this version is selected)." }
+          ]
+        }
+      ],
+      "currentlySelected": 1
+    },
+    {
+      "versions": [
+        {
+          "type": "multiStep",
+          "role": "assistant",
+          "steps": [
+            {
+              "type": "contentBlock",
+              "content": [
+                { "type": "toolCallRequest", "name": "another_tool" }
+              ]
+            },
+            {
+              "type": "contentBlock",
+              "content": [
+                { "type": "toolCallResult" }
+              ]
+            },
+            {
+              "type": "status"
+            }
+          ]
+        }
+      ],
+      "currentlySelected": 0
+    }
+  ]
+}`
+
+func writeFixture(t *testing.T, dir, folder, filename string) string {
+	t.Helper()
+	folderPath := filepath.Join(dir, folder)
+	if err := os.MkdirAll(folderPath, 0o755); err != nil {
+		t.Fatalf("mkdir fixture folder: %v", err)
+	}
+	path := filepath.Join(folderPath, filename)
+	if err := os.WriteFile(path, []byte(fixtureConversationJSON), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+func TestParseFile_ExtractsSingleStepAndMultiStepText(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFixture(t, dir, "Test.", "1700000000000.conversation.json")
+
+	sessionID, records, err := ParseFile(path, 0)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+
+	wantSessionID := "Test.-1700000000000"
+	if sessionID != wantSessionID {
+		t.Errorf("sessionID = %q, want %q", sessionID, wantSessionID)
+	}
+
+	// 4 messages total, but message index 3 (final multiStep) is pure tool
+	// calls with no prose -> dropped. Expect 3 emitted records.
+	if len(records) != 3 {
+		t.Fatalf("len(records) = %d, want 3; records=%+v", len(records), records)
+	}
+
+	// Record 0: singleStep user turn.
+	if records[0].Role != "user" {
+		t.Errorf("records[0].Role = %q, want user", records[0].Role)
+	}
+	if records[0].Text != "Hello, this is a test question." {
+		t.Errorf("records[0].Text = %q", records[0].Text)
+	}
+	if records[0].TurnIndex != 0 {
+		t.Errorf("records[0].TurnIndex = %d, want 0", records[0].TurnIndex)
+	}
+
+	// Record 1: multiStep assistant turn — text from two contentBlock steps
+	// joined, tool call / tool result / toolStatus / debugInfoBlock skipped.
+	if records[1].Role != "assistant" {
+		t.Errorf("records[1].Role = %q, want assistant", records[1].Role)
+	}
+	wantText := "Let me look that up.\nHere is the answer based on the tool result."
+	if records[1].Text != wantText {
+		t.Errorf("records[1].Text = %q, want %q", records[1].Text, wantText)
+	}
+	if records[1].TurnIndex != 1 {
+		t.Errorf("records[1].TurnIndex = %d, want 1", records[1].TurnIndex)
+	}
+
+	// Record 2: singleStep user turn — must reflect the SELECTED version
+	// (index 1), not version 0 (the discarded draft).
+	if records[2].Text != "Edited follow-up question (this version is selected)." {
+		t.Errorf("records[2].Text = %q — version selection not honored", records[2].Text)
+	}
+	if records[2].TurnIndex != 2 {
+		t.Errorf("records[2].TurnIndex = %d, want 2 (skipped message must not consume an index)", records[2].TurnIndex)
+	}
+
+	// Every record must carry the required ingest schema fields.
+	for i, r := range records {
+		if r.Schema != IngestSchema {
+			t.Errorf("records[%d].Schema = %q, want %q", i, r.Schema, IngestSchema)
+		}
+		if r.Source != Source {
+			t.Errorf("records[%d].Source = %q, want %q", i, r.Source, Source)
+		}
+		if r.SessionID != wantSessionID {
+			t.Errorf("records[%d].SessionID = %q, want %q", i, r.SessionID, wantSessionID)
+		}
+		if r.Timestamp == "" {
+			t.Errorf("records[%d].Timestamp is empty", i)
+		}
+		if _, err := time.Parse(time.RFC3339, r.Timestamp); err != nil {
+			t.Errorf("records[%d].Timestamp %q not RFC3339: %v", i, r.Timestamp, err)
+		}
+		if r.SessionTitle != "Test conversation title" {
+			t.Errorf("records[%d].SessionTitle = %q", i, r.SessionTitle)
+		}
+		if r.Refs == nil || r.Refs.StableID == "" {
+			t.Errorf("records[%d].Refs.StableID is empty", i)
+		}
+	}
+}
+
+func TestParseFile_StableIDIsIdempotentAcrossReparse(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFixture(t, dir, "Test.", "1700000000000.conversation.json")
+
+	_, records1, err := ParseFile(path, 0)
+	if err != nil {
+		t.Fatalf("first ParseFile: %v", err)
+	}
+	_, records2, err := ParseFile(path, 0)
+	if err != nil {
+		t.Fatalf("second ParseFile: %v", err)
+	}
+
+	if len(records1) != len(records2) {
+		t.Fatalf("record count changed across re-parse: %d vs %d", len(records1), len(records2))
+	}
+	for i := range records1 {
+		if records1[i].Refs.StableID != records2[i].Refs.StableID {
+			t.Errorf("record %d stable_id changed across re-parse: %q vs %q",
+				i, records1[i].Refs.StableID, records2[i].Refs.StableID)
+		}
+	}
+}
+
+func TestParseFile_EmitsValidJSONLLines(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFixture(t, dir, "Test.", "1700000000000.conversation.json")
+
+	_, records, err := ParseFile(path, 0)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+
+	outPath := filepath.Join(dir, "out.jsonl")
+	if err := WriteJSONL(outPath, records); err != nil {
+		t.Fatalf("WriteJSONL: %v", err)
+	}
+
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read emitted jsonl: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != len(records) {
+		t.Fatalf("emitted %d lines, want %d", len(lines), len(records))
+	}
+	for i, line := range lines {
+		var decoded map[string]any
+		if err := json.Unmarshal([]byte(line), &decoded); err != nil {
+			t.Fatalf("line %d not valid JSON: %v (line=%q)", i, err, line)
+		}
+		for _, field := range []string{"schema", "source", "session_id", "role", "timestamp", "text"} {
+			if _, ok := decoded[field]; !ok {
+				t.Errorf("line %d missing required ingest field %q", i, field)
+			}
+		}
+		if decoded["schema"] != IngestSchema {
+			t.Errorf("line %d schema = %v, want %q", i, decoded["schema"], IngestSchema)
+		}
+	}
+}
+
+func TestSessionIDFromPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"/home/u/.lmstudio/conversations/Cog./1783432270992.conversation.json", "Cog.-1783432270992"},
+		{"/home/u/.lmstudio/conversations/On a plane/123.conversation.json", "On a plane-123"},
+	}
+	for _, c := range cases {
+		if got := SessionIDFromPath(c.path); got != c.want {
+			t.Errorf("SessionIDFromPath(%q) = %q, want %q", c.path, got, c.want)
+		}
+	}
+}
+
+func TestExtractRecords_SkipsMessageWithNoSelectableVersion(t *testing.T) {
+	conv := Conversation{
+		CreatedAt: 1700000000000,
+		Messages: []LSMessage{
+			{
+				Versions:          []LSVersion{{Type: "singleStep", Role: "user", Content: []LSContentBlock{{Type: "text", Text: "hi"}}}},
+				CurrentlySelected: 5, // out of range — must be skipped, not panic
+			},
+			{
+				Versions:          []LSVersion{{Type: "singleStep", Role: "user", Content: []LSContentBlock{{Type: "text", Text: "second message"}}}},
+				CurrentlySelected: 0,
+			},
+		},
+	}
+	records := ExtractRecords(conv, "sess-x", "", 0)
+	if len(records) != 1 {
+		t.Fatalf("len(records) = %d, want 1", len(records))
+	}
+	if records[0].Text != "second message" {
+		t.Errorf("records[0].Text = %q", records[0].Text)
+	}
+	if records[0].TurnIndex != 0 {
+		t.Errorf("records[0].TurnIndex = %d, want 0", records[0].TurnIndex)
+	}
+}
+
+func TestExtractRecords_UnknownRoleSkipped(t *testing.T) {
+	conv := Conversation{
+		CreatedAt: 1700000000000,
+		Messages: []LSMessage{
+			{
+				Versions:          []LSVersion{{Type: "singleStep", Role: "weirdrole", Content: []LSContentBlock{{Type: "text", Text: "hi"}}}},
+				CurrentlySelected: 0,
+			},
+		},
+	}
+	records := ExtractRecords(conv, "sess-x", "", 0)
+	if len(records) != 0 {
+		t.Fatalf("len(records) = %d, want 0 for unknown role", len(records))
+	}
+}
+
+func TestExtractRecords_TruncatesLongText(t *testing.T) {
+	longText := strings.Repeat("a", 100)
+	conv := Conversation{
+		CreatedAt: 1700000000000,
+		Messages: []LSMessage{
+			{
+				Versions:          []LSVersion{{Type: "singleStep", Role: "user", Content: []LSContentBlock{{Type: "text", Text: longText}}}},
+				CurrentlySelected: 0,
+			},
+		},
+	}
+	records := ExtractRecords(conv, "sess-x", "", 10)
+	if len(records) != 1 {
+		t.Fatalf("len(records) = %d, want 1", len(records))
+	}
+	if !strings.HasSuffix(records[0].Text, "[truncated]") {
+		t.Errorf("records[0].Text = %q, want truncation marker", records[0].Text)
+	}
+}
+
+func TestEpochMsToRFC3339(t *testing.T) {
+	got := epochMsToRFC3339(1700000000000)
+	want := time.Unix(1700000000, 0).UTC().Format(time.RFC3339)
+	if got != want {
+		t.Errorf("epochMsToRFC3339(1700000000000) = %q, want %q", got, want)
+	}
+	// Non-positive input must not produce an empty string (ingest consumer
+	// rejects empty timestamps).
+	if epochMsToRFC3339(0) == "" {
+		t.Error("epochMsToRFC3339(0) returned empty string")
+	}
+}

--- a/internal/lmstudio/types.go
+++ b/internal/lmstudio/types.go
@@ -1,0 +1,143 @@
+// Package lmstudio implements an observer that projects LM Studio local-model
+// conversation history into the CogOS Conversations Observatory's normalized
+// ingest surface (cogos.observatory.conversations/v0.1), so LM Studio sessions
+// become searchable via cog_search_conversations / cog_list_conversations
+// alongside Claude Code, Hermes, and other sources.
+//
+// This package is a producer, not a consumer: it does not read or write the
+// observatory index directly. It watches LM Studio's conversation JSON files
+// and emits normalized JSONL records into
+// <workspace>/.cog/observatory/ingest/lm-studio/*.jsonl, where the existing
+// internal/conversations Reconcilable (unmodified) picks them up on its next
+// reconcile cycle via the generic ingest_dirs mechanism.
+//
+// Package layout:
+//   - types.go   — LM Studio conversation JSON schema (read-side) + emitted
+//                  ingest record shape (write-side)
+//   - parser.go  — decodes one *.conversation.json file into ingest records
+//   - watch.go   — discovers conversation files under the LM Studio dir and
+//                  tracks which ones have already been emitted (by mtime+size)
+//   - emit.go    — serializes ingest records as JSONL and writes them to the
+//                  ingest directory
+package lmstudio
+
+import "encoding/json"
+
+// Source is the observer source id used in emitted ingest records and as the
+// ingest subdirectory name: .cog/observatory/ingest/lm-studio/.
+const Source = "lm-studio"
+
+// IngestSchema is the normalized ingest schema this observer speaks.
+const IngestSchema = "cogos.observatory.conversations/v0.1"
+
+// ─── LM Studio on-disk conversation format ──────────────────────────────────
+//
+// ~/.lmstudio/conversations/<folder>/<epoch-ms>.conversation.json
+//
+// Verified against a real LM Studio conversation file (10 messages, mixing
+// singleStep and multiStep assistant turns) on 2026-07-07. Fields not needed
+// for ingest (preset, tokenCount, plugins, clientInputFiles, etc.) are
+// omitted from these structs; json.Unmarshal ignores unknown fields.
+
+// Conversation is the top-level shape of one LM Studio *.conversation.json file.
+type Conversation struct {
+	Name           string          `json:"name"`
+	CreatedAt      int64           `json:"createdAt"` // epoch milliseconds
+	SystemPrompt   string          `json:"systemPrompt"`
+	Messages       []LSMessage     `json:"messages"`
+	LastUsedModel  *LSModelRef     `json:"lastUsedModel,omitempty"`
+}
+
+// LSModelRef carries the model identifier used for (at least) the most
+// recent turn in the conversation. LM Studio does not record a per-message
+// model id, so this is attached at the session level.
+type LSModelRef struct {
+	Identifier            string `json:"identifier"`
+	IndexedModelIdentifier string `json:"indexedModelIdentifier,omitempty"`
+}
+
+// LSMessage is one entry in Conversation.Messages. LM Studio supports
+// message editing / regeneration, so each message carries a Versions slice
+// and a CurrentlySelected index; only the selected version is live.
+type LSMessage struct {
+	Versions          []LSVersion `json:"versions"`
+	CurrentlySelected int         `json:"currentlySelected"`
+}
+
+// Selected returns the currently-selected version, or nil if the index is
+// out of range (defensive — malformed/truncated files should not panic).
+func (m LSMessage) Selected() *LSVersion {
+	if m.CurrentlySelected < 0 || m.CurrentlySelected >= len(m.Versions) {
+		return nil
+	}
+	return &m.Versions[m.CurrentlySelected]
+}
+
+// LSVersion is one version of a message. Type is either "singleStep" (plain
+// user/assistant turn: role + content[] text blocks) or "multiStep"
+// (assistant turn broken into steps — tool calls interleaved with text).
+type LSVersion struct {
+	Type  string `json:"type"`
+	Role  string `json:"role"`
+
+	// singleStep fields.
+	Content []LSContentBlock `json:"content,omitempty"`
+
+	// multiStep fields.
+	Steps []LSStep `json:"steps,omitempty"`
+
+	SenderInfo *LSSenderInfo `json:"senderInfo,omitempty"`
+}
+
+// LSSenderInfo carries the model identifier for a multiStep assistant turn.
+type LSSenderInfo struct {
+	SenderName string `json:"senderName,omitempty"`
+}
+
+// LSStep is one step of a multiStep version. Only "contentBlock" steps carry
+// text/tool content; "status", "debugInfoBlock", and "toolStatus" steps are
+// recognized but skipped (no operator-visible text).
+type LSStep struct {
+	Type    string           `json:"type"`
+	Content []LSContentBlock `json:"content,omitempty"`
+}
+
+// LSContentBlock is one item within a singleStep's content[] or a multiStep
+// contentBlock step's content[]. Type "text" carries Text; "toolCallRequest"
+// and "toolCallResult" are recorded minimally (name only) — full tool
+// input/output is not operator utterance and is out of scope for v0.1.
+type LSContentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+
+	// toolCallRequest fields.
+	Name       string          `json:"name,omitempty"`
+	Parameters json.RawMessage `json:"parameters,omitempty"`
+
+	// toolCallResult fields (structure varies; not decoded beyond presence).
+}
+
+// ─── Emitted ingest record (cogos.observatory.conversations/v0.1) ──────────
+
+// IngestRefs is the optional refs object carried on emitted records. StableID
+// gives the observatory a dedup key that survives re-emission across runs.
+type IngestRefs struct {
+	StableID string `json:"stable_id,omitempty"`
+}
+
+// IngestRecord mirrors the wire shape consumed by
+// internal/conversations.ingestAccumulator.ConsumeFile (see
+// myrgic/cogos internal/conversations/ingest_parser.go, ingestRecord).
+// Field order/names must match that consumer exactly.
+type IngestRecord struct {
+	Schema       string      `json:"schema"`
+	Source       string      `json:"source"`
+	SessionID    string      `json:"session_id"`
+	SessionTitle string      `json:"session_title,omitempty"`
+	TurnIndex    int         `json:"turn_index"`
+	Role         string      `json:"role"`
+	Timestamp    string      `json:"timestamp"`
+	Text         string      `json:"text"`
+	Identity     string      `json:"identity,omitempty"`
+	Refs         *IngestRefs `json:"refs,omitempty"`
+}

--- a/internal/lmstudio/watch.go
+++ b/internal/lmstudio/watch.go
@@ -1,0 +1,170 @@
+// watch.go — discovers LM Studio conversation files and tracks which have
+// already been emitted, so repeated runs are incremental (only re-parse
+// files that are new or have changed size/mtime since the last run).
+//
+// This mirrors the drift-detection approach in
+// internal/conversations.isDrift (size is the definitive signal; mtime with
+// a small tolerance is the secondary signal), but state is tracked
+// independently in this package's own state file — this observer does not
+// read or write the observatory's own index/state.
+package lmstudio
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+// DefaultLMStudioDir returns the default LM Studio conversations directory:
+// $HOME/.lmstudio/conversations. Honors the LMSTUDIO_CONVERSATIONS_DIR
+// environment variable when set, so the path is configurable without code
+// changes (and never hardcodes a specific user's home directory).
+func DefaultLMStudioDir() (string, error) {
+	if dir := os.Getenv("LMSTUDIO_CONVERSATIONS_DIR"); dir != "" {
+		return dir, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("lmstudio: resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".lmstudio", "conversations"), nil
+}
+
+// ConversationFile describes one discovered *.conversation.json file.
+type ConversationFile struct {
+	Path  string    `json:"path"`
+	Mtime time.Time `json:"mtime"`
+	Size  int64     `json:"size"`
+}
+
+// DiscoverConversationFiles walks root recursively and returns every file
+// matching *.conversation.json, sorted by path for deterministic output.
+// A missing root is not an error — LM Studio may not be installed, or the
+// directory may not exist yet on a fresh machine — it returns an empty slice.
+func DiscoverConversationFiles(root string) ([]ConversationFile, error) {
+	var out []ConversationFile
+
+	if _, err := os.Stat(root); err != nil {
+		if os.IsNotExist(err) {
+			return out, nil
+		}
+		return nil, fmt.Errorf("lmstudio: stat %s: %w", root, err)
+	}
+
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// Skip unreadable entries rather than aborting the whole walk.
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if filepath.Ext(path) != ".json" || !hasConversationSuffix(path) {
+			return nil
+		}
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			return nil
+		}
+		out = append(out, ConversationFile{
+			Path:  path,
+			Mtime: info.ModTime(),
+			Size:  info.Size(),
+		})
+		return nil
+	})
+	if walkErr != nil {
+		return nil, fmt.Errorf("lmstudio: walk %s: %w", root, walkErr)
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+	return out, nil
+}
+
+// hasConversationSuffix reports whether path ends in ".conversation.json".
+func hasConversationSuffix(path string) bool {
+	const suffix = ".conversation.json"
+	if len(path) < len(suffix) {
+		return false
+	}
+	return path[len(path)-len(suffix):] == suffix
+}
+
+// ─── Emitted-state tracking ─────────────────────────────────────────────────
+
+// EmittedState records, per source file, the (size, mtime) that was last
+// successfully emitted. Used to skip unchanged files on subsequent runs.
+type EmittedState struct {
+	// Files maps absolute conversation file path -> last-emitted snapshot.
+	Files map[string]ConversationFile `json:"files"`
+}
+
+// LoadEmittedState reads the state file at path. A missing file is not an
+// error — returns an empty state (first run).
+func LoadEmittedState(path string) (*EmittedState, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &EmittedState{Files: make(map[string]ConversationFile)}, nil
+		}
+		return nil, fmt.Errorf("lmstudio: read state %s: %w", path, err)
+	}
+	var st EmittedState
+	if jsonErr := json.Unmarshal(data, &st); jsonErr != nil {
+		return nil, fmt.Errorf("lmstudio: parse state %s: %w", path, jsonErr)
+	}
+	if st.Files == nil {
+		st.Files = make(map[string]ConversationFile)
+	}
+	return &st, nil
+}
+
+// Save writes the state atomically (write to temp file, then rename) so a
+// crash mid-write never leaves a truncated/corrupt state file.
+func (st *EmittedState) Save(path string) error {
+	data, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return fmt.Errorf("lmstudio: marshal state: %w", err)
+	}
+	if mkErr := os.MkdirAll(filepath.Dir(path), 0o755); mkErr != nil {
+		return fmt.Errorf("lmstudio: mkdir for state %s: %w", path, mkErr)
+	}
+	tmp := path + ".tmp"
+	if wErr := os.WriteFile(tmp, data, 0o644); wErr != nil {
+		return fmt.Errorf("lmstudio: write temp state %s: %w", tmp, wErr)
+	}
+	if rErr := os.Rename(tmp, path); rErr != nil {
+		return fmt.Errorf("lmstudio: rename state into place %s: %w", path, rErr)
+	}
+	return nil
+}
+
+// NeedsEmit reports whether f is new or has drifted (size or mtime changed
+// beyond a 2s tolerance, mirroring internal/conversations.isDrift) since the
+// last recorded emission.
+func (st *EmittedState) NeedsEmit(f ConversationFile) bool {
+	prev, ok := st.Files[f.Path]
+	if !ok {
+		return true
+	}
+	if prev.Size != f.Size {
+		return true
+	}
+	diff := prev.Mtime.Sub(f.Mtime)
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff > 2*time.Second
+}
+
+// Record marks f as emitted at its current (size, mtime).
+func (st *EmittedState) Record(f ConversationFile) {
+	if st.Files == nil {
+		st.Files = make(map[string]ConversationFile)
+	}
+	st.Files[f.Path] = f
+}

--- a/internal/lmstudio/watch_test.go
+++ b/internal/lmstudio/watch_test.go
@@ -1,0 +1,140 @@
+// watch_test.go — unit tests for conversation-file discovery and the
+// emitted-state drift tracking that makes repeated Run() calls incremental.
+package lmstudio
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestDiscoverConversationFiles_MissingRootIsNotError(t *testing.T) {
+	files, err := DiscoverConversationFiles(filepath.Join(t.TempDir(), "does-not-exist"))
+	if err != nil {
+		t.Fatalf("DiscoverConversationFiles on missing root: %v", err)
+	}
+	if len(files) != 0 {
+		t.Errorf("len(files) = %d, want 0", len(files))
+	}
+}
+
+func TestDiscoverConversationFiles_FindsNestedConversationJSON(t *testing.T) {
+	root := t.TempDir()
+	writeFixture(t, root, "Folder A", "111.conversation.json")
+	writeFixture(t, root, "Folder B", "222.conversation.json")
+
+	// Non-matching files must be ignored.
+	if err := os.WriteFile(filepath.Join(root, "Folder A", "notes.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write decoy: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "Folder A", "other.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write decoy json: %v", err)
+	}
+
+	files, err := DiscoverConversationFiles(root)
+	if err != nil {
+		t.Fatalf("DiscoverConversationFiles: %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("len(files) = %d, want 2; files=%+v", len(files), files)
+	}
+	for _, f := range files {
+		if filepath.Ext(f.Path) != ".json" || !hasConversationSuffix(f.Path) {
+			t.Errorf("discovered non-conversation file: %s", f.Path)
+		}
+	}
+}
+
+func TestEmittedState_NeedsEmit(t *testing.T) {
+	st := &EmittedState{Files: make(map[string]ConversationFile)}
+	f := ConversationFile{Path: "/a/b.conversation.json", Size: 100, Mtime: time.Now()}
+
+	if !st.NeedsEmit(f) {
+		t.Error("new file should need emit")
+	}
+	st.Record(f)
+	if st.NeedsEmit(f) {
+		t.Error("unchanged file should not need emit after Record")
+	}
+
+	grown := f
+	grown.Size = 200
+	if !st.NeedsEmit(grown) {
+		t.Error("size change should need emit")
+	}
+
+	touched := f
+	touched.Mtime = f.Mtime.Add(10 * time.Second)
+	if !st.NeedsEmit(touched) {
+		t.Error("mtime drift beyond tolerance should need emit")
+	}
+
+	jitter := f
+	jitter.Mtime = f.Mtime.Add(1 * time.Second)
+	if st.NeedsEmit(jitter) {
+		t.Error("mtime jitter within 2s tolerance should NOT need emit")
+	}
+}
+
+func TestEmittedState_SaveAndLoadRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "state", "emitted.json")
+
+	st := &EmittedState{Files: make(map[string]ConversationFile)}
+	f := ConversationFile{Path: "/a/b.conversation.json", Size: 42, Mtime: time.Now().Truncate(time.Second)}
+	st.Record(f)
+
+	if err := st.Save(statePath); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := LoadEmittedState(statePath)
+	if err != nil {
+		t.Fatalf("LoadEmittedState: %v", err)
+	}
+	got, ok := loaded.Files[f.Path]
+	if !ok {
+		t.Fatalf("loaded state missing recorded file %s", f.Path)
+	}
+	if got.Size != f.Size {
+		t.Errorf("loaded size = %d, want %d", got.Size, f.Size)
+	}
+	if !got.Mtime.Equal(f.Mtime) {
+		t.Errorf("loaded mtime = %v, want %v", got.Mtime, f.Mtime)
+	}
+}
+
+func TestLoadEmittedState_MissingFileIsEmpty(t *testing.T) {
+	st, err := LoadEmittedState(filepath.Join(t.TempDir(), "nope.json"))
+	if err != nil {
+		t.Fatalf("LoadEmittedState missing file: %v", err)
+	}
+	if len(st.Files) != 0 {
+		t.Errorf("expected empty state, got %d entries", len(st.Files))
+	}
+}
+
+func TestDefaultLMStudioDir_HonorsEnvOverride(t *testing.T) {
+	t.Setenv("LMSTUDIO_CONVERSATIONS_DIR", "/custom/path")
+	got, err := DefaultLMStudioDir()
+	if err != nil {
+		t.Fatalf("DefaultLMStudioDir: %v", err)
+	}
+	if got != "/custom/path" {
+		t.Errorf("DefaultLMStudioDir() = %q, want /custom/path", got)
+	}
+}
+
+func TestDefaultLMStudioDir_FallsBackToHome(t *testing.T) {
+	t.Setenv("LMSTUDIO_CONVERSATIONS_DIR", "")
+	got, err := DefaultLMStudioDir()
+	if err != nil {
+		t.Fatalf("DefaultLMStudioDir: %v", err)
+	}
+	home, _ := os.UserHomeDir()
+	want := filepath.Join(home, ".lmstudio", "conversations")
+	if got != want {
+		t.Errorf("DefaultLMStudioDir() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Adds a standalone producer (internal/lmstudio + cmd/lmstudio-observer) projecting LM Studio conversations into the Conversations Observatory ingest surface (cogos.observatory.conversations/v0.1, source=lm-studio). Purely additive - no changes to internal/engine or internal/conversations. See commit message for full details. Tests: go build/vet clean, 20 unit tests passing, manually verified against a real local LM Studio conversation file (fixture content is synthesized placeholder text only).