### PR TITLE
feat(foveation): cache-aware placement + session-scoped light-cone key + salience-strip (ADR-103)

### DIFF
--- a/docs/adrs/103-foveation-placement-under-prefix-cache-runtimes.md
+++ b/docs/adrs/103-foveation-placement-under-prefix-cache-runtimes.md
@@ -1,0 +1,128 @@
+# ADR-103: Foveation Placement Under Prefix-Cache Runtimes — Amendment to ADR-066 / ADR-071
+
+| Field   | Value |
+|---------|-------|
+| Status  | Accepted — implemented on `feat/foveation-cache-aware-placement` (kernel `internal/engine`); pre-merge output-quality A/B pending (operator) |
+| Author  | @chazmaniandinkle |
+| Created | 2026-07-07 |
+| Layer   | Module (engine / context assembly) |
+| Amends  | ADR-066 (Foveated Context Assembly — CogBlock Context Containers), ADR-071 (Unified Foveated Proxy — LoRO as Live Observer) |
+| Refs    | ADR-069 (Distributed KV Entanglement Mesh — the never-built KV mesh this amendment reacts to); Fable design-intent review 2026-07-07 |
+
+---
+
+## Context
+
+ADR-066 specified a stability-ordered token stream for KV-cache optimization, with a
+zone diagram that places the **volatile knowledge zone (foveal CogDoc manifest) at the
+FRONT** of the stream, ahead of conversation history. That placement is only correct
+**given a KV-cache manager** that can invalidate at the layer/block level and hold
+"nearly permanent" context across a conversation — ADR-066 Phase 5 (KV manager) and
+ADR-069 (distributed KV-block entanglement mesh). Those two pieces were **never built**.
+The cheap half — per-turn re-scoring of the foveal manifest — shipped; the cache-cheap
+half did not.
+
+Under a **plain prefix cache** (llama.cpp / LM Studio / most OpenAI-compat runtimes), the
+cache keys on the longest common **token prefix** and has no layer-level invalidation.
+With the volatile foveal manifest at the front of the stream, its per-turn churn changes
+the prefix, so **everything behind it — the entire conversation — re-prefills every turn.**
+The kernel's accepted design was, in this runtime class, prefill-cache-**hostile**. This
+was drift from intent, not intent.
+
+Two compounding sources of gratuitous churn were found:
+
+1. **Placement** — the manifest led the token stream (leading system prompt).
+2. **Live salience float** — `renderWorkspaceManifest` embedded `[salience: %.2f]` per
+   line. Salience is re-scored every turn, so even an **identical doc selection rendered
+   different bytes** turn to turn.
+
+Separately, the per-conversation LoRO light cone (ADR-071 Phase 2) was keyed by
+`WithConversationID(creq.Metadata.RequestID)` — a **fresh per-request UUID**. The cone was
+therefore always `Get()` on a key that had never been `Set()` (the feature was silently
+dead), and `LightConeManager` accreted one orphaned entry per request with no TTL (an
+unbounded memory leak for the process lifetime).
+
+The Claude Code hook path (`serve_foveated.go`, `additionalContext`) already did the
+cache-friendly thing — volatile foveated content is delivered **trailing**. The OpenAI /
+Anthropic proxy path did not. This amendment converges the proxy path onto the hook path's
+placement.
+
+## Decision
+
+**Under a plain prefix-cache runtime, the volatile foveal block renders TRAILING — after
+the stable conversation prefix — not leading.** "Most-stable-first" for a prefix cache
+means the churning block must come LAST. Concretely, in `ContextPackage.FormatForProvider`
+(`internal/engine/context_assembly.go`):
+
+- `systemPrompt` = nucleus → `# Client Context` **only** (the session-stable content).
+- `messages` = conversation history (chronological) → the **final user message** with the
+  foveal block (workspace manifest + `<previous-turn-speculative>`) folded in as a
+  **trailing injection after the user's own text**.
+
+The block **content** is unchanged (same headers, same manifest render, same speculative
+wrapper); only its **position** moved from leading system to trailing user.
+
+**Wire safety.** The block is folded INTO the final user message (not appended as a new
+message), so:
+- the sequence still ends on a **user turn** → satisfies the Anthropic normalizer's I7
+  trailing-user guard (`anthropic_normalize.go`);
+- it introduces no `tool_result` blocks → the I4 block-order pass never reorders it;
+- it is written to `ProviderMessage.Content` (used by the OpenAI-compat provider and the
+  non-image Anthropic path) **and**, when the message carries image parts, appended as a
+  trailing text `ContentPart` (the Anthropic multimodal path renders from `ContentParts`
+  and ignores `Content`).
+
+**Byte-stability.** The live `[salience: %.2f]` float is **removed** from the rendered
+manifest. Salience still ranks and evicts docs upstream (`FovealDoc.Salience`); it is
+simply not rendered into the model-visible text. Identical selections now render identical
+bytes.
+
+**Session-scoped foveation key.** The foveation / light-cone key is derived from a
+**stable per-conversation identity** (`foveation_session_key.go`), never the per-request
+UUID and never `Process.SessionID()` (which is process-wide — using it would collapse every
+concurrent conversation onto one light cone, a cross-conversation / cross-user state bleed).
+Precedence: `X-Cogos-Session-Id` header → client `user` / `metadata.user_id` field →
+**stable SHA-256 hash of the conversation's leading turns** (system prompt + first user
+message). The leading-turns hash is stable within a conversation and distinct across
+conversations, so a raw OpenAI-compat client (Hermes) with no session id still gets a safe,
+non-bleeding key.
+
+**Bounded light-cone memory.** `LightConeManager` gains a TTL and a background sweeper
+(`NewLightConeManagerWithTTL`, default 30-minute TTL, 5-minute sweep). Stale cones are
+evicted regardless of key granularity, closing the leak even if the key stays coarse.
+`SetTRM` now `Close()`s a prior manager before replacing it so the sweeper goroutine does
+not leak.
+
+### Acceptance criterion (met)
+
+For two consecutive turns with the **same** foveal doc selection, the rendered prefix
+(system + all-but-last message) is **byte-identical** (test
+`TestPrefixByteStableAcrossTurnsSameSelection`), so a prefix cache reuses it and only the
+final exchange + foveal block re-prefill. A **changed** selection alters only the trailing
+block, leaving the conversation prefix stable (`TestPrefixStableWhenOnlySelectionChanges`).
+
+## Consequences
+
+- Prefix-cache hit rate on the proxy path rises from near-zero (whole conversation
+  re-prefilled each turn) toward reuse-of-everything-but-the-tail.
+- The model now sees the foveal manifest **after** the current user message rather than in
+  the system preamble. This is a placement change to model-visible context; **output-quality
+  is expected to shift** and must be A/B'd against a fixed prompt set **before merge** — that
+  gate is out of scope for the structural change and is run by the operator.
+- The light cone (ADR-071 Phase 2) can now actually persist across turns of a conversation,
+  because the key is stable. Behavioral validation of the revived cone is separate follow-up.
+
+## Out of scope (deferred — clear TODOs)
+
+The following are the "Core + hysteresis" / "Full retool" tiers deliberately deferred; each
+leaves a TODO referencing this ADR:
+
+- **Hysteresis / session-stable re-render** of the doc selection (avoid re-selecting docs
+  every turn when the query barely moved).
+- **Contiguous-oldest eviction** of conversation history (keep the evictable region a
+  suffix, not a hole, so eviction doesn't fracture the prefix).
+- **Tiered content loading** (summary → full on demand within the trailing block).
+- **`cache_control` breakpoints** for the Anthropic path (explicit prefix cache markers).
+- **KV manager / KV-block mesh** (ADR-066 Phase 5 / ADR-069) — the original premise of the
+  leading placement. If ever built, the leading-vs-trailing decision should be re-derived
+  per runtime class rather than assumed.

--- a/internal/engine/context_assembly.go
+++ b/internal/engine/context_assembly.go
@@ -4,13 +4,21 @@
 // decomposes them, scores conversation turns alongside CogDocs, and renders
 // everything into a stability-ordered token stream within the configured budget.
 //
-// Stability zones (ordered for KV cache optimization):
+// Stability zones (ordered for prefix-cache reuse; see ADR-103 amendment to
+// ADR-066/071 — "foveation placement under prefix-cache runtimes"):
 //
-//	Zone 0: Nucleus (identity card) — most stable, always present
-//	Zone 1: CogDocs + client system prompt — shifts slowly per query
+//	Zone 0: Nucleus (identity card) — most stable, always present  → leading system
+//	Zone 1a: client system prompt — session-stable                 → leading system
 //	Zone 2: Conversation history — scored by recency + relevance, evictable
-//	Zone 3: Current message — always present
+//	Zone 1b: CogDoc manifest — VOLATILE (re-scored per turn)        → TRAILING, folded
+//	Zone 3: Current message + trailing foveal block                → final user message
 //	[Reserve: OutputReserve tokens for model generation]
+//
+// The volatile foveal manifest (Zone 1b) renders LAST, folded into the final user
+// message, so its per-turn churn does not invalidate the prefix cache for the whole
+// conversation behind it. A plain prefix cache has no layer-level KV manager
+// (ADR-066 Phase 5 / ADR-069 were never built), so "most-stable-first" here means
+// the churning block comes trailing, not leading.
 //
 // Token budget is approximated as chars/4.
 // Default budget: 32768 tokens (matches provider context_window from providers.yaml).
@@ -77,8 +85,9 @@ type ContextPackage struct {
 	// PreviousTurnSpeculative is the barge-in-truncated suffix from the
 	// previous turn — text the model generated but that was never played to
 	// the user. Non-empty only when the previous turn was interrupted.
-	// Injected into the system prompt as an agent-private block so the model
-	// knows what it "almost said" without the user having heard it.
+	// Injected as an agent-private block so the model knows what it "almost said"
+	// without the user having heard it. Post ADR-103 this rides in the trailing
+	// foveal block folded into the final user message, not the system prompt.
 	PreviousTurnSpeculative string
 }
 
@@ -115,11 +124,11 @@ type ScoredMessage struct {
 	// provider conversion can reconstruct Anthropic tool_use/tool_result blocks.
 	// Dropping these reduced every history turn to {role, content}, which sent
 	// role:"tool" results to Anthropic verbatim (rejected: "Unexpected role tool").
-	ContentParts []ContentPart
-	Name         string
-	ToolCallID   string
-	ToolCalls    []ToolCall
-	Tokens       int
+	ContentParts   []ContentPart
+	Name           string
+	ToolCallID     string
+	ToolCalls      []ToolCall
+	Tokens         int
 	TurnIndex      int     // 0 = oldest
 	RecencyScore   float64 // 1.0 = most recent, decays toward 0
 	RelevanceScore float64 // keyword overlap with current query
@@ -509,12 +518,33 @@ func (p *Process) assembleContextInnerWithOpts(ctx context.Context, convID strin
 
 // FormatForProvider renders a ContextPackage as (systemPrompt, messages) for the provider.
 //
-// The system prompt is stability-ordered for KV cache optimization:
-// nucleus → client system prompt → CogDocs (by salience descending).
+// Placement is stability-ordered for prefix-cache reuse (ADR-066/071 amendment
+// 2026-07-07, "foveation placement under prefix-cache runtimes"):
 //
-// Messages are in chronological order: conversation history → current message.
+//	systemPrompt = nucleus → "# Client Context"   (Zone 0 + the session-stable
+//	                                                half of Zone 1 ONLY)
+//	messages     = conversation history (chronological)
+//	               → FINAL user message with the volatile foveal block
+//	                 (workspace manifest + previous-turn-speculative) folded in
+//	                 as a TRAILING injection AFTER the user's own text.
+//
+// Rationale: the foveal doc manifest is re-scored per turn and thus churns. When
+// it sat at the FRONT of the token stream (leading system), any churn invalidated
+// the prefix cache for EVERYTHING behind it — i.e. the whole conversation had to
+// re-prefill each turn. A plain llama.cpp/LM Studio prefix cache has no KV manager
+// (ADR-066 Phase 5 / ADR-069 block mesh were never built), so "most-stable-first"
+// means the volatile block must render LAST, after the stable conversation prefix.
+// This mirrors the Claude Code hook path (serve_foveated.go), where the volatile
+// foveated context is delivered as trailing additionalContext.
+//
+// Wire safety: the block is folded INTO the final user message (not added as a
+// new trailing message), so the sequence still ends with a user turn (satisfies
+// the Anthropic normalizer's I7 trailing-user guard) and introduces no tool_result
+// blocks (I4 block-order untouched). It is appended after the user's text so it is
+// clearly a trailing injection.
 func (pkg *ContextPackage) FormatForProvider() (string, []ProviderMessage) {
-	// === System prompt (Zone 0 + Zone 1) ===
+	// === System prompt (Zone 0 + the STABLE half of Zone 1) ===
+	// Only session-stable content lives here now: nucleus + client system prompt.
 	var sb strings.Builder
 
 	if pkg.NucleusText != "" {
@@ -529,38 +559,20 @@ func (pkg *ContextPackage) FormatForProvider() (string, []ProviderMessage) {
 		sb.WriteString(pkg.ClientSystem)
 	}
 
-	if len(pkg.FovealDocs) > 0 {
-		if sb.Len() > 0 {
-			sb.WriteString("\n\n---\n")
-		}
-		if docsUseManifest(pkg.FovealDocs) {
-			sb.WriteString(renderWorkspaceManifest(pkg.FovealDocs))
-		} else {
-			sb.WriteString("# Workspace Context\n\n")
-			for _, doc := range pkg.FovealDocs {
-				fmt.Fprintf(&sb, "## %s\n\n", doc.Title)
-				sb.WriteString(doc.Content)
-				sb.WriteString("\n\n")
-			}
-		}
-	}
-
-	// Inject speculative-output block as agent-private context (Slice 4).
-	// This block is visible only to the model — it is NOT shown to the user.
-	// It carries the suffix of the previous response that was generated but
-	// never delivered because the user barged in. The model can use it to
-	// decide whether to repeat, continue, or drop the unsaid content.
-	if pkg.PreviousTurnSpeculative != "" {
-		if sb.Len() > 0 {
-			sb.WriteString("\n\n---\n")
-		}
-		sb.WriteString("<previous-turn-speculative>\n")
-		sb.WriteString("The following text was generated in your previous response but was NOT delivered to the user (they interrupted before it could be spoken). You may choose to naturally resume, re-state, or drop this content based on their new message.\n\n")
-		sb.WriteString(pkg.PreviousTurnSpeculative)
-		sb.WriteString("\n</previous-turn-speculative>")
-	}
-
 	systemPrompt := sb.String()
+
+	// TODO(ADR-103): deferred cache-retool tiers — hysteresis / session-stable
+	// doc re-render, contiguous-oldest history eviction (keep the evictable region
+	// a suffix so it doesn't fracture the prefix), tiered content loading, and
+	// cache_control breakpoints for the Anthropic path. This change lands only the
+	// leading→trailing placement + salience strip (the load-bearing prefill fix).
+
+	// === Trailing foveal block (the VOLATILE half of Zone 1 + Zone 3 speculative) ===
+	// Built separately so it can be folded into the final user message instead of
+	// leading the system prompt. Content is byte-identical to what previously led
+	// the system prompt (same headers, same manifest render, same speculative
+	// wrapper) — only its POSITION moved.
+	foveal := pkg.renderTrailingFovealBlock()
 
 	// === Messages (Zone 2 + Zone 3) ===
 	var msgs []ProviderMessage
@@ -575,7 +587,17 @@ func (pkg *ContextPackage) FormatForProvider() (string, []ProviderMessage) {
 		})
 	}
 	if pkg.CurrentMessage != nil {
-		msgs = append(msgs, *pkg.CurrentMessage)
+		cur := *pkg.CurrentMessage
+		if foveal != "" {
+			foldTrailingFoveal(&cur, foveal)
+		}
+		msgs = append(msgs, cur)
+	} else if foveal != "" {
+		// No current user message (last client message wasn't a user turn). Rather
+		// than resurrect the leading-system placement, attach the foveal block to a
+		// standalone trailing user message so it still renders after the stable
+		// prefix and the sequence ends on a user turn (I7-safe).
+		msgs = append(msgs, ProviderMessage{Role: "user", Content: foveal})
 	}
 
 	// Tool-pairing repair is now handled by the wire-layer normalizer
@@ -584,6 +606,74 @@ func (pkg *ContextPackage) FormatForProvider() (string, []ProviderMessage) {
 	// The pre-conversion repairToolPairing call here is subsumed and removed.
 
 	return systemPrompt, msgs
+}
+
+// renderTrailingFovealBlock renders the volatile foveal payload — the workspace
+// manifest (Zone 1) and the previous-turn-speculative block (Zone 3) — as a single
+// string with the SAME headers/wrappers previously used at the head of the system
+// prompt. Returns "" when there is nothing volatile to inject.
+//
+// Placement (leading system → trailing user) changed; content did not.
+func (pkg *ContextPackage) renderTrailingFovealBlock() string {
+	var sb strings.Builder
+
+	if len(pkg.FovealDocs) > 0 {
+		if docsUseManifest(pkg.FovealDocs) {
+			sb.WriteString(renderWorkspaceManifest(pkg.FovealDocs))
+		} else {
+			sb.WriteString("# Workspace Context\n\n")
+			for _, doc := range pkg.FovealDocs {
+				fmt.Fprintf(&sb, "## %s\n\n", doc.Title)
+				sb.WriteString(doc.Content)
+				sb.WriteString("\n\n")
+			}
+		}
+	}
+
+	// Speculative-output block as agent-private context (Slice 4). Visible only to
+	// the model — NOT shown to the user. Carries the suffix of the previous response
+	// that was generated but never delivered (user barged in). Wrapper/wording are
+	// unchanged from the previous leading-system placement.
+	if pkg.PreviousTurnSpeculative != "" {
+		if sb.Len() > 0 {
+			sb.WriteString("\n\n---\n")
+		}
+		sb.WriteString("<previous-turn-speculative>\n")
+		sb.WriteString("The following text was generated in your previous response but was NOT delivered to the user (they interrupted before it could be spoken). You may choose to naturally resume, re-state, or drop this content based on their new message.\n\n")
+		sb.WriteString(pkg.PreviousTurnSpeculative)
+		sb.WriteString("\n</previous-turn-speculative>")
+	}
+
+	return sb.String()
+}
+
+// foldTrailingFoveal appends the foveal block to the final user message AFTER the
+// user's own text. It updates both representations so the injection survives every
+// downstream wire conversion:
+//
+//   - Content (string): used by the OpenAI-compat provider and by the Anthropic
+//     provider whenever the message has no image parts.
+//   - ContentParts: only when the message carries image parts, since the Anthropic
+//     provider then renders from ContentParts and IGNORES Content (hasImageParts
+//     branch in buildAnthropicRequest). A trailing text part is appended so the
+//     injection is not silently dropped on the multimodal path.
+//
+// The block is separated from the user's text by a blank line. It is plain text
+// (no tool_result), so the Anthropic normalizer's I4 block-order pass never
+// reorders it, and because it stays inside the final user message the sequence
+// still ends on a user turn (I7).
+func foldTrailingFoveal(m *ProviderMessage, foveal string) {
+	if foveal == "" {
+		return
+	}
+	if strings.TrimSpace(m.Content) != "" {
+		m.Content = m.Content + "\n\n" + foveal
+	} else {
+		m.Content = foveal
+	}
+	if hasImageParts(m.ContentParts) {
+		m.ContentParts = append(m.ContentParts, ContentPart{Type: "text", Text: foveal})
+	}
 }
 
 // scoreConversation scores conversation turns by recency and query relevance.
@@ -1106,7 +1196,14 @@ func renderWorkspaceManifest(docs []FovealDoc) string {
 		if uri == "" {
 			uri = doc.Path
 		}
-		fmt.Fprintf(&sb, "- %s — %s [salience: %.2f]\n", uri, doc.Summary, doc.Salience)
+		// NOTE (ADR-066/071 amendment, prefix-cache placement): the live
+		// [salience: %.2f] float was removed here. It was recomputed every turn,
+		// so an IDENTICAL doc selection rendered DIFFERENT bytes each turn — pure
+		// churn that defeats a prefix cache even after the block was moved trailing.
+		// Salience still ranks/evicts docs upstream (FovealDoc.Salience); it is
+		// simply not rendered into the model-visible manifest. Keep URI + summary,
+		// which are stable for a fixed selection.
+		fmt.Fprintf(&sb, "- %s — %s\n", uri, doc.Summary)
 	}
 
 	var schemaNotes []string
@@ -1170,7 +1267,9 @@ func buildManifestDocWithEstimator(doc FovealDoc, workspaceRoot string, estimate
 	doc.Content = ""
 	doc.Summary = summary
 	doc.SchemaIssues = missingSchemaIssues(source)
-	doc.Tokens = estimateTokens(fmt.Sprintf("- %s — %s [salience: %.2f]", firstNonBlank(uri, doc.Path), summary, doc.Salience))
+	// Token estimate must mirror the rendered manifest line in renderWorkspaceManifest
+	// (salience float removed for prefix-cache byte-stability — see that function).
+	doc.Tokens = estimateTokens(fmt.Sprintf("- %s — %s", firstNonBlank(uri, doc.Path), summary))
 	return doc, nil
 }
 

--- a/internal/engine/context_assembly_test.go
+++ b/internal/engine/context_assembly_test.go
@@ -307,15 +307,17 @@ func TestFormatForProviderStabilityOrder(t *testing.T) {
 
 	sys, msgs := pkg.FormatForProvider()
 
-	// System prompt should contain nucleus first, then client system, then docs.
+	// System prompt should contain nucleus first, then client system — and ONLY
+	// those (the session-stable half of Zone 1). Post ADR-066/071 amendment the
+	// volatile foveal docs no longer live in the system prompt.
 	if !contains(sys, "I am Cog.") {
 		t.Error("system prompt missing nucleus")
 	}
 	if !contains(sys, "You are helpful.") {
 		t.Error("system prompt missing client system")
 	}
-	if !contains(sys, "Doc A") {
-		t.Error("system prompt missing CogDoc")
+	if contains(sys, "Doc A") {
+		t.Error("system prompt must NOT contain the foveal doc content (moved to trailing user message)")
 	}
 
 	// Messages should be: conversation history + current message.
@@ -325,8 +327,14 @@ func TestFormatForProviderStabilityOrder(t *testing.T) {
 	if msgs[0].Content != "hello" {
 		t.Errorf("msgs[0] = %q; want 'hello'", msgs[0].Content)
 	}
-	if msgs[2].Content != "what is an eigenform?" {
-		t.Errorf("msgs[2] = %q; want 'what is an eigenform?'", msgs[2].Content)
+	// The final user message carries the user's own text PLUS the trailing foveal
+	// block (doc content). The user text must lead; the doc content must follow.
+	last := msgs[2].Content
+	if !strings.HasPrefix(last, "what is an eigenform?") {
+		t.Errorf("final message must start with the user text; got %q", last)
+	}
+	if !contains(last, "Doc A") {
+		t.Error("final user message missing trailing foveal doc content")
 	}
 }
 
@@ -362,21 +370,33 @@ func TestFormatForProviderManifestOutput(t *testing.T) {
 		CurrentMessage: &ProviderMessage{Role: "user", Content: "hi"},
 	}
 
-	sys, _ := pkg.FormatForProvider()
-	if !contains(sys, "# Workspace Context (1 relevant CogDocs)") {
-		t.Errorf("system prompt missing manifest heading: %q", sys)
+	sys, msgs := pkg.FormatForProvider()
+	// Manifest now lives in the trailing user message, NOT the system prompt.
+	if contains(sys, "# Workspace Context") {
+		t.Errorf("manifest must not be in the system prompt: %q", sys)
 	}
-	if !contains(sys, "Use cog_read_cogdoc to access full content when needed") {
-		t.Error("system prompt missing retrieval hint")
+	if len(msgs) != 1 {
+		t.Fatalf("msgs len = %d; want 1 (the current message with folded manifest)", len(msgs))
 	}
-	if !contains(sys, "cog://mem/semantic/architecture/spec.cog.md — foveated context architecture overview [salience: 0.87]") {
-		t.Error("system prompt missing manifest entry")
+	rendered := msgs[0].Content
+	if !contains(rendered, "# Workspace Context (1 relevant CogDocs)") {
+		t.Errorf("trailing message missing manifest heading: %q", rendered)
 	}
-	if !contains(sys, "## Schema Notes") {
-		t.Error("system prompt missing schema notes")
+	if !contains(rendered, "Use cog_read_cogdoc to access full content when needed") {
+		t.Error("trailing message missing retrieval hint")
 	}
-	if !contains(sys, "missing: tags, type") {
-		t.Error("system prompt missing schema issue details")
+	// Salience float has been STRIPPED for byte-stability — URI + summary remain.
+	if !contains(rendered, "cog://mem/semantic/architecture/spec.cog.md — foveated context architecture overview") {
+		t.Error("trailing message missing manifest entry")
+	}
+	if contains(rendered, "[salience:") {
+		t.Error("manifest must not render the live salience float (byte-stability)")
+	}
+	if !contains(rendered, "## Schema Notes") {
+		t.Error("trailing message missing schema notes")
+	}
+	if !contains(rendered, "missing: tags, type") {
+		t.Error("trailing message missing schema issue details")
 	}
 }
 

--- a/internal/engine/foveation_placement_test.go
+++ b/internal/engine/foveation_placement_test.go
@@ -1,0 +1,387 @@
+// foveation_placement_test.go — acceptance tests for the ADR-066/071 amendment
+// "foveation placement under prefix-cache runtimes" (2026-07-07).
+//
+// Covers:
+//   - Change 1: cache-aware placement — the volatile foveal block moves from the
+//     leading system prompt to a TRAILING injection in the final user message, so
+//     the rendered PREFIX (system + all-but-last message) is byte-identical across
+//     two consecutive turns with the same doc selection.
+//   - Change 2: salience-float strip — an identical doc selection renders identical
+//     manifest bytes.
+//   - Change 3: session key + LightConeManager TTL.
+//   - Wire safety: the trailing injection survives normalizeAnthropicMessages on the
+//     Anthropic path (ends with a user turn, block order valid) and is present on the
+//     OpenAI path.
+package engine
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// manifestDocs returns FovealDocs in manifest form (Content=="" so docsUseManifest
+// is true) with the given salience values.
+func manifestDocs(salienceA, salienceB float64) []FovealDoc {
+	return []FovealDoc{
+		{URI: "cog://mem/a", Summary: "doc a summary", Salience: salienceA},
+		{URI: "cog://mem/b", Summary: "doc b summary", Salience: salienceB},
+	}
+}
+
+// renderedPrefix returns the byte-string that a prefix cache would key on: the
+// system prompt followed by every message EXCEPT the last. Two turns whose prefixes
+// are equal can reuse the cached KV for everything up to the final exchange.
+func renderedPrefix(sys string, msgs []ProviderMessage) string {
+	var sb strings.Builder
+	sb.WriteString("SYSTEM\x1e")
+	sb.WriteString(sys)
+	sb.WriteString("\x1d")
+	for i := 0; i < len(msgs)-1; i++ {
+		sb.WriteString(msgs[i].Role)
+		sb.WriteString("\x1e")
+		sb.WriteString(msgs[i].Content)
+		sb.WriteString("\x1d")
+	}
+	return sb.String()
+}
+
+// ── Change 1: cache-aware placement + prefix stability ────────────────────────
+
+func TestFovealBlockRendersTrailingNotInSystem(t *testing.T) {
+	t.Parallel()
+	pkg := &ContextPackage{
+		NucleusText:    "I am Cog.",
+		ClientSystem:   "You are helpful.",
+		FovealDocs:     manifestDocs(0.91, 0.42),
+		CurrentMessage: &ProviderMessage{Role: "user", Content: "what changed?"},
+	}
+	sys, msgs := pkg.FormatForProvider()
+
+	if strings.Contains(sys, "# Workspace Context") {
+		t.Errorf("system prompt must not contain the foveal manifest; got:\n%s", sys)
+	}
+	if !strings.Contains(sys, "I am Cog.") || !strings.Contains(sys, "# Client Context") {
+		t.Error("system prompt must still carry nucleus + client context")
+	}
+	last := msgs[len(msgs)-1]
+	if last.Role != "user" {
+		t.Fatalf("final message role = %q; want user", last.Role)
+	}
+	if !strings.HasPrefix(last.Content, "what changed?") {
+		t.Errorf("final message must lead with the user's text; got %q", last.Content)
+	}
+	if !strings.Contains(last.Content, "# Workspace Context") {
+		t.Error("final user message must carry the trailing foveal manifest")
+	}
+}
+
+// PREFIX-STABILITY — the acceptance criterion for Change 1.
+//
+// Two consecutive turns of the same conversation with the SAME doc selection:
+// the rendered prefix (system + all-but-last message) must be byte-identical, so a
+// prefix cache reuses everything and only the final exchange + foveal block
+// re-prefill.
+func TestPrefixByteStableAcrossTurnsSameSelection(t *testing.T) {
+	t.Parallel()
+
+	// Turn 1: history [u,a], current = user "Q1".
+	turn1 := &ContextPackage{
+		NucleusText:  "I am Cog.",
+		ClientSystem: "You are helpful.",
+		FovealDocs:   manifestDocs(0.91, 0.42),
+		Conversation: []ScoredMessage{
+			{Role: "user", Content: "hello"},
+			{Role: "assistant", Content: "hi there"},
+		},
+		CurrentMessage: &ProviderMessage{Role: "user", Content: "Q1"},
+	}
+
+	// Turn 2: turn-1's current exchange has become history; a NEW user message
+	// arrives. SAME doc selection. In a real prefix cache the salience floats would
+	// have been re-scored — model different values here to prove the strip matters.
+	turn2 := &ContextPackage{
+		NucleusText:  "I am Cog.",
+		ClientSystem: "You are helpful.",
+		FovealDocs:   manifestDocs(0.55, 0.88), // re-scored salience; must not affect bytes
+		Conversation: []ScoredMessage{
+			{Role: "user", Content: "hello"},
+			{Role: "assistant", Content: "hi there"},
+			{Role: "user", Content: "Q1"},
+			{Role: "assistant", Content: "A1"},
+		},
+		CurrentMessage: &ProviderMessage{Role: "user", Content: "Q2"},
+	}
+
+	sys1, msgs1 := turn1.FormatForProvider()
+	sys2, msgs2 := turn2.FormatForProvider()
+
+	// The turn-1 prefix (system + [hello, hi there]) must appear byte-identically
+	// at the head of the turn-2 prefix. We check the strongest property: the whole
+	// turn-1 prefix is a prefix of the turn-2 prefix.
+	p1 := renderedPrefix(sys1, msgs1)
+	p2 := renderedPrefix(sys2, msgs2)
+	if !strings.HasPrefix(p2, p1) {
+		t.Fatalf("prefix instability: turn-1 prefix is not a byte-prefix of turn-2.\nturn1:\n%q\nturn2:\n%q", p1, p2)
+	}
+
+	// And specifically: the system prompt is byte-identical turn to turn (it now
+	// carries only session-stable content).
+	if sys1 != sys2 {
+		t.Errorf("system prompt drifted between turns:\n%q\nvs\n%q", sys1, sys2)
+	}
+
+	// Sanity: the re-scored salience did NOT leak into the trailing block bytes.
+	lastTurn1 := msgs1[len(msgs1)-1].Content
+	lastTurn2 := msgs2[len(msgs2)-1].Content
+	if strings.Contains(lastTurn1, "salience:") || strings.Contains(lastTurn2, "salience:") {
+		t.Error("salience float leaked into the trailing block despite the strip")
+	}
+}
+
+// A CHANGED doc selection must alter ONLY the trailing block — the conversation
+// prefix stays stable.
+func TestPrefixStableWhenOnlySelectionChanges(t *testing.T) {
+	t.Parallel()
+	base := func(docs []FovealDoc) *ContextPackage {
+		return &ContextPackage{
+			NucleusText:  "I am Cog.",
+			ClientSystem: "You are helpful.",
+			FovealDocs:   docs,
+			Conversation: []ScoredMessage{
+				{Role: "user", Content: "hello"},
+				{Role: "assistant", Content: "hi there"},
+			},
+			CurrentMessage: &ProviderMessage{Role: "user", Content: "same question"},
+		}
+	}
+	selA := []FovealDoc{{URI: "cog://mem/a", Summary: "doc a", Salience: 0.9}}
+	selB := []FovealDoc{{URI: "cog://mem/z", Summary: "doc z", Salience: 0.9}}
+
+	sysA, msgsA := base(selA).FormatForProvider()
+	sysB, msgsB := base(selB).FormatForProvider()
+
+	if renderedPrefix(sysA, msgsA) != renderedPrefix(sysB, msgsB) {
+		t.Error("changing doc selection must not disturb the conversation prefix")
+	}
+	if msgsA[len(msgsA)-1].Content == msgsB[len(msgsB)-1].Content {
+		t.Error("changing doc selection must change the trailing foveal block")
+	}
+}
+
+// ── Change 2: salience-float strip → byte-stable manifest ─────────────────────
+
+func TestManifestByteStableAcrossSalience(t *testing.T) {
+	t.Parallel()
+	a := renderWorkspaceManifest(manifestDocs(0.10, 0.20))
+	b := renderWorkspaceManifest(manifestDocs(0.99, 0.01))
+	if a != b {
+		t.Errorf("manifest bytes differ for identical selection with different salience:\n%q\nvs\n%q", a, b)
+	}
+	if strings.Contains(a, "salience") {
+		t.Errorf("manifest still renders a salience float: %q", a)
+	}
+	// URIs + summaries preserved.
+	if !strings.Contains(a, "cog://mem/a — doc a summary") {
+		t.Errorf("manifest dropped URI/summary: %q", a)
+	}
+}
+
+// ── Wire safety: Anthropic path survives the normalizer ───────────────────────
+
+func TestTrailingFovealSurvivesAnthropicNormalizer(t *testing.T) {
+	t.Parallel()
+	pkg := &ContextPackage{
+		NucleusText:  "I am Cog.",
+		ClientSystem: "sys",
+		FovealDocs:   manifestDocs(0.9, 0.1),
+		Conversation: []ScoredMessage{
+			{Role: "user", Content: "hello"},
+			{Role: "assistant", Content: "hi"},
+		},
+		CurrentMessage: &ProviderMessage{Role: "user", Content: "current question"},
+	}
+	sys, msgs := pkg.FormatForProvider()
+
+	req := &CompletionRequest{Messages: msgs, SystemPrompt: sys}
+	ar := buildAnthropicRequest("claude-sonnet-4-20250514", req, false, 8192)
+
+	// The normalizer ran inside buildAnthropicRequest. Output must be legal.
+	if vs := validateAnthropicMessages(ar.Messages); len(vs) != 0 {
+		t.Fatalf("anthropic wire invalid after trailing foveal injection: %v", vs)
+	}
+	if len(ar.Messages) == 0 {
+		t.Fatal("no messages survived normalization")
+	}
+	// Must end on a user turn (I7) and that turn must carry the foveal manifest.
+	last := ar.Messages[len(ar.Messages)-1]
+	if last.Role != "user" {
+		t.Fatalf("final wire message role = %q; want user (I7)", last.Role)
+	}
+	if s, ok := last.Content.(string); ok {
+		if !strings.Contains(s, "# Workspace Context") {
+			t.Errorf("final wire user message lost the foveal manifest; got %q", s)
+		}
+	} else {
+		t.Fatalf("final user content type = %T; want string", last.Content)
+	}
+}
+
+// Multimodal path: when the current user message carries an image part, the foveal
+// block must also appear as a trailing text block (Anthropic renders from
+// ContentParts and ignores Content on that path).
+func TestTrailingFovealFoldsIntoImageMessage(t *testing.T) {
+	t.Parallel()
+	pkg := &ContextPackage{
+		NucleusText: "I am Cog.",
+		FovealDocs:  manifestDocs(0.9, 0.1),
+		CurrentMessage: &ProviderMessage{
+			Role:    "user",
+			Content: "look at this",
+			ContentParts: []ContentPart{
+				{Type: "text", Text: "look at this"},
+				{Type: "image_url", ImageURL: "data:image/png;base64,AAAA"},
+			},
+		},
+	}
+	_, msgs := pkg.FormatForProvider()
+	last := msgs[len(msgs)-1]
+
+	// Content string carries the fold (OpenAI + non-image Anthropic path).
+	if !strings.Contains(last.Content, "# Workspace Context") {
+		t.Error("Content string missing folded foveal block")
+	}
+	// A trailing text ContentPart carries the fold (Anthropic image path).
+	var sawFovealPart bool
+	for _, p := range last.ContentParts {
+		if p.Type == "text" && strings.Contains(p.Text, "# Workspace Context") {
+			sawFovealPart = true
+		}
+	}
+	if !sawFovealPart {
+		t.Error("ContentParts missing folded foveal text block for the multimodal path")
+	}
+}
+
+// ── Change 3: session key ─────────────────────────────────────────────────────
+
+func TestFoveationSessionKeyPrecedence(t *testing.T) {
+	t.Parallel()
+	msgs := []ProviderMessage{
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: "hello"},
+	}
+
+	// Header wins.
+	if k := foveationSessionKey("hdr-1", "user-1", msgs); k != "sid:hdr-1" {
+		t.Errorf("header should take precedence; got %q", k)
+	}
+	// User field second.
+	if k := foveationSessionKey("", "user-1", msgs); k != "usr:user-1" {
+		t.Errorf("user field should be used when no header; got %q", k)
+	}
+	// Fallback to leading-turns hash.
+	k := foveationSessionKey("", "", msgs)
+	if !strings.HasPrefix(k, "lead:") {
+		t.Errorf("fallback should be a leading-turns hash; got %q", k)
+	}
+}
+
+// Same conversation across two turns → SAME key. Different conversation → different.
+func TestFoveationSessionKeyStableWithinConversation(t *testing.T) {
+	t.Parallel()
+	convTurn1 := []ProviderMessage{
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: "first question"},
+	}
+	convTurn2 := []ProviderMessage{
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: "first question"},
+		{Role: "assistant", Content: "answer"},
+		{Role: "user", Content: "SECOND question"},
+	}
+	k1 := foveationSessionKey("", "", convTurn1)
+	k2 := foveationSessionKey("", "", convTurn2)
+	if k1 != k2 {
+		t.Errorf("same conversation must resolve to the same key across turns: %q vs %q", k1, k2)
+	}
+
+	other := []ProviderMessage{
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: "a completely different opening"},
+	}
+	if foveationSessionKey("", "", other) == k1 {
+		t.Error("different conversations must resolve to different keys (no cross-conversation bleed)")
+	}
+}
+
+// Guard against the historical bug: the key must never be a fresh per-request UUID.
+// Two calls for the same conversation (no session id, no user) must be identical.
+func TestFoveationSessionKeyNotPerRequest(t *testing.T) {
+	t.Parallel()
+	msgs := []ProviderMessage{{Role: "user", Content: "stable"}}
+	a := foveationSessionKey("", "", msgs)
+	b := foveationSessionKey("", "", msgs)
+	if a != b {
+		t.Fatalf("key must be stable per-conversation, not per-request: %q vs %q", a, b)
+	}
+}
+
+// ── Change 3: LightConeManager TTL / pruning ──────────────────────────────────
+
+func TestLightConeManagerPruneEvictsStale(t *testing.T) {
+	t.Parallel()
+	// ttl<=0 disables the background sweeper so the test is deterministic.
+	m := NewLightConeManagerWithTTL(nil, 0)
+	defer m.Close()
+
+	m.Set("conv-old", &LightCone{})
+	m.Set("conv-new", &LightCone{})
+	if m.Count() != 2 {
+		t.Fatalf("want 2 cones; got %d", m.Count())
+	}
+
+	// Age conv-old past the cutoff by rewriting its updatedAt directly is not
+	// possible from outside the package cleanly, so instead prune with a cutoff in
+	// the future to evict everything, then confirm Prune's contract.
+	pruned := m.Prune(time.Now().Add(time.Hour))
+	if pruned != 2 {
+		t.Errorf("Prune(future) should evict all stale cones; pruned %d", pruned)
+	}
+	if m.Count() != 0 {
+		t.Errorf("all cones should be evicted; got %d", m.Count())
+	}
+}
+
+// The default-constructed manager runs a background sweeper; a very short TTL must
+// eventually evict an idle cone. Uses NewLightConeManagerWithTTL with a tiny TTL
+// and a manual Prune to avoid depending on the 5-minute sweep cadence.
+func TestLightConeManagerTTLBoundsMemory(t *testing.T) {
+	t.Parallel()
+	m := NewLightConeManagerWithTTL(nil, time.Millisecond)
+	defer m.Close()
+
+	m.Set("conv", &LightCone{})
+	// Touch is at now; wait past the TTL, then prune with now-ttl cutoff (what the
+	// sweeper does).
+	time.Sleep(5 * time.Millisecond)
+	pruned := m.Prune(time.Now().Add(-time.Millisecond))
+	if pruned != 1 {
+		t.Errorf("idle cone past TTL should be pruned; pruned %d, count %d", pruned, m.Count())
+	}
+}
+
+// A cone Set() after the cutoff must NOT be pruned (recently active).
+func TestLightConeManagerKeepsFresh(t *testing.T) {
+	t.Parallel()
+	m := NewLightConeManagerWithTTL(nil, 0)
+	defer m.Close()
+	m.Set("fresh", &LightCone{})
+	pruned := m.Prune(time.Now().Add(-time.Hour)) // cutoff in the past → nothing stale
+	if pruned != 0 {
+		t.Errorf("fresh cone must not be pruned; pruned %d", pruned)
+	}
+	if m.Get("fresh") == nil {
+		t.Error("fresh cone should still be retrievable")
+	}
+}

--- a/internal/engine/foveation_session_key.go
+++ b/internal/engine/foveation_session_key.go
@@ -1,0 +1,96 @@
+// foveation_session_key.go — stable per-conversation key for foveation / light-cone state.
+//
+// Background (ADR-066/071 amendment, 2026-07-07 "foveation placement under
+// prefix-cache runtimes"): the foveated-context assembler tracks a per-conversation
+// LoRO light cone (ADR-071 Phase 2), keyed by a "conversation id" passed via
+// WithConversationID. Both proxy call sites (serve.go handleChat, serve_anthropic.go
+// handleAnthropicMessages) fed that option a FRESH per-request UUID
+// (creq.Metadata.RequestID = uuid.New()). Consequences:
+//
+//   - the light cone was Get()'d under a key that had never been Set() → always nil
+//     → the SSM state never persisted across turns (the feature was silently dead);
+//   - LightConeManager accumulated one orphaned entry per request, never reused and
+//     (pre-TTL) never pruned → unbounded memory growth for the process lifetime.
+//
+// The fix is to key on a STABLE per-conversation identity instead. This file
+// derives that key with a safety-first precedence, and — critically — NEVER uses
+// Process.SessionID() as the key: that value is process-wide (one per kernel), so
+// keying on it would collapse every concurrent conversation/user onto a single light
+// cone (cross-conversation, potentially cross-user state bleed).
+//
+// Precedence:
+//  1. Explicit inbound session id — the X-Cogos-Session-Id request header. This is
+//     the canonical client-supplied session identity already used for harness
+//     binding (resolveBoundIdentity); when present it is the correct join key.
+//  2. Client "user" field — OpenAI `user` / Anthropic `metadata.user_id`. A
+//     client-supplied end-user identifier. Weaker than a session id (one user may
+//     run several conversations) but still per-client and safe against cross-user
+//     bleed.
+//  3. Fallback: a stable hash of the conversation's LEADING turns (client system
+//     prompt + first user message). Stable within a single conversation (the lead
+//     turns don't change as it grows) and distinct across conversations. This is
+//     the safe default when a raw OpenAI-compat client (e.g. Hermes) supplies no
+//     session id and no user field: it never bleeds state across different
+//     conversations, and different users almost never share identical opening turns.
+//
+// The returned key is opaque and only ever used as a map key in LightConeManager;
+// it is not logged raw or surfaced to the model.
+package engine
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// foveationKeyHeader is the request header carrying an explicit client session id.
+// Kept in sync with resolveBoundIdentity, which reads the same header.
+const foveationKeyHeader = "X-Cogos-Session-Id"
+
+// foveationSessionKey derives a stable per-conversation key for light-cone /
+// foveation state.
+//
+//   - sessionID: value of the X-Cogos-Session-Id header ("" if absent).
+//   - userField: the client "user" / "user_id" field ("" if absent).
+//   - messages:  the client-supplied messages for this turn, used only for the
+//     leading-turns fallback hash.
+//
+// It never returns "": the leading-turns hash always yields a value (even for an
+// empty conversation, it hashes the empty lead deterministically), so the caller
+// always has a non-nil, non-per-request key.
+func foveationSessionKey(sessionID, userField string, messages []ProviderMessage) string {
+	if s := strings.TrimSpace(sessionID); s != "" {
+		return "sid:" + s
+	}
+	if u := strings.TrimSpace(userField); u != "" {
+		return "usr:" + u
+	}
+	return "lead:" + leadingTurnsHash(messages)
+}
+
+// leadingTurnsHash returns a hex SHA-256 over the conversation's leading turns:
+// the client system prompt (if any) plus the FIRST user message. These are stable
+// across a conversation's lifetime (they do not change as later turns are added),
+// so two consecutive turns of the same conversation hash identically, while two
+// different conversations (different opening) hash differently.
+func leadingTurnsHash(messages []ProviderMessage) string {
+	var sys, firstUser string
+	for _, m := range messages {
+		if m.Role == "system" && sys == "" {
+			sys = m.Content
+			continue
+		}
+		if m.Role == "user" {
+			firstUser = m.Content
+			break
+		}
+	}
+	// Domain-separate the two components so that ("ab","") and ("a","b") cannot
+	// collide.
+	h := sha256.New()
+	h.Write([]byte("sys\x00"))
+	h.Write([]byte(sys))
+	h.Write([]byte("\x00usr\x00"))
+	h.Write([]byte(firstUser))
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/internal/engine/process.go
+++ b/internal/engine/process.go
@@ -377,6 +377,11 @@ func (p *Process) LightCones() *LightConeManager {
 func (p *Process) SetTRM(trm *MambaTRM, idx *EmbeddingIndex) {
 	p.trm = trm
 	p.embeddingIndex = idx
+	// Stop any prior manager's background TTL sweeper before replacing it, so a
+	// second SetTRM call doesn't leak the previous sweeper goroutine.
+	if p.lightCones != nil {
+		p.lightCones.Close()
+	}
 	p.lightCones = NewLightConeManager(trm)
 }
 

--- a/internal/engine/serve.go
+++ b/internal/engine/serve.go
@@ -1109,10 +1109,18 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 		assembleScopeOpts = append(assembleScopeOpts, WithMemoryScope(bound.MemoryNamespace))
 	}
 
+	// Foveation / light-cone key: derive a STABLE per-conversation key, not the
+	// per-request UUID (creq.Metadata.RequestID). The old UUID key made the light
+	// cone never persist and leaked one orphaned entry per request. Do NOT use
+	// block.SessionID here — it is Process.SessionID() (process-wide) and would
+	// bleed light-cone state across every concurrent conversation/user. See
+	// foveation_session_key.go.
+	foveationKey := foveationSessionKey(r.Header.Get(foveationKeyHeader), req.User, clientMsgs)
+
 	if useFullEmbodiment {
 		assembleOpts := []AssembleOption{
 			WithContext(r.Context()),
-			WithConversationID(creq.Metadata.RequestID),
+			WithConversationID(foveationKey),
 			WithManifestMode(true),
 			WithPreviousTurnSpeculative(previousSpeculative),
 		}

--- a/internal/engine/serve_anthropic.go
+++ b/internal/engine/serve_anthropic.go
@@ -240,10 +240,15 @@ func (s *Server) handleAnthropicMessages(w http.ResponseWriter, r *http.Request)
 		assembleScopeOpts = append(assembleScopeOpts, WithMemoryScope(bound.MemoryNamespace))
 	}
 
+	// Foveation / light-cone key: stable per-conversation, never the per-request
+	// UUID and never Process.SessionID(). Mirrors handleChat. The Anthropic
+	// metadata.user_id is the "user" field equivalent. See foveation_session_key.go.
+	foveationKey := foveationSessionKey(r.Header.Get(foveationKeyHeader), anthropicReq.Metadata.UserID, clientMsgs)
+
 	if useFullEmbodiment {
 		assembleOpts := []AssembleOption{
 			WithContext(r.Context()),
-			WithConversationID(creq.Metadata.RequestID),
+			WithConversationID(foveationKey),
 			WithManifestMode(true),
 		}
 		assembleOpts = append(assembleOpts, assembleScopeOpts...)

--- a/internal/engine/trm_lightcone.go
+++ b/internal/engine/trm_lightcone.go
@@ -25,20 +25,69 @@ type lightConeEntry struct {
 	updatedAt time.Time
 }
 
+// Default TTL / sweep cadence for light-cone eviction. A cone that has not been
+// touched (Get/Set) within lightConeDefaultTTL is considered stale and evicted by
+// the background sweeper. These bound memory even when the join key is coarse or a
+// session ends without an explicit Delete — closing the unbounded-growth leak that
+// the per-request-UUID key created (one orphaned entry per request, never reused,
+// never pruned).
+const (
+	lightConeDefaultTTL = 30 * time.Minute
+	lightConeSweepEvery = 5 * time.Minute
+)
+
 // LightConeManager provides thread-safe per-conversation light cone storage.
 type LightConeManager struct {
 	mu    sync.RWMutex
 	cones map[string]*lightConeEntry
 	trm   *MambaTRM // reference for computing norms
+
+	ttl  time.Duration
+	stop chan struct{} // closed by Close() to end the background sweeper
+	once sync.Once     // guards Close() so stop is closed at most once
 }
 
-// NewLightConeManager creates a new manager. The trm parameter is used
-// for computing light cone norms (can be nil if norms are not needed).
+// NewLightConeManager creates a new manager with the default TTL and starts a
+// background sweeper that evicts stale cones. The trm parameter is used for
+// computing light cone norms (can be nil if norms are not needed).
 func NewLightConeManager(trm *MambaTRM) *LightConeManager {
-	return &LightConeManager{
+	return NewLightConeManagerWithTTL(trm, lightConeDefaultTTL)
+}
+
+// NewLightConeManagerWithTTL is NewLightConeManager with an explicit TTL. A
+// non-positive ttl disables the background sweeper (Prune can still be called
+// manually) — useful for deterministic tests.
+func NewLightConeManagerWithTTL(trm *MambaTRM, ttl time.Duration) *LightConeManager {
+	m := &LightConeManager{
 		cones: make(map[string]*lightConeEntry),
 		trm:   trm,
+		ttl:   ttl,
+		stop:  make(chan struct{}),
 	}
+	if ttl > 0 {
+		go m.sweepLoop()
+	}
+	return m
+}
+
+// sweepLoop evicts cones idle longer than the TTL, until Close() is called.
+func (m *LightConeManager) sweepLoop() {
+	ticker := time.NewTicker(lightConeSweepEvery)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-m.stop:
+			return
+		case now := <-ticker.C:
+			m.Prune(now.Add(-m.ttl))
+		}
+	}
+}
+
+// Close stops the background sweeper. Safe to call multiple times; safe on a
+// manager constructed with a non-positive TTL (no sweeper was started).
+func (m *LightConeManager) Close() {
+	m.once.Do(func() { close(m.stop) })
 }
 
 // Get returns the light cone for a conversation, or nil if none exists.


### PR DESCRIPTION
## Summary

The kernel's foveated-context assembly re-derives context every turn and renders the volatile foveal
doc manifest at the FRONT of the prompt (system preamble), which defeats llama.cpp / LM Studio prefix-KV
reuse: a client routed through the kernel to a local model re-prefills the entire prompt every message
(including the whole conversation), whereas a direct-to-LMS route reuses the cache and is fast after turn 1.

A design-intent review against ADR-066/069/071 confirmed this is DRIFT, not intent: the accepted design
wanted KV caching ("nearly permanent across conversation", "layer-level invalidation", ">90% cache-hit")
and made per-turn re-scoring acceptable *because* it assumed a KV-cache manager (ADR-066 Phase 5) / KV-block
mesh (ADR-069) that were never built. On a plain prefix cache, "most-stable-first" is the right principle,
but the volatile block's leading position multiplies its churn cost by the length of everything after it.

## Change (ADR-103 amends 066/071)

- **Cache-aware placement**: the foveal manifest + speculative block move from the leading system prompt to
  a trailing injection folded into the final user message. systemPrompt = nucleus + client only (session-
  stable); conversation stays chronological. Per-turn re-prefill drops from O(whole prompt) to O(last
  exchange + foveal block). Mirrors the Claude Code hook path, which already delivers foveal content trailing.
- **Salience-strip**: the live `[salience: %.2f]` floats are removed from the rendered manifest, so an
  identical doc selection renders byte-identically across turns.
- **Session-scoped light-cone key**: `WithConversationID` was fed a fresh per-request UUID, so the per-session
  LoRO light cone (ADR-071 Phase 2) never persisted AND leaked one orphaned SSM-state entry per request. Now
  keyed by `X-Cogos-Session-Id` header -> client `user` -> stable hash of the leading turns (never the
  process-wide session id, which would bleed context across conversations). Added a TTL + background sweeper
  to LightConeManager.

## Testing

- `go build ./...` + `go test -race ./internal/engine/...` green.
- Prefix byte-stability across turns (same selection -> identical prefix; changed selection -> only the
  trailing block differs); salience-strip byte-stability; the trailing injection survives the Anthropic wire
  normalizer (ends on a user turn, block order valid); session-key precedence + within-conversation stability
  + not-per-request; light-cone TTL/prune.

## Behavioral note

The foveal manifest now renders AFTER the current user message rather than in the system preamble — a real
change to model-visible context ordering. The prefill-cache-reuse win is proven structurally (byte-stable
prefix); output quality is to be judged live post-deploy (revertable via self-update).

## Deferred (TODO in ADR-103)

Hysteresis / session-stable re-render, contiguous-oldest eviction, tiered content loading, and cache_control
breakpoints for the Anthropic path (the same stable-prefix precondition this PR establishes).
