### PR TITLE
fix(site): real per-app content-hash drift detection

### DIFF
--- a/internal/providers/site/site.go
+++ b/internal/providers/site/site.go
@@ -15,7 +15,10 @@ package site
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -24,6 +27,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -31,6 +35,57 @@ import (
 	"github.com/myrgic/cogos/pkg/substrate/reconcile"
 	"gopkg.in/yaml.v3"
 )
+
+// artifactSHAFile is the deploy-embedded manifest recording the content hash of
+// the artifact a target was built from. FetchLive reads it back to compare live
+// against a freshly-built artifact; Deploy writes it before staging.
+const artifactSHAFile = ".artifact-sha"
+
+// artifactHash computes a deterministic sha256 over every file in distDir,
+// hashing the sorted sequence of (relative-path, file-bytes) so the result is
+// independent of filesystem walk order. Directories and symlinks are ignored;
+// only regular file contents contribute. Returns lowercase hex.
+//
+// Each entry is length-prefixed (path length, path, content length, content) so
+// that no two distinct trees can collide by concatenation ambiguity.
+func artifactHash(distDir string) (string, error) {
+	var rels []string
+	err := filepath.Walk(distDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		rel, err := filepath.Rel(distDir, path)
+		if err != nil {
+			return err
+		}
+		rels = append(rels, filepath.ToSlash(rel))
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("artifactHash: walk %s: %w", distDir, err)
+	}
+	sort.Strings(rels)
+
+	h := sha256.New()
+	var lenBuf [8]byte
+	for _, rel := range rels {
+		binary.BigEndian.PutUint64(lenBuf[:], uint64(len(rel)))
+		h.Write(lenBuf[:])
+		h.Write([]byte(rel))
+
+		data, err := os.ReadFile(filepath.Join(distDir, filepath.FromSlash(rel)))
+		if err != nil {
+			return "", fmt.Errorf("artifactHash: read %s: %w", rel, err)
+		}
+		binary.BigEndian.PutUint64(lenBuf[:], uint64(len(data)))
+		h.Write(lenBuf[:])
+		h.Write(data)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
 
 func init() {
 	sp := newSiteProvider()
@@ -75,12 +130,16 @@ type siteSpec struct {
 	RedirectTo *string    `yaml:"redirect_to,omitempty" json:"redirect_to,omitempty"`
 }
 
-type sourceSpec struct{ Path string `yaml:"path" json:"path"` }
+type sourceSpec struct {
+	Path string `yaml:"path" json:"path"`
+}
 type buildSpec struct {
 	Command string `yaml:"command" json:"command"`
 	Dist    string `yaml:"dist"    json:"dist"`
 }
-type httpsSpec struct{ Required bool `yaml:"required" json:"required"` }
+type httpsSpec struct {
+	Required bool `yaml:"required" json:"required"`
+}
 type deploySpec struct {
 	Strategy string         `yaml:"strategy" json:"strategy"`
 	Target   map[string]any `yaml:"target"   json:"target"`
@@ -125,10 +184,17 @@ type siteProvider struct {
 	mu         sync.Mutex
 	root       string
 	strategies map[string]deployStrategy
+
+	// buildHashFn builds an app and returns the content hash of its dist tree.
+	// Injectable so tests can drive ComputePlan's drift logic without running a
+	// real build; defaults to (*siteProvider).buildAndHash.
+	buildHashFn func(ctx context.Context, appDir, name string) (string, error)
 }
 
 func newSiteProvider() *siteProvider {
-	return &siteProvider{strategies: map[string]deployStrategy{}}
+	sp := &siteProvider{strategies: map[string]deployStrategy{}}
+	sp.buildHashFn = sp.buildAndHash
+	return sp
 }
 
 func (s *siteProvider) RegisterStrategy(name string, strat deployStrategy) {
@@ -241,7 +307,32 @@ func (s *siteProvider) ComputePlan(config any, live any, state *reconcile.State)
 			continue
 		}
 
-		if liveState.ArtifactSHA == "" {
+		// Drift detection: build the artifact and hash its content, then compare
+		// against the hash recorded at the live target (.artifact-sha). A build
+		// or hash failure is surfaced as an update (safer to attempt a deploy
+		// than to silently skip a possibly-stale target).
+		//
+		// NOTE: this builds the app to hash it, duplicating the build ApplyPlan
+		// performs when the update is applied. Acceptable for now — plan and
+		// apply run the same build.sh, so the extra build is cheap and keeps the
+		// diff honest (an empty stub check could never detect content changes).
+		localSHA, buildErr := s.buildHashFn(context.Background(), appDir, name)
+		if buildErr != nil {
+			plan.Warnings = append(plan.Warnings,
+				fmt.Sprintf("%s: drift build failed, assuming update: %v", name, buildErr))
+			plan.Actions = append(plan.Actions, reconcile.Action{
+				Action:       reconcile.ActionUpdate,
+				ResourceType: "site",
+				Name:         name,
+				Details:      details,
+			})
+			plan.Summary.Updates++
+			continue
+		}
+		details["artifact_sha"] = localSHA
+
+		if liveState.ArtifactSHA == "" || liveState.ArtifactSHA != localSHA {
+			// No recorded content hash at the target, or the content changed.
 			plan.Actions = append(plan.Actions, reconcile.Action{
 				Action:       reconcile.ActionUpdate,
 				ResourceType: "site",
@@ -423,6 +514,18 @@ func siteBuild(ctx context.Context, appDir, name string) error {
 	return nil
 }
 
+// buildAndHash runs the app's build (the same build.sh path ApplyPlan uses) and
+// returns the content hash of the produced dist directory. The build writes to
+// appDir/dist in place — build.sh hard-codes that path and relies on the app's
+// location for its ../../packages copies, so there is no separate temp build dir
+// to redirect to or clean up; the dist tree is the artifact ApplyPlan deploys.
+func (s *siteProvider) buildAndHash(ctx context.Context, appDir, name string) (string, error) {
+	if err := siteBuild(ctx, appDir, name); err != nil {
+		return "", err
+	}
+	return artifactHash(filepath.Join(appDir, "dist"))
+}
+
 // ─── GHPagesStrategy ─────────────────────────────────────────────────────────
 
 type ghPagesStrategy struct{ mu sync.Mutex }
@@ -457,6 +560,10 @@ func (g *ghPagesStrategy) FetchLive(ctx context.Context, app siteCRD) (liveSiteS
 	}
 	state := liveSiteState{ResolvedFromTarget: true, Metadata: make(map[string]any)}
 
+	// The main ref establishes whether the target is deployed at all. Its commit
+	// SHA is not content-comparable (it changes on every force-push regardless of
+	// artifact content), so it is recorded only as metadata; ArtifactSHA comes
+	// from the deploy-embedded .artifact-sha manifest below.
 	refData, err := ghAPI(ctx, fmt.Sprintf("/repos/%s/git/refs/heads/main", repo))
 	if err != nil {
 		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "Not Found") {
@@ -466,12 +573,14 @@ func (g *ghPagesStrategy) FetchLive(ctx context.Context, app siteCRD) (liveSiteS
 		return liveSiteState{}, fmt.Errorf("FetchLive: fetch main ref: %w", err)
 	}
 	var refResp struct {
-		Object struct{ SHA string `json:"sha"` } `json:"object"`
+		Object struct {
+			SHA string `json:"sha"`
+		} `json:"object"`
 	}
 	if err := json.Unmarshal(refData, &refResp); err != nil {
 		return liveSiteState{}, fmt.Errorf("FetchLive: parse ref response: %w", err)
 	}
-	state.ArtifactSHA = refResp.Object.SHA
+	state.Metadata["commit_sha"] = refResp.Object.SHA
 
 	cnameData, err := ghAPI(ctx, fmt.Sprintf("/repos/%s/contents/CNAME", repo))
 	if err == nil {
@@ -486,6 +595,24 @@ func (g *ghPagesStrategy) FetchLive(ctx context.Context, app siteCRD) (liveSiteS
 			}
 		}
 	}
+
+	// Fetch the deploy-embedded artifact content hash (optional — 404 is normal
+	// for a target deployed before .artifact-sha was introduced; an empty
+	// ArtifactSHA then forces an update on the next reconcile).
+	shaData, err := ghAPI(ctx, fmt.Sprintf("/repos/%s/contents/%s", repo, artifactSHAFile))
+	if err == nil {
+		var shaResp struct {
+			Content  string `json:"content"`
+			Encoding string `json:"encoding"`
+		}
+		if err := json.Unmarshal(shaData, &shaResp); err == nil && shaResp.Encoding == "base64" {
+			decoded, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(shaResp.Content, "\n", ""))
+			if err == nil {
+				state.ArtifactSHA = strings.TrimSpace(string(decoded))
+			}
+		}
+	}
+
 	state.Metadata["repo"] = repo
 	return state, nil
 }
@@ -512,6 +639,17 @@ func (g *ghPagesStrategy) Deploy(ctx context.Context, app siteCRD, artifactDir s
 	}
 	if err := copyDir(artifactDir, tmpDir); err != nil {
 		return fmt.Errorf("Deploy: copy artifact: %w", err)
+	}
+	// Record the content hash of the artifact this deploy ships, so a later
+	// FetchLive can detect drift. Hash the source artifactDir (before CNAME and
+	// .artifact-sha are added to the deploy tree) so it matches the hash Diff
+	// computes over a freshly-built dist.
+	sha, err := artifactHash(artifactDir)
+	if err != nil {
+		return fmt.Errorf("Deploy: hash artifact: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, artifactSHAFile), []byte(sha), 0644); err != nil {
+		return fmt.Errorf("Deploy: write %s: %w", artifactSHAFile, err)
 	}
 	if err := os.WriteFile(filepath.Join(tmpDir, "CNAME"), []byte(app.Spec.Domain), 0644); err != nil {
 		return fmt.Errorf("Deploy: write CNAME: %w", err)

--- a/site_provider.go
+++ b/site_provider.go
@@ -22,6 +22,11 @@ type SiteProvider struct {
 	mu         sync.Mutex
 	root       string
 	strategies map[string]DeployStrategy
+
+	// buildHashFn builds an app and returns the content hash of its dist tree.
+	// Injectable so tests can drive ComputePlan's drift logic without running a
+	// real build; when nil, ComputePlan falls back to (*SiteProvider).buildAndHash.
+	buildHashFn func(ctx context.Context, appDir, name string) (string, error)
 }
 
 func defaultStrategies() map[string]DeployStrategy {
@@ -131,8 +136,9 @@ func (s *SiteProvider) FetchLive(ctx context.Context, config any) (any, error) {
 // ─── ComputePlan ────────────────────────────────────────────────────────────────
 
 // ComputePlan diffs declared SiteCRDs against live deployment state.
-// Drift detection in v0.0.1: absent live → create; ResolvedFromTarget=false → create;
-// ArtifactSHA empty → update; otherwise → skip. Full SHA comparison is planned for v0.1.
+// Drift detection: ResolvedFromTarget=false → create; otherwise build the app
+// and hash its content, comparing against the hash recorded at the live target
+// (.artifact-sha). Empty live hash or a mismatch → update; equal → skip.
 func (s *SiteProvider) ComputePlan(config any, live any, state *ReconcileState) (*ReconcilePlan, error) {
 	crds, ok := config.([]SiteCRD)
 	if !ok {
@@ -146,6 +152,11 @@ func (s *SiteProvider) ComputePlan(config any, live any, state *ReconcileState) 
 	s.mu.Lock()
 	root := s.root
 	s.mu.Unlock()
+
+	buildHash := s.buildHashFn
+	if buildHash == nil {
+		buildHash = s.buildAndHash
+	}
 
 	plan := &ReconcilePlan{
 		ResourceType: "site",
@@ -186,8 +197,32 @@ func (s *SiteProvider) ComputePlan(config any, live any, state *ReconcileState) 
 			continue
 		}
 
-		// Artifact SHA empty signals a deployed-but-unknown state — treat as update
-		if liveState.ArtifactSHA == "" {
+		// Drift detection: build the artifact and hash its content, then compare
+		// against the hash recorded at the live target (.artifact-sha). A build
+		// or hash failure is surfaced as an update (safer to attempt a deploy
+		// than to silently skip a possibly-stale target).
+		//
+		// NOTE: this builds the app to hash it, duplicating the build ApplyPlan
+		// performs when the update is applied. Acceptable for now — plan and
+		// apply run the same build.sh, so the extra build is cheap and keeps the
+		// diff honest (an empty stub check could never detect content changes).
+		localSHA, buildErr := buildHash(context.Background(), appDir, name)
+		if buildErr != nil {
+			plan.Warnings = append(plan.Warnings,
+				fmt.Sprintf("%s: drift build failed, assuming update: %v", name, buildErr))
+			plan.Actions = append(plan.Actions, ReconcileAction{
+				Action:       ActionUpdate,
+				ResourceType: "site",
+				Name:         name,
+				Details:      details,
+			})
+			plan.Summary.Updates++
+			continue
+		}
+		details["artifact_sha"] = localSHA
+
+		if liveState.ArtifactSHA == "" || liveState.ArtifactSHA != localSHA {
+			// No recorded content hash at the target, or the content changed.
 			plan.Actions = append(plan.Actions, ReconcileAction{
 				Action:       ActionUpdate,
 				ResourceType: "site",

--- a/site_provider_config.go
+++ b/site_provider_config.go
@@ -4,14 +4,69 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 
 	"gopkg.in/yaml.v3"
 )
+
+// artifactSHAFile is the deploy-embedded manifest recording the content hash of
+// the artifact a target was built from. FetchLive reads it back to compare live
+// against a freshly-built artifact; Deploy writes it before staging.
+const artifactSHAFile = ".artifact-sha"
+
+// artifactHash computes a deterministic sha256 over every file in distDir,
+// hashing the sorted sequence of (relative-path, file-bytes) so the result is
+// independent of filesystem walk order. Directories and symlinks are ignored;
+// only regular file contents contribute. Returns lowercase hex.
+//
+// Each entry is length-prefixed (path length, path, content length, content) so
+// that no two distinct trees can collide by concatenation ambiguity.
+func artifactHash(distDir string) (string, error) {
+	var rels []string
+	err := filepath.Walk(distDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		rel, err := filepath.Rel(distDir, path)
+		if err != nil {
+			return err
+		}
+		rels = append(rels, filepath.ToSlash(rel))
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("artifactHash: walk %s: %w", distDir, err)
+	}
+	sort.Strings(rels)
+
+	h := sha256.New()
+	var lenBuf [8]byte
+	for _, rel := range rels {
+		binary.BigEndian.PutUint64(lenBuf[:], uint64(len(rel)))
+		h.Write(lenBuf[:])
+		h.Write([]byte(rel))
+
+		data, err := os.ReadFile(filepath.Join(distDir, filepath.FromSlash(rel)))
+		if err != nil {
+			return "", fmt.Errorf("artifactHash: read %s: %w", rel, err)
+		}
+		binary.BigEndian.PutUint64(lenBuf[:], uint64(len(data)))
+		h.Write(lenBuf[:])
+		h.Write(data)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
 
 // siteLoadCRDs walks <root>/apps/*/site.yaml and returns parsed SiteCRDs.
 // Parse errors are hard failures; validation errors are logged as warnings
@@ -60,4 +115,16 @@ func siteBuild(ctx context.Context, appDir, name string) error {
 	}
 	log.Printf("[site] build %s: %s", name, out)
 	return nil
+}
+
+// buildAndHash runs the app's build (the same build.sh path ApplyPlan uses) and
+// returns the content hash of the produced dist directory. The build writes to
+// appDir/dist in place — build.sh hard-codes that path and relies on the app's
+// location for its ../../packages copies, so there is no separate temp build dir
+// to redirect to or clean up; the dist tree is the artifact ApplyPlan deploys.
+func (s *SiteProvider) buildAndHash(ctx context.Context, appDir, name string) (string, error) {
+	if err := siteBuild(ctx, appDir, name); err != nil {
+		return "", err
+	}
+	return artifactHash(filepath.Join(appDir, "dist"))
 }

--- a/site_provider_test.go
+++ b/site_provider_test.go
@@ -202,8 +202,8 @@ func TestSiteProvider_LoadConfig_InvalidValidation(t *testing.T) {
 func TestSiteProvider_LoadConfig_MixedValidAndInvalid(t *testing.T) {
 	root := t.TempDir()
 	buildAppsDir(t, root, map[string]string{
-		"good-app":  validSiteYAML("good-app", "good.example.com"),
-		"bad-app":   invalidSiteYAML("bad-app"),
+		"good-app": validSiteYAML("good-app", "good.example.com"),
+		"bad-app":  invalidSiteYAML("bad-app"),
 	})
 
 	sp := &SiteProvider{strategies: defaultStrategies()}
@@ -310,10 +310,17 @@ func TestSiteProvider_FetchLive_StrategyError(t *testing.T) {
 
 // ─── ComputePlan tests ───────────────────────────────────────────────────────────
 
+// stubBuildHash returns a fixed hash for every app, letting ComputePlan drift
+// tests exercise the compare logic without running a real build.
+func stubBuildHash(sha string) func(context.Context, string, string) (string, error) {
+	return func(context.Context, string, string) (string, error) { return sha, nil }
+}
+
 func TestSiteProvider_ComputePlan_AllSynced(t *testing.T) {
 	mock := &mockDeployStrategy{}
 	sp := newProviderWithMock(mock)
 	sp.root = "/fake/root"
+	sp.buildHashFn = stubBuildHash("deadbeef") // local build matches live → skip
 
 	crds := []SiteCRD{makeCRD("app-a", "a.example.com")}
 	liveMap := map[string]LiveSiteState{
@@ -335,10 +342,37 @@ func TestSiteProvider_ComputePlan_AllSynced(t *testing.T) {
 	}
 }
 
+func TestSiteProvider_ComputePlan_ContentDrift_IsUpdate(t *testing.T) {
+	mock := &mockDeployStrategy{}
+	sp := newProviderWithMock(mock)
+	sp.root = "/fake/root"
+	sp.buildHashFn = stubBuildHash("newsha") // local build differs from live → update
+
+	crds := []SiteCRD{makeCRD("app-a", "a.example.com")}
+	liveMap := map[string]LiveSiteState{
+		"app-a": {ArtifactSHA: "oldsha", ResolvedFromTarget: true},
+	}
+
+	plan, err := sp.ComputePlan(crds, liveMap, nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if len(plan.Actions) != 1 {
+		t.Fatalf("ComputePlan: got %d actions, want 1", len(plan.Actions))
+	}
+	if plan.Actions[0].Action != ActionUpdate {
+		t.Errorf("ComputePlan: got action %q, want Update on content drift", plan.Actions[0].Action)
+	}
+	if plan.Summary.Updates != 1 {
+		t.Errorf("ComputePlan: Summary.Updates = %d, want 1", plan.Summary.Updates)
+	}
+}
+
 func TestSiteProvider_ComputePlan_EmptyArtifactSHA_IsUpdate(t *testing.T) {
 	mock := &mockDeployStrategy{}
 	sp := newProviderWithMock(mock)
 	sp.root = "/fake/root"
+	sp.buildHashFn = stubBuildHash("anysha") // live has no recorded hash → update regardless
 
 	crds := []SiteCRD{makeCRD("app-a", "a.example.com")}
 	liveMap := map[string]LiveSiteState{
@@ -438,6 +472,14 @@ func TestSiteProvider_ComputePlan_SummaryCounts(t *testing.T) {
 	mock := &mockDeployStrategy{}
 	sp := newProviderWithMock(mock)
 	sp.root = "/fake/root"
+	// app-skip's freshly-built hash matches its live hash → skip; app-update has
+	// no live hash → update; app-create is not deployed → create.
+	sp.buildHashFn = func(_ context.Context, _, name string) (string, error) {
+		if name == "app-skip" {
+			return "sha1", nil
+		}
+		return "other", nil
+	}
 
 	crds := []SiteCRD{
 		makeCRD("app-skip", "skip.example.com"),

--- a/site_strategy_ghpages.go
+++ b/site_strategy_ghpages.go
@@ -79,8 +79,9 @@ func ghAPI(ctx context.Context, path string) ([]byte, error) {
 
 // FetchLive retrieves the current deployed state from the GitHub Pages target repo.
 // It queries:
-//   - /repos/<repo>/git/refs/heads/main → ArtifactSHA (current HEAD)
+//   - /repos/<repo>/git/refs/heads/main → existence + Metadata["commit_sha"]
 //   - /repos/<repo>/contents/CNAME → CNAMEContent (optional; 404 = empty)
+//   - /repos/<repo>/contents/.artifact-sha → ArtifactSHA (optional; 404 = empty)
 func (g *GHPagesStrategy) FetchLive(ctx context.Context, app SiteCRD) (LiveSiteState, error) {
 	repo, err := g.resolveRepo(app)
 	if err != nil {
@@ -92,7 +93,10 @@ func (g *GHPagesStrategy) FetchLive(ctx context.Context, app SiteCRD) (LiveSiteS
 		Metadata:           make(map[string]any),
 	}
 
-	// Query main branch SHA
+	// Query main branch ref. This establishes whether the target is deployed at
+	// all. The commit SHA is not content-comparable (it changes on every
+	// force-push regardless of artifact content), so it is recorded only as
+	// metadata; ArtifactSHA comes from the deploy-embedded .artifact-sha manifest.
 	refData, err := ghAPIRunner(ctx, fmt.Sprintf("/repos/%s/git/refs/heads/main", repo))
 	if err != nil {
 		// If the repo doesn't exist yet or has no main branch, treat as not deployed
@@ -111,7 +115,7 @@ func (g *GHPagesStrategy) FetchLive(ctx context.Context, app SiteCRD) (LiveSiteS
 	if err := json.Unmarshal(refData, &refResp); err != nil {
 		return LiveSiteState{}, fmt.Errorf("FetchLive: parse ref response: %w", err)
 	}
-	state.ArtifactSHA = refResp.Object.SHA
+	state.Metadata["commit_sha"] = refResp.Object.SHA
 
 	// Query CNAME (optional — 404 is normal)
 	cnameData, err := ghAPIRunner(ctx, fmt.Sprintf("/repos/%s/contents/CNAME", repo))
@@ -129,6 +133,25 @@ func (g *GHPagesStrategy) FetchLive(ctx context.Context, app SiteCRD) (LiveSiteS
 		}
 	}
 	// CNAME fetch errors are silently ignored — it's optional
+
+	// Query the deploy-embedded artifact content hash (optional — 404 is normal
+	// for a target deployed before .artifact-sha was introduced; an empty
+	// ArtifactSHA then forces an update on the next reconcile).
+	shaData, err := ghAPIRunner(ctx, fmt.Sprintf("/repos/%s/contents/%s", repo, artifactSHAFile))
+	if err == nil {
+		var shaResp struct {
+			Content  string `json:"content"`
+			Encoding string `json:"encoding"`
+		}
+		if err := json.Unmarshal(shaData, &shaResp); err == nil && shaResp.Encoding == "base64" {
+			decoded, err := base64.StdEncoding.DecodeString(
+				strings.ReplaceAll(shaResp.Content, "\n", ""))
+			if err == nil {
+				state.ArtifactSHA = strings.TrimSpace(string(decoded))
+			}
+		}
+	}
+	// .artifact-sha fetch errors are silently ignored — it's optional
 
 	state.Metadata["repo"] = repo
 	return state, nil
@@ -168,6 +191,18 @@ func (g *GHPagesStrategy) Deploy(ctx context.Context, app SiteCRD, artifactDir s
 	// Copy artifact contents into temp dir
 	if err := copyDir(artifactDir, tmpDir); err != nil {
 		return fmt.Errorf("Deploy: copy artifact: %w", err)
+	}
+
+	// Record the content hash of the artifact this deploy ships, so a later
+	// FetchLive can detect drift. Hash the source artifactDir (before CNAME and
+	// .artifact-sha are added to the deploy tree) so it matches the hash
+	// ComputePlan computes over a freshly-built dist.
+	sha, err := artifactHash(artifactDir)
+	if err != nil {
+		return fmt.Errorf("Deploy: hash artifact: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, artifactSHAFile), []byte(sha), 0644); err != nil {
+		return fmt.Errorf("Deploy: write %s: %w", artifactSHAFile, err)
 	}
 
 	// Write CNAME file (domain without trailing newline)

--- a/site_strategy_ghpages_test.go
+++ b/site_strategy_ghpages_test.go
@@ -51,6 +51,18 @@ func makeCNAMEJSON(domain string) []byte {
 	return b
 }
 
+// makeContentsJSON returns JSON bytes simulating a gh api .../contents/<file>
+// response with base64-encoded content (used for the .artifact-sha manifest).
+func makeContentsJSON(name, content string) []byte {
+	encoded := base64.StdEncoding.EncodeToString([]byte(content + "\n"))
+	b, _ := json.Marshal(map[string]any{
+		"name":     name,
+		"content":  encoded,
+		"encoding": "base64",
+	})
+	return b
+}
+
 // notFoundErr returns a fake 404 error matching FetchLive's detection heuristic.
 func notFoundErr(path string) error {
 	return fmt.Errorf("gh api %s: exit status 1: 404 Not Found", path)
@@ -97,6 +109,9 @@ func TestGHPagesStrategy_FetchLive_SuccessPath(t *testing.T) {
 		if strings.Contains(path, "contents/CNAME") {
 			return makeCNAMEJSON("myrgic.com"), nil
 		}
+		if strings.Contains(path, "contents/.artifact-sha") {
+			return makeContentsJSON(".artifact-sha", "cafef00d"), nil
+		}
 		return nil, fmt.Errorf("unexpected path: %s", path)
 	})
 
@@ -108,8 +123,12 @@ func TestGHPagesStrategy_FetchLive_SuccessPath(t *testing.T) {
 	if !state.ResolvedFromTarget {
 		t.Error("ResolvedFromTarget: want true")
 	}
-	if state.ArtifactSHA != "abc123def456" {
-		t.Errorf("ArtifactSHA: got %q, want abc123def456", state.ArtifactSHA)
+	// ArtifactSHA is the deploy-embedded content hash, not the git commit SHA.
+	if state.ArtifactSHA != "cafef00d" {
+		t.Errorf("ArtifactSHA: got %q, want cafef00d", state.ArtifactSHA)
+	}
+	if state.Metadata["commit_sha"] != "abc123def456" {
+		t.Errorf("Metadata[commit_sha]: got %v, want abc123def456", state.Metadata["commit_sha"])
 	}
 	if state.CNAMEContent != "myrgic.com" {
 		t.Errorf("CNAMEContent: got %q, want myrgic.com", state.CNAMEContent)
@@ -117,6 +136,35 @@ func TestGHPagesStrategy_FetchLive_SuccessPath(t *testing.T) {
 	repo, ok := state.Metadata["repo"]
 	if !ok || repo != "myrgic/myrgic.github.io" {
 		t.Errorf("Metadata[repo]: got %v, want myrgic/myrgic.github.io", repo)
+	}
+}
+
+func TestGHPagesStrategy_FetchLive_MissingArtifactSHA_NotAnError(t *testing.T) {
+	app := ghCRD("no-sha", "nosha.example.com", "myrgic/no-sha")
+
+	withRunner(t, func(ctx context.Context, path string) ([]byte, error) {
+		if strings.Contains(path, "git/refs/heads/main") {
+			return makeRefJSON("abc999"), nil
+		}
+		if strings.Contains(path, "contents/CNAME") {
+			return makeCNAMEJSON("nosha.example.com"), nil
+		}
+		if strings.Contains(path, "contents/.artifact-sha") {
+			return nil, notFoundErr(path) // manifest absent (pre-.artifact-sha deploy)
+		}
+		return nil, fmt.Errorf("unexpected path: %s", path)
+	})
+
+	g := ghPages()
+	state, err := g.FetchLive(context.Background(), app)
+	if err != nil {
+		t.Fatalf("FetchLive: .artifact-sha 404 should not error, got: %v", err)
+	}
+	if !state.ResolvedFromTarget {
+		t.Error("ResolvedFromTarget: want true (repo exists; .artifact-sha is optional)")
+	}
+	if state.ArtifactSHA != "" {
+		t.Errorf("ArtifactSHA: want empty when .artifact-sha absent, got %q", state.ArtifactSHA)
 	}
 }
 
@@ -150,6 +198,9 @@ func TestGHPagesStrategy_FetchLive_MissingCNAME_NotAnError(t *testing.T) {
 		if strings.Contains(path, "contents/CNAME") {
 			return nil, notFoundErr(path) // CNAME not present
 		}
+		if strings.Contains(path, "contents/.artifact-sha") {
+			return makeContentsJSON(".artifact-sha", "beadfeed"), nil
+		}
 		return nil, fmt.Errorf("unexpected path: %s", path)
 	})
 
@@ -161,8 +212,11 @@ func TestGHPagesStrategy_FetchLive_MissingCNAME_NotAnError(t *testing.T) {
 	if !state.ResolvedFromTarget {
 		t.Error("ResolvedFromTarget: want true (repo exists; CNAME is optional)")
 	}
-	if state.ArtifactSHA != "deadbeef1234" {
-		t.Errorf("ArtifactSHA: got %q, want deadbeef1234", state.ArtifactSHA)
+	if state.ArtifactSHA != "beadfeed" {
+		t.Errorf("ArtifactSHA: got %q, want beadfeed", state.ArtifactSHA)
+	}
+	if state.Metadata["commit_sha"] != "deadbeef1234" {
+		t.Errorf("Metadata[commit_sha]: got %v, want deadbeef1234", state.Metadata["commit_sha"])
 	}
 	if state.CNAMEContent != "" {
 		t.Errorf("CNAMEContent: want empty when CNAME absent, got %q", state.CNAMEContent)


### PR DESCRIPTION
The SiteProvider drift check was a stub that only deployed never-before-deployed targets, so content-only changes (a fresh build of an app) were silently skipped and never shipped. This replaces it with a real per-app content-hash comparison: a deterministic sha256 over the built dist tree, written to each target as `.artifact-sha`, read back by FetchLive, and compared in Diff against a freshly-built hash. Differ or missing plans as update; equal plans as skip. Verified end to end: an eigen-form.js change flipped the plan from 5x skip to 5x update and the apply deployed all five sites. Tests added for synced, content-drift, and missing-marker cases.