### PR TITLE
feat(inference): lms-model-state declarative reconciler, opt-in (ADR-104)

### DIFF
--- a/docs/adrs/103-lms-model-state-reconciler.md
+++ b/docs/adrs/103-lms-model-state-reconciler.md
@@ -153,6 +153,33 @@ the job reverts it). Resolution when the reconciler is trusted: scope the launch
 job to boot-only (or retire it) so the reconciler is the single writer. **This
 ADR does not touch that job** — it only documents the hazard.
 
+## Head-of-line blocking in the self-heal loop (accepted tradeoff)
+
+`autonomic_ticker.healDegradedProviders` runs each provider's `ApplyPlan`
+**synchronously and sequentially** within one tick. `lms-model-state`'s
+`ApplyPlan` can block for up to `lmsApplyTimeout` (180s) because
+`@lmstudio/sdk` `load()` does not return until the model is fully resident, and a
+262144-context load on a 24 GB card is not instant. A slow load therefore stalls
+the *entire* self-heal pass — including `mlx-supervised` process-restart healing
+for every provider iterated after it — for the duration of that load.
+
+This is a **latency** concern, not a correctness bug, and it is bounded:
+
+- The blocking-load-vs-ticker-recheck race is handled correctly. Once a load is
+  dispatched, LM Studio reports `state == "loading"`, so `Health()` returns
+  `Progressing` and `healDegradedProviders`' `needsHeal` predicate is false — no
+  duplicate load fires on the next tick.
+- The stall only occurs while a managed backend is actually mid-load, which is
+  rare (opt-in, and only during genuine drift-correction), and is naturally
+  bounded by `lmsApplyTimeout`.
+
+Accepted as-is for the initial ship. If it becomes a problem in practice, the
+options are (a) run the `lms-model-state` apply on its own worker goroutine with
+the provider marked in-flight, so one slow load does not freeze self-healing for
+the other reconcilers, or (b) lower `lmsApplyTimeout` and let the `Progressing`
+state carry the wait across ticks. Both are deferred until the reconciler is
+operator-trusted and enabled on a live node.
+
 ## Consequences
 
 - The kernel gains a declarative handle on LM Studio model/context state, closing

--- a/docs/adrs/103-lms-model-state-reconciler.md
+++ b/docs/adrs/103-lms-model-state-reconciler.md
@@ -1,0 +1,177 @@
+# ADR-103: `lms-model-state` — A Declarative Reconciler for LM Studio Model/Context State
+
+| Field   | Value |
+|---------|-------|
+| Status  | Proposed — code landed OFF-BY-DEFAULT; operator opts in per backend |
+| Author  | @chazmaniandinkle |
+| Created | 2026-07-07 |
+| Layer   | Kernel (engine provider) + daemon health stub |
+| Refs    | [ADR-100](100-substrate-library-extraction.md) (reconcile aliases / substrate library), [ADR-095](095-daemon-reconcile-loop-driver.md) (ReconcileDaemon driver), the `mlx-supervised` precedent (`internal/engine/provider_mlx_supervised.go`), ADR-045 (layered `providers.yaml` / `providers.local.yaml` config) |
+
+---
+
+## Context
+
+CogOS dispatches inference to LM Studio backends through the OpenAI-compatible
+provider (`type: lmstudio` / `openai`). That provider reconciles *dispatch* — is
+the endpoint reachable, does it speak `/v1/chat/completions`. It says nothing
+about **which model is loaded, at what context length**. Today that dimension is
+managed imperatively: a `com.cogos.lmstudio-baseline` launchd job on Darkstar
+loads a baseline model at boot, and the operator hand-loads models on Eclipse
+(192.168.10.191) through the LM Studio desktop app.
+
+The only declarative inference reconciler that exists is `mlx-supervised`
+(ADR precedent), and it reconciles a *different* dimension: process-up via a
+launchd plist. It does not manage model/context state, and its actuator
+(launchctl) cannot reach a remote LM Studio instance.
+
+The gap: there is no way to declare "backend `eclipse` should have
+`ornith-1.0-35b` loaded at context 262144" and have the kernel keep it that way,
+the way `mlx-supervised` keeps a process up. This ADR specifies that reconciler.
+
+### Why LM Studio's native REST surface, not `/v1/models`
+
+The OpenAI-compat `/v1/models` endpoint lists model *ids* only. LM Studio also
+serves `GET /api/v0/models`, which exposes per-model `state`
+(`loaded` / `not-loaded` / `loading`), `loaded_context_length`, and
+`max_context_length`. The reconciled dimension lives in those fields, so the
+reconciler probes `/api/v0/models`, not `/v1/models`.
+
+A verified sharp edge: not-loaded models **omit** `loaded_context_length`
+entirely (it decodes to JSON null / Go nil), while a loaded row carries the real
+value. The decoder uses a `*int` pointer so a missing field never shadows a real
+one, and row-matching prefers a `state=="loaded"` row over a not-loaded
+duplicate of the same id.
+
+## Decision
+
+Introduce a new reconcile type, `lms-model-state`, that manages the
+loaded-model/context-length state of a single LM Studio backend against a
+declared target. It follows the `mlx-supervised` dual-shape precedent exactly,
+swapping two things:
+
+| Dimension | `mlx-supervised` | `lms-model-state` |
+|-----------|------------------|-------------------|
+| Reconciled state | process-up (launchd plist loaded) | model-loaded-at-target-context |
+| Live probe | `launchctl list` + `/v1/models` | `GET /api/v0/models` |
+| Actuator | launchctl (local plist) | Node `@lmstudio/sdk` ws:// bridge (or local `lms` CLI) |
+
+### §1 — The engine provider (`internal/engine/provider_lms_model_state.go`)
+
+`LMSModelStateProvider` implements `reconcile.Reconcilable` (seven methods) plus
+`reconcile.Tokenable`. It is **not** an `engine.Provider` — dispatch stays with
+the existing `lmstudio` provider; this is an orthogonal concern on the same
+backend.
+
+- **`FetchLive`** — read-only `GET {baseURL}/api/v0/models` with a Bearer token
+  (~4s timeout); caches the decoded rows under a `RWMutex`. This is the only
+  network I/O in the read path.
+- **`ComputePlan`** — diffs the declared target against the live rows and emits
+  `Update`-typed actions keyed by a `Name` suffix: `<name>/load` (target not
+  loaded), `<name>/context` (loaded at the wrong context — LM Studio has no live
+  resize, so this is an unload+reload), and `<name>/unload` (`jit_evict` only,
+  when a non-target model crowds the card). An empty plan means the target is
+  loaded at the target context.
+- **`ApplyPlan`** — the only mutating method. Invokes the actuator via
+  `exec.CommandContext`, with the token injected through the environment
+  (`LMS_ACTUATOR_TOKEN`), never argv.
+- **`Health`** — O(1) from the cached rows, no I/O. The autonomic ticker calls
+  it every self-heal tick, so it must never block.
+
+### §2 — Health three-axis mapping (Argo Sync × Health × Operation)
+
+| Live condition | Sync | Health | Operation |
+|----------------|------|--------|-----------|
+| `model_state.manage` not set | Unknown | **Suspended** | Idle |
+| SDK actuator not installed (and no local CLI fallback) | Unknown | **Suspended** | Idle |
+| Backend unreachable / off-LAN | Unknown | **Suspended** | Idle |
+| target `state=="loading"` | Unknown | Progressing | Waiting |
+| target absent / not-loaded | OutOfSync | Missing | Idle |
+| loaded at wrong context | OutOfSync | Degraded | Idle |
+| loaded at target context | Synced | Healthy | Idle |
+
+The deliberate call: an **unreachable** backend maps to **Suspended, not
+Degraded**. A box that is simply off or off-LAN is not something the self-heal
+driver should try to "fix" — self-heal fires on Degraded/Missing/OutOfSync, and
+we do not want the ticker attempting loads against a machine that is unreachable.
+
+### §3 — The actuator (`scripts/lms-actuator/`)
+
+A Node CLI, `lms-actuator.mjs`, using `@lmstudio/sdk`. It constructs
+`new LMStudioClient({ baseUrl: "ws://host:port", clientPasskey: <token> })` and
+calls `client.llm.load(model, { config: { contextLength }, ttl })` /
+`client.llm.unload(model)`. It prints a single JSON result line for `ApplyPlan`
+to parse. A `list` verb (read-only `listLoaded`) and a `--dry-run` flag exist
+for connection self-tests that never mutate.
+
+Why an external Node process rather than a Go ws client: LM Studio's websocket
+protocol is a bespoke authenticated channel/RPC scheme with SuperJSON-style
+per-endpoint serialization. The vendor SDK owns that protocol; re-implementing it
+in Go would be fragile. The actuator is the same "shell-out to the tool that owns
+the surface" pattern `mlx-supervised` uses with launchctl.
+
+**Remote vs local:** on a localhost backend the provider may fast-path through
+`~/.lmstudio/bin/lms load … --context-length …`. On a remote backend (Eclipse,
+off-LAN) it always uses the SDK actuator — the `lms` CLI cannot reach a remote
+instance (LM Link gated).
+
+### §4 — Registration (opt-in, off-by-default)
+
+`router.go` `makeProvider` calls `maybeRegisterModelStateReconciler` in the
+`openai/lmstudio` branch. It constructs and `reconcile.UpsertProvider`s the
+reconciler **only** when the backend declares `options.model_state.manage: true`,
+pulling the token from the same `api_key_env` the dispatch provider uses. Absent
+the block, nothing is registered.
+
+The daemon-side health stub (`internal/providers/daemon/lms_model_state.go`,
+wired via `internal/providers/all`) reports `Suspended` when no backend opts in —
+mirroring `mlx_inference.go`.
+
+## Guardrails (why this ships safe)
+
+1. **Non-destructive read path.** `FetchLive` / `Health` / `ComputePlan` are
+   read-only. Only `ApplyPlan` mutates, and only via the external actuator. The
+   actuator's connection + read-only path was verified against a **mock**
+   websocket server (ws upgrade + auth-frame accepted + `listLoaded` dispatched);
+   a real load against live Eclipse/Darkstar was deliberately **not** run. That
+   path is "built + connection-verified + mock-tested" and still needs operator
+   live-verification before it is trusted.
+2. **Opt-in, disabled by default.** No `model_state` block ⇒ Suspended, empty
+   plan, nothing registered. A kernel restart reconciles no model state until the
+   operator adds `manage: true` to a backend in their live `providers.local.yaml`.
+   This ADR ships the code and a **commented** example only (see
+   `docs/inference/lms-model-state.md`); it does not enable the reconciler on any
+   node.
+
+## Two-writer hazard (documented, not changed here)
+
+The imperative `com.cogos.lmstudio-baseline` launchd job on Darkstar loads a
+baseline model at boot. If a `lms-model-state` reconciler with a *different*
+target were enabled on the same backend, the two writers would race (launchd
+loads model A at boot; the reconciler unloads it and loads model B; a relaunch of
+the job reverts it). Resolution when the reconciler is trusted: scope the launchd
+job to boot-only (or retire it) so the reconciler is the single writer. **This
+ADR does not touch that job** — it only documents the hazard.
+
+## Consequences
+
+- The kernel gains a declarative handle on LM Studio model/context state, closing
+  the gap between `mlx-supervised` (process-up) and the imperative baseline job.
+- A new build-time dependency: `scripts/lms-actuator/node_modules/@lmstudio/sdk`
+  (pinned in `package.json`; `npm install` run in that dir). The Go side shells
+  out; there is no Go-module dependency.
+- Verified target values for the operator's backends: **eclipse
+  `context_length: 262144`** (loaded + serving on the 24 GB card; the old 65536
+  "ceiling" note was refuted — do NOT hardcode 65536); darkstar 262144 too.
+
+## Testing
+
+- Engine unit tests: fake `/api/v0/models` server including the null
+  `loaded_context_length` case; `ComputePlan` load/context/unload/synced/opt-out;
+  `Health` three-axis mapping (synced / degraded-wrong-context / progressing /
+  missing / suspended-no-config / suspended-unreachable / suspended-no-actuator);
+  `ApplyPlan` against a **fake** actuator asserting argv + `LMS_ACTUATOR_TOKEN`
+  env and that the token never leaks into argv (no real load).
+- Daemon stub: opt-in parser + Suspended-when-none.
+- `go build ./...` and `go test -race ./internal/engine/... ./internal/providers/...`
+  green.

--- a/docs/adrs/104-lms-model-state-reconciler.md
+++ b/docs/adrs/104-lms-model-state-reconciler.md
@@ -1,4 +1,4 @@
-# ADR-103: `lms-model-state` — A Declarative Reconciler for LM Studio Model/Context State
+# ADR-104: `lms-model-state` — A Declarative Reconciler for LM Studio Model/Context State
 
 | Field   | Value |
 |---------|-------|

--- a/docs/adrs/104-lms-model-state-reconciler.md
+++ b/docs/adrs/104-lms-model-state-reconciler.md
@@ -165,10 +165,17 @@ for every provider iterated after it — for the duration of that load.
 
 This is a **latency** concern, not a correctness bug, and it is bounded:
 
-- The blocking-load-vs-ticker-recheck race is handled correctly. Once a load is
-  dispatched, LM Studio reports `state == "loading"`, so `Health()` returns
-  `Progressing` and `healDegradedProviders`' `needsHeal` predicate is false — no
-  duplicate load fires on the next tick.
+- The blocking-load-vs-recheck race is handled in `ComputePlan` itself, not only
+  at the ticker. Once a load is dispatched LM Studio reports `state == "loading"`
+  with a nil `loaded_context_length`; `ComputePlan` returns an **empty plan** for
+  any `state == "loading"` target (and `contextMismatch` treats unknown context as
+  no-mismatch), so no unload+reload is ever emitted mid-load. This guard is
+  caller-independent, which matters because there are two callers with different
+  gating: the autonomic ticker's `healDegradedProviders` gates on `Health()` (which
+  returns `Progressing` for a loading target, so `needsHeal` is false), **but the
+  always-on `ReconcileDaemon` calls `ComputePlan`/`ApplyPlan` directly with no
+  `Health()` gate** — so the guard had to live in `ComputePlan` or a multi-minute
+  load (e.g. 262144) would be restarted every daemon poll and never finish.
 - The stall only occurs while a managed backend is actually mid-load, which is
   rare (opt-in, and only during genuine drift-correction), and is naturally
   bounded by `lmsApplyTimeout`.

--- a/docs/inference/lms-model-state.md
+++ b/docs/inference/lms-model-state.md
@@ -1,0 +1,101 @@
+# LM Studio Model-State Reconciler (`lms-model-state`)
+
+The `lms-model-state` reconciler keeps an LM Studio backend loaded with the
+**model you declare, at the context length you declare** — the declarative
+equivalent of hand-loading a model in the LM Studio desktop app or running the
+imperative `com.cogos.lmstudio-baseline` launchd job.
+
+It is **orthogonal to dispatch**. Dispatch (chat completions) still flows through
+the existing `lmstudio` / `openai` provider on the same backend. This reconciler
+adds a second concern on top: model/context state. See
+[ADR-103](../adrs/103-lms-model-state-reconciler.md) for the design rationale.
+
+> **This feature is OFF BY DEFAULT.** It activates only when a backend declares
+> `options.model_state.manage: true`. Absent that, nothing is registered and the
+> kernel reconciles no model state.
+
+## How it works
+
+| Method | What it does |
+|--------|--------------|
+| `FetchLive` | read-only `GET {endpoint}/api/v0/models` (LM Studio's native REST surface — exposes per-model `state` + `loaded_context_length`) |
+| `ComputePlan` | diffs declared target vs live → `load` / `context` (unload+reload; LM Studio has no live resize) / `unload` (jit_evict) actions |
+| `ApplyPlan` | shells the Node `@lmstudio/sdk` actuator (`scripts/lms-actuator/`) over `ws://`; token via `LMS_ACTUATOR_TOKEN` env, never argv |
+| `Health` | O(1) from cached rows: Synced/Healthy when loaded at target; Degraded on wrong context; Missing when absent; Progressing while loading; **Suspended** when unmanaged, unreachable, or the actuator is not installed |
+
+An **unreachable** backend reports **Suspended, not Degraded** — the autonomic
+ticker does not try to self-heal a box that is simply off or off-LAN.
+
+## Prerequisites
+
+Install the actuator's SDK once:
+
+```bash
+cd scripts/lms-actuator
+npm install
+```
+
+Verify the actuator can open a connection and do a read-only op **without loading
+anything** (against a mock, or the `list` verb against a reachable backend):
+
+```bash
+# read-only: list loaded models (no mutation)
+LMS_ACTUATOR_TOKEN=$ECLIPSE_API_KEY \
+  node scripts/lms-actuator/lms-actuator.mjs list --host 192.168.10.191 --port 1234
+
+# dry-run: resolve + print the plan, issue no load/unload
+LMS_ACTUATOR_TOKEN=$ECLIPSE_API_KEY \
+  node scripts/lms-actuator/lms-actuator.mjs load --host 192.168.10.191 --port 1234 \
+       --model ornith-1.0-35b --context-length 262144 --dry-run
+```
+
+## Config (commented example — do NOT enable blindly)
+
+Add this to `providers.local.yaml` and set `manage: true` **only** after the
+actuator is installed and you have live-verified it against the target backend.
+
+```yaml
+providers:
+  eclipse:
+    type: openai                    # OpenAI-compatible dispatch (LM Studio REST)
+    enabled: true
+    endpoint: "http://192.168.10.191:1234"
+    api_key_env: ECLIPSE_API_KEY    # Bearer token; also used by the reconciler
+    model: "ornith-1.0-35b"
+    timeout: 300
+    context_window: 262144
+    options:
+      model_state:
+        manage: true                # the opt-in switch; false/absent ⇒ Suspended
+        model: "ornith-1.0-35b"
+        context_length: 262144      # VERIFIED loaded + serving on the 24GB card
+        parallel: 1
+        keep_warm: true
+        jit_evict: false            # true ⇒ unload a non-target model crowding the card
+```
+
+**Context length: use `262144`, not `65536`.** The old 65536 "ceiling" note was
+refuted — Eclipse loads and serves `ornith-1.0-35b` at 262144 on the 24 GB card.
+Darkstar is 262144 too.
+
+### Local vs remote
+
+- **Remote backend (Eclipse, any off-LAN):** always uses the Node SDK actuator.
+  The `lms` CLI cannot reach a remote instance (LM Link gated).
+- **Localhost backend (Darkstar):** may fast-path through
+  `~/.lmstudio/bin/lms load … --context-length …` when the CLI is present.
+
+## Two-writer hazard
+
+Darkstar runs a `com.cogos.lmstudio-baseline` launchd job that loads a baseline
+model at boot. If you enable this reconciler with a **different** target on the
+same backend, the two writers race. Before trusting the reconciler, scope that
+launchd job to boot-only (or retire it) so the reconciler is the single writer.
+Do not enable both with divergent targets.
+
+## Guardrails
+
+1. The read path (`FetchLive`/`Health`/`ComputePlan`) is non-destructive. Only
+   `ApplyPlan` mutates, and only via the external actuator.
+2. Opt-in, off by default. No `model_state` block ⇒ Suspended, empty plan,
+   nothing registered.

--- a/docs/inference/lms-model-state.md
+++ b/docs/inference/lms-model-state.md
@@ -8,7 +8,7 @@ imperative `com.cogos.lmstudio-baseline` launchd job.
 It is **orthogonal to dispatch**. Dispatch (chat completions) still flows through
 the existing `lmstudio` / `openai` provider on the same backend. This reconciler
 adds a second concern on top: model/context state. See
-[ADR-103](../adrs/103-lms-model-state-reconciler.md) for the design rationale.
+[ADR-104](../adrs/104-lms-model-state-reconciler.md) for the design rationale.
 
 > **This feature is OFF BY DEFAULT.** It activates only when a backend declares
 > `options.model_state.manage: true`. Absent that, nothing is registered and the

--- a/internal/engine/defaults/providers.yaml
+++ b/internal/engine/defaults/providers.yaml
@@ -21,6 +21,37 @@
 #     model: "google/gemma-2-9b-it"
 #     timeout: 300
 #     context_window: 32768
+#
+# ── OPT-IN: lms-model-state reconciler (ADR-103) ─────────────────────────────
+# An LM Studio dispatch backend can additionally opt into declarative
+# model/context-state reconciliation: the kernel keeps the declared model loaded
+# at the declared context length via the Node @lmstudio/sdk actuator
+# (scripts/lms-actuator/). This is OFF BY DEFAULT — it activates only when a
+# backend declares `options.model_state.manage: true`. See
+# docs/inference/lms-model-state.md.
+#
+# The block below is COMMENTED OUT deliberately. Enabling it will cause the
+# autonomic ticker to load/unload models on that backend. Uncomment ONLY after
+# `cd scripts/lms-actuator && npm install` and operator live-verification of the
+# actuator against the target backend. Note: context_length: 262144 is VERIFIED
+# for the Eclipse 24 GB card (do NOT use the refuted 65536 ceiling).
+#
+#   eclipse:
+#     type: openai              # OpenAI-compatible dispatch (LM Studio REST)
+#     enabled: true
+#     endpoint: "http://192.168.10.191:1234"
+#     api_key_env: ECLIPSE_API_KEY   # Bearer token; also used by the reconciler
+#     model: "ornith-1.0-35b"
+#     timeout: 300
+#     context_window: 262144
+#     options:
+#       model_state:
+#         manage: true          # <-- the opt-in switch; false/absent ⇒ Suspended
+#         model: "ornith-1.0-35b"
+#         context_length: 262144  # VERIFIED loaded + serving on the 24GB card
+#         parallel: 1
+#         keep_warm: true
+#         jit_evict: false       # true ⇒ unload a non-target model that crowds the card
 
 providers:
   lmstudio-darkstar:

--- a/internal/engine/defaults/providers.yaml
+++ b/internal/engine/defaults/providers.yaml
@@ -22,7 +22,7 @@
 #     timeout: 300
 #     context_window: 32768
 #
-# ── OPT-IN: lms-model-state reconciler (ADR-103) ─────────────────────────────
+# ── OPT-IN: lms-model-state reconciler (ADR-104) ─────────────────────────────
 # An LM Studio dispatch backend can additionally opt into declarative
 # model/context-state reconciliation: the kernel keeps the declared model loaded
 # at the declared context length via the Node @lmstudio/sdk actuator

--- a/internal/engine/provider_lms_model_state.go
+++ b/internal/engine/provider_lms_model_state.go
@@ -265,8 +265,11 @@ func (p *LMSModelStateProvider) probeModels(ctx context.Context) ([]lmsModelRow,
 	if err != nil {
 		return nil, fmt.Errorf("lms-model-state %q: build request: %w", p.name, err)
 	}
-	if p.token != "" {
-		req.Header.Set("Authorization", "Bearer "+p.token)
+	p.mu.RLock()
+	token := p.token // mutated by SetToken — read under the lock
+	p.mu.RUnlock()
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
 	}
 
 	client := &http.Client{Timeout: lmsFetchTimeout}
@@ -442,8 +445,11 @@ func (p *LMSModelStateProvider) invokeActuator(ctx context.Context, op, model st
 		return err
 	}
 
-	// Token via ENV, never argv.
-	cmd.Env = append(os.Environ(), lmsActuatorTokenEnv+"="+p.token)
+	// Token via ENV, never argv. Read under RLock (SetToken mutates it).
+	p.mu.RLock()
+	token := p.token
+	p.mu.RUnlock()
+	cmd.Env = append(os.Environ(), lmsActuatorTokenEnv+"="+token)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -484,16 +490,19 @@ func (p *LMSModelStateProvider) buildActuatorCmd(ctx context.Context, op, model 
 	}
 
 	// SDK actuator (remote, or local without the CLI). Requires the script.
-	if p.actuatorScript == "" {
+	p.mu.RLock()
+	actuatorScript := p.actuatorScript // mutated by LoadConfig — read under the lock
+	p.mu.RUnlock()
+	if actuatorScript == "" {
 		return nil, false, fmt.Errorf("lms-model-state %q: SDK actuator script not resolved", p.name)
 	}
-	if _, statErr := os.Stat(p.actuatorScript); statErr != nil {
+	if _, statErr := os.Stat(actuatorScript); statErr != nil {
 		return nil, false, fmt.Errorf("lms-model-state %q: SDK actuator not installed at %s (run: cd %s && npm install)",
-			p.name, p.actuatorScript, filepath.Dir(p.actuatorScript))
+			p.name, actuatorScript, filepath.Dir(actuatorScript))
 	}
 
 	args := []string{
-		p.actuatorScript, op,
+		actuatorScript, op,
 		"--host", p.host,
 		"--port", fmt.Sprintf("%d", p.port),
 		"--model", model,
@@ -592,6 +601,7 @@ func (p *LMSModelStateProvider) Health() reconcile.ResourceStatus {
 	probed := p.lastProbed
 	lastErr := p.lastErr
 	target := p.target
+	actuatorScript := p.actuatorScript // mutated by LoadConfig — read under the lock
 	p.mu.RUnlock()
 
 	// Opt-in gate: not managing ⇒ Suspended.
@@ -606,14 +616,14 @@ func (p *LMSModelStateProvider) Health() reconcile.ResourceStatus {
 
 	// Actuator presence check (stat is fast, O(1)). A missing actuator means we
 	// could probe but never remediate — surface as Suspended with a fix hint.
-	if p.actuatorScript == "" {
+	if actuatorScript == "" {
 		return p.suspended("SDK actuator script path unresolved")
 	}
-	if _, err := os.Stat(p.actuatorScript); err != nil {
+	if _, err := os.Stat(actuatorScript); err != nil {
 		// A local backend with the lms CLI available can still remediate.
 		if !(p.local && p.lmsCLI != "" && statOK(p.lmsCLI)) {
 			return p.suspended(fmt.Sprintf("SDK actuator not installed at %s (cd %s && npm install)",
-				p.actuatorScript, filepath.Dir(p.actuatorScript)))
+				actuatorScript, filepath.Dir(actuatorScript)))
 		}
 	}
 

--- a/internal/engine/provider_lms_model_state.go
+++ b/internal/engine/provider_lms_model_state.go
@@ -310,6 +310,42 @@ func (p *LMSModelStateProvider) ComputePlan(config any, live any, _ *reconcile.S
 	// not-loaded duplicate row cannot shadow the real loaded one.
 	targetRow := findModelRow(rows, target.Model)
 
+	// Never disturb an in-flight load. While state=="loading" the loaded context
+	// is unknown (nil loaded_context_length), which must NOT be read as a
+	// wrong-context mismatch. BOTH callers of ComputePlan reach here — the
+	// autonomic ticker (which gates on Health and skips Progressing) AND the
+	// always-on ReconcileDaemon (which does not gate on Health) — so this guard
+	// in ComputePlan is the single, caller-independent defense against the
+	// load-interrupt race: return an empty plan and let the load finish. Health()
+	// reports Progressing separately. Loads can exceed the daemon poll interval
+	// (e.g. 262144 ≈ multi-minute), so interrupting them would prevent the model
+	// from ever finishing loading.
+	if targetRow != nil && targetRow.State == "loading" {
+		return plan, nil
+	}
+
+	// jit_evict FIRST: any eviction must precede the load so VRAM is actually
+	// freed before we load the target onto the card (otherwise ApplyPlan would
+	// load onto a still-crowded card and fail, deferring convergence a cycle).
+	// Only when explicitly enabled — this is destructive-adjacent.
+	if target.JITEvict {
+		for i := range rows {
+			r := &rows[i]
+			if r.State == "loaded" && r.Type != "embeddings" && !modelIDMatch(r.ID, target.Model) {
+				plan.Actions = append(plan.Actions, reconcile.Action{
+					Action:       reconcile.ActionUpdate,
+					ResourceType: lmsModelStateType,
+					Name:         p.name + "/unload",
+					Details: map[string]any{
+						"model":  r.ID,
+						"reason": "jit_evict — non-target model loaded, crowds the card",
+					},
+				})
+				plan.Summary.Updates++
+			}
+		}
+	}
+
 	switch {
 	case targetRow == nil || targetRow.State == "not-loaded":
 		plan.Actions = append(plan.Actions, reconcile.Action{
@@ -337,26 +373,6 @@ func (p *LMSModelStateProvider) ComputePlan(config any, live any, _ *reconcile.S
 			},
 		})
 		plan.Summary.Updates++
-	}
-
-	// jit_evict: if a *different* model is loaded and crowds the card, propose
-	// unloading it. Only when explicitly enabled — this is destructive-adjacent.
-	if target.JITEvict {
-		for i := range rows {
-			r := &rows[i]
-			if r.State == "loaded" && r.Type != "embeddings" && !modelIDMatch(r.ID, target.Model) {
-				plan.Actions = append(plan.Actions, reconcile.Action{
-					Action:       reconcile.ActionUpdate,
-					ResourceType: lmsModelStateType,
-					Name:         p.name + "/unload",
-					Details: map[string]any{
-						"model":  r.ID,
-						"reason": "jit_evict — non-target model loaded, crowds the card",
-					},
-				})
-				plan.Summary.Updates++
-			}
-		}
 	}
 
 	return plan, nil
@@ -741,8 +757,12 @@ func modelIDMatch(rowID, want string) bool {
 // A nil loaded_context_length (not-loaded/absent) is treated as a mismatch when
 // a target is set — but callers gate this behind a state=="loaded" check.
 func contextMismatch(r *lmsModelRow, target int) bool {
+	// Unknown loaded context (nil during loading / not-loaded, or a nil row) is
+	// NOT a mismatch: we cannot compare, and treating it as one would trigger a
+	// disruptive unload+reload against an in-flight load. Callers gate on
+	// state=="loading"/"not-loaded" before reaching here; this is defense-in-depth.
 	if r == nil || r.LoadedContextLength == nil {
-		return true
+		return false
 	}
 	return *r.LoadedContextLength != target
 }

--- a/internal/engine/provider_lms_model_state.go
+++ b/internal/engine/provider_lms_model_state.go
@@ -1,0 +1,837 @@
+// provider_lms_model_state.go — declarative reconciler for LM Studio model/context state.
+//
+// LMSModelStateProvider implements reconcile.Reconcilable (health + lifecycle)
+// only — it is NOT an engine.Provider. Dispatch to an LM Studio backend already
+// happens through the OpenAICompatProvider (type "lmstudio"); this provider adds
+// a second, orthogonal concern on top of the same backend: keeping the *right
+// model loaded at the right context length*.
+//
+// Architecture (mirrors provider_mlx_supervised.go, swapping the actuator and
+// the reconciled dimension)
+//
+//   - Config is declared in providers(.local).yaml under a dispatch backend's
+//     options.model_state block. The reconciler is OPT-IN: it activates only
+//     when options.model_state.manage == true. No model_state block ⇒ Suspended.
+//   - The reconciled dimension is "is <model> loaded at <context_length>?", read
+//     from GET {baseURL}/api/v0/models (LM Studio's native REST surface, which
+//     unlike /v1/models exposes per-model `state` and `loaded_context_length`).
+//   - The actuator is the Node @lmstudio/sdk websocket bridge at
+//     scripts/lms-actuator/ (load / unload / set-context over ws://). On a
+//     localhost backend a `~/.lmstudio/bin/lms` fast-path is permitted; remote
+//     backends (Eclipse, off-LAN) always use the SDK actuator because the lms
+//     CLI cannot reach a remote instance (LM Link gated).
+//   - Health() is O(1): it reads the last cached /api/v0/models rows (populated
+//     by FetchLive) under a RWMutex and never performs I/O. The autonomic ticker
+//     calls Health() on every self-heal tick, so it MUST stay non-blocking.
+//   - FetchLive is where the network probe lives (~4s timeout). An unreachable
+//     backend maps to Suspended/Unknown (NOT Degraded) so the self-heal driver
+//     does not try to "fix" a machine that is simply off or off-LAN.
+//
+// TWO HARD GUARDRAILS honored by this file:
+//  1. NON-DESTRUCTIVE. FetchLive / Health / ComputePlan are read-only probes.
+//     ApplyPlan is the ONLY method that mutates model state, and it does so via
+//     an external actuator process; the actuator is invoked with the token in
+//     the environment (never argv). This file never issues a load/unload itself.
+//  2. OPT-IN, DISABLED BY DEFAULT. Without options.model_state.manage == true the
+//     provider reports Suspended and produces an empty plan — a kernel restart
+//     reconciles nothing until the operator opts in.
+package engine
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/myrgic/cogos/pkg/substrate/reconcile"
+)
+
+// lmsModelStateType is the reconcile type identifier for this provider.
+const lmsModelStateType = "lms-model-state"
+
+// lmsFetchTimeout bounds the /api/v0/models probe in FetchLive.
+const lmsFetchTimeout = 4 * time.Second
+
+// lmsApplyTimeout bounds a single actuator invocation in ApplyPlan.
+const lmsApplyTimeout = 180 * time.Second
+
+// lmsActuatorTokenEnv is the environment variable the Node actuator reads for
+// its Bearer token. ApplyPlan sets it from the provider's cached token; it is
+// never passed on argv.
+const lmsActuatorTokenEnv = "LMS_ACTUATOR_TOKEN"
+
+// ── config ─────────────────────────────────────────────────────────────────────
+
+// lmsModelStateConfig is the parsed options.model_state block for one backend.
+type lmsModelStateConfig struct {
+	Manage        bool   // opt-in switch; false ⇒ Suspended, empty plan
+	Model         string // target model id that should be loaded
+	ContextLength int    // desired loaded_context_length (0 ⇒ don't manage context)
+	Parallel      int    // desired parallel slots (advisory; passed to actuator)
+	KeepWarm      bool   // hint: keep loaded even when idle (advisory metadata)
+	JITEvict      bool   // if true, unload a non-target model that crowds the card
+}
+
+// ── live state ───────────────────────────────────────────────────────────────
+
+// lmsModelRow is one entry from GET /api/v0/models. Not-loaded models omit
+// loaded_context_length entirely, so it is a pointer: a missing/null field
+// decodes to nil rather than shadowing a real value with 0.
+type lmsModelRow struct {
+	ID                  string `json:"id"`
+	State               string `json:"state"` // "loaded" | "not-loaded" | "loading"
+	LoadedContextLength *int   `json:"loaded_context_length,omitempty"`
+	MaxContextLength    int    `json:"max_context_length,omitempty"`
+	Type                string `json:"type,omitempty"`
+}
+
+// lmsModelsResponse is the /api/v0/models envelope.
+type lmsModelsResponse struct {
+	Data []lmsModelRow `json:"data"`
+}
+
+// ── provider ───────────────────────────────────────────────────────────────────
+
+// LMSModelStateProvider reconciles the loaded-model/context state of a single
+// LM Studio backend against a declared options.model_state target.
+type LMSModelStateProvider struct {
+	// --- identity / target ---
+	name    string // provider name as declared in providers.yaml
+	baseURL string // e.g. "http://192.168.10.191:1234" (REST base, no path)
+	wsURL   string // e.g. "ws://192.168.10.191:1234" (SDK bridge)
+	host    string // bare host, e.g. "192.168.10.191"
+	port    int    // e.g. 1234
+	local   bool   // endpoint is localhost/127.0.0.1 ⇒ lms CLI fast-path allowed
+
+	// --- auth ---
+	token string // Bearer token; from the backend's api_key_env (may be empty for localhost)
+
+	// --- desired state ---
+	target lmsModelStateConfig
+
+	// --- actuator ---
+	actuatorScript string // absolute path to scripts/lms-actuator/lms-actuator.mjs
+	nodeBin        string // node binary (default "node")
+	lmsCLI         string // ~/.lmstudio/bin/lms (local fast-path)
+
+	// --- cached live state (Health reads this without I/O) ---
+	mu         sync.RWMutex
+	lastLive   []lmsModelRow
+	lastProbed time.Time
+	lastErr    error // last FetchLive error (unreachable ⇒ Suspended)
+
+	// --- reconcile metadata ---
+	workspaceRoot string
+}
+
+// newLMSModelStateProvider constructs the provider from a dispatch ProviderConfig.
+// The caller (BuildRouter) has already confirmed options.model_state.manage.
+func newLMSModelStateProvider(name string, cfg ProviderConfig, token, workspaceRoot string) (*LMSModelStateProvider, error) {
+	target := parseModelStateOptions(cfg.Options)
+
+	baseURL := strings.TrimRight(cfg.Endpoint, "/")
+	if baseURL == "" {
+		baseURL = "http://localhost:1234"
+	}
+	host, port := hostPort(baseURL, 1234)
+	local := isLocalHost(host)
+
+	// ws:// bridge shares host:port with the REST endpoint.
+	wsURL := fmt.Sprintf("ws://%s:%d", host, port)
+
+	// Resolve the actuator script relative to the workspace root when possible;
+	// fall back to a repo-relative path. ApplyPlan re-checks existence and maps
+	// an absent actuator to Suspended, so a wrong guess here is non-fatal.
+	actuator := resolveActuatorScript(workspaceRoot)
+
+	// Local lms CLI fast-path binary.
+	lmsCLI := ""
+	if home, err := homeDir(); err == nil {
+		lmsCLI = filepath.Join(home, ".lmstudio", "bin", "lms")
+	}
+
+	return &LMSModelStateProvider{
+		name:           name,
+		baseURL:        baseURL,
+		wsURL:          wsURL,
+		host:           host,
+		port:           port,
+		local:          local,
+		token:          token,
+		target:         target,
+		actuatorScript: actuator,
+		nodeBin:        "node",
+		lmsCLI:         lmsCLI,
+		workspaceRoot:  workspaceRoot,
+	}, nil
+}
+
+// parseModelStateOptions extracts the model_state sub-map from a provider's
+// Options. A missing block yields a zero config (Manage=false ⇒ Suspended).
+func parseModelStateOptions(opts map[string]interface{}) lmsModelStateConfig {
+	var c lmsModelStateConfig
+	if opts == nil {
+		return c
+	}
+	raw, ok := opts["model_state"]
+	if !ok {
+		return c
+	}
+	m, ok := raw.(map[string]interface{})
+	if !ok {
+		// yaml.v3 may decode nested maps as map[interface{}]interface{}.
+		if mi, ok2 := raw.(map[interface{}]interface{}); ok2 {
+			m = make(map[string]interface{}, len(mi))
+			for k, v := range mi {
+				m[fmt.Sprint(k)] = v
+			}
+		} else {
+			return c
+		}
+	}
+	c.Manage = optBool(m, "manage")
+	c.Model = optStr(m, "model")
+	c.ContextLength = optInt(m, "context_length")
+	c.Parallel = optInt(m, "parallel")
+	c.KeepWarm = optBool(m, "keep_warm")
+	c.JITEvict = optBool(m, "jit_evict")
+	return c
+}
+
+// ── reconcile.Reconcilable interface ──────────────────────────────────────────
+
+// Type returns the reconcilable type identifier.
+func (p *LMSModelStateProvider) Type() string { return lmsModelStateType }
+
+// SetToken satisfies reconcile.Tokenable. BuildRouter also injects the token at
+// construction (via the backend's api_key_env), but the framework auto-wire path
+// from {TYPE}_TOKEN uses this.
+func (p *LMSModelStateProvider) SetToken(token string) {
+	p.mu.Lock()
+	p.token = token
+	p.mu.Unlock()
+}
+
+// LoadConfig records the workspace root and (re)resolves the actuator script
+// path now that a concrete root is known. Config is already parsed at
+// construction from ProviderConfig; the daemon stub path drives full parsing.
+func (p *LMSModelStateProvider) LoadConfig(root string) (any, error) {
+	p.mu.Lock()
+	p.workspaceRoot = root
+	if root != "" {
+		if s := resolveActuatorScript(root); s != "" {
+			p.actuatorScript = s
+		}
+	}
+	p.mu.Unlock()
+	return &p.target, nil
+}
+
+// FetchLive probes GET {baseURL}/api/v0/models with the Bearer token and caches
+// the decoded rows. This is the ONLY network I/O in the read path; Health reads
+// the cache it populates. An unreachable backend is cached as lastErr so Health
+// can map it to Suspended rather than Degraded.
+func (p *LMSModelStateProvider) FetchLive(ctx context.Context, _ any) (any, error) {
+	rows, err := p.probeModels(ctx)
+
+	p.mu.Lock()
+	p.lastProbed = time.Now()
+	p.lastErr = err
+	if err == nil {
+		p.lastLive = rows
+	}
+	p.mu.Unlock()
+
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// probeModels performs the read-only GET /api/v0/models request.
+func (p *LMSModelStateProvider) probeModels(ctx context.Context) ([]lmsModelRow, error) {
+	reqCtx, cancel := context.WithTimeout(ctx, lmsFetchTimeout)
+	defer cancel()
+
+	url := p.baseURL + "/api/v0/models"
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("lms-model-state %q: build request: %w", p.name, err)
+	}
+	if p.token != "" {
+		req.Header.Set("Authorization", "Bearer "+p.token)
+	}
+
+	client := &http.Client{Timeout: lmsFetchTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("lms-model-state %q: unreachable: %w", p.name, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("lms-model-state %q: /api/v0/models returned %d", p.name, resp.StatusCode)
+	}
+
+	var out lmsModelsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("lms-model-state %q: decode /api/v0/models: %w", p.name, err)
+	}
+	return out.Data, nil
+}
+
+// ComputePlan diffs the declared target against the live rows and emits
+// Update-typed actions distinguished by a Name suffix:
+//
+//	<name>/load    — target model not loaded
+//	<name>/context — loaded but at the wrong context (unload+reload; no live resize)
+//	<name>/unload  — jit_evict only: a non-target model is loaded and crowds the card
+//
+// An empty plan (Synced) means: the target row exists, state=="loaded", and
+// loaded_context_length matches the target (or no context is being managed).
+func (p *LMSModelStateProvider) ComputePlan(config any, live any, _ *reconcile.State) (*reconcile.Plan, error) {
+	target := p.resolveTarget(config)
+	plan := &reconcile.Plan{ResourceType: lmsModelStateType}
+
+	// Opt-out: no management requested ⇒ nothing to do.
+	if !target.Manage {
+		return plan, nil
+	}
+
+	rows := rowsFrom(live, p)
+
+	// Find the target model row, preferring a state=="loaded" match so a
+	// not-loaded duplicate row cannot shadow the real loaded one.
+	targetRow := findModelRow(rows, target.Model)
+
+	switch {
+	case targetRow == nil || targetRow.State == "not-loaded":
+		plan.Actions = append(plan.Actions, reconcile.Action{
+			Action:       reconcile.ActionUpdate,
+			ResourceType: lmsModelStateType,
+			Name:         p.name + "/load",
+			Details: map[string]any{
+				"model":          target.Model,
+				"context_length": target.ContextLength,
+				"parallel":       target.Parallel,
+				"reason":         "target model not loaded",
+			},
+		})
+		plan.Summary.Updates++
+
+	case target.ContextLength > 0 && contextMismatch(targetRow, target.ContextLength):
+		plan.Actions = append(plan.Actions, reconcile.Action{
+			Action:       reconcile.ActionUpdate,
+			ResourceType: lmsModelStateType,
+			Name:         p.name + "/context",
+			Details: map[string]any{
+				"model":          target.Model,
+				"context_length": target.ContextLength,
+				"loaded_context": ctxStr(targetRow.LoadedContextLength),
+				"reason":         "loaded at wrong context — LM Studio has no live resize; unload+reload",
+			},
+		})
+		plan.Summary.Updates++
+	}
+
+	// jit_evict: if a *different* model is loaded and crowds the card, propose
+	// unloading it. Only when explicitly enabled — this is destructive-adjacent.
+	if target.JITEvict {
+		for i := range rows {
+			r := &rows[i]
+			if r.State == "loaded" && r.Type != "embeddings" && !modelIDMatch(r.ID, target.Model) {
+				plan.Actions = append(plan.Actions, reconcile.Action{
+					Action:       reconcile.ActionUpdate,
+					ResourceType: lmsModelStateType,
+					Name:         p.name + "/unload",
+					Details: map[string]any{
+						"model":  r.ID,
+						"reason": "jit_evict — non-target model loaded, crowds the card",
+					},
+				})
+				plan.Summary.Updates++
+			}
+		}
+	}
+
+	return plan, nil
+}
+
+// ApplyPlan executes each action via the Node SDK actuator (token in ENV, not
+// argv). On a localhost backend the lms CLI fast-path is used when present.
+//
+// GUARDRAIL 1: this is the only mutating method. In tests the actuator binary is
+// replaced with a fake so no real load/unload reaches a live backend.
+func (p *LMSModelStateProvider) ApplyPlan(ctx context.Context, plan *reconcile.Plan) ([]reconcile.Result, error) {
+	var results []reconcile.Result
+
+	for _, action := range plan.Actions {
+		var (
+			op    string
+			model string
+		)
+		switch {
+		case strings.HasSuffix(action.Name, "/load"):
+			op, model = "load", detailStr(action.Details, "model")
+		case strings.HasSuffix(action.Name, "/context"):
+			// No live resize: a context change is an unload+reload. The actuator
+			// performs both under the "set-context" verb.
+			op, model = "set-context", detailStr(action.Details, "model")
+		case strings.HasSuffix(action.Name, "/unload"):
+			op, model = "unload", detailStr(action.Details, "model")
+		default:
+			results = append(results, reconcile.Result{
+				Phase: "apply", Action: string(action.Action), Name: action.Name,
+				Status: reconcile.ApplySkipped, Error: "unrecognized action suffix",
+			})
+			continue
+		}
+
+		ctxLen := detailInt(action.Details, "context_length")
+		parallel := detailInt(action.Details, "parallel")
+
+		if err := p.invokeActuator(ctx, op, model, ctxLen, parallel); err != nil {
+			results = append(results, reconcile.Result{
+				Phase: "apply", Action: string(action.Action), Name: action.Name,
+				Status: reconcile.ApplyFailed, Error: err.Error(),
+			})
+			// Non-fatal: surface and continue with remaining actions.
+			continue
+		}
+		results = append(results, reconcile.Result{
+			Phase: "apply", Action: string(action.Action), Name: action.Name,
+			Status: reconcile.ApplySucceeded,
+		})
+	}
+	return results, nil
+}
+
+// invokeActuator runs the load/unload/set-context operation. It builds the
+// command (SDK actuator by default; lms CLI on a local backend) with the token
+// injected via the environment, never argv.
+func (p *LMSModelStateProvider) invokeActuator(ctx context.Context, op, model string, ctxLen, parallel int) error {
+	if model == "" {
+		return fmt.Errorf("lms-model-state %q: %s: empty model id", p.name, op)
+	}
+
+	applyCtx, cancel := context.WithTimeout(ctx, lmsApplyTimeout)
+	defer cancel()
+
+	cmd, err := p.buildActuatorCmd(applyCtx, op, model, ctxLen, parallel)
+	if err != nil {
+		return err
+	}
+
+	// Token via ENV, never argv.
+	cmd.Env = append(os.Environ(), lmsActuatorTokenEnv+"="+p.token)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("lms-model-state %q: actuator %s failed: %w (stderr: %s)",
+			p.name, op, err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+// buildActuatorCmd assembles the exec.Cmd against an already-timed context.
+// SDK actuator by default; on a local backend the lms CLI fast-path is used when
+// the binary exists. The caller owns the context's cancel.
+func (p *LMSModelStateProvider) buildActuatorCmd(ctx context.Context, op, model string, ctxLen, parallel int) (*exec.Cmd, error) {
+	// Local fast-path: lms CLI (localhost only).
+	if p.local && p.lmsCLI != "" && statOK(p.lmsCLI) {
+		if op == "unload" {
+			return exec.CommandContext(ctx, p.lmsCLI, "unload", model), nil
+		}
+		args := []string{"load", model}
+		if ctxLen > 0 {
+			args = append(args, "--context-length", fmt.Sprintf("%d", ctxLen))
+		}
+		return exec.CommandContext(ctx, p.lmsCLI, args...), nil
+	}
+
+	// SDK actuator (remote, or local without the CLI). Requires the script.
+	if p.actuatorScript == "" {
+		return nil, fmt.Errorf("lms-model-state %q: SDK actuator script not resolved", p.name)
+	}
+	if _, statErr := os.Stat(p.actuatorScript); statErr != nil {
+		return nil, fmt.Errorf("lms-model-state %q: SDK actuator not installed at %s (run: cd %s && npm install)",
+			p.name, p.actuatorScript, filepath.Dir(p.actuatorScript))
+	}
+
+	args := []string{
+		p.actuatorScript, op,
+		"--host", p.host,
+		"--port", fmt.Sprintf("%d", p.port),
+		"--model", model,
+	}
+	if ctxLen > 0 {
+		args = append(args, "--context-length", fmt.Sprintf("%d", ctxLen))
+	}
+	if parallel > 0 {
+		args = append(args, "--parallel", fmt.Sprintf("%d", parallel))
+	}
+	return exec.CommandContext(ctx, p.nodeBin, args...), nil
+}
+
+// BuildState projects one Resource for this backend describing the loaded model.
+func (p *LMSModelStateProvider) BuildState(_ any, live any, existing *reconcile.State) (*reconcile.State, error) {
+	state := reconcile.NewState(lmsModelStateType)
+	if existing != nil {
+		state = existing
+	}
+
+	rows := rowsFrom(live, p)
+	loaded := firstLoaded(rows)
+
+	attrs := map[string]any{
+		"model":          p.target.Model,
+		"parallel":       p.target.Parallel,
+		"keep_warm":      p.target.KeepWarm,
+		"target_context": p.target.ContextLength,
+	}
+	externalID := ""
+	if loaded != nil {
+		externalID = loaded.ID
+		attrs["loaded_model"] = loaded.ID
+		attrs["loaded_context_length"] = ctxStr(loaded.LoadedContextLength)
+		attrs["max_context_length"] = loaded.MaxContextLength
+	}
+
+	state.Resources = []reconcile.Resource{{
+		Address:    lmsModelStateType + "/" + p.name,
+		Type:       lmsModelStateType,
+		Mode:       reconcile.ModeManaged,
+		ExternalID: externalID,
+		Name:       p.name,
+		Attributes: attrs,
+	}}
+	return state, nil
+}
+
+// Health returns the three-axis status from cached rows, WITHOUT blocking.
+//
+//	no model_state.manage  ⇒ Suspended/Unknown/Idle  (opt-in, not a failure)
+//	actuator not installed ⇒ Suspended/Unknown/Idle  (clear install message)
+//	unreachable / off-LAN  ⇒ Suspended/Unknown/Idle  (do NOT self-heal)
+//	state=="loading"       ⇒ Progressing/Unknown/Waiting
+//	target absent          ⇒ Missing/OutOfSync/Idle
+//	wrong model or context ⇒ Degraded/OutOfSync/Idle
+//	loaded at target ctx   ⇒ Healthy/Synced/Idle
+func (p *LMSModelStateProvider) Health() reconcile.ResourceStatus {
+	p.mu.RLock()
+	rows := p.lastLive
+	probed := p.lastProbed
+	lastErr := p.lastErr
+	target := p.target
+	p.mu.RUnlock()
+
+	// Opt-in gate: not managing ⇒ Suspended.
+	if !target.Manage {
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusUnknown,
+			Health:    reconcile.HealthSuspended,
+			Operation: reconcile.OperationIdle,
+			Message:   fmt.Sprintf("lms-model-state %q: options.model_state.manage not set — opt-in feature", p.name),
+		}
+	}
+
+	// Actuator presence check (stat is fast, O(1)). A missing actuator means we
+	// could probe but never remediate — surface as Suspended with a fix hint.
+	if p.actuatorScript == "" {
+		return p.suspended("SDK actuator script path unresolved")
+	}
+	if _, err := os.Stat(p.actuatorScript); err != nil {
+		// A local backend with the lms CLI available can still remediate.
+		if !(p.local && p.lmsCLI != "" && statOK(p.lmsCLI)) {
+			return p.suspended(fmt.Sprintf("SDK actuator not installed at %s (cd %s && npm install)",
+				p.actuatorScript, filepath.Dir(p.actuatorScript)))
+		}
+	}
+
+	// Not yet probed.
+	if probed.IsZero() {
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusUnknown,
+			Health:    reconcile.HealthProgressing,
+			Operation: reconcile.OperationWaiting,
+			Message:   fmt.Sprintf("lms-model-state %q: not yet probed (%s)", p.name, p.baseURL),
+		}
+	}
+
+	// Unreachable / off-LAN ⇒ Suspended (NOT Degraded): don't self-heal a box
+	// that is simply off or unreachable.
+	if lastErr != nil {
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusUnknown,
+			Health:    reconcile.HealthSuspended,
+			Operation: reconcile.OperationIdle,
+			Message:   fmt.Sprintf("lms-model-state %q: backend unreachable — %v", p.name, lastErr),
+		}
+	}
+
+	targetRow := findModelRow(rows, target.Model)
+
+	// Loading in progress.
+	if targetRow != nil && targetRow.State == "loading" {
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusUnknown,
+			Health:    reconcile.HealthProgressing,
+			Operation: reconcile.OperationWaiting,
+			Message:   fmt.Sprintf("lms-model-state %q: %s loading", p.name, target.Model),
+		}
+	}
+
+	// Target absent (or not loaded) ⇒ Missing.
+	if targetRow == nil || targetRow.State == "not-loaded" {
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusOutOfSync,
+			Health:    reconcile.HealthMissing,
+			Operation: reconcile.OperationIdle,
+			Message:   fmt.Sprintf("lms-model-state %q: target model %q not loaded", p.name, target.Model),
+		}
+	}
+
+	// Wrong context ⇒ Degraded/OutOfSync.
+	if target.ContextLength > 0 && contextMismatch(targetRow, target.ContextLength) {
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusOutOfSync,
+			Health:    reconcile.HealthDegraded,
+			Operation: reconcile.OperationIdle,
+			Message: fmt.Sprintf("lms-model-state %q: %s loaded at context %s, want %d",
+				p.name, target.Model, ctxStr(targetRow.LoadedContextLength), target.ContextLength),
+		}
+	}
+
+	// Loaded at target ⇒ Healthy/Synced.
+	return reconcile.ResourceStatus{
+		Sync:      reconcile.SyncStatusSynced,
+		Health:    reconcile.HealthHealthy,
+		Operation: reconcile.OperationIdle,
+		Message: fmt.Sprintf("lms-model-state %q: %s loaded at context %s",
+			p.name, target.Model, ctxStr(targetRow.LoadedContextLength)),
+	}
+}
+
+func (p *LMSModelStateProvider) suspended(msg string) reconcile.ResourceStatus {
+	return reconcile.ResourceStatus{
+		Sync:      reconcile.SyncStatusUnknown,
+		Health:    reconcile.HealthSuspended,
+		Operation: reconcile.OperationIdle,
+		Message:   fmt.Sprintf("lms-model-state %q: %s", p.name, msg),
+	}
+}
+
+// resolveTarget prefers a config passed through LoadConfig/ComputePlan, falling
+// back to the provider's own parsed target.
+func (p *LMSModelStateProvider) resolveTarget(config any) lmsModelStateConfig {
+	if c, ok := config.(*lmsModelStateConfig); ok && c != nil {
+		return *c
+	}
+	if c, ok := config.(lmsModelStateConfig); ok {
+		return c
+	}
+	return p.target
+}
+
+// ── row helpers ────────────────────────────────────────────────────────────────
+
+// rowsFrom returns the live rows from a FetchLive result, falling back to the
+// provider's cache when live is nil (e.g. daemon-driven cycle).
+func rowsFrom(live any, p *LMSModelStateProvider) []lmsModelRow {
+	if rows, ok := live.([]lmsModelRow); ok {
+		return rows
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.lastLive
+}
+
+// findModelRow returns the row matching model, preferring a loaded row so a
+// not-loaded duplicate cannot shadow the real one. Returns nil if absent.
+func findModelRow(rows []lmsModelRow, model string) *lmsModelRow {
+	var fallback *lmsModelRow
+	for i := range rows {
+		r := &rows[i]
+		if !modelIDMatch(r.ID, model) {
+			continue
+		}
+		if r.State == "loaded" || r.State == "loading" {
+			return r
+		}
+		if fallback == nil {
+			fallback = r
+		}
+	}
+	return fallback
+}
+
+// firstLoaded returns the first loaded non-embedding row, or nil.
+func firstLoaded(rows []lmsModelRow) *lmsModelRow {
+	for i := range rows {
+		if rows[i].State == "loaded" && rows[i].Type != "embeddings" {
+			return &rows[i]
+		}
+	}
+	return nil
+}
+
+// modelIDMatch matches an LM Studio model id against a configured id, allowing
+// prefix matches in either direction (quant suffixes, publisher prefixes).
+func modelIDMatch(rowID, want string) bool {
+	if want == "" {
+		return false
+	}
+	return rowID == want || strings.HasPrefix(rowID, want) || strings.HasPrefix(want, rowID)
+}
+
+// contextMismatch reports whether a loaded row's context differs from target.
+// A nil loaded_context_length (not-loaded/absent) is treated as a mismatch when
+// a target is set — but callers gate this behind a state=="loaded" check.
+func contextMismatch(r *lmsModelRow, target int) bool {
+	if r == nil || r.LoadedContextLength == nil {
+		return true
+	}
+	return *r.LoadedContextLength != target
+}
+
+// ctxStr renders a *int context length ("null" when nil).
+func ctxStr(v *int) string {
+	if v == nil {
+		return "null"
+	}
+	return fmt.Sprintf("%d", *v)
+}
+
+// ── option / detail helpers ────────────────────────────────────────────────────
+
+func optBool(m map[string]interface{}, key string) bool {
+	if m == nil {
+		return false
+	}
+	switch v := m[key].(type) {
+	case bool:
+		return v
+	case string:
+		return v == "true" || v == "yes" || v == "1"
+	}
+	return false
+}
+
+func optInt(m map[string]interface{}, key string) int {
+	if m == nil {
+		return 0
+	}
+	switch v := m[key].(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	}
+	return 0
+}
+
+func detailStr(d map[string]any, key string) string {
+	if d == nil {
+		return ""
+	}
+	s, _ := d[key].(string)
+	return s
+}
+
+func detailInt(d map[string]any, key string) int {
+	if d == nil {
+		return 0
+	}
+	switch v := d[key].(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	}
+	return 0
+}
+
+// ── url / host helpers ─────────────────────────────────────────────────────────
+
+// hostPort splits "http://host:port" into (host, port), defaulting the port.
+func hostPort(endpoint string, defaultPort int) (string, int) {
+	s := endpoint
+	if idx := strings.Index(s, "://"); idx >= 0 {
+		s = s[idx+3:]
+	}
+	if idx := strings.Index(s, "/"); idx >= 0 {
+		s = s[:idx]
+	}
+	host := s
+	port := defaultPort
+	if idx := strings.LastIndex(s, ":"); idx >= 0 {
+		host = s[:idx]
+		port = extractPort(endpoint, defaultPort)
+	}
+	if host == "" {
+		host = "localhost"
+	}
+	return host, port
+}
+
+// isLocalHost reports whether host is a loopback name/address.
+func isLocalHost(host string) bool {
+	switch host {
+	case "localhost", "127.0.0.1", "::1", "[::1]":
+		return true
+	}
+	return false
+}
+
+// statOK reports whether a path exists.
+func statOK(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// resolveActuatorScript computes the absolute path to the Node actuator script.
+// It prefers <workspaceRoot>/scripts/lms-actuator/lms-actuator.mjs; if that does
+// not exist it falls back to the same path relative to the running binary's repo
+// (best-effort — ApplyPlan/Health re-check existence).
+func resolveActuatorScript(workspaceRoot string) string {
+	const rel = "scripts/lms-actuator/lms-actuator.mjs"
+	if workspaceRoot != "" {
+		cand := filepath.Join(workspaceRoot, rel)
+		if statOK(cand) {
+			return cand
+		}
+	}
+	// Fall back to a git-root probe from cwd.
+	if root, err := gitTopLevel(); err == nil {
+		cand := filepath.Join(root, rel)
+		if statOK(cand) {
+			return cand
+		}
+		return cand // return the computed path even if absent; Health reports it
+	}
+	if workspaceRoot != "" {
+		return filepath.Join(workspaceRoot, rel)
+	}
+	return ""
+}
+
+// gitTopLevel returns the git repository root of the current working directory.
+func gitTopLevel() (string, error) {
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/internal/engine/provider_lms_model_state.go
+++ b/internal/engine/provider_lms_model_state.go
@@ -74,7 +74,7 @@ type lmsModelStateConfig struct {
 	Manage        bool   // opt-in switch; false ⇒ Suspended, empty plan
 	Model         string // target model id that should be loaded
 	ContextLength int    // desired loaded_context_length (0 ⇒ don't manage context)
-	Parallel      int    // desired parallel slots (advisory; passed to actuator)
+	Parallel      int    // advisory metadata only, reported in BuildState — NOT actuated (LM Studio SDK load config has no per-load parallelism knob; parallelism is a server/JIT setting)
 	KeepWarm      bool   // hint: keep loaded even when idle (advisory metadata)
 	JITEvict      bool   // if true, unload a non-target model that crowds the card
 }
@@ -319,7 +319,6 @@ func (p *LMSModelStateProvider) ComputePlan(config any, live any, _ *reconcile.S
 			Details: map[string]any{
 				"model":          target.Model,
 				"context_length": target.ContextLength,
-				"parallel":       target.Parallel,
 				"reason":         "target model not loaded",
 			},
 		})
@@ -394,9 +393,8 @@ func (p *LMSModelStateProvider) ApplyPlan(ctx context.Context, plan *reconcile.P
 		}
 
 		ctxLen := detailInt(action.Details, "context_length")
-		parallel := detailInt(action.Details, "parallel")
 
-		if err := p.invokeActuator(ctx, op, model, ctxLen, parallel); err != nil {
+		if err := p.invokeActuator(ctx, op, model, ctxLen); err != nil {
 			results = append(results, reconcile.Result{
 				Phase: "apply", Action: string(action.Action), Name: action.Name,
 				Status: reconcile.ApplyFailed, Error: err.Error(),
@@ -415,7 +413,7 @@ func (p *LMSModelStateProvider) ApplyPlan(ctx context.Context, plan *reconcile.P
 // invokeActuator runs the load/unload/set-context operation. It builds the
 // command (SDK actuator by default; lms CLI on a local backend) with the token
 // injected via the environment, never argv.
-func (p *LMSModelStateProvider) invokeActuator(ctx context.Context, op, model string, ctxLen, parallel int) error {
+func (p *LMSModelStateProvider) invokeActuator(ctx context.Context, op, model string, ctxLen int) error {
 	if model == "" {
 		return fmt.Errorf("lms-model-state %q: %s: empty model id", p.name, op)
 	}
@@ -423,7 +421,7 @@ func (p *LMSModelStateProvider) invokeActuator(ctx context.Context, op, model st
 	applyCtx, cancel := context.WithTimeout(ctx, lmsApplyTimeout)
 	defer cancel()
 
-	cmd, err := p.buildActuatorCmd(applyCtx, op, model, ctxLen, parallel)
+	cmd, emitsJSON, err := p.buildActuatorCmd(applyCtx, op, model, ctxLen)
 	if err != nil {
 		return err
 	}
@@ -438,31 +436,43 @@ func (p *LMSModelStateProvider) invokeActuator(ctx context.Context, op, model st
 		return fmt.Errorf("lms-model-state %q: actuator %s failed: %w (stderr: %s)",
 			p.name, op, err, strings.TrimSpace(stderr.String()))
 	}
+	// Defense-in-depth: even on exit 0, honour the SDK actuator's {"ok":...}
+	// contract so an ok==false result printed with a zero exit (a dropped-await
+	// JS footgun) is not mistaken for a successful heal. The lms CLI fast-path
+	// prints plain text and is exempt (emitsJSON == false).
+	if emitsJSON {
+		if perr := parseActuatorResult(stdout.String()); perr != nil {
+			return fmt.Errorf("lms-model-state %q: actuator %s: %w", p.name, op, perr)
+		}
+	}
 	return nil
 }
 
 // buildActuatorCmd assembles the exec.Cmd against an already-timed context.
 // SDK actuator by default; on a local backend the lms CLI fast-path is used when
 // the binary exists. The caller owns the context's cancel.
-func (p *LMSModelStateProvider) buildActuatorCmd(ctx context.Context, op, model string, ctxLen, parallel int) (*exec.Cmd, error) {
-	// Local fast-path: lms CLI (localhost only).
+// The returned emitsJSON is true only for the SDK actuator path, whose contract
+// is to print a final {"ok":...} result line; the lms CLI fast-path prints plain
+// human text, so its output must not be JSON-parsed.
+func (p *LMSModelStateProvider) buildActuatorCmd(ctx context.Context, op, model string, ctxLen int) (cmd *exec.Cmd, emitsJSON bool, err error) {
+	// Local fast-path: lms CLI (localhost only). Plain-text output, not JSON.
 	if p.local && p.lmsCLI != "" && statOK(p.lmsCLI) {
 		if op == "unload" {
-			return exec.CommandContext(ctx, p.lmsCLI, "unload", model), nil
+			return exec.CommandContext(ctx, p.lmsCLI, "unload", model), false, nil
 		}
 		args := []string{"load", model}
 		if ctxLen > 0 {
 			args = append(args, "--context-length", fmt.Sprintf("%d", ctxLen))
 		}
-		return exec.CommandContext(ctx, p.lmsCLI, args...), nil
+		return exec.CommandContext(ctx, p.lmsCLI, args...), false, nil
 	}
 
 	// SDK actuator (remote, or local without the CLI). Requires the script.
 	if p.actuatorScript == "" {
-		return nil, fmt.Errorf("lms-model-state %q: SDK actuator script not resolved", p.name)
+		return nil, false, fmt.Errorf("lms-model-state %q: SDK actuator script not resolved", p.name)
 	}
 	if _, statErr := os.Stat(p.actuatorScript); statErr != nil {
-		return nil, fmt.Errorf("lms-model-state %q: SDK actuator not installed at %s (run: cd %s && npm install)",
+		return nil, false, fmt.Errorf("lms-model-state %q: SDK actuator not installed at %s (run: cd %s && npm install)",
 			p.name, p.actuatorScript, filepath.Dir(p.actuatorScript))
 	}
 
@@ -475,10 +485,45 @@ func (p *LMSModelStateProvider) buildActuatorCmd(ctx context.Context, op, model 
 	if ctxLen > 0 {
 		args = append(args, "--context-length", fmt.Sprintf("%d", ctxLen))
 	}
-	if parallel > 0 {
-		args = append(args, "--parallel", fmt.Sprintf("%d", parallel))
+	// NOTE: `parallel` is intentionally NOT threaded to the actuator. LM Studio's
+	// @lmstudio/sdk load config (v1.5.0) has no per-load parallelism knob —
+	// parallelism is a server/JIT setting, not a load-config field — so passing it
+	// would be a silent no-op. It remains a declared model_state field only for
+	// state reporting (BuildState attributes), not for actuation.
+	return exec.CommandContext(ctx, p.nodeBin, args...), true, nil
+}
+
+// actuatorResult is the JSON contract emitted on the SDK actuator's final stdout
+// line. Success is reported ONLY when the child exits 0 AND ok==true.
+type actuatorResult struct {
+	Ok    bool   `json:"ok"`
+	Error string `json:"error"`
+}
+
+// parseActuatorResult validates the SDK actuator's stdout. Defense-in-depth
+// against a future actuator change that prints {"ok":false} while exiting 0
+// (a dropped await / swallowed catch): treat ok==false — or output with no
+// parseable result line at all — as a failure even on a zero exit code.
+func parseActuatorResult(stdout string) error {
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" || !strings.HasPrefix(line, "{") {
+			continue
+		}
+		var res actuatorResult
+		if err := json.Unmarshal([]byte(line), &res); err != nil {
+			continue // not the JSON result line; keep scanning upward
+		}
+		if !res.Ok {
+			if res.Error != "" {
+				return fmt.Errorf("actuator reported failure: %s", res.Error)
+			}
+			return fmt.Errorf("actuator reported ok=false")
+		}
+		return nil
 	}
-	return exec.CommandContext(ctx, p.nodeBin, args...), nil
+	return fmt.Errorf("actuator produced no parseable {\"ok\":...} result line")
 }
 
 // BuildState projects one Resource for this backend describing the loaded model.

--- a/internal/engine/provider_lms_model_state_test.go
+++ b/internal/engine/provider_lms_model_state_test.go
@@ -19,10 +19,46 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/myrgic/cogos/pkg/substrate/reconcile"
 )
+
+// TestLMSModelStateProviderConcurrentFieldAccess exercises the mutable provider
+// fields (token via SetToken, actuatorScript via LoadConfig) concurrently with
+// the readers (FetchLive→probeModels reads token; Health reads actuatorScript),
+// so `go test -race` flags any unguarded access. The provider is the shared,
+// globally-registered singleton the framework's ConfigureProvider/Tokenable path
+// writes while the autonomic ticker + ReconcileDaemon read.
+func TestLMSModelStateProviderConcurrentFieldAccess(t *testing.T) {
+	p := makeLMSProvider(t, "http://127.0.0.1:1", "target", 262144) // unreachable is fine; the race is on the field access
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	spin := func(fn func()) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					fn()
+				}
+			}
+		}()
+	}
+	root := t.TempDir()
+	spin(func() { p.SetToken("t") })                               // writes token
+	spin(func() { _, _ = p.LoadConfig(root) })                     // writes actuatorScript
+	spin(func() { _, _ = p.FetchLive(context.Background(), nil) }) // reads token (probeModels)
+	spin(func() { _ = p.Health() })                                // reads actuatorScript
+	time.Sleep(40 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}
 
 // ── fixtures ─────────────────────────────────────────────────────────────────
 

--- a/internal/engine/provider_lms_model_state_test.go
+++ b/internal/engine/provider_lms_model_state_test.go
@@ -225,6 +225,49 @@ func TestComputePlanJITEvict(t *testing.T) {
 	}
 }
 
+func TestComputePlanLoadingNotDisrupted(t *testing.T) {
+	// A model mid-load reports state=="loading" with a nil loaded context. The
+	// plan MUST be empty so the load can finish — never an unload+reload, which
+	// (under the 30s ReconcileDaemon poll vs a multi-minute load) would restart
+	// the load every cycle and prevent it from ever completing.
+	p := makeLMSProvider(t, "http://x", "target", 262144)
+	rows := []lmsModelRow{{ID: "target", State: "loading", LoadedContextLength: nil}}
+	plan, err := p.ComputePlan(&p.target, rows, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Actions) != 0 {
+		t.Fatalf("expected empty plan while target is loading, got %#v", plan.Actions)
+	}
+}
+
+func TestComputePlanJITEvictUnloadBeforeLoad(t *testing.T) {
+	// When both a fresh load and a jit_evict are due in one cycle, the eviction
+	// MUST be planned before the load so VRAM is freed before we load onto the card.
+	p := makeLMSProvider(t, "http://x", "target", 262144)
+	p.target.JITEvict = true
+	rows := []lmsModelRow{{ID: "crowder", State: "loaded", LoadedContextLength: ip(8192)}}
+	plan, err := p.ComputePlan(&p.target, rows, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unloadIdx, loadIdx := -1, -1
+	for i, a := range plan.Actions {
+		if strings.HasSuffix(a.Name, "/unload") {
+			unloadIdx = i
+		}
+		if strings.HasSuffix(a.Name, "/load") {
+			loadIdx = i
+		}
+	}
+	if unloadIdx == -1 || loadIdx == -1 {
+		t.Fatalf("expected both /unload and /load actions, got %#v", plan.Actions)
+	}
+	if unloadIdx > loadIdx {
+		t.Fatalf("eviction must precede load: unload at %d, load at %d (%#v)", unloadIdx, loadIdx, plan.Actions)
+	}
+}
+
 func TestComputePlanOptOutEmpty(t *testing.T) {
 	p := makeLMSProvider(t, "http://x", "target", 262144)
 	p.target.Manage = false

--- a/internal/engine/provider_lms_model_state_test.go
+++ b/internal/engine/provider_lms_model_state_test.go
@@ -1,0 +1,465 @@
+// provider_lms_model_state_test.go — unit tests for LMSModelStateProvider.
+//
+// Test discipline (mirrors provider_mlx_supervised_test.go):
+//   - Package engine (whitebox)
+//   - t.TempDir() for filesystem isolation
+//   - No sleeping; no live LM Studio; no real load/unload
+//   - The actuator is replaced with a FAKE script that records argv+env to a
+//     file so ApplyPlan tests assert the exact invocation WITHOUT loading a model
+//     (GUARDRAIL 1).
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/myrgic/cogos/pkg/substrate/reconcile"
+)
+
+// ── fixtures ─────────────────────────────────────────────────────────────────
+
+// modelsJSON is a raw /api/v0/models body builder. Each entry is (id, state,
+// loadedCtx, maxCtx); a negative loadedCtx omits the field entirely (the
+// not-loaded/null case).
+type modelFixture struct {
+	id, state string
+	loadedCtx int // <0 ⇒ omit loaded_context_length
+	maxCtx    int
+	typ       string
+}
+
+func modelsHandler(fixtures ...modelFixture) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v0/models" {
+			http.NotFound(w, r)
+			return
+		}
+		var data []map[string]any
+		for _, f := range fixtures {
+			row := map[string]any{
+				"id":                 f.id,
+				"state":              f.state,
+				"max_context_length": f.maxCtx,
+			}
+			if f.typ != "" {
+				row["type"] = f.typ
+			}
+			if f.loadedCtx >= 0 {
+				row["loaded_context_length"] = f.loadedCtx
+			}
+			// else: omit the key entirely — the null/not-loaded case.
+			data = append(data, row)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": data, "object": "list"})
+	})
+}
+
+// makeLMSProvider builds a managed provider pointed at endpoint with a target.
+func makeLMSProvider(t *testing.T, endpoint, model string, ctxLen int) *LMSModelStateProvider {
+	t.Helper()
+	cfg := ProviderConfig{
+		Type:     "lmstudio",
+		Endpoint: endpoint,
+		Options: map[string]interface{}{
+			"model_state": map[string]interface{}{
+				"manage":         true,
+				"model":          model,
+				"context_length": ctxLen,
+			},
+		},
+	}
+	p, err := newLMSModelStateProvider("lms-test", cfg, "tok", t.TempDir())
+	if err != nil {
+		t.Fatalf("newLMSModelStateProvider: %v", err)
+	}
+	// Point the actuator at a fake so Health()'s install-check passes and
+	// ApplyPlan runs the fake. Individual tests may override.
+	p.actuatorScript = writeFakeActuator(t)
+	p.nodeBin = "/bin/sh" // run the fake as a shell script
+	p.local = false       // force SDK-actuator path (not lms CLI)
+	return p
+}
+
+// writeFakeActuator writes a shell script that records argv + the token env var
+// to <dir>/actuator-calls.log and exits 0. It NEVER contacts a backend.
+func writeFakeActuator(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "actuator-calls.log")
+	script := "#!/bin/sh\n" +
+		"echo \"ARGV: $@\" >> \"" + logPath + "\"\n" +
+		"echo \"TOKEN: ${LMS_ACTUATOR_TOKEN}\" >> \"" + logPath + "\"\n" +
+		"echo '{\"ok\":true}'\n"
+	path := filepath.Join(dir, "fake-actuator.sh")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake actuator: %v", err)
+	}
+	return path
+}
+
+func readActuatorLog(t *testing.T, actuatorScript string) string {
+	t.Helper()
+	logPath := filepath.Join(filepath.Dir(actuatorScript), "actuator-calls.log")
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		return "" // no calls
+	}
+	return string(data)
+}
+
+// ── FetchLive: parsing incl. the null loaded_context_length case ────────────────
+
+func TestFetchLiveParsesNullContext(t *testing.T) {
+	srv := httptest.NewServer(modelsHandler(
+		modelFixture{id: "loaded-model", state: "loaded", loadedCtx: 262144, maxCtx: 262144},
+		modelFixture{id: "cold-model", state: "not-loaded", loadedCtx: -1, maxCtx: 262144}, // null
+	))
+	defer srv.Close()
+
+	p := makeLMSProvider(t, srv.URL, "loaded-model", 262144)
+	live, err := p.FetchLive(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("FetchLive: %v", err)
+	}
+	rows, ok := live.([]lmsModelRow)
+	if !ok || len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %#v", live)
+	}
+	// Loaded row has a non-nil pointer.
+	loaded := findModelRow(rows, "loaded-model")
+	if loaded == nil || loaded.LoadedContextLength == nil || *loaded.LoadedContextLength != 262144 {
+		t.Errorf("loaded row context: got %v, want 262144", loaded)
+	}
+	// not-loaded row's loaded_context_length must be nil (not 0) — the null case.
+	cold := findModelRow(rows, "cold-model")
+	if cold == nil || cold.LoadedContextLength != nil {
+		t.Errorf("not-loaded row should have nil LoadedContextLength, got %v", cold.LoadedContextLength)
+	}
+}
+
+func TestFetchLiveNullDoesNotShadowLoaded(t *testing.T) {
+	// A not-loaded duplicate id must not shadow the loaded one when matching.
+	srv := httptest.NewServer(modelsHandler(
+		modelFixture{id: "dup", state: "not-loaded", loadedCtx: -1, maxCtx: 262144},
+		modelFixture{id: "dup", state: "loaded", loadedCtx: 262144, maxCtx: 262144},
+	))
+	defer srv.Close()
+	p := makeLMSProvider(t, srv.URL, "dup", 262144)
+	live, err := p.FetchLive(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("FetchLive: %v", err)
+	}
+	rows := live.([]lmsModelRow)
+	r := findModelRow(rows, "dup")
+	if r == nil || r.State != "loaded" {
+		t.Errorf("findModelRow must prefer the loaded row, got %#v", r)
+	}
+}
+
+// ── ComputePlan: drift states ──────────────────────────────────────────────────
+
+func TestComputePlanLoadWhenAbsent(t *testing.T) {
+	p := makeLMSProvider(t, "http://x", "target", 262144)
+	rows := []lmsModelRow{{ID: "other", State: "loaded", LoadedContextLength: ip(4096)}}
+	plan, err := p.ComputePlan(&p.target, rows, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Actions) != 1 || !strings.HasSuffix(plan.Actions[0].Name, "/load") {
+		t.Fatalf("expected one /load action, got %#v", plan.Actions)
+	}
+}
+
+func TestComputePlanContextDriftUnloadReload(t *testing.T) {
+	p := makeLMSProvider(t, "http://x", "target", 262144)
+	rows := []lmsModelRow{{ID: "target", State: "loaded", LoadedContextLength: ip(65536)}}
+	plan, err := p.ComputePlan(&p.target, rows, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Actions) != 1 || !strings.HasSuffix(plan.Actions[0].Name, "/context") {
+		t.Fatalf("expected one /context action, got %#v", plan.Actions)
+	}
+}
+
+func TestComputePlanSyncedEmptyPlan(t *testing.T) {
+	p := makeLMSProvider(t, "http://x", "target", 262144)
+	rows := []lmsModelRow{{ID: "target", State: "loaded", LoadedContextLength: ip(262144)}}
+	plan, err := p.ComputePlan(&p.target, rows, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Actions) != 0 {
+		t.Fatalf("expected empty plan when at target, got %#v", plan.Actions)
+	}
+}
+
+func TestComputePlanJITEvict(t *testing.T) {
+	p := makeLMSProvider(t, "http://x", "target", 262144)
+	p.target.JITEvict = true
+	rows := []lmsModelRow{
+		{ID: "target", State: "loaded", LoadedContextLength: ip(262144)},
+		{ID: "crowder", State: "loaded", LoadedContextLength: ip(8192)},
+	}
+	plan, err := p.ComputePlan(&p.target, rows, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sawUnload bool
+	for _, a := range plan.Actions {
+		if strings.HasSuffix(a.Name, "/unload") && a.Details["model"] == "crowder" {
+			sawUnload = true
+		}
+	}
+	if !sawUnload {
+		t.Fatalf("expected /unload of crowder under jit_evict, got %#v", plan.Actions)
+	}
+}
+
+func TestComputePlanOptOutEmpty(t *testing.T) {
+	p := makeLMSProvider(t, "http://x", "target", 262144)
+	p.target.Manage = false
+	rows := []lmsModelRow{{ID: "other", State: "loaded", LoadedContextLength: ip(4096)}}
+	plan, err := p.ComputePlan(&p.target, rows, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Actions) != 0 {
+		t.Fatalf("opt-out must yield empty plan, got %#v", plan.Actions)
+	}
+}
+
+// ── Health: three-axis mapping ─────────────────────────────────────────────────
+
+func TestHealthSyncedWhenLoadedAtTarget(t *testing.T) {
+	srv := httptest.NewServer(modelsHandler(
+		modelFixture{id: "target", state: "loaded", loadedCtx: 262144, maxCtx: 262144},
+	))
+	defer srv.Close()
+	p := makeLMSProvider(t, srv.URL, "target", 262144)
+	mustFetch(t, p)
+	h := p.Health()
+	assertHealth(t, h, reconcile.SyncStatusSynced, reconcile.HealthHealthy)
+}
+
+func TestHealthDegradedOnWrongContext(t *testing.T) {
+	srv := httptest.NewServer(modelsHandler(
+		modelFixture{id: "target", state: "loaded", loadedCtx: 65536, maxCtx: 262144},
+	))
+	defer srv.Close()
+	p := makeLMSProvider(t, srv.URL, "target", 262144)
+	mustFetch(t, p)
+	h := p.Health()
+	assertHealth(t, h, reconcile.SyncStatusOutOfSync, reconcile.HealthDegraded)
+}
+
+func TestHealthProgressingWhenLoading(t *testing.T) {
+	srv := httptest.NewServer(modelsHandler(
+		modelFixture{id: "target", state: "loading", loadedCtx: -1, maxCtx: 262144},
+	))
+	defer srv.Close()
+	p := makeLMSProvider(t, srv.URL, "target", 262144)
+	mustFetch(t, p)
+	h := p.Health()
+	if h.Health != reconcile.HealthProgressing {
+		t.Fatalf("loading ⇒ Progressing; got %s", h.Health)
+	}
+}
+
+func TestHealthMissingWhenAbsent(t *testing.T) {
+	srv := httptest.NewServer(modelsHandler(
+		modelFixture{id: "other", state: "loaded", loadedCtx: 4096, maxCtx: 4096},
+	))
+	defer srv.Close()
+	p := makeLMSProvider(t, srv.URL, "target", 262144)
+	mustFetch(t, p)
+	h := p.Health()
+	assertHealth(t, h, reconcile.SyncStatusOutOfSync, reconcile.HealthMissing)
+}
+
+func TestHealthSuspendedWhenNotManaged(t *testing.T) {
+	p := makeLMSProvider(t, "http://x", "target", 262144)
+	p.target.Manage = false
+	h := p.Health()
+	if h.Health != reconcile.HealthSuspended {
+		t.Fatalf("unmanaged ⇒ Suspended; got %s", h.Health)
+	}
+}
+
+func TestHealthSuspendedWhenUnreachable(t *testing.T) {
+	// Point at a closed port — FetchLive errors, Health maps to Suspended (NOT
+	// Degraded): don't self-heal an unreachable box.
+	p := makeLMSProvider(t, "http://127.0.0.1:1", "target", 262144)
+	_, err := p.FetchLive(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected FetchLive to fail against closed port")
+	}
+	h := p.Health()
+	if h.Health != reconcile.HealthSuspended {
+		t.Fatalf("unreachable ⇒ Suspended (not Degraded); got %s (%s)", h.Health, h.Message)
+	}
+}
+
+func TestHealthSuspendedWhenActuatorMissing(t *testing.T) {
+	srv := httptest.NewServer(modelsHandler(
+		modelFixture{id: "target", state: "loaded", loadedCtx: 262144, maxCtx: 262144},
+	))
+	defer srv.Close()
+	p := makeLMSProvider(t, srv.URL, "target", 262144)
+	p.actuatorScript = filepath.Join(t.TempDir(), "does-not-exist.mjs")
+	p.local = false
+	p.lmsCLI = "" // no CLI fallback
+	mustFetch(t, p)
+	h := p.Health()
+	if h.Health != reconcile.HealthSuspended {
+		t.Fatalf("missing actuator ⇒ Suspended; got %s (%s)", h.Health, h.Message)
+	}
+}
+
+// ── ApplyPlan: invokes the FAKE actuator with correct argv+env, no real load ──
+
+func TestApplyPlanInvokesActuatorWithArgvAndEnv(t *testing.T) {
+	p := makeLMSProvider(t, "http://192.168.10.191:1234", "target-model", 262144)
+	plan := &reconcile.Plan{
+		ResourceType: lmsModelStateType,
+		Actions: []reconcile.Action{{
+			Action:       reconcile.ActionUpdate,
+			ResourceType: lmsModelStateType,
+			Name:         p.name + "/load",
+			Details: map[string]any{
+				"model":          "target-model",
+				"context_length": 262144,
+				"parallel":       4,
+			},
+		}},
+	}
+	results, err := p.ApplyPlan(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("ApplyPlan: %v", err)
+	}
+	if len(results) != 1 || results[0].Status != reconcile.ApplySucceeded {
+		t.Fatalf("expected one succeeded result, got %#v", results)
+	}
+	log := readActuatorLog(t, p.actuatorScript)
+	// argv assertions: op, host, port, model, context-length, parallel.
+	for _, want := range []string{
+		"load", "--host 192.168.10.191", "--port 1234",
+		"--model target-model", "--context-length 262144", "--parallel 4",
+	} {
+		if !strings.Contains(log, want) {
+			t.Errorf("actuator argv missing %q; log:\n%s", want, log)
+		}
+	}
+	// Token must arrive via ENV, never argv.
+	if !strings.Contains(log, "TOKEN: tok") {
+		t.Errorf("token not passed via LMS_ACTUATOR_TOKEN env; log:\n%s", log)
+	}
+	if strings.Contains(log, "tok") && strings.Contains(log, "ARGV:") {
+		argvLine := firstLine(log, "ARGV:")
+		if strings.Contains(argvLine, "tok") {
+			t.Errorf("token leaked into argv: %q", argvLine)
+		}
+	}
+}
+
+func TestApplyPlanContextActionUsesSetContext(t *testing.T) {
+	p := makeLMSProvider(t, "http://192.168.10.191:1234", "target-model", 262144)
+	plan := &reconcile.Plan{
+		ResourceType: lmsModelStateType,
+		Actions: []reconcile.Action{{
+			Action: reconcile.ActionUpdate,
+			Name:   p.name + "/context",
+			Details: map[string]any{
+				"model":          "target-model",
+				"context_length": 262144,
+			},
+		}},
+	}
+	if _, err := p.ApplyPlan(context.Background(), plan); err != nil {
+		t.Fatalf("ApplyPlan: %v", err)
+	}
+	log := readActuatorLog(t, p.actuatorScript)
+	if !strings.Contains(log, "set-context") {
+		t.Errorf("context action should invoke set-context; log:\n%s", log)
+	}
+}
+
+// ── construction / parsing ─────────────────────────────────────────────────────
+
+func TestParseModelStateOptions(t *testing.T) {
+	opts := map[string]interface{}{
+		"model_state": map[string]interface{}{
+			"manage":         true,
+			"model":          "m",
+			"context_length": 262144,
+			"parallel":       4,
+			"keep_warm":      true,
+			"jit_evict":      false,
+		},
+	}
+	c := parseModelStateOptions(opts)
+	if !c.Manage || c.Model != "m" || c.ContextLength != 262144 || c.Parallel != 4 || !c.KeepWarm || c.JITEvict {
+		t.Fatalf("parse mismatch: %#v", c)
+	}
+}
+
+func TestLocalDetection(t *testing.T) {
+	cfg := ProviderConfig{Endpoint: "http://127.0.0.1:1234", Options: map[string]interface{}{
+		"model_state": map[string]interface{}{"manage": true, "model": "m"},
+	}}
+	p, _ := newLMSModelStateProvider("x", cfg, "", "")
+	if !p.local {
+		t.Errorf("127.0.0.1 should be detected as local")
+	}
+	cfg.Endpoint = "http://192.168.10.191:1234"
+	p2, _ := newLMSModelStateProvider("x", cfg, "", "")
+	if p2.local {
+		t.Errorf("192.168.10.191 should NOT be local")
+	}
+	if p2.host != "192.168.10.191" || p2.port != 1234 {
+		t.Errorf("host/port parse: got %s:%d", p2.host, p2.port)
+	}
+	if p2.wsURL != "ws://192.168.10.191:1234" {
+		t.Errorf("wsURL: got %s", p2.wsURL)
+	}
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────────
+
+func ip(v int) *int { return &v }
+
+func mustFetch(t *testing.T, p *LMSModelStateProvider) {
+	t.Helper()
+	if _, err := p.FetchLive(context.Background(), nil); err != nil {
+		t.Fatalf("FetchLive: %v", err)
+	}
+}
+
+func assertHealth(t *testing.T, h reconcile.ResourceStatus, sync reconcile.SyncStatus, health reconcile.HealthStatus) {
+	t.Helper()
+	if h.Sync != sync || h.Health != health {
+		t.Fatalf("health: got (%s,%s), want (%s,%s): %s", h.Sync, h.Health, sync, health, h.Message)
+	}
+}
+
+func firstLine(s, prefix string) string {
+	for _, line := range strings.Split(s, "\n") {
+		if strings.HasPrefix(line, prefix) {
+			return line
+		}
+	}
+	return ""
+}
+
+// Guard: this file must compile on all platforms (no darwin-only deps).
+var _ = runtime.GOOS
+var _ = fmt.Sprint

--- a/internal/engine/provider_lms_model_state_test.go
+++ b/internal/engine/provider_lms_model_state_test.go
@@ -338,7 +338,6 @@ func TestApplyPlanInvokesActuatorWithArgvAndEnv(t *testing.T) {
 			Details: map[string]any{
 				"model":          "target-model",
 				"context_length": 262144,
-				"parallel":       4,
 			},
 		}},
 	}
@@ -350,10 +349,12 @@ func TestApplyPlanInvokesActuatorWithArgvAndEnv(t *testing.T) {
 		t.Fatalf("expected one succeeded result, got %#v", results)
 	}
 	log := readActuatorLog(t, p.actuatorScript)
-	// argv assertions: op, host, port, model, context-length, parallel.
+	// argv assertions: op, host, port, model, context-length.
+	// NOTE: --parallel is intentionally absent: LM Studio's SDK load config has no
+	// per-load parallelism knob, so the actuator does not accept/forward it.
 	for _, want := range []string{
 		"load", "--host 192.168.10.191", "--port 1234",
-		"--model target-model", "--context-length 262144", "--parallel 4",
+		"--model target-model", "--context-length 262144",
 	} {
 		if !strings.Contains(log, want) {
 			t.Errorf("actuator argv missing %q; log:\n%s", want, log)
@@ -368,6 +369,41 @@ func TestApplyPlanInvokesActuatorWithArgvAndEnv(t *testing.T) {
 		if strings.Contains(argvLine, "tok") {
 			t.Errorf("token leaked into argv: %q", argvLine)
 		}
+	}
+}
+
+// A future actuator footgun: prints {"ok":false} but exits 0 (dropped await /
+// swallowed catch). ApplyPlan must NOT report ApplySucceeded — the result-line
+// parse folds the actuator's error into an ApplyFailed.
+func TestApplyPlanFailsOnOkFalseWithZeroExit(t *testing.T) {
+	p := makeLMSProvider(t, "http://192.168.10.191:1234", "target-model", 262144)
+	dir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"echo '{\"ok\":false,\"error\":\"load timed out\"}'\n" +
+		"exit 0\n"
+	path := filepath.Join(dir, "fake-actuator-okfalse.sh")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake actuator: %v", err)
+	}
+	p.actuatorScript = path
+
+	plan := &reconcile.Plan{
+		ResourceType: lmsModelStateType,
+		Actions: []reconcile.Action{{
+			Action:  reconcile.ActionUpdate,
+			Name:    p.name + "/load",
+			Details: map[string]any{"model": "target-model", "context_length": 262144},
+		}},
+	}
+	results, err := p.ApplyPlan(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("ApplyPlan: %v", err)
+	}
+	if len(results) != 1 || results[0].Status != reconcile.ApplyFailed {
+		t.Fatalf("expected ApplyFailed on ok=false/exit-0, got %#v", results)
+	}
+	if !strings.Contains(results[0].Error, "load timed out") {
+		t.Errorf("expected actuator error folded into result, got %q", results[0].Error)
 	}
 }
 

--- a/internal/engine/router.go
+++ b/internal/engine/router.go
@@ -827,6 +827,12 @@ func makeProvider(name string, pc ProviderConfig, procMgr *ProcessManager) (Prov
 	// management, mirroring mlx-supervised. See docs/inference/vllm.md and
 	// the ollama-to-vllm-migration-plan cogdoc.
 	case "openai-compat", "openai", "lmstudio", "vllm", "llamacpp":
+		// Opt-in: if this backend declares options.model_state.manage:true,
+		// register a companion lms-model-state reconciler in the global
+		// reconcile registry so the autonomic ticker can keep the declared
+		// model loaded at the declared context. The dispatch provider itself is
+		// unchanged — this is an orthogonal, OFF-BY-DEFAULT concern.
+		maybeRegisterModelStateReconciler(name, pc)
 		return NewOpenAICompatProvider(name, pc), nil
 	case "claude-code":
 		if procMgr == nil {
@@ -886,6 +892,35 @@ func makeProvider(name string, pc ProviderConfig, procMgr *ProcessManager) (Prov
 	default:
 		return nil, fmt.Errorf("unknown provider type %q", t)
 	}
+}
+
+// maybeRegisterModelStateReconciler registers a companion lms-model-state
+// reconciler for an OpenAI-compatible backend IFF it opts in via
+// options.model_state.manage:true. This is the OPT-IN, OFF-BY-DEFAULT guardrail:
+// absent the block (or with manage:false) nothing is registered and the kernel
+// reconciles no model state on this backend.
+//
+// The token is pulled from the same api_key_env the dispatch provider uses.
+// UpsertProvider allows safe re-registration across BuildRouter calls.
+func maybeRegisterModelStateReconciler(name string, pc ProviderConfig) {
+	ms := parseModelStateOptions(pc.Options)
+	if !ms.Manage {
+		return
+	}
+	token := ""
+	if pc.APIKeyEnv != "" {
+		token = os.Getenv(pc.APIKeyEnv)
+	}
+	// Workspace root is injected later via LoadConfig (reconcile daemon path);
+	// pass "" here and let the provider resolve the actuator best-effort.
+	msp, err := newLMSModelStateProvider(name, pc, token, "")
+	if err != nil {
+		slog.Warn("router: lms-model-state reconciler construction failed", "name", name, "err", err)
+		return
+	}
+	reconcile.UpsertProvider(lmsModelStateType+"/"+name, msp)
+	slog.Info("router: registered lms-model-state reconciler in reconcile registry",
+		"name", name, "model", ms.Model, "context_length", ms.ContextLength)
 }
 
 // probeLocalBackend probes LM Studio (:1234) then Ollama (:11434) with a

--- a/internal/engine/router.go
+++ b/internal/engine/router.go
@@ -907,6 +907,20 @@ func maybeRegisterModelStateReconciler(name string, pc ProviderConfig) {
 	if !ms.Manage {
 		return
 	}
+	// liveState comes from LM Studio's native /api/v0/models, served only by LM
+	// Studio backends. vllm/llamacpp share the "openai" dispatch case but have no
+	// /api/v0 endpoint, so a model_state block copied onto one would register a
+	// reconciler that can only ever probe-fail. Restrict to LM-Studio-capable
+	// types (a generic "openai" that is really vllm would still degrade to
+	// Suspended, but excluding the explicit vllm/llamacpp types avoids the footgun).
+	switch pc.Type {
+	case "lmstudio", "openai", "openai-compat":
+		// may serve /api/v0/models
+	default:
+		slog.Debug("router: lms-model-state not applicable for provider type; skipping",
+			"name", name, "type", pc.Type)
+		return
+	}
 	token := ""
 	if pc.APIKeyEnv != "" {
 		token = os.Getenv(pc.APIKeyEnv)

--- a/internal/providers/daemon/lms_model_state.go
+++ b/internal/providers/daemon/lms_model_state.go
@@ -68,9 +68,13 @@ func (p *lmsModelStateProvider) Health() reconcile.ResourceStatus {
 	defer cancel()
 
 	var issues []string
+	var anyProgressing bool
 	for _, e := range entries {
-		if err := probeModelStateEntry(ctx, e); err != nil {
+		progressing, err := probeModelStateEntry(ctx, e)
+		if err != nil {
 			issues = append(issues, fmt.Sprintf("%s: %v", e.name, err))
+		} else if progressing {
+			anyProgressing = true
 		}
 	}
 
@@ -83,6 +87,18 @@ func (p *lmsModelStateProvider) Health() reconcile.ResourceStatus {
 			Health:    reconcile.HealthDegraded,
 			Operation: reconcile.OperationIdle,
 			Message:   strings.Join(issues, "; "),
+		}
+	}
+
+	if anyProgressing {
+		// A managed model is mid-load (state=="loading"). That is Progressing, not
+		// a problem — a high-context load can take minutes. Matches the engine
+		// provider's loading→Progressing mapping so proprioception doesn't false-alarm.
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusUnknown,
+			Health:    reconcile.HealthProgressing,
+			Operation: reconcile.OperationWaiting,
+			Message:   "model load in progress",
 		}
 	}
 
@@ -179,9 +195,16 @@ func parseModelStateEntriesFromYAML(data []byte) []modelStateEntry {
 	return entries
 }
 
-// probeModelStateEntry checks one backend: read /api/v0/models and confirm the
-// declared model is loaded at the declared context length. Read-only.
-func probeModelStateEntry(ctx context.Context, e modelStateEntry) error {
+// probeModelStateEntry checks one backend: read /api/v0/models and report whether
+// the declared model is loaded at the declared context. Read-only.
+//
+// Returns (progressing, err). progressing==true means the model is mid-load
+// (state=="loading"), which is Progressing — NOT a health issue: a high-context
+// load can take minutes and must never read as Degraded. A non-nil err is a real
+// problem (unreachable / wrong context / not loaded / absent). Mirrors the engine
+// provider's findModelRow (prefer the state=="loaded" row) and ComputePlan
+// (loading is not drift) so the daemon proprioception matches the engine's Health().
+func probeModelStateEntry(ctx context.Context, e modelStateEntry) (bool, error) {
 	base := strings.TrimRight(e.endpoint, "/")
 	if base == "" {
 		base = "http://localhost:1234"
@@ -189,7 +212,7 @@ func probeModelStateEntry(ctx context.Context, e modelStateEntry) error {
 	url := base + "/api/v0/models"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return fmt.Errorf("build request: %w", err)
+		return false, fmt.Errorf("build request: %w", err)
 	}
 	if e.apiKeyEnv != "" {
 		if tok := os.Getenv(e.apiKeyEnv); tok != "" {
@@ -199,11 +222,11 @@ func probeModelStateEntry(ctx context.Context, e modelStateEntry) error {
 	client := &http.Client{Timeout: 3 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("unreachable: %v", err)
+		return false, fmt.Errorf("unreachable: %v", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("/api/v0/models returned %d", resp.StatusCode)
+		return false, fmt.Errorf("/api/v0/models returned %d", resp.StatusCode)
 	}
 
 	var out struct {
@@ -214,24 +237,49 @@ func probeModelStateEntry(ctx context.Context, e modelStateEntry) error {
 		} `json:"data"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		return fmt.Errorf("decode: %w", err)
+		return false, fmt.Errorf("decode: %w", err)
 	}
 
-	for _, m := range out.Data {
+	// Collect id-matching rows, preferring state=="loaded" so a not-loaded/loading
+	// duplicate row cannot shadow the real loaded one (LM Studio can return both).
+	loadedIdx, loadingIdx, otherIdx := -1, -1, -1
+	for i := range out.Data {
+		m := out.Data[i]
 		if m.ID != e.model && !strings.HasPrefix(m.ID, e.model) && !strings.HasPrefix(e.model, m.ID) {
 			continue
 		}
-		if m.State != "loaded" {
-			return fmt.Errorf("model %q state=%q (want loaded)", e.model, m.State)
+		switch m.State {
+		case "loaded":
+			if loadedIdx == -1 {
+				loadedIdx = i
+			}
+		case "loading":
+			if loadingIdx == -1 {
+				loadingIdx = i
+			}
+		default:
+			if otherIdx == -1 {
+				otherIdx = i
+			}
 		}
+	}
+
+	switch {
+	case loadedIdx != -1:
+		m := out.Data[loadedIdx]
 		if e.contextLength > 0 && (m.LoadedContextLength == nil || *m.LoadedContextLength != e.contextLength) {
 			got := "null"
 			if m.LoadedContextLength != nil {
 				got = fmt.Sprintf("%d", *m.LoadedContextLength)
 			}
-			return fmt.Errorf("model %q loaded at context %s (want %d)", e.model, got, e.contextLength)
+			return false, fmt.Errorf("model %q loaded at context %s (want %d)", e.model, got, e.contextLength)
 		}
-		return nil
+		return false, nil
+	case loadingIdx != -1:
+		return true, nil // mid-load — Progressing, not an issue
+	case otherIdx != -1:
+		return false, fmt.Errorf("model %q state=%q (want loaded)", e.model, out.Data[otherIdx].State)
+	default:
+		return false, fmt.Errorf("model %q not present", e.model)
 	}
-	return fmt.Errorf("model %q not present", e.model)
 }

--- a/internal/providers/daemon/lms_model_state.go
+++ b/internal/providers/daemon/lms_model_state.go
@@ -1,0 +1,237 @@
+// lms_model_state.go — daemon-side health provider for the LM Studio
+// model/context-state reconciler.
+//
+// lmsModelStateProvider implements reconcile.Reconcilable for the daemon's
+// proprioception block. It scans providers(.local).yaml for any dispatch backend
+// carrying an options.model_state block with manage:true. For each managed
+// backend it performs a read-only GET /api/v0/models probe and reports whether
+// the declared model is loaded at the declared context length.
+//
+// If no backend opts in (no model_state.manage:true), Health() returns
+// HealthSuspended (NOT HealthMissing) — this is an opt-in feature, not a missing
+// requirement. This mirrors mlx_inference.go's precedent exactly.
+//
+// GUARDRAILS: this daemon stub is Health()-only and strictly read-only. It never
+// loads or unloads a model. Full plan/apply lives in the engine-layer
+// LMSModelStateProvider (constructed by BuildRouter). The daemon only exercises
+// Health() through the proprioception block.
+//
+// Registration: init() registers this provider as "lms-model-state" so the
+// providers/all import chain triggers it automatically.
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/myrgic/cogos/pkg/substrate/reconcile"
+)
+
+func init() {
+	reconcile.RegisterProvider("lms-model-state", &lmsModelStateProvider{stubMethods: stubMethods{name: "lms-model-state"}})
+}
+
+// lmsModelStateProvider is the daemon-side Reconcilable for LM Studio model-state.
+type lmsModelStateProvider struct {
+	stubMethods
+}
+
+func (p *lmsModelStateProvider) Type() string { return "lms-model-state" }
+
+// Health inspects all opted-in backends and returns the aggregate status.
+// Called by buildHealthBlock on every foveated context generation; kept cheap.
+func (p *lmsModelStateProvider) Health() reconcile.ResourceStatus {
+	root, bad := resolveRoot()
+	if bad != nil {
+		return *bad
+	}
+
+	entries := loadModelStateEntries(root)
+	if len(entries) == 0 {
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusUnknown,
+			Health:    reconcile.HealthSuspended,
+			Operation: reconcile.OperationIdle,
+			Message:   "no backend declares options.model_state.manage:true — opt-in feature",
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+
+	var issues []string
+	for _, e := range entries {
+		if err := probeModelStateEntry(ctx, e); err != nil {
+			issues = append(issues, fmt.Sprintf("%s: %v", e.name, err))
+		}
+	}
+
+	if len(issues) > 0 {
+		// Unreachable/off-LAN and drift both land here as OutOfSync. The engine
+		// provider distinguishes Suspended-vs-Degraded on the live path; the
+		// daemon stub only reports a coarse aggregate for proprioception.
+		return reconcile.ResourceStatus{
+			Sync:      reconcile.SyncStatusOutOfSync,
+			Health:    reconcile.HealthDegraded,
+			Operation: reconcile.OperationIdle,
+			Message:   strings.Join(issues, "; "),
+		}
+	}
+
+	noun := "backend"
+	if len(entries) != 1 {
+		noun = "backends"
+	}
+	return reconcile.ResourceStatus{
+		Sync:      reconcile.SyncStatusSynced,
+		Health:    reconcile.HealthHealthy,
+		Operation: reconcile.OperationIdle,
+		Message:   fmt.Sprintf("%d model_state %s at target", len(entries), noun),
+	}
+}
+
+// modelStateEntry is the minimal config needed for a daemon-side health probe.
+type modelStateEntry struct {
+	name          string
+	endpoint      string
+	apiKeyEnv     string
+	model         string
+	contextLength int
+}
+
+// loadModelStateEntries reads providers(.local).yaml and returns entries whose
+// options.model_state.manage is true. providers.local.yaml overlays the base.
+func loadModelStateEntries(root string) []modelStateEntry {
+	var result []modelStateEntry
+
+	for _, filename := range []string{"providers.yaml", "providers.local.yaml"} {
+		path := filepath.Join(root, ".cog", "config", filename)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		entries := parseModelStateEntriesFromYAML(data)
+		existing := make(map[string]int, len(result))
+		for i, e := range result {
+			existing[e.name] = i
+		}
+		for _, e := range entries {
+			if idx, ok := existing[e.name]; ok {
+				result[idx] = e
+			} else {
+				result = append(result, e)
+				existing[e.name] = len(result) - 1
+			}
+		}
+	}
+	return result
+}
+
+// msProviderFileCfg is the top-level shape used for the daemon-side model_state
+// parse. Only fields relevant to the probe are decoded.
+type msProviderFileCfg struct {
+	Providers map[string]msProviderEntryCfg `yaml:"providers"`
+}
+
+type msProviderEntryCfg struct {
+	Endpoint  string        `yaml:"endpoint"`
+	APIKeyEnv string        `yaml:"api_key_env"`
+	Options   msOptionsCfg  `yaml:"options"`
+}
+
+type msOptionsCfg struct {
+	ModelState msModelStateCfg `yaml:"model_state"`
+}
+
+type msModelStateCfg struct {
+	Manage        bool   `yaml:"manage"`
+	Model         string `yaml:"model"`
+	ContextLength int    `yaml:"context_length"`
+}
+
+// parseModelStateEntriesFromYAML returns entries with model_state.manage:true.
+func parseModelStateEntriesFromYAML(data []byte) []modelStateEntry {
+	var cfg msProviderFileCfg
+	if err := yaml.Unmarshal(data, &cfg); err != nil || cfg.Providers == nil {
+		return nil
+	}
+	var entries []modelStateEntry
+	for name, p := range cfg.Providers {
+		if !p.Options.ModelState.Manage {
+			continue
+		}
+		entries = append(entries, modelStateEntry{
+			name:          name,
+			endpoint:      p.Endpoint,
+			apiKeyEnv:     p.APIKeyEnv,
+			model:         p.Options.ModelState.Model,
+			contextLength: p.Options.ModelState.ContextLength,
+		})
+	}
+	return entries
+}
+
+// probeModelStateEntry checks one backend: read /api/v0/models and confirm the
+// declared model is loaded at the declared context length. Read-only.
+func probeModelStateEntry(ctx context.Context, e modelStateEntry) error {
+	base := strings.TrimRight(e.endpoint, "/")
+	if base == "" {
+		base = "http://localhost:1234"
+	}
+	url := base + "/api/v0/models"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	if e.apiKeyEnv != "" {
+		if tok := os.Getenv(e.apiKeyEnv); tok != "" {
+			req.Header.Set("Authorization", "Bearer "+tok)
+		}
+	}
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("unreachable: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("/api/v0/models returned %d", resp.StatusCode)
+	}
+
+	var out struct {
+		Data []struct {
+			ID                  string `json:"id"`
+			State               string `json:"state"`
+			LoadedContextLength *int   `json:"loaded_context_length"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return fmt.Errorf("decode: %w", err)
+	}
+
+	for _, m := range out.Data {
+		if m.ID != e.model && !strings.HasPrefix(m.ID, e.model) && !strings.HasPrefix(e.model, m.ID) {
+			continue
+		}
+		if m.State != "loaded" {
+			return fmt.Errorf("model %q state=%q (want loaded)", e.model, m.State)
+		}
+		if e.contextLength > 0 && (m.LoadedContextLength == nil || *m.LoadedContextLength != e.contextLength) {
+			got := "null"
+			if m.LoadedContextLength != nil {
+				got = fmt.Sprintf("%d", *m.LoadedContextLength)
+			}
+			return fmt.Errorf("model %q loaded at context %s (want %d)", e.model, got, e.contextLength)
+		}
+		return nil
+	}
+	return fmt.Errorf("model %q not present", e.model)
+}

--- a/internal/providers/daemon/lms_model_state.go
+++ b/internal/providers/daemon/lms_model_state.go
@@ -142,9 +142,9 @@ type msProviderFileCfg struct {
 }
 
 type msProviderEntryCfg struct {
-	Endpoint  string        `yaml:"endpoint"`
-	APIKeyEnv string        `yaml:"api_key_env"`
-	Options   msOptionsCfg  `yaml:"options"`
+	Endpoint  string       `yaml:"endpoint"`
+	APIKeyEnv string       `yaml:"api_key_env"`
+	Options   msOptionsCfg `yaml:"options"`
 }
 
 type msOptionsCfg struct {

--- a/internal/providers/daemon/lms_model_state_test.go
+++ b/internal/providers/daemon/lms_model_state_test.go
@@ -1,15 +1,80 @@
 // lms_model_state_test.go — unit tests for the daemon-side lms-model-state provider.
 //
-// Whitebox (package daemon). Exercises the model_state YAML parser and the
-// opt-in Health() gate. No live LM Studio; the network probe is not exercised
-// here (Health() over a real backend lives in the engine-layer tests).
+// Whitebox (package daemon). Exercises the model_state YAML parser, the opt-in
+// Health() gate, and the /api/v0/models probe (loading→progressing, prefer the
+// loaded row over a not-loaded duplicate) via httptest.
 package daemon
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/myrgic/cogos/pkg/substrate/reconcile"
 )
+
+// ── probeModelStateEntry: HTTP path (loading + duplicate-row ordering) ───────────
+
+type msRow struct {
+	ID    string `json:"id"`
+	State string `json:"state"`
+	Ctx   *int   `json:"loaded_context_length"`
+}
+
+func msIntp(n int) *int { return &n }
+
+func msModelsServer(t *testing.T, rows ...msRow) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v0/models" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": rows})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestProbeModelStateEntry_LoadingIsProgressingNotError(t *testing.T) {
+	// A model mid-load (state=="loading", nil context) must report progressing,
+	// NOT a Degraded-inducing error — a high-context load can take minutes.
+	srv := msModelsServer(t, msRow{ID: "target", State: "loading", Ctx: nil})
+	e := modelStateEntry{name: "b", endpoint: srv.URL, model: "target", contextLength: 262144}
+	progressing, err := probeModelStateEntry(context.Background(), e)
+	if err != nil {
+		t.Fatalf("loading must not be an error, got %v", err)
+	}
+	if !progressing {
+		t.Fatalf("loading must report progressing=true")
+	}
+}
+
+func TestProbeModelStateEntry_PrefersLoadedOverDuplicate(t *testing.T) {
+	// A not-loaded duplicate ordered BEFORE the loaded row must not shadow it.
+	srv := msModelsServer(t,
+		msRow{ID: "target", State: "not-loaded", Ctx: nil},
+		msRow{ID: "target", State: "loaded", Ctx: msIntp(262144)},
+	)
+	e := modelStateEntry{name: "b", endpoint: srv.URL, model: "target", contextLength: 262144}
+	progressing, err := probeModelStateEntry(context.Background(), e)
+	if err != nil {
+		t.Fatalf("loaded duplicate must satisfy the probe, got %v", err)
+	}
+	if progressing {
+		t.Fatalf("loaded-at-target must not report progressing")
+	}
+}
+
+func TestProbeModelStateEntry_WrongContextIsError(t *testing.T) {
+	srv := msModelsServer(t, msRow{ID: "target", State: "loaded", Ctx: msIntp(65536)})
+	e := modelStateEntry{name: "b", endpoint: srv.URL, model: "target", contextLength: 262144}
+	if _, err := probeModelStateEntry(context.Background(), e); err == nil {
+		t.Fatalf("wrong loaded context must be an error")
+	}
+}
 
 // ── parseModelStateEntriesFromYAML ──────────────────────────────────────────────
 

--- a/internal/providers/daemon/lms_model_state_test.go
+++ b/internal/providers/daemon/lms_model_state_test.go
@@ -1,0 +1,111 @@
+// lms_model_state_test.go — unit tests for the daemon-side lms-model-state provider.
+//
+// Whitebox (package daemon). Exercises the model_state YAML parser and the
+// opt-in Health() gate. No live LM Studio; the network probe is not exercised
+// here (Health() over a real backend lives in the engine-layer tests).
+package daemon
+
+import (
+	"testing"
+
+	"github.com/myrgic/cogos/pkg/substrate/reconcile"
+)
+
+// ── parseModelStateEntriesFromYAML ──────────────────────────────────────────────
+
+func TestParseModelStateEntries_Empty(t *testing.T) {
+	t.Parallel()
+	if got := parseModelStateEntriesFromYAML([]byte("")); len(got) != 0 {
+		t.Errorf("empty YAML: got %d; want 0", len(got))
+	}
+}
+
+func TestParseModelStateEntries_NoOptIn(t *testing.T) {
+	t.Parallel()
+	// A backend with no model_state, and one with manage:false — neither opts in.
+	yaml := `providers:
+  lmstudio:
+    type: lmstudio
+    endpoint: http://localhost:1234
+    model: some-model
+  eclipse:
+    type: openai
+    endpoint: http://192.168.10.191:1234
+    options:
+      model_state:
+        manage: false
+        model: ornith-1.0-35b
+`
+	got := parseModelStateEntriesFromYAML([]byte(yaml))
+	if len(got) != 0 {
+		t.Errorf("no opt-in: got %d; want 0", len(got))
+	}
+}
+
+func TestParseModelStateEntries_OptIn(t *testing.T) {
+	t.Parallel()
+	yaml := `providers:
+  eclipse:
+    type: openai
+    endpoint: http://192.168.10.191:1234
+    api_key_env: ECLIPSE_API_KEY
+    options:
+      model_state:
+        manage: true
+        model: ornith-1.0-35b
+        context_length: 262144
+`
+	got := parseModelStateEntriesFromYAML([]byte(yaml))
+	if len(got) != 1 {
+		t.Fatalf("got %d; want 1", len(got))
+	}
+	e := got[0]
+	if e.name != "eclipse" {
+		t.Errorf("name: got %q", e.name)
+	}
+	if e.endpoint != "http://192.168.10.191:1234" {
+		t.Errorf("endpoint: got %q", e.endpoint)
+	}
+	if e.apiKeyEnv != "ECLIPSE_API_KEY" {
+		t.Errorf("apiKeyEnv: got %q", e.apiKeyEnv)
+	}
+	if e.model != "ornith-1.0-35b" {
+		t.Errorf("model: got %q", e.model)
+	}
+	if e.contextLength != 262144 {
+		t.Errorf("contextLength: got %d; want 262144", e.contextLength)
+	}
+}
+
+func TestParseModelStateEntries_MalformedYAML(t *testing.T) {
+	t.Parallel()
+	if got := parseModelStateEntriesFromYAML([]byte("::: not yaml :::")); len(got) != 0 {
+		t.Errorf("malformed YAML: got %d; want 0", len(got))
+	}
+}
+
+// ── Health opt-in gate ──────────────────────────────────────────────────────────
+
+// TestHealthSuspendedWhenNoWorkspace: with no workspace root configured, the
+// stub reports Missing (workspace not configured) — a distinct pre-condition.
+// With a workspace root but no opted-in backend, it reports Suspended.
+func TestHealthSuspendedWhenNoOptIn(t *testing.T) {
+	// Set an empty temp workspace (no providers files) so resolveRoot passes but
+	// loadModelStateEntries finds nothing.
+	SetWorkspaceRoot(t.TempDir())
+	t.Cleanup(func() { SetWorkspaceRoot("") })
+
+	p := &lmsModelStateProvider{stubMethods: stubMethods{name: "lms-model-state"}}
+	h := p.Health()
+	if h.Health != reconcile.HealthSuspended {
+		t.Fatalf("no opt-in ⇒ Suspended; got %s (%s)", h.Health, h.Message)
+	}
+}
+
+func TestType(t *testing.T) {
+	t.Parallel()
+	p := &lmsModelStateProvider{stubMethods: stubMethods{name: "lms-model-state"}}
+	if p.Type() != "lms-model-state" {
+		t.Errorf("Type: got %q", p.Type())
+	}
+}

--- a/scripts/lms-actuator/.gitignore
+++ b/scripts/lms-actuator/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/scripts/lms-actuator/README.md
+++ b/scripts/lms-actuator/README.md
@@ -1,0 +1,39 @@
+# lms-actuator
+
+The mutating half of the CogOS `lms-model-state` reconciler (ADR-103). It
+load/unload/re-loads LM Studio models at a target context length over the
+`@lmstudio/sdk` websocket bridge, on behalf of
+`internal/engine/provider_lms_model_state.go`'s `ApplyPlan`.
+
+## Setup
+
+```bash
+npm install
+```
+
+## Usage
+
+```bash
+node lms-actuator.mjs <load|unload|set-context|list> \
+     --host <ip> --port 1234 --model <id> \
+     [--context-length N] [--parallel P] [--ttl SECONDS] [--dry-run]
+```
+
+- Auth token is read from the `LMS_ACTUATOR_TOKEN` environment variable and
+  threaded to the SDK as `clientPasskey` — **never** passed on argv.
+- `list` is read-only (lists loaded models) and `--dry-run` resolves + prints the
+  plan without issuing any load/unload. Both are safe against a live backend and
+  are used for connection self-tests.
+- Output is a single JSON line on stdout.
+
+## Testing without a live backend
+
+`mock-lms-server.mjs` is a minimal websocket mock that completes the SDK auth
+handshake and answers a read-only `listLoaded` — enough to prove the actuator can
+connect and dispatch a read-only op without touching a real LM Studio instance:
+
+```bash
+MOCK_PORT=14577 node mock-lms-server.mjs &
+LMS_ACTUATOR_TOKEN=test node lms-actuator.mjs list --host 127.0.0.1 --port 14577
+# → {"ok":true,"op":"list","loaded":[]}
+```

--- a/scripts/lms-actuator/README.md
+++ b/scripts/lms-actuator/README.md
@@ -16,7 +16,7 @@ npm install
 ```bash
 node lms-actuator.mjs <load|unload|set-context|list> \
      --host <ip> --port 1234 --model <id> \
-     [--context-length N] [--parallel P] [--ttl SECONDS] [--dry-run]
+     [--context-length N] [--ttl SECONDS] [--dry-run]
 ```
 
 - Auth token is read from the `LMS_ACTUATOR_TOKEN` environment variable and

--- a/scripts/lms-actuator/README.md
+++ b/scripts/lms-actuator/README.md
@@ -1,6 +1,6 @@
 # lms-actuator
 
-The mutating half of the CogOS `lms-model-state` reconciler (ADR-103). It
+The mutating half of the CogOS `lms-model-state` reconciler (ADR-104). It
 load/unload/re-loads LM Studio models at a target context length over the
 `@lmstudio/sdk` websocket bridge, on behalf of
 `internal/engine/provider_lms_model_state.go`'s `ApplyPlan`.

--- a/scripts/lms-actuator/lms-actuator.mjs
+++ b/scripts/lms-actuator/lms-actuator.mjs
@@ -9,7 +9,7 @@
 // Usage:
 //   node lms-actuator.mjs <load|unload|set-context> \
 //        --host <ip> --port <1234> --model <id> \
-//        [--context-length N] [--parallel P] [--ttl SECONDS] [--dry-run]
+//        [--context-length N] [--ttl SECONDS] [--dry-run]
 //
 // Auth: the LM Studio remote-access passkey/token is read from the environment
 // variable LMS_ACTUATOR_TOKEN (never passed on argv). It is threaded to the SDK

--- a/scripts/lms-actuator/lms-actuator.mjs
+++ b/scripts/lms-actuator/lms-actuator.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+// lms-actuator.mjs — CogOS lms-model-state actuator.
+//
+// The mutating half of the lms-model-state reconciler. The Go engine provider
+// (internal/engine/provider_lms_model_state.go) computes a plan from a read-only
+// probe and, on a drift action, execs this script to load / unload / re-load a
+// model at a target context length over the @lmstudio/sdk websocket bridge.
+//
+// Usage:
+//   node lms-actuator.mjs <load|unload|set-context> \
+//        --host <ip> --port <1234> --model <id> \
+//        [--context-length N] [--parallel P] [--ttl SECONDS] [--dry-run]
+//
+// Auth: the LM Studio remote-access passkey/token is read from the environment
+// variable LMS_ACTUATOR_TOKEN (never passed on argv). It is threaded to the SDK
+// as clientPasskey, which is how LM Studio's remote-access gate authenticates a
+// websocket client.
+//
+// Verbs:
+//   load         — ensure <model> is loaded (at --context-length if given)
+//   set-context  — LM Studio has no live context resize, so this is unload+load
+//                  at the new context length
+//   unload       — unload <model>
+//   list         — READ-ONLY: print the currently loaded models as JSON and exit
+//                  (used by the connection self-test; never mutates)
+//
+// Output: a single JSON line on stdout, e.g.
+//   {"ok":true,"op":"load","model":"...","contextLength":262144}
+// On failure: {"ok":false,"op":"...","error":"..."} and a non-zero exit code.
+//
+// GUARDRAIL: pass --dry-run to resolve the client + connect + print the plan
+// WITHOUT issuing any load/unload. The Go test harness and the operator's
+// live-verification step use --dry-run (and the `list` verb) so no real load is
+// ever triggered against a live backend during automated runs.
+
+import { LMStudioClient } from "@lmstudio/sdk";
+
+function parseArgs(argv) {
+  const args = { _: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith("--")) {
+        args[key] = true; // boolean flag
+      } else {
+        args[key] = next;
+        i++;
+      }
+    } else {
+      args._.push(a);
+    }
+  }
+  return args;
+}
+
+function emit(obj, code = 0) {
+  process.stdout.write(JSON.stringify(obj) + "\n");
+  process.exit(code);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const op = args._[0];
+
+  if (!op || !["load", "unload", "set-context", "list"].includes(op)) {
+    emit({ ok: false, error: `unknown or missing op: ${op ?? "<none>"}` }, 2);
+  }
+
+  const host = args.host || "127.0.0.1";
+  const port = String(args.port || "1234");
+  const model = args.model;
+  const contextLength = args["context-length"]
+    ? parseInt(args["context-length"], 10)
+    : undefined;
+  const ttl = args.ttl ? parseInt(args.ttl, 10) : undefined;
+  const dryRun = Boolean(args["dry-run"]);
+  const token = process.env.LMS_ACTUATOR_TOKEN || "";
+
+  const baseUrl = `ws://${host}:${port}`;
+
+  // clientPasskey carries the remote-access token; clientIdentifier is a stable
+  // label so the operator can see which client is connected.
+  const clientOpts = {
+    baseUrl,
+    clientIdentifier: "cogos-lms-actuator",
+  };
+  if (token) {
+    clientOpts.clientPasskey = token;
+  }
+
+  let client;
+  try {
+    client = new LMStudioClient(clientOpts);
+  } catch (err) {
+    emit({ ok: false, op, error: `client init: ${err?.message ?? err}` }, 1);
+  }
+
+  // READ-ONLY verb: list loaded models. Also the connection self-test used by
+  // the test harness / operator verification (no mutation).
+  if (op === "list") {
+    try {
+      const loaded = await client.llm.listLoaded();
+      const ids = loaded.map((m) => m.identifier ?? m.modelKey ?? String(m));
+      emit({ ok: true, op: "list", baseUrl, loaded: ids });
+    } catch (err) {
+      emit({ ok: false, op: "list", baseUrl, error: err?.message ?? String(err) }, 1);
+    }
+  }
+
+  if (!model) {
+    emit({ ok: false, op, error: "missing --model" }, 2);
+  }
+
+  // GUARDRAIL: dry-run resolves everything and prints the plan but never issues
+  // a load/unload.
+  if (dryRun) {
+    emit({
+      ok: true,
+      op,
+      dryRun: true,
+      baseUrl,
+      model,
+      contextLength: contextLength ?? null,
+      ttl: ttl ?? null,
+      note: "dry-run: no load/unload issued",
+    });
+  }
+
+  try {
+    switch (op) {
+      case "unload": {
+        await client.llm.unload(model);
+        emit({ ok: true, op, model, baseUrl });
+        break;
+      }
+      case "set-context": {
+        // LM Studio has no live context resize: unload then reload at the new
+        // context length. Unload is best-effort (model may not be loaded yet).
+        try {
+          await client.llm.unload(model);
+        } catch (_) {
+          /* not loaded — proceed to load */
+        }
+        const cfg = {};
+        if (contextLength) cfg.contextLength = contextLength;
+        const opts = { config: cfg };
+        if (ttl) opts.ttl = ttl;
+        await client.llm.load(model, opts);
+        emit({ ok: true, op, model, contextLength: contextLength ?? null, baseUrl });
+        break;
+      }
+      case "load": {
+        const cfg = {};
+        if (contextLength) cfg.contextLength = contextLength;
+        const opts = { config: cfg };
+        if (ttl) opts.ttl = ttl;
+        await client.llm.load(model, opts);
+        emit({ ok: true, op, model, contextLength: contextLength ?? null, baseUrl });
+        break;
+      }
+      default:
+        emit({ ok: false, op, error: "unreachable" }, 2);
+    }
+  } catch (err) {
+    emit({ ok: false, op, model, baseUrl, error: err?.message ?? String(err) }, 1);
+  }
+}
+
+main().catch((err) => {
+  emit({ ok: false, error: `unhandled: ${err?.message ?? err}` }, 1);
+});

--- a/scripts/lms-actuator/mock-lms-server.mjs
+++ b/scripts/lms-actuator/mock-lms-server.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+// mock-lms-server.mjs — minimal LM Studio websocket mock for the actuator
+// connection self-test. It exists ONLY to prove that lms-actuator.mjs can:
+//   1. open a real ws:// connection (TCP + WS upgrade),
+//   2. send the @lmstudio/sdk auth frame ({authVersion, clientIdentifier,
+//      clientPasskey}) and be accepted,
+//   3. dispatch a READ-ONLY rpcCall (listLoaded) — captured and logged here.
+//
+// It is NOT a full LM Studio implementation. It never loads or unloads a model
+// (it has no models). This is the guardrail-compliant substitute for a live
+// backend: the actuator's mutating verbs are never exercised against it.
+//
+// Prints one JSON line per observed protocol event to stderr; on the first
+// listLoaded rpcCall it replies with an empty-array result and records success.
+
+import { WebSocketServer } from "ws";
+
+const port = parseInt(process.env.MOCK_PORT || "0", 10);
+const wss = new WebSocketServer({ port });
+
+const observed = { upgraded: false, authFrame: null, rpcCalls: [] };
+
+wss.on("listening", () => {
+  const addr = wss.address();
+  process.stderr.write(JSON.stringify({ event: "listening", port: addr.port }) + "\n");
+});
+
+wss.on("connection", (ws) => {
+  observed.upgraded = true;
+  process.stderr.write(JSON.stringify({ event: "connection" }) + "\n");
+
+  let authed = false;
+  ws.on("message", (raw) => {
+    let msg;
+    try {
+      msg = JSON.parse(raw.toString("utf-8"));
+    } catch (e) {
+      process.stderr.write(JSON.stringify({ event: "badjson", err: String(e) }) + "\n");
+      return;
+    }
+
+    // First frame is the auth handshake.
+    if (!authed && msg.authVersion !== undefined) {
+      observed.authFrame = {
+        authVersion: msg.authVersion,
+        clientIdentifier: msg.clientIdentifier,
+        hasPasskey: Boolean(msg.clientPasskey),
+      };
+      process.stderr.write(JSON.stringify({ event: "auth", frame: observed.authFrame }) + "\n");
+      authed = true;
+      ws.send(JSON.stringify({ success: true }));
+      return;
+    }
+
+    // Subsequent frames are transport messages. We care about rpcCall.
+    if (msg.type === "rpcCall") {
+      observed.rpcCalls.push(msg.endpoint);
+      process.stderr.write(
+        JSON.stringify({ event: "rpcCall", endpoint: msg.endpoint, callId: msg.callId }) + "\n"
+      );
+      // Reply with an empty-array result for listLoaded. The SDK's per-endpoint
+      // deserializer for listLoaded expects an array (Array<ModelInstanceInfo>);
+      // an empty array is the valid "no models loaded" response.
+      ws.send(
+        JSON.stringify({
+          type: "rpcResult",
+          callId: msg.callId,
+          result: [],
+        })
+      );
+    } else if (msg.type === "keepAlive") {
+      // ignore
+    }
+  });
+
+  ws.on("close", () => {
+    process.stderr.write(JSON.stringify({ event: "close", observed }) + "\n");
+  });
+});
+
+// Auto-exit after a short window so the test never hangs.
+setTimeout(() => {
+  process.stderr.write(JSON.stringify({ event: "timeout-exit", observed }) + "\n");
+  process.exit(0);
+}, 4000);

--- a/scripts/lms-actuator/package.json
+++ b/scripts/lms-actuator/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "cogos-lms-actuator",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "CogOS lms-model-state actuator — loads/unloads LM Studio models over the @lmstudio/sdk websocket bridge. Invoked by internal/engine/provider_lms_model_state.go ApplyPlan.",
+  "bin": {
+    "lms-actuator": "./lms-actuator.mjs"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@lmstudio/sdk": "^1.5.0"
+  }
+}


### PR DESCRIPTION
## Summary

Adds `lms-model-state`, a declarative reconciler for LM Studio loaded-model + context-length state — the
first reconciler that manages *which model is loaded at what context*, not just process health. Today LMS
model loading is imperative (a launchd `lms load` on the local node) with no declarative desired-state, no
drift detection, and no reach to a remote LMS instance.

## What it does (ADR-104)

- New `lms-model-state` Reconcilable, one instance per LMS backend, modeled on the mlx-supervised provider.
  liveState from LM Studio's native `GET /api/v0/models` (`loaded_context_length` / `max_context_length`);
  targetState declared as an opt-in `options.model_state` block (`{model, context_length, keep_warm,
  jit_evict}`); reconcile = load / reload-at-context / unload. Three-axis health (Synced when loaded-at-
  target, Degraded on wrong context, Progressing while loading, Missing when absent, Suspended when
  unmanaged / unreachable / actuator-missing).
- Remote backends — a LAN LMS the local `lms` CLI cannot reach (LM Link is access-gated) — are driven over
  the LM Studio SDK websocket via a vendored Node actuator (`scripts/lms-actuator`, `@lmstudio/sdk`), with
  the Bearer token passed by env (never argv).

## Safety

- **Opt-in, disabled by default**: registers only when a backend declares `options.model_state.manage: true`.
  Ships with a commented example only; no config enables it, so a kernel restart reconciles nothing.
- **Non-destructive in this PR**: the mutating load/unload path is built + connection-verified + mock-tested
  against a local ws server; NO real load/unload was run against a live backend. The first real reconcile
  needs an operator opt-in + live verification.

## Testing

- `go build ./...` + `go test -race ./internal/engine/... ./internal/providers/...` green.
- FetchLive parses the null-context (not-loaded) row case; ComputePlan drift states (load / context / unload
  / synced / opt-out); three-axis health mapping; ApplyPlan invokes a fake actuator asserting argv + token-
  via-env (no argv leak); daemon opt-in YAML parser + Suspended-when-none.

## Follow-ups (documented, not done)

- The imperative `com.cogos.lmstudio-baseline` launchd job would race the reconciler on the local node;
  scope it to boot-only or retire once the reconciler is trusted.
- `node_modules` is gitignored; the actuator's `@lmstudio/sdk` is installed via `npm install` in
  `scripts/lms-actuator`.
