### PR TITLE
ci(release): sign checksums.txt with Sigstore/cosign (keyless)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,14 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    # id-token: write is the OIDC permission cosign's keyless flow needs to
+    # mint a short-lived Fulcio signing cert bound to this workflow's identity
+    # (repo + ref + workflow path). No signing key is generated or stored —
+    # the identity IS the key material, which is the point: nothing to leak,
+    # rotate, or scope wrong. See docs/release-signing.md for the trust model.
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Download all build artifacts
         uses: actions/download-artifact@v4
@@ -155,6 +163,46 @@ jobs:
         run: |
           cd dist && sha256sum cogos-* > checksums.txt
           ls -lh
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      # Sign checksums.txt, not each binary individually. checksums.txt
+      # already binds every artifact's content (sha256) into one file; one
+      # signature over that file transitively covers every listed binary at
+      # far lower cost than N per-binary signatures. A consumer verifies the
+      # signature once, then trusts the checksums to validate whichever
+      # binary they downloaded (see docs/release-signing.md).
+      #
+      # Keyless: no --key flag. cosign sign-blob talks to Fulcio (cert
+      # authority) using the job's GitHub OIDC token, and to Rekor (public
+      # transparency log) to record the signing event — both public-good
+      # Sigstore infra, no secrets configured in this repo. --yes skips the
+      # interactive confirmation prompt (this is a non-interactive CI job).
+      - name: Sign checksums.txt (Sigstore keyless)
+        working-directory: dist
+        run: |
+          cosign sign-blob \
+            --yes \
+            --output-signature checksums.txt.sig \
+            --output-certificate checksums.txt.pem \
+            checksums.txt
+          ls -lh checksums.txt.sig checksums.txt.pem
+
+      # Fail loudly if verification against our own just-produced signature
+      # doesn't pass, rather than shipping a release with a broken signature
+      # nobody notices until a consumer's verify command fails. Pins the
+      # identity/issuer the same way docs/release-signing.md tells consumers
+      # to — if this regexp and the docs drift apart, this step is the guard.
+      - name: Verify signature (fail closed before publishing)
+        working-directory: dist
+        run: |
+          cosign verify-blob \
+            --certificate checksums.txt.pem \
+            --signature checksums.txt.sig \
+            --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/release.yml@.*" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            checksums.txt
 
       - name: Create Release
         uses: softprops/action-gh-release@v2

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -18,6 +18,8 @@
   - darwin/amd64, darwin/arm64 (macOS Intel + Apple Silicon)
   - windows/amd64, windows/arm64
 - SHA-256 checksums generated
+- `checksums.txt` signed keylessly with Sigstore/cosign (see
+  [release-signing.md](release-signing.md) for what's signed and how to verify)
 - GitHub Release created with binaries attached and auto-generated release notes
 
 ## Installing from a release

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -1,0 +1,127 @@
+# Release signing
+
+Starting with the release that ships this document, every GitHub release of
+`cogos` carries a [Sigstore](https://www.sigstore.dev/) keyless signature over
+`checksums.txt`, alongside the existing SHA-256 checksums.
+
+This closes the gap noted in the v1.0 alignment ledger (`L12-RELEASE-INTEGRITY`):
+the GitHub release channel is the sole trust path onto boundary-isolated
+consumer nodes, and the kernel's `cogos self-update` command downloads and
+installs binaries from that channel onto a running system. A checksum alone
+protects against corruption in transit; it does not prove the artifact came
+from this repository's CI rather than a compromised or spoofed release.
+
+## What is signed
+
+- **`checksums.txt`** — the SHA-256 digest of every released binary
+  (`cogos-<os>-<arch>[.exe]`), one line per artifact.
+- The signature is **not** applied to each binary individually. Signing the
+  checksums file is sufficient: the file's own content already binds every
+  binary's digest, so one signature transitively covers every artifact listed
+  in it. A binary that doesn't match its line in a validly-signed
+  `checksums.txt` fails verification just as surely as if it had been signed
+  directly.
+
+Two new files are uploaded alongside `checksums.txt` on every release:
+
+- **`checksums.txt.sig`** — the Sigstore signature (base64-encoded).
+- **`checksums.txt.pem`** — the short-lived X.509 signing certificate issued
+  by Sigstore's Fulcio CA for that specific CI run.
+
+## How a consumer verifies
+
+Requires [cosign](https://docs.sigstore.dev/cosign/system_config/installation/)
+(`brew install cosign`, or download from the
+[cosign releases page](https://github.com/sigstore/cosign/releases)).
+
+```sh
+# From the same release, download: checksums.txt, checksums.txt.sig,
+# checksums.txt.pem, and the binary you want to run.
+
+cosign verify-blob \
+  --certificate checksums.txt.pem \
+  --signature checksums.txt.sig \
+  --certificate-identity-regexp "^https://github.com/myrgic/cogos/.github/workflows/release.yml@.*" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  checksums.txt
+```
+
+A successful run prints `Verified OK`. This proves `checksums.txt` was signed
+by a GitHub Actions run of *this repository's* `release.yml` workflow — not
+by an arbitrary developer key, and not by a workflow in a fork.
+
+Only after that verification passes, check the binary against the
+now-trusted checksums file:
+
+```sh
+# macOS / Linux
+sha256sum -c --ignore-missing checksums.txt
+
+# or, to check one specific artifact by hand:
+shasum -a 256 cogos-darwin-arm64
+grep cogos-darwin-arm64 checksums.txt
+```
+
+```powershell
+# Windows
+Get-FileHash -Algorithm SHA256 cogos-windows-amd64.exe
+# Compare the hash against the matching line in checksums.txt
+```
+
+If either step fails — signature verification or the checksum comparison —
+do not run the binary.
+
+### Why `--certificate-identity-regexp` and not a plain string
+
+The identity Fulcio embeds in the certificate is the full workflow ref,
+including the commit/tag it ran at (e.g.
+`https://github.com/myrgic/cogos/.github/workflows/release.yml@refs/tags/v0.17.0`).
+The regexp pins the repository and workflow path while allowing the ref
+suffix to vary release to release, so the same verify command works
+unmodified for every future tag.
+
+## Trust model
+
+- **`checksums.txt` protects against corruption and tampering in the
+  distribution channel** (a bit-flipped download, a proxy that silently
+  swaps a byte). This existed before this change and is unaffected by it.
+- **The Sigstore signature binds `checksums.txt` to this repository's CI
+  identity** — specifically, to a run of `.github/workflows/release.yml` in
+  `myrgic/cogos`, authenticated via that job's short-lived GitHub OIDC token
+  (`id-token: write` permission scoped to the `release` job only). It proves
+  *provenance* (this file was produced by our release workflow, not planted
+  by someone else), which a checksum alone cannot do.
+- **Keyless means there is no long-lived private key to protect, rotate, or
+  leak.** Each signing operation requests a short-lived certificate from
+  Sigstore's public Fulcio certificate authority, scoped to the exact
+  workflow identity for that single CI run, and records the signing event in
+  Sigstore's public Rekor transparency log. No secret is stored in this
+  repository's GitHub Actions configuration for this purpose.
+- **What this does *not* cover:** compromise of the GitHub Actions runner
+  itself during a release build (a signature only attests "this identity
+  signed this content," not "this identity's build environment was
+  uncompromised"), and compromise of the Sigstore public-good infrastructure
+  itself (Fulcio/Rekor), both of which are out of scope for a repository-level
+  control. It also does not yet protect the `cogos self-update` code path at
+  the point of *applying* an update — see the tracking issue below.
+- **Windows binaries remain unsigned by a traditional code-signing
+  certificate** (see `docs/RELEASING.md`'s SmartScreen note) — Sigstore
+  signing is a separate, additional control and does not change that
+  SmartScreen will still warn on first run.
+
+## Known gap: `cogos self-update` does not verify this signature yet
+
+This change adds signing to the release pipeline only. The kernel's
+`cogos self-update` command (`internal/engine/cli_selfupdate_unix.go`)
+currently verifies the downloaded binary's SHA-256 against `checksums.txt`
+(`verifyChecksum` / `verifyChecksumAgainst`) but does not verify a Sigstore
+signature over that checksums file before trusting it.
+
+Tracked in a follow-up issue: **self-update: verify cosign signature before
+applying update**. Closing that gap completes the trust chain end-to-end —
+today, a party that could tamper with both the binary and `checksums.txt` in
+transit (without access to this repo's OIDC-derived signing identity) could
+still defeat the *existing* checksum-only verification in self-update, even
+though a human following the manual steps above would catch the missing/
+invalid signature. Manual installs are covered as of this document; the
+self-update code path is not, yet.


### PR DESCRIPTION
## What

Adds Sigstore/cosign **keyless** signing to `.github/workflows/release.yml`:

- New `id-token: write` permission on the `release` job (scoped to that job only, not workflow-wide) — the OIDC token cosign's keyless flow needs to mint a short-lived Fulcio signing certificate bound to this exact CI run's identity.
- `sigstore/cosign-installer@v3` installs `cosign` on the runner.
- `cosign sign-blob` signs `checksums.txt` (not each binary individually — the checksums file already binds every binary's digest, so one signature transitively covers all of them at far lower cost).
- Uploads `checksums.txt.sig` (signature) and `checksums.txt.pem` (short-lived signing cert) alongside the existing release assets.
- A `cosign verify-blob` self-check runs in the same job **before** `Create Release`, so a broken/mismatched signature fails the release job loudly instead of shipping unverifiable artifacts silently.
- New `docs/release-signing.md`: what's signed, the exact consumer verify command (with the expected certificate identity regexp + OIDC issuer), and the trust model (checksum protects against transit corruption; signature binds the file to this repo's CI identity — two different, complementary guarantees). Linked from `docs/RELEASING.md`.

## Why

Ratified v1.0 alignment ledger item **L12-RELEASE-INTEGRITY** (phase 1, release-side signing — ledger entry `L12`, ratification `A6`). The GitHub release channel is the sole trust path onto boundary-isolated consumer nodes, and `cogos self-update` downloads and applies binaries from that channel onto a running system. Today the only integrity control is a SHA-256 checksum — real, but it only protects against corruption in transit, not against a compromised or spoofed release: nothing currently proves a given `checksums.txt` was produced by this repo's own CI.

## Scope limit

This PR **does not modify the kernel's self-update Go code**
(`internal/engine/cli_selfupdate_unix.go`). Filed and referenced here:
**#454 — self-update: verify cosign signature before applying update**,
which tracks wiring `cosign verify-blob` into the unattended
`cogos self-update` path itself (a separate design/test effort — mocking
signed vs. tampered release fixtures, rollback-on-failed-verify).

## Test evidence

This is a workflow + docs change; `release.yml` cannot be fully exercised without pushing a real tag (that's honest, not a gap I'm papering over). What I did verify:

- `actionlint` (installed locally, `/opt/homebrew/bin/actionlint`) run against `.github/workflows/release.yml`: zero new findings introduced by this change. The one pre-existing shellcheck info-level note (`SC2086` on the unrelated `sha256sum cogos-*` glob in the `Checksums` step) exists identically on `origin/main` before this PR — confirmed via `git stash`/`actionlint`/`git stash pop` — and is untouched by this diff.
- Careful manual review of the added steps against cosign's documented keyless flow (Fulcio cert issuance via OIDC, Rekor transparency log, no stored secret) and against GitHub's documented OIDC permission model (`id-token: write` scoped to the `release` job).
- `git diff --stat` confirms a minimal, scoped diff (2 files modified, 1 added, 177 insertions, 0 deletions) with no touches to any Go source, and no touches to the files reserved for sibling Wave-0 lanes (`internal/engine/context_assembly*`, `trm_lightcone.go`, `foveation_*`, `provider_lms_model_state*`, `serve_anthropic.go`) or to `.cog/mem/working/first-instruments/`.
- What I could **not** test: an actual signing run against Sigstore's public Fulcio/Rekor infra (requires a real tag push + real GitHub Actions OIDC context, which only exists once this merges and a release is cut). The `cosign verify-blob` self-check added in this PR is the mechanism that will catch a broken flow the first time a tag is pushed, rather than shipping silently-unverifiable assets.

## Files touched

- `.github/workflows/release.yml`
- `docs/RELEASING.md`
- `docs/release-signing.md` (new)
