### PR TITLE
ci(shell): add shell-hardening gate for scripts/*.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,15 @@ jobs:
         with:
           version: v2.11
 
+      # Shell-hardening gate (ledger L15): every tracked scripts/*.sh file
+      # must declare `set -euo pipefail` (or `set -eu` for POSIX sh, which
+      # has no pipefail) or carry a documented `# no-pipefail: <reason>`
+      # opt-out — plus a shellcheck error-severity pass (0 pre-existing
+      # findings at error severity, so any hit is a real regression).
+      # ubuntu-latest ships shellcheck preinstalled.
+      - name: Shell hardening gate
+        run: ./scripts/check-shell-hardening.sh scripts
+
   e2e:
     runs-on: ubuntu-latest
     needs: build

--- a/internal/shellgate/shellgate_test.go
+++ b/internal/shellgate/shellgate_test.go
@@ -1,0 +1,215 @@
+// shellgate_test.go — regression tests for scripts/check-shell-hardening.sh
+// (ledger L15: cheap CI gate requiring `set -euo pipefail` — or a
+// documented `# no-pipefail:` opt-out — in every tracked scripts/*.sh
+// file, plus a shellcheck error-severity pass).
+//
+// This package holds no production code; it exists solely so `go test
+// ./...` (the CI test job) exercises the gate script's pass/fail logic
+// directly, rather than only ever observing it green against the
+// already-hardened tree. Each test builds a throwaway git repo with a
+// `scripts/` directory and a handful of fixture .sh files, then shells
+// out to the real check-shell-hardening.sh against that fixture tree.
+package shellgate
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// repoRoot walks up from this file's directory to find the repository
+// root (identified by the presence of go.work or go.mod at the top).
+// internal/shellgate -> internal -> <repo root>.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not determine test file path")
+	}
+	// this file: <root>/internal/shellgate/shellgate_test.go
+	root := filepath.Dir(filepath.Dir(filepath.Dir(thisFile)))
+	gatePath := filepath.Join(root, "scripts", "check-shell-hardening.sh")
+	if _, err := os.Stat(gatePath); err != nil {
+		t.Fatalf("expected gate script at %s: %v", gatePath, err)
+	}
+	return root
+}
+
+// newFixtureRepo creates a temp directory, git-inits it, writes the given
+// scripts/<name> -> content files, and `git add`s them so the gate's
+// `git ls-files` scoping picks them up (the gate only checks *tracked*
+// files by design).
+func newFixtureRepo(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	runOK := func(name string, args ...string) {
+		t.Helper()
+		cmd := exec.Command(name, args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%s %s failed: %v\n%s", name, strings.Join(args, " "), err, out)
+		}
+	}
+
+	runOK("git", "init", "-q")
+	runOK("git", "config", "user.email", "gate-test@example.invalid")
+	runOK("git", "config", "user.name", "gate-test")
+
+	scriptsDir := filepath.Join(dir, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+		t.Fatalf("mkdir scripts: %v", err)
+	}
+
+	for name, content := range files {
+		p := filepath.Join(scriptsDir, name)
+		if err := os.WriteFile(p, []byte(content), 0o755); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+
+	runOK("git", "add", "-A")
+	runOK("git", "commit", "-q", "-m", "fixture")
+
+	return dir
+}
+
+// runGate invokes the real check-shell-hardening.sh against the fixture
+// repo's scripts/ dir and returns (exitCode, combinedOutput).
+func runGate(t *testing.T, fixtureDir string) (int, string) {
+	t.Helper()
+	root := repoRoot(t)
+	gate := filepath.Join(root, "scripts", "check-shell-hardening.sh")
+
+	cmd := exec.Command("bash", gate, filepath.Join(fixtureDir, "scripts"))
+	out, err := cmd.CombinedOutput()
+
+	exitCode := 0
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			t.Fatalf("failed to run gate script: %v\n%s", err, out)
+		}
+	}
+	return exitCode, string(out)
+}
+
+func TestGate_PassesHardenedBashScript(t *testing.T) {
+	dir := newFixtureRepo(t, map[string]string{
+		"good.sh": "#!/usr/bin/env bash\nset -euo pipefail\necho hi\n",
+	})
+	code, out := runGate(t, dir)
+	if code != 0 {
+		t.Fatalf("expected pass (exit 0), got exit %d:\n%s", code, out)
+	}
+	if !strings.Contains(out, "PASSED") {
+		t.Fatalf("expected PASSED in output, got:\n%s", out)
+	}
+}
+
+func TestGate_PassesHardenedPosixShScript(t *testing.T) {
+	// POSIX sh has no pipefail — `set -eu` is the correct hardening form.
+	dir := newFixtureRepo(t, map[string]string{
+		"good.sh": "#!/bin/sh\nset -eu\necho hi\n",
+	})
+	code, out := runGate(t, dir)
+	if code != 0 {
+		t.Fatalf("expected pass (exit 0), got exit %d:\n%s", code, out)
+	}
+}
+
+func TestGate_PassesDocumentedOptOut(t *testing.T) {
+	dir := newFixtureRepo(t, map[string]string{
+		"lib.sh": "#!/bin/sh\n# no-pipefail: sourced library, set -e would leak into the caller's shell\necho hi\n",
+	})
+	code, out := runGate(t, dir)
+	if code != 0 {
+		t.Fatalf("expected pass (exit 0) for documented opt-out, got exit %d:\n%s", code, out)
+	}
+}
+
+func TestGate_FailsUnhardenedScript(t *testing.T) {
+	dir := newFixtureRepo(t, map[string]string{
+		"bad.sh": "#!/usr/bin/env bash\necho hi\n",
+	})
+	code, out := runGate(t, dir)
+	if code == 0 {
+		t.Fatalf("expected failure (nonzero exit) for un-hardened script, got exit 0:\n%s", out)
+	}
+	if !strings.Contains(out, "bad.sh") {
+		t.Fatalf("expected failure output to name bad.sh, got:\n%s", out)
+	}
+}
+
+func TestGate_SkipsNonShellShebang(t *testing.T) {
+	// A .sh-suffixed file whose shebang is not a shell interpreter (e.g. a
+	// misnamed Python script) must be skipped entirely, not flagged.
+	dir := newFixtureRepo(t, map[string]string{
+		"not_shell.sh": "#!/usr/bin/env python3\nprint('hi')\n",
+	})
+	code, out := runGate(t, dir)
+	if code != 0 {
+		t.Fatalf("expected pass (exit 0) — non-shell-shebang file should be skipped, got exit %d:\n%s", code, out)
+	}
+	if !strings.Contains(out, "skipped 1") {
+		t.Fatalf("expected output to report 1 skipped file, got:\n%s", out)
+	}
+}
+
+func TestGate_FailsOnShellcheckErrorSeverity(t *testing.T) {
+	if _, err := exec.LookPath("shellcheck"); err != nil {
+		t.Skip("shellcheck not installed — skipping error-severity test")
+	}
+	// SC2154-class parse error: an unterminated quote is a shellcheck
+	// error-severity finding (not just a warning), and also independently
+	// hardened so this isolates the shellcheck check specifically.
+	dir := newFixtureRepo(t, map[string]string{
+		"broken.sh": "#!/usr/bin/env bash\nset -euo pipefail\necho \"unterminated\n",
+	})
+	code, out := runGate(t, dir)
+	if code == 0 {
+		t.Fatalf("expected failure (nonzero exit) for shellcheck error-severity finding, got exit 0:\n%s", out)
+	}
+	if !strings.Contains(out, "broken.sh") {
+		t.Fatalf("expected failure output to name broken.sh, got:\n%s", out)
+	}
+}
+
+func TestGate_MixedTreePassesOnlyWhenAllFilesClean(t *testing.T) {
+	dir := newFixtureRepo(t, map[string]string{
+		"good.sh":      "#!/usr/bin/env bash\nset -euo pipefail\necho hi\n",
+		"lib.sh":       "#!/bin/sh\n# no-pipefail: sourced library\necho hi\n",
+		"not_shell.sh": "#!/usr/bin/env python3\nprint('hi')\n",
+	})
+	code, out := runGate(t, dir)
+	if code != 0 {
+		t.Fatalf("expected pass for a fully-compliant mixed tree, got exit %d:\n%s", code, out)
+	}
+	if !strings.Contains(out, "checked 2") || !strings.Contains(out, "skipped 1") {
+		t.Fatalf("expected checked=2 skipped=1 in output, got:\n%s", out)
+	}
+}
+
+// TestRealScriptsDirectoryPassesGate is the actual acceptance check: run
+// the gate against this repo's own scripts/ directory (the real thing the
+// CI job invokes), so a regression in the checked-in scripts themselves
+// fails `go test ./...`, not just the CI-only shell step.
+func TestRealScriptsDirectoryPassesGate(t *testing.T) {
+	root := repoRoot(t)
+	gate := filepath.Join(root, "scripts", "check-shell-hardening.sh")
+
+	cmd := exec.Command("bash", gate, filepath.Join(root, "scripts"))
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("check-shell-hardening.sh failed against repo scripts/:\n%s", out)
+	}
+	if !strings.Contains(string(out), "PASSED") {
+		t.Fatalf("expected PASSED, got:\n%s", out)
+	}
+}

--- a/scripts/agent-test.sh
+++ b/scripts/agent-test.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Test agent lifecycle
+set -eu
 . .cog/cog
 
 echo "=== Testing Agent Lifecycle ==="

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# no-pipefail: sourced library (not executed standalone) — 'set -e'/'pipefail'
+# here would mutate the *calling* shell's option state for every session that
+# sources this file, which is a correctness hazard, not a style choice.
 # .cog/lib/bootstrap.sh - Agent bootstrap sequence
 #
 # Agents source this to initialize themselves properly.

--- a/scripts/check-shell-hardening.sh
+++ b/scripts/check-shell-hardening.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# check-shell-hardening.sh — CI gate for scripts/*.sh hardening (ledger L15).
+#
+# Enforces two cheap, mechanical properties on every tracked *.sh file under
+# scripts/:
+#
+#   1. Error-handling discipline: the file either declares
+#      `set -euo pipefail` (bash/ksh/zsh — pipefail is not POSIX) or
+#      `set -eu` (POSIX sh, no pipefail support), OR carries a documented
+#      opt-out comment of the form:
+#
+#          # no-pipefail: <reason>
+#
+#      Typical valid reason: the file is a sourced library (`. lib.sh` /
+#      `source lib.sh`), and `set -e`/`pipefail` in a sourced file mutates
+#      the *calling* shell's option state — a real footgun, not a style nit.
+#
+#   2. shellcheck, at error severity only, if shellcheck is installed. Error
+#      severity was 0 across the repo at the time this gate was added, so
+#      any error-level finding is a regression, not pre-existing debt.
+#      Warning/info/style findings are NOT enforced here — ~294 pre-existing
+#      warnings exist across scripts/*.sh; burning that down is separate
+#      follow-up work (see ledger L9), not this gate's job.
+#
+# Files whose shebang is not a shell interpreter (e.g. a `.sh`-suffixed
+# Python script) are skipped entirely — the check is shebang-driven, not
+# extension-driven.
+#
+# Usage: ./scripts/check-shell-hardening.sh [scripts-dir]
+#
+# no-pipefail: this file's own shebang is bash and it does declare
+# set -euo pipefail below; this header note exists only so a future reader
+# grepping for "no-pipefail:" understands the convention from the canonical
+# source. (Not itself an opt-out — see the `set` line immediately below.)
+
+set -euo pipefail
+
+SCRIPTS_DIR="${1:-scripts}"
+
+if [[ ! -d "$SCRIPTS_DIR" ]]; then
+  echo "check-shell-hardening: no such directory: $SCRIPTS_DIR" >&2
+  exit 1
+fi
+
+have_shellcheck=0
+if command -v shellcheck >/dev/null 2>&1; then
+  have_shellcheck=1
+else
+  echo "check-shell-hardening: shellcheck not found on PATH — skipping shellcheck pass (pipefail check still enforced)" >&2
+fi
+
+fail=0
+checked=0
+skipped=0
+
+is_shell_shebang() {
+  # $1 = first line of file
+  case "$1" in
+    "#!"*"/sh"|"#!"*"/sh "*|"#!"*"/bash"|"#!"*"/bash "*|"#!"*"/env sh"|"#!"*"/env bash"|"#!"*"/env sh "*|"#!"*"/env bash "*|"#!"*"/zsh"|"#!"*"/env zsh")
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+# Only *tracked* files are checked (matches the ledger L15 scope — "every
+# tracked .sh file"), resolved via `git ls-files` scoped to SCRIPTS_DIR's
+# repo root so the result is correct regardless of whether SCRIPTS_DIR was
+# passed as a relative or absolute path. Falls back to a plain find-based
+# listing outside a git repo (e.g. a downloaded tarball checkout).
+#
+# Deliberately avoids `mapfile` (bash 4+) so this runs under macOS's
+# default bash 3.2 as well as CI's modern bash — a `while read` loop over
+# process substitution is bash-3.2-portable.
+list_sh_files() {
+  repo_root="$(git -C "$SCRIPTS_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ -n "$repo_root" ]]; then
+    rel_scripts_dir="$(cd "$SCRIPTS_DIR" && pwd | sed "s#^$repo_root/*##")"
+    git -C "$repo_root" ls-files -- "${rel_scripts_dir}/*.sh" | sed "s#^#$repo_root/#"
+  else
+    find "$SCRIPTS_DIR" -maxdepth 1 -name "*.sh" -type f | sort
+  fi
+}
+
+while IFS= read -r f; do
+  [[ -f "$f" ]] || continue
+  first_line="$(head -n1 "$f")"
+
+  if ! is_shell_shebang "$first_line"; then
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  checked=$((checked + 1))
+
+  # Accept any of: `set -euo pipefail`, `set -eu` (POSIX sh has no
+  # pipefail), or a documented `# no-pipefail: <reason>` opt-out. Matched
+  # as plain substrings (not a permissive regex) to keep false-accepts out.
+  if grep -Eq '^[[:space:]]*set[[:space:]]+-euo[[:space:]]+pipefail([[:space:]]|$)' "$f" \
+     || grep -Eq '^[[:space:]]*set[[:space:]]+-eu([[:space:]]|$)' "$f" \
+     || grep -q '# no-pipefail:' "$f"; then
+    : # OK — either hardened or documented opt-out
+  else
+    echo "FAIL: $f — missing 'set -euo pipefail' (or 'set -eu' for POSIX sh) and no '# no-pipefail: <reason>' opt-out comment" >&2
+    fail=1
+  fi
+
+  if [[ "$have_shellcheck" -eq 1 ]]; then
+    if ! shellcheck -S error "$f"; then
+      echo "FAIL: $f — shellcheck reported error-severity findings (see above)" >&2
+      fail=1
+    fi
+  fi
+done < <(list_sh_files)
+
+echo "check-shell-hardening: checked $checked shell script(s), skipped $skipped non-shell-shebang .sh file(s)"
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "check-shell-hardening: FAILED" >&2
+  exit 1
+fi
+
+echo "check-shell-hardening: PASSED"

--- a/scripts/delta.sh
+++ b/scripts/delta.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# no-pipefail: sourced library (not executed standalone) — 'set -e'/'pipefail'
+# here would mutate the *calling* shell's option state for every session that
+# sources this file, which is a correctness hazard, not a style choice.
 # .cog/lib/delta.sh
 # Delta computation utilities for agent state validation
 

--- a/scripts/ledger.sh
+++ b/scripts/ledger.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# no-pipefail: sourced library (not executed standalone) — 'set -e'/'pipefail'
+# here would mutate the *calling* shell's option state for every session that
+# sources this file, which is a correctness hazard, not a style choice.
 # .cog/lib/ledger.sh - Ledger crystallization interface
 #
 # The Demon's Ledger crystallization layer.

--- a/scripts/merkle.sh
+++ b/scripts/merkle.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# no-pipefail: sourced library (not executed standalone) — 'set -e'/'pipefail'
+# here would mutate the *calling* shell's option state for every session that
+# sources this file, which is a correctness hazard, not a style choice.
 # .cog/lib/merkle.sh - Merkle proof utilities
 #
 # Leverages git's internal Merkle tree structure for efficient verification.

--- a/scripts/observer.sh
+++ b/scripts/observer.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# no-pipefail: sourced library (not executed standalone) — 'set -e'/'pipefail'
+# here would mutate the *calling* shell's option state for every session that
+# sources this file, which is a correctness hazard, not a style choice.
 # .cog/lib/observer.sh - Perspectival Observer System
 #
 # Lightweight observers that validate coherence from different perspectives.

--- a/scripts/ports.sh
+++ b/scripts/ports.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# no-pipefail: sourced library (not executed standalone) — 'set -e'/'pipefail'
+# here would mutate the *calling* shell's option state for every session that
+# sources this file, which is a correctness hazard, not a style choice.
 # .cog/lib/shell/ports.sh - Port Registry Management
 #
 # Provides port registry operations:

--- a/scripts/roles.sh
+++ b/scripts/roles.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# no-pipefail: sourced library (not executed standalone) — 'set -e'/'pipefail'
+# here would mutate the *calling* shell's option state for every session that
+# sources this file, which is a correctness hazard, not a style choice.
 # .cog/lib/roles.sh - Role management primitives
 #
 # Roles define agent capabilities and constraints.

--- a/scripts/salience.sh
+++ b/scripts/salience.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# no-pipefail: sourced library (not executed standalone) — 'set -e'/'pipefail'
+# here would mutate the *calling* shell's option state for every session that
+# sources this file, which is a correctness hazard, not a style choice.
 # .cog/lib/salience.sh - Git-Derived Salience System
 #
 # Implements ADR-018: Salience System (Git-Derived Attention)

--- a/scripts/security.sh
+++ b/scripts/security.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# no-pipefail: sourced library (not executed standalone) — 'set -e'/'pipefail'
+# here would mutate the *calling* shell's option state for every session that
+# sources this file, which is a correctness hazard, not a style choice.
 # .cog/lib/security.sh - Role-based path enforcement
 #
 # Enforces view constraints defined in ROLE.cog.md files.

--- a/scripts/signals.sh
+++ b/scripts/signals.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# no-pipefail: sourced library (not executed standalone) — 'set -e'/'pipefail'
+# here would mutate the *calling* shell's option state for every session that
+# sources this file, which is a correctness hazard, not a style choice.
 # .cog/lib/signals.sh - Signal layer shell interface
 #
 # Mutable, time-decaying state for real-time queries.

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -8,8 +8,11 @@
 #
 # Projection sync mechanism for .cog/ <-> cog branch (OBSOLETE)
 
-# Note: Don't use 'set -euo pipefail' here as it affects the parent shell
-# The kernel manages its own error handling
+# no-pipefail: sourced library (not executed standalone) — 'set -e'/'pipefail'
+# here would mutate the *calling* shell's option state for every session that
+# sources this file, which is a correctness hazard, not a style choice.
+# (Pre-existing note, same reasoning: don't use 'set -euo pipefail' here as it
+# affects the parent shell; the kernel manages its own error handling.)
 
 # Get the hash of current .cog/ state
 cog_state_hash() {

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# no-pipefail: sourced library (not executed standalone) — 'set -e'/'pipefail'
+# here would mutate the *calling* shell's option state for every session that
+# sources this file, which is a correctness hazard, not a style choice.
 # .cog/lib/validate.sh - Cogdoc Validation Library
 #
 # Validates cogdocs have proper YAML frontmatter and required fields.

--- a/scripts/vectors.sh
+++ b/scripts/vectors.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# no-pipefail: sourced library (not executed standalone) — 'set -e'/'pipefail'
+# here would mutate the *calling* shell's option state for every session that
+# sources this file, which is a correctness hazard, not a style choice.
 # .cog/lib/vectors.sh - Vector database operations
 #
 # Shell interface to the JSONL-based vector store for semantic search.

--- a/scripts/wave.sh
+++ b/scripts/wave.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# no-pipefail: sourced library (not executed standalone) — 'set -e'/'pipefail'
+# here would mutate the *calling* shell's option state for every session that
+# sources this file, which is a correctness hazard, not a style choice.
 # wave.sh - Wave Terminal integration functions
 #
 # Provides wsh wrapper functions for cog-workspace integration.


### PR DESCRIPTION
## What

Extends the existing `lint` CI job (ci.yml) with a new step running
`scripts/check-shell-hardening.sh`, a cheap mechanical gate requiring
every tracked `scripts/*.sh` file to:

1. Declare `set -euo pipefail` (bash/ksh/zsh) — or `set -eu` for POSIX
   `sh`, which has no `pipefail` — **or** carry a documented opt-out
   comment: `# no-pipefail: <reason>`.
2. Pass `shellcheck -S error` (error severity only; 0 pre-existing
   findings at that severity across the repo today, so any hit is a
   regression, not accumulated debt). Falls back to pipefail-only
   checking if `shellcheck` isn't on PATH (ubuntu-latest ships it
   preinstalled, so CI always exercises this).

The check is shebang-driven, not extension-driven: a `.sh`-suffixed
file whose shebang isn't a shell interpreter (there's one — a Python
script misnamed `audit-root-package.sh`) is skipped entirely.

## Why

Ledger L15 (v1.0 alignment discovery, `DIVERGENCE-LEDGER-DRAFT.md`):
prevents the git-pipe-exit-masking bug class (a destructive command
chained after an unguarded pipe silently proceeds on failure) from
entering `scripts/` as it grows, at near-zero ongoing cost.

## How

- Audited all 27 tracked `.sh` files. 15 were missing the property:
  - **1 trivial fix**: `agent-test.sh` — standalone POSIX-sh script,
    no pipelines, no reason not to harden. Added `set -eu`.
  - **14 grandfathered with documented opt-out**: `bootstrap.sh`,
    `delta.sh`, `ledger.sh`, `merkle.sh`, `observer.sh`, `ports.sh`,
    `roles.sh`, `salience.sh`, `security.sh`, `signals.sh`, `sync.sh`,
    `validate.sh`, `vectors.sh`, `wave.sh` — all sourced
    `.cog/lib/*.sh` libraries, never executed standalone. `set -e`/
    `pipefail` in a **sourced** file mutates the *calling* shell's
    option state — a real correctness hazard, not a style nit — so
    force-adding it would be wrong, not merely unnecessary. `sync.sh`
    already carried an unstructured version of this same reasoning;
    normalized it to the `# no-pipefail:` tag the gate recognizes.
- shellcheck at error severity: 0 findings repo-wide before this PR,
  so the gate adds this as a pure tripwire, no grandfathering needed.
  (294 pre-existing *warning*-severity findings exist and are
  deliberately left alone — that's a separate, much larger burn-down,
  tracked under ledger L9, not this gate's scope.)

## Test evidence

- New package `internal/shellgate` (`shellgate_test.go`): 8 Go tests
  shelling out to the real gate script against disposable git-repo
  fixtures, proving it actually catches what it claims to — hardened
  bash/POSIX-sh pass, documented opt-out passes, unhardened script
  fails, non-shell-shebang `.sh` is skipped, a shellcheck
  error-severity finding fails, a mixed tree passes only when every
  file is clean — plus an acceptance test running the gate against
  this repo's own `scripts/` directory (the same invocation CI makes).
  All pass under `go test -race -count=1 ./internal/shellgate/...`.
- `go build ./...`, `go vet ./...`, and `golangci-lint run
  ./internal/shellgate/...` (v2.11, matching CI) are clean.
- Ran `scripts/check-shell-hardening.sh scripts` directly — PASSED,
  both with and without `shellcheck` on `PATH` (exercises both
  branches).
- Verified diff-stat sanity after rebasing onto `origin/main` (picked
  up #452/#453, no overlap): 18 files changed / 394 insertions / 2
  deletions, unchanged before and after rebase.

## Scope note

Touches only `scripts/*.sh`, `.github/workflows/ci.yml`, and a new
`internal/shellgate` package — no changes to
`internal/engine/context_assembly*`, `trm_lightcone.go`,
`foveation_*`, `provider_lms_model_state*`, `serve_anthropic.go`, or
`.cog/mem/working/first-instruments/`.