### PR TITLE
feat(inference): live /v1/models composition (Anthropic + LM Studio backends)

### DIFF
--- a/internal/engine/provider.go
+++ b/internal/engine/provider.go
@@ -49,6 +49,13 @@ type Provider interface {
 	Ping(ctx context.Context) (time.Duration, error)
 }
 
+// ModelLister is implemented by providers that can enumerate the concrete model
+// IDs they currently serve upstream. handleModels type-asserts this; providers
+// that don't implement it contribute only their configured Model().
+type ModelLister interface {
+	ListModels(ctx context.Context) ([]string, error)
+}
+
 // CancelSafeCompleter is implemented by providers whose Complete() cannot
 // reliably propagate ctx-cancellation to the server (#432). Such providers
 // expose CompleteCancelSafe, which routes the request through their
@@ -390,6 +397,10 @@ type Router interface {
 	// to pin requests to an on-device provider. Returns ("", false) when no
 	// local provider is registered.
 	FirstLocalProvider() (string, bool)
+
+	// RangeProviders calls fn for each registered provider under a read lock.
+	// Order is by Name(). fn must not call back into the router (no re-entrancy).
+	RangeProviders(fn func(p Provider))
 
 	// Stats returns routing statistics.
 	Stats() RouterStats

--- a/internal/engine/provider_claudeoauth.go
+++ b/internal/engine/provider_claudeoauth.go
@@ -222,10 +222,22 @@ func (s *claudeCodeCredentialSource) Resolve() (OAuthCredential, error) {
 	return OAuthCredential{}, fmt.Errorf("claude-oauth: no credential found in keychain, env, or %s", s.credPath)
 }
 
+// keychainExecTimeout bounds the `security find-generic-password` subprocess so
+// a hung/locked/prompting keychain cannot block a credential Resolve() past this
+// budget. Resolve() is called (transitively) from the /v1/models ListModels
+// probe and from Available(); neither could kill the keychain exec before,
+// because the CredentialSource.Resolve() contract carries no context. Bounding
+// it here keeps the exec self-contained and hardens both callers without
+// widening the shared interface. A timeout is treated as "no keychain credential"
+// and falls through to the env-var / file sources.
+const keychainExecTimeout = 2 * time.Second
+
 // readKeychain reads the "Claude Code-credentials" keychain entry on macOS.
 // Source: _read_claude_code_credentials_from_keychain.
 func (s *claudeCodeCredentialSource) readKeychain() (OAuthCredential, bool) {
-	out, err := exec.Command("security", "find-generic-password",
+	ctx, cancel := context.WithTimeout(context.Background(), keychainExecTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "security", "find-generic-password",
 		"-s", "Claude Code-credentials",
 		"-w").Output()
 	if err != nil {
@@ -659,6 +671,84 @@ func (p *ClaudeOAuthProvider) probeAvailable(ctx context.Context) bool {
 	}
 
 	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+// ListModels enumerates the Anthropic model IDs the subscription can serve by
+// performing the authenticated GET /v1/models behind the credential lifecycle,
+// mirroring Available()'s auth + reactive-refresh-on-401 pattern but parsing the
+// response body ({"data":[{"id":...}]}) instead of discarding it. Satisfies the
+// ModelLister interface used by the /v1/models composition handler.
+//
+// The credential lifecycle stays READ-ONLY here (like Available): the kernel is
+// a keychain mirror and never POSTs a refresh; ReactiveRefreshAndRetry delegates
+// any refresh to the owner. Bounded by the same short probe timeout so one slow
+// upstream cannot stall the /v1/models composition beyond a few seconds.
+func (p *ClaudeOAuthProvider) ListModels(ctx context.Context) ([]string, error) {
+	listCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	token, err := p.lc.FreshToken(listCtx)
+	if err != nil {
+		return nil, fmt.Errorf("claude-oauth: ListModels: credential: %w", err)
+	}
+
+	ids, status, err := p.fetchModelIDs(listCtx, token)
+	if err != nil {
+		return nil, err
+	}
+	if status == http.StatusUnauthorized {
+		// Reactive refresh once (read-only: delegates to the credential owner),
+		// then retry — mirrors Available()'s 401 handling.
+		token, err = p.lc.ReactiveRefreshAndRetry(listCtx)
+		if err != nil {
+			return nil, fmt.Errorf("claude-oauth: ListModels: reactive refresh: %w", err)
+		}
+		ids, status, err = p.fetchModelIDs(listCtx, token)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if status < 200 || status >= 300 {
+		return nil, fmt.Errorf("claude-oauth: ListModels: /v1/models status %d", status)
+	}
+	return ids, nil
+}
+
+// fetchModelIDs performs a single authenticated GET /v1/models and parses the
+// Anthropic model-list body ({"data":[{"id":...}]}). It returns the parsed IDs
+// (only when the status is 2xx), the HTTP status code (so the caller can drive
+// the reactive-refresh-on-401 retry), and any transport/decode error.
+func (p *ClaudeOAuthProvider) fetchModelIDs(ctx context.Context, token string) ([]string, int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.endpoint+"/v1/models", nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	p.setOAuthHeaders(req, token, false)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("claude-oauth: ListModels: /v1/models: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, resp.StatusCode, nil
+	}
+	var body struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, resp.StatusCode, fmt.Errorf("claude-oauth: ListModels: decode: %w", err)
+	}
+	ids := make([]string, 0, len(body.Data))
+	for _, m := range body.Data {
+		if m.ID != "" {
+			ids = append(ids, m.ID)
+		}
+	}
+	return ids, resp.StatusCode, nil
 }
 
 // Capabilities returns what this provider supports.

--- a/internal/engine/provider_ollama.go
+++ b/internal/engine/provider_ollama.go
@@ -204,6 +204,13 @@ func (p *OllamaProvider) Ping(ctx context.Context) (time.Duration, error) {
 	return time.Since(start), nil
 }
 
+// ListModels enumerates the locally-available Ollama models (GET /api/tags).
+// Satisfies the ModelLister interface used by the /v1/models composition
+// handler.
+func (p *OllamaProvider) ListModels(ctx context.Context) ([]string, error) {
+	return p.listModels(ctx)
+}
+
 // listModels queries GET /api/tags and returns the names of all locally
 // available Ollama models. Empty names are filtered out. This is the shared
 // implementation used by Available() and any future listing callers, extracted

--- a/internal/engine/provider_openai.go
+++ b/internal/engine/provider_openai.go
@@ -243,6 +243,13 @@ func (p *OpenAICompatProvider) effectiveModel(req *CompletionRequest) string {
 	return p.model
 }
 
+// ListModels enumerates the concrete model IDs this OpenAI-compatible endpoint
+// currently serves (GET /v1/models). Satisfies the ModelLister interface used
+// by the /v1/models composition handler.
+func (p *OpenAICompatProvider) ListModels(ctx context.Context) ([]string, error) {
+	return p.listModels(ctx)
+}
+
 // listModels fetches the model list from /v1/models.
 func (p *OpenAICompatProvider) listModels(ctx context.Context) ([]string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.endpoint+"/v1/models", nil)

--- a/internal/engine/resolve.go
+++ b/internal/engine/resolve.go
@@ -31,6 +31,7 @@ package engine
 
 import (
 	"log/slog"
+	"strings"
 )
 
 // ModelResolution is the output of ResolveModelRequest.
@@ -73,6 +74,81 @@ var intentAliases = map[string]ModelResolution{
 	// via this alias default.
 	"ollama":       {PreferProvider: "lmstudio-darkstar", InjectKernelTools: true},
 	"kernel-agent": {PreferProvider: "lmstudio-darkstar", InjectKernelTools: true},
+}
+
+// resolveLiveCatalog resolves the two id families that the live GET /v1/models
+// endpoint advertises beyond the static alias table, so an advertised id never
+// gets a boundary 400 (the admission-parity invariant). It is the single source
+// of truth shared by ResolveModelRequest and IsKnownModel.
+//
+//   - Composite "<provider>/<model>": split on the FIRST "/". When the prefix is
+//     a REGISTERED provider name, resolve to {PreferProvider: prefix,
+//     ModelOverride: suffix}. When the prefix is not a registered provider (e.g.
+//     an "openrouter/x/y"-style id), report no match so the caller falls through
+//     to the existing logic — this guard prevents mis-splitting such ids.
+//   - Live claude ids: when a frontier provider is registered (see
+//     frontierProviderName — the same predicate isFrontierConfigured emits on)
+//     AND the id has the "claude-" prefix, resolve to that provider with
+//     ModelOverride=model. This makes newly-shipped Anthropic ids (not in
+//     intentAliases) both admissible and routable — matching the "claude-oauth
+//     is model-agnostic" design intent — and keeps emit/admit in lockstep so a
+//     bare claude id like claude-haiku-4-5-20251001 is never advertised-then-
+//     rejected.
+//
+// Returns (resolution, true) on a match; (zero, false) otherwise. A nil router
+// yields no match (the caller handles the nil-router path).
+func resolveLiveCatalog(router Router, model string) (ModelResolution, bool) {
+	if router == nil || model == "" {
+		return ModelResolution{}, false
+	}
+
+	// Composite "<provider>/<model>": only when the prefix is a registered
+	// provider name; otherwise fall through so multi-segment ids aren't
+	// mis-split.
+	if i := strings.Index(model, "/"); i > 0 && i < len(model)-1 {
+		prefix, suffix := model[:i], model[i+1:]
+		if name, ok := router.ProviderForName(prefix); ok {
+			return ModelResolution{PreferProvider: name, ModelOverride: suffix}, true
+		}
+	}
+
+	// Live claude ids → the registered frontier provider (claude-oauth first).
+	if strings.HasPrefix(model, "claude-") {
+		if name, ok := frontierProviderName(router); ok {
+			return ModelResolution{PreferProvider: name, ModelOverride: model}, true
+		}
+	}
+
+	return ModelResolution{}, false
+}
+
+// frontierProviderName returns the registered frontier provider to route
+// managed-Claude ids to. It MUST admit under exactly the same conditions that
+// serve_compat.go's isFrontierConfigured emits the bare claude ids, or the
+// endpoint advertises a claude id that IsKnownModel rejects (advertise-then-
+// reject; the admission-parity invariant). isFrontierConfigured matches by
+// provider name {claude-oauth, anthropic, claude-code} OR by a provider serving
+// claude-sonnet-4-6 / claude-opus-4-7 under any name — so this helper checks the
+// same predicates and returns a routable provider name for each.
+//
+// Preference order mirrors the model-agnostic frontier failover: the direct-API
+// providers (claude-oauth, then anthropic) first, then the claude-code CLI, then
+// whatever provider serves the representative sonnet/opus model strings.
+func frontierProviderName(router Router) (string, bool) {
+	if router == nil {
+		return "", false
+	}
+	for _, name := range []string{"claude-oauth", "anthropic", "claude-code"} {
+		if n, ok := router.ProviderForName(name); ok {
+			return n, true
+		}
+	}
+	for _, model := range []string{"claude-sonnet-4-6", "claude-opus-4-7"} {
+		if n, ok := router.ProviderForModel(model); ok {
+			return n, true
+		}
+	}
+	return "", false
 }
 
 // ResolveModelRequest maps a model string to a ModelResolution using the
@@ -135,6 +211,14 @@ func ResolveModelRequest(router Router, model string, requestID string) ModelRes
 	if name, ok := router.ProviderForName(model); ok {
 		return ModelResolution{PreferProvider: name}
 	}
+
+	// Live-catalog parity: composite "<provider>/<model>" and newly-shipped
+	// claude-* ids advertised by GET /v1/models must both admit (IsKnownModel)
+	// and route. Checked before the generic ProviderForModel fallback so a
+	// composite id resolves to its named provider with the suffix as override.
+	if res, ok := resolveLiveCatalog(router, model); ok {
+		return res
+	}
 	// Model-ID pass-through: set ModelOverride and, if a provider serves this
 	// model, also set PreferProvider.
 	res := ModelResolution{ModelOverride: model}
@@ -179,6 +263,13 @@ func IsKnownModel(router Router, model string) bool {
 		return true
 	}
 	if _, ok := router.ProviderForModel(model); ok {
+		return true
+	}
+	// Live-catalog parity: composite "<provider>/<model>" ids and newly-shipped
+	// claude-* ids advertised at GET /v1/models are admissible even when they are
+	// not in the static alias table nor served by a ProviderForModel match. Same
+	// helper ResolveModelRequest uses, so admission and routing never diverge.
+	if _, ok := resolveLiveCatalog(router, model); ok {
 		return true
 	}
 	return false

--- a/internal/engine/resolve_test.go
+++ b/internal/engine/resolve_test.go
@@ -34,6 +34,7 @@ type stubRouter struct {
 	byName  map[string]string // name → name
 	byModel map[string]string // model → provider name
 	local   []string          // providers with IsLocal=true, in order
+	provs   []Provider        // providers visited by RangeProviders (opt-in)
 }
 
 func newStubRouter() *stubRouter {
@@ -69,6 +70,15 @@ func (r *stubRouter) FirstLocalProvider() (string, bool) {
 		return r.local[0], true
 	}
 	return "", false
+}
+
+// RangeProviders visits the stub's registered providers. The stub tracks only
+// provider names/models, not Provider values, so it visits nothing by default;
+// tests that need live enumeration wire providers via provs (see below).
+func (r *stubRouter) RangeProviders(fn func(p Provider)) {
+	for _, p := range r.provs {
+		fn(p)
+	}
 }
 
 // Unused Router interface methods — satisfy the interface without panicking.
@@ -472,47 +482,65 @@ func TestModelsMenu_Eclipse26B_AbsentWhenNotConfigured(t *testing.T) {
 	}
 }
 
-func TestModelsMenu_Eclipse26B_PresentWhenEclipseRegistered(t *testing.T) {
+func TestModelsMenu_Eclipse26B_PresentWhenModelServed(t *testing.T) {
 	t.Parallel()
 
+	// A provider that actually SERVES the eclipse-26b model string. This is the
+	// only condition under which IsKnownModel(router,"eclipse-26b") is true, so it
+	// is the only condition under which the static eclipse-26b id may be emitted
+	// (emit ⇔ admit — the admission-parity invariant). A provider merely NAMED
+	// "eclipse"/"lmstudio" that serves some other model must NOT surface it (see
+	// TestModelsMenu_Eclipse26B_AbsentWhenNameOnly).
 	eclipseStub := NewStubProvider("eclipse", "eclipse response")
+	eclipseStub.model = "eclipse-26b"
 	router := NewSimpleRouter(RoutingConfig{Default: "eclipse"})
 	router.RegisterProvider(eclipseStub)
 
 	srv := newTestServerWithRouter(t, router)
 	resp := fetchModels(t, srv)
-	body, _ := json.Marshal(resp)
 
-	if !bytes.Contains(body, []byte("eclipse-26b")) {
-		t.Errorf("eclipse-26b should appear when eclipse provider is registered; body: %s", body)
-	}
-	// Verify tier.
+	var found bool
 	for _, m := range resp.Data {
 		if m.ID == "eclipse-26b" {
+			found = true
 			if m.Tier != "lan-local" {
 				t.Errorf("eclipse-26b tier = %q; want lan-local", m.Tier)
 			}
 			if m.OwnedBy != "cogos" {
 				t.Errorf("eclipse-26b owned_by = %q; want cogos", m.OwnedBy)
 			}
-			return
 		}
 	}
-	t.Error("eclipse-26b model entry not found in response Data")
+	if !found {
+		t.Errorf("eclipse-26b model entry not found in response Data: %+v", resp.Data)
+	}
+
+	// Admission parity: the advertised id must satisfy IsKnownModel.
+	if !IsKnownModel(router, "eclipse-26b") {
+		t.Error("eclipse-26b advertised but IsKnownModel returned false (advertise-then-reject)")
+	}
 }
 
-func TestModelsMenu_Eclipse26B_PresentWhenLMStudioRegistered(t *testing.T) {
+func TestModelsMenu_Eclipse26B_AbsentWhenNameOnly(t *testing.T) {
 	t.Parallel()
 
+	// Provider named "lmstudio"/"eclipse" but serving a DIFFERENT model — the
+	// pre-existing name-detection would have emitted eclipse-26b here, but the
+	// kernel boundary would then 400 a client selecting it (IsKnownModel false).
+	// Emit-gate is now ProviderForModel("eclipse-26b"), so it must NOT appear.
 	lmsStub := NewStubProvider("lmstudio", "lms response")
+	lmsStub.model = "ornith-1.0-35b"
 	router := NewSimpleRouter(RoutingConfig{Default: "lmstudio"})
 	router.RegisterProvider(lmsStub)
 
 	srv := newTestServerWithRouter(t, router)
 	body, _ := json.Marshal(fetchModels(t, srv))
 
-	if !bytes.Contains(body, []byte("eclipse-26b")) {
-		t.Errorf("eclipse-26b should appear when lmstudio provider is registered; body: %s", body)
+	if bytes.Contains(body, []byte("eclipse-26b")) {
+		t.Errorf("eclipse-26b must NOT be advertised when no provider serves it (IsKnownModel would 400 it); body: %s", body)
+	}
+	if IsKnownModel(router, "eclipse-26b") {
+		t.Error("IsKnownModel(eclipse-26b) should be false when no provider serves that model")
 	}
 }
 
@@ -659,6 +687,123 @@ func TestResolveModelRequest_26B_FallsThrough(t *testing.T) {
 	res := ResolveModelRequest(nil, "26b", "req-26b")
 	if res.PreferProvider != "" {
 		t.Errorf("26b: PreferProvider = %q; want empty (fall-through)", res.PreferProvider)
+	}
+}
+
+// ── Live-catalog parity: composite ids + newly-shipped claude ids ────────────
+//
+// These exercise resolveLiveCatalog through both ResolveModelRequest (routing)
+// and IsKnownModel (admission) so the two never diverge — the admission-parity
+// invariant that keeps GET /v1/models from advertising an id the boundary 400s.
+
+func TestResolveLiveCatalog_CompositeID_ResolvesAndAdmits(t *testing.T) {
+	t.Parallel()
+
+	router := NewSimpleRouter(RoutingConfig{})
+	router.RegisterProvider(NewStubProvider("lmstudio-eclipse", "r"))
+
+	const id = "lmstudio-eclipse/ornith-1.0-35b"
+	res := ResolveModelRequest(router, id, "t")
+	if res.PreferProvider != "lmstudio-eclipse" {
+		t.Errorf("composite PreferProvider = %q; want lmstudio-eclipse", res.PreferProvider)
+	}
+	if res.ModelOverride != "ornith-1.0-35b" {
+		t.Errorf("composite ModelOverride = %q; want ornith-1.0-35b", res.ModelOverride)
+	}
+	if !IsKnownModel(router, id) {
+		t.Errorf("composite id %q must be admissible", id)
+	}
+}
+
+func TestResolveLiveCatalog_CompositeID_UnregisteredPrefixFallsThrough(t *testing.T) {
+	t.Parallel()
+
+	// "openrouter" is NOT a registered provider, so an "openrouter/x/y"-style id
+	// must NOT be mis-split: it falls through to the generic model-id path
+	// (ModelOverride = whole string, no PreferProvider) and IsKnownModel is false.
+	router := NewSimpleRouter(RoutingConfig{})
+	router.RegisterProvider(NewStubProvider("lmstudio-darkstar", "r"))
+
+	const id = "openrouter/anthropic/claude-3"
+	res := ResolveModelRequest(router, id, "t")
+	if res.PreferProvider != "" {
+		t.Errorf("unregistered-prefix PreferProvider = %q; want empty (fall-through)", res.PreferProvider)
+	}
+	if res.ModelOverride != id {
+		t.Errorf("unregistered-prefix ModelOverride = %q; want whole id %q", res.ModelOverride, id)
+	}
+	if IsKnownModel(router, id) {
+		t.Errorf("unregistered-prefix id %q must NOT admit", id)
+	}
+}
+
+func TestResolveLiveCatalog_NewClaudeID_RoutesToOAuthAndAdmits(t *testing.T) {
+	t.Parallel()
+
+	router := NewSimpleRouter(RoutingConfig{})
+	router.RegisterProvider(NewStubProvider("claude-oauth", "r"))
+
+	// A newly-shipped claude id not present in intentAliases.
+	const id = "claude-opus-4-9-20260101"
+	res := ResolveModelRequest(router, id, "t")
+	if res.PreferProvider != "claude-oauth" {
+		t.Errorf("new claude id PreferProvider = %q; want claude-oauth", res.PreferProvider)
+	}
+	if res.ModelOverride != id {
+		t.Errorf("new claude id ModelOverride = %q; want %q", res.ModelOverride, id)
+	}
+	if !IsKnownModel(router, id) {
+		t.Errorf("new claude id %q must be admissible", id)
+	}
+}
+
+func TestResolveLiveCatalog_NewClaudeID_NoFrontierProviderRejects(t *testing.T) {
+	t.Parallel()
+
+	// No frontier provider registered → a bare claude id is NOT admissible and
+	// does not resolve to a frontier provider.
+	router := NewSimpleRouter(RoutingConfig{})
+	router.RegisterProvider(NewStubProvider("lmstudio-darkstar", "r"))
+
+	const id = "claude-opus-4-9-20260101"
+	if IsKnownModel(router, id) {
+		t.Errorf("claude id %q must NOT admit without a frontier provider", id)
+	}
+	res := ResolveModelRequest(router, id, "t")
+	if res.PreferProvider != "" {
+		t.Errorf("no-frontier claude id PreferProvider = %q; want empty", res.PreferProvider)
+	}
+}
+
+func TestFrontierProviderName_MatchesEmitGate(t *testing.T) {
+	t.Parallel()
+
+	// claude-code alone must yield a routable frontier provider (Finding-1: the
+	// admit gate must match isFrontierConfigured's emit gate, which includes the
+	// claude-code name).
+	rCC := NewSimpleRouter(RoutingConfig{})
+	rCC.RegisterProvider(NewStubProvider("claude-code", "r"))
+	if name, ok := frontierProviderName(rCC); !ok || name != "claude-code" {
+		t.Errorf("frontierProviderName(claude-code) = (%q,%v); want (claude-code,true)", name, ok)
+	}
+
+	// A provider serving claude-sonnet-4-6 under a non-canonical name also
+	// qualifies (matches isFrontierConfigured's ProviderForModel branch).
+	rModel := NewSimpleRouter(RoutingConfig{})
+	sp := NewStubProvider("my-anthropic", "r")
+	sp.model = "claude-sonnet-4-6"
+	rModel.RegisterProvider(sp)
+	if name, ok := frontierProviderName(rModel); !ok || name != "my-anthropic" {
+		t.Errorf("frontierProviderName(serves sonnet) = (%q,%v); want (my-anthropic,true)", name, ok)
+	}
+
+	// Preference: claude-oauth wins when several are registered.
+	rPref := NewSimpleRouter(RoutingConfig{})
+	rPref.RegisterProvider(NewStubProvider("claude-code", "r"))
+	rPref.RegisterProvider(NewStubProvider("anthropic", "r"))
+	rPref.RegisterProvider(NewStubProvider("claude-oauth", "r"))
+	if name, ok := frontierProviderName(rPref); !ok || name != "claude-oauth" {
+		t.Errorf("frontierProviderName preference = (%q,%v); want (claude-oauth,true)", name, ok)
 	}
 }
 

--- a/internal/engine/router.go
+++ b/internal/engine/router.go
@@ -168,6 +168,21 @@ func (r *SimpleRouter) FirstLocalProvider() (string, bool) {
 	return "", false
 }
 
+// RangeProviders calls fn for each registered provider. Providers are visited
+// in Name() order. A snapshot of the provider slice is taken under the read
+// lock and the lock is released before fn runs, so fn may perform network I/O
+// (e.g. a live GET /v1/models) without holding r.mu — and must not call back
+// into the router (no re-entrancy).
+func (r *SimpleRouter) RangeProviders(fn func(p Provider)) {
+	r.mu.RLock()
+	providers := make([]Provider, len(r.providers))
+	copy(providers, r.providers)
+	r.mu.RUnlock()
+	for _, p := range providers {
+		fn(p)
+	}
+}
+
 // Route selects the best available provider for the request.
 func (r *SimpleRouter) Route(ctx context.Context, req *CompletionRequest) (Provider, *RoutingDecision, error) {
 	start := time.Now()

--- a/internal/engine/serve_compat.go
+++ b/internal/engine/serve_compat.go
@@ -24,6 +24,7 @@
 package engine
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -31,6 +32,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -124,107 +126,362 @@ func (s *Server) handleCard(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(card)
 }
 
-// handleModels returns an OpenAI-compatible model list (G2 both-menu).
+// compatModelPermission mirrors the OpenAI model_permission object.
+type compatModelPermission struct {
+	ID            string `json:"id"`
+	Object        string `json:"object"`
+	Created       int64  `json:"created"`
+	AllowSampling bool   `json:"allow_sampling"`
+	AllowLogprobs bool   `json:"allow_logprobs"`
+	AllowView     bool   `json:"allow_view"`
+}
+
+// compatModel is a single entry in the /v1/models list. `tier` and
+// `description` are cogos extensions ignored by standard OpenAI clients.
+type compatModel struct {
+	ID          string                  `json:"id"`
+	Object      string                  `json:"object"`
+	Created     int64                   `json:"created"`
+	OwnedBy     string                  `json:"owned_by"`
+	Permission  []compatModelPermission `json:"permission"`
+	Tier        string                  `json:"tier,omitempty"`
+	Description string                  `json:"description,omitempty"`
+}
+
+type compatModelsResponse struct {
+	Object string        `json:"object"`
+	Data   []compatModel `json:"data"`
+}
+
+// mkCompatModel builds a compatModel with the boilerplate permission block.
+func mkCompatModel(id, owner, tier, description string, now int64) compatModel {
+	return compatModel{
+		ID: id, Object: "model", Created: now, OwnedBy: owner,
+		Tier:        tier,
+		Description: description,
+		Permission: []compatModelPermission{{
+			ID:            "modelperm-" + id,
+			Object:        "model_permission",
+			Created:       now,
+			AllowSampling: true,
+			AllowLogprobs: true,
+			AllowView:     true,
+		}},
+	}
+}
+
+// modelsPerProviderTimeout bounds each provider's live ListModels call during
+// /v1/models composition. One down or slow (or 401ing) backend must never fail
+// the endpoint nor block it beyond this budget — it is skipped (graceful
+// degradation).
+const modelsPerProviderTimeout = 2 * time.Second
+
+// modelsCacheTTL bounds how long a composed /v1/models list is reused before it
+// is recomposed (which fires the live per-provider probes). Keeps concurrent
+// callers from stampeding every backend on every request.
+const modelsCacheTTL = 45 * time.Second
+
+// modelsCacheEntry holds the last composed /v1/models list for one router and
+// when it was built. Recomposition happens under the entry's lock
+// (single-flight): concurrent callers on a cold/stale entry collapse into one
+// composition instead of each firing the live backend probes. This mirrors the
+// hold-lock-during-fetch rationale of the provider Available() TTL caches (#441).
+type modelsCacheEntry struct {
+	mu        sync.Mutex
+	data      []compatModel
+	fetchedAt time.Time
+}
+
+// modelsListCaches keys a modelsCacheEntry by the router it was composed from,
+// so that distinct routers (the daemon's single live router in production; many
+// independent routers in tests) never serve each other's stale menus. The outer
+// mutex guards only the map; the per-router probe/compose runs under the entry's
+// own lock. A nil router uses the shared zero-key entry.
 //
-// Menu order and fields:
-//  1. Intent aliases (owned_by "cogos"): foreground, deliberation, local.
-//     These are always present — they are software-defined names, not
-//     hardware-presence signals.
-//  2. Raw frontier model IDs (owned_by "anthropic"): claude-sonnet-4-6,
-//     claude-opus-4-7.
-//  3. eclipse-26b (owned_by "cogos", tier "lan-local") — ONLY when the
-//     eclipse provider is registered in the router. Gated on config presence;
-//     no live HTTP probe on every call.
+// Entries are intentionally NEVER evicted. In production this is bounded: the
+// daemon builds exactly one long-lived router, so the map holds a single entry
+// for the process lifetime. The unbounded shape only matters if the kernel ever
+// recreates routers at runtime (reload/reconcile) — should that land, evict the
+// stale router's entry on teardown (e.g. in SimpleRouter.Close) or re-key this
+// cache off the Server (one per daemon) instead of the Router. In tests each
+// freshly-constructed router leaks one entry, which is negligible for a test
+// process.
+var (
+	modelsListCachesMu sync.Mutex
+	modelsListCaches   = map[Router]*modelsCacheEntry{}
+)
+
+// modelsCacheFor returns the cache entry for a router, creating it on first use.
+func modelsCacheFor(router Router) *modelsCacheEntry {
+	modelsListCachesMu.Lock()
+	defer modelsListCachesMu.Unlock()
+	e, ok := modelsListCaches[router]
+	if !ok {
+		e = &modelsCacheEntry{}
+		modelsListCaches[router] = e
+	}
+	return e
+}
+
+// handleModels returns an OpenAI-compatible model list — a live view of the
+// providers/models actually registered and loaded, plus the always-on
+// software-defined intent aliases.
 //
-// Extension fields `tier` and `description` are ignored by standard OpenAI
-// clients; cogos-aware clients use them for UI display / routing decisions.
-// The alias IDs here MUST match the intentAliases table in resolve.go so that
-// selecting any entry from this menu resolves correctly on both gateway and
-// dispatch.
+// Menu shape:
+//  1. Intent aliases (owned_by "cogos"): foreground, deliberation (frontier),
+//     local. Gated on isFrontierConfigured / isLocalConfigured — software-defined
+//     names, not hardware-presence signals. These MUST match the intentAliases
+//     table in resolve.go so a selected entry resolves on both gateway and
+//     dispatch.
+//  2. Static frontier IDs (owned_by "anthropic", tier "frontier-managed"):
+//     claude-sonnet-4-6, claude-opus-4-7, claude-haiku-4-5-20251001. Retained so
+//     existing clients keep working even when the live Anthropic catalog probe
+//     is unavailable.
+//  3. Static eclipse-26b (tier "lan-local") when a provider actually serves the
+//     eclipse-26b model string (ProviderForModel) — retained for the same
+//     reason, and gated on the same predicate that admits it so it is never
+//     advertised-then-rejected.
+//  4. LIVE-enumerated IDs: each registered provider that implements ModelLister
+//     is probed (GET /v1/models) with a bounded per-provider timeout,
+//     concurrently. Frontier providers emit their claude ids BARE
+//     (owned_by "anthropic"); OpenAI-compat / local providers emit composite
+//     "<provider>/<model>" ids (owned_by "cogos:<provider>"). Embedding models
+//     are tagged (description "embedding"), never dropped. A provider whose probe
+//     errors or times out is skipped — the endpoint never 500s and never blocks
+//     beyond the per-provider budget.
+//
+// The composed list is deduped by final id and served from a ~45s TTL cache so
+// concurrent callers don't stampede every backend.
+//
+// THE ADMISSION-PARITY INVARIANT: every id emitted here satisfies
+// IsKnownModel(router, id) == true (resolve.go), so a client selecting any
+// advertised id never gets a boundary 400.
 func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
 	s.logCompatDeprecated(r)
-	type modelPermission struct {
-		ID            string `json:"id"`
-		Object        string `json:"object"`
-		Created       int64  `json:"created"`
-		AllowSampling bool   `json:"allow_sampling"`
-		AllowLogprobs bool   `json:"allow_logprobs"`
-		AllowView     bool   `json:"allow_view"`
-	}
-	type model struct {
-		ID          string            `json:"id"`
-		Object      string            `json:"object"`
-		Created     int64             `json:"created"`
-		OwnedBy     string            `json:"owned_by"`
-		Permission  []modelPermission `json:"permission"`
-		Tier        string            `json:"tier,omitempty"`
-		Description string            `json:"description,omitempty"`
-	}
-	type response struct {
-		Object string  `json:"object"`
-		Data   []model `json:"data"`
-	}
 
-	now := time.Now().Unix()
-	mkModel := func(id, owner, tier, description string) model {
-		return model{
-			ID: id, Object: "model", Created: now, OwnedBy: owner,
-			Tier:        tier,
-			Description: description,
-			Permission: []modelPermission{{
-				ID:            "modelperm-" + id,
-				Object:        "model_permission",
-				Created:       now,
-				AllowSampling: true,
-				AllowLogprobs: true,
-				AllowView:     true,
-			}},
-		}
-	}
-
-	// Gate every entry on real provider availability. All checks are in-memory
-	// map lookups (no I/O) — same pattern as isEclipseConfigured.
-	frontierConfigured := isFrontierConfigured(s.router)
-	localConfigured := isLocalConfigured(s.router)
-	eclipseConfigured := isEclipseConfigured(s.router)
-
-	var data []model
-	if frontierConfigured {
-		// Intent aliases for frontier-managed tiers.
-		data = append(data,
-			mkModel("foreground", "cogos", "frontier-managed",
-				"interactive, full capability (managed Claude, Max sub)"),
-			mkModel("deliberation", "cogos", "frontier-managed",
-				"heavier reasoning (Opus)"),
-		)
-	}
-	if localConfigured {
-		// Intent alias for the local-sovereign tier.
-		data = append(data,
-			mkModel("local", "cogos", "local-sovereign",
-				"private, no egress (E4B on this node)"),
-		)
-	}
-	if frontierConfigured {
-		// Raw frontier model IDs.
-		data = append(data,
-			mkModel("claude-sonnet-4-6", "anthropic", "frontier-managed", ""),
-			mkModel("claude-opus-4-7", "anthropic", "frontier-managed", ""),
-			mkModel("claude-haiku-4-5-20251001", "anthropic", "frontier-managed", "fast, low-cost"),
-		)
-	}
-	if eclipseConfigured {
-		data = append(data,
-			mkModel("eclipse-26b", "cogos", "lan-local",
-				"LAN-resident 26B model (Eclipse node)"),
-		)
-	}
+	data := composeModelsList(r.Context(), s.router)
 
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(response{
+	_ = json.NewEncoder(w).Encode(compatModelsResponse{
 		Object: "list",
 		Data:   data,
 	})
+}
+
+// composeModelsList returns the /v1/models entries, served from the TTL cache
+// when fresh and recomposed under the cache lock (single-flight) when
+// cold/stale. The caller's ctx bounds the live provider probes; each probe is
+// additionally capped at modelsPerProviderTimeout.
+func composeModelsList(ctx context.Context, router Router) []compatModel {
+	entry := modelsCacheFor(router)
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	if entry.data != nil && time.Since(entry.fetchedAt) < modelsCacheTTL {
+		return entry.data
+	}
+	data := buildModelsList(ctx, router)
+	entry.data = data
+	entry.fetchedAt = time.Now()
+	return data
+}
+
+// buildModelsList composes the model menu: intent aliases + static frontier /
+// eclipse ids (config-gated, in-memory) followed by the live-enumerated ids from
+// every ModelLister provider (bounded, concurrent, graceful-skip). Deduped by
+// final id, first occurrence wins so the static entries keep their curated
+// tier/description when a live probe would re-emit the same id.
+func buildModelsList(ctx context.Context, router Router) []compatModel {
+	now := time.Now().Unix()
+
+	// Gate the static/alias entries on real provider availability. All checks
+	// are in-memory map lookups (no I/O) — same pattern as isEclipseConfigured.
+	frontierConfigured := isFrontierConfigured(router)
+	localConfigured := isLocalConfigured(router)
+	// The static eclipse-26b id is admissible (IsKnownModel true) ONLY when a
+	// provider actually serves the eclipse-26b model string. Gating its emission
+	// on the same predicate keeps emit and admit in lockstep — emitting it merely
+	// because a provider named "eclipse"/"lmstudio" exists (isEclipseConfigured's
+	// broader name match) would advertise an id the kernel then 400s. The real
+	// eclipse model is surfaced via live enumeration as a composite id regardless.
+	eclipseServed := eclipseModelServed(router)
+
+	var data []compatModel
+	seen := make(map[string]bool)
+	add := func(m compatModel) {
+		if m.ID == "" || seen[m.ID] {
+			return
+		}
+		seen[m.ID] = true
+		data = append(data, m)
+	}
+
+	if frontierConfigured {
+		// Intent aliases for frontier-managed tiers.
+		add(mkCompatModel("foreground", "cogos", "frontier-managed",
+			"interactive, full capability (managed Claude, Max sub)", now))
+		add(mkCompatModel("deliberation", "cogos", "frontier-managed",
+			"heavier reasoning (Opus)", now))
+	}
+	if localConfigured {
+		// Intent alias for the local-sovereign tier.
+		add(mkCompatModel("local", "cogos", "local-sovereign",
+			"private, no egress (E4B on this node)", now))
+	}
+	if frontierConfigured {
+		// Static frontier model IDs — retained so clients keep working even when
+		// the live Anthropic catalog probe is unavailable.
+		add(mkCompatModel("claude-sonnet-4-6", "anthropic", "frontier-managed", "", now))
+		add(mkCompatModel("claude-opus-4-7", "anthropic", "frontier-managed", "", now))
+		add(mkCompatModel("claude-haiku-4-5-20251001", "anthropic", "frontier-managed", "fast, low-cost", now))
+	}
+	if eclipseServed {
+		add(mkCompatModel("eclipse-26b", "cogos", "lan-local",
+			"LAN-resident 26B model (Eclipse node)", now))
+	}
+
+	// Live enumeration: probe every ModelLister provider concurrently, each
+	// bounded, skipping any that error/time out.
+	for _, m := range liveModelEntries(ctx, router, now) {
+		add(m)
+	}
+
+	return data
+}
+
+// liveModelEntries walks the router's providers, probing each ModelLister with a
+// bounded per-provider timeout, concurrently, and returns the composed live
+// entries. A provider whose probe errors or times out is skipped (slog.Debug):
+// the endpoint never fails and never blocks beyond modelsPerProviderTimeout.
+// Order is deterministic (by provider Name(), which RangeProviders guarantees),
+// so the caller's first-occurrence dedupe is stable.
+func liveModelEntries(ctx context.Context, router Router, now int64) []compatModel {
+	if router == nil {
+		return nil
+	}
+
+	// Snapshot the ModelLister providers in Name() order.
+	var listers []Provider
+	router.RangeProviders(func(p Provider) {
+		if _, ok := p.(ModelLister); ok {
+			listers = append(listers, p)
+		}
+	})
+	if len(listers) == 0 {
+		return nil
+	}
+
+	// Probe concurrently; per-provider results indexed to preserve order.
+	results := make([][]compatModel, len(listers))
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	for i, p := range listers {
+		wg.Add(1)
+		go func(i int, p Provider) {
+			defer wg.Done()
+			pctx, cancel := context.WithTimeout(ctx, modelsPerProviderTimeout)
+			defer cancel()
+			ids, err := p.(ModelLister).ListModels(pctx)
+			if err != nil {
+				slog.Debug("compat: /v1/models: provider enumeration skipped",
+					"provider", p.Name(), "err", err)
+				return
+			}
+			entries := make([]compatModel, 0, len(ids))
+			frontier := isFrontierProvider(p)
+			for _, id := range ids {
+				if id == "" {
+					continue
+				}
+				entries = append(entries, modelEntryFor(p, id, frontier, now))
+			}
+			mu.Lock()
+			results[i] = entries
+			mu.Unlock()
+		}(i, p)
+	}
+	wg.Wait()
+
+	var out []compatModel
+	for _, entries := range results {
+		out = append(out, entries...)
+	}
+	return out
+}
+
+// isFrontierProvider reports whether p is an Anthropic/Claude frontier provider,
+// so its live model ids are emitted BARE (owned_by "anthropic", preserving
+// existing client naming) rather than composite.
+//
+// The set is the explicit canonical name list ONLY — deliberately NOT a
+// !IsLocal structural fallthrough. Bare claude ids are admitted by
+// resolveLiveCatalog's claude-* branch, which requires a frontier provider
+// (frontierProviderName, same name set). A non-local, non-claude ModelLister
+// (none exists today — OpenAICompatProvider is IsLocal=true — but a future one
+// could) whose ids were emitted bare would have NO admission path (not a
+// composite prefix, not a claude- id, not ProviderForModel), producing an
+// advertise-then-reject. Restricting to the names that have a real bare
+// admission path keeps emit ⇔ admit; everything else emits composite, which
+// always admits via the ProviderForName prefix guard.
+func isFrontierProvider(p Provider) bool {
+	switch p.Name() {
+	case "claude-oauth", "anthropic", "claude-code":
+		return true
+	}
+	return false
+}
+
+// isEmbeddingModelID reports whether a model id names an embedding model, so the
+// entry is tagged (description "embedding") instead of presented as a chat model.
+func isEmbeddingModelID(id string) bool {
+	l := strings.ToLower(id)
+	return strings.Contains(l, "text-embedding") || strings.Contains(l, "embed")
+}
+
+// modelEntryFor builds the compatModel for a live-enumerated id. Frontier
+// providers emit bare claude ids (owned_by "anthropic"); OpenAI-compat / local
+// providers emit composite "<provider>/<model>" ids (owned_by "cogos:<provider>")
+// with a tier derived from the provider name/capabilities. Embedding ids are
+// tagged rather than dropped.
+//
+// Bare emission is additionally guarded on the "claude-" prefix: resolveLiveCatalog
+// only admits bare frontier ids that start with "claude-", so an id from a frontier
+// provider that lacks the prefix (Anthropic's /v1/models returns only claude-* ids
+// today, so this is defensive) falls back to composite emission — which always
+// admits via the ProviderForName prefix guard — rather than becoming an
+// advertise-then-reject bare id.
+func modelEntryFor(p Provider, id string, frontier bool, now int64) compatModel {
+	desc := ""
+	if isEmbeddingModelID(id) {
+		desc = "embedding"
+	}
+	if frontier && strings.HasPrefix(id, "claude-") {
+		return mkCompatModel(id, "anthropic", "frontier-managed", desc, now)
+	}
+	name := p.Name()
+	composite := name + "/" + id
+	tier := "frontier-managed"
+	switch {
+	case strings.Contains(strings.ToLower(name), "eclipse"):
+		tier = "lan-local"
+	case p.Capabilities().IsLocal:
+		tier = "local-sovereign"
+	}
+	return mkCompatModel(composite, "cogos:"+name, tier, desc, now)
+}
+
+// eclipseModelServed reports whether some registered provider actually serves
+// the eclipse-26b model string. This is exactly the condition under which
+// IsKnownModel(router, "eclipse-26b") is true (via ProviderForModel), so it is
+// the correct emit-gate for the static eclipse-26b menu entry: emit ⇔ admit.
+// The broader name-based isEclipseConfigured is retained for callers that only
+// need to know an eclipse/lmstudio provider is present, but must NOT gate the
+// static id emission (that would advertise-then-reject).
+func eclipseModelServed(router Router) bool {
+	if router == nil {
+		return false
+	}
+	_, ok := router.ProviderForModel("eclipse-26b")
+	return ok
 }
 
 // isEclipseConfigured returns true when the router has a registered provider

--- a/internal/engine/serve_compat.go
+++ b/internal/engine/serve_compat.go
@@ -272,6 +272,14 @@ func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
 // when fresh and recomposed under the cache lock (single-flight) when
 // cold/stale. The caller's ctx bounds the live provider probes; each probe is
 // additionally capped at modelsPerProviderTimeout.
+//
+// If the caller's ctx is cancelled/expired while composing, the live per-provider
+// probes (whose contexts descend from it) return early and otherwise-healthy
+// providers are skipped, yielding an incomplete list. That partial list is served
+// to this caller but is NOT written to the shared cache: a caller going away says
+// nothing about provider health, and caching it would serve the degraded menu to
+// every unrelated caller until the TTL expires. Same guard the Available() TTL
+// cache applies (#441).
 func composeModelsList(ctx context.Context, router Router) []compatModel {
 	entry := modelsCacheFor(router)
 	entry.mu.Lock()
@@ -280,6 +288,12 @@ func composeModelsList(ctx context.Context, router Router) []compatModel {
 		return entry.data
 	}
 	data := buildModelsList(ctx, router)
+	if ctx.Err() != nil {
+		// Caller cancelled/timed out mid-compose — do not poison the shared cache
+		// with a list that may be missing healthy providers. Leave the entry cold
+		// so the next caller rebuilds cleanly.
+		return data
+	}
 	entry.data = data
 	entry.fetchedAt = time.Now()
 	return data

--- a/internal/engine/serve_compat_models_test.go
+++ b/internal/engine/serve_compat_models_test.go
@@ -41,6 +41,12 @@ func newListerStub(name string, isLocal bool, ids ...string) *listerStub {
 
 func (l *listerStub) ListModels(ctx context.Context) ([]string, error) {
 	l.calls++
+	// Respect caller cancellation like a real ctx-aware HTTP probe would, so a
+	// cancelled/expired caller context makes this stub fail (skipped by
+	// liveModelEntries) rather than returning ids unconditionally.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if l.listErr != nil {
 		return nil, l.listErr
 	}
@@ -374,4 +380,49 @@ func modelIDKeys(m map[string]modelsResponseModel) []string {
 		out = append(out, k)
 	}
 	return out
+}
+
+// compatModelIDs indexes a composed list by id for presence checks.
+func compatModelIDs(ms []compatModel) map[string]bool {
+	out := make(map[string]bool, len(ms))
+	for _, m := range ms {
+		out[m.ID] = true
+	}
+	return out
+}
+
+// TestComposeModelsList_CancelledCallerDoesNotPoisonCache pins the #441-class
+// guard: a caller that cancels mid-compose cancels the in-flight per-provider
+// probes (their ctx descends from the caller's), so a healthy provider is skipped
+// and the composed list comes back incomplete. That incomplete list must NOT be
+// written to the shared 45s TTL cache — the next caller with a healthy context
+// must still receive the full menu. Without the guard, the first (cancelled) call
+// would cache the degraded list and the second call would serve it for up to 45s.
+func TestComposeModelsList_CancelledCallerDoesNotPoisonCache(t *testing.T) {
+	// No t.Parallel: reasons about the per-router package cache entry. The entry
+	// is keyed by this router alone, so it does not race other tests.
+	lister := newListerStub("lmstudio-darkstar", true, "gemma-4-26b", "qwen-3-14b")
+	frontier := newListerStub("claude-oauth", false, "claude-opus-4-8")
+
+	router := NewSimpleRouter(RoutingConfig{Default: "claude-oauth"})
+	router.RegisterProvider(lister)
+	router.RegisterProvider(frontier)
+
+	// First call under an already-cancelled caller context: the live probes see
+	// ctx.Err() and are skipped, so the healthy lister's composite ids are absent.
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	first := compatModelIDs(composeModelsList(cancelled, router))
+	if first["lmstudio-darkstar/gemma-4-26b"] {
+		t.Fatalf("precondition failed: cancelled-caller probe should have been skipped; got %v", first)
+	}
+
+	// Second call under a healthy context: because the cancelled build was NOT
+	// cached, this must rebuild cleanly and surface the healthy lister's models.
+	second := compatModelIDs(composeModelsList(context.Background(), router))
+	for _, want := range []string{"lmstudio-darkstar/gemma-4-26b", "lmstudio-darkstar/qwen-3-14b"} {
+		if !second[want] {
+			t.Errorf("cache poisoned by cancelled caller: %q missing after healthy rebuild; got %v", want, second)
+		}
+	}
 }

--- a/internal/engine/serve_compat_models_test.go
+++ b/internal/engine/serve_compat_models_test.go
@@ -1,0 +1,377 @@
+// serve_compat_models_test.go — tests for the live /v1/models composition
+// (handleModels / composeModelsList / liveModelEntries / modelEntryFor) and the
+// admission-parity invariant it must uphold with resolve.go.
+//
+// THE ADMISSION-PARITY INVARIANT under test: every id handleModels advertises
+// must satisfy IsKnownModel(router, id) == true, else a client selecting it gets
+// a boundary 400 (advertise-then-reject). Each composition test that asserts an
+// id is present also asserts IsKnownModel for it.
+//
+// Covers spec Section 6:
+//   - composite ids from an OpenAI-compat ModelLister stub
+//   - bare claude ids from a claude-oauth ModelLister stub
+//   - a ModelLister whose ListModels errors is SKIPPED (still 200, others present)
+//   - a non-lister provider contributes no live ids (only its static/alias path)
+//   - embedding-tagged ids
+//   - RangeProviders visits every registered provider exactly once
+package engine
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// listerStub is a StubProvider that also implements ModelLister, so it is
+// live-enumerated by handleModels. ids are returned by ListModels; listErr, when
+// set, makes ListModels fail (exercising the graceful-skip path). isLocal picks
+// composite (local) vs bare (frontier, when named accordingly) emission.
+type listerStub struct {
+	*StubProvider
+	ids     []string
+	listErr error
+	calls   int
+}
+
+func newListerStub(name string, isLocal bool, ids ...string) *listerStub {
+	sp := NewStubProvider(name, "resp")
+	sp.capabilities.IsLocal = isLocal
+	return &listerStub{StubProvider: sp, ids: ids}
+}
+
+func (l *listerStub) ListModels(ctx context.Context) ([]string, error) {
+	l.calls++
+	if l.listErr != nil {
+		return nil, l.listErr
+	}
+	return l.ids, nil
+}
+
+// modelIDs returns the set of ids present in a /v1/models response.
+func modelIDSet(resp modelsResponse) map[string]modelsResponseModel {
+	m := make(map[string]modelsResponseModel, len(resp.Data))
+	for _, e := range resp.Data {
+		m[e.ID] = e
+	}
+	return m
+}
+
+// freshModelsServer builds a Server on the given router with an empty models
+// cache so each test observes a live composition (the package-level TTL cache is
+// keyed per-router; a freshly-constructed router is always cold).
+func freshModelsServer(t *testing.T, router Router) *Server {
+	t.Helper()
+	return newTestServerWithRouter(t, router)
+}
+
+// TestHandleModels_CompositeAndBare exercises the core live-composition menu:
+// an OpenAI-compat lister → composite ids; a claude-oauth lister → bare claude
+// ids; a plain non-lister provider contributes no live id. Every advertised id
+// must admit (IsKnownModel).
+func TestHandleModels_CompositeAndBare(t *testing.T) {
+	t.Parallel()
+
+	// OpenAI-compat local lister serving two ids → composite "<name>/<id>".
+	openai := newListerStub("lmstudio-darkstar", true, "gemma-4-26b", "qwen-3-14b")
+	// Frontier lister (claude-oauth) → bare claude ids.
+	claude := newListerStub("claude-oauth", false, "claude-opus-4-8", "claude-haiku-4-5-20251001")
+	// A non-lister local provider — contributes only via alias/static paths.
+	plain := NewStubProvider("mlx-lm", "resp")
+
+	router := NewSimpleRouter(RoutingConfig{Default: "claude-oauth"})
+	router.RegisterProvider(openai)
+	router.RegisterProvider(claude)
+	router.RegisterProvider(plain)
+
+	srv := freshModelsServer(t, router)
+	resp := fetchModels(t, srv)
+	byID := modelIDSet(resp)
+
+	// Composite ids for the OpenAI-compat lister.
+	for _, want := range []string{"lmstudio-darkstar/gemma-4-26b", "lmstudio-darkstar/qwen-3-14b"} {
+		m, ok := byID[want]
+		if !ok {
+			t.Errorf("composite id %q missing; got ids %v", want, modelIDKeys(byID))
+			continue
+		}
+		if m.OwnedBy != "cogos:lmstudio-darkstar" {
+			t.Errorf("%q owned_by = %q; want cogos:lmstudio-darkstar", want, m.OwnedBy)
+		}
+		if !IsKnownModel(router, want) {
+			t.Errorf("ADMISSION PARITY: advertised %q but IsKnownModel=false", want)
+		}
+	}
+
+	// Bare claude ids for the frontier lister.
+	for _, want := range []string{"claude-opus-4-8", "claude-haiku-4-5-20251001"} {
+		m, ok := byID[want]
+		if !ok {
+			t.Errorf("bare claude id %q missing; got ids %v", want, modelIDKeys(byID))
+			continue
+		}
+		if m.OwnedBy != "anthropic" {
+			t.Errorf("%q owned_by = %q; want anthropic", want, m.OwnedBy)
+		}
+		if !IsKnownModel(router, want) {
+			t.Errorf("ADMISSION PARITY: advertised %q but IsKnownModel=false", want)
+		}
+	}
+
+	// The non-lister provider must not have produced any "mlx-lm/..." id.
+	for id := range byID {
+		if len(id) > len("mlx-lm/") && id[:len("mlx-lm/")] == "mlx-lm/" {
+			t.Errorf("non-lister provider produced a live id %q", id)
+		}
+	}
+
+	// Full admission-parity sweep: every advertised id must admit.
+	for _, e := range resp.Data {
+		if !IsKnownModel(router, e.ID) {
+			t.Errorf("ADMISSION PARITY: advertised %q but IsKnownModel=false", e.ID)
+		}
+	}
+}
+
+// TestHandleModels_FrontierNonClaudeIDFallsToComposite verifies the parity
+// guard in modelEntryFor: a frontier provider that enumerates a NON-claude id
+// (defensive — Anthropic returns only claude-* ids today) must emit it composite
+// (which admits via ProviderForName), never bare (which would 400 — no admission
+// path for a bare non-claude id).
+func TestHandleModels_FrontierNonClaudeIDFallsToComposite(t *testing.T) {
+	t.Parallel()
+
+	// claude-oauth is frontier-by-name but here reports an odd non-claude id.
+	fr := newListerStub("claude-oauth", false, "weird-legacy-id", "claude-opus-4-8")
+	router := NewSimpleRouter(RoutingConfig{Default: "claude-oauth"})
+	router.RegisterProvider(fr)
+
+	srv := freshModelsServer(t, router)
+	resp := fetchModels(t, srv)
+	byID := modelIDSet(resp)
+
+	// The claude-prefixed id emits bare.
+	if _, ok := byID["claude-opus-4-8"]; !ok {
+		t.Errorf("claude-opus-4-8 should emit bare; got %v", modelIDKeys(byID))
+	}
+	// The non-claude id must NOT be bare.
+	if _, bare := byID["weird-legacy-id"]; bare {
+		t.Error("non-claude id from frontier provider emitted BARE with no admission path")
+	}
+	// It must be composite instead.
+	if _, ok := byID["claude-oauth/weird-legacy-id"]; !ok {
+		t.Errorf("non-claude frontier id should fall back to composite; got %v", modelIDKeys(byID))
+	}
+	// Admission parity for every advertised id.
+	for _, e := range resp.Data {
+		if !IsKnownModel(router, e.ID) {
+			t.Errorf("ADMISSION PARITY: advertised %q but IsKnownModel=false", e.ID)
+		}
+	}
+}
+
+// TestHandleModels_ListerErrorSkipped verifies graceful degradation: a provider
+// whose ListModels errors is skipped, the endpoint still returns 200, and the
+// other providers' ids are still present.
+func TestHandleModels_ListerErrorSkipped(t *testing.T) {
+	t.Parallel()
+
+	good := newListerStub("lmstudio-darkstar", true, "gemma-4-26b")
+	bad := newListerStub("lmstudio-eclipse", true, "ornith-1.0-35b")
+	bad.listErr = errors.New("boom: upstream 401")
+
+	router := NewSimpleRouter(RoutingConfig{Default: "lmstudio-darkstar"})
+	router.RegisterProvider(good)
+	router.RegisterProvider(bad)
+
+	srv := freshModelsServer(t, router)
+	resp := fetchModels(t, srv) // fetchModels already asserts 200
+	byID := modelIDSet(resp)
+
+	if _, ok := byID["lmstudio-darkstar/gemma-4-26b"]; !ok {
+		t.Errorf("healthy provider's id missing after peer error; got %v", modelIDKeys(byID))
+	}
+	if _, ok := byID["lmstudio-eclipse/ornith-1.0-35b"]; ok {
+		t.Error("errored provider's id should have been skipped")
+	}
+	if bad.calls == 0 {
+		t.Error("errored lister was never probed")
+	}
+}
+
+// TestHandleModels_EmbeddingTagged verifies an embedding model id is listed with
+// description "embedding" rather than dropped or presented as a chat model.
+func TestHandleModels_EmbeddingTagged(t *testing.T) {
+	t.Parallel()
+
+	openai := newListerStub("lmstudio-darkstar", true, "text-embedding-nomic", "gemma-4-26b")
+	router := NewSimpleRouter(RoutingConfig{Default: "lmstudio-darkstar"})
+	router.RegisterProvider(openai)
+
+	srv := freshModelsServer(t, router)
+	resp := fetchModels(t, srv)
+	byID := modelIDSet(resp)
+
+	emb, ok := byID["lmstudio-darkstar/text-embedding-nomic"]
+	if !ok {
+		t.Fatalf("embedding id missing; got %v", modelIDKeys(byID))
+	}
+	if emb.Description != "embedding" {
+		t.Errorf("embedding id description = %q; want %q", emb.Description, "embedding")
+	}
+	// Non-embedding id must NOT be tagged.
+	chat, ok := byID["lmstudio-darkstar/gemma-4-26b"]
+	if !ok {
+		t.Fatalf("chat id missing; got %v", modelIDKeys(byID))
+	}
+	if chat.Description == "embedding" {
+		t.Errorf("chat id wrongly tagged as embedding")
+	}
+}
+
+// TestHandleModels_FrontierNameGatesBareEmission verifies the Finding-3 fix: a
+// non-local, non-claude ModelLister must emit COMPOSITE ids (which always admit
+// via the ProviderForName prefix guard), never bare — because bare ids from a
+// non-claude provider would have no admission path.
+func TestHandleModels_FrontierNameGatesBareEmission(t *testing.T) {
+	t.Parallel()
+
+	// A non-local lister with a non-claude name (the fragile !IsLocal case).
+	rogue := newListerStub("some-cloud", false, "mystery-model-1")
+	router := NewSimpleRouter(RoutingConfig{Default: "some-cloud"})
+	router.RegisterProvider(rogue)
+
+	srv := freshModelsServer(t, router)
+	resp := fetchModels(t, srv)
+	byID := modelIDSet(resp)
+
+	// Must be emitted composite (owned_by cogos:some-cloud), not bare.
+	if _, bare := byID["mystery-model-1"]; bare {
+		t.Error("non-claude provider emitted a BARE id with no admission path (advertise-then-reject)")
+	}
+	composite := "some-cloud/mystery-model-1"
+	m, ok := byID[composite]
+	if !ok {
+		t.Fatalf("expected composite id %q; got %v", composite, modelIDKeys(byID))
+	}
+	if m.OwnedBy != "cogos:some-cloud" {
+		t.Errorf("%q owned_by = %q; want cogos:some-cloud", composite, m.OwnedBy)
+	}
+	// Admission parity for every advertised id.
+	for _, e := range resp.Data {
+		if !IsKnownModel(router, e.ID) {
+			t.Errorf("ADMISSION PARITY: advertised %q but IsKnownModel=false", e.ID)
+		}
+	}
+}
+
+// TestHandleModels_HaikuAdmitsUnderClaudeCodeOnly verifies the Finding-1 fix:
+// when the frontier tier is present ONLY via a provider named "claude-code"
+// (not claude-oauth/anthropic), the static bare claude-haiku-4-5-20251001 id is
+// both emitted and admissible — no advertise-then-reject.
+func TestHandleModels_HaikuAdmitsUnderClaudeCodeOnly(t *testing.T) {
+	t.Parallel()
+
+	cc := newCloudStub("claude-code", "cc resp") // frontier by name, no ModelLister
+	router := NewSimpleRouter(RoutingConfig{Default: "claude-code"})
+	router.RegisterProvider(cc)
+
+	srv := freshModelsServer(t, router)
+	resp := fetchModels(t, srv)
+	byID := modelIDSet(resp)
+
+	// The static frontier ids are emitted because isFrontierConfigured matches
+	// the claude-code name.
+	if _, ok := byID["claude-haiku-4-5-20251001"]; !ok {
+		t.Fatalf("claude-haiku-4-5-20251001 not advertised under claude-code-only config; got %v", modelIDKeys(byID))
+	}
+	// ...and every one of them must admit.
+	for _, id := range []string{"claude-sonnet-4-6", "claude-opus-4-7", "claude-haiku-4-5-20251001"} {
+		if !IsKnownModel(router, id) {
+			t.Errorf("ADMISSION PARITY: advertised %q but IsKnownModel=false under claude-code-only config", id)
+		}
+	}
+	// Routing parity: the id resolves to the claude-code provider with the id as
+	// override.
+	res := ResolveModelRequest(router, "claude-haiku-4-5-20251001", "t")
+	if res.PreferProvider != "claude-code" {
+		t.Errorf("claude-haiku-4-5-20251001 PreferProvider = %q; want claude-code", res.PreferProvider)
+	}
+	if res.ModelOverride != "claude-haiku-4-5-20251001" {
+		t.Errorf("claude-haiku-4-5-20251001 ModelOverride = %q; want the bare id", res.ModelOverride)
+	}
+}
+
+// TestHandleModels_HaikuAdmitsUnderNonCanonicalSonnetProvider verifies the other
+// Finding-1 branch: frontier tier present only via a provider serving
+// claude-sonnet-4-6 under a NON-canonical name still admits the static haiku id.
+func TestHandleModels_HaikuAdmitsUnderNonCanonicalSonnetProvider(t *testing.T) {
+	t.Parallel()
+
+	// Provider named "my-anthropic" that SERVES claude-sonnet-4-6.
+	fr := newCloudStub("my-anthropic", "resp")
+	fr.model = "claude-sonnet-4-6"
+	router := NewSimpleRouter(RoutingConfig{Default: "my-anthropic"})
+	router.RegisterProvider(fr)
+
+	srv := freshModelsServer(t, router)
+	resp := fetchModels(t, srv)
+	byID := modelIDSet(resp)
+
+	if _, ok := byID["claude-haiku-4-5-20251001"]; !ok {
+		t.Fatalf("haiku id not advertised via non-canonical sonnet provider; got %v", modelIDKeys(byID))
+	}
+	for _, e := range resp.Data {
+		if !IsKnownModel(router, e.ID) {
+			t.Errorf("ADMISSION PARITY: advertised %q but IsKnownModel=false", e.ID)
+		}
+	}
+	// Routing target is the non-canonical provider (frontierProviderName falls
+	// through to the ProviderForModel(sonnet) match).
+	res := ResolveModelRequest(router, "claude-haiku-4-5-20251001", "t")
+	if res.PreferProvider != "my-anthropic" {
+		t.Errorf("haiku PreferProvider = %q; want my-anthropic", res.PreferProvider)
+	}
+}
+
+// TestRangeProviders_VisitsEachOnce asserts RangeProviders visits every
+// registered provider exactly once, in Name() order.
+func TestRangeProviders_VisitsEachOnce(t *testing.T) {
+	t.Parallel()
+
+	router := NewSimpleRouter(RoutingConfig{})
+	names := []string{"charlie", "alpha", "bravo"}
+	for _, n := range names {
+		router.RegisterProvider(NewStubProvider(n, "r"))
+	}
+
+	seen := map[string]int{}
+	var order []string
+	router.RangeProviders(func(p Provider) {
+		seen[p.Name()]++
+		order = append(order, p.Name())
+	})
+
+	if len(order) != len(names) {
+		t.Fatalf("RangeProviders visited %d providers; want %d (%v)", len(order), len(names), order)
+	}
+	for _, n := range names {
+		if seen[n] != 1 {
+			t.Errorf("provider %q visited %d times; want 1", n, seen[n])
+		}
+	}
+	// Name() order (SimpleRouter sorts on registration).
+	want := []string{"alpha", "bravo", "charlie"}
+	for i, n := range want {
+		if order[i] != n {
+			t.Errorf("visit order[%d] = %q; want %q (%v)", i, order[i], n, order)
+		}
+	}
+}
+
+func modelIDKeys(m map[string]modelsResponseModel) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

The OpenAI-compatible `GET /v1/models` endpoint returned a hand-curated static list: three
hardcoded Anthropic model ids plus a single `eclipse-26b` alias gated by a provider-name check.
Every time a backend loaded/unloaded a model or Anthropic shipped a new id, the list drifted and
had to be edited by hand, then duplicated again in downstream consumers' provider catalogs.

This makes `/v1/models` compose a **live** view from the providers actually registered in the router:

- **Anthropic**: enumerated live via the existing Claude OAuth provider's authenticated
  `GET /v1/models` (Max-subscription OAuth, no API key, zero incremental cost). New Anthropic
  model ids surface automatically.
- **OpenAI-compatible / LM Studio backends**: each registered `ModelLister` provider is probed at
  `<endpoint>/v1/models`; served models are emitted as `<provider>/<model>`. Embedding models are
  tagged rather than dropped.
- **Intent aliases** (`foreground`, `deliberation`, `local`) and the frontier/local tier gating are
  preserved unchanged.

## Design

- **`ModelLister` (optional interface)**: providers that can enumerate served models implement
  `ListModels(ctx)`. The `Provider` interface is untouched, so non-listing providers are unaffected.
- **`Router.RangeProviders`**: enumerate registered providers under a read-lock snapshot so
  per-provider network I/O runs lock-free.
- **Graceful degradation**: each backend is probed concurrently with a 2s per-provider timeout; a
  down / 401 / timeout backend is skipped (debug-logged) and never fails or blocks the endpoint. The
  list stays 200 with whatever is reachable.
- **TTL cache**: the composed list is cached ~45s, single-flight, to avoid probing every backend on
  each request.
- **Admission parity (load-bearing)**: the kernel boundary rejects unknown model ids with 400. A
  shared `resolveLiveCatalog` helper is wired into **both** `ResolveModelRequest` and
  `IsKnownModel`, so every id the endpoint advertises also routes and admits. It covers composite
  `<provider>/<model>` ids (only when the prefix is a registered provider name) and live `claude-*`
  ids (routed to the frontier provider, `claude-oauth` preferred). This also closes a latent
  advertise-then-reject in the previous static list: `eclipse-26b` and `claude-haiku-4-5-20251001`
  could be emitted under configs where they were not admissible. The emit gate and admit gate now
  share one predicate.

## Testing

- `go build ./...` clean.
- `go test -race ./internal/engine/...` green.
- New `serve_compat_models_test.go`: live composition (composite ids, bare claude ids,
  embedding-tagged, a `ListModels`-error provider skipped while the endpoint stays 200, non-lister
  contributes nothing, `RangeProviders` visits each provider once) plus config-reachability parity
  cases.
- `resolve_test.go`: composite-id resolve+admit, newly-shipped claude-id admit/route,
  unregistered-prefix fall-through, no-frontier reject.

## Follow-ups (not in this PR)

- Downstream consumers that maintain their own per-provider model catalogs can defer to this
  endpoint once it is authoritative, removing the hand-sync entirely.
- The Claude OAuth keychain credential exec is bounded at the exec site; a future change could
  thread a context through the shared credential source.
- The models cache is keyed by router and documented as never-evicting (benign for the single
  production router; would need eviction if routers are recreated at runtime).

Deploy: rebuild + reinstall the kernel binary and restart the daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
