### PR TITLE
fix(config): gate config-mutation HTTP endpoints behind EnableConfigMutation

### DIFF
--- a/internal/engine/boot.go
+++ b/internal/engine/boot.go
@@ -230,6 +230,11 @@ func (k *Kernel) Stop() error {
 func Boot(ctx context.Context, cfg *Config, opts ...BootOption) (*Kernel, error) {
 	bootCfg := applyBootOptions(opts)
 
+	// L5-HTTP-AUTHZ: warn loudly (never block) if the HTTP surface is about
+	// to bind non-loopback with no auth token configured. See
+	// boot_bindaddr_warning.go for the rationale.
+	warnIfUnauthenticatedNonLoopback(cfg)
+
 	// Load nucleus (identity core).
 	nucleus, err := LoadNucleus(cfg)
 	if err != nil {

--- a/internal/engine/boot_bindaddr_warning.go
+++ b/internal/engine/boot_bindaddr_warning.go
@@ -33,9 +33,19 @@ func hasHTTPAuthToken(cfg *Config) bool {
 // warnIfUnauthenticatedNonLoopback logs a loud warning at boot when
 // cfg.BindAddr is resolved to a non-loopback address and no HTTP auth token
 // is configured. It never blocks startup — refuse-to-start is a later
-// decision (L5-HTTP-AUTHZ).
+// decision (L5-HTTP-AUTHZ). Logs via slog.Default(); see
+// warnIfUnauthenticatedNonLoopbackTo for a variant that takes an explicit
+// logger (used by tests to avoid mutating global slog state).
 func warnIfUnauthenticatedNonLoopback(cfg *Config) {
-	if cfg == nil {
+	warnIfUnauthenticatedNonLoopbackTo(slog.Default(), cfg)
+}
+
+// warnIfUnauthenticatedNonLoopbackTo is the logger-injectable core of
+// warnIfUnauthenticatedNonLoopback. Split out so tests can assert on the
+// emitted warning without racing on the process-global slog default (see
+// serve_config_gate_test.go).
+func warnIfUnauthenticatedNonLoopbackTo(logger *slog.Logger, cfg *Config) {
+	if cfg == nil || logger == nil {
 		return
 	}
 	bindAddr := cfg.BindAddr
@@ -48,7 +58,7 @@ func warnIfUnauthenticatedNonLoopback(cfg *Config) {
 	if hasHTTPAuthToken(cfg) {
 		return
 	}
-	slog.Warn("SECURITY: kernel HTTP API is binding to a non-loopback address with no auth token configured — "+
+	logger.Warn("SECURITY: kernel HTTP API is binding to a non-loopback address with no auth token configured — "+
 		"the entire HTTP surface (including config mutation, skill exec, and service control when enabled) "+
 		"is reachable by anything that can reach this address/port; loopback-bind is currently the kernel's "+
 		"only access-control boundary",

--- a/internal/engine/boot_bindaddr_warning.go
+++ b/internal/engine/boot_bindaddr_warning.go
@@ -1,0 +1,73 @@
+// boot_bindaddr_warning.go — non-loopback bind-address warning (L5-HTTP-AUTHZ).
+//
+// The kernel's HTTP surface has no bearer/API-key auth middleware (see
+// serve.go); its access-control boundary is "bind to loopback only" plus a
+// handful of opt-in-default-off gates (EnableSkillExec, EnableServiceControl,
+// EnableConfigMutation). That boundary only holds if the operator keeps
+// Config.BindAddr on loopback. cfg.BindAddr is a supported config surface
+// that can be set to "0.0.0.0" (or any non-loopback address) for pod/LAN/
+// Tailnet deployments, and the kernel currently has no auth-token config
+// field at all — so widening the bind address removes the *only* access
+// control that exists, with no compensating control available today.
+//
+// Refuse-to-start is an explicit later decision (tracked in the v1.0
+// alignment ledger, L5). For now: warn loudly at boot so the gap is visible
+// in logs rather than silent.
+package engine
+
+import (
+	"log/slog"
+	"net"
+)
+
+// hasHTTPAuthToken reports whether the kernel config carries an HTTP
+// bearer/API-key auth field. There is currently no such field anywhere in
+// Config — this always returns false. It exists as a named seam so that
+// when an auth-token field is added, this function (and the warning it
+// gates) gets updated in the same change rather than silently going stale.
+func hasHTTPAuthToken(cfg *Config) bool {
+	_ = cfg
+	return false
+}
+
+// warnIfUnauthenticatedNonLoopback logs a loud warning at boot when
+// cfg.BindAddr is resolved to a non-loopback address and no HTTP auth token
+// is configured. It never blocks startup — refuse-to-start is a later
+// decision (L5-HTTP-AUTHZ).
+func warnIfUnauthenticatedNonLoopback(cfg *Config) {
+	if cfg == nil {
+		return
+	}
+	bindAddr := cfg.BindAddr
+	if bindAddr == "" {
+		bindAddr = "127.0.0.1"
+	}
+	if isLoopbackBindAddr(bindAddr) {
+		return
+	}
+	if hasHTTPAuthToken(cfg) {
+		return
+	}
+	slog.Warn("SECURITY: kernel HTTP API is binding to a non-loopback address with no auth token configured — "+
+		"the entire HTTP surface (including config mutation, skill exec, and service control when enabled) "+
+		"is reachable by anything that can reach this address/port; loopback-bind is currently the kernel's "+
+		"only access-control boundary",
+		"bind_addr", bindAddr, "port", cfg.Port)
+}
+
+// isLoopbackBindAddr reports whether addr (a Config.BindAddr value — a bare
+// host, not host:port) resolves to a loopback address. Handles the literal
+// forms the kernel actually accepts: "127.0.0.1", "localhost", "::1", and
+// any other address net.ParseIP recognizes as loopback. Unparseable or
+// unresolved hostnames are treated as non-loopback (fail toward warning,
+// not toward silence).
+func isLoopbackBindAddr(addr string) bool {
+	if addr == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(addr)
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback()
+}

--- a/internal/engine/config.go
+++ b/internal/engine/config.go
@@ -143,6 +143,14 @@ type Config struct {
 	// operations. Set enable_service_control: true in kernel.yaml to opt in.
 	EnableServiceControl bool
 
+	// EnableConfigMutation gates the config-mutation HTTP endpoints:
+	// GET/PATCH /v1/config and POST /v1/config/rollback.
+	// Default false: live config read/mutation/rollback via HTTP is disabled by
+	// default because any local process on the same host could otherwise read
+	// or rewrite kernel.yaml. Set enable_config_mutation: true in kernel.yaml
+	// to opt in.
+	EnableConfigMutation bool
+
 	// DigestPaths maps stream tailer adapter names to JSONL file/directory paths.
 	// Empty map means external digestion is disabled.
 	DigestPaths map[string]string
@@ -222,6 +230,7 @@ type kernelConfigSection struct {
 	ToolCallValidation    *bool    `yaml:"tool_call_validation_enabled"`
 	EnableSkillExec       *bool    `yaml:"enable_skill_exec"`
 	EnableServiceControl  *bool    `yaml:"enable_service_control"`
+	EnableConfigMutation  *bool    `yaml:"enable_config_mutation"`
 	IdentityNakedDefault  *bool    `yaml:"identity_naked_default,omitempty"`
 	LocalModel            string   `yaml:"local_model"`
 	HarnessProvider       string   `yaml:"harness_provider"`
@@ -371,6 +380,9 @@ func applyKernelSection(cfg *Config, s kernelConfigSection) {
 	}
 	if s.EnableServiceControl != nil {
 		cfg.EnableServiceControl = *s.EnableServiceControl
+	}
+	if s.EnableConfigMutation != nil {
+		cfg.EnableConfigMutation = *s.EnableConfigMutation
 	}
 	if s.IdentityNakedDefault != nil {
 		cfg.IdentityNakedDefault = *s.IdentityNakedDefault

--- a/internal/engine/config_write_wire_test.go
+++ b/internal/engine/config_write_wire_test.go
@@ -103,6 +103,7 @@ func TestResourceConfig_Reads(t *testing.T) {
 func TestHandleConfigGet_IncludesDefaults(t *testing.T) {
 	t.Parallel()
 	srv := newTestServer(t)
+	srv.cfg.EnableConfigMutation = true
 	seedKernelYAML(t, srv.cfg.WorkspaceRoot, "port: 6931\n")
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/config?include_defaults=1&include_raw_yaml=1", nil)
@@ -134,6 +135,7 @@ func TestHandleConfigGet_IncludesDefaults(t *testing.T) {
 func TestHandleConfigPatch_Success(t *testing.T) {
 	t.Parallel()
 	srv := newTestServer(t)
+	srv.cfg.EnableConfigMutation = true
 	seedKernelYAML(t, srv.cfg.WorkspaceRoot, "port: 6931\n")
 
 	body := map[string]any{
@@ -160,6 +162,7 @@ func TestHandleConfigPatch_Success(t *testing.T) {
 func TestHandleConfigPatch_ValidationFailure(t *testing.T) {
 	t.Parallel()
 	srv := newTestServer(t)
+	srv.cfg.EnableConfigMutation = true
 	seedKernelYAML(t, srv.cfg.WorkspaceRoot, "port: 6931\n")
 
 	body := map[string]any{

--- a/internal/engine/config_write_wire_test.go
+++ b/internal/engine/config_write_wire_test.go
@@ -16,10 +16,17 @@ import (
 )
 
 // newMCPForTest builds an MCPServer wired to a fresh workspace + process.
+// EnableConfigMutation defaults to true here since these tests exercise
+// config read/write/rollback behavior itself, not the gate — mirroring
+// newTestServer's HTTP-side callers (TestHandleConfigGet_IncludesDefaults
+// et al.) which set srv.cfg.EnableConfigMutation = true explicitly. Gate
+// behavior itself is covered by TestConfigMutationMCP_GateDisabled/
+// GateEnabled in serve_config_gate_test.go.
 func newMCPForTest(t *testing.T) (*MCPServer, string) {
 	t.Helper()
 	root := makeWorkspace(t)
 	cfg := makeConfig(t, root)
+	cfg.EnableConfigMutation = true
 	process := NewProcess(cfg, makeNucleus("Cog", "tester"))
 	return NewMCPServer(cfg, makeNucleus("Cog", "tester"), process), root
 }

--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -423,17 +423,17 @@ func (m *MCPServer) registerTools() {
 	// Config mutation API (Agent O design — closes Agent F gaps #5 + #19).
 	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_read_config",
-		Description: "Read the kernel config (.cog/config/kernel.yaml). Returns the effective resolved config (defaults + file overrides). Optional include_raw_yaml returns the raw file bytes; include_defaults also returns the hardcoded defaults for diffing. kernel.yaml only — sibling configs (providers.yaml, secrets.yaml) are out of scope.",
+		Description: "Read the kernel config (.cog/config/kernel.yaml). Returns the effective resolved config (defaults + file overrides). Optional include_raw_yaml returns the raw file bytes; include_defaults also returns the hardcoded defaults for diffing. kernel.yaml only — sibling configs (providers.yaml, secrets.yaml) are out of scope. Gated by Config.EnableConfigMutation (default false, parity with the REST /v1/config surface); returns a disabled error when the gate is off.",
 	}, m.toolReadConfig)
 
 	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_write_config",
-		Description: "Merge a patch into the kernel config (.cog/config/kernel.yaml) using RFC 7396 JSON merge-patch semantics: fields omitted from the patch are left unchanged; explicit null removes a field and restores the default on next boot. Validated before persisting — returns violations without writing on failure. Atomic write + rotating .bak-<timestamp> backups (keeps 10). Takes effect on next daemon restart (requires_restart: true in response). Fallback: edit .cog/config/kernel.yaml and run `./scripts/cog restart`. No authentication — the kernel assumes a trusted local caller.",
+		Description: "Merge a patch into the kernel config (.cog/config/kernel.yaml) using RFC 7396 JSON merge-patch semantics: fields omitted from the patch are left unchanged; explicit null removes a field and restores the default on next boot. Validated before persisting — returns violations without writing on failure. Atomic write + rotating .bak-<timestamp> backups (keeps 10). Takes effect on next daemon restart (requires_restart: true in response). Fallback: edit .cog/config/kernel.yaml and run `./scripts/cog restart`. Gated by Config.EnableConfigMutation (default false); set enable_config_mutation: true in kernel.yaml to opt in. No further authentication beyond the gate — the kernel assumes a trusted local caller once enabled.",
 	}, m.toolWriteConfig)
 
 	trackToolDeferred(m, &mcp.Tool{
 		Name:        "cog_rollback_config",
-		Description: "Restore kernel.yaml from a prior .bak-<timestamp> backup. Pass list_only=true to enumerate available backups without restoring. If backup is empty, the most recent backup is used. Atomic restore; response carries updated backup list.",
+		Description: "Restore kernel.yaml from a prior .bak-<timestamp> backup. Pass list_only=true to enumerate available backups without restoring. If backup is empty, the most recent backup is used. Atomic restore; response carries updated backup list. Gated by Config.EnableConfigMutation (default false), same as cog_read_config/cog_write_config.",
 	}, m.toolRollbackConfig)
 
 	trackToolDeferred(m, &mcp.Tool{
@@ -2468,7 +2468,31 @@ type rollbackConfigInput struct {
 	ListOnly bool   `json:"list_only,omitempty" jsonschema:"If true, return the list of backups without restoring"`
 }
 
+// requireConfigMutationMCP checks the EnableConfigMutation gate for the MCP
+// transport. Returns a non-nil (*mcp.CallToolResult, any, error) triple when
+// the gate is closed — callers should return it immediately — and a nil
+// triple when the gate is open and the caller should proceed. Mirrors the
+// HTTP gate's error shape (requireConfigMutation in serve_config.go) so a
+// caller sees the same {"error":"disabled","detail":"..."} body regardless
+// of transport; unlike the HTTP path this is surfaced as an MCP tool error
+// (IsError: true) rather than a 403 status code.
+func (m *MCPServer) requireConfigMutationMCP() (*mcp.CallToolResult, any, error) {
+	if m.cfg != nil && m.cfg.EnableConfigMutation {
+		return nil, nil, nil
+	}
+	b, _ := json.Marshal(map[string]string{
+		"error":  "disabled",
+		"detail": "config access via MCP is disabled; set enable_config_mutation: true in kernel.yaml",
+	})
+	res, _, _ := textResult(string(b))
+	res.IsError = true
+	return res, nil, nil
+}
+
 func (m *MCPServer) toolReadConfig(ctx context.Context, req *mcp.CallToolRequest, input readConfigInput) (*mcp.CallToolResult, any, error) {
+	if res, data, err := m.requireConfigMutationMCP(); res != nil {
+		return res, data, err
+	}
 	snapshot, err := ReadConfigSnapshot(m.cfg.WorkspaceRoot, input.IncludeRawYAML, input.IncludeDefaults)
 	if err != nil {
 		// Parse error — still surface whatever we could read but tag the error.
@@ -2485,6 +2509,9 @@ func (m *MCPServer) toolReadConfig(ctx context.Context, req *mcp.CallToolRequest
 }
 
 func (m *MCPServer) toolWriteConfig(ctx context.Context, req *mcp.CallToolRequest, input writeConfigInput) (*mcp.CallToolResult, any, error) {
+	if res, data, err := m.requireConfigMutationMCP(); res != nil {
+		return res, data, err
+	}
 	result, err := WriteConfigPatch(m.cfg.WorkspaceRoot, input.Patch, WriteConfigOptions{
 		Scope:  input.Scope,
 		DryRun: input.DryRun,
@@ -2496,6 +2523,9 @@ func (m *MCPServer) toolWriteConfig(ctx context.Context, req *mcp.CallToolReques
 }
 
 func (m *MCPServer) toolRollbackConfig(ctx context.Context, req *mcp.CallToolRequest, input rollbackConfigInput) (*mcp.CallToolResult, any, error) {
+	if res, data, err := m.requireConfigMutationMCP(); res != nil {
+		return res, data, err
+	}
 	result, err := RollbackConfig(m.cfg.WorkspaceRoot, RollbackOptions{
 		Backup:   input.Backup,
 		ListOnly: input.ListOnly,

--- a/internal/engine/mcp_server.go
+++ b/internal/engine/mcp_server.go
@@ -543,7 +543,7 @@ func (m *MCPServer) registerResources() {
 	m.server.AddResource(&mcp.Resource{
 		URI:         "cogos://config",
 		Name:        "Kernel Config",
-		Description: "Effective kernel configuration (kernel.yaml resolved against defaults)",
+		Description: "Effective kernel configuration (kernel.yaml resolved against defaults). Gated by Config.EnableConfigMutation (default false), same as cog_read_config/cog_write_config/cog_rollback_config; returns a disabled error when the gate is off.",
 		MIMEType:    "application/json",
 	}, m.resourceConfig)
 
@@ -2536,7 +2536,20 @@ func (m *MCPServer) toolRollbackConfig(ctx context.Context, req *mcp.CallToolReq
 	return marshalResult(result)
 }
 
+// resourceConfig serves the cogos://config MCP resource. Gated by
+// Config.EnableConfigMutation, same as the three cog_*_config tools — a
+// cog-review re-review round (PR #460) found this resource read the exact
+// same ReadConfigSnapshot data via the untouched Resources API, bypassing
+// the gate the tools had just been given. MCP resources have no IsError /
+// structured-error-body convention (unlike CallToolResult); the established
+// pattern in this file (see resourceState above) is to return a plain Go
+// error, which the MCP SDK surfaces as a protocol-level error to the
+// caller — so this uses the same "disabled" wording as the tool/HTTP gates
+// rather than a JSON body.
 func (m *MCPServer) resourceConfig(_ context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	if m.cfg == nil || !m.cfg.EnableConfigMutation {
+		return nil, fmt.Errorf("disabled: config access via MCP is disabled; set enable_config_mutation: true in kernel.yaml")
+	}
 	snapshot, _ := ReadConfigSnapshot(m.cfg.WorkspaceRoot, false, true)
 	b, err := json.Marshal(snapshot)
 	if err != nil {

--- a/internal/engine/serve_config.go
+++ b/internal/engine/serve_config.go
@@ -4,6 +4,12 @@
 //	PATCH /v1/config             — RFC 7396 merge-patch (validated, atomic, backed up)
 //	POST  /v1/config/rollback    — restore from a .bak-<timestamp> file
 //
+// All three routes are gated by Config.EnableConfigMutation (default false),
+// parity with EnableSkillExec (serve_skills.go) / EnableServiceControl
+// (serve_services.go): any local process on the same host could otherwise
+// read or rewrite kernel.yaml over loopback. Set enable_config_mutation:
+// true in kernel.yaml to opt in.
+//
 // All handlers return JSON on success and on structured-error paths.
 package engine
 
@@ -20,11 +26,31 @@ func (s *Server) registerConfigRoutes(mux *http.ServeMux) {
 	s.route(mux, "POST /v1/config/rollback", s.handleConfigRollback)
 }
 
+// requireConfigMutation checks the gate and writes a 403 if disabled.
+// Returns true if the handler should continue, false if it has already
+// written an error response. Mirrors requireServiceControl in
+// serve_services.go.
+func (s *Server) requireConfigMutation(w http.ResponseWriter) bool {
+	if s.cfg == nil || !s.cfg.EnableConfigMutation {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error":  "disabled",
+			"detail": "config access via HTTP is disabled; set enable_config_mutation: true in kernel.yaml",
+		})
+		return false
+	}
+	return true
+}
+
 // handleConfigGet returns the effective kernel config. Query params:
 //
 //	include_raw_yaml=1   — also return raw kernel.yaml bytes
 //	include_defaults=1   — also return hardcoded defaults
 func (s *Server) handleConfigGet(w http.ResponseWriter, r *http.Request) {
+	if !s.requireConfigMutation(w) {
+		return
+	}
 	q := r.URL.Query()
 	includeRaw := truthyQuery(q.Get("include_raw_yaml"))
 	includeDefaults := truthyQuery(q.Get("include_defaults"))
@@ -54,6 +80,9 @@ type configPatchRequest struct {
 }
 
 func (s *Server) handleConfigPatch(w http.ResponseWriter, r *http.Request) {
+	if !s.requireConfigMutation(w) {
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 
 	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20)) // 1 MB is vast for a scalar config
@@ -95,6 +124,9 @@ func (s *Server) handleConfigPatch(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleConfigRollback(w http.ResponseWriter, r *http.Request) {
+	if !s.requireConfigMutation(w) {
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 	var body rollbackConfigInput
 	if r.ContentLength > 0 {

--- a/internal/engine/serve_config_gate_test.go
+++ b/internal/engine/serve_config_gate_test.go
@@ -344,3 +344,46 @@ func TestConfigMutationMCP_GateEnabled(t *testing.T) {
 		}
 	})
 }
+
+// TestResourceConfigMCP_GateDisabled verifies the cogos://config MCP
+// resource returns an error (mentioning "disabled") when EnableConfigMutation
+// is false. Regression test for the second cog-review round on PR #460: the
+// resource read the same ReadConfigSnapshot data via the untouched Resources
+// API, bypassing the gate the three cog_*_config tools had just been given.
+func TestResourceConfigMCP_GateDisabled(t *testing.T) {
+	t.Parallel()
+	server := newConfigGateTestMCPServer(t, false)
+	fakeReq := &mcp.ReadResourceRequest{Params: &mcp.ReadResourceParams{URI: "cogos://config"}}
+	result, err := server.resourceConfig(context.Background(), fakeReq)
+	if err == nil {
+		t.Fatalf("resourceConfig returned no error with gate disabled; result=%+v", result)
+	}
+	if !strings.Contains(err.Error(), "disabled") {
+		t.Errorf("error = %q; want mention of \"disabled\"", err.Error())
+	}
+	if !strings.Contains(err.Error(), "enable_config_mutation") {
+		t.Errorf("error = %q; want mention of enable_config_mutation", err.Error())
+	}
+	if result != nil {
+		t.Errorf("result = %+v; want nil when gated off", result)
+	}
+}
+
+// TestResourceConfigMCP_GateEnabled verifies the cogos://config MCP resource
+// reaches ReadConfigSnapshot (no error, effective_config present) when
+// EnableConfigMutation is true.
+func TestResourceConfigMCP_GateEnabled(t *testing.T) {
+	t.Parallel()
+	server := newConfigGateTestMCPServer(t, true)
+	fakeReq := &mcp.ReadResourceRequest{Params: &mcp.ReadResourceParams{URI: "cogos://config"}}
+	result, err := server.resourceConfig(context.Background(), fakeReq)
+	if err != nil {
+		t.Fatalf("resourceConfig: %v", err)
+	}
+	if len(result.Contents) != 1 {
+		t.Fatalf("contents len = %d; want 1", len(result.Contents))
+	}
+	if !strings.Contains(result.Contents[0].Text, "effective_config") {
+		t.Errorf("resource text missing effective_config; got %s", result.Contents[0].Text)
+	}
+}

--- a/internal/engine/serve_config_gate_test.go
+++ b/internal/engine/serve_config_gate_test.go
@@ -1,22 +1,33 @@
 // serve_config_gate_test.go — outside-in httptest coverage for the
 // EnableConfigMutation gate on GET/PATCH /v1/config and POST
-// /v1/config/rollback (L5-HTTP-AUTHZ, ledger L5).
+// /v1/config/rollback (L5-HTTP-AUTHZ, ledger L5), plus the matching MCP
+// transport gate on cog_read_config/cog_write_config/cog_rollback_config
+// (mcp_server.go) added in the same PR after cog-review flagged that the
+// REST gate alone left the MCP tool surface unprotected.
 //
 // Covers:
-//  1. Gate — 403 for all three routes when EnableConfigMutation=false (default).
-//  2. Gated-on — 200 for all three routes when EnableConfigMutation=true.
+//  1. Gate — 403 for all three REST routes when EnableConfigMutation=false
+//     (default).
+//  2. Gated-on — 200 for all three REST routes when EnableConfigMutation=true.
 //  3. Boot warning — non-loopback BindAddr with no auth token configured logs
 //     a warning; loopback BindAddr does not.
+//  4. MCP gate — cog_read_config/cog_write_config/cog_rollback_config return
+//     an IsError result with {"error":"disabled",...} when the gate is off,
+//     and reach the real handler when the gate is on — same gate, second
+//     transport.
 package engine
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // newConfigGateTestServer returns an HTTP handler backed by a Server whose
@@ -211,4 +222,125 @@ func TestIsLoopbackBindAddr(t *testing.T) {
 			t.Errorf("isLoopbackBindAddr(%q) = true; want false", addr)
 		}
 	}
+}
+
+// ── MCP transport gate ───────────────────────────────────────────────────────
+
+// newConfigGateTestMCPServer returns an MCPServer whose EnableConfigMutation
+// gate is set as requested, wired to a fresh temp workspace (no kernel.yaml
+// present) so ReadConfigSnapshot/WriteConfigPatch/RollbackConfig have a valid
+// root to operate against once the gate is open.
+func newConfigGateTestMCPServer(t *testing.T, enableConfigMutation bool) *MCPServer {
+	t.Helper()
+	root := t.TempDir()
+	cfg := makeConfig(t, root)
+	cfg.EnableConfigMutation = enableConfigMutation
+	nucleus := makeNucleus("Test", "tester")
+	process := NewProcess(cfg, nucleus)
+	t.Cleanup(func() {
+		if b := process.Broker(); b != nil {
+			_ = b.Close()
+		}
+	})
+	return NewMCPServer(cfg, nucleus, process)
+}
+
+// TestConfigMutationMCP_GateDisabled verifies all three MCP config tools
+// return an IsError result carrying {"error":"disabled",...} — the same
+// shape as the REST gate's 403 body — when EnableConfigMutation is false
+// (the default). Closes the gap cog-review found: the REST gate alone left
+// cog_read_config/cog_write_config/cog_rollback_config reachable over the
+// same HTTP bind address via POST /mcp with no check at all.
+func TestConfigMutationMCP_GateDisabled(t *testing.T) {
+	t.Parallel()
+	server := newConfigGateTestMCPServer(t, false)
+
+	t.Run("read", func(t *testing.T) {
+		t.Parallel()
+		result, _, err := server.toolReadConfig(context.Background(), nil, readConfigInput{})
+		assertMCPGateDisabled(t, result, err)
+	})
+
+	t.Run("write", func(t *testing.T) {
+		t.Parallel()
+		result, _, err := server.toolWriteConfig(context.Background(), nil, writeConfigInput{
+			Patch: map[string]any{"port": float64(7000)},
+		})
+		assertMCPGateDisabled(t, result, err)
+	})
+
+	t.Run("rollback", func(t *testing.T) {
+		t.Parallel()
+		result, _, err := server.toolRollbackConfig(context.Background(), nil, rollbackConfigInput{ListOnly: true})
+		assertMCPGateDisabled(t, result, err)
+	})
+}
+
+// assertMCPGateDisabled checks the shared gate-error shape returned by
+// requireConfigMutationMCP.
+func assertMCPGateDisabled(t *testing.T, result *mcp.CallToolResult, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil || !result.IsError {
+		t.Fatalf("result.IsError = false; want true (gate should reject)")
+	}
+	var resp map[string]string
+	decodeMCPJSON(t, result, &resp)
+	if resp["error"] != "disabled" {
+		t.Errorf("error = %q; want \"disabled\"", resp["error"])
+	}
+	if !strings.Contains(resp["detail"], "enable_config_mutation") {
+		t.Errorf("detail = %q; want mention of enable_config_mutation", resp["detail"])
+	}
+}
+
+// TestConfigMutationMCP_GateEnabled verifies all three MCP config tools reach
+// their real handlers (no IsError, normal result shape) when
+// EnableConfigMutation is true.
+func TestConfigMutationMCP_GateEnabled(t *testing.T) {
+	t.Parallel()
+	server := newConfigGateTestMCPServer(t, true)
+
+	t.Run("read", func(t *testing.T) {
+		t.Parallel()
+		result, _, err := server.toolReadConfig(context.Background(), nil, readConfigInput{})
+		if err != nil {
+			t.Fatalf("toolReadConfig: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("result.IsError = true; want gate-open passthrough, got %+v", result)
+		}
+		var decoded ReadConfigResult
+		decodeMCPJSON(t, result, &decoded)
+		if decoded.Path == "" {
+			t.Errorf("path missing from read result")
+		}
+	})
+
+	t.Run("write", func(t *testing.T) {
+		t.Parallel()
+		result, _, err := server.toolWriteConfig(context.Background(), nil, writeConfigInput{
+			Patch:  map[string]any{"port": float64(7000)},
+			DryRun: true,
+		})
+		if err != nil {
+			t.Fatalf("toolWriteConfig: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("result.IsError = true; want gate-open passthrough, got %+v", result)
+		}
+	})
+
+	t.Run("rollback", func(t *testing.T) {
+		t.Parallel()
+		result, _, err := server.toolRollbackConfig(context.Background(), nil, rollbackConfigInput{ListOnly: true})
+		if err != nil {
+			t.Fatalf("toolRollbackConfig: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("result.IsError = true; want gate-open passthrough (list_only, no backups yet), got %+v", result)
+		}
+	})
 }

--- a/internal/engine/serve_config_gate_test.go
+++ b/internal/engine/serve_config_gate_test.go
@@ -1,0 +1,216 @@
+// serve_config_gate_test.go — outside-in httptest coverage for the
+// EnableConfigMutation gate on GET/PATCH /v1/config and POST
+// /v1/config/rollback (L5-HTTP-AUTHZ, ledger L5).
+//
+// Covers:
+//  1. Gate — 403 for all three routes when EnableConfigMutation=false (default).
+//  2. Gated-on — 200 for all three routes when EnableConfigMutation=true.
+//  3. Boot warning — non-loopback BindAddr with no auth token configured logs
+//     a warning; loopback BindAddr does not.
+package engine
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newConfigGateTestServer returns an HTTP handler backed by a Server whose
+// EnableConfigMutation gate is set as requested. Uses a real temp workspace
+// root (no kernel.yaml present) so ReadConfigSnapshot/WriteConfigPatch/
+// RollbackConfig have a valid root to operate against.
+func newConfigGateTestServer(t *testing.T, enableConfigMutation bool) http.Handler {
+	t.Helper()
+	root := t.TempDir()
+	cfg := makeConfig(t, root)
+	cfg.EnableConfigMutation = enableConfigMutation
+	nucleus := makeNucleus("Test", "tester")
+	proc := NewProcess(cfg, nucleus)
+
+	srv := NewServer(cfg, nucleus, proc)
+	t.Cleanup(func() {
+		if b := proc.Broker(); b != nil {
+			_ = b.Close()
+		}
+	})
+	return srv.Handler()
+}
+
+// TestConfigMutation_GateDisabled verifies all three config routes return
+// 403 with a "disabled" error when EnableConfigMutation is false (the
+// default) — matching the EnableSkillExec / EnableServiceControl convention.
+func TestConfigMutation_GateDisabled(t *testing.T) {
+	t.Parallel()
+	handler := newConfigGateTestServer(t, false)
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{"get", http.MethodGet, "/v1/config", ""},
+		{"patch", http.MethodPatch, "/v1/config", `{"patch":{"port":7000}}`},
+		{"rollback", http.MethodPost, "/v1/config/rollback", ""},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var body *bytes.Reader
+			if tc.body != "" {
+				body = bytes.NewReader([]byte(tc.body))
+			} else {
+				body = bytes.NewReader(nil)
+			}
+			req := httptest.NewRequest(tc.method, tc.path, body)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("%s %s: status=%d body=%q; want 403", tc.method, tc.path, rec.Code, rec.Body.String())
+			}
+			var resp map[string]string
+			if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("%s %s: decode response: %v; body=%q", tc.method, tc.path, err, rec.Body.String())
+			}
+			if resp["error"] != "disabled" {
+				t.Errorf("%s %s: error=%q; want \"disabled\"", tc.method, tc.path, resp["error"])
+			}
+			if !strings.Contains(resp["detail"], "enable_config_mutation") {
+				t.Errorf("%s %s: detail=%q; want mention of enable_config_mutation", tc.method, tc.path, resp["detail"])
+			}
+			if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+				t.Errorf("%s %s: content-type=%q; want application/json", tc.method, tc.path, ct)
+			}
+		})
+	}
+}
+
+// TestConfigMutation_GateEnabled verifies all three config routes are
+// reachable (not 403) when EnableConfigMutation is true.
+func TestConfigMutation_GateEnabled(t *testing.T) {
+	t.Parallel()
+	handler := newConfigGateTestServer(t, true)
+
+	t.Run("get", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/v1/config", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET /v1/config: status=%d body=%q; want 200", rec.Code, rec.Body.String())
+		}
+		var snap map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &snap); err != nil {
+			t.Fatalf("decode snapshot: %v; body=%q", err, rec.Body.String())
+		}
+		if _, ok := snap["effective_config"]; !ok {
+			t.Errorf("snapshot missing effective_config field: %v", snap)
+		}
+	})
+
+	t.Run("patch", func(t *testing.T) {
+		t.Parallel()
+		body := bytes.NewReader([]byte(`{"patch":{"heartbeat_interval":45},"dry_run":true}`))
+		req := httptest.NewRequest(http.MethodPatch, "/v1/config", body)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("PATCH /v1/config: status=%d body=%q; want 200", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("rollback", func(t *testing.T) {
+		t.Parallel()
+		body := bytes.NewReader([]byte(`{"list_only":true}`))
+		req := httptest.NewRequest(http.MethodPost, "/v1/config/rollback", body)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		// No backups exist in a fresh temp workspace; list_only must still
+		// reach the handler (not be gated) and return a structured result
+		// rather than a 403.
+		if rec.Code == http.StatusForbidden {
+			t.Fatalf("POST /v1/config/rollback: got 403 with gate enabled; body=%q", rec.Body.String())
+		}
+	})
+}
+
+// ─── Boot bind-address warning ──────────────────────────────────────────────
+
+// captureSlog redirects the default slog logger to a buffer for the duration
+// of fn, then restores it.
+func captureSlog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	fn()
+	return buf.String()
+}
+
+func TestWarnIfUnauthenticatedNonLoopback_WarnsOnNonLoopback(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{BindAddr: "0.0.0.0", Port: 6931}
+	out := captureSlog(t, func() {
+		warnIfUnauthenticatedNonLoopback(cfg)
+	})
+	if !strings.Contains(out, "SECURITY") {
+		t.Errorf("expected a SECURITY warning for non-loopback bind, got: %q", out)
+	}
+	if !strings.Contains(out, "0.0.0.0") {
+		t.Errorf("expected the bind address in the warning, got: %q", out)
+	}
+}
+
+func TestWarnIfUnauthenticatedNonLoopback_SilentOnLoopback(t *testing.T) {
+	t.Parallel()
+	cases := []string{"127.0.0.1", "localhost", "::1", ""}
+	for _, addr := range cases {
+		addr := addr
+		t.Run("addr="+addr, func(t *testing.T) {
+			t.Parallel()
+			cfg := &Config{BindAddr: addr, Port: 6931}
+			out := captureSlog(t, func() {
+				warnIfUnauthenticatedNonLoopback(cfg)
+			})
+			if strings.Contains(out, "SECURITY") {
+				t.Errorf("expected no warning for loopback bind_addr=%q, got: %q", addr, out)
+			}
+		})
+	}
+}
+
+func TestWarnIfUnauthenticatedNonLoopback_LANAddress(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{BindAddr: "192.168.10.191", Port: 6931}
+	out := captureSlog(t, func() {
+		warnIfUnauthenticatedNonLoopback(cfg)
+	})
+	if !strings.Contains(out, "SECURITY") {
+		t.Errorf("expected a SECURITY warning for LAN bind, got: %q", out)
+	}
+}
+
+func TestIsLoopbackBindAddr(t *testing.T) {
+	t.Parallel()
+	loopback := []string{"127.0.0.1", "localhost", "::1", "127.5.5.5"}
+	nonLoopback := []string{"0.0.0.0", "192.168.1.10", "10.0.0.5", ""}
+
+	for _, addr := range loopback {
+		if !isLoopbackBindAddr(addr) {
+			t.Errorf("isLoopbackBindAddr(%q) = false; want true", addr)
+		}
+	}
+	for _, addr := range nonLoopback {
+		if isLoopbackBindAddr(addr) {
+			t.Errorf("isLoopbackBindAddr(%q) = true; want false", addr)
+		}
+	}
+}

--- a/internal/engine/serve_config_gate_test.go
+++ b/internal/engine/serve_config_gate_test.go
@@ -143,23 +143,21 @@ func TestConfigMutation_GateEnabled(t *testing.T) {
 
 // ─── Boot bind-address warning ──────────────────────────────────────────────
 
-// captureSlog redirects the default slog logger to a buffer for the duration
-// of fn, then restores it.
-func captureSlog(t *testing.T, fn func()) string {
-	t.Helper()
+// captureSlogTo builds a logger writing to a fresh buffer, calls fn with it,
+// and returns everything logged. Unlike mutating slog.SetDefault, this never
+// touches process-global state, so it's safe under t.Parallel() alongside
+// any other test in the package that might also log.
+func captureSlogTo(fn func(*slog.Logger)) string {
 	var buf bytes.Buffer
-	prev := slog.Default()
-	t.Cleanup(func() { slog.SetDefault(prev) })
-	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
-	fn()
+	fn(slog.New(slog.NewTextHandler(&buf, nil)))
 	return buf.String()
 }
 
 func TestWarnIfUnauthenticatedNonLoopback_WarnsOnNonLoopback(t *testing.T) {
 	t.Parallel()
 	cfg := &Config{BindAddr: "0.0.0.0", Port: 6931}
-	out := captureSlog(t, func() {
-		warnIfUnauthenticatedNonLoopback(cfg)
+	out := captureSlogTo(func(l *slog.Logger) {
+		warnIfUnauthenticatedNonLoopbackTo(l, cfg)
 	})
 	if !strings.Contains(out, "SECURITY") {
 		t.Errorf("expected a SECURITY warning for non-loopback bind, got: %q", out)
@@ -177,8 +175,8 @@ func TestWarnIfUnauthenticatedNonLoopback_SilentOnLoopback(t *testing.T) {
 		t.Run("addr="+addr, func(t *testing.T) {
 			t.Parallel()
 			cfg := &Config{BindAddr: addr, Port: 6931}
-			out := captureSlog(t, func() {
-				warnIfUnauthenticatedNonLoopback(cfg)
+			out := captureSlogTo(func(l *slog.Logger) {
+				warnIfUnauthenticatedNonLoopbackTo(l, cfg)
 			})
 			if strings.Contains(out, "SECURITY") {
 				t.Errorf("expected no warning for loopback bind_addr=%q, got: %q", addr, out)
@@ -190,8 +188,8 @@ func TestWarnIfUnauthenticatedNonLoopback_SilentOnLoopback(t *testing.T) {
 func TestWarnIfUnauthenticatedNonLoopback_LANAddress(t *testing.T) {
 	t.Parallel()
 	cfg := &Config{BindAddr: "192.168.10.191", Port: 6931}
-	out := captureSlog(t, func() {
-		warnIfUnauthenticatedNonLoopback(cfg)
+	out := captureSlogTo(func(l *slog.Logger) {
+		warnIfUnauthenticatedNonLoopbackTo(l, cfg)
 	})
 	if !strings.Contains(out, "SECURITY") {
 		t.Errorf("expected a SECURITY warning for LAN bind, got: %q", out)


### PR DESCRIPTION
## What

Gates **every surface** of the config-mutation data behind a new
`EnableConfigMutation` config flag (default `false`, `enable_config_mutation`
in `kernel.yaml`), exact parity with the existing `EnableSkillExec`
(`serve_skills.go:88`) / `EnableServiceControl` (`serve_services.go:223`)
opt-in-default-off gates:

- REST: `GET/PATCH /v1/config` and `POST /v1/config/rollback`
  (`serve_config.go`).
- MCP tools: `cog_read_config` / `cog_write_config` / `cog_rollback_config`
  (`mcp_server.go`) — added after cog-review's first pass found these three
  MCP tools called the identical `ReadConfigSnapshot`/`WriteConfigPatch`/
  `RollbackConfig` functions with no gate check at all, leaving the MCP
  transport (served over the same HTTP bind address via `POST /mcp`) fully
  open regardless of the REST gate.
- MCP resource: `cogos://config` (`resourceConfig`) — added after a second
  cog-review pass found this resource read the same `ReadConfigSnapshot`
  data via the untouched Resources API, a third exposure of the identical
  config data bypassing the gate on all three tools.

**All three surfaces are now closed behind the same flag** — the ledger item
below is fully addressed, not just the REST half.

Also adds a boot-time warning (never blocking -- refuse-to-start is an
explicit later decision) when `Config.BindAddr` resolves to a non-loopback
address and no HTTP auth-token config field exists -- which is currently
true unconditionally, since the kernel has no such field anywhere in
`Config`. Loopback-bind is the kernel's only HTTP access-control boundary
today, and `BindAddr` is a supported config surface that can be widened to
`0.0.0.0` for pod/LAN/Tailnet deployments (`serve_cors.go`).

## Why

Ledger item `L5-HTTP-AUTHZ` (v1.0 alignment discovery,
`.cog/mem/working/v1-alignment/discovery/DIVERGENCE-LEDGER-DRAFT.md`):
config mutation was the one HTTP surface with **no gate at all**, unlike
skills/services. This closes that specific gap and adds the companion
non-loopback-bind visibility the ledger flagged as the cheap, AUTO-eligible
piece of that finding (the broader "should the kernel gain real bearer/API-
key auth" call is left to the operator per the ledger's OPERATOR/AUTO
split).

## How

- `internal/engine/config.go`: new `Config.EnableConfigMutation bool` field
  + `enable_config_mutation` YAML tag + `applyKernelSection` wiring,
  mirroring `EnableSkillExec`/`EnableServiceControl` field-for-field.
- `internal/engine/serve_config.go`: new `requireConfigMutation` gate
  helper (mirrors `requireServiceControl`), called at the top of all three
  handlers (`handleConfigGet`, `handleConfigPatch`, `handleConfigRollback`).
  403 response shape (`{"error":"disabled","detail":"..."}`) matches the
  existing convention exactly.
- `internal/engine/boot_bindaddr_warning.go` (new): `isLoopbackBindAddr`
  (handles `127.0.0.1`, `localhost`, `::1`, and any `net.ParseIP`-loopback
  address; unparseable/hostname values fail toward warning, not silence)
  + `warnIfUnauthenticatedNonLoopback`, wired into `Boot()` right at entry.
  `hasHTTPAuthToken` is a named seam that always returns `false` today --
  documented so a future auth-token field updates this function in the
  same change instead of the warning silently going stale.
- `internal/engine/config_write_wire_test.go`: three pre-existing tests
  (`TestHandleConfigGet_IncludesDefaults`, `TestHandleConfigPatch_Success`,
  `TestHandleConfigPatch_ValidationFailure`) called the handlers directly
  against the shared `newTestServer` fixture, which defaults the gate off --
  updated each to set `EnableConfigMutation = true` since they're testing
  mutation behavior itself, not the gate.
- `internal/engine/mcp_server.go`: new `requireConfigMutationMCP` gate
  helper, called at the top of `toolReadConfig`/`toolWriteConfig`/
  `toolRollbackConfig`. Mirrors the HTTP gate's error body
  (`{"error":"disabled","detail":"..."}`) exactly, but returns it as an MCP
  tool error (`IsError: true`) rather than a 403 status -- there is no HTTP
  status code on this transport. Tool descriptions updated to document the
  gate; the stale "No authentication" note on `cog_write_config` (written
  before any gate existed on either transport) is corrected to describe the
  gate.
- `internal/engine/config_write_wire_test.go`: `newMCPForTest` now sets
  `EnableConfigMutation = true` by default (its existing tests exercise
  config read/write/rollback behavior itself, not the gate) -- mirrors the
  same rationale as the HTTP-side fixture updates above.
- `internal/engine/mcp_server.go`: `resourceConfig` now checks the same gate
  before calling `ReadConfigSnapshot`. MCP resources have no
  `IsError`/structured-error-body convention (unlike `CallToolResult`), so
  this returns a plain Go error carrying the same "disabled"/
  `enable_config_mutation` wording -- matching the established pattern for
  resource-read failures elsewhere in this file (see `resourceState`).

## Test evidence

New file `internal/engine/serve_config_gate_test.go`, outside-in via
`httptest` against `srv.Handler()`:

- `TestConfigMutation_GateDisabled` -- all three routes (GET/PATCH/POST
  rollback) return 403 + `{"error":"disabled"}` when the gate is off
  (the default).
- `TestConfigMutation_GateEnabled` -- all three routes reach their real
  handlers (200, not 403) when the gate is on.
- `TestIsLoopbackBindAddr` -- loopback/non-loopback address table.
- `TestWarnIfUnauthenticatedNonLoopback_WarnsOnNonLoopback` /
  `_SilentOnLoopback` / `_LANAddress` -- boot-warning behavior across
  `0.0.0.0`, a LAN IP, `127.0.0.1`, `localhost`, `::1`, and empty
  (defaults to loopback).
- `TestConfigMutationMCP_GateDisabled` -- all three MCP tools
  (`cog_read_config`/`cog_write_config`/`cog_rollback_config`) return an
  `IsError` result with `{"error":"disabled",...}` when the gate is off.
- `TestConfigMutationMCP_GateEnabled` -- all three MCP tools reach their
  real handlers (no `IsError`) when the gate is on.
- `TestResourceConfigMCP_GateDisabled` -- `cogos://config` returns an error
  mentioning "disabled" when the gate is off.
- `TestResourceConfigMCP_GateEnabled` -- `cogos://config` returns the
  effective config (no error) when the gate is on.

```
go build ./...                                            # clean
go vet ./...                                               # clean
go test ./internal/engine/... -count=1                     # ok
go test ./... -count=1                                     # ok, full repo
go test ./internal/engine/... -run 'TestConfigMutation|TestResourceConfig|TestWarnIfUnauthenticatedNonLoopback|TestIsLoopbackBindAddr' -race -count=5 -v
                                                             # stable across 5 runs w/ race detector
```

Rebased cleanly onto current `origin/main` (no overlap with #452/#453,
which this lane was scoped to avoid -- `context_assembly*`,
`trm_lightcone.go`, `foveation_*`, `provider_lms_model_state*`,
`serve_anthropic.go` are all untouched).

No `CHANGELOG.md` entry -- matches the current warn-only CI convention and
recent merged PRs (#446-#453), none of which touch it.
