### PR TITLE
fix(dispatch): guard reachability cache against caller-ctx cancellation

### DIFF
--- a/agent_dispatch.go
+++ b/agent_dispatch.go
@@ -304,6 +304,17 @@ func (d *HarnessDispatcher) endpointReachable(ctx context.Context, url string) b
 	}
 	resp, err := http.DefaultClient.Do(httpReq)
 	if err != nil {
+		// A negative caused only by the CALLER's ctx going away (e.g. an HTTP
+		// client disconnecting mid-request, since ctx traces back to r.Context()
+		// via DispatchToHarness) says nothing about endpoint health, so don't
+		// poison the shared reachByURL cache for every other in-flight dispatch.
+		// A probeCtx deadline (reachabilityProbeTimeout firing on a slow/hung
+		// endpoint) is a real "unreachable" signal and must still be cached —
+		// same distinction the three providers' Available() already make
+		// (provider_openai.go, provider_ollama.go, provider_claudeoauth.go).
+		if ctx.Err() == context.Canceled {
+			return false
+		}
 		log.Printf("[dispatch] endpoint probe failed (%s): %v", url, err)
 		d.cacheReachability(url, false)
 		return false

--- a/agent_dispatch_test.go
+++ b/agent_dispatch_test.go
@@ -390,6 +390,75 @@ func TestDispatch_LMStudioUnreachableDegradesToE4B(t *testing.T) {
 	}
 }
 
+// TestEndpointReachable_CallerCancelDoesNotPoisonCache verifies that a probe
+// failure caused by the CALLER's context being cancelled (e.g. an HTTP client
+// disconnecting mid-dispatch, per serve_agents.go's r.Context() plumbing)
+// does NOT write a negative result into the shared reachByURL cache. Without
+// this guard, one caller's disconnect poisons endpointReachable for every
+// other in-flight dispatch against the same URL for reachabilityCacheTTL.
+func TestEndpointReachable_CallerCancelDoesNotPoisonCache(t *testing.T) {
+	// A blocking handler so the probe is still in-flight when we cancel.
+	block := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-block
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	defer close(block)
+
+	d := &HarnessDispatcher{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan bool, 1)
+	go func() {
+		done <- d.endpointReachable(ctx, server.URL)
+	}()
+	// Give the probe goroutine time to start the request, then cancel the
+	// CALLER's context (not the probe's own timeout).
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case ok := <-done:
+		if ok {
+			t.Fatalf("expected endpointReachable to return false on caller-cancel, got true")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("endpointReachable did not return after caller cancel")
+	}
+
+	d.mu.Lock()
+	_, cached := d.reachByURL[server.URL]
+	d.mu.Unlock()
+	if cached {
+		t.Errorf("expected no cache entry after caller-context cancel, but one was written")
+	}
+}
+
+// TestEndpointReachable_GenuineRefusalWritesCache verifies the companion
+// case: a real probe failure (connection refused, not a caller cancel) must
+// still populate reachByURL, or a genuinely-down endpoint would be re-probed
+// on every dispatch instead of being cached negative for reachabilityCacheTTL.
+func TestEndpointReachable_GenuineRefusalWritesCache(t *testing.T) {
+	d := &HarnessDispatcher{}
+	const unreachable = "http://127.0.0.1:1" // port 1 closed by convention
+
+	ok := d.endpointReachable(context.Background(), unreachable)
+	if ok {
+		t.Fatalf("expected endpointReachable=false for a closed port")
+	}
+
+	d.mu.Lock()
+	entry, cached := d.reachByURL[unreachable]
+	d.mu.Unlock()
+	if !cached {
+		t.Fatalf("expected a genuine refusal to write the reachability cache")
+	}
+	if entry.ok {
+		t.Errorf("expected cached entry to be negative, got ok=true")
+	}
+}
+
 // TestDispatch_SystemPromptOverride confirms the per-call SystemPrompt
 // reaches the model in the system message slot.
 func TestDispatch_SystemPromptOverride(t *testing.T) {


### PR DESCRIPTION
## What

`endpointReachable` (agent_dispatch.go:283) unconditionally wrote a negative
result into the shared `reachByURL` cache on any probe HTTP failure, with no
guard for the case where the failure was caused by the **caller's** context
being cancelled rather than a genuine endpoint refusal.

## Why

`ctx` here traces back to `r.Context()` (`serve_agents.go:116` ->
`QueryDispatchToHarness` -> `DispatchToHarness` -> `endpointReachable`). An
HTTP client disconnecting mid-dispatch cancels that context, which aborts the
in-flight `/v1/models` probe with a "context canceled" error — indistinguishable
from a real refusal at the `err != nil` check. Before this fix, that caused a
`cacheReachability(url, false)` write that poisons the cache for
`reachabilityCacheTTL` (60s), so every *other* concurrent/subsequent dispatch
against the same LM Studio / local endpoint would wrongly degrade (e.g. 26B ->
e4b) even though the endpoint was never actually down.

This is the same shape as an already-fixed bug in the three provider
`Available()` implementations (`provider_openai.go:131`,
`provider_ollama.go:117`, `provider_claudeoauth.go:612`), which all skip the
cache write when `ctx.Err() == context.Canceled` but do still cache a negative
on `context.DeadlineExceeded` (the probe's own timeout firing on a genuinely
slow/hung endpoint). `endpointReachable` just hadn't received the same guard.

## How

Added the identical guard: on `ctx.Err() == context.Canceled`, return `false`
without calling `cacheReachability`. The `probeCtx` (bounded by
`reachabilityProbeTimeout`) deadline case is untouched and still writes a
cached negative, since that's a real "this endpoint is slow/unresponsive"
signal.

## Test evidence

Two new regression tests in `agent_dispatch_test.go`:

- `TestEndpointReachable_CallerCancelDoesNotPoisonCache` — probes a
  deliberately-blocked test server, cancels the caller-supplied `ctx`
  mid-request, and asserts `reachByURL` has **no** entry for the URL
  afterward. Verified this test fails without the fix (reverted the source
  change locally, confirmed the test catches the regression, then restored
  the fix).
- `TestEndpointReachable_GenuineRefusalWritesCache` — probes a closed port
  (connection refused, not a caller cancel) and asserts the cache **is**
  populated with a negative entry, preserving the original "cache genuine
  failures" behavior.

```
go build ./...   # clean
go vet ./...     # clean
go test .        # ok  github.com/myrgic/cogos  11.477s (full root package suite)
go test . -run 'TestEndpointReachable|TestDispatch' -v   # all PASS
```

## Acceptance

- [x] Identical guard shape to the three existing provider `Available()` fixes
- [x] Regression test proven to fail pre-fix, pass post-fix
- [x] No changes outside `agent_dispatch.go` / `agent_dispatch_test.go`
- [x] `go build ./...`, `go vet ./...`, `go test .` all clean