### PR TITLE
fix(conversations): atomic + cross-process-locked writes to _meta.json

### DIFF
--- a/bus_session.go
+++ b/bus_session.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/myrgic/cogos/pkg/filelock"
 )
 
 // ADR-084 dataref migration policy (Phase 1: schema-additive).
@@ -177,8 +179,31 @@ func (m *busSessionManager) createMCPBus(sessionID, origin string) (string, erro
 	return busID, nil
 }
 
+// registryLockTimeout bounds how long a registry writer waits for the
+// cross-process advisory lock before failing the operation.
+const registryLockTimeout = 5 * time.Second
+
+// acquireRegistryLock takes the cross-process advisory lock guarding the
+// load-modify-save cycle on registry.json. The daemon's
+// internal/engine.BusSessionManager takes the SAME lock (registry.json.lock),
+// so concurrent `cog bus`/`cog infer` invocations and a running daemon
+// serialize instead of last-writer-wins silently dropping each other's
+// registry entries.
+func (m *busSessionManager) acquireRegistryLock() (*filelock.FileLock, error) {
+	if err := os.MkdirAll(m.busesDir(), 0755); err != nil {
+		return nil, err
+	}
+	return filelock.Acquire(m.registryPath()+".lock", registryLockTimeout)
+}
+
 // registerBus adds or updates a bus entry in the registry.
 func (m *busSessionManager) registerBus(busID, sessionID, origin string) error {
+	lock, err := m.acquireRegistryLock()
+	if err != nil {
+		return fmt.Errorf("acquire registry lock: %w", err)
+	}
+	defer lock.Release()
+
 	registry := m.loadRegistry()
 
 	// Check if bus already exists
@@ -229,12 +254,10 @@ func (m *busSessionManager) loadRegistry() []busRegistryEntry {
 // one being added. Mirrors the daemon-side BusSessionManager.saveRegistry
 // (internal/engine/bus_session.go).
 //
-// NOTE: this closes the truncation→total-loss failure mode but does NOT add a
-// cross-process advisory lock. Full serialization of this root-CLI writer
-// against the daemon's writer of the same registry.json requires both sides to
-// take a shared filelock; that coordination is deferred to the L1 disposition
-// of the root bus-CLI (whether this cross-process scenario survives at all
-// depends on relocate-vs-delete). Tracked separately; see PR body.
+// Cross-process serialization: every load-modify-save cycle on the registry
+// (registerBus, updateRegistrySeq) holds the shared advisory lock from
+// acquireRegistryLock; the daemon-side writer holds the same lock. Callers of
+// saveRegistry must hold that lock.
 func (m *busSessionManager) saveRegistry(entries []busRegistryEntry) error {
 	if err := os.MkdirAll(m.busesDir(), 0755); err != nil {
 		return err
@@ -432,6 +455,15 @@ func (m *busSessionManager) getLastEvent(busID string) (int, string) {
 
 // updateRegistrySeq updates the last event seq/timestamp in the registry.
 func (m *busSessionManager) updateRegistrySeq(busID string, seq int, ts string) {
+	lock, err := m.acquireRegistryLock()
+	if err != nil {
+		// Best-effort metadata update: skipping is safer than an unserialized
+		// read-modify-write that can drop a concurrent writer's entry.
+		log.Printf("[bus] skipping registry seq update (lock unavailable): %v", err)
+		return
+	}
+	defer lock.Release()
+
 	registry := m.loadRegistry()
 	for i, entry := range registry {
 		if entry.BusID == busID {

--- a/bus_session.go
+++ b/bus_session.go
@@ -221,6 +221,20 @@ func (m *busSessionManager) loadRegistry() []busRegistryEntry {
 }
 
 // saveRegistry writes the bus registry to disk.
+//
+// The write is atomic (tmp + rename): a plain truncate-before-write left
+// registry.json empty if the process was killed mid-write, and loadRegistry
+// swallows the resulting parse error and returns an empty registry — so the
+// next save from any process would discard every registered bus, not just the
+// one being added. Mirrors the daemon-side BusSessionManager.saveRegistry
+// (internal/engine/bus_session.go).
+//
+// NOTE: this closes the truncation→total-loss failure mode but does NOT add a
+// cross-process advisory lock. Full serialization of this root-CLI writer
+// against the daemon's writer of the same registry.json requires both sides to
+// take a shared filelock; that coordination is deferred to the L1 disposition
+// of the root bus-CLI (whether this cross-process scenario survives at all
+// depends on relocate-vs-delete). Tracked separately; see PR body.
 func (m *busSessionManager) saveRegistry(entries []busRegistryEntry) error {
 	if err := os.MkdirAll(m.busesDir(), 0755); err != nil {
 		return err
@@ -229,7 +243,15 @@ func (m *busSessionManager) saveRegistry(entries []busRegistryEntry) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(m.registryPath(), data, 0644)
+	tmp := m.registryPath() + ".tmp"
+	if err := os.WriteFile(tmp, data, 0644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, m.registryPath()); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
 }
 
 // appendBusEvent appends a new CogBlock to a bus's event chain.

--- a/bus_session.go
+++ b/bus_session.go
@@ -180,8 +180,14 @@ func (m *busSessionManager) createMCPBus(sessionID, origin string) (string, erro
 }
 
 // registryLockTimeout bounds how long a registry writer waits for the
-// cross-process advisory lock before failing the operation.
+// cross-process advisory lock before failing the operation (registration:
+// correctness-critical, cold path).
 const registryLockTimeout = 5 * time.Second
+
+// registrySeqLockTimeout bounds the best-effort seq-metadata update on the
+// append hot path — short, because a skipped update self-heals on the next
+// append and a long wait would delay the append caller.
+const registrySeqLockTimeout = 500 * time.Millisecond
 
 // acquireRegistryLock takes the cross-process advisory lock guarding the
 // load-modify-save cycle on registry.json. The daemon's
@@ -332,15 +338,16 @@ func (m *busSessionManager) appendBusEvent(busID, eventType, from string, payloa
 	}
 	f.Close()
 
-	// Update registry
-	m.updateRegistrySeq(busID, newSeq, evt.Ts)
-
 	// Snapshot handlers while locked, then release BEFORE dispatching.
 	// This prevents deadlocks when handlers call appendBusEvent (e.g. tool
 	// router posting tool.result in response to tool.invoke).
 	handlers := make([]busEventHandler, len(m.eventHandlers))
 	copy(handlers, m.eventHandlers)
 	m.mu.Unlock()
+
+	// Registry seq update runs OUTSIDE m.mu: it blocks (briefly) on the
+	// cross-process filelock, and must never stall unrelated bus operations.
+	m.updateRegistrySeq(busID, newSeq, evt.Ts)
 
 	// Dispatch handlers outside the lock — safe because each handler
 	// that needs to write back to the bus will re-acquire the lock via
@@ -410,11 +417,12 @@ func (m *busSessionManager) appendBusEventRef(busID, eventType, from, digest, me
 	}
 	f.Close()
 
-	m.updateRegistrySeq(busID, newSeq, evt.Ts)
-
 	handlers := make([]busEventHandler, len(m.eventHandlers))
 	copy(handlers, m.eventHandlers)
 	m.mu.Unlock()
+
+	// Outside m.mu — see updateRegistrySeq's lock-ordering contract.
+	m.updateRegistrySeq(busID, newSeq, evt.Ts)
 
 	for _, h := range handlers {
 		h.handler(busID, &evt)
@@ -454,12 +462,22 @@ func (m *busSessionManager) getLastEvent(busID string) (int, string) {
 }
 
 // updateRegistrySeq updates the last event seq/timestamp in the registry.
+// Caller must NOT hold m.mu — this blocks (briefly) on the cross-process
+// registry filelock, and holding the in-process mutex across that wait would
+// let one contended peer stall every unrelated bus operation in this process.
+//
+// Best-effort + monotonic: seq metadata self-heals on the next append, so on
+// lock contention we skip (short registrySeqLockTimeout) rather than wait,
+// and the IfNewer guard makes an out-of-order update a harmless no-op instead
+// of a seq regression.
 func (m *busSessionManager) updateRegistrySeq(busID string, seq int, ts string) {
-	lock, err := m.acquireRegistryLock()
+	if err := os.MkdirAll(m.busesDir(), 0755); err != nil {
+		log.Printf("[bus] skipping registry seq update: %v", err)
+		return
+	}
+	lock, err := filelock.Acquire(m.registryPath()+".lock", registrySeqLockTimeout)
 	if err != nil {
-		// Best-effort metadata update: skipping is safer than an unserialized
-		// read-modify-write that can drop a concurrent writer's entry.
-		log.Printf("[bus] skipping registry seq update (lock unavailable): %v", err)
+		log.Printf("[bus] skipping registry seq update (lock contended): %v", err)
 		return
 	}
 	defer lock.Release()
@@ -467,6 +485,9 @@ func (m *busSessionManager) updateRegistrySeq(busID string, seq int, ts string) 
 	registry := m.loadRegistry()
 	for i, entry := range registry {
 		if entry.BusID == busID {
+			if entry.LastEventSeq >= seq {
+				return // stale out-of-order update; newer one already landed
+			}
 			registry[i].LastEventSeq = seq
 			registry[i].LastEventAt = ts
 			registry[i].EventCount = seq

--- a/bus_session.go
+++ b/bus_session.go
@@ -631,7 +631,19 @@ func (m *busSessionManager) resetBus(busID string) error {
 }
 
 // archiveBus does the locked portion of resetBus: archive + registry update.
+//
+// Lock ordering per the file's contract: the cross-process registry filelock
+// is acquired BEFORE m.mu (cold path — full registryLockTimeout), so the
+// registry read-modify-write below cannot race a peer process's
+// registerBus/updateRegistrySeq, and no goroutine ever waits on the filelock
+// while holding m.mu.
 func (m *busSessionManager) archiveBus(busID string) (string, error) {
+	rlock, err := m.acquireRegistryLock()
+	if err != nil {
+		return "", fmt.Errorf("acquire registry lock: %w", err)
+	}
+	defer rlock.Release()
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/bus_session.go
+++ b/bus_session.go
@@ -117,10 +117,15 @@ func (m *busSessionManager) eventsPath(busID string) string {
 
 // createChatBus creates a new bus for a chat conversation.
 // The bus ID is derived from the session ID: bus_chat_{sessionID}.
+//
+// Deliberately does NOT hold m.mu: everything here is either idempotent
+// filesystem setup or registerBus, which takes the cross-process registry
+// filelock internally — and per the lock-ordering contract the filelock is
+// never acquired while holding m.mu (a contended peer must not stall
+// unrelated bus operations). Concurrent calls for the same session are safe:
+// MkdirAll/Create-if-absent are idempotent, and registerBus is serialized by
+// the filelock with update-in-place semantics for an existing busID.
 func (m *busSessionManager) createChatBus(sessionID, origin string) (string, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	busID := fmt.Sprintf("bus_chat_%s", sessionID)
 
 	// Create bus directory
@@ -149,10 +154,10 @@ func (m *busSessionManager) createChatBus(sessionID, origin string) (string, err
 
 // createMCPBus creates a new bus for an MCP HTTP session.
 // The bus ID is derived from the session ID: bus_mcp_{sessionID}.
+//
+// No m.mu — same reasoning as createChatBus: idempotent filesystem setup plus
+// filelock-guarded registerBus; the filelock is never acquired under m.mu.
 func (m *busSessionManager) createMCPBus(sessionID, origin string) (string, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	busID := fmt.Sprintf("bus_mcp_%s", sessionID)
 
 	// Create bus directory

--- a/bus_session_multiwriter_test.go
+++ b/bus_session_multiwriter_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// TestRegisterBus_ConcurrentManagersAllSurvive simulates the cross-process
+// race on registry.json: multiple busSessionManager instances (as separate
+// `cog bus`/`cog infer` processes would be — no shared in-process state)
+// concurrently register distinct buses. Without the cross-process filelock
+// around the load-modify-save cycle, last-writer-wins drops entries; with it,
+// every registration must survive.
+func TestRegisterBus_ConcurrentManagersAllSurvive(t *testing.T) {
+	root := t.TempDir()
+	const n = 8
+
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			// A fresh manager per goroutine: no shared mutex, mirroring
+			// separate OS processes contending on the same file.
+			m := newBusSessionManager(root)
+			if err := m.registerBus(fmt.Sprintf("bus-%d", i), fmt.Sprintf("sess-%d", i), "test"); err != nil {
+				errs <- fmt.Errorf("register bus-%d: %w", i, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+
+	m := newBusSessionManager(root)
+	registry := m.loadRegistry()
+	if len(registry) != n {
+		t.Fatalf("expected %d registry entries to survive concurrent registration, got %d (lost updates)", n, len(registry))
+	}
+	seen := map[string]bool{}
+	for _, e := range registry {
+		seen[e.BusID] = true
+	}
+	for i := 0; i < n; i++ {
+		if !seen[fmt.Sprintf("bus-%d", i)] {
+			t.Fatalf("registry entry bus-%d was dropped", i)
+		}
+	}
+}

--- a/internal/conversations/index.go
+++ b/internal/conversations/index.go
@@ -25,7 +25,15 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/myrgic/cogos/pkg/filelock"
 )
+
+// metaLockTimeout bounds how long UpsertSession/DeleteSession wait to acquire
+// the cross-process lock on _meta.json before giving up. Generous relative to
+// the write itself (a few JSON marshals + one rename) but short enough that a
+// wedged peer doesn't hang the caller indefinitely.
+const metaLockTimeout = 5 * time.Second
 
 // Index holds all indexed turns in memory plus a reference to the projection
 // directory for persistence.
@@ -58,6 +66,15 @@ type Index struct {
 	lastMetaMtime time.Time
 	lastMetaSize  int64
 	lastMetaHash  string
+}
+
+// metaDelta describes the change a single writeMetaFileLocked call must apply
+// to _meta.json, as opposed to a full re-assertion of this process's in-memory
+// idx.sessions snapshot (which could be stale relative to a peer process's
+// more recent write — see writeMetaFileLocked).
+type metaDelta struct {
+	upserts map[string]SessionMeta
+	deletes []string
 }
 
 // NewIndex creates an Index backed by projDir. projDir is created if absent.
@@ -163,6 +180,23 @@ func (idx *Index) LoadIfChanged() (bool, error) {
 }
 
 // UpsertSession writes session meta + turns to memory and to disk.
+//
+// The on-disk _meta.json is a shared file: the daemon's own reconcile/ticker
+// cycle and a separately-invoked "cog reconcile conversations" CLI process
+// can both call UpsertSession/DeleteSession against the same projDir
+// (issue #449). Without coordination the two read-modify-write cycles
+// interleave and the second writer's plain marshal-of-idx.sessions silently
+// drops whatever the first writer added, because each process's in-memory
+// idx.sessions only reflects its own view as of its last Load.
+//
+// To close that window, the on-disk write is guarded by a cross-process
+// filelock (metaLockPath) and, while holding it, writeMetaFileLocked re-reads
+// the current _meta.json from disk and applies only *this call's* delta
+// (metaDelta) on top of it — never a full re-assertion of this process's
+// entire in-memory idx.sessions snapshot, which could itself be stale
+// relative to a peer's more recent write and would silently resurrect
+// whatever the peer already removed. See writeMetaFileLocked for why a
+// snapshot-merge (rather than a delta-merge) is unsound.
 func (idx *Index) UpsertSession(meta SessionMeta, turns []Turn) error {
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
@@ -174,8 +208,10 @@ func (idx *Index) UpsertSession(meta SessionMeta, turns []Turn) error {
 	if err := idx.writeTurnsFile(meta.SessionID, turns); err != nil {
 		return fmt.Errorf("conversations/index: write turns %s: %w", meta.SessionID, err)
 	}
-	// Persist meta index (marshals idx.sessions; must hold the lock).
-	return idx.writeMetaFileLocked()
+	// Persist meta index under the cross-process lock. Only this call's own
+	// upsert is applied as a delta on top of the current on-disk state — see
+	// writeMetaFileLocked.
+	return idx.writeMetaFileLocked(metaDelta{upserts: map[string]SessionMeta{meta.SessionID: meta}})
 }
 
 // DeleteSession removes a session from memory and disk.
@@ -190,7 +226,7 @@ func (idx *Index) DeleteSession(sessionID string) error {
 	if err := os.Remove(turnsPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("conversations/index: remove turns file: %w", err)
 	}
-	return idx.writeMetaFileLocked()
+	return idx.writeMetaFileLocked(metaDelta{deletes: []string{sessionID}})
 }
 
 // GetMeta returns the SessionMeta for a session, or false if not indexed.
@@ -382,6 +418,14 @@ func (idx *Index) metaPath() string {
 	return filepath.Join(idx.projDir, "_meta.json")
 }
 
+// metaLockPath is the advisory cross-process lock file guarding the
+// read-modify-write cycle on _meta.json. A sibling file, not metaPath itself,
+// so the lock's own lifecycle (create/lock/unlock) never touches the JSON
+// content file that Load/LoadIfChanged read.
+func (idx *Index) metaLockPath() string {
+	return filepath.Join(idx.projDir, "_meta.json.lock")
+}
+
 // sha256Hex returns the hex-encoded SHA-256 of b.
 func sha256Hex(b []byte) string {
 	sum := sha256.Sum256(b)
@@ -400,16 +444,76 @@ func (idx *Index) turnsPath(sessionID string) string {
 	return filepath.Join(idx.projDir, turnsFilename(sessionID))
 }
 
-// writeMetaFileLocked persists the session meta index. Callers must hold
-// idx.mu (write lock) because it marshals idx.sessions.
-func (idx *Index) writeMetaFileLocked() error {
-	b, err := json.MarshalIndent(idx.sessions, "", "  ")
+// writeMetaFileLocked persists delta (this call's own upserts/deletes) into
+// _meta.json. Callers must hold idx.mu (write lock).
+//
+// The write is atomic (tmp + rename, same pattern as
+// BusSessionManager.saveRegistry in internal/engine/bus_session.go) — a plain
+// truncate-before-write left _meta.json empty (and every subsequent Load
+// silently falling back to an empty index) if the process was killed
+// mid-write.
+//
+// It also takes the cross-process filelock (pkg/filelock) around the full
+// read-modify-write cycle: re-read whatever is currently on disk, apply only
+// delta on top of it, then atomically write the result. This is what closes
+// issue #449 — a CLI reconcile and the daemon's own reconcile cycle can each
+// read-modify-write _meta.json independently; taking the lock serializes the
+// two cycles, and applying a per-call delta (rather than a full marshal of
+// this process's in-memory idx.sessions) means a writer never re-asserts a
+// stale snapshot that could silently resurrect a session a peer has since
+// deleted, or drop one a peer has since added. A snapshot-merge was tried
+// first and found unsound by TestCrossProcessDeleteSurvivesConcurrentUpsert:
+// re-adding every key from idx.sessions on top of the freshly-read on-disk
+// map reintroduces this process's own stale copy of a session a peer already
+// deleted, because idx.sessions only reflects this process's last Load, not
+// the peer's more recent delete.
+func (idx *Index) writeMetaFileLocked(delta metaDelta) error {
+	lock, err := filelock.Acquire(idx.metaLockPath(), metaLockTimeout)
+	if err != nil {
+		return fmt.Errorf("conversations/index: acquire meta lock: %w", err)
+	}
+	defer lock.Release()
+
+	merged := make(map[string]SessionMeta)
+	if data, readErr := os.ReadFile(idx.metaPath()); readErr == nil {
+		var onDisk map[string]SessionMeta
+		if jsonErr := json.Unmarshal(data, &onDisk); jsonErr == nil {
+			for k, v := range onDisk {
+				merged[k] = v
+			}
+		}
+		// A corrupt/unparseable on-disk file is treated as empty rather than
+		// aborting the write — delta is still applied and this call becomes
+		// the one restoring a valid file.
+	} else if !os.IsNotExist(readErr) {
+		return fmt.Errorf("conversations/index: read meta for merge: %w", readErr)
+	}
+
+	for k, v := range delta.upserts {
+		merged[k] = v
+	}
+	for _, k := range delta.deletes {
+		delete(merged, k)
+	}
+
+	b, err := json.MarshalIndent(merged, "", "  ")
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(idx.metaPath(), b, 0o644); err != nil {
+	tmp := idx.metaPath() + fmt.Sprintf(".tmp.%d", time.Now().UnixNano())
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
 		return err
 	}
+	if err := os.Rename(tmp, idx.metaPath()); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+
+	// Adopt the merged-and-written view as this process's in-memory sessions
+	// too, so a peer's concurrent addition/removal becomes visible here
+	// without waiting for the next Load/LoadIfChanged.
+	idx.sessions = merged
+
 	// Record our own write — hash of the exact bytes we wrote, plus the
 	// post-write stat — so the next LoadIfChanged recognises the file as
 	// unchanged-by-others and skips the full reload. Called under idx.mu (the

--- a/internal/conversations/index.go
+++ b/internal/conversations/index.go
@@ -630,8 +630,21 @@ func sessionMapsEqual(a, b map[string]SessionMeta) bool {
 // session's turns file. Keyed per-session (not a single shared lock across
 // all sessions) so two different sessions' writers never contend on the same
 // lock — only two writers of the *same* sessionID, which is the actual race.
+//
+// Deliberately NOT simply turnsPath(sessionID)+".lock": turnsPath("_meta")
+// resolves to the same path as metaPath() ("_meta.json"), since turnsFilename
+// just appends ".json" to the (slash-escaped) sessionID with no reserved-name
+// exclusion. A session literally named "_meta" would otherwise make
+// turnsLockPath collide with metaLockPath, and UpsertSession/DeleteSession —
+// which hold the turnsLockPath lock for the whole call, including the nested
+// writeMetaFileLocked call that acquires metaLockPath — would self-deadlock
+// against its own second acquisition until metaLockTimeout elapses. The
+// distinct ".sessions.lock" suffix (rather than plain ".lock", which would
+// reproduce exactly metaLockPath's "_meta.json.lock" for sessionID=="_meta")
+// guarantees turns-lock paths never collide with metaLockPath regardless of
+// sessionID content.
 func (idx *Index) turnsLockPath(sessionID string) string {
-	return idx.turnsPath(sessionID) + ".lock"
+	return idx.turnsPath(sessionID) + ".sessions.lock"
 }
 
 // writeTurnsFileLocked persists the full turns list for sessionID. Callers

--- a/internal/conversations/index.go
+++ b/internal/conversations/index.go
@@ -198,9 +198,9 @@ func (idx *Index) LoadIfChanged() (bool, error) {
 // whatever the peer already removed. See writeMetaFileLocked for why a
 // snapshot-merge (rather than a delta-merge) is unsound.
 //
-// UpsertSession and DeleteSession additionally hold ONE per-sessionID lock
-// (turnsLockPath) across their ENTIRE body — both the turns-file operation
-// and the _meta.json write — rather than acquiring it twice as two separate,
+// UpsertSession and DeleteSession additionally hold ONE per-sessionID
+// cross-process lock (turnsLockPath) across both the turns-file operation
+// and the _meta.json write, rather than acquiring it twice as two separate,
 // independently-released critical sections. cog-review (PR #458, third
 // pass) found that with two separate acquisitions, a concurrent
 // DeleteSession(sid) on one Index instance and UpsertSession(sid, ...) on
@@ -215,18 +215,25 @@ func (idx *Index) LoadIfChanged() (bool, error) {
 // DeleteSession(sid) for the identical sessionID fully mutually exclusive
 // end-to-end, closing that interleaving. Different sessionIDs still use
 // different lock files and proceed with no contention.
+//
+// idx.mu is deliberately NOT held across the cross-process locking/disk I/O
+// above — only around the brief in-memory map mutation at the very end.
+// cog-review (PR #458, fifth pass) found that an earlier version held
+// idx.mu.Lock() for the whole call, meaning the up-to-2×metaLockTimeout
+// (≈10s) a writer could block waiting on a peer process's cross-process lock
+// also blocked every concurrent GetMeta/ListSessions/GetTurn/Search call
+// (which take idx.mu.RLock()) on the SAME in-process Index — e.g. the
+// daemon's MCP handlers (cog_search_conversations et al., all sharing one
+// Provider.index) would freeze for that whole window whenever a CLI
+// reconcile process was mid-write. Disk I/O and cross-process coordination
+// now happen with idx.mu unheld; only the final idx.sessions/idx.turns
+// mutation takes the lock, and only briefly.
 func (idx *Index) UpsertSession(meta SessionMeta, turns []Turn) error {
-	idx.mu.Lock()
-	defer idx.mu.Unlock()
-
 	lock, err := filelock.Acquire(idx.turnsLockPath(meta.SessionID), metaLockTimeout)
 	if err != nil {
 		return fmt.Errorf("conversations/index: acquire session lock for %s: %w", meta.SessionID, err)
 	}
 	defer lock.Release()
-
-	idx.sessions[meta.SessionID] = meta
-	idx.turns[meta.SessionID] = turns
 
 	// Persist turns file (lock for this sessionID already held above).
 	if err := idx.writeTurnsFileLocked(meta.SessionID, turns); err != nil {
@@ -241,31 +248,44 @@ func (idx *Index) UpsertSession(meta SessionMeta, turns []Turn) error {
 	// which can be for different sessionIDs at once). Only this call's own
 	// upsert is applied as a delta on top of the current on-disk state — see
 	// writeMetaFileLocked.
-	return idx.writeMetaFileLocked(metaDelta{upserts: map[string]SessionMeta{meta.SessionID: meta}})
+	if err := idx.writeMetaFileLocked(metaDelta{upserts: map[string]SessionMeta{meta.SessionID: meta}}); err != nil {
+		return err
+	}
+
+	// Commit the in-memory view last, under a short-lived write lock — no
+	// disk I/O or cross-process locking happens while idx.mu is held.
+	idx.mu.Lock()
+	idx.sessions[meta.SessionID] = meta
+	idx.turns[meta.SessionID] = turns
+	idx.mu.Unlock()
+	return nil
 }
 
 // DeleteSession removes a session from memory and disk.
 //
 // See UpsertSession's doc comment for why this holds one turnsLockPath(sessionID)
-// lock across both the turns-file removal and the _meta.json write, rather
-// than two separate acquisitions.
+// cross-process lock across both the turns-file removal and the _meta.json
+// write (rather than two separate acquisitions), and why idx.mu is held only
+// briefly at the end rather than across the whole call.
 func (idx *Index) DeleteSession(sessionID string) error {
-	idx.mu.Lock()
-	defer idx.mu.Unlock()
-
 	lock, err := filelock.Acquire(idx.turnsLockPath(sessionID), metaLockTimeout)
 	if err != nil {
 		return fmt.Errorf("conversations/index: acquire session lock for %s: %w", sessionID, err)
 	}
 	defer lock.Release()
 
-	delete(idx.sessions, sessionID)
-	delete(idx.turns, sessionID)
-
 	if err := idx.removeTurnsFileLocked(sessionID); err != nil {
 		return fmt.Errorf("conversations/index: remove turns file: %w", err)
 	}
-	return idx.writeMetaFileLocked(metaDelta{deletes: []string{sessionID}})
+	if err := idx.writeMetaFileLocked(metaDelta{deletes: []string{sessionID}}); err != nil {
+		return err
+	}
+
+	idx.mu.Lock()
+	delete(idx.sessions, sessionID)
+	delete(idx.turns, sessionID)
+	idx.mu.Unlock()
+	return nil
 }
 
 // removeTurnsFileLocked deletes sessionID's turns file. Callers must already
@@ -493,7 +513,13 @@ func (idx *Index) turnsPath(sessionID string) string {
 }
 
 // writeMetaFileLocked persists delta (this call's own upserts/deletes) into
-// _meta.json. Callers must hold idx.mu (write lock).
+// _meta.json. Callers must NOT hold idx.mu — this method takes its own
+// short-lived idx.mu R/W locks internally, separately from the blocking
+// cross-process metaLockPath acquisition, so that a peer-process write
+// contending on metaLockPath never also blocks concurrent in-process readers
+// (GetMeta/ListSessions/GetTurn/Search) that only need idx.mu.RLock(). See
+// UpsertSession's doc comment for the availability regression this avoids
+// (cog-review, PR #458, fifth pass).
 //
 // The write is atomic (tmp + rename, same pattern as
 // BusSessionManager.saveRegistry in internal/engine/bus_session.go) — a plain
@@ -529,18 +555,22 @@ func (idx *Index) turnsPath(sessionID string) string {
 // cog_list_conversations would then list a session that
 // cog_get_turn/cog_search could never actually serve.
 //
-// The fix: after computing merged, compare it against idx.sessions as the
-// caller already left it (delta pre-applied by UpsertSession/DeleteSession
-// before calling here). If they're equal, no peer wrote anything this
-// process doesn't already fully know about (turns included) — the common
-// sole-writer case — so it's safe to keep the LoadIfChanged fast-path
-// bookkeeping (lastMeta{Mtime,Size,Hash}) in sync with what was just written,
-// same as before this fix. If they differ, a peer's content is present in
-// merged that idx.sessions doesn't have turns for; leave idx.sessions and the
-// lastMeta bookkeeping untouched by this call, so the next LoadIfChanged
-// detects the file changed out from under its recorded baseline and performs
-// a full reload — sessions map AND turns map together — keeping the two maps
-// consistent with each other at the cost of that one reload.
+// The fix: after computing merged, compare it against what idx.sessions will
+// be once the caller applies its own delta (UpsertSession/DeleteSession
+// apply the in-memory mutation after this call returns, not before — see
+// their doc comments — so this method computes the expected post-delta view
+// itself from a fresh idx.mu.RLock() snapshot plus delta, rather than reading
+// idx.sessions as literally-currently-mutated). If they're equal, no peer
+// wrote anything this process doesn't already fully know about (turns
+// included) — the common sole-writer case — so it's safe to keep the
+// LoadIfChanged fast-path bookkeeping (lastMeta{Mtime,Size,Hash}) in sync
+// with what was just written, same as before this fix. If they differ, a
+// peer's content is present in merged that idx.sessions doesn't have turns
+// for; leave the lastMeta bookkeeping untouched by this call, so the next
+// LoadIfChanged detects the file changed out from under its recorded
+// baseline and performs a full reload — sessions map AND turns map together —
+// keeping the two maps consistent with each other at the cost of that one
+// reload.
 func (idx *Index) writeMetaFileLocked(delta metaDelta) error {
 	lock, err := filelock.Acquire(idx.metaLockPath(), metaLockTimeout)
 	if err != nil {
@@ -583,23 +613,44 @@ func (idx *Index) writeMetaFileLocked(delta metaDelta) error {
 		return err
 	}
 
-	// Only adopt merged (and the fast-path bookkeeping) when it exactly
-	// matches idx.sessions as the caller left it — i.e. no peer content is
-	// present that this process's idx.turns doesn't already cover. See the
-	// func comment above for why an unconditional adopt reintroduces the
-	// sessions/turns split-brain cog-review flagged on PR #458.
-	if sessionMapsEqual(merged, idx.sessions) {
+	// Compute what idx.sessions will look like once the caller applies its
+	// own delta (which happens after this method returns — see
+	// UpsertSession/DeleteSession), from a fresh idx.mu.RLock() snapshot.
+	// This is a short, non-blocking critical section — no disk I/O or
+	// cross-process locking happens while idx.mu is held.
+	idx.mu.RLock()
+	expected := make(map[string]SessionMeta, len(idx.sessions))
+	for k, v := range idx.sessions {
+		expected[k] = v
+	}
+	idx.mu.RUnlock()
+	for k, v := range delta.upserts {
+		expected[k] = v
+	}
+	for _, k := range delta.deletes {
+		delete(expected, k)
+	}
+
+	// Only refresh the fast-path bookkeeping when merged exactly matches the
+	// expected post-delta idx.sessions — i.e. no peer content is present that
+	// this process's idx.turns doesn't already cover. See the func comment
+	// above for why an unconditional refresh reintroduces the sessions/turns
+	// split-brain cog-review flagged on PR #458. Bookkeeping fields are
+	// mutated under their own short idx.mu.Lock(), separate from the
+	// RLock() snapshot above.
+	if sessionMapsEqual(merged, expected) {
+		idx.mu.Lock()
 		idx.lastMetaHash = sha256Hex(b)
 		if fi, statErr := os.Stat(idx.metaPath()); statErr == nil {
 			idx.lastMetaMtime = fi.ModTime()
 			idx.lastMetaSize = fi.Size()
 		}
+		idx.mu.Unlock()
 	}
-	// else: leave idx.sessions/lastMeta* exactly as they were. idx.sessions
-	// still holds this call's own delta (applied by the caller), which is
-	// consistent with idx.turns; the on-disk file now also carries the
-	// peer's content, which the next LoadIfChanged's content-hash check will
-	// notice (it no longer matches lastMetaHash) and reload properly.
+	// else: leave lastMeta* exactly as they were, so the next LoadIfChanged's
+	// content-hash check notices the file changed out from under its
+	// recorded baseline (it no longer matches lastMetaHash) and reloads
+	// properly — sessions map AND turns map together.
 	return nil
 }
 

--- a/internal/conversations/index.go
+++ b/internal/conversations/index.go
@@ -222,11 +222,29 @@ func (idx *Index) DeleteSession(sessionID string) error {
 	delete(idx.sessions, sessionID)
 	delete(idx.turns, sessionID)
 
-	turnsPath := idx.turnsPath(sessionID)
-	if err := os.Remove(turnsPath); err != nil && !os.IsNotExist(err) {
+	// Same per-session lock writeTurnsFile takes, so a concurrent peer
+	// UpsertSession for this exact sessionID can't recreate the turns file
+	// in between this Remove and the caller's write, and vice versa.
+	if err := idx.removeTurnsFile(sessionID); err != nil {
 		return fmt.Errorf("conversations/index: remove turns file: %w", err)
 	}
 	return idx.writeMetaFileLocked(metaDelta{deletes: []string{sessionID}})
+}
+
+// removeTurnsFile deletes sessionID's turns file under the same per-session
+// cross-process lock writeTurnsFile uses, so a delete can't race a
+// concurrent peer write of the same sessionID's turns file.
+func (idx *Index) removeTurnsFile(sessionID string) error {
+	lock, err := filelock.Acquire(idx.turnsLockPath(sessionID), metaLockTimeout)
+	if err != nil {
+		return fmt.Errorf("acquire turns lock for %s: %w", sessionID, err)
+	}
+	defer lock.Release()
+
+	if err := os.Remove(idx.turnsPath(sessionID)); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
 }
 
 // GetMeta returns the SessionMeta for a session, or false if not indexed.
@@ -578,12 +596,53 @@ func sessionMapsEqual(a, b map[string]SessionMeta) bool {
 	return true
 }
 
+// turnsLockPath is the advisory cross-process lock file guarding a single
+// session's turns file. Keyed per-session (not a single shared lock across
+// all sessions) so two different sessions' writers never contend on the same
+// lock — only two writers of the *same* sessionID, which is the actual race.
+func (idx *Index) turnsLockPath(sessionID string) string {
+	return idx.turnsPath(sessionID) + ".lock"
+}
+
+// writeTurnsFile persists the full turns list for sessionID.
+//
+// Same shape as writeMetaFileLocked and fixed for the same reason
+// (cog-review, PR #458): the daemon's reconcile ticker and a
+// separately-invoked "cog reconcile conversations" CLI process can both
+// detect drift on the same session's source JSONL in the same window and
+// each call UpsertSession(meta, turns) for the identical sessionID
+// concurrently, racing on this exact file. Unlike _meta.json (a shared map
+// needing a read-merge-write), each turns file is owned wholly by one
+// sessionID and every writer replaces the full content, so no on-disk merge
+// is needed here — only atomicity (tmp + rename, preventing a torn read on
+// loadTurnsFile) and a cross-process lock (preventing the interleaving
+// itself, so the two writes fully serialize rather than merely not tearing
+// each other's bytes). Without either, loadTurnsFile's json.Unmarshal can
+// fail on a corrupted file and Load drops the session's meta and turns
+// entirely (index.go's Load: on a per-session parse error it deletes the
+// session from the in-memory map rather than surfacing a partial result) —
+// a stronger data-loss outcome than #449's "last writer wins on one field".
 func (idx *Index) writeTurnsFile(sessionID string, turns []Turn) error {
+	lock, err := filelock.Acquire(idx.turnsLockPath(sessionID), metaLockTimeout)
+	if err != nil {
+		return fmt.Errorf("conversations/index: acquire turns lock for %s: %w", sessionID, err)
+	}
+	defer lock.Release()
+
 	b, err := json.MarshalIndent(turns, "", "  ")
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(idx.turnsPath(sessionID), b, 0o644)
+	path := idx.turnsPath(sessionID)
+	tmp := path + fmt.Sprintf(".tmp.%d", time.Now().UnixNano())
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
 }
 
 func (idx *Index) loadTurnsFile(sessionID string) ([]Turn, error) {

--- a/internal/conversations/index.go
+++ b/internal/conversations/index.go
@@ -197,50 +197,80 @@ func (idx *Index) LoadIfChanged() (bool, error) {
 // relative to a peer's more recent write and would silently resurrect
 // whatever the peer already removed. See writeMetaFileLocked for why a
 // snapshot-merge (rather than a delta-merge) is unsound.
+//
+// UpsertSession and DeleteSession additionally hold ONE per-sessionID lock
+// (turnsLockPath) across their ENTIRE body — both the turns-file operation
+// and the _meta.json write — rather than acquiring it twice as two separate,
+// independently-released critical sections. cog-review (PR #458, third
+// pass) found that with two separate acquisitions, a concurrent
+// DeleteSession(sid) on one Index instance and UpsertSession(sid, ...) on
+// another could interleave between them: B's turns write completes and
+// releases the turns lock; A acquires that now-free lock, removes the turns
+// file, and moves on to the meta lock; B then writes sid back into
+// _meta.json. Net result: _meta.json lists sid with no turns file on disk —
+// the exact sessions/turns split-brain this whole PR exists to prevent,
+// reached via a path the original fix didn't cover because "the turns lock"
+// and "the meta lock" were two separate atomic units instead of one.
+// Holding a single lock across both operations makes UpsertSession(sid) and
+// DeleteSession(sid) for the identical sessionID fully mutually exclusive
+// end-to-end, closing that interleaving. Different sessionIDs still use
+// different lock files and proceed with no contention.
 func (idx *Index) UpsertSession(meta SessionMeta, turns []Turn) error {
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
 
+	lock, err := filelock.Acquire(idx.turnsLockPath(meta.SessionID), metaLockTimeout)
+	if err != nil {
+		return fmt.Errorf("conversations/index: acquire session lock for %s: %w", meta.SessionID, err)
+	}
+	defer lock.Release()
+
 	idx.sessions[meta.SessionID] = meta
 	idx.turns[meta.SessionID] = turns
 
-	// Persist turns file.
-	if err := idx.writeTurnsFile(meta.SessionID, turns); err != nil {
+	// Persist turns file (lock for this sessionID already held above).
+	if err := idx.writeTurnsFileLocked(meta.SessionID, turns); err != nil {
 		return fmt.Errorf("conversations/index: write turns %s: %w", meta.SessionID, err)
 	}
-	// Persist meta index under the cross-process lock. Only this call's own
+	// Persist meta index under the SAME per-sessionID lock plus the separate
+	// metaLockPath lock writeMetaFileLocked takes internally (metaLockPath
+	// guards the shared _meta.json map across ALL sessionIDs, so it's still
+	// needed in addition to this per-session lock — the two guard different
+	// things: this lock serializes "turns + meta for sessionID X" as one
+	// unit; metaLockPath serializes concurrent writers of _meta.json itself,
+	// which can be for different sessionIDs at once). Only this call's own
 	// upsert is applied as a delta on top of the current on-disk state — see
 	// writeMetaFileLocked.
 	return idx.writeMetaFileLocked(metaDelta{upserts: map[string]SessionMeta{meta.SessionID: meta}})
 }
 
 // DeleteSession removes a session from memory and disk.
+//
+// See UpsertSession's doc comment for why this holds one turnsLockPath(sessionID)
+// lock across both the turns-file removal and the _meta.json write, rather
+// than two separate acquisitions.
 func (idx *Index) DeleteSession(sessionID string) error {
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
 
+	lock, err := filelock.Acquire(idx.turnsLockPath(sessionID), metaLockTimeout)
+	if err != nil {
+		return fmt.Errorf("conversations/index: acquire session lock for %s: %w", sessionID, err)
+	}
+	defer lock.Release()
+
 	delete(idx.sessions, sessionID)
 	delete(idx.turns, sessionID)
 
-	// Same per-session lock writeTurnsFile takes, so a concurrent peer
-	// UpsertSession for this exact sessionID can't recreate the turns file
-	// in between this Remove and the caller's write, and vice versa.
-	if err := idx.removeTurnsFile(sessionID); err != nil {
+	if err := idx.removeTurnsFileLocked(sessionID); err != nil {
 		return fmt.Errorf("conversations/index: remove turns file: %w", err)
 	}
 	return idx.writeMetaFileLocked(metaDelta{deletes: []string{sessionID}})
 }
 
-// removeTurnsFile deletes sessionID's turns file under the same per-session
-// cross-process lock writeTurnsFile uses, so a delete can't race a
-// concurrent peer write of the same sessionID's turns file.
-func (idx *Index) removeTurnsFile(sessionID string) error {
-	lock, err := filelock.Acquire(idx.turnsLockPath(sessionID), metaLockTimeout)
-	if err != nil {
-		return fmt.Errorf("acquire turns lock for %s: %w", sessionID, err)
-	}
-	defer lock.Release()
-
+// removeTurnsFileLocked deletes sessionID's turns file. Callers must already
+// hold the turnsLockPath(sessionID) lock (see UpsertSession/DeleteSession).
+func (idx *Index) removeTurnsFileLocked(sessionID string) error {
 	if err := os.Remove(idx.turnsPath(sessionID)); err != nil && !os.IsNotExist(err) {
 		return err
 	}
@@ -604,7 +634,10 @@ func (idx *Index) turnsLockPath(sessionID string) string {
 	return idx.turnsPath(sessionID) + ".lock"
 }
 
-// writeTurnsFile persists the full turns list for sessionID.
+// writeTurnsFileLocked persists the full turns list for sessionID. Callers
+// must already hold the turnsLockPath(sessionID) lock (see
+// UpsertSession/DeleteSession, which hold it across both this write and the
+// companion _meta.json write as one unit).
 //
 // Same shape as writeMetaFileLocked and fixed for the same reason
 // (cog-review, PR #458): the daemon's reconcile ticker and a
@@ -615,20 +648,15 @@ func (idx *Index) turnsLockPath(sessionID string) string {
 // needing a read-merge-write), each turns file is owned wholly by one
 // sessionID and every writer replaces the full content, so no on-disk merge
 // is needed here — only atomicity (tmp + rename, preventing a torn read on
-// loadTurnsFile) and a cross-process lock (preventing the interleaving
-// itself, so the two writes fully serialize rather than merely not tearing
-// each other's bytes). Without either, loadTurnsFile's json.Unmarshal can
-// fail on a corrupted file and Load drops the session's meta and turns
-// entirely (index.go's Load: on a per-session parse error it deletes the
-// session from the in-memory map rather than surfacing a partial result) —
-// a stronger data-loss outcome than #449's "last writer wins on one field".
-func (idx *Index) writeTurnsFile(sessionID string, turns []Turn) error {
-	lock, err := filelock.Acquire(idx.turnsLockPath(sessionID), metaLockTimeout)
-	if err != nil {
-		return fmt.Errorf("conversations/index: acquire turns lock for %s: %w", sessionID, err)
-	}
-	defer lock.Release()
-
+// loadTurnsFile) and the cross-process lock the caller holds (preventing the
+// interleaving itself, so writes for a given sessionID fully serialize
+// rather than merely not tearing each other's bytes). Without atomicity,
+// loadTurnsFile's json.Unmarshal can fail on a corrupted file and Load drops
+// the session's meta and turns entirely (index.go's Load: on a per-session
+// parse error it deletes the session from the in-memory map rather than
+// surfacing a partial result) — a stronger data-loss outcome than #449's
+// "last writer wins on one field".
+func (idx *Index) writeTurnsFileLocked(sessionID string, turns []Turn) error {
 	b, err := json.MarshalIndent(turns, "", "  ")
 	if err != nil {
 		return err

--- a/internal/conversations/index.go
+++ b/internal/conversations/index.go
@@ -467,6 +467,32 @@ func (idx *Index) turnsPath(sessionID string) string {
 // map reintroduces this process's own stale copy of a session a peer already
 // deleted, because idx.sessions only reflects this process's last Load, not
 // the peer's more recent delete.
+//
+// Deliberately does NOT unconditionally adopt the disk-merged map (which may
+// contain a peer process's session keys) into idx.sessions, and does NOT
+// unconditionally update lastMeta{Mtime,Size,Hash} to describe the merged
+// file's on-disk stats. An earlier version of this fix did both
+// unconditionally, and cog-review (PR #458) correctly flagged the resulting
+// metadata/turns split-brain: idx.sessions would gain a peer's session key
+// while idx.turns — populated only by this process's own Load/UpsertSession —
+// never got that session's turns, and because lastMetaHash was set to match
+// the bytes just written, the next LoadIfChanged saw "no external change" and
+// skipped the full reload that would otherwise have backfilled idx.turns.
+// cog_list_conversations would then list a session that
+// cog_get_turn/cog_search could never actually serve.
+//
+// The fix: after computing merged, compare it against idx.sessions as the
+// caller already left it (delta pre-applied by UpsertSession/DeleteSession
+// before calling here). If they're equal, no peer wrote anything this
+// process doesn't already fully know about (turns included) — the common
+// sole-writer case — so it's safe to keep the LoadIfChanged fast-path
+// bookkeeping (lastMeta{Mtime,Size,Hash}) in sync with what was just written,
+// same as before this fix. If they differ, a peer's content is present in
+// merged that idx.sessions doesn't have turns for; leave idx.sessions and the
+// lastMeta bookkeeping untouched by this call, so the next LoadIfChanged
+// detects the file changed out from under its recorded baseline and performs
+// a full reload — sessions map AND turns map together — keeping the two maps
+// consistent with each other at the cost of that one reload.
 func (idx *Index) writeMetaFileLocked(delta metaDelta) error {
 	lock, err := filelock.Acquire(idx.metaLockPath(), metaLockTimeout)
 	if err != nil {
@@ -509,21 +535,47 @@ func (idx *Index) writeMetaFileLocked(delta metaDelta) error {
 		return err
 	}
 
-	// Adopt the merged-and-written view as this process's in-memory sessions
-	// too, so a peer's concurrent addition/removal becomes visible here
-	// without waiting for the next Load/LoadIfChanged.
-	idx.sessions = merged
-
-	// Record our own write — hash of the exact bytes we wrote, plus the
-	// post-write stat — so the next LoadIfChanged recognises the file as
-	// unchanged-by-others and skips the full reload. Called under idx.mu (the
-	// "Locked" suffix), so these fields are mutated under the write lock.
-	idx.lastMetaHash = sha256Hex(b)
-	if fi, statErr := os.Stat(idx.metaPath()); statErr == nil {
-		idx.lastMetaMtime = fi.ModTime()
-		idx.lastMetaSize = fi.Size()
+	// Only adopt merged (and the fast-path bookkeeping) when it exactly
+	// matches idx.sessions as the caller left it — i.e. no peer content is
+	// present that this process's idx.turns doesn't already cover. See the
+	// func comment above for why an unconditional adopt reintroduces the
+	// sessions/turns split-brain cog-review flagged on PR #458.
+	if sessionMapsEqual(merged, idx.sessions) {
+		idx.lastMetaHash = sha256Hex(b)
+		if fi, statErr := os.Stat(idx.metaPath()); statErr == nil {
+			idx.lastMetaMtime = fi.ModTime()
+			idx.lastMetaSize = fi.Size()
+		}
 	}
+	// else: leave idx.sessions/lastMeta* exactly as they were. idx.sessions
+	// still holds this call's own delta (applied by the caller), which is
+	// consistent with idx.turns; the on-disk file now also carries the
+	// peer's content, which the next LoadIfChanged's content-hash check will
+	// notice (it no longer matches lastMetaHash) and reload properly.
 	return nil
+}
+
+// sessionMapsEqual reports whether a and b contain exactly the same set of
+// session IDs mapped to byte-for-byte-equal SessionMeta values, using each
+// value's JSON encoding for the comparison (SessionMeta has no slice/map
+// fields, so this is equivalent to a field-by-field equality check but
+// avoids having to keep a manual comparator in sync with the struct).
+func sessionMapsEqual(a, b map[string]SessionMeta) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, av := range a {
+		bv, ok := b[k]
+		if !ok {
+			return false
+		}
+		aj, aerr := json.Marshal(av)
+		bj, berr := json.Marshal(bv)
+		if aerr != nil || berr != nil || string(aj) != string(bj) {
+			return false
+		}
+	}
+	return true
 }
 
 func (idx *Index) writeTurnsFile(sessionID string, turns []Turn) error {

--- a/internal/conversations/index_multiwriter_test.go
+++ b/internal/conversations/index_multiwriter_test.go
@@ -166,3 +166,126 @@ func TestCrossProcessDeleteSurvivesConcurrentUpsert(t *testing.T) {
 		t.Fatalf("_meta.json has %d sessions, want 20 (the concurrent 'other-*' upserts)", len(onDisk))
 	}
 }
+
+// TestPeerWriteDoesNotDesyncSessionsAndTurns is the regression test for the
+// finding cog-review raised on an earlier version of this fix (PR #458):
+// writeMetaFileLocked must never let idx.sessions gain a peer process's
+// session key without idx.turns having that session's turns loaded, because
+// idx.sessions backs ListSessions/GetMeta (used by cog_list_conversations)
+// while idx.turns backs GetTurn/Search (used by cog_get_turn/cog_search) —
+// a split between them means a session is listed but its content is
+// unreachable.
+//
+// Drives two Index instances against the same projDir: idxB writes a session
+// idxA never loads via Load/LoadIfChanged. idxA then performs its own,
+// unrelated UpsertSession (writeMetaFileLocked observes idxB's session on
+// disk while merging). The invariant checked is: for every session_id idxA's
+// in-memory idx.sessions knows about, idx.turns must also know about it —
+// i.e. UpsertSession must never introduce a sessions/turns split-brain as a
+// side effect of coordinating with a peer's write.
+func TestPeerWriteDoesNotDesyncSessionsAndTurns(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	idxA, err := NewIndex(dir)
+	if err != nil {
+		t.Fatalf("NewIndex A: %v", err)
+	}
+	idxB, err := NewIndex(dir)
+	if err != nil {
+		t.Fatalf("NewIndex B: %v", err)
+	}
+
+	now := time.Now()
+
+	// idxA establishes a baseline session so it has a non-empty in-memory
+	// view before the peer write happens.
+	if err := idxA.UpsertSession(
+		SessionMeta{SessionID: "a-baseline", TurnCount: 1, FirstTurnAt: now, LastTurnAt: now},
+		[]Turn{{UUID: "a-baseline", SessionID: "a-baseline", TurnIndex: 0, Role: "user", Timestamp: now, Text: "hi"}},
+	); err != nil {
+		t.Fatalf("idxA baseline UpsertSession: %v", err)
+	}
+
+	// idxB, standing in for a separate CLI process, writes a session idxA
+	// never observes via Load/LoadIfChanged.
+	if err := idxB.UpsertSession(
+		SessionMeta{SessionID: "b-peer-only", TurnCount: 1, FirstTurnAt: now, LastTurnAt: now},
+		[]Turn{{UUID: "b-peer-only", SessionID: "b-peer-only", TurnIndex: 0, Role: "user", Timestamp: now, Text: "hi from B"}},
+	); err != nil {
+		t.Fatalf("idxB UpsertSession: %v", err)
+	}
+
+	// idxA now does its own, unrelated write. Its writeMetaFileLocked call
+	// will read _meta.json off disk (which now contains "b-peer-only") while
+	// merging in its own delta.
+	if err := idxA.UpsertSession(
+		SessionMeta{SessionID: "a-second", TurnCount: 1, FirstTurnAt: now, LastTurnAt: now},
+		[]Turn{{UUID: "a-second", SessionID: "a-second", TurnIndex: 0, Role: "user", Timestamp: now, Text: "hi again"}},
+	); err != nil {
+		t.Fatalf("idxA second UpsertSession: %v", err)
+	}
+
+	// Invariant: every session_id in idxA's in-memory idx.sessions must also
+	// be present in idx.turns. "b-peer-only" must NOT appear in idxA's
+	// idx.sessions unless idxA has actually loaded its turns (which it
+	// hasn't, since it never called Load/LoadIfChanged after idxB's write).
+	// Scoped explicitly (not deferred) so the RLock is released before the
+	// LoadIfChanged call further down, which takes its own write lock.
+	func() {
+		idxA.mu.RLock()
+		defer idxA.mu.RUnlock()
+		for sid := range idxA.sessions {
+			if _, ok := idxA.turns[sid]; !ok {
+				t.Fatalf("idx.sessions contains %q but idx.turns does not — sessions/turns split-brain (peer-write desync)", sid)
+			}
+		}
+		if _, ok := idxA.sessions["b-peer-only"]; ok {
+			t.Fatalf("idxA.sessions unexpectedly contains peer-only session %q without ever loading its turns", "b-peer-only")
+		}
+	}()
+
+	// Meanwhile the on-disk file must still contain all three sessions —
+	// idxA's write must not have dropped idxB's peer session even though
+	// idxA didn't adopt it into memory.
+	raw, err := os.ReadFile(idxA.metaPath())
+	if err != nil {
+		t.Fatalf("read _meta.json: %v", err)
+	}
+	var onDisk map[string]SessionMeta
+	if err := json.Unmarshal(raw, &onDisk); err != nil {
+		t.Fatalf("_meta.json is not valid JSON: %v", err)
+	}
+	for _, want := range []string{"a-baseline", "b-peer-only", "a-second"} {
+		if _, ok := onDisk[want]; !ok {
+			t.Fatalf("_meta.json missing expected session %q after idxA's second write; got keys: %v", want, onDisk)
+		}
+	}
+
+	// And idxA's own view is self-consistent when it does reload: turns for
+	// everything idxA has ever upserted are still resolvable via GetTurn.
+	if _, ok := idxA.GetTurn("a-baseline", 0); !ok {
+		t.Fatalf("idxA lost its own baseline turn after the peer-write interleaving")
+	}
+	if _, ok := idxA.GetTurn("a-second", 0); !ok {
+		t.Fatalf("idxA lost its own second turn after the peer-write interleaving")
+	}
+
+	// A subsequent LoadIfChanged must detect the peer's on-disk addition
+	// (content differs from idxA's own lastMetaHash baseline) and perform a
+	// full reload that backfills idx.turns for "b-peer-only" too.
+	reloaded, err := idxA.LoadIfChanged()
+	if err != nil {
+		t.Fatalf("LoadIfChanged: %v", err)
+	}
+	if !reloaded {
+		t.Fatalf("LoadIfChanged reported no change, but the on-disk file contains idxB's peer write that idxA never adopted")
+	}
+	if _, ok := idxA.GetMeta("b-peer-only"); !ok {
+		t.Fatalf("after LoadIfChanged, idxA still doesn't know about peer session %q", "b-peer-only")
+	}
+	if _, ok := idxA.GetTurn("b-peer-only", 0); !ok {
+		t.Fatalf("after LoadIfChanged, idxA knows about peer session %q via sessions but still can't resolve its turns", "b-peer-only")
+	}
+}

--- a/internal/conversations/index_multiwriter_test.go
+++ b/internal/conversations/index_multiwriter_test.go
@@ -362,3 +362,115 @@ func TestCrossProcessSameSessionTurnsFileRace(t *testing.T) {
 		t.Fatalf("turns file has %d entries, want exactly 1 (one writer's full replace, not a merge/tear)", len(turns))
 	}
 }
+
+// TestCrossProcessDeleteUpsertSameSessionNoSplitBrain is the regression test
+// for cog-review's third finding on PR #458: DeleteSession(sid) on one Index
+// instance racing UpsertSession(sid, ...) on another, for the IDENTICAL
+// sessionID, must never leave _meta.json listing a session whose turns file
+// is missing (or vice versa) on disk. The original fix took the per-session
+// turns lock and the global meta lock as two SEPARATE, independently
+// released critical sections, which left a window: instance B's turns write
+// completes and releases the turns lock; instance A acquires that freed
+// lock, removes the turns file, and moves on to the meta lock; B then writes
+// sid back into _meta.json. The fix holds ONE per-sessionID lock across both
+// the turns operation and the meta write in each of UpsertSession and
+// DeleteSession, so the two calls for the same sessionID are fully mutually
+// exclusive end-to-end.
+//
+// This drives many rounds of concurrent delete-vs-upsert on the same
+// sessionID from two Index instances and asserts, after each round settles,
+// that the on-disk state is one of exactly two consistent outcomes:
+// (a) sid absent from _meta.json AND its turns file absent, or
+// (b) sid present in _meta.json AND its turns file present and valid.
+// A split-brain (present in one but not the other) fails the test.
+func TestCrossProcessDeleteUpsertSameSessionNoSplitBrain(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	const sessionID = "delete-upsert-race"
+	now := time.Now()
+
+	idxA, err := NewIndex(dir)
+	if err != nil {
+		t.Fatalf("NewIndex A: %v", err)
+	}
+	idxB, err := NewIndex(dir)
+	if err != nil {
+		t.Fatalf("NewIndex B: %v", err)
+	}
+
+	const rounds = 50
+	for r := 0; r < rounds; r++ {
+		// Seed the session so there's something for the delete side to race
+		// against on this round.
+		if err := idxB.UpsertSession(
+			SessionMeta{SessionID: sessionID, TurnCount: 1, FirstTurnAt: now, LastTurnAt: now},
+			[]Turn{{UUID: sessionID, SessionID: sessionID, TurnIndex: 0, Role: "user", Timestamp: now, Text: "seed"}},
+		); err != nil {
+			t.Fatalf("round %d: seed UpsertSession: %v", r, err)
+		}
+
+		var wg sync.WaitGroup
+		errs := make(chan error, 2)
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			if err := idxA.DeleteSession(sessionID); err != nil {
+				errs <- err
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			if err := idxB.UpsertSession(
+				SessionMeta{SessionID: sessionID, TurnCount: 1, FirstTurnAt: now, LastTurnAt: now},
+				[]Turn{{UUID: sessionID, SessionID: sessionID, TurnIndex: 0, Role: "user", Timestamp: now, Text: "round " + strconv.Itoa(r)}},
+			); err != nil {
+				errs <- err
+			}
+		}()
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			t.Fatalf("round %d: writer error: %v", r, err)
+		}
+
+		// Check on-disk consistency for this round.
+		raw, err := os.ReadFile(idxA.metaPath())
+		if err != nil {
+			t.Fatalf("round %d: read _meta.json: %v", r, err)
+		}
+		var onDisk map[string]SessionMeta
+		if err := json.Unmarshal(raw, &onDisk); err != nil {
+			t.Fatalf("round %d: _meta.json is not valid JSON: %v", r, err)
+		}
+		_, listedInMeta := onDisk[sessionID]
+
+		verify, err := NewIndex(dir)
+		if err != nil {
+			t.Fatalf("round %d: NewIndex for verify: %v", r, err)
+		}
+		// os.Stat, not loadTurnsFile, so presence/absence is unambiguous
+		// regardless of turns-list length (loadTurnsFile returns nil for
+		// both "file missing" and "file present but empty array").
+		_, statErr := os.Stat(verify.turnsPath(sessionID))
+		hasTurnsFile := statErr == nil
+		if statErr != nil && !os.IsNotExist(statErr) {
+			t.Fatalf("round %d: stat turns file: %v", r, statErr)
+		}
+		if _, parseErr := verify.loadTurnsFile(sessionID); parseErr != nil {
+			t.Fatalf("round %d: turns file corrupted: %v", r, parseErr)
+		}
+
+		if listedInMeta != hasTurnsFile {
+			t.Fatalf("round %d: split-brain — sid listed in _meta.json=%v but turns file present=%v", r, listedInMeta, hasTurnsFile)
+		}
+
+		// Re-sync both instances' in-memory view for the next round.
+		if _, err := idxA.LoadIfChanged(); err != nil {
+			t.Fatalf("round %d: idxA LoadIfChanged: %v", r, err)
+		}
+		if _, err := idxB.LoadIfChanged(); err != nil {
+			t.Fatalf("round %d: idxB LoadIfChanged: %v", r, err)
+		}
+	}
+}

--- a/internal/conversations/index_multiwriter_test.go
+++ b/internal/conversations/index_multiwriter_test.go
@@ -474,3 +474,45 @@ func TestCrossProcessDeleteUpsertSameSessionNoSplitBrain(t *testing.T) {
 		}
 	}
 }
+
+// TestTurnsLockPathDoesNotCollideWithMetaLockPath guards against the
+// self-deadlock cog-review flagged (unverified, low-likelihood) on PR #458's
+// fourth review pass: a session literally named "_meta" would make
+// turnsPath("_meta") resolve to the same path as metaPath() ("_meta.json"),
+// so a naive turnsLockPath == turnsPath+".lock" would collide with
+// metaLockPath's "_meta.json.lock" — and since UpsertSession/DeleteSession
+// hold the turnsLockPath lock across the whole call, including the nested
+// writeMetaFileLocked call that acquires metaLockPath, that collision would
+// make UpsertSession("_meta", ...) self-deadlock against its own second lock
+// acquisition until metaLockTimeout elapses.
+func TestTurnsLockPathDoesNotCollideWithMetaLockPath(t *testing.T) {
+	t.Parallel()
+
+	idx, err := NewIndex(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewIndex: %v", err)
+	}
+
+	if got, meta := idx.turnsLockPath("_meta"), idx.metaLockPath(); got == meta {
+		t.Fatalf("turnsLockPath(%q) == metaLockPath() == %q — collision would self-deadlock UpsertSession/DeleteSession for this sessionID", "_meta", meta)
+	}
+
+	// End-to-end: UpsertSession/DeleteSession for a session literally named
+	// "_meta" must complete promptly, not hang until metaLockTimeout.
+	now := time.Now()
+	done := make(chan error, 1)
+	go func() {
+		done <- idx.UpsertSession(
+			SessionMeta{SessionID: "_meta", TurnCount: 1, FirstTurnAt: now, LastTurnAt: now},
+			[]Turn{{UUID: "_meta", SessionID: "_meta", TurnIndex: 0, Role: "user", Timestamp: now, Text: "hi"}},
+		)
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("UpsertSession(\"_meta\", ...): %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("UpsertSession(\"_meta\", ...) did not return within 2s — likely self-deadlocked on a turnsLockPath/metaLockPath collision")
+	}
+}

--- a/internal/conversations/index_multiwriter_test.go
+++ b/internal/conversations/index_multiwriter_test.go
@@ -20,6 +20,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/myrgic/cogos/pkg/filelock"
 )
 
 // TestCrossProcessUpsertRace drives two separate *Index instances against the
@@ -514,5 +516,84 @@ func TestTurnsLockPathDoesNotCollideWithMetaLockPath(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("UpsertSession(\"_meta\", ...) did not return within 2s — likely self-deadlocked on a turnsLockPath/metaLockPath collision")
+	}
+}
+
+// TestReadsNotBlockedByPeerHoldingCrossProcessLock is the regression test for
+// cog-review's fifth-round finding on PR #458: an earlier version of
+// UpsertSession/DeleteSession held idx.mu.Lock() (the in-process
+// sync.RWMutex also taken by GetMeta/ListSessions/GetTurn/Search) across the
+// blocking cross-process filelock.Acquire calls, so a daemon write blocked
+// waiting on a peer process's lock also froze every concurrent MCP read on
+// the same Index for up to ~2×metaLockTimeout. This simulates "a peer
+// process holds the per-session lock" by acquiring turnsLockPath directly
+// (bypassing the Index API, the way a genuinely separate OS process would
+// hold it) and asserts that concurrent GetMeta/ListSessions/Search calls on
+// the same Index still return promptly rather than blocking for the
+// contending UpsertSession call's lock-wait.
+func TestReadsNotBlockedByPeerHoldingCrossProcessLock(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	idx, err := NewIndex(dir)
+	if err != nil {
+		t.Fatalf("NewIndex: %v", err)
+	}
+
+	const sessionID = "contended-session"
+	now := time.Now()
+	if err := idx.UpsertSession(
+		SessionMeta{SessionID: sessionID, TurnCount: 1, FirstTurnAt: now, LastTurnAt: now},
+		[]Turn{{UUID: sessionID, SessionID: sessionID, TurnIndex: 0, Role: "user", Timestamp: now, Text: "hello world"}},
+	); err != nil {
+		t.Fatalf("seed UpsertSession: %v", err)
+	}
+
+	// Simulate a peer process holding the per-session lock for longer than
+	// this test's read-latency budget, by acquiring it directly rather than
+	// through a concurrent UpsertSession call (avoids a timing race on which
+	// goroutine acquires first).
+	peerLock, err := filelock.Acquire(idx.turnsLockPath(sessionID), 2*time.Second)
+	if err != nil {
+		t.Fatalf("peer filelock.Acquire: %v", err)
+	}
+	defer peerLock.Release()
+
+	// A concurrent UpsertSession for the SAME sessionID will now block
+	// waiting for peerLock, up to metaLockTimeout (5s). It runs in the
+	// background; this test does not wait for it to finish.
+	go func() {
+		_ = idx.UpsertSession(
+			SessionMeta{SessionID: sessionID, TurnCount: 1, FirstTurnAt: now, LastTurnAt: now},
+			[]Turn{{UUID: sessionID, SessionID: sessionID, TurnIndex: 0, Role: "user", Timestamp: now, Text: "contended write"}},
+		)
+	}()
+
+	// Give the goroutine above a moment to actually reach and block on
+	// filelock.Acquire before asserting reads are unaffected.
+	time.Sleep(100 * time.Millisecond)
+
+	const readBudget = 500 * time.Millisecond
+	checks := []struct {
+		name string
+		run  func()
+	}{
+		{"GetMeta", func() { idx.GetMeta(sessionID) }},
+		{"ListSessions", func() { idx.ListSessions(time.Time{}, time.Time{}, "") }},
+		{"Search", func() { idx.Search("hello", time.Time{}, time.Time{}, "", "", 0) }},
+		{"GetTurn", func() { idx.GetTurn(sessionID, 0) }},
+	}
+	for _, c := range checks {
+		done := make(chan struct{})
+		go func() {
+			c.run()
+			close(done)
+		}()
+		select {
+		case <-done:
+			// OK — returned promptly, not blocked by the peer's held lock.
+		case <-time.After(readBudget):
+			t.Fatalf("%s did not return within %v while a peer held the per-session cross-process lock — idx.mu is being held across the blocking lock acquisition again", c.name, readBudget)
+		}
 	}
 }

--- a/internal/conversations/index_multiwriter_test.go
+++ b/internal/conversations/index_multiwriter_test.go
@@ -1,0 +1,168 @@
+// index_multiwriter_test.go — cross-process write-race regression test for
+// _meta.json (issue #449).
+//
+// index_race_test.go covers concurrency within a single *Index (in-memory map
+// races between goroutines sharing one process's view). This file covers the
+// distinct failure mode reported in #449: two independent *Index instances —
+// standing in for a CLI-invoked "cog reconcile conversations" process and the
+// daemon's own reconcile cycle — pointed at the same on-disk projDir, each
+// doing its own read-modify-write of _meta.json with no shared in-memory
+// state. Before the filelock+merge fix, whichever instance's
+// writeMetaFileLocked ran last would marshal only its own idx.sessions and
+// silently drop whatever the other instance had already added — the exact
+// "last writer wins" bug the issue describes.
+package conversations
+
+import (
+	"encoding/json"
+	"os"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestCrossProcessUpsertRace drives two separate *Index instances against the
+// same projDir concurrently, each upserting its own disjoint set of sessions,
+// and asserts that every session from both instances survives on disk in a
+// well-formed _meta.json — i.e. no interleaving of the two writers silently
+// drops an entry or corrupts the file.
+func TestCrossProcessUpsertRace(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	idxA, err := NewIndex(dir)
+	if err != nil {
+		t.Fatalf("NewIndex A: %v", err)
+	}
+	idxB, err := NewIndex(dir)
+	if err != nil {
+		t.Fatalf("NewIndex B: %v", err)
+	}
+
+	const perWriter = 100
+	now := time.Now()
+
+	writer := func(idx *Index, tag string, wg *sync.WaitGroup, errs chan<- error) {
+		defer wg.Done()
+		for i := 0; i < perWriter; i++ {
+			sid := tag + "-" + strconv.Itoa(i)
+			meta := SessionMeta{SessionID: sid, TurnCount: 1, FirstTurnAt: now, LastTurnAt: now}
+			turns := []Turn{{UUID: sid, SessionID: sid, TurnIndex: 0, Role: "user", Timestamp: now, Text: "hi " + sid}}
+			if err := idx.UpsertSession(meta, turns); err != nil {
+				errs <- err
+				return
+			}
+		}
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	wg.Add(2)
+	go writer(idxA, "proc-a", &wg, errs)
+	go writer(idxB, "proc-b", &wg, errs)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("writer error: %v", err)
+	}
+
+	// The on-disk _meta.json must be valid JSON and contain every session
+	// from both writers — nothing dropped, nothing torn.
+	raw, err := os.ReadFile(idxA.metaPath())
+	if err != nil {
+		t.Fatalf("read _meta.json: %v", err)
+	}
+	var onDisk map[string]SessionMeta
+	if err := json.Unmarshal(raw, &onDisk); err != nil {
+		t.Fatalf("_meta.json is not valid JSON after concurrent writers: %v\ncontent: %s", err, raw)
+	}
+
+	want := 2 * perWriter
+	if len(onDisk) != want {
+		missingA, missingB := 0, 0
+		for i := 0; i < perWriter; i++ {
+			if _, ok := onDisk["proc-a-"+strconv.Itoa(i)]; !ok {
+				missingA++
+			}
+			if _, ok := onDisk["proc-b-"+strconv.Itoa(i)]; !ok {
+				missingB++
+			}
+		}
+		t.Fatalf("_meta.json has %d sessions, want %d (missing from proc-a: %d, missing from proc-b: %d) — writers clobbered each other",
+			len(onDisk), want, missingA, missingB)
+	}
+}
+
+// TestCrossProcessDeleteSurvivesConcurrentUpsert verifies that a delete from
+// one Index instance is not resurrected by a concurrent upsert wave from a
+// second instance touching unrelated session keys — the pendingDeletes /
+// merge-then-delete ordering in writeMetaFileLocked.
+func TestCrossProcessDeleteSurvivesConcurrentUpsert(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	idxA, err := NewIndex(dir)
+	if err != nil {
+		t.Fatalf("NewIndex A: %v", err)
+	}
+	idxB, err := NewIndex(dir)
+	if err != nil {
+		t.Fatalf("NewIndex B: %v", err)
+	}
+
+	now := time.Now()
+	doomed := SessionMeta{SessionID: "doomed", TurnCount: 1, FirstTurnAt: now, LastTurnAt: now}
+	if err := idxA.UpsertSession(doomed, []Turn{{UUID: "doomed", SessionID: "doomed", TurnIndex: 0, Role: "user", Timestamp: now, Text: "x"}}); err != nil {
+		t.Fatalf("seed UpsertSession: %v", err)
+	}
+	// idxB has not yet Loaded, so it doesn't know about "doomed" — mirrors a
+	// freshly-started peer process.
+	if _, err := idxB.LoadIfChanged(); err != nil {
+		t.Fatalf("idxB LoadIfChanged: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		if err := idxA.DeleteSession("doomed"); err != nil {
+			errs <- err
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 20; i++ {
+			sid := "other-" + strconv.Itoa(i)
+			meta := SessionMeta{SessionID: sid, TurnCount: 1, FirstTurnAt: now, LastTurnAt: now}
+			if err := idxB.UpsertSession(meta, []Turn{{UUID: sid, SessionID: sid, TurnIndex: 0, Role: "user", Timestamp: now, Text: "y"}}); err != nil {
+				errs <- err
+				return
+			}
+		}
+	}()
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("writer error: %v", err)
+	}
+
+	raw, err := os.ReadFile(idxA.metaPath())
+	if err != nil {
+		t.Fatalf("read _meta.json: %v", err)
+	}
+	var onDisk map[string]SessionMeta
+	if err := json.Unmarshal(raw, &onDisk); err != nil {
+		t.Fatalf("_meta.json is not valid JSON: %v", err)
+	}
+	if _, stillThere := onDisk["doomed"]; stillThere {
+		t.Fatalf("deleted session %q was resurrected by a concurrent peer upsert", "doomed")
+	}
+	if len(onDisk) != 20 {
+		t.Fatalf("_meta.json has %d sessions, want 20 (the concurrent 'other-*' upserts)", len(onDisk))
+	}
+}

--- a/internal/conversations/index_multiwriter_test.go
+++ b/internal/conversations/index_multiwriter_test.go
@@ -289,3 +289,76 @@ func TestPeerWriteDoesNotDesyncSessionsAndTurns(t *testing.T) {
 		t.Fatalf("after LoadIfChanged, idxA knows about peer session %q via sessions but still can't resolve its turns", "b-peer-only")
 	}
 }
+
+// TestCrossProcessSameSessionTurnsFileRace is the regression test for the
+// finding cog-review raised on PR #458's second review pass: writeTurnsFile
+// itself (not just _meta.json) needs an atomic write and a cross-process
+// lock, because two Index instances (standing in for the daemon's reconcile
+// ticker and a separately-invoked "cog reconcile conversations" CLI process)
+// can detect drift on the SAME sessionID's source JSONL in the same window
+// and both call UpsertSession(meta, turns) for that identical sessionID
+// concurrently — racing on the one turns file rather than two different
+// ones. Before the fix this could interleave/tear the write; loadTurnsFile
+// would then fail to json.Unmarshal the corrupted file and Load() drops the
+// session's meta+turns from the index entirely (index.go's Load: a
+// per-session parse error deletes that session from the in-memory sessions
+// map) — a stronger data-loss outcome than a merely-missing field.
+//
+// This test can't deterministically force the interleaving (the lock
+// serializes the writers), but it repeatedly drives many concurrent
+// same-sessionID writers under `-race` and asserts the turns file is always
+// valid, non-torn JSON afterward with the last writer's content —
+// serialization, not corruption.
+func TestCrossProcessSameSessionTurnsFileRace(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	const sessionID = "shared-session"
+	const writers = 8
+	const itersPerWriter = 30
+
+	var wg sync.WaitGroup
+	errs := make(chan error, writers)
+	now := time.Now()
+
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			idx, err := NewIndex(dir)
+			if err != nil {
+				errs <- err
+				return
+			}
+			for i := 0; i < itersPerWriter; i++ {
+				turns := []Turn{
+					{UUID: sessionID, SessionID: sessionID, TurnIndex: 0, Role: "user", Timestamp: now, Text: "writer " + strconv.Itoa(w) + " iter " + strconv.Itoa(i)},
+				}
+				meta := SessionMeta{SessionID: sessionID, TurnCount: 1, FirstTurnAt: now, LastTurnAt: now}
+				if err := idx.UpsertSession(meta, turns); err != nil {
+					errs <- err
+					return
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("writer error: %v", err)
+	}
+
+	// The turns file must be valid, untorn JSON — never partially-written
+	// bytes from two interleaved writers.
+	verify, err := NewIndex(dir)
+	if err != nil {
+		t.Fatalf("NewIndex for verify: %v", err)
+	}
+	turns, err := verify.loadTurnsFile(sessionID)
+	if err != nil {
+		t.Fatalf("turns file is corrupted after concurrent same-session writers: %v", err)
+	}
+	if len(turns) != 1 {
+		t.Fatalf("turns file has %d entries, want exactly 1 (one writer's full replace, not a merge/tear)", len(turns))
+	}
+}

--- a/internal/engine/bus_session.go
+++ b/internal/engine/bus_session.go
@@ -30,6 +30,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/myrgic/cogos/pkg/filelock"
 	"github.com/myrgic/cogos/pkg/substrate/cogfield"
 )
 
@@ -178,8 +179,31 @@ func (m *BusSessionManager) RegisterBus(busID, sessionID, origin string) error {
 	return m.registerBusLocked(busID, sessionID, origin)
 }
 
+// registryLockTimeout bounds how long a registry writer waits for the
+// cross-process advisory lock before failing the operation.
+const registryLockTimeout = 5 * time.Second
+
+// acquireRegistryLock takes the cross-process advisory lock guarding the
+// load-modify-save cycle on registry.json. The root-package CLI writer
+// (busSessionManager, reachable from `cog bus send`/`cog infer`) takes the
+// SAME lock, so a running daemon and concurrent CLI invocations serialize
+// instead of last-writer-wins silently dropping each other's entries.
+// Lock ordering: m.mu is always taken before this filelock.
+func (m *BusSessionManager) acquireRegistryLock() (*filelock.FileLock, error) {
+	if err := os.MkdirAll(m.BusesDir(), 0755); err != nil {
+		return nil, err
+	}
+	return filelock.Acquire(m.RegistryPath()+".lock", registryLockTimeout)
+}
+
 // registerBusLocked is the locked-variant helper. Caller must hold m.mu.
 func (m *BusSessionManager) registerBusLocked(busID, sessionID, origin string) error {
+	lock, err := m.acquireRegistryLock()
+	if err != nil {
+		return fmt.Errorf("acquire registry lock: %w", err)
+	}
+	defer lock.Release()
+
 	registry := m.loadRegistry()
 
 	for i, entry := range registry {
@@ -420,6 +444,15 @@ func (m *BusSessionManager) LatestEventHash(busID string) (hash string, seq int6
 // updateRegistrySeqLocked updates the last event seq/timestamp in the registry.
 // Caller must hold m.mu.
 func (m *BusSessionManager) updateRegistrySeqLocked(busID string, seq int, ts string) {
+	lock, err := m.acquireRegistryLock()
+	if err != nil {
+		// Best-effort metadata update: skipping is safer than an unserialized
+		// read-modify-write that can drop a concurrent writer's entry.
+		slog.Warn("bus: skipping registry seq update (lock unavailable)", "err", err, "bus_id", busID)
+		return
+	}
+	defer lock.Release()
+
 	registry := m.loadRegistry()
 	for i, entry := range registry {
 		if entry.BusID == busID {

--- a/internal/engine/bus_session.go
+++ b/internal/engine/bus_session.go
@@ -173,15 +173,31 @@ func (m *BusSessionManager) EnsureBus(busID string) error {
 }
 
 // RegisterBus adds or updates a bus entry in the registry.
+//
+// Lock ordering: registry filelock BEFORE m.mu, never the reverse — acquiring
+// the cross-process lock while holding the in-process mutex would let one
+// contended peer process stall every unrelated bus operation in this process.
 func (m *BusSessionManager) RegisterBus(busID, sessionID, origin string) error {
+	lock, err := m.acquireRegistryLock()
+	if err != nil {
+		return fmt.Errorf("acquire registry lock: %w", err)
+	}
+	defer lock.Release()
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.registerBusLocked(busID, sessionID, origin)
 }
 
 // registryLockTimeout bounds how long a registry writer waits for the
-// cross-process advisory lock before failing the operation.
+// cross-process advisory lock before failing the operation (registration:
+// correctness-critical, cold path).
 const registryLockTimeout = 5 * time.Second
+
+// registrySeqLockTimeout bounds the best-effort seq-metadata update on the
+// append hot path — short, because a skipped update self-heals on the next
+// append and a long wait would delay the AppendEvent caller.
+const registrySeqLockTimeout = 500 * time.Millisecond
 
 // acquireRegistryLock takes the cross-process advisory lock guarding the
 // load-modify-save cycle on registry.json. The root-package CLI writer
@@ -196,14 +212,10 @@ func (m *BusSessionManager) acquireRegistryLock() (*filelock.FileLock, error) {
 	return filelock.Acquire(m.RegistryPath()+".lock", registryLockTimeout)
 }
 
-// registerBusLocked is the locked-variant helper. Caller must hold m.mu.
+// registerBusLocked is the locked-variant helper. Caller must hold BOTH the
+// registry filelock (see acquireRegistryLock) and m.mu, acquired in that
+// order.
 func (m *BusSessionManager) registerBusLocked(busID, sessionID, origin string) error {
-	lock, err := m.acquireRegistryLock()
-	if err != nil {
-		return fmt.Errorf("acquire registry lock: %w", err)
-	}
-	defer lock.Release()
-
 	registry := m.loadRegistry()
 
 	for i, entry := range registry {
@@ -368,12 +380,14 @@ func (m *BusSessionManager) AppendEvent(busID, eventType, from string, payload m
 		}
 	}
 
-	m.updateRegistrySeqLocked(busID, newSeq, evt.Ts)
-
 	// Snapshot handlers while locked, then dispatch OUTSIDE the lock.
 	handlers := make([]busEventHandler, len(m.eventHandlers))
 	copy(handlers, m.eventHandlers)
 	m.mu.Unlock()
+
+	// Registry seq update runs OUTSIDE m.mu: it blocks (briefly) on the
+	// cross-process filelock, and must never stall unrelated bus operations.
+	m.updateRegistrySeqIfNewer(busID, newSeq, evt.Ts)
 
 	for _, h := range handlers {
 		h.handler(busID, &evt)
@@ -441,14 +455,25 @@ func (m *BusSessionManager) LatestEventHash(busID string) (hash string, seq int6
 	return h, int64(s), nil
 }
 
-// updateRegistrySeqLocked updates the last event seq/timestamp in the registry.
-// Caller must hold m.mu.
-func (m *BusSessionManager) updateRegistrySeqLocked(busID string, seq int, ts string) {
-	lock, err := m.acquireRegistryLock()
+// updateRegistrySeqIfNewer updates the last event seq/timestamp in the
+// registry. Caller must NOT hold m.mu — this method blocks (briefly) on the
+// cross-process registry filelock, and holding the in-process mutex across
+// that wait would let one contended peer stall every unrelated bus operation
+// in this process (the exact hazard this PR fixes elsewhere).
+//
+// Best-effort + monotonic: the seq update is derivable metadata that
+// self-heals on the next append, so on lock contention we skip rather than
+// wait long (registrySeqLockTimeout), and because callers run outside m.mu
+// their updates can arrive out of order — the IfNewer guard makes a stale
+// update a harmless no-op instead of a seq regression.
+func (m *BusSessionManager) updateRegistrySeqIfNewer(busID string, seq int, ts string) {
+	if err := os.MkdirAll(m.BusesDir(), 0755); err != nil {
+		slog.Warn("bus: skipping registry seq update", "err", err, "bus_id", busID)
+		return
+	}
+	lock, err := filelock.Acquire(m.RegistryPath()+".lock", registrySeqLockTimeout)
 	if err != nil {
-		// Best-effort metadata update: skipping is safer than an unserialized
-		// read-modify-write that can drop a concurrent writer's entry.
-		slog.Warn("bus: skipping registry seq update (lock unavailable)", "err", err, "bus_id", busID)
+		slog.Warn("bus: skipping registry seq update (lock contended)", "err", err, "bus_id", busID)
 		return
 	}
 	defer lock.Release()
@@ -456,6 +481,9 @@ func (m *BusSessionManager) updateRegistrySeqLocked(busID string, seq int, ts st
 	registry := m.loadRegistry()
 	for i, entry := range registry {
 		if entry.BusID == busID {
+			if entry.LastEventSeq >= seq {
+				return // stale out-of-order update; newer one already landed
+			}
 			registry[i].LastEventSeq = seq
 			registry[i].LastEventAt = ts
 			registry[i].EventCount = seq

--- a/internal/engine/bus_session_multiwriter_test.go
+++ b/internal/engine/bus_session_multiwriter_test.go
@@ -1,0 +1,64 @@
+package engine
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// TestRegisterBus_ConcurrentManagersAllSurvive simulates the cross-process
+// race on registry.json: multiple BusSessionManager instances (as a daemon
+// and concurrent CLI processes would be — no shared in-process mutex)
+// concurrently register distinct buses. Without the cross-process filelock
+// around the load-modify-save cycle, last-writer-wins drops entries; with it,
+// every registration must survive.
+func TestRegisterBus_ConcurrentManagersAllSurvive(t *testing.T) {
+	root := t.TempDir()
+	const n = 8
+
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			m := NewBusSessionManager(root)
+			if err := m.RegisterBus(fmt.Sprintf("bus-%d", i), fmt.Sprintf("sess-%d", i), "test"); err != nil {
+				errs <- fmt.Errorf("register bus-%d: %w", i, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+
+	m := NewBusSessionManager(root)
+	registry := m.LoadRegistry()
+	if len(registry) != n {
+		t.Fatalf("expected %d registry entries to survive concurrent registration, got %d (lost updates)", n, len(registry))
+	}
+}
+
+// TestUpdateRegistrySeqIfNewer_NoRegression verifies the monotonic guard:
+// because seq updates run outside m.mu they can arrive out of order, and a
+// stale update must be a no-op rather than regressing LastEventSeq.
+func TestUpdateRegistrySeqIfNewer_NoRegression(t *testing.T) {
+	root := t.TempDir()
+	m := NewBusSessionManager(root)
+	if err := m.RegisterBus("bus-a", "sess-a", "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	m.updateRegistrySeqIfNewer("bus-a", 5, "2026-07-07T00:00:05Z")
+	m.updateRegistrySeqIfNewer("bus-a", 3, "2026-07-07T00:00:03Z") // stale, out of order
+
+	registry := m.LoadRegistry()
+	if len(registry) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(registry))
+	}
+	if registry[0].LastEventSeq != 5 {
+		t.Fatalf("seq regressed: expected LastEventSeq=5 after stale update, got %d", registry[0].LastEventSeq)
+	}
+}

--- a/internal/engine/cli_reconcile.go
+++ b/internal/engine/cli_reconcile.go
@@ -101,6 +101,20 @@ func runReconcileCmd(args []string, defaultWorkspace string) {
 		os.Exit(1)
 	}
 
+	// Acquire the cross-process state lock for the full
+	// LoadState → ComputePlan → ApplyPlan → BuildState → WriteState cycle so
+	// this CLI invocation can't race the daemon's own reconcile-loop cycle
+	// for the same providerType (same bug class as issue #449's _meta.json
+	// race; see pkg/substrate/reconcile/state.go doc comment). Held across
+	// the whole cycle, including the dry-run/read-only path, for simplicity —
+	// a stale read under contention is harmless, a racing write is not.
+	stateLock, lockErr := reconcile.AcquireStateLock(root, providerType)
+	if lockErr != nil {
+		fmt.Fprintf(os.Stderr, "error: acquire state lock for %s: %v\n", providerType, lockErr)
+		os.Exit(1)
+	}
+	defer stateLock.Release()
+
 	// Load persisted state.
 	state, _ := reconcile.LoadState(root, providerType)
 

--- a/internal/engine/reconcile_daemon.go
+++ b/internal/engine/reconcile_daemon.go
@@ -600,6 +600,24 @@ func (d *ReconcileDaemon) runOneCycle(ctx context.Context, providerType string) 
 		return fmt.Errorf("FetchLive %s: %w", providerType, err)
 	}
 
+	// Acquire the cross-process state lock for the full
+	// LoadState → ComputePlan → ApplyPlan → BuildState → WriteState cycle
+	// (steps 3-7 below) so this daemon cycle can't race a CLI-invoked
+	// `cogos reconcile <type>` run against the same providerType (same bug
+	// class as issue #449's _meta.json race; see
+	// pkg/substrate/reconcile/state.go doc comment). Released via defer so
+	// every early-return path below (ComputePlan/ApplyPlan/BuildState
+	// failures) still releases it. A lock-acquire failure (peer holds it
+	// past StateLockTimeout) is treated like any other phase failure: warn
+	// and skip this cycle, retried on the next tick.
+	lock, lockErr := reconcile.AcquireStateLock(d.cfg.WorkspaceRoot, providerType)
+	if lockErr != nil {
+		slog.Warn("reconcile-daemon: acquire state lock failed",
+			"provider", providerType, "err", lockErr)
+		return fmt.Errorf("acquire state lock %s: %w", providerType, lockErr)
+	}
+	defer lock.Release()
+
 	// Step 3: Load persisted state.
 	stateStart := time.Now()
 	state, stateErr := reconcile.LoadState(d.cfg.WorkspaceRoot, providerType)

--- a/internal/eval/dispatch_triggers_multiwriter_test.go
+++ b/internal/eval/dispatch_triggers_multiwriter_test.go
@@ -1,0 +1,122 @@
+// dispatch_triggers_multiwriter_test.go — cross-process write-race
+// regression test for eval-dispatch-triggers.json, the sibling of issue
+// #449's _meta.json race flagged by cog-review on PR #458 (fifth review
+// pass, head 9d0aa2e): writeDispatchTrigger (called from the cog_run_experiment
+// MCP tool handler) and readAndClearDispatchTriggers (called by the daemon's
+// eval ComputePlan cycle) both did a plain os.WriteFile with no atomic
+// tmp+rename and no cross-process lock, so a concurrent trigger-add and
+// trigger-drain could interleave and silently drop the just-added trigger,
+// or clobber the clear back to non-empty.
+package eval
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+)
+
+// TestDispatchTriggers_ConcurrentWritesAllSurvive drives N goroutines each
+// calling writeDispatchTrigger for a distinct experimentID against the same
+// root concurrently, and asserts every trigger survives a single
+// readAndClearDispatchTriggers call afterward — i.e. no interleaved writer
+// silently dropped a peer's just-added entry.
+func TestDispatchTriggers_ConcurrentWritesAllSurvive(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	const numWriters = 50
+	var wg sync.WaitGroup
+	errs := make(chan error, numWriters)
+	wg.Add(numWriters)
+	for i := 0; i < numWriters; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			expID := "exp-" + strconv.Itoa(i)
+			if err := writeDispatchTrigger(dir, expID, i%2 == 0); err != nil {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("writeDispatchTrigger error: %v", err)
+	}
+
+	triggers := readAndClearDispatchTriggers(dir)
+	if len(triggers) != numWriters {
+		missing := 0
+		for i := 0; i < numWriters; i++ {
+			if _, ok := triggers["exp-"+strconv.Itoa(i)]; !ok {
+				missing++
+			}
+		}
+		t.Fatalf("triggers count = %d, want %d (missing %d) — concurrent writers clobbered each other", len(triggers), numWriters, missing)
+	}
+	for i := 0; i < numWriters; i++ {
+		expID := "exp-" + strconv.Itoa(i)
+		want := i%2 == 0
+		if got, ok := triggers[expID]; !ok {
+			t.Errorf("%s missing from triggers", expID)
+		} else if got != want {
+			t.Errorf("%s force = %v, want %v", expID, got, want)
+		}
+	}
+
+	// A second read must see no pending triggers — the clear must have won.
+	if t2 := readAndClearDispatchTriggers(dir); len(t2) != 0 {
+		t.Errorf("expected triggers cleared after read, got %v", t2)
+	}
+}
+
+// TestDispatchTriggers_WriteDuringClearDoesNotLoseEitherSide races a single
+// writeDispatchTrigger call against a concurrent readAndClearDispatchTriggers
+// call for a *different* experimentID already on disk, and asserts that
+// whichever interleaving occurs, the final on-disk state is exactly one of
+// two well-defined outcomes — never a torn/corrupt file, and never a silent
+// merge that loses the write while also failing to have cleared the
+// pre-existing entry.
+func TestDispatchTriggers_WriteDuringClearDoesNotLoseEitherSide(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	// Seed one pre-existing trigger that the "clear" side will consume.
+	if err := writeDispatchTrigger(dir, "pre-existing", false); err != nil {
+		t.Fatalf("seed writeDispatchTrigger: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	var clearResult map[string]bool
+	go func() {
+		defer wg.Done()
+		clearResult = readAndClearDispatchTriggers(dir)
+	}()
+	go func() {
+		defer wg.Done()
+		_ = writeDispatchTrigger(dir, "new-trigger", true)
+	}()
+	wg.Wait()
+
+	// The clear call must have seen the pre-existing trigger (it ran either
+	// before or after the concurrent write, but the write only ever adds
+	// "new-trigger", never removes "pre-existing").
+	if _, ok := clearResult["pre-existing"]; !ok {
+		t.Errorf("readAndClearDispatchTriggers did not observe pre-existing trigger: %v", clearResult)
+	}
+
+	// Whatever remains on disk after both calls settle must be exactly
+	// {"new-trigger": true} if the write landed after the clear, or empty if
+	// the write landed before the clear (and was itself cleared). It must
+	// never silently contain "pre-existing" again (the lock ensures the
+	// write always operates on a post-clear read, not a stale pre-clear
+	// snapshot) and it must be well-formed.
+	final := readAndClearDispatchTriggers(dir)
+	if _, ok := final["pre-existing"]; ok {
+		t.Errorf("pre-existing trigger resurrected after clear: %v", final)
+	}
+	if len(final) > 1 {
+		t.Errorf("unexpected extra triggers remained: %v", final)
+	}
+}

--- a/internal/eval/eval_sidecar_multiwriter_test.go
+++ b/internal/eval/eval_sidecar_multiwriter_test.go
@@ -1,15 +1,24 @@
-// dispatch_triggers_multiwriter_test.go — cross-process write-race
-// regression test for eval-dispatch-triggers.json, the sibling of issue
-// #449's _meta.json race flagged by cog-review on PR #458 (fifth review
-// pass, head 9d0aa2e): writeDispatchTrigger (called from the cog_run_experiment
-// MCP tool handler) and readAndClearDispatchTriggers (called by the daemon's
-// eval ComputePlan cycle) both did a plain os.WriteFile with no atomic
-// tmp+rename and no cross-process lock, so a concurrent trigger-add and
-// trigger-drain could interleave and silently drop the just-added trigger,
-// or clobber the clear back to non-empty.
+// eval_sidecar_multiwriter_test.go — cross-process write-race regression
+// tests for the eval package's two JSON state sidecars, both siblings of
+// issue #449's _meta.json race flagged by cog-review on PR #458:
+//
+//   - eval-dispatch-triggers.json (fifth review pass, head 9d0aa2e):
+//     writeDispatchTrigger (cog_run_experiment MCP handler) and
+//     readAndClearDispatchTriggers (daemon eval ComputePlan cycle) both did a
+//     plain os.WriteFile with no atomic tmp+rename and no cross-process lock.
+//   - eval-baselines.json (sixth review pass, head c5726e2): writePinBaseline
+//     (cog_pin_baseline MCP handler) had the identical unlocked, non-atomic
+//     os.WriteFile read-modify-write; an earlier round of this PR incorrectly
+//     judged it out of scope on the claim that no concurrent reader/writer
+//     exists, which cog-review corrected — provider_impl.go's LoadConfig
+//     reads this file every reconcile cycle, and concurrent cog_pin_baseline
+//     calls race each other with no serialization at all.
 package eval
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strconv"
 	"sync"
 	"testing"
@@ -118,5 +127,64 @@ func TestDispatchTriggers_WriteDuringClearDoesNotLoseEitherSide(t *testing.T) {
 	}
 	if len(final) > 1 {
 		t.Errorf("unexpected extra triggers remained: %v", final)
+	}
+}
+
+// TestWritePinBaseline_ConcurrentWritesAllSurvive drives N goroutines each
+// calling writePinBaseline for a distinct experimentID against the same root
+// concurrently, and asserts every pin survives on disk — i.e. no interleaved
+// writer silently dropped a peer's just-written pin (the race cog-review's
+// sixth review pass confirmed was live: two concurrent cog_pin_baseline MCP
+// calls with no serialization).
+func TestWritePinBaseline_ConcurrentWritesAllSurvive(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	const numWriters = 50
+	var wg sync.WaitGroup
+	errs := make(chan error, numWriters)
+	wg.Add(numWriters)
+	for i := 0; i < numWriters; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			expID := "exp-" + strconv.Itoa(i)
+			runID := "run-" + strconv.Itoa(i)
+			if err := writePinBaseline(dir, expID, runID); err != nil {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("writePinBaseline error: %v", err)
+	}
+
+	pinsPath := filepath.Join(dir, ".cog", "state", "eval-baselines.json")
+	data, err := os.ReadFile(pinsPath)
+	if err != nil {
+		t.Fatalf("read pins file: %v", err)
+	}
+	var pins map[string]string
+	if err := json.Unmarshal(data, &pins); err != nil {
+		t.Fatalf("pins file is not valid JSON after concurrent writers: %v\ncontent: %s", err, data)
+	}
+
+	if len(pins) != numWriters {
+		missing := 0
+		for i := 0; i < numWriters; i++ {
+			if _, ok := pins["exp-"+strconv.Itoa(i)]; !ok {
+				missing++
+			}
+		}
+		t.Fatalf("pins count = %d, want %d (missing %d) — concurrent writers clobbered each other", len(pins), numWriters, missing)
+	}
+	for i := 0; i < numWriters; i++ {
+		expID := "exp-" + strconv.Itoa(i)
+		want := "run-" + strconv.Itoa(i)
+		if got := pins[expID]; got != want {
+			t.Errorf("%s = %q, want %q", expID, got, want)
+		}
 	}
 }

--- a/internal/eval/mcp_tools.go
+++ b/internal/eval/mcp_tools.go
@@ -456,11 +456,35 @@ func writeFileAtomic(path string, data []byte) error {
 // writePinBaseline writes a baseline pin to .cog/state/eval-baselines.json.
 // The file is a JSON map[string]string: experiment_id → run_id.
 // Implements cog_pin_baseline's storage logic (design memo Q1 / Q10).
+// pinBaselineLockPath returns the advisory cross-process lock file guarding
+// the read-modify-write cycle on eval-baselines.json.
+func pinBaselineLockPath(root string) string {
+	return filepath.Join(root, ".cog", "state", "eval-baselines.json.lock")
+}
+
+// writePinBaseline writes a baseline pin to .cog/state/eval-baselines.json.
+// The file is a JSON map[string]string: experiment_id -> run_id.
+// Implements cog_pin_baseline's storage logic (design memo Q1 / Q10).
+//
+// This was originally left unlocked/non-atomic on the (incorrect) claim
+// that no concurrent reader/writer exists — cog-review's re-review round on
+// this PR corrected that: internal/eval/provider_impl.go's LoadConfig reads
+// eval-baselines.json on every reconcile cycle (both the daemon's own loop
+// and `cogos reconcile eval`), and two concurrent cog_pin_baseline MCP calls
+// race each other with no serialization at all. Same bug class, same fix:
+// atomic tmp+rename write plus a cross-process filelock spanning the full
+// read-modify-write cycle.
 func writePinBaseline(root, experimentID, runID string) error {
 	stateDir := filepath.Join(root, ".cog", "state")
 	if err := os.MkdirAll(stateDir, 0o755); err != nil {
 		return fmt.Errorf("mkdir %s: %w", stateDir, err)
 	}
+
+	lock, err := filelock.Acquire(pinBaselineLockPath(root), dispatchTriggersLockTimeout)
+	if err != nil {
+		return fmt.Errorf("acquire pin-baseline lock: %w", err)
+	}
+	defer lock.Release()
 
 	pinsPath := filepath.Join(stateDir, "eval-baselines.json")
 	pins := map[string]string{}
@@ -474,7 +498,7 @@ func writePinBaseline(root, experimentID, runID string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(pinsPath, b, 0o644)
+	return writeFileAtomic(pinsPath, b)
 }
 
 // evalErrorResult builds a CallToolResult carrying an error message.

--- a/internal/eval/mcp_tools.go
+++ b/internal/eval/mcp_tools.go
@@ -20,8 +20,11 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/myrgic/cogos/pkg/filelock"
 )
 
 // RegisterEvalTools registers the four eval MCP tools on the given server.
@@ -337,15 +340,43 @@ func makePinBaselineHandler(p *EvalProvider) mcp.ToolHandlerFor[pinBaselineInput
 	}
 }
 
+// dispatchTriggersLockTimeout bounds how long writeDispatchTrigger /
+// readAndClearDispatchTriggers wait to acquire the cross-process lock on
+// eval-dispatch-triggers.json. Mirrors metaLockTimeout in
+// internal/conversations/index.go / StateLockTimeout in
+// pkg/substrate/reconcile/state.go (same bug class, same timeout budget).
+const dispatchTriggersLockTimeout = 5 * time.Second
+
+// dispatchTriggersLockPath returns the advisory cross-process lock file
+// guarding the read-modify-write cycle on eval-dispatch-triggers.json. A
+// sibling file, not the triggers file itself, so the lock's own lifecycle
+// never touches the JSON content file readAndClearDispatchTriggers reads.
+func dispatchTriggersLockPath(root string) string {
+	return filepath.Join(root, ".cog", "state", "eval-dispatch-triggers.json.lock")
+}
+
 // writeDispatchTrigger records an on-demand experiment trigger in
 // .cog/state/eval-dispatch-triggers.json. The map value is "force" (bool).
 // ComputePlan calls readAndClearDispatchTriggers() to consume and atomically
 // remove entries so they fire exactly once.
+//
+// Reachable from an MCP tool handler (cog_run_experiment) racing the
+// daemon's own eval ComputePlan cycle calling readAndClearDispatchTriggers
+// concurrently — the same read-modify-write race issue #449 was filed for on
+// the conversations index's _meta.json. Fixed the same way: an atomic
+// tmp+rename write, plus a cross-process filelock held across the full
+// read-modify-write cycle so a concurrent writer/clearer can't interleave.
 func writeDispatchTrigger(root, experimentID string, force bool) error {
 	stateDir := filepath.Join(root, ".cog", "state")
 	if err := os.MkdirAll(stateDir, 0o755); err != nil {
 		return fmt.Errorf("mkdir %s: %w", stateDir, err)
 	}
+
+	lock, err := filelock.Acquire(dispatchTriggersLockPath(root), dispatchTriggersLockTimeout)
+	if err != nil {
+		return fmt.Errorf("acquire dispatch-triggers lock: %w", err)
+	}
+	defer lock.Release()
 
 	triggersPath := filepath.Join(stateDir, "eval-dispatch-triggers.json")
 	triggers := map[string]bool{}
@@ -363,14 +394,31 @@ func writeDispatchTrigger(root, experimentID string, force bool) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(triggersPath, b, 0o644)
+	return writeFileAtomic(triggersPath, b)
 }
 
 // readAndClearDispatchTriggers reads the pending trigger file and clears it.
 // Returns map[experimentID]force. The file is removed (not just emptied) so
 // a missing file is the normal steady state. Called by ComputePlan before
 // rule evaluation.
+//
+// Takes the same cross-process lock as writeDispatchTrigger around the full
+// read-then-clear cycle, so a concurrent writeDispatchTrigger call (e.g. a
+// user invoking cog_run_experiment via MCP at the same moment the daemon's
+// eval reconcile cycle is draining triggers) can't have its just-added
+// trigger silently wiped by the clear, or have the clear itself clobbered
+// back to non-empty.
 func readAndClearDispatchTriggers(root string) map[string]bool {
+	lock, err := filelock.Acquire(dispatchTriggersLockPath(root), dispatchTriggersLockTimeout)
+	if err != nil {
+		// Lock contention/timeout: treat like "no triggers pending" rather
+		// than blocking the reconcile cycle indefinitely or erroring — the
+		// next cycle will retry. Mirrors the pre-existing best-effort
+		// posture of this function (write errors were already ignored).
+		return map[string]bool{}
+	}
+	defer lock.Release()
+
 	triggersPath := filepath.Join(root, ".cog", "state", "eval-dispatch-triggers.json")
 	data, err := os.ReadFile(triggersPath)
 	if err != nil {
@@ -382,9 +430,27 @@ func readAndClearDispatchTriggers(root string) map[string]bool {
 
 	// Clear the file atomically — write an empty map so a partial read can't
 	// see stale triggers on the next cycle. Ignore write errors (best-effort).
-	_ = os.WriteFile(triggersPath, []byte("{}"), 0o644)
+	_ = writeFileAtomic(triggersPath, []byte("{}"))
 
 	return triggers
+}
+
+// writeFileAtomic writes data to path via tmp+rename, same pattern as
+// BusSessionManager.saveRegistry (internal/engine/bus_session.go) and
+// writeMetaFileLocked (internal/conversations/index.go) — a plain
+// os.WriteFile can leave the file empty or torn if the process is killed
+// mid-write, which a subsequent json.Unmarshal would either fail on or
+// silently read as a valid-but-wrong empty map.
+func writeFileAtomic(path string, data []byte) error {
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return fmt.Errorf("writing tmp %s: %w", path, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("renaming %s: %w", path, err)
+	}
+	return nil
 }
 
 // writePinBaseline writes a baseline pin to .cog/state/eval-baselines.json.

--- a/internal/eval/mcp_tools.go
+++ b/internal/eval/mcp_tools.go
@@ -453,9 +453,6 @@ func writeFileAtomic(path string, data []byte) error {
 	return nil
 }
 
-// writePinBaseline writes a baseline pin to .cog/state/eval-baselines.json.
-// The file is a JSON map[string]string: experiment_id → run_id.
-// Implements cog_pin_baseline's storage logic (design memo Q1 / Q10).
 // pinBaselineLockPath returns the advisory cross-process lock file guarding
 // the read-modify-write cycle on eval-baselines.json.
 func pinBaselineLockPath(root string) string {

--- a/internal/eval/mcp_tools.go
+++ b/internal/eval/mcp_tools.go
@@ -360,12 +360,16 @@ func dispatchTriggersLockPath(root string) string {
 // ComputePlan calls readAndClearDispatchTriggers() to consume and atomically
 // remove entries so they fire exactly once.
 //
-// Reachable from an MCP tool handler (cog_run_experiment) racing the
-// daemon's own eval ComputePlan cycle calling readAndClearDispatchTriggers
-// concurrently — the same read-modify-write race issue #449 was filed for on
-// the conversations index's _meta.json. Fixed the same way: an atomic
-// tmp+rename write, plus a cross-process filelock held across the full
-// read-modify-write cycle so a concurrent writer/clearer can't interleave.
+// Concurrency the lock actually guards (corrected, review round on ee61416):
+// in the SHIPPED cmd/cogos binary the reconcile provider for "eval" is a
+// no-op stub (internal/providers/daemon/daemon.go) — the real EvalProvider is
+// wired only to the MCP tool handlers plus a one-time boot LoadConfig, so the
+// daemon's reconcile loop does NOT touch this file today. The live races are
+// (a) two concurrent MCP tool invocations (multiple sessions) hitting the
+// same trigger file, and (b) any future wiring that registers the real
+// provider for reconcile (the root-package parallel tree already does).
+// Same read-modify-write class as issue #449, same fix: atomic tmp+rename
+// write plus a cross-process filelock across the full cycle.
 func writeDispatchTrigger(root, experimentID string, force bool) error {
 	stateDir := filepath.Join(root, ".cog", "state")
 	if err := os.MkdirAll(stateDir, 0o755); err != nil {
@@ -464,13 +468,15 @@ func pinBaselineLockPath(root string) string {
 // Implements cog_pin_baseline's storage logic (design memo Q1 / Q10).
 //
 // This was originally left unlocked/non-atomic on the (incorrect) claim
-// that no concurrent reader/writer exists — cog-review's re-review round on
-// this PR corrected that: internal/eval/provider_impl.go's LoadConfig reads
-// eval-baselines.json on every reconcile cycle (both the daemon's own loop
-// and `cogos reconcile eval`), and two concurrent cog_pin_baseline MCP calls
-// race each other with no serialization at all. Same bug class, same fix:
-// atomic tmp+rename write plus a cross-process filelock spanning the full
-// read-modify-write cycle.
+// that no concurrent reader/writer exists. Corrected justification (review
+// round on ee61416): in the SHIPPED cmd/cogos binary the "eval" reconcile
+// provider is a no-op stub, so the daemon reconcile loop does NOT read this
+// file each cycle — the real EvalProvider's LoadConfig runs once at boot and
+// via MCP handlers only. The live race is two concurrent cog_pin_baseline
+// MCP calls interleaving with each other (and with any future real-provider
+// reconcile wiring, which the root-package parallel tree already has). Same
+// bug class, same fix: atomic tmp+rename write plus a cross-process filelock
+// spanning the full read-modify-write cycle.
 func writePinBaseline(root, experimentID, runID string) error {
 	stateDir := filepath.Join(root, ".cog", "state")
 	if err := os.MkdirAll(stateDir, 0o755); err != nil {

--- a/pkg/substrate/reconcile/state.go
+++ b/pkg/substrate/reconcile/state.go
@@ -4,7 +4,24 @@
 //
 // Each provider stores state at .cog/config/{resource_type}/.state.json
 // using the State format from types.go.
-
+//
+// LoadState and WriteState are individually safe (WriteState is atomic:
+// tmp + rename), but the reconcile cycle that uses them —
+// LoadState → ComputePlan → ApplyPlan → BuildState → WriteState, run by both
+// `cogos reconcile <type>` (internal/engine/cli_reconcile.go) and the
+// daemon's own periodic reconcile loop (internal/engine/reconcile_daemon.go)
+// against the identical un-namespaced state file — is a read-modify-write
+// cycle with no cross-process coordination. BuildState derives the entire
+// new Resources slice fresh from live state plus the existing state's
+// Serial/Lineage (it does not apply a delta on top of a re-read of disk), so
+// unlike the conversations index's _meta.json fix (issue #449, per-session
+// delta merge), there is no sound delta-merge here: two concurrent cycles'
+// WriteState calls race on a plain last-write-wins tmp+rename, and whichever
+// lands last silently discards the other cycle's Serial/Resources.
+//
+// Callers that run a full LoadState→WriteState cycle for a given
+// resourceType must wrap it in AcquireStateLock/Release (see doc comment)
+// to serialize concurrent cycles for the same resourceType across processes.
 package reconcile
 
 import (
@@ -15,11 +32,55 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/myrgic/cogos/pkg/filelock"
 )
+
+// StateLockTimeout bounds how long AcquireStateLock waits to acquire the
+// cross-process lock before giving up. Mirrors metaLockTimeout in
+// internal/conversations/index.go (same bug class, same timeout budget).
+const StateLockTimeout = 5 * time.Second
 
 // StatePath returns the path to a provider's state file.
 func StatePath(root, resourceType string) string {
 	return filepath.Join(root, ".cog", "config", resourceType, ".state.json")
+}
+
+// StateLockPath returns the path to the advisory cross-process lock file
+// guarding a resource type's LoadState→WriteState reconcile cycle. A
+// sibling file, not the state file itself, so the lock's own lifecycle never
+// touches the JSON content file LoadState reads.
+func StateLockPath(root, resourceType string) string {
+	return StatePath(root, resourceType) + ".lock"
+}
+
+// AcquireStateLock takes the cross-process advisory lock for resourceType's
+// reconcile cycle. Callers must run their entire
+// LoadState → ComputePlan → ApplyPlan → BuildState → WriteState cycle while
+// holding the returned lock, then Release it — this is what serializes a
+// CLI-invoked `cogos reconcile <type>` run against the daemon's own
+// reconcile-loop cycle for the same resourceType, closing the same bug class
+// issue #449 fixed for the conversations index's _meta.json.
+//
+//	lock, err := reconcile.AcquireStateLock(root, resourceType)
+//	if err != nil {
+//	    return err
+//	}
+//	defer lock.Release()
+//	state, _ := reconcile.LoadState(root, resourceType)
+//	... ComputePlan / ApplyPlan / BuildState ...
+//	reconcile.WriteState(root, resourceType, newState)
+func AcquireStateLock(root, resourceType string) (*filelock.FileLock, error) {
+	lockPath := StateLockPath(root, resourceType)
+	// The lock must be acquirable before the state file (and its directory)
+	// necessarily exist — the very first reconcile cycle for a resourceType
+	// has no .state.json yet. WriteState creates the directory too, but that
+	// happens after LoadState/lock-acquire in the caller's cycle, so ensure
+	// it here rather than requiring every caller to mkdir before locking.
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0755); err != nil {
+		return nil, fmt.Errorf("creating state dir for %s lock: %w", resourceType, err)
+	}
+	return filelock.Acquire(lockPath, StateLockTimeout)
 }
 
 // LoadState loads the state file for a given resource type.

--- a/pkg/substrate/reconcile/state_lock_test.go
+++ b/pkg/substrate/reconcile/state_lock_test.go
@@ -1,0 +1,194 @@
+// state_lock_test.go — cross-process write-race regression test for the
+// generic reconcile framework's state file (pkg/substrate/reconcile/state.go),
+// the sibling of issue #449's _meta.json race flagged by cog-review on PR
+// #458 (fifth review pass, head 9d0aa2e): LoadState/WriteState back every
+// resource-provider type via the identical
+// LoadState → ComputePlan → ApplyPlan → BuildState → WriteState cycle run by
+// both `cogos reconcile <type>` and the daemon's own reconcile loop, with no
+// cross-process coordination prior to this fix.
+//
+// Unlike the conversations index fix, BuildState fully re-derives Resources
+// from live state each cycle rather than applying a delta on top of a fresh
+// disk read, so there is no sound delta-merge here — the fix is
+// AcquireStateLock/Release serializing the whole cycle, verified below by
+// simulating N concurrent "reconcile cycles" (each acquiring the lock,
+// loading state, incrementing a resource's revision, writing state, then
+// releasing) and asserting no cycle's update is silently lost to a
+// last-write-wins race.
+package reconcile
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/myrgic/cogos/pkg/filelock"
+)
+
+// TestAcquireStateLock_SerializesConcurrentCycles drives N goroutines, each
+// standing in for an independent process's full reconcile cycle
+// (AcquireStateLock → LoadState → mutate → WriteState → Release) against the
+// same resourceType, and asserts every cycle's contribution survives on disk.
+// Without the lock, two cycles' WriteState calls can interleave: cycle B
+// reads state before cycle A's WriteState lands, so B's WriteState (built
+// from the pre-A snapshot) discards A's Serial bump and Resources entry — a
+// classic last-writer-wins race. With the lock serializing LoadState through
+// WriteState, no cycle can observe a stale read.
+func TestAcquireStateLock_SerializesConcurrentCycles(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	const resourceType = "test-resource"
+	const numCycles = 50
+
+	var wg sync.WaitGroup
+	errs := make(chan error, numCycles)
+	wg.Add(numCycles)
+	for i := 0; i < numCycles; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			lock, err := AcquireStateLock(root, resourceType)
+			if err != nil {
+				errs <- err
+				return
+			}
+			defer lock.Release()
+
+			state, err := LoadState(root, resourceType)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if state == nil {
+				state = NewState(resourceType)
+				state.Serial = 0 // WriteState increments; NewState's Serial isn't persisted yet
+			}
+			state.Resources = append(state.Resources, Resource{
+				Address: "test." + strconv.Itoa(i),
+				Type:    "test",
+				Mode:    ModeManaged,
+				Name:    "resource-" + strconv.Itoa(i),
+			})
+			if err := WriteState(root, resourceType, state); err != nil {
+				errs <- err
+				return
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("cycle error: %v", err)
+	}
+
+	final, err := LoadState(root, resourceType)
+	if err != nil {
+		t.Fatalf("LoadState final: %v", err)
+	}
+	if final == nil {
+		t.Fatal("final state is nil")
+	}
+	if final.Serial != numCycles {
+		t.Errorf("Serial = %d, want %d — a concurrent cycle's WriteState was silently lost", final.Serial, numCycles)
+	}
+	if len(final.Resources) != numCycles {
+		missing := 0
+		seen := map[string]bool{}
+		for _, r := range final.Resources {
+			seen[r.Address] = true
+		}
+		for i := 0; i < numCycles; i++ {
+			if !seen["test."+strconv.Itoa(i)] {
+				missing++
+			}
+		}
+		t.Fatalf("Resources count = %d, want %d (missing %d entries) — cycles clobbered each other", len(final.Resources), numCycles, missing)
+	}
+
+	// The on-disk file must be well-formed JSON — no torn writes.
+	raw, err := os.ReadFile(StatePath(root, resourceType))
+	if err != nil {
+		t.Fatalf("read state file: %v", err)
+	}
+	var onDisk State
+	if err := json.Unmarshal(raw, &onDisk); err != nil {
+		t.Fatalf("state file is not valid JSON after concurrent cycles: %v\ncontent: %s", err, raw)
+	}
+}
+
+// TestStateLockPath_IsSiblingOfStateFile verifies the lock file lives beside
+// the state file, not on top of it — the lock's own open/lock/unlock
+// lifecycle must never touch the JSON content file LoadState reads (mirrors
+// metaLockPath's contract in internal/conversations/index.go).
+func TestStateLockPath_IsSiblingOfStateFile(t *testing.T) {
+	t.Parallel()
+	root := "/workspace"
+	statePath := StatePath(root, "discord")
+	lockPath := StateLockPath(root, "discord")
+	if lockPath == statePath {
+		t.Fatalf("StateLockPath must differ from StatePath, both are %q", statePath)
+	}
+	if lockPath != statePath+".lock" {
+		t.Errorf("StateLockPath = %q, want %q", lockPath, statePath+".lock")
+	}
+}
+
+// TestAcquireStateLock_ContendsOnSameResourceType verifies a second
+// AcquireStateLock call for the same resourceType genuinely blocks while a
+// peer holds the lock (simulated by acquiring StateLockPath directly, the
+// way a separate OS process would), and that the block is scoped to that
+// resourceType — a concurrent AcquireStateLock for a different resourceType
+// is unaffected. Mirrors the contention-shape convention in
+// TestReadsNotBlockedByPeerHoldingCrossProcessLock
+// (internal/conversations/index_multiwriter_test.go): probe with a budget
+// well under StateLockTimeout rather than waiting out the full 5s timeout.
+func TestAcquireStateLock_ContendsOnSameResourceType(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	lockPath := StateLockPath(root, "held-resource")
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	peerLock, err := filelock.Acquire(lockPath, 2*time.Second)
+	if err != nil {
+		t.Fatalf("peer filelock.Acquire: %v", err)
+	}
+	defer peerLock.Release()
+
+	contended := make(chan error, 1)
+	go func() {
+		lock, err := AcquireStateLock(root, "held-resource")
+		if err == nil {
+			lock.Release()
+		}
+		contended <- err
+	}()
+
+	const probeBudget = 300 * time.Millisecond
+	select {
+	case err := <-contended:
+		t.Fatalf("AcquireStateLock for the same resourceType returned (err=%v) while a peer held the lock — contention was not enforced", err)
+	case <-time.After(probeBudget):
+		// Expected: still blocked waiting on the peer's held lock.
+	}
+
+	// A different resourceType must not contend — its lock file is distinct.
+	other, err := AcquireStateLock(root, "other-resource")
+	if err != nil {
+		t.Fatalf("acquire unrelated resourceType should not contend: %v", err)
+	}
+	other.Release()
+
+	// Release the peer lock so the contended goroutine's Acquire can
+	// succeed and the test can exit cleanly instead of leaking a goroutine
+	// blocked until StateLockTimeout.
+	peerLock.Release()
+	if err := <-contended; err != nil {
+		t.Fatalf("AcquireStateLock after peer released: %v", err)
+	}
+}

--- a/sdk/thread.go
+++ b/sdk/thread.go
@@ -201,6 +201,24 @@ func (p *threadProjector) setThread(uri *ParsedURI, content []byte) error {
 }
 
 // patchThread updates thread metadata.
+//
+// Multi-writer audit (v1.0 alignment, ledger L10): patchThread's
+// load-then-write of threadMetaPath (via fs.WriteJSON, already atomic —
+// tmp+rename in sdk/internal/fs) is a read-modify-write over a shared file,
+// the same shape that required the filelock+delta fix in
+// internal/conversations/index.go for issue #449. It is NOT given the same
+// cross-process lock here because, as of this audit, sdk.Kernel (the only
+// type that constructs a threadProjector, see cogos.go's RegisterProjector
+// call) has zero callers outside the sdk package itself — neither
+// cmd/cogos/internal/engine (the daemon) nor any root-tree CLI command
+// constructs an sdk.Kernel or resolves a cog:thread/* URI through it. The
+// only repo-wide sdk import outside sdk/ itself is inference.go's
+// sdk.ParseURI, unrelated to thread mutation. So no CLI+daemon (or any
+// two-process) interleaving on threadMetaPath currently exists to race on. If
+// sdk.Kernel is ever wired into a live entrypoint (daemon or CLI) that can run
+// concurrently with another writer of the same node's thread files, apply the
+// same filelock-plus-delta pattern used in internal/conversations/index.go
+// before that happens.
 func (p *threadProjector) patchThread(uri *ParsedURI, content []byte) error {
 	threadID := uri.Path
 	if threadID == "" || threadID == "current" {


### PR DESCRIPTION
## What

Fixes #449 (conversations index multi-writer race on `_meta.json`), and two
related multi-writer races on the same code path discovered while fixing it:
a matching race on each session's turns file, and a delete-vs-upsert
interleaving across the two.

Also extends the same atomic-write + cross-process-lock fix to three more
confirmed sites of the identical bug class, flagged across two more
cog-review rounds (fifth pass, head `9d0aa2e`; sixth pass, head `c5726e2`):
`pkg/substrate/reconcile/state.go` (the generic reconcile framework backing
every other resource-provider type), and both of `internal/eval/mcp_tools.go`'s
JSON sidecars — the dispatch-trigger trigger file and the baseline-pin file
(the latter initially misjudged as out of scope; corrected in the sixth
round). See "5.", "6.", and "7." below.

## How

**1. `_meta.json` (issue #449's original race).**
`internal/conversations/index.go`'s `writeMetaFileLocked` did a plain
`os.WriteFile` with no cross-process coordination. A CLI-invoked
`cog reconcile conversations` run and the daemon's own reconcile cycle could
each read-modify-write `_meta.json` independently; the second writer's
marshal-of-its-own-in-memory-snapshot silently dropped whatever the first
writer had already committed ("last writer wins").

- **Atomic write**: tmp + rename, same pattern as
  `BusSessionManager.saveRegistry` (`internal/engine/bus_session.go:240`).
- **Cross-process lock** (`metaLockPath`, a sibling `_meta.json.lock` file)
  around the full read-modify-write cycle.
- **Delta application, not snapshot merge**: each write applies only the
  calling method's own delta (one upsert or one delete) on top of a fresh
  read of the on-disk state, never a full re-marshal of the process's
  in-memory `idx.sessions` (which could be stale relative to a peer's more
  recent write and would silently resurrect a session the peer already
  deleted).
- The disk-merged map is only adopted into `idx.sessions` (and the
  `LoadIfChanged` fast-path bookkeeping refreshed) when it's provably
  identical to what this process already has fully loaded (turns included).
  Otherwise the next `LoadIfChanged` detects the on-disk change and performs
  a real reload, keeping `idx.sessions` and `idx.turns` consistent with each
  other (this refinement came out of a cog-review round — see commit
  history for the earlier, unsound version and why).

**2. Each session's turns file (same race, different file).**
`writeTurnsFile` had the identical non-atomic, non-locked shape as the
original `_meta.json` bug, on a path this PR already touches. Fixed the same
way: atomic tmp+rename, plus a per-sessionID cross-process lock
(`turnsLockPath`) so two processes racing on the *same* session's turns file
fully serialize instead of tearing each other's write.

**3. Delete-vs-upsert interleaving across the two locks.**
Taking the turns lock and the meta lock as two *separate*,
independently-released critical sections left a window: instance B's turns
write completes and releases the turns lock; instance A acquires that
now-free lock, removes the turns file, and moves on to the meta lock; B then
writes the session back into `_meta.json`. Net result: `_meta.json` lists a
session whose turns file is gone — a split-brain reachable only via this
interleaving. Fixed by holding **one** per-sessionID lock across the entire
`UpsertSession`/`DeleteSession` body (both the turns operation and the meta
write), making the two calls for the same sessionID fully mutually exclusive
end-to-end. Different sessionIDs still use different lock files and proceed
with no contention.

**4. Lock-path collision edge case.**
`turnsLockPath(sessionID)` used to be `turnsPath(sessionID)+".lock"`; for a
session literally named `_meta`, `turnsPath("_meta")` resolves to the same
file as `metaPath()` (`_meta.json`), which would make `turnsLockPath`
collide with `metaLockPath` and self-deadlock `UpsertSession("_meta", ...)`
against its own nested `writeMetaFileLocked` call. Fixed with a distinct
`.sessions.lock` suffix.

**Also audited** `sdk/thread.go:250` (the other shared-file read-modify-write
path named in ledger item L10). Its meta write is already atomic via
`fs.WriteJSON`/`WriteAtomic`. No lock was added there — `sdk.Kernel` (the
only type that constructs the `threadProjector` doing this write) has zero
callers repo-wide outside the `sdk` package itself, so there is no live
CLI+daemon (or any two-process) interleaving on `threadMetaPath` to race on
today. Documented this finding inline so the same lock pattern is applied if
`sdk.Kernel` is ever wired into a live entrypoint.

**5. `pkg/substrate/reconcile/state.go` — the generic reconcile framework's
state file (cog-review finding, fifth pass).** `LoadState`/`WriteState` back
every registered resource-provider type (site, component, agent, service,
discord, eval, rbac_bindings, identity, openclaw, ...) via the identical
`LoadState → ComputePlan → ApplyPlan → BuildState → WriteState` cycle run by
both `cogos reconcile <type>` (`internal/engine/cli_reconcile.go`) and the
daemon's own periodic reconcile loop (`internal/engine/reconcile_daemon.go`)
against the same un-namespaced `.state.json` — the same architecture that
produced issue #449 in the first place, one layer up. `WriteState` was
already atomic (tmp+rename); the read-modify-write *cycle* around it had no
cross-process coordination, so two concurrent cycles' `WriteState` calls race
last-write-wins and silently discard the other cycle's `Serial`/`Resources`.

Unlike the conversations index fix, `BuildState` fully re-derives the entire
`Resources` slice from live state plus the existing state's `Serial`/`Lineage`
each cycle — it does not apply a delta on top of a fresh disk read — so there
is no sound delta-merge available here (a snapshot-merge would hit the same
unsoundness the conversations fix explicitly rejected). The fix is a new
`AcquireStateLock`/`Release` pair (`pkg/substrate/reconcile/state.go`,
`StateLockPath` = a sibling `.state.json.lock` file, `StateLockTimeout` =
5s, matching `metaLockTimeout`) that callers wrap around their entire
`LoadState → ... → WriteState` cycle, wired into both
`cli_reconcile.go:runReconcileCmd` and
`reconcile_daemon.go:runOneCycle` (held via `defer` across every early-return
path — `ComputePlan`/`ApplyPlan`/`BuildState` failures all still release it).

**6. `internal/eval/mcp_tools.go` — the eval dispatch-trigger sidecar (same
cog-review finding).** `writeDispatchTrigger` (called from the
`cog_run_experiment` MCP tool handler) and `readAndClearDispatchTriggers`
(called by the daemon's own eval `ComputePlan` cycle) both did a plain
`os.WriteFile` on `eval-dispatch-triggers.json` — no atomic tmp+rename, no
lock at all, the least-protected instance of this bug class in the repo. A
user calling `cog_run_experiment` at the same moment the daemon is draining
triggers could have the just-added trigger silently wiped by the concurrent
clear (or the clear itself clobbered back to non-empty) with no error
surfaced to the caller — an experiment dispatch silently dropped. Fixed with
the same atomic tmp+rename write (`writeFileAtomic`) plus a cross-process
`filelock` (`dispatchTriggersLockPath`, `dispatchTriggersLockTimeout` = 5s)
held across the full read-modify-write cycle in both functions.

**7. `internal/eval/mcp_tools.go` — the baseline-pin sidecar (sixth
cog-review pass; corrects an earlier judgment call in this same PR).**
`writePinBaseline` (`eval-baselines.json`, same file as the dispatch triggers)
shares the identical unlocked, non-atomic `os.WriteFile` read-modify-write
shape. An earlier round of this PR judged it out of scope on the claim that
no concurrent reader/writer exists — that claim was **incorrect**:
`internal/eval/provider_impl.go`'s `LoadConfig` reads `eval-baselines.json` on
every reconcile cycle (both the daemon's loop and `cogos reconcile eval`),
and two concurrent `cog_pin_baseline` MCP calls race each other with zero
serialization. Fixed the same way: atomic tmp+rename (`writeFileAtomic`,
shared with the dispatch-trigger fix) plus a cross-process `filelock`
(`pinBaselineLockPath`) spanning the read-modify-write cycle.
`LoadConfig`'s read itself needed no lock — once the write is atomic, a
racing plain read can only observe the file whole, pre- or post-rename,
never torn.

## Test evidence

Six new tests in `internal/conversations/index_multiwriter_test.go`, all run
under `-race`:

- `TestCrossProcessUpsertRace` — two `*Index` instances upsert 100 disjoint
  sessions each concurrently; asserts all 200 survive in valid `_meta.json`.
- `TestCrossProcessDeleteSurvivesConcurrentUpsert` — a delete on one instance
  is never resurrected by a concurrent peer upsert of unrelated sessions.
- `TestPeerWriteDoesNotDesyncSessionsAndTurns` — a peer's on-disk addition
  never enters `idx.sessions` without `idx.turns` also covering it; a
  subsequent `LoadIfChanged` correctly backfills both.
- `TestCrossProcessSameSessionTurnsFileRace` — 8 concurrent writers hammering
  the *same* sessionID's turns file 30x each; the file is always valid,
  untorn JSON afterward.
- `TestCrossProcessDeleteUpsertSameSessionNoSplitBrain` — 50 rounds of
  concurrent delete-vs-upsert on the identical sessionID; `_meta.json` and
  the turns file are always consistent (both present or both absent).
- `TestTurnsLockPathDoesNotCollideWithMetaLockPath` — asserts the two lock
  paths differ and that `UpsertSession("_meta", ...)` completes promptly
  rather than hanging on a self-deadlock.

```
$ go test ./internal/conversations/... -race -count=3
ok  	github.com/myrgic/cogos/internal/conversations	21.9s
```

Full repo build: `go build ./...` clean. All pre-existing
`internal/conversations` tests (including the `load_guard_test.go`
sole-writer/external-write/same-size-rewrite trio, which the sole-writer
fast-path change had to keep passing) still pass under `-race`.

**New for the two sibling-completion sites (5. and 6. above):**

`pkg/substrate/reconcile/state_lock_test.go`:
- `TestAcquireStateLock_SerializesConcurrentCycles` — 50 goroutines each
  simulating a full reconcile cycle (`AcquireStateLock` → `LoadState` →
  append one resource → `WriteState` → `Release`); asserts final `Serial` ==
  50 and all 50 `Resources` entries survive (no cycle's write silently lost).
- `TestAcquireStateLock_ContendsOnSameResourceType` — a peer holding
  `StateLockPath` blocks a concurrent `AcquireStateLock` for the same
  `resourceType` (probed under a budget well below `StateLockTimeout`), while
  a different `resourceType`'s lock is unaffected.
- `TestStateLockPath_IsSiblingOfStateFile` — lock path is a sibling file, not
  the state file itself.

`internal/eval/eval_sidecar_multiwriter_test.go` (renamed from
`dispatch_triggers_multiwriter_test.go` once it grew to cover both sidecars):
- `TestDispatchTriggers_ConcurrentWritesAllSurvive` — 50 goroutines each
  calling `writeDispatchTrigger` for a distinct experiment ID concurrently;
  asserts all 50 survive a single `readAndClearDispatchTriggers` call.
- `TestDispatchTriggers_WriteDuringClearDoesNotLoseEitherSide` — races one
  `writeDispatchTrigger` call against a concurrent
  `readAndClearDispatchTriggers` call for a pre-existing trigger; asserts the
  clear always observes the pre-existing entry and the pre-existing entry is
  never resurrected after the clear.
- `TestWritePinBaseline_ConcurrentWritesAllSurvive` — 50 goroutines each
  calling `writePinBaseline` for a distinct experiment ID concurrently;
  asserts all 50 pins survive on disk in valid JSON.

```
$ go test ./pkg/substrate/reconcile/... -race -count=3
ok  	github.com/myrgic/cogos/pkg/substrate/reconcile	9.055s
$ go test ./internal/eval/... -race -count=3
ok  	github.com/myrgic/cogos/internal/eval	8.580s
$ go build ./... && go test ./... -count=1
ok (all packages, full repo)
```

## Acceptance

- [x] Fixes #449
- [x] `go build ./...` clean
- [x] `go test ./internal/conversations/... -race` green (existing + 6 new)
- [x] `sdk/thread.go` sibling audited and disposition documented inline
- [x] Delete/upsert split-brain and lock-collision findings from review
      addressed with regression tests
- [x] `pkg/substrate/reconcile/state.go` sibling race fixed
      (`AcquireStateLock`/`Release` wraps the full cycle in both
      `cli_reconcile.go` and `reconcile_daemon.go`), with regression tests
- [x] `internal/eval/mcp_tools.go:344` sibling race fixed (atomic write +
      cross-process lock on `eval-dispatch-triggers.json`), with regression
      tests
- [x] `writePinBaseline` / `eval-baselines.json` sibling race fixed (same
      atomic write + cross-process lock), with regression tests — corrects
      this PR's own earlier out-of-scope judgment call after cog-review
      showed `provider_impl.go`'s `LoadConfig` does read this file every
      reconcile cycle

---

**Update (round 4, head fix/shared-file-atomic-writes):** cog-review flagged the root-package `busSessionManager.saveRegistry` (bus_session.go:224) as an un-swept sibling. Addressed: made it atomic (tmp+rename), closing the truncation→total-registry-loss failure mode (the severe half). The remaining cross-process last-writer-wins race between this root-CLI writer and the daemon writer of the same registry.json requires a shared filelock on BOTH sides; the daemon half is engine bus-registration behavior and the root half is L1-dispositioned, so full cross-process coordination is deferred to #461 (not silently dropped). This PR closes #449 and the atomic-write half of the whole class; #461 tracks the cross-process-lock remainder.


### Registry.json cross-process lock (0b33810)
Both writers of `.cog/.state/buses/registry.json` (root CLI `busSessionManager` and daemon `internal/engine.BusSessionManager`) now take the same `registry.json.lock` advisory filelock around every load-modify-save cycle, closing the last-writer-wins entry-drop the review's round-N finding described. Regression test: `TestRegisterBus_ConcurrentManagersAllSurvive` (independent manager instances = separate-process simulation). Nothing on this file is deferred to L1.



### Lock-ordering fix (082ecb7)
Round-N+1 review correctly flagged that the new registry filelock was acquired inside `m.mu` on the append hot path (nested-lock class this PR fixes elsewhere). Fixed: seq updates run outside `m.mu` with a 500ms best-effort timeout and a monotonic `IfNewer` guard (out-of-order updates are no-ops, not regressions); registration orders filelock BEFORE `m.mu`; engine side gains the multiwriter + monotonic regression tests it was missing. Blast radius: append latency under peer contention is now bounded by 500ms best-effort skip instead of 5s in-mutex stall; no unrelated bus operation queues behind a contended peer.
